### PR TITLE
Add exports to link a shared WebCore with WebKitLegacy for WinCairo

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityListBox.h
+++ b/Source/WebCore/accessibility/AccessibilityListBox.h
@@ -38,7 +38,7 @@ public:
     virtual ~AccessibilityListBox();
 
     bool canSetSelectedChildren() const override;
-    void setSelectedChildren(const AccessibilityChildrenVector&) override;
+    WEBCORE_EXPORT void setSelectedChildren(const AccessibilityChildrenVector&) override;
     AccessibilityRole roleValue() const override { return AccessibilityRole::ListBox; }
         
     void selectedChildren(AccessibilityChildrenVector&) override;

--- a/Source/WebCore/accessibility/win/AccessibilityObjectWrapperWin.h
+++ b/Source/WebCore/accessibility/win/AccessibilityObjectWrapperWin.h
@@ -43,7 +43,7 @@ namespace WebCore {
         bool attached() const { return m_object; }
         AccessibilityObject* accessibilityObject() const { return m_object; }
 
-        void accessibilityAttributeValue(const AtomString&, VARIANT*);
+        WEBCORE_EXPORT void accessibilityAttributeValue(const AtomString&, VARIANT*);
 
     protected:
         AccessibilityObjectWrapper(AccessibilityObject* obj) : m_object(obj) { }

--- a/Source/WebCore/bindings/js/JSWindowProxy.h
+++ b/Source/WebCore/bindings/js/JSWindowProxy.h
@@ -42,7 +42,7 @@ namespace WebCore {
 class AbstractDOMWindow;
 class AbstractFrame;
 
-class JSWindowProxy final : public JSC::JSProxy {
+class WEBCORE_EXPORT JSWindowProxy final : public JSC::JSProxy {
 public:
     using Base = JSC::JSProxy;
     static constexpr bool needsDestruction = true;
@@ -62,7 +62,7 @@ public:
     WindowProxy* windowProxy() const;
 
     AbstractDOMWindow& wrapped() const;
-    static WEBCORE_EXPORT WindowProxy* toWrapped(JSC::VM&, JSC::JSValue);
+    static WindowProxy* toWrapped(JSC::VM&, JSC::JSValue);
 
     DOMWrapperWorld& world() { return m_world; }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -630,7 +630,7 @@ public:
     Ref<Text> createEditingTextNode(String&&);
 
     enum class ResolveStyleType { Normal, Rebuild };
-    void resolveStyle(ResolveStyleType = ResolveStyleType::Normal);
+    WEBCORE_EXPORT void resolveStyle(ResolveStyleType = ResolveStyleType::Normal);
     WEBCORE_EXPORT bool updateStyleIfNeeded();
     bool needsStyleRecalc() const;
     unsigned lastStyleUpdateSizeForTesting() const { return m_lastStyleUpdateSizeForTesting; }

--- a/Source/WebCore/dom/SimpleRange.cpp
+++ b/Source/WebCore/dom/SimpleRange.cpp
@@ -155,7 +155,10 @@ template<TreeType treeType> bool contains(const SimpleRange& range, const std::o
     return point && contains<treeType>(range, *point);
 }
 
-template bool contains<ComposedTree>(const SimpleRange&, const std::optional<BoundaryPoint>&);
+template<> bool contains<ComposedTree>(const SimpleRange& range, const std::optional<BoundaryPoint>& point)
+{
+    return point && contains<ComposedTree>(range, *point);
+}
 
 bool containsForTesting(TreeType type, const SimpleRange& range, const BoundaryPoint& point)
 {

--- a/Source/WebCore/dom/SimpleRange.h
+++ b/Source/WebCore/dom/SimpleRange.h
@@ -70,6 +70,8 @@ template<TreeType = Tree> bool contains(const SimpleRange&, const std::optional<
 template<TreeType = Tree> bool contains(const SimpleRange& outerRange, const SimpleRange& innerRange);
 template<TreeType = Tree> bool contains(const SimpleRange&, const Node&);
 
+template<> WEBCORE_EXPORT bool contains<ComposedTree>(const SimpleRange&, const std::optional<BoundaryPoint>&);
+
 WEBCORE_EXPORT bool containsForTesting(TreeType, const SimpleRange& outerRange, const SimpleRange& innerRange);
 WEBCORE_EXPORT bool containsForTesting(TreeType, const SimpleRange&, const Node&);
 WEBCORE_EXPORT bool containsForTesting(TreeType, const SimpleRange&, const BoundaryPoint&);

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -195,8 +195,8 @@ public:
     WEBCORE_EXPORT bool canEdit() const;
     WEBCORE_EXPORT bool canEditRichly() const;
 
-    bool canDHTMLCut();
-    bool canDHTMLCopy();
+    WEBCORE_EXPORT bool canDHTMLCut();
+    WEBCORE_EXPORT bool canDHTMLCopy();
     WEBCORE_EXPORT bool canDHTMLPaste();
     bool tryDHTMLCopy();
     bool tryDHTMLCut();
@@ -370,7 +370,7 @@ public:
     bool shouldBeginEditing(const SimpleRange&);
     bool shouldEndEditing(const SimpleRange&);
 
-    void clearUndoRedoOperations();
+    WEBCORE_EXPORT void clearUndoRedoOperations();
     bool canUndo() const;
     void undo();
     bool canRedo() const;
@@ -401,7 +401,7 @@ public:
     WEBCORE_EXPORT void confirmComposition(const String&); // if no existing composition, replaces selection
     void confirmOrCancelCompositionAndNotifyClient();
     WEBCORE_EXPORT void cancelComposition();
-    bool cancelCompositionIfSelectionIsInvalid();
+    WEBCORE_EXPORT bool cancelCompositionIfSelectionIsInvalid();
     WEBCORE_EXPORT std::optional<SimpleRange> compositionRange() const;
     WEBCORE_EXPORT bool getCompositionSelection(unsigned& selectionStart, unsigned& selectionEnd) const;
 
@@ -433,7 +433,7 @@ public:
 
     EditingBehavior behavior() const;
 
-    std::optional<SimpleRange> selectedRange();
+    WEBCORE_EXPORT std::optional<SimpleRange> selectedRange();
 
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT void confirmMarkedText();

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -205,7 +205,7 @@ public:
     WEBCORE_EXPORT void setCaretBlinkingSuspended(bool);
     WEBCORE_EXPORT bool isCaretBlinkingSuspended() const;
 
-    void setFocused(bool);
+    WEBCORE_EXPORT void setFocused(bool);
     bool isFocused() const { return m_focused; }
     WEBCORE_EXPORT bool isFocusedAndActive() const;
     void pageActivationChanged();

--- a/Source/WebCore/editing/VisibleUnits.h
+++ b/Source/WebCore/editing/VisibleUnits.h
@@ -42,8 +42,8 @@ WEBCORE_EXPORT VisiblePosition startOfWord(const VisiblePosition&, EWordSide = R
 WEBCORE_EXPORT VisiblePosition endOfWord(const VisiblePosition&, EWordSide = RightWordIfOnBoundary);
 WEBCORE_EXPORT VisiblePosition previousWordPosition(const VisiblePosition&);
 WEBCORE_EXPORT VisiblePosition nextWordPosition(const VisiblePosition&);
-VisiblePosition rightWordPosition(const VisiblePosition&, bool skipsSpaceWhenMovingRight);
-VisiblePosition leftWordPosition(const VisiblePosition&, bool skipsSpaceWhenMovingRight);
+WEBCORE_EXPORT VisiblePosition rightWordPosition(const VisiblePosition&, bool skipsSpaceWhenMovingRight);
+WEBCORE_EXPORT VisiblePosition leftWordPosition(const VisiblePosition&, bool skipsSpaceWhenMovingRight);
 bool isStartOfWord(const VisiblePosition&);
 
 // sentences

--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -119,7 +119,7 @@ public:
     RadioButtonGroups& radioButtonGroups() { return m_radioButtonGroups; }
 
     WEBCORE_EXPORT const Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>& unsafeListedElements() const;
-    Vector<Ref<FormListedElement>> copyListedElementsVector() const;
+    WEBCORE_EXPORT Vector<Ref<FormListedElement>> copyListedElementsVector() const;
     const Vector<WeakPtr<HTMLImageElement, WeakPtrImplWithEventTargetData>>& imageElements() const { return m_imageElements; }
 
     StringPairVector textFieldValues() const;

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -116,7 +116,7 @@ public:
     // Logs an access denied message to the console for the specified URL.
     void printAccessDeniedMessage(const URL& url) const;
 
-    CachedResource* cachedResource(const String& url) const;
+    WEBCORE_EXPORT CachedResource* cachedResource(const String& url) const;
     CachedResource* cachedResource(const URL& url) const;
 
     typedef HashMap<String, CachedResourceHandle<CachedResource>> DocumentResourceMap;

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -319,8 +319,8 @@ public:
 
     // Events
     // EventTarget API
-    bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) final;
-    bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) final;
+    WEBCORE_EXPORT bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) final;
+    WEBCORE_EXPORT bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) final;
     void removeAllEventListeners() final;
 
     using EventTarget::dispatchEvent;

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -34,7 +34,7 @@ namespace WebCore {
 class DeprecatedGlobalSettings {
 public:
 #if PLATFORM(WIN)
-    static void setShouldUseHighResolutionTimers(bool);
+    WEBCORE_EXPORT static void setShouldUseHighResolutionTimers(bool);
     static bool shouldUseHighResolutionTimers() { return shared().m_shouldUseHighResolutionTimers; }
 #endif
 

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -147,7 +147,7 @@ public:
     void startPanScrolling(RenderElement&);
 #endif
 
-    void stopAutoscrollTimer(bool rendererIsBeingDestroyed = false);
+    WEBCORE_EXPORT void stopAutoscrollTimer(bool rendererIsBeingDestroyed = false);
     RenderBox* autoscrollRenderer() const;
     void updateAutoscrollRenderer();
     bool autoscrollInProgress() const;
@@ -192,7 +192,7 @@ public:
     IntPoint targetPositionInWindowForSelectionAutoscroll() const;
     bool shouldUpdateAutoscroll();
 
-    static RefPtr<Frame> subframeForTargetNode(Node*);
+    WEBCORE_EXPORT static RefPtr<Frame> subframeForTargetNode(Node*);
     static RefPtr<Frame> subframeForHitTestResult(const MouseEventWithHitTestResults&);
 
     WEBCORE_EXPORT bool scrollOverflow(ScrollDirection, ScrollGranularity, Node* startingNode = nullptr);
@@ -205,7 +205,7 @@ public:
     WEBCORE_EXPORT bool mouseMoved(const PlatformMouseEvent&);
     WEBCORE_EXPORT bool passMouseMovedEventToScrollbars(const PlatformMouseEvent&);
 
-    void lostMouseCapture();
+    WEBCORE_EXPORT void lostMouseCapture();
 
     WEBCORE_EXPORT bool handleMousePressEvent(const PlatformMouseEvent&);
     bool handleMouseMoveEvent(const PlatformMouseEvent&, HitTestResult* = nullptr, bool onlyUpdateScrollbars = false);

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -192,7 +192,7 @@ public:
 
     Settings& settings() const { return *m_settings; }
 
-    void setPrinting(bool printing, const FloatSize& pageSize, const FloatSize& originalPageSize, float maximumShrinkRatio, AdjustViewSizeOrNot);
+    WEBCORE_EXPORT void setPrinting(bool printing, const FloatSize& pageSize, const FloatSize& originalPageSize, float maximumShrinkRatio, AdjustViewSizeOrNot);
     bool shouldUsePrintingLayout() const;
     WEBCORE_EXPORT FloatSize resizePageRectsKeepingRatio(const FloatSize& originalSize, const FloatSize& expectedSize);
 
@@ -258,8 +258,8 @@ public:
     WEBCORE_EXPORT std::optional<SimpleRange> rangeForPoint(const IntPoint& framePoint);
 
     WEBCORE_EXPORT String searchForLabelsAboveCell(const JSC::Yarr::RegularExpression&, HTMLTableCellElement*, size_t* resultDistanceFromStartOfCell);
-    String searchForLabelsBeforeElement(const Vector<String>& labels, Element*, size_t* resultDistance, bool* resultIsInCellAbove);
-    String matchLabelsAgainstElement(const Vector<String>& labels, Element*);
+    WEBCORE_EXPORT String searchForLabelsBeforeElement(const Vector<String>& labels, Element*, size_t* resultDistance, bool* resultIsInCellAbove);
+    WEBCORE_EXPORT String matchLabelsAgainstElement(const Vector<String>& labels, Element*);
 
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT int preferredHeight() const;

--- a/Source/WebCore/page/FrameViewLayoutContext.h
+++ b/Source/WebCore/page/FrameViewLayoutContext.h
@@ -52,7 +52,7 @@ public:
     FrameViewLayoutContext(FrameView&);
     ~FrameViewLayoutContext();
 
-    void layout();
+    WEBCORE_EXPORT void layout();
     bool needsLayout() const;
 
     // We rely on the side-effects of layout, like compositing updates, to update state in various subsystems

--- a/Source/WebCore/page/win/FrameWin.h
+++ b/Source/WebCore/page/win/FrameWin.h
@@ -34,7 +34,7 @@ class Frame;
 class IntRect;
 
 GDIObject<HBITMAP> imageFromRect(const Frame*, IntRect&);
-GDIObject<HBITMAP> imageFromSelection(Frame*, bool forceBlackText);
-void computePageRectsForFrame(Frame*, const IntRect& printRect, float headerHeight, float footerHeight, float userScaleFactor, Vector<IntRect>& outPages, int& outPageHeight);
+WEBCORE_EXPORT GDIObject<HBITMAP> imageFromSelection(Frame*, bool forceBlackText);
+WEBCORE_EXPORT void computePageRectsForFrame(Frame*, const IntRect& printRect, float headerHeight, float footerHeight, float userScaleFactor, Vector<IntRect>& outPages, int& outPageHeight);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -272,8 +272,8 @@ namespace WebCore {
     String unknownFileSizeText();
 
 #if PLATFORM(WIN)
-    String uploadFileText();
-    String allFilesText();
+    WEBCORE_EXPORT String uploadFileText();
+    WEBCORE_EXPORT String allFilesText();
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -291,7 +291,7 @@ public:
 
 #if PLATFORM(WIN)
     COMPtr<IDataObject> dataObject() const { return m_dataObject; }
-    void setExternalDataObject(IDataObject*);
+    WEBCORE_EXPORT void setExternalDataObject(IDataObject*);
     const DragDataMap& dragDataMap() const { return m_dragDataMap; }
     void writeURLToWritableDataObject(const URL&, const String&);
     COMPtr<WCDataObject> writableDataObject() const { return m_writableDataObject; }

--- a/Source/WebCore/platform/PlatformKeyboardEvent.h
+++ b/Source/WebCore/platform/PlatformKeyboardEvent.h
@@ -125,7 +125,7 @@ namespace WebCore {
 #endif
 
 #if PLATFORM(WIN)
-        PlatformKeyboardEvent(HWND, WPARAM, LPARAM, Type, bool);
+        WEBCORE_EXPORT PlatformKeyboardEvent(HWND, WPARAM, LPARAM, Type, bool);
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebCore/platform/PlatformWheelEvent.h
+++ b/Source/WebCore/platform/PlatformWheelEvent.h
@@ -189,7 +189,7 @@ public:
 #endif
 
 #if PLATFORM(WIN)
-    PlatformWheelEvent(HWND, WPARAM, LPARAM, bool isMouseHWheel);
+    WEBCORE_EXPORT PlatformWheelEvent(HWND, WPARAM, LPARAM, bool isMouseHWheel);
 #endif
 
 protected:

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -335,7 +335,7 @@ public:
 
     // Functions for converting to and from screen coordinates.
     WEBCORE_EXPORT IntRect contentsToScreen(const IntRect&) const;
-    IntPoint screenToContents(const IntPoint&) const;
+    WEBCORE_EXPORT IntPoint screenToContents(const IntPoint&) const;
 
     // The purpose of this function is to answer whether or not the scroll view is currently visible. Animations and painting updates can be suspended if
     // we know that we are either not in a window right now or if that window is not visible.

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -65,7 +65,7 @@ public:
 
     void didChangeAlignmentInterval();
 
-    static void fireTimersInNestedEventLoop();
+    WEBCORE_EXPORT static void fireTimersInNestedEventLoop();
 
 private:
     virtual void fired() = 0;

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -116,7 +116,7 @@ public:
 
     WEBCORE_EXPORT virtual void setFocus(bool);
 
-    void setCursor(const Cursor&);
+    WEBCORE_EXPORT void setCursor(const Cursor&);
 
     WEBCORE_EXPORT virtual void show();
     WEBCORE_EXPORT virtual void hide();

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -206,7 +206,7 @@ public:
 #if PLATFORM(WIN)
     SCRIPT_FONTPROPERTIES* scriptFontProperties() const;
     SCRIPT_CACHE* scriptCache() const { return &m_scriptCache; }
-    static void setShouldApplyMacAscentHack(bool);
+    WEBCORE_EXPORT static void setShouldApplyMacAscentHack(bool);
     static bool shouldApplyMacAscentHack();
     static float ascentConsideringMacAscentHack(const WCHAR*, float ascent, float descent);
 #endif

--- a/Source/WebCore/platform/graphics/IntSize.h
+++ b/Source/WebCore/platform/graphics/IntSize.h
@@ -163,8 +163,8 @@ public:
 #endif
 
 #if PLATFORM(WIN)
-    IntSize(const SIZE&);
-    operator SIZE() const;
+    WEBCORE_EXPORT IntSize(const SIZE&);
+    WEBCORE_EXPORT operator SIZE() const;
 #endif
 
     String toJSONString() const;

--- a/Source/WebCore/platform/graphics/cairo/RefPtrCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/RefPtrCairo.h
@@ -35,7 +35,7 @@ namespace WTF {
 
 template<>
 struct DefaultRefDerefTraits<cairo_t> {
-    static void refIfNotNull(cairo_t* ptr);
+    WEBCORE_EXPORT static void refIfNotNull(cairo_t* ptr);
     WEBCORE_EXPORT static void derefIfNotNull(cairo_t* ptr);
 };
 

--- a/Source/WebCore/platform/graphics/opengl/TemporaryOpenGLSetting.h
+++ b/Source/WebCore/platform/graphics/opengl/TemporaryOpenGLSetting.h
@@ -44,8 +44,8 @@ namespace WebCore {
 class TemporaryOpenGLSetting {
     WTF_MAKE_NONCOPYABLE(TemporaryOpenGLSetting);
 public:
-    TemporaryOpenGLSetting(GCGLenum capability, GCGLenum scopedState);
-    ~TemporaryOpenGLSetting();
+    WEBCORE_EXPORT TemporaryOpenGLSetting(GCGLenum capability, GCGLenum scopedState);
+    WEBCORE_EXPORT ~TemporaryOpenGLSetting();
 
 private:
     const GCGLenum m_capability;

--- a/Source/WebCore/platform/graphics/win/FullScreenController.h
+++ b/Source/WebCore/platform/graphics/win/FullScreenController.h
@@ -35,17 +35,17 @@ class FullScreenControllerClient;
 
 class FullScreenController {
 public:
-    FullScreenController(FullScreenControllerClient*);
-    ~FullScreenController();
+    WEBCORE_EXPORT FullScreenController(FullScreenControllerClient*);
+    WEBCORE_EXPORT ~FullScreenController();
 
 public:
-    void enterFullScreen();
-    void exitFullScreen();
-    void repaintCompleted();
+    WEBCORE_EXPORT void enterFullScreen();
+    WEBCORE_EXPORT void exitFullScreen();
+    WEBCORE_EXPORT void repaintCompleted();
     
-    bool isFullScreen() const;
+    WEBCORE_EXPORT bool isFullScreen() const;
 
-    void close();
+    WEBCORE_EXPORT void close();
 
 protected:
     void enterFullScreenRepaintCompleted();

--- a/Source/WebCore/platform/network/FormData.h
+++ b/Source/WebCore/platform/network/FormData.h
@@ -138,7 +138,7 @@ public:
     WEBCORE_EXPORT static Ref<FormData> create();
     WEBCORE_EXPORT static Ref<FormData> create(const void*, size_t);
     WEBCORE_EXPORT static Ref<FormData> create(const CString&);
-    static Ref<FormData> create(Vector<uint8_t>&&);
+    WEBCORE_EXPORT static Ref<FormData> create(Vector<uint8_t>&&);
     static Ref<FormData> create(const Vector<char>&);
     static Ref<FormData> create(const Vector<uint8_t>&);
     static Ref<FormData> create(const DOMFormData&, EncodingType = EncodingType::FormURLEncoded);

--- a/Source/WebCore/platform/network/ResourceHandle.h
+++ b/Source/WebCore/platform/network/ResourceHandle.h
@@ -144,7 +144,7 @@ public:
 #endif
 
 #if OS(WINDOWS) && USE(CURL)
-    static void setHostAllowsAnyHTTPSCertificate(const String&);
+    WEBCORE_EXPORT static void setHostAllowsAnyHTTPSCertificate(const String&);
     static void setClientCertificateInfo(const String&, const String&, const String&);
 #endif
 

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -132,7 +132,7 @@ public:
     WEBCORE_EXPORT void setCachePolicy(ResourceRequestCachePolicy cachePolicy);
     
     WEBCORE_EXPORT double timeoutInterval() const; // May return 0 when using platform default.
-    void setTimeoutInterval(double timeoutInterval);
+    WEBCORE_EXPORT void setTimeoutInterval(double);
     
     WEBCORE_EXPORT const URL& firstPartyForCookies() const;
     WEBCORE_EXPORT void setFirstPartyForCookies(const URL&);
@@ -212,7 +212,7 @@ public:
     bool platformRequestUpdated() const { return m_platformRequestUpdated; }
 
     WEBCORE_EXPORT bool allowCookies() const;
-    void setAllowCookies(bool allowCookies);
+    WEBCORE_EXPORT void setAllowCookies(bool);
 
     WEBCORE_EXPORT ResourceLoadPriority priority() const;
     WEBCORE_EXPORT void setPriority(ResourceLoadPriority);

--- a/Source/WebCore/platform/network/curl/CurlCacheManager.h
+++ b/Source/WebCore/platform/network/curl/CurlCacheManager.h
@@ -38,11 +38,11 @@ namespace WebCore {
 class CurlCacheManager {
     friend NeverDestroyed<CurlCacheManager>;
 public:
-    static CurlCacheManager& singleton();
+    WEBCORE_EXPORT static CurlCacheManager& singleton();
 
-    void setCacheDirectory(const String&);
+    WEBCORE_EXPORT void setCacheDirectory(const String&);
     const String& cacheDirectory() { return m_cacheDir; }
-    void setStorageSizeLimit(size_t);
+    WEBCORE_EXPORT void setStorageSizeLimit(size_t);
 
     bool isCached(const String&) const;
     HTTPHeaderMap& requestHeaders(const String&); // Load headers

--- a/Source/WebCore/platform/network/curl/CurlDownload.h
+++ b/Source/WebCore/platform/network/curl/CurlDownload.h
@@ -51,18 +51,18 @@ public:
 class CurlDownload final : public ThreadSafeRefCounted<CurlDownload>, public CurlRequestClient {
 public:
     CurlDownload() = default;
-    ~CurlDownload();
+    WEBCORE_EXPORT ~CurlDownload();
 
     void ref() override { ThreadSafeRefCounted<CurlDownload>::ref(); }
     void deref() override { ThreadSafeRefCounted<CurlDownload>::deref(); }
 
-    void init(CurlDownloadListener&, const URL&);
-    void init(CurlDownloadListener&, ResourceHandle*, const ResourceRequest&, const ResourceResponse&);
+    WEBCORE_EXPORT void init(CurlDownloadListener&, const URL&);
+    WEBCORE_EXPORT void init(CurlDownloadListener&, ResourceHandle*, const ResourceRequest&, const ResourceResponse&);
 
     void setListener(CurlDownloadListener* listener) { m_listener = listener; }
 
-    void start();
-    bool cancel();
+    WEBCORE_EXPORT void start();
+    WEBCORE_EXPORT bool cancel();
 
     bool deletesFileUponFailure() const { return m_deletesFileUponFailure; }
     void setDeletesFileUponFailure(bool deletesFileUponFailure) { m_deletesFileUponFailure = deletesFileUponFailure; }
@@ -72,10 +72,10 @@ public:
 private:
     Ref<CurlRequest> createCurlRequest(ResourceRequest&);
     void curlDidSendData(CurlRequest&, unsigned long long, unsigned long long) override { }
-    void curlDidReceiveResponse(CurlRequest&, CurlResponse&&) override;
-    void curlDidReceiveData(CurlRequest&, const SharedBuffer&) override;
-    void curlDidComplete(CurlRequest&, NetworkLoadMetrics&&) override;
-    void curlDidFailWithError(CurlRequest&, ResourceError&&, CertificateInfo&&) override;
+    WEBCORE_EXPORT void curlDidReceiveResponse(CurlRequest&, CurlResponse&&) override;
+    WEBCORE_EXPORT void curlDidReceiveData(CurlRequest&, const SharedBuffer&) override;
+    WEBCORE_EXPORT void curlDidComplete(CurlRequest&, NetworkLoadMetrics&&) override;
+    WEBCORE_EXPORT void curlDidFailWithError(CurlRequest&, ResourceError&&, CertificateInfo&&) override;
 
     bool shouldRedirectAsGET(const ResourceRequest&, bool crossOrigin);
     void willSendRequest();

--- a/Source/WebCore/platform/network/curl/DownloadBundle.h
+++ b/Source/WebCore/platform/network/curl/DownloadBundle.h
@@ -32,7 +32,7 @@ namespace DownloadBundle {
 
 bool appendResumeData(const uint8_t*, uint32_t, const String& bundlePath);
 bool extractResumeData(const String& bundlePath, Vector<uint8_t>& resumeData);
-const String& fileExtension();
+WEBCORE_EXPORT const String& fileExtension();
 
 } // namespace DownloadBundle
 } // namespace WebCore

--- a/Source/WebCore/platform/win/BString.h
+++ b/Source/WebCore/platform/win/BString.h
@@ -43,22 +43,22 @@ namespace WebCore {
     class BString {
     public:
         WEBCORE_EXPORT BString();
-        BString(const wchar_t*);
-        BString(const wchar_t*, size_t length);
-        BString(const String&);
-        BString(const AtomString&);
-        BString(const URL&);
+        WEBCORE_EXPORT BString(const wchar_t*);
+        WEBCORE_EXPORT BString(const wchar_t*, size_t length);
+        WEBCORE_EXPORT BString(const String&);
+        WEBCORE_EXPORT BString(const AtomString&);
+        WEBCORE_EXPORT BString(const URL&);
 #if USE(CF)
-        BString(CFStringRef);
+        WEBCORE_EXPORT BString(CFStringRef);
 #endif
         WEBCORE_EXPORT ~BString();
 
-        void adoptBSTR(BSTR);
-        void clear();
+        WEBCORE_EXPORT void adoptBSTR(BSTR);
+        WEBCORE_EXPORT void clear();
 
-        BString(const BString&);
+        WEBCORE_EXPORT BString(const BString&);
         BString& operator=(const BString&);
-        BString& operator=(const BSTR&);
+        WEBCORE_EXPORT BString& operator=(const BSTR&);
 
         BSTR* operator&() { ASSERT(!m_bstr); return &m_bstr; }
         operator BSTR() const { return m_bstr; }
@@ -69,10 +69,10 @@ namespace WebCore {
         BSTR m_bstr;
     };
 
-    bool operator ==(const BString&, const BString&);
+    WEBCORE_EXPORT bool operator ==(const BString&, const BString&);
     bool operator !=(const BString&, const BString&);
     bool operator ==(const BString&, BSTR);
-    bool operator !=(const BString&, BSTR);
+    WEBCORE_EXPORT bool operator !=(const BString&, BSTR);
     bool operator ==(BSTR, const BString&);
     bool operator !=(BSTR, const BString&);
 

--- a/Source/WebCore/platform/win/PopupMenuWin.h
+++ b/Source/WebCore/platform/win/PopupMenuWin.h
@@ -39,7 +39,7 @@ class AccessiblePopupMenu;
 
 class PopupMenuWin : public PopupMenu, private ScrollableArea {
 public:
-    PopupMenuWin(PopupMenuClient*);
+    WEBCORE_EXPORT PopupMenuWin(PopupMenuClient*);
     ~PopupMenuWin();
 
     void show(const IntRect&, FrameView*, int index) override;
@@ -47,7 +47,7 @@ public:
     void updateFromElement() override;
     void disconnectClient() override;
 
-    static LPCWSTR popupClassName();
+    WEBCORE_EXPORT static LPCWSTR popupClassName();
 
     String debugDescription() const final;
 

--- a/Source/WebCore/platform/win/SearchPopupMenuWin.h
+++ b/Source/WebCore/platform/win/SearchPopupMenuWin.h
@@ -28,7 +28,7 @@ namespace WebCore {
 
 class SearchPopupMenuWin : public SearchPopupMenu {
 public:
-    SearchPopupMenuWin(PopupMenuClient*);
+    WEBCORE_EXPORT SearchPopupMenuWin(PopupMenuClient*);
 
     virtual PopupMenu* popupMenu();
     virtual void saveRecentSearches(const AtomString& name, const Vector<RecentSearch>&);

--- a/Source/WebCore/platform/win/SystemInfo.h
+++ b/Source/WebCore/platform/win/SystemInfo.h
@@ -63,7 +63,7 @@ enum WindowsVersion {
 // and dwMinorVersion field values, respectively.
 WindowsVersion windowsVersion(int* major = 0, int* minor = 0);
 
-String windowsVersionForUAString();
+WEBCORE_EXPORT String windowsVersionForUAString();
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/win/WebCoreBundleWin.h
+++ b/Source/WebCore/platform/win/WebCoreBundleWin.h
@@ -35,7 +35,7 @@ typedef struct __CFBundle* CFBundleRef;
 namespace WebCore {
 
 #if USE(CF)
-CFBundleRef webKitBundle();
+WEBCORE_EXPORT CFBundleRef webKitBundle();
 #endif
 
 WEBCORE_EXPORT String webKitBundlePath();

--- a/Source/WebCore/platform/win/WebCoreTextRenderer.h
+++ b/Source/WebCore/platform/win/WebCoreTextRenderer.h
@@ -41,8 +41,8 @@ namespace WebCore {
     void WebCoreSetShouldUseFontSmoothing(bool);
     bool WebCoreShouldUseFontSmoothing();
 
-    void WebCoreSetAlwaysUsesComplexTextCodePath(bool);
-    bool WebCoreAlwaysUsesComplexTextCodePath();
+    WEBCORE_EXPORT void WebCoreSetAlwaysUsesComplexTextCodePath(bool);
+    WEBCORE_EXPORT bool WebCoreAlwaysUsesComplexTextCodePath();
 
 } // namespace WebCore
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -459,7 +459,7 @@ public:
 
     // Returns the nearest enclosing layer that is scrollable.
     // FIXME: This can return the RenderView's layer when callers probably want the FrameView as a ScrollableArea.
-    RenderLayer* enclosingScrollableLayer(IncludeSelfOrNot, CrossFrameBoundaries) const;
+    WEBCORE_EXPORT RenderLayer* enclosingScrollableLayer(IncludeSelfOrNot, CrossFrameBoundaries) const;
 
     // Returns true when the layer could do touch scrolling, but doesn't look at whether there is actually scrollable overflow.
     bool canUseCompositedScrolling() const;
@@ -640,7 +640,7 @@ public:
     // layers that intersect the point from front to back.
     void paint(GraphicsContext&, const LayoutRect& damageRect, const LayoutSize& subpixelOffset = LayoutSize(), OptionSet<PaintBehavior> = PaintBehavior::Normal,
         RenderObject* subtreePaintRoot = nullptr, OptionSet<PaintLayerFlag> = { }, SecurityOriginPaintPolicy = SecurityOriginPaintPolicy::AnyOrigin, EventRegionContext* = nullptr);
-    bool hitTest(const HitTestRequest&, HitTestResult&);
+    WEBCORE_EXPORT bool hitTest(const HitTestRequest&, HitTestResult&);
     bool hitTest(const HitTestRequest&, const HitTestLocation&, HitTestResult&);
 
     enum class ClipRectsOption : uint8_t {

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -81,7 +81,7 @@ public:
     void panScrollFromPoint(const IntPoint&);
 
     // Scrolling methods for layers that can scroll their overflow.
-    void scrollByRecursively(const IntSize& delta, ScrollableArea** scrolledArea = nullptr);
+    WEBCORE_EXPORT void scrollByRecursively(const IntSize& delta, ScrollableArea** scrolledArea = nullptr);
 
     // Attempt to scroll the given ScrollOffset, returning the real target offset after it has
     // been adjusted by scroll snapping.


### PR DESCRIPTION
#### 5e74bd17fb9dc8f9d55c9df54f384addae36e993
<pre>
Add exports to link a shared WebCore with WebKitLegacy for WinCairo
<a href="https://bugs.webkit.org/show_bug.cgi?id=248508">https://bugs.webkit.org/show_bug.cgi?id=248508</a>

Reviewed by Darin Adler.

Add `WEBCORE_EXPORT` everywhere needed to build a `SHARED` WebCore and
link with WebKitLegacy.

The `JSWindowProxy` class was exported completely. The `s_info` variable
is declared through `DECLARE_INFO` which doesn&apos;t export it. There is a
`DECLARE_EXPORT_INFO` macro but it uses `JS_EXPORT_PRIVATE` which is
incorrect in WebCore.

* Source/WebCore/accessibility/AccessibilityListBox.h:
* Source/WebCore/accessibility/win/AccessibilityObjectWrapperWin.h:
* Source/WebCore/bindings/js/JSWindowProxy.h:
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/SimpleRange.cpp:
* Source/WebCore/dom/SimpleRange.h:
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/editing/VisibleUnits.h:
* Source/WebCore/html/HTMLFormElement.h:
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/DeprecatedGlobalSettings.h:
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/FrameViewLayoutContext.h:
* Source/WebCore/page/win/FrameWin.h:
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebCore/platform/Pasteboard.h:
* Source/WebCore/platform/PlatformKeyboardEvent.h:
* Source/WebCore/platform/PlatformWheelEvent.h:
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/platform/Timer.h:
* Source/WebCore/platform/Widget.h:
* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/IntSize.h:
* Source/WebCore/platform/graphics/cairo/RefPtrCairo.h:
* Source/WebCore/platform/graphics/opengl/TemporaryOpenGLSetting.h:
* Source/WebCore/platform/graphics/win/FullScreenController.h:
* Source/WebCore/platform/network/FormData.h:
* Source/WebCore/platform/network/ResourceHandle.h:
* Source/WebCore/platform/network/ResourceRequestBase.h:
* Source/WebCore/platform/network/curl/CurlCacheManager.h:
* Source/WebCore/platform/network/curl/CurlDownload.h:
* Source/WebCore/platform/network/curl/DownloadBundle.h:
* Source/WebCore/platform/win/BString.h:
* Source/WebCore/platform/win/PopupMenuWin.h:
* Source/WebCore/platform/win/SearchPopupMenuWin.h:
* Source/WebCore/platform/win/SystemInfo.h:
* Source/WebCore/platform/win/WebCoreBundleWin.h:
* Source/WebCore/platform/win/WebCoreTextRenderer.h:
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.h:

Canonical link: <a href="https://commits.webkit.org/257503@main">https://commits.webkit.org/257503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97ff33001af4c090ba2d935734db4c58b6167546

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108432 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168682 "Failed to checkout and rebase branch from PR 6955") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85602 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91549 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106387 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90236 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33672 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21581 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76527 "Found 4 new API test failures: /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/console-api, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/js-exception, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/security-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2135 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23097 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45503 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5158 "'git push ...'") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42572 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->