### PR TITLE
[GTK][WPE] Deprecate WebKitDOMDocument

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMDocument.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMDocument.cpp
@@ -29,6 +29,8 @@
 #include "WebKitDOMEventTarget.h"
 #endif
 
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
+
 namespace WebKit {
 
 WebKitDOMDocument* kit(WebCore::Document* obj)
@@ -56,9 +58,7 @@ WebKitDOMDocument* wrapDocument(WebCore::Document* coreObject)
 } // namespace WebKit
 
 #if PLATFORM(GTK)
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 G_DEFINE_TYPE_WITH_CODE(WebKitDOMDocument, webkit_dom_document, WEBKIT_DOM_TYPE_NODE, G_IMPLEMENT_INTERFACE(WEBKIT_DOM_TYPE_EVENT_TARGET, webkitDOMDocumentDOMEventTargetInit))
-G_GNUC_END_IGNORE_DEPRECATIONS;
 #else
 G_DEFINE_TYPE(WebKitDOMDocument, webkit_dom_document, WEBKIT_DOM_TYPE_NODE)
 #endif
@@ -74,3 +74,5 @@ static void webkit_dom_document_class_init(WebKitDOMDocumentClass* documentClass
 static void webkit_dom_document_init(WebKitDOMDocument*)
 {
 }
+
+G_GNUC_END_IGNORE_DEPRECATIONS;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.cpp
@@ -102,8 +102,7 @@ WebKitWebEditor* webkitWebEditorCreate(WebKitWebPage* webPage)
  * webkit_web_editor_get_page:
  * @editor: a #WebKitWebEditor
  *
- * Gets the #WebKitWebPage that is associated with the #WebKitWebEditor that can
- * be used to access the #WebKitDOMDocument currently loaded into it.
+ * Gets the #WebKitWebPage that is associated with the #WebKitWebEditor.
  *
  * Returns: (transfer none): the associated #WebKitWebPage
  *

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
@@ -658,6 +658,8 @@ void webkitWebPageDidReceiveUserMessage(WebKitWebPage* webPage, UserMessage&& me
  *
  * Returns: (transfer none): the #WebKitDOMDocument currently loaded, or %NULL
  *    if no document is currently loaded.
+ *
+ * Deprecated: 2.40. Use JavaScriptCore API instead.
  */
 WebKitDOMDocument* webkit_web_page_get_dom_document(WebKitWebPage* webPage)
 {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in
@@ -81,7 +81,7 @@ struct _WebKitWebPageClass {
 WEBKIT_API GType
 webkit_web_page_get_type                    (void);
 
-WEBKIT_API WebKitDOMDocument *
+WEBKIT_DEPRECATED WebKitDOMDocument *
 webkit_web_page_get_dom_document            (WebKitWebPage *web_page);
 
 WEBKIT_API guint64

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDocument.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDocument.h
@@ -45,7 +45,7 @@ struct _WebKitDOMDocumentClass {
     WebKitDOMNodeClass parent_class;
 };
 
-WEBKIT_API GType
+WEBKIT_DEPRECATED GType
 webkit_dom_document_get_type(void);
 
 /**

--- a/Source/WebKit/WebProcess/InjectedBundle/API/wpe/DOM/WebKitDOMDocument.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/wpe/DOM/WebKitDOMDocument.h
@@ -48,7 +48,7 @@ struct _WebKitDOMDocumentClass {
     WebKitDOMNodeClass parent_class;
 };
 
-WEBKIT_API GType
+WEBKIT_DEPRECATED GType
 webkit_dom_document_get_type(void);
 
 G_END_DECLS

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/FrameTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/FrameTest.cpp
@@ -72,9 +72,11 @@ private:
         g_assert_true(JSC_IS_CONTEXT(jsContext.get()));
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
 
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        G_GNUC_END_IGNORE_DEPRECATIONS;
 
         GRefPtr<JSCValue> jsDocument = adoptGRef(webkit_frame_get_js_value_for_dom_object(frame, WEBKIT_DOM_OBJECT(document)));
         g_assert_true(JSC_IS_VALUE(jsDocument.get()));

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/WebExtensionTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/WebExtensionTest.cpp
@@ -160,8 +160,8 @@ static void emitDocumentLoaded(GDBusConnection* connection)
 static void documentLoadedCallback(WebKitWebPage* webPage, WebKitWebExtension* extension)
 {
 #if PLATFORM(GTK)
-    WebKitDOMDocument* document = webkit_web_page_get_dom_document(webPage);
     G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
+    WebKitDOMDocument* document = webkit_web_page_get_dom_document(webPage);
     GRefPtr<WebKitDOMDOMWindow> window = adoptGRef(webkit_dom_document_get_default_view(document));
     webkit_dom_dom_window_webkit_message_handlers_post_message(window.get(), "dom", "DocumentLoaded");
     G_GNUC_END_IGNORE_DEPRECATIONS;
@@ -593,10 +593,9 @@ static void methodCallCallback(GDBusConnection* connection, const char* sender, 
         if (!page)
             return;
 
-        WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         WebKitFrame* frame = webkit_web_page_get_main_frame(page);
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(frame));
-        GRefPtr<JSCValue> jsDocument = adoptGRef(webkit_frame_get_js_value_for_dom_object(frame, WEBKIT_DOM_OBJECT(document)));
+        GRefPtr<JSCValue> jsDocument = adoptGRef(jsc_context_get_value(jsContext.get(), "document"));
         GRefPtr<JSCValue> jsInputElement = adoptGRef(jsc_value_object_invoke_method(jsDocument.get(), "getElementById", G_TYPE_STRING, elementID, G_TYPE_NONE));
         WebKitDOMNode* node = webkit_dom_node_for_js_value(jsInputElement.get());
         gboolean isUserEdited = webkit_dom_element_html_input_element_is_user_edited(WEBKIT_DOM_ELEMENT(node));

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/AutocleanupsTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/AutocleanupsTest.cpp
@@ -42,8 +42,10 @@ private:
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(page));
 
         // Transfer none
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         g_autoptr(WebKitDOMDocument) document = WEBKIT_DOM_DOCUMENT(g_object_ref(G_OBJECT(webkit_web_page_get_dom_document(page))));
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
+        G_GNUC_END_IGNORE_DEPRECATIONS;
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         // Transfer full


### PR DESCRIPTION
#### decc6377af1375f1f98d4a63dc3c46044283c53c
<pre>
[GTK][WPE] Deprecate WebKitDOMDocument
<a href="https://bugs.webkit.org/show_bug.cgi?id=248520">https://bugs.webkit.org/show_bug.cgi?id=248520</a>

Reviewed by Žan Doberšek.

All methods and properties are deprecated and the js value can be obtained with JSC API.

* Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMDocument.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in:
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDocument.h:
* Source/WebKit/WebProcess/InjectedBundle/API/wpe/DOM/WebKitDOMDocument.h:
* Tools/TestWebKitAPI/Tests/WebKitGLib/FrameTest.cpp:
(WebKitFrameTest::testJavaScriptValues):
* Tools/TestWebKitAPI/Tests/WebKitGLib/WebExtensionTest.cpp:
(documentLoadedCallback):
(methodCallCallback):
* Tools/TestWebKitAPI/Tests/WebKitGtk/AutocleanupsTest.cpp:
(AutocleanupsTest::testWebProcessAutocleanups):

Canonical link: <a href="https://commits.webkit.org/257225@main">https://commits.webkit.org/257225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d935c6073f7692007d526e11610b7dfb5505a61

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107568 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167832 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7810 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36085 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90701 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104174 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5871 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84703 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33003 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89455 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1293 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20887 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1254 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22390 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44845 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2482 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41798 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->