### PR TITLE
Keep `br` while replacing plain texts with content ending with newline

### DIFF
--- a/LayoutTests/editing/pasteboard/paste-newline-in-all-selected-textarea-expected.txt
+++ b/LayoutTests/editing/pasteboard/paste-newline-in-all-selected-textarea-expected.txt
@@ -1,0 +1,5 @@
+PASS textarea.value is "\n"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/pasteboard/paste-newline-in-all-selected-textarea.html
+++ b/LayoutTests/editing/pasteboard/paste-newline-in-all-selected-textarea.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+<textarea id="test" cols=5 rows=4>
+This test verifies that pasting a newline in a textarea with all text selected
+produces a newline.
+
+</textarea>
+<script src="../../resources/js-test.js"></script>
+<script>
+var textarea = document.getElementById('test');
+textarea.focus();
+
+// copy a new line
+textarea.setSelectionRange(99, 100);
+document.execCommand('Copy');
+
+document.execCommand('SelectAll');
+document.execCommand('Paste');
+shouldBeEqualToString('textarea.value', '\n');
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -1356,7 +1356,7 @@ void ReplaceSelectionCommand::doApply()
     if (!startOfInsertedContent.isNull() && insertionBlock && insertionPos.deprecatedNode() == insertionBlock->parentNode() && (unsigned)insertionPos.deprecatedEditingOffset() < insertionBlock->computeNodeIndex() && !isStartOfParagraph(startOfInsertedContent))
         insertNodeAt(HTMLBRElement::create(document()), startOfInsertedContent.deepEquivalent());
 
-    if (endBR && (plainTextFragment || shouldRemoveEndBR(endBR.get(), originalVisPosBeforeEndBR))) {
+    if (endBR && (plainTextFragment || (shouldRemoveEndBR(endBR.get(), originalVisPosBeforeEndBR) && !(fragment.hasInterchangeNewlineAtEnd() && selectionIsPlainText)))) {
         RefPtr parent { endBR->parentNode() };
         insertedNodes.willRemoveNode(endBR.get());
         removeNode(*endBR);


### PR DESCRIPTION
#### a4612d781cd3a4631a4e3d9875175f03adda2c2c
<pre>
Keep `br` while replacing plain texts with content ending with newline

Keep `br` while replacing plain texts with content ending with newline
<a href="https://bugs.webkit.org/show_bug.cgi?id=90206">https://bugs.webkit.org/show_bug.cgi?id=90206</a>

Reviewed by Ryosuke Niwa.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=165565

The &lt;br&gt; after the insert position was removed while inserting a text
ending with a newline. This caused the loss of the newline at the end
of the inserted text. This fix adds extra condition checking for this
scenario and keeps the &lt;br&gt; while replacing plain texts with content
ending with newline.

* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(ReplaceSelectionCommand::doApply): Update logic to account for &apos;br&apos; while inserting text with newline
* LayoutTests/editing/pasteboard/paste-newline-in-all-selected-textarea.html: Add Test Case
* LayoutTests/editing/pasteboard/paste-newline-in-all-selected-textarea-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/257205@main">https://commits.webkit.org/257205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/040ed598b890a6189351e326f21a8108189ecfdd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107535 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167803 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7776 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36052 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104147 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5885 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84672 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32983 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89433 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1263 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1228 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22370 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4962 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6088 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44820 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41775 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->