### PR TITLE
[run-benchmark] Error when running a plan with source type git_archive on a system with GNU tar

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py
@@ -129,8 +129,8 @@ class BenchmarkBuilder(object):
         relpath_in_repo = match.group('path').lstrip('/')
         reference = match.group('reference')
         with tempfile.TemporaryDirectory() as temp_dir:
-            output = os.path.join(temp_dir, 'temp.tar')
-            subprocess.check_call(['git', 'archive', '--format=tar', reference, relpath_in_repo, '-o', output],
+            output = os.path.join(temp_dir, 'temp.tar.gz')
+            subprocess.check_call(['git', 'archive', '--format=tar.gz', reference, relpath_in_repo, '-o', output],
                                   cwd=get_path_from_project_root('../../../../'))
             temp_extract_path = os.path.join(temp_dir, 'extract')
             os.makedirs(temp_extract_path)

--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
@@ -85,7 +85,7 @@ class BenchmarkRunner(object):
         plans = [os.path.splitext(plan_file)[0] for plan_file in os.listdir(BenchmarkRunner.plan_directory()) if plan_file.endswith(".plan")]
         return plans
 
-    def _run_one_test(self, web_root, test_file):
+    def _run_one_test(self, web_root, test_file, iteration):
         raise NotImplementedError('BenchmarkRunner is an abstract class and shouldn\'t be instantiated.')
 
     def _run_benchmark(self, count, web_root):


### PR DESCRIPTION
#### 3e0b8aa34ac72fb7a7334c6e4d4cd16099ccbb91
<pre>
[run-benchmark] Error when running a plan with source type git_archive on a system with GNU tar
<a href="https://bugs.webkit.org/show_bug.cgi?id=248500">https://bugs.webkit.org/show_bug.cgi?id=248500</a>

Reviewed by Dewei Zhu.

Create the git archive file in .tar.gz format so the format of
the archive file is the one expected by GNU tar when the flag
&apos;z&apos; is passed to it.

Meanwhile at this, add also the &apos;iteration&apos; missing parameter in
the arguments of the skeleton BenchmarkRunner._run_one_test() class.
All the subclasses that inherit BenchmarkRunner() have this parameter
since 256544@main

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py:
(BenchmarkBuilder._prepare_content_from_local_git_archive):
* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py:
(BenchmarkRunner._run_one_test):

Canonical link: <a href="https://commits.webkit.org/257218@main">https://commits.webkit.org/257218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8089e2841ed73367dda1b4b68d95a95703efa609

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107522 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167793 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101998 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7763 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36042 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90667 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104137 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5837 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84661 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32969 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/101607 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89420 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1253 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20854 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1218 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22358 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6077 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44809 "Found 1 new test failure: fast/images/animated-heics-verify.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2479 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41763 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->