### PR TITLE
Textarea placeholder text does not disappear when inserting text without a user gesture

### DIFF
--- a/LayoutTests/fast/forms/textarea/textarea-placeholder-visibility-3-expected.html
+++ b/LayoutTests/fast/forms/textarea/textarea-placeholder-visibility-3-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<p id="description">Focus field with a placeholder, then type.</p>
+<div>
+<textarea id=i1>Text</textarea>
+</div>
+<script>
+var i1 = document.getElementById('i1');
+i1.focus();
+i1.setSelectionRange(4, 4);
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/textarea/textarea-placeholder-visibility-3.html
+++ b/LayoutTests/fast/forms/textarea/textarea-placeholder-visibility-3.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<p id="description">Focus field with a placeholder, then type.</p>
+<div>
+<textarea id=i1 placeholder="Placeholder"></textarea>
+</div>
+<script>
+var i1 = document.getElementById('i1');
+i1.focus();
+document.execCommand("InsertText", false, "Text");
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -291,6 +291,7 @@ void HTMLTextAreaElement::subtreeHasChanged()
 {
     setFormControlValueMatchesRenderer(false);
     updateValidity();
+    updatePlaceholderVisibility();
 
     if (!focused())
         return;


### PR DESCRIPTION
#### ffe47a6f01ddccf0a295321b0b5270f1fb93db1c
<pre>
Textarea placeholder text does not disappear when inserting text without a user gesture

Textarea placeholder text does not disappear when inserting text without a user gesture
<a href="https://bugs.webkit.org/show_bug.cgi?id=248526">https://bugs.webkit.org/show_bug.cgi?id=248526</a>

Reviewed by Aditya Keerthi.

This patch is to align Webkit with Gecko / Firefox and Blink / Chromium.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=195023

This patch is adding add condition for &quot;subtreeHasChanged&quot; function to update
placeholder visibility after the text is insert via execCommand / JavaScript
without user interaction.

* Source/WebCore/html/HTMLTextareaElement.cpp:
(HTMLTextAreaElement::subtreeHasChanged): Add logic to update Placeholder Visibility
* LayoutTests/fast/forms/textarea/textarea-placeholder-visisbility-3.html: Add Test Case
* LayoutTests/fast/forms/textarea/textarea-placeholder-visisbility-3-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/257210@main">https://commits.webkit.org/257210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ede508276d1f2f2865ac6f1e51face476bcd0a30

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107586 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167852 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7829 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36106 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90726 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104188 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5884 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84726 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33011 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89468 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1309 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1271 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22402 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4967 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6136 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2598 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41817 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->