### PR TITLE
Don't directly expose s_instanceHandle on Windows

### DIFF
--- a/Source/WebCore/platform/win/WebCoreInstanceHandle.cpp
+++ b/Source/WebCore/platform/win/WebCoreInstanceHandle.cpp
@@ -28,6 +28,17 @@
 
 namespace WebCore {
 
-HINSTANCE s_instanceHandle;
+// The global DLL or application instance used for all windows.
+HINSTANCE s_instanceHandle = nullptr;
+
+void setInstanceHandle(HINSTANCE instanceHandle)
+{
+    s_instanceHandle = instanceHandle;
+}
+
+HINSTANCE instanceHandle()
+{
+    return s_instanceHandle;
+}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/win/WebCoreInstanceHandle.h
+++ b/Source/WebCore/platform/win/WebCoreInstanceHandle.h
@@ -23,19 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef WebCoreInstanceHandle_h
-#define WebCoreInstanceHandle_h
+#pragma once
 
 typedef struct HINSTANCE__* HINSTANCE;
 
 namespace WebCore {
 
-// The global DLL or application instance used for all windows.
-extern HINSTANCE s_instanceHandle;
-
-inline void setInstanceHandle(HINSTANCE instanceHandle) { s_instanceHandle = instanceHandle; }
-inline HINSTANCE instanceHandle() { return s_instanceHandle; }
+WEBCORE_EXPORT void setInstanceHandle(HINSTANCE);
+WEBCORE_EXPORT HINSTANCE instanceHandle();
     
 }
-
-#endif // WebCoreInstanceHandle_h


### PR DESCRIPTION
#### 32233601e2c90586467b9f5aedac76e0c874e032
<pre>
Don&apos;t directly expose s_instanceHandle on Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=248503">https://bugs.webkit.org/show_bug.cgi?id=248503</a>

Reviewed by Alex Christensen and Fujii Hironori.

All accesses of `s_instanceHandle` used the getter/setter functions so
just remove it from the header. Export the functions so WebCore can be
turned into a shared library.

* Source/WebCore/platform/win/WebCoreInstanceHandle.cpp:
* Source/WebCore/platform/win/WebCoreInstanceHandle.h:

Canonical link: <a href="https://commits.webkit.org/257183@main">https://commits.webkit.org/257183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fbd2152f26899b307c103ba28f74eddb0cb26a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107530 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167799 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7771 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36048 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90689 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104143 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5843 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84668 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32986 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89425 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1259 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1224 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22363 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4945 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6084 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2524 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41768 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->