### PR TITLE
Add a 'status' field to feature flags denoting their use case

### DIFF
--- a/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesExperimentalFeatures.cpp.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesExperimentalFeatures.cpp.erb
@@ -41,7 +41,7 @@ const Vector<RefPtr<API::Object>>& WebPreferences::experimentalFeatures()
 <%- if @pref.condition -%>
 #if <%= @pref.condition %>
 <%- end -%>
-        API::ExperimentalFeature::create(<%= @pref.humanReadableName %>""_s, "<%= @pref.name %>"_s, <%= @pref.humanReadableDescription %>""_s, DEFAULT_VALUE_FOR_<%= @pref.name %>, <%= @pref.hidden %>),
+        API::ExperimentalFeature::create(<%= @pref.humanReadableName %>""_s, "<%= @pref.name %>"_s, <%= @pref.apiStatus %>, <%= @pref.humanReadableDescription %>""_s, DEFAULT_VALUE_FOR_<%= @pref.name %>, <%= @pref.hidden %>),
 <%- if @pref.condition -%>
 #endif
 <%- end -%>

--- a/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesInternalDebugFeatures.cpp.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesInternalDebugFeatures.cpp.erb
@@ -40,7 +40,7 @@ const Vector<RefPtr<API::Object>>& WebPreferences::internalDebugFeatures()
 <%- if @pref.condition -%>
 #if <%= @pref.condition %>
 <%- end -%>
-        API::InternalDebugFeature::create(<%= @pref.humanReadableName %>""_s, "<%= @pref.name %>"_s, <%= @pref.humanReadableDescription %>""_s, DEFAULT_VALUE_FOR_<%= @pref.name %>, <%= @pref.hidden %>),
+        API::InternalDebugFeature::create(<%= @pref.humanReadableName %>""_s, "<%= @pref.name %>"_s, <%= @pref.apiStatus %>, <%= @pref.humanReadableDescription %>""_s, DEFAULT_VALUE_FOR_<%= @pref.name %>, <%= @pref.hidden %>),
 <%- if @pref.condition -%>
 #endif
 <%- end -%>

--- a/Source/WebKit/UIProcess/API/APIExperimentalFeature.cpp
+++ b/Source/WebKit/UIProcess/API/APIExperimentalFeature.cpp
@@ -28,14 +28,15 @@
 
 namespace API {
 
-Ref<ExperimentalFeature> ExperimentalFeature::create(const WTF::String& name, const WTF::String& key, const WTF::String& details, bool defaultValue, bool hidden)
+Ref<ExperimentalFeature> ExperimentalFeature::create(const WTF::String& name, const WTF::String& key, FeatureStatus status, const WTF::String& details, bool defaultValue, bool hidden)
 {
-    return adoptRef(*new ExperimentalFeature(name, key, details, defaultValue, hidden));
+    return adoptRef(*new ExperimentalFeature(name, key, status, details, defaultValue, hidden));
 }
 
-ExperimentalFeature::ExperimentalFeature(const WTF::String& name, const WTF::String& key, const WTF::String& details, bool defaultValue, bool hidden)
+ExperimentalFeature::ExperimentalFeature(const WTF::String& name, const WTF::String& key, FeatureStatus status, const WTF::String& details, bool defaultValue, bool hidden)
     : m_name(name)
     , m_key(key)
+    , m_status(status)
     , m_details(details)
     , m_defaultValue(defaultValue)
     , m_hidden(hidden)

--- a/Source/WebKit/UIProcess/API/APIExperimentalFeature.h
+++ b/Source/WebKit/UIProcess/API/APIExperimentalFeature.h
@@ -26,6 +26,7 @@
 #ifndef APIExperimentalFeature_h
 #define APIExperimentalFeature_h
 
+#include "APIFeatureStatus.h"
 #include "APIObject.h"
 #include <wtf/text/WTFString.h>
 
@@ -33,20 +34,23 @@ namespace API {
 
 class ExperimentalFeature final : public ObjectImpl<Object::Type::ExperimentalFeature> {
 public:
-    static Ref<ExperimentalFeature> create(const WTF::String& name, const WTF::String& key, const WTF::String& details, bool defaultValue, bool hidden);
+
+    static Ref<ExperimentalFeature> create(const WTF::String& name, const WTF::String& key, FeatureStatus, const WTF::String& details, bool defaultValue, bool hidden);
     virtual ~ExperimentalFeature() = default;
 
     WTF::String name() const { return m_name; }
     WTF::String key() const { return m_key; }
+    FeatureStatus status() const { return m_status; }
     WTF::String details() const { return m_details; }
     bool defaultValue() const { return m_defaultValue; }
     bool isHidden() const { return m_hidden; }
-
+    
 private:
-    explicit ExperimentalFeature(const WTF::String& name, const WTF::String& key, const WTF::String& details, bool defaultValue, bool hidden);
+    explicit ExperimentalFeature(const WTF::String& name, const WTF::String& key, FeatureStatus, const WTF::String& details, bool defaultValue, bool hidden);
 
     WTF::String m_name;
     WTF::String m_key;
+    FeatureStatus m_status;
     WTF::String m_details;
     bool m_defaultValue;
     bool m_hidden;

--- a/Source/WebKit/UIProcess/API/APIFeatureStatus.h
+++ b/Source/WebKit/UIProcess/API/APIFeatureStatus.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,19 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKFoundation.h>
-#import <WebKit/WebFeature.h>
+#pragma once
 
-#import <Foundation/Foundation.h>
-
-WK_CLASS_AVAILABLE(macos(10.14.4), ios(12.2))
-@interface _WKInternalDebugFeature : NSObject
-
-@property (nonatomic, readonly, copy) NSString *key;
-@property (nonatomic, readonly, copy) NSString *name;
-@property (nonatomic, readonly) WebFeatureStatus status;
-@property (nonatomic, readonly, copy) NSString *details;
-@property (nonatomic, readonly) BOOL defaultValue;
-@property (nonatomic, readonly, getter=isHidden) BOOL hidden;
-
-@end
+namespace API {
+enum class FeatureStatus : uint8_t {
+    // For customizing WebKit behavior in embedding applications.
+    Embedder,
+    // Feature in active development. Unfinished, no promise it is usable or safe.
+    Unstable,
+    // Tools for debugging the WebKit engine. Not generally useful to web developers.
+    Internal,
+    // Tools for web developers.
+    Developer,
+    // Enabled by default in test infrastructure, but not ready to ship yet.
+    Testable,
+    // Enabled by default in Safari Technology Preview, but not considered ready to ship yet.
+    Preview,
+    // Enabled by default and ready for general use.
+    Stable
+};
+}

--- a/Source/WebKit/UIProcess/API/APIInternalDebugFeature.cpp
+++ b/Source/WebKit/UIProcess/API/APIInternalDebugFeature.cpp
@@ -28,14 +28,15 @@
 
 namespace API {
 
-Ref<InternalDebugFeature> InternalDebugFeature::create(const WTF::String& name, const WTF::String& key, const WTF::String& details, bool defaultValue, bool hidden)
+Ref<InternalDebugFeature> InternalDebugFeature::create(const WTF::String& name, const WTF::String& key, FeatureStatus status, const WTF::String& details, bool defaultValue, bool hidden)
 {
-    return adoptRef(*new InternalDebugFeature(name, key, details, defaultValue, hidden));
+    return adoptRef(*new InternalDebugFeature(name, key, status, details, defaultValue, hidden));
 }
 
-InternalDebugFeature::InternalDebugFeature(const WTF::String& name, const WTF::String& key, const WTF::String& details, bool defaultValue, bool hidden)
+InternalDebugFeature::InternalDebugFeature(const WTF::String& name, const WTF::String& key, FeatureStatus status, const WTF::String& details, bool defaultValue, bool hidden)
     : m_name(name)
     , m_key(key)
+    , m_status(status)
     , m_details(details)
     , m_defaultValue(defaultValue)
     , m_hidden(hidden)

--- a/Source/WebKit/UIProcess/API/APIInternalDebugFeature.h
+++ b/Source/WebKit/UIProcess/API/APIInternalDebugFeature.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "APIFeatureStatus.h"
 #include "APIObject.h"
 #include <wtf/text/WTFString.h>
 
@@ -32,20 +33,22 @@ namespace API {
 
 class InternalDebugFeature final : public ObjectImpl<Object::Type::InternalDebugFeature> {
 public:
-    static Ref<InternalDebugFeature> create(const WTF::String& name, const WTF::String& key, const WTF::String& details, bool defaultValue, bool hidden);
+    static Ref<InternalDebugFeature> create(const WTF::String& name, const WTF::String& key, FeatureStatus, const WTF::String& details, bool defaultValue, bool hidden);
     virtual ~InternalDebugFeature() = default;
 
     WTF::String name() const { return m_name; }
     WTF::String key() const { return m_key; }
+    FeatureStatus status() const { return m_status; }
     WTF::String details() const { return m_details; }
     bool defaultValue() const { return m_defaultValue; }
     bool isHidden() const { return m_hidden; }
 
 private:
-    explicit InternalDebugFeature(const WTF::String& name, const WTF::String& key, const WTF::String& details, bool defaultValue, bool hidden);
+    explicit InternalDebugFeature(const WTF::String& name, const WTF::String& key, FeatureStatus, const WTF::String& details, bool defaultValue, bool hidden);
 
     WTF::String m_name;
     WTF::String m_key;
+    FeatureStatus m_status;
     WTF::String m_details;
     bool m_defaultValue;
     bool m_hidden;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKExperimentalFeature.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKExperimentalFeature.h
@@ -24,6 +24,7 @@
  */
 
 #import <WebKit/WKFoundation.h>
+#import <WebKit/WebFeature.h>
 
 #import <Foundation/Foundation.h>
 
@@ -32,6 +33,7 @@ WK_CLASS_AVAILABLE(macos(10.12), ios(10.0))
 
 @property (nonatomic, readonly, copy) NSString *key;
 @property (nonatomic, readonly, copy) NSString *name;
+@property (nonatomic, readonly) WebFeatureStatus status;
 @property (nonatomic, readonly, copy) NSString *details;
 @property (nonatomic, readonly) BOOL defaultValue;
 @property (nonatomic, readonly, getter=isHidden) BOOL hidden;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKExperimentalFeature.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKExperimentalFeature.mm
@@ -50,6 +50,28 @@
     return _experimentalFeature->name();
 }
 
+- (WebFeatureStatus)status
+{
+    switch (_experimentalFeature->status()) {
+    case API::FeatureStatus::Embedder:
+        return WebFeatureStatusEmbedder;
+    case API::FeatureStatus::Unstable:
+        return WebFeatureStatusUnstable;
+    case API::FeatureStatus::Internal:
+        return WebFeatureStatusInternal;
+    case API::FeatureStatus::Developer:
+        return WebFeatureStatusDeveloper;
+    case API::FeatureStatus::Testable:
+        return WebFeatureStatusTestable;
+    case API::FeatureStatus::Preview:
+        return WebFeatureStatusPreview;
+    case API::FeatureStatus::Stable:
+        return WebFeatureStatusStable;
+    default:
+        ASSERT_NOT_REACHED();
+    }
+}
+
 - (NSString *)key
 {
     return _experimentalFeature->key();

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInternalDebugFeature.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInternalDebugFeature.mm
@@ -50,6 +50,28 @@
     return _internalDebugFeature->name();
 }
 
+- (WebFeatureStatus)status
+{
+    switch (_internalDebugFeature->status()) {
+    case API::FeatureStatus::Embedder:
+        return WebFeatureStatusEmbedder;
+    case API::FeatureStatus::Unstable:
+        return WebFeatureStatusUnstable;
+    case API::FeatureStatus::Internal:
+        return WebFeatureStatusInternal;
+    case API::FeatureStatus::Developer:
+        return WebFeatureStatusDeveloper;
+    case API::FeatureStatus::Testable:
+        return WebFeatureStatusTestable;
+    case API::FeatureStatus::Preview:
+        return WebFeatureStatusPreview;
+    case API::FeatureStatus::Stable:
+        return WebFeatureStatusStable;
+    default:
+        ASSERT_NOT_REACHED();
+    }
+}
+
 - (NSString *)key
 {
     return _internalDebugFeature->key();

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2040,6 +2040,7 @@
 		D952EC7A289C6BFA006C240A /* WebPermissionControllerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = D952EC76289C4299006C240A /* WebPermissionControllerProxy.h */; };
 		D952EC7E289C9A4C006C240A /* WebPermissionControllerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = D952EC7B289C9A4C006C240A /* WebPermissionControllerProxyMessages.h */; };
 		D952EC7F289C9A4C006C240A /* WebPermissionControllerProxyMessagesReplies.h in Headers */ = {isa = PBXBuildFile; fileRef = D952EC7C289C9A4C006C240A /* WebPermissionControllerProxyMessagesReplies.h */; };
+		DD284682291F7D210009A61D /* APIFeatureStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = DD284681291F7CEF0009A61D /* APIFeatureStatus.h */; };
 		DD4DB786280F945A001700D4 /* ElementAttribute.js in Headers */ = {isa = PBXBuildFile; fileRef = 990657341F323CBF00944F9C /* ElementAttribute.js */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4DB787280F945E001700D4 /* ElementDisplayed.js in Headers */ = {isa = PBXBuildFile; fileRef = 990657331F323CBF00944F9C /* ElementDisplayed.js */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4DB788280F9471001700D4 /* EnterFullscreen.js in Headers */ = {isa = PBXBuildFile; fileRef = 99CA66C8203668220074F35E /* EnterFullscreen.js */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7142,6 +7143,7 @@
 		D952EC7B289C9A4C006C240A /* WebPermissionControllerProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebPermissionControllerProxyMessages.h; sourceTree = "<group>"; };
 		D952EC7C289C9A4C006C240A /* WebPermissionControllerProxyMessagesReplies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebPermissionControllerProxyMessagesReplies.h; sourceTree = "<group>"; };
 		D952EC7D289C9A4C006C240A /* WebPermissionControllerProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebPermissionControllerProxyMessageReceiver.cpp; sourceTree = "<group>"; };
+		DD284681291F7CEF0009A61D /* APIFeatureStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APIFeatureStatus.h; sourceTree = "<group>"; };
 		DDA0A17C27E55E24005E086E /* DOMCSSImportRule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DOMCSSImportRule.h; path = ../WebKitLegacy/mac/DOM/DOMCSSImportRule.h; sourceTree = "<group>"; };
 		DDA0A17D27E55E24005E086E /* DOMMutationEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DOMMutationEvent.h; path = ../WebKitLegacy/mac/DOM/DOMMutationEvent.h; sourceTree = "<group>"; };
 		DDA0A17E27E55E24005E086E /* DOMText.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DOMText.h; path = ../WebKitLegacy/mac/DOM/DOMText.h; sourceTree = "<group>"; };
@@ -12566,6 +12568,7 @@
 				1F7D36C018DA513F00D9D659 /* APIDownloadClient.h */,
 				317FE7C11C487A6600A0CA89 /* APIExperimentalFeature.cpp */,
 				317FE7C21C487A6600A0CA89 /* APIExperimentalFeature.h */,
+				DD284681291F7CEF0009A61D /* APIFeatureStatus.h */,
 				00B9661518E24CBA00CE1F88 /* APIFindClient.h */,
 				2DD67A2D1BD819730053B251 /* APIFindMatchesClient.h */,
 				37E25D6D18FDE5D6005D3A00 /* APIFormClient.h */,
@@ -14663,6 +14666,7 @@
 				1F7D36C118DA513F00D9D659 /* APIDownloadClient.h in Headers */,
 				516A4A5D120A2CCD00C05B7F /* APIError.h in Headers */,
 				317FE7C51C487A6C00A0CA89 /* APIExperimentalFeature.h in Headers */,
+				DD284682291F7D210009A61D /* APIFeatureStatus.h in Headers */,
 				00B9661618E24CBA00CE1F88 /* APIFindClient.h in Headers */,
 				2DD67A2E1BD819730053B251 /* APIFindMatchesClient.h in Headers */,
 				37E25D6E18FDE5D6005D3A00 /* APIFormClient.h in Headers */,

--- a/Source/WebKitLegacy/mac/Scripts/PreferencesTemplates/WebPreferencesExperimentalFeatures.mm.erb
+++ b/Source/WebKitLegacy/mac/Scripts/PreferencesTemplates/WebPreferencesExperimentalFeatures.mm.erb
@@ -44,7 +44,13 @@ using namespace WebKit;
 <%- if @pref.condition -%>
 #if <%= @pref.condition %>
 <%- end -%>
-        adoptNS([[WebFeature alloc] initWithKey:@"<%= @pref.name %>" preferenceKey:@"<%= @pref.preferenceKey %>" name:@<%= @pref.humanReadableName %> details:@<%= @pref.humanReadableDescription %> defaultValue:DEFAULT_VALUE_FOR_<%= @pref.name %> hidden:<%= @pref.hidden %>]).get(),
+        adoptNS([[WebFeature alloc] initWithKey:@"<%= @pref.name %>"
+                                  preferenceKey:@"<%= @pref.preferenceKey %>"
+                                           name:@<%= @pref.humanReadableName %>
+                                         status:<%= @pref.webFeatureStatus %>
+                                        details:@<%= @pref.humanReadableDescription %>
+                                   defaultValue:DEFAULT_VALUE_FOR_<%= @pref.name %>
+                                        hidden:<%= @pref.hidden %>]).get(),
 <%- if @pref.condition -%>
 #endif
 <%- end -%>

--- a/Source/WebKitLegacy/mac/Scripts/PreferencesTemplates/WebPreferencesInternalFeatures.mm.erb
+++ b/Source/WebKitLegacy/mac/Scripts/PreferencesTemplates/WebPreferencesInternalFeatures.mm.erb
@@ -43,7 +43,13 @@ using namespace WebKit;
 <%- if @pref.condition -%>
 #if <%= @pref.condition %>
 <%- end -%>
-        adoptNS([[WebFeature alloc] initWithKey:@"<%= @pref.name %>" preferenceKey:@"<%= @pref.preferenceKey %>" name:@<%= @pref.humanReadableName %> details:@<%= @pref.humanReadableDescription %> defaultValue:DEFAULT_VALUE_FOR_<%= @pref.name %> hidden:<%= @pref.hidden %>]).get(),
+        adoptNS([[WebFeature alloc] initWithKey:@"<%= @pref.name %>"
+                                  preferenceKey:@"<%= @pref.preferenceKey %>"
+                                           name:@<%= @pref.humanReadableName %>
+                                         status:<%= @pref.webFeatureStatus %>
+                                        details:@<%= @pref.humanReadableDescription %>
+                                   defaultValue:DEFAULT_VALUE_FOR_<%= @pref.name %>
+                                         hidden:<%= @pref.hidden %>]).get(),
 <%- if @pref.condition -%>
 #endif
 <%- end -%>

--- a/Source/WebKitLegacy/mac/WebView/WebFeature.h
+++ b/Source/WebKitLegacy/mac/WebView/WebFeature.h
@@ -27,11 +27,33 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*!
+ @enum WebFeatureStatus
+ @abstract Field indicating the purpose and level of completeness of a web feature. Used to determine which UI (if any) should reveal a feature.
+ */
+typedef NS_ENUM(NSUInteger, WebFeatureStatus) {
+    /// For customizing WebKit behavior in embedding applications.
+    WebFeatureStatusEmbedder,
+    /// Feature in active development. Unfinished, no promise it is usable or safe.
+    WebFeatureStatusUnstable,
+    /// Tools for debugging the WebKit engine. Not generally useful to web developers.
+    WebFeatureStatusInternal,
+    /// Tools for web developers.
+    WebFeatureStatusDeveloper,
+    /// Enabled by default in test infrastructure, but not ready to ship yet.
+    WebFeatureStatusTestable,
+    /// Enabled by default in Safari Technology Preview, but not considered ready to ship yet.
+    WebFeatureStatusPreview,
+    /// Enabled by default and ready for general use.
+    WebFeatureStatusStable
+};
+
 @interface WebFeature : NSObject
 
 @property (nonatomic, readonly, copy) NSString *key;
 @property (nonatomic, readonly, copy) NSString *preferenceKey;
 @property (nonatomic, readonly, copy) NSString *name;
+@property (nonatomic, readonly) WebFeatureStatus status;
 @property (nonatomic, readonly, copy) NSString *details;
 @property (nonatomic, readonly) BOOL defaultValue;
 @property (nonatomic, readonly, getter=isHidden) BOOL hidden;

--- a/Source/WebKitLegacy/mac/WebView/WebFeature.m
+++ b/Source/WebKitLegacy/mac/WebView/WebFeature.m
@@ -27,7 +27,7 @@
 
 @implementation WebFeature
 
-- (instancetype)initWithKey:(NSString *)key preferenceKey:(NSString *)preferenceKey name:(NSString *)name details:(NSString *)details defaultValue:(BOOL)defaultValue hidden:(BOOL)hidden
+- (instancetype)initWithKey:(NSString *)key preferenceKey:(NSString *)preferenceKey name:(NSString *)name status:(WebFeatureStatus)status details:(NSString *)details defaultValue:(BOOL)defaultValue hidden:(BOOL)hidden
 {
     if (!(self = [super init]))
         return nil;
@@ -35,6 +35,7 @@
     _key = [key copy];
     _preferenceKey = [preferenceKey copy];
     _name = [name copy];
+    _status = status;
     _details = [details copy];
     _defaultValue = defaultValue;
     _hidden = hidden;

--- a/Source/WebKitLegacy/mac/WebView/WebFeatureInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebFeatureInternal.h
@@ -27,7 +27,7 @@
 
 @interface WebFeature (Internal)
 
-- (instancetype)initWithKey:(NSString *)key preferenceKey:(NSString *)preferenceKey name:(NSString *)name details:(NSString *)details defaultValue:(BOOL)defaultValue hidden:(BOOL)hidden;
+- (instancetype)initWithKey:(NSString *)key preferenceKey:(NSString *)preferenceKey name:(NSString *)name status:(WebFeatureStatus)status details:(NSString *)details defaultValue:(BOOL)defaultValue hidden:(BOOL)hidden;
 
 @end
 


### PR DESCRIPTION
#### 429cc4c7898637e262eae873994cbec3c7ffcdf6
<pre>
Add a &apos;status&apos; field to feature flags denoting their use case
<a href="https://bugs.webkit.org/show_bug.cgi?id=247926">https://bugs.webkit.org/show_bug.cgi?id=247926</a>
rdar://92112770

Reviewed by Brent Fulgham.

Add enum types representing different semantic labels for feature flags.
Add status fields to our various feature flag types:

- Cross-platform WebKit: API::ExperimentalFeature.status() and API::InternalDebugFeature.status()
- Cocoa WebKit SPI: -[_WKExperimentalFeature status] and -[_WKInternalDebugFeature status]
- WebKitLegacy: -[WebFeature status]

Update GeneratePreferences.rb to read a &quot;status&quot; field from
WebPreferences yamls, and update its templates to pass this through to
the feature instantiation site.

Currently, individual preferences do not declare their own status;
instead, the generator picks an appropriate status based on which file
the preference is declared in. Eventually, we will merge these files into a
single preferences manifest, and use the status field to determine where
a feature gets exposed.

* Source/WTF/Scripts/GeneratePreferences.rb:
* Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesExperimentalFeatures.cpp.erb:
* Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesInternalDebugFeatures.cpp.erb:
* Source/WebKit/UIProcess/API/APIExperimentalFeature.cpp:
(API::ExperimentalFeature::create):
(API::ExperimentalFeature::ExperimentalFeature):
* Source/WebKit/UIProcess/API/APIExperimentalFeature.h:
* Source/WebKit/UIProcess/API/APIFeatureStatus.h: Copied from Source/WebKitLegacy/mac/WebView/WebFeatureInternal.h.
* Source/WebKit/UIProcess/API/APIInternalDebugFeature.cpp:
(API::InternalDebugFeature::create):
(API::InternalDebugFeature::InternalDebugFeature):
* Source/WebKit/UIProcess/API/APIInternalDebugFeature.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKExperimentalFeature.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKExperimentalFeature.mm:
(-[_WKExperimentalFeature status]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInternalDebugFeature.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInternalDebugFeature.mm:
(-[_WKInternalDebugFeature status]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKitLegacy/mac/Scripts/PreferencesTemplates/WebPreferencesExperimentalFeatures.mm.erb:
* Source/WebKitLegacy/mac/Scripts/PreferencesTemplates/WebPreferencesInternalFeatures.mm.erb:
* Source/WebKitLegacy/mac/WebView/WebFeature.h:
* Source/WebKitLegacy/mac/WebView/WebFeature.m:
(-[WebFeature initWithKey:preferenceKey:name:status:details:defaultValue:hidden:]):
(-[WebFeature initWithKey:preferenceKey:name:details:defaultValue:hidden:]): Deleted.
* Source/WebKitLegacy/mac/WebView/WebFeatureInternal.h:

Canonical link: <a href="https://commits.webkit.org/257166@main">https://commits.webkit.org/257166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dbe895eb70adabf0ffa31849d9bdeeb57ae93b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107521 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167792 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7762 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36041 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104136 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103710 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84660 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32909 "layout-tests (failure)") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/101606 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87705 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88916 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1252 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84630 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1217 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28605 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4931 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6076 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87468 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41762 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19623 "Passed tests") | 
<!--EWS-Status-Bubble-End-->