### PR TITLE
[ New Test ] (256342@main): [ macOS Debug ] fast/events/message-port-gc-after-removing-event-listener.html is a flaky crash

### DIFF
--- a/Source/WebCore/bindings/js/JSCustomEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCustomEventCustom.cpp
@@ -36,7 +36,8 @@ namespace WebCore {
 
 JSC::JSValue JSCustomEvent::detail(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
-    return cachedPropertyValue(lexicalGlobalObject, *this, wrapped().cachedDetail(), [this] {
+    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedDetail(), [this](JSC::ThrowScope&) {
         return wrapped().detail().getValue(JSC::jsNull());
     });
 }

--- a/Source/WebCore/bindings/js/JSHistoryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHistoryCustom.cpp
@@ -38,7 +38,8 @@ using namespace JSC;
 
 JSValue JSHistory::state(JSGlobalObject& lexicalGlobalObject) const
 {
-    return cachedPropertyValue(lexicalGlobalObject, *this, wrapped().cachedState(), [this, &lexicalGlobalObject] {
+    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedState(), [this, &lexicalGlobalObject](JSC::ThrowScope&) {
         auto* serialized = wrapped().state();
         return serialized ? serialized->deserialize(lexicalGlobalObject, globalObject()) : jsNull();
     });

--- a/Source/WebCore/bindings/js/JSIDBCursorCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBCursorCustom.cpp
@@ -37,14 +37,16 @@ using namespace JSC;
 
 JSC::JSValue JSIDBCursor::key(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
-    return cachedPropertyValue(lexicalGlobalObject, *this, wrapped().keyWrapper(), [&] {
+    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().keyWrapper(), [&](JSC::ThrowScope&) {
         return toJS(lexicalGlobalObject, lexicalGlobalObject, wrapped().key());
     });
 }
 
 JSC::JSValue JSIDBCursor::primaryKey(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
-    return cachedPropertyValue(lexicalGlobalObject, *this, wrapped().primaryKeyWrapper(), [&] {
+    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().primaryKeyWrapper(), [&](JSC::ThrowScope&) {
         return toJS(lexicalGlobalObject, lexicalGlobalObject, wrapped().primaryKey());
     });
 }

--- a/Source/WebCore/bindings/js/JSIDBCursorWithValueCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBCursorWithValueCustom.cpp
@@ -35,7 +35,8 @@ using namespace JSC;
 
 JSC::JSValue JSIDBCursorWithValue::value(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
-    return cachedPropertyValue(lexicalGlobalObject, *this, wrapped().valueWrapper(), [&] {
+    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().valueWrapper(), [&](JSC::ThrowScope&) {
         auto result = deserializeIDBValueWithKeyInjection(lexicalGlobalObject, wrapped().value(), wrapped().primaryKey(), wrapped().primaryKeyPath());
         return result ? result.value() : jsNull();
     });

--- a/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
@@ -38,9 +38,9 @@ using namespace JSC;
 
 JSC::JSValue JSIDBRequest::result(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
+    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
     auto result = wrapped().result();
     if (UNLIKELY(result.hasException())) {
-        auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
         propagateException(lexicalGlobalObject, throwScope, result.releaseException());
         return jsNull();
     }
@@ -54,34 +54,31 @@ JSC::JSValue JSIDBRequest::result(JSC::JSGlobalObject& lexicalGlobalObject) cons
     }, [] (uint64_t number) {
         return toJS<IDLUnsignedLongLong>(number);
     }, [&] (const RefPtr<IDBCursor>& cursor) {
-        return cachedPropertyValue(lexicalGlobalObject, *this, resultWrapper, [&] {
-            auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+        return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, resultWrapper, [&](JSC::ThrowScope& throwScope) {
             return toJS<IDLInterface<IDBCursor>>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), throwScope, cursor.get());
         });
     }, [&] (const RefPtr<IDBDatabase>& database) {
-        return cachedPropertyValue(lexicalGlobalObject, *this, resultWrapper, [&] {
-            auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+        return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, resultWrapper, [&](JSC::ThrowScope& throwScope) {
             return toJS<IDLInterface<IDBDatabase>>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), throwScope, database.get());
         });
     }, [&] (const IDBKeyData& keyData) {
-        return cachedPropertyValue(lexicalGlobalObject, *this, resultWrapper, [&] {
+        return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, resultWrapper, [&](JSC::ThrowScope&) {
             return toJS<IDLIDBKeyData>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), keyData);
         });
     }, [&] (const Vector<IDBKeyData>& keyDatas) {
-        return cachedPropertyValue(lexicalGlobalObject, *this, resultWrapper, [&] {
+        return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, resultWrapper, [&](JSC::ThrowScope&) {
             return toJS<IDLSequence<IDLIDBKeyData>>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), keyDatas);
         });
     }, [&] (const IDBGetResult& getResult) {
-        return cachedPropertyValue(lexicalGlobalObject, *this, resultWrapper, [&] {
+        return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, resultWrapper, [&](JSC::ThrowScope&) {
             auto result = deserializeIDBValueWithKeyInjection(lexicalGlobalObject, getResult.value(), getResult.keyData(), getResult.keyPath());
             return result ? result.value() : jsNull();
         });
     }, [&] (const IDBGetAllResult& getAllResult) {
-        return cachedPropertyValue(lexicalGlobalObject, *this, resultWrapper, [&] {
+        return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, resultWrapper, [&](JSC::ThrowScope& throwScope) {
             auto& keys = getAllResult.keys();
             auto& values = getAllResult.values();
             auto& keyPath = getAllResult.keyPath();
-            auto scope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
             JSC::MarkedArgumentBuffer list;
             for (unsigned i = 0; i < values.size(); i ++) {
                 auto result = deserializeIDBValueWithKeyInjection(lexicalGlobalObject, values[i], keys[i], keyPath);
@@ -89,7 +86,7 @@ JSC::JSValue JSIDBRequest::result(JSC::JSGlobalObject& lexicalGlobalObject) cons
                     return jsNull();
                 list.append(result.value());
                 if (UNLIKELY(list.hasOverflowed())) {
-                    propagateException(lexicalGlobalObject, scope, Exception(UnknownError));
+                    propagateException(lexicalGlobalObject, throwScope, Exception(UnknownError));
                     return jsNull();
                 }
             }

--- a/Source/WebCore/bindings/js/JSMessageEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMessageEventCustom.cpp
@@ -46,15 +46,15 @@ namespace WebCore {
 JSC::JSValue JSMessageEvent::ports(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
     auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
-    return cachedPropertyValue(lexicalGlobalObject, *this, wrapped().cachedPorts(), [&] {
-        JSC::JSValue ports = toJS<IDLFrozenArray<IDLInterface<MessagePort>>>(lexicalGlobalObject, *globalObject(), throwScope, wrapped().ports());
-        return ports;
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedPorts(), [&](JSC::ThrowScope& throwScope) {
+        return toJS<IDLFrozenArray<IDLInterface<MessagePort>>>(lexicalGlobalObject, *globalObject(), throwScope, wrapped().ports());
     });
 }
 
 JSC::JSValue JSMessageEvent::data(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
-    return cachedPropertyValue(lexicalGlobalObject, *this, wrapped().cachedData(), [this, &lexicalGlobalObject] {
+    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedData(), [this, &lexicalGlobalObject](JSC::ThrowScope&) {
         return WTF::switchOn(wrapped().data(), [this] (MessageEvent::JSValueTag) -> JSC::JSValue {
             return wrapped().jsData().getValue(JSC::jsNull());
         }, [this, &lexicalGlobalObject] (const Ref<SerializedScriptValue>& data) {

--- a/Source/WebCore/bindings/js/JSPaymentMethodChangeEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPaymentMethodChangeEventCustom.cpp
@@ -32,7 +32,8 @@ namespace WebCore {
 
 JSC::JSValue JSPaymentMethodChangeEvent::methodDetails(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
-    return cachedPropertyValue(lexicalGlobalObject, *this, wrapped().cachedMethodDetails(), [this, &lexicalGlobalObject] {
+    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedMethodDetails(), [this, &lexicalGlobalObject](JSC::ThrowScope&) {
         return WTF::switchOn(wrapped().methodDetails(), [](const JSValueInWrappedObject& methodDetails) -> JSC::JSValue {
             return methodDetails.getValue(JSC::jsNull());
         }, [&lexicalGlobalObject](const PaymentMethodChangeEvent::MethodDetailsFunction& function) -> JSC::JSValue {

--- a/Source/WebCore/bindings/js/JSPaymentResponseCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPaymentResponseCustom.cpp
@@ -32,7 +32,8 @@ namespace WebCore {
 
 JSC::JSValue JSPaymentResponse::details(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
-    return cachedPropertyValue(lexicalGlobalObject, *this, wrapped().cachedDetails(), [this, &lexicalGlobalObject] {
+    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedDetails(), [this, &lexicalGlobalObject](JSC::ThrowScope&) {
         return wrapped().detailsFunction()(lexicalGlobalObject).get();
     });
 }

--- a/Source/WebCore/bindings/js/JSWebXRRigidTransformCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebXRRigidTransformCustom.cpp
@@ -37,7 +37,7 @@ using namespace JSC;
 JSC::JSValue JSWebXRRigidTransform::matrix(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
     auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
-    return cachedPropertyValue(lexicalGlobalObject, *this, wrapped().cachedMatrix(), [&] {
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedMatrix(), [&](JSC::ThrowScope& throwScope) {
         JSC::JSValue matrix = toJS<IDLFloat32Array>(lexicalGlobalObject, *globalObject(), throwScope, wrapped().matrix());
         return matrix;
     });

--- a/Source/WebCore/bindings/js/JSWebXRViewCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebXRViewCustom.cpp
@@ -37,7 +37,7 @@ using namespace JSC;
 JSC::JSValue JSWebXRView::projectionMatrix(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
     auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
-    return cachedPropertyValue(lexicalGlobalObject, *this, wrapped().cachedProjectionMatrix(), [&] {
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedProjectionMatrix(), [&](JSC::ThrowScope& throwScope) {
         JSC::JSValue matrix = toJS<IDLFloat32Array>(lexicalGlobalObject, *globalObject(), throwScope, wrapped().projectionMatrix());
         return matrix;
     });


### PR DESCRIPTION
#### c9f7f8272c109b646186c8081915367dd781e723
<pre>
[ New Test ] (256342@main): [ macOS Debug ] fast/events/message-port-gc-after-removing-event-listener.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=248496">https://bugs.webkit.org/show_bug.cgi?id=248496</a>
rdar://102784521

Reviewed by Alex Christensen.

The crash would occur when the dedicated would get terminated (because the page
is being navigated) while it is accessing messageEvent.ports).

JSMessageEvent::ports() would call cachedPropertyValue(), which in turn would
call the passed-in lambda to get the JSValue to cache. Because the worker is
getting terminated, the call to toJS&lt;&gt;() in the lambda would cause a
termination exception to be thrown and the lambda would return a default
constructed JSValue.

However, cachedPropertyValue() would fail to check for the exception case and
try to cache the default-constructed JSValue. To address the issue, we now
pass a throwScope to cachedPropertyValue() and cachedPropertyValue() checks
if there was an exception thrown after calling the lambda. If an exception
was thrown, it early returns instead of trying to cache the JSValue.

* Source/WebCore/bindings/js/JSCustomEventCustom.cpp:
(WebCore::JSCustomEvent::detail const):
* Source/WebCore/bindings/js/JSHistoryCustom.cpp:
(WebCore::JSHistory::state const):
* Source/WebCore/bindings/js/JSIDBCursorCustom.cpp:
(WebCore::JSIDBCursor::key const):
(WebCore::JSIDBCursor::primaryKey const):
* Source/WebCore/bindings/js/JSIDBCursorWithValueCustom.cpp:
(WebCore::JSIDBCursorWithValue::value const):
* Source/WebCore/bindings/js/JSIDBRequestCustom.cpp:
(WebCore::JSIDBRequest::result const):
* Source/WebCore/bindings/js/JSMessageEventCustom.cpp:
(WebCore::JSMessageEvent::ports const):
(WebCore::JSMessageEvent::data const):
* Source/WebCore/bindings/js/JSPaymentMethodChangeEventCustom.cpp:
(WebCore::JSPaymentMethodChangeEvent::methodDetails const):
* Source/WebCore/bindings/js/JSPaymentResponseCustom.cpp:
(WebCore::JSPaymentResponse::details const):
* Source/WebCore/bindings/js/JSValueInWrappedObject.h:
(WebCore::cachedPropertyValue):
* Source/WebCore/bindings/js/JSWebXRRigidTransformCustom.cpp:
(WebCore::JSWebXRRigidTransform::matrix const):
* Source/WebCore/bindings/js/JSWebXRViewCustom.cpp:
(WebCore::JSWebXRView::projectionMatrix const):

Canonical link: <a href="https://commits.webkit.org/257180@main">https://commits.webkit.org/257180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c422834ecad06f1a253d04a4b503832526a0c79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107524 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167795 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7765 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36044 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90672 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104139 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5838 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84663 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32975 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89426 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88919 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1255 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84633 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1220 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22361 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28616 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4944 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6079 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87471 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41766 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19624 "Passed tests") | 
<!--EWS-Status-Bubble-End-->