### PR TITLE
Allow deprecated API usage in getDisplayMedia code

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CGDisplayStreamCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CGDisplayStreamCaptureSource.cpp
@@ -65,8 +65,10 @@ void CGDisplayStreamCaptureSource::stop()
     if (!m_isRunning)
         return;
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (m_displayStream)
         CGDisplayStreamStop(m_displayStream.get());
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     m_isRunning = false;
 }
@@ -92,7 +94,10 @@ bool CGDisplayStreamCaptureSource::startDisplayStream()
         }
     }
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     auto err = CGDisplayStreamStart(m_displayStream.get());
+    ALLOW_DEPRECATED_DECLARATIONS_END
+
     if (err) {
         ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "CGDisplayStreamStart failed with error ", static_cast<int>(err));
         return false;
@@ -112,7 +117,9 @@ void CGDisplayStreamCaptureSource::commitConfiguration(const RealtimeMediaSource
     m_frameRate = settings.frameRate();
 
     if (m_displayStream) {
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         CGDisplayStreamStop(m_displayStream.get());
+        ALLOW_DEPRECATED_DECLARATIONS_END
         m_displayStream = nullptr;
     }
 
@@ -164,7 +171,9 @@ CGDisplayStreamFrameAvailableHandler CGDisplayStreamCaptureSource::frameAvailabl
             return;
 
         size_t count;
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         auto* rects = CGDisplayStreamUpdateGetRects(updateRef, kCGDisplayStreamUpdateDirtyRects, &count);
+        ALLOW_DEPRECATED_DECLARATIONS_END
         if (!rects || !count)
             return;
 

--- a/Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.mm
@@ -132,6 +132,7 @@ RetainPtr<CGDisplayStreamRef> CGDisplayStreamScreenCaptureSource::createDisplayS
     ASSERT(frameRate());
     ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, "frame rate ", frameRate(), ", size ", width, "x", height);
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     NSDictionary* streamOptions = @{
         (__bridge NSString *)kCGDisplayStreamMinimumFrameTime : @(1 / frameRate()),
         (__bridge NSString *)kCGDisplayStreamQueueDepth : @(screenQueueMaximumLength),
@@ -139,7 +140,9 @@ RetainPtr<CGDisplayStreamRef> CGDisplayStreamScreenCaptureSource::createDisplayS
         (__bridge NSString *)kCGDisplayStreamShowCursor : @YES,
     };
 
-    return adoptCF(CGDisplayStreamCreateWithDispatchQueue(m_displayID, width, height, preferedPixelBufferFormat(), (__bridge CFDictionaryRef)streamOptions, captureQueue(), frameAvailableHandler()));
+    auto stream = adoptCF(CGDisplayStreamCreateWithDispatchQueue(m_displayID, width, height, preferedPixelBufferFormat(), (__bridge CFDictionaryRef)streamOptions, captureQueue(), frameAvailableHandler()));
+    ALLOW_DEPRECATED_DECLARATIONS_END
+    return stream;
 }
 
 IntSize CGDisplayStreamScreenCaptureSource::intrinsicSize() const


### PR DESCRIPTION
#### 25261a14c658e9a59e15bc264c51ca8043961d01
<pre>
Allow deprecated API usage in getDisplayMedia code
<a href="https://bugs.webkit.org/show_bug.cgi?id=248521">https://bugs.webkit.org/show_bug.cgi?id=248521</a>
rdar://problem/102804392

Reviewed by Eric Carlson.

* Source/WebCore/platform/mediastream/mac/CGDisplayStreamCaptureSource.cpp:
(WebCore::CGDisplayStreamCaptureSource::stop):
(WebCore::CGDisplayStreamCaptureSource::startDisplayStream):
(WebCore::CGDisplayStreamCaptureSource::commitConfiguration):
(WebCore::CGDisplayStreamCaptureSource::frameAvailableHandler):
* Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.mm:
(WebCore::CGDisplayStreamScreenCaptureSource::createDisplayStream):

Canonical link: <a href="https://commits.webkit.org/257201@main">https://commits.webkit.org/257201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49a2739321b3f6a7f9413631aaa3e1e7ba0a75eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107575 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167839 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7817 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36092 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90715 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104180 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5876 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84710 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33004 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89459 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1299 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1260 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22394 "Found 1 new test failure: streams/readable-stream-default-controller-error.html (failure)") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6125 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2475 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2566 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41806 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->