### PR TITLE
Resync Source/ThirdParty/libwebrtc/Source/webrtc/test/testsupport/file_utils_unittest.cc as it has merge conflicts

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/testsupport/file_utils_unittest.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/testsupport/file_utils_unittest.cc
@@ -40,13 +40,8 @@ std::string Path(absl::string_view path) {
 }
 
 // Remove files and directories in a directory non-recursively and writes the
-<<<<<<< HEAD
 // number of deleted items in `num_deleted_entries`.
 void CleanDir(absl::string_view dir, size_t* num_deleted_entries) {
-=======
-// number of deleted items in |num_deleted_entries|.
-void CleanDir(const std::string& dir, size_t* num_deleted_entries) {
->>>>>>> parent of 8e32ad0e8387 (revert libwebrtc changes to help bump)
   RTC_DCHECK(num_deleted_entries);
   *num_deleted_entries = 0;
   absl::optional<std::vector<std::string>> dir_content = ReadDirectory(dir);


### PR DESCRIPTION
#### e0a92e88357038da6cbfa9cf3f426a41d7425931
<pre>
Resync Source/ThirdParty/libwebrtc/Source/webrtc/test/testsupport/file_utils_unittest.cc as it has merge conflicts
<a href="https://bugs.webkit.org/show_bug.cgi?id=248522">https://bugs.webkit.org/show_bug.cgi?id=248522</a>
rdar://problem/102804676

Reviewed by Eric Carlson.

* Source/ThirdParty/libwebrtc/Source/webrtc/test/testsupport/file_utils_unittest.cc:

Canonical link: <a href="https://commits.webkit.org/257244@main">https://commits.webkit.org/257244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed141c9fdb14ef3b5872d90ed7e50bcc54f056b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107576 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167840 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7818 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36093 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90717 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104181 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5875 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84711 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33007 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75940 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1300 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20893 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1261 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22396 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4989 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6126 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44849 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2567 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41808 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->