### PR TITLE
DumpRenderTree: dumpChildFramesAsText inconsistent with WTR

### DIFF
--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1632,7 +1632,7 @@ void dump()
         if (gTestRunner->dumpAsAudio()) {
             resultData = dumpAudio();
             resultMimeType = @"audio/wav";
-        } else if (gTestRunner->dumpAsText()) {
+        } else if (gTestRunner->dumpAsText() || gTestRunner->dumpChildFramesAsText()) {
             resultString = dumpFramesAsText(mainFrame);
         } else if (gTestRunner->dumpAsPDF()) {
             resultData = dumpFrameAsPDF(mainFrame);

--- a/Tools/DumpRenderTree/win/DumpRenderTree.cpp
+++ b/Tools/DumpRenderTree/win/DumpRenderTree.cpp
@@ -744,7 +744,7 @@ void dump()
             }
         }
 
-        if (::gTestRunner->dumpAsText()) {
+        if (::gTestRunner->dumpAsText() || ::gTestRunner->dumpChildFramesAsText()) {
             resultString = dumpFramesAsText(frame).data();
         } else {
             COMPtr<IWebFramePrivate> framePrivate;


### PR DESCRIPTION
#### 6155452b4f3443d561bcf998d5b934aefbb7c167
<pre>
DumpRenderTree: dumpChildFramesAsText inconsistent with WTR
<a href="https://bugs.webkit.org/show_bug.cgi?id=248531">https://bugs.webkit.org/show_bug.cgi?id=248531</a>

Reviewed by Darin Adler and David Kilzer.

DumpRenderTree needs dumpAsText as well in order for
dumpChildFramesAsText to work, whereas WTR doesn&apos;t.
Fix this inconsistency in DRT.

* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(dump):
* Tools/DumpRenderTree/win/DumpRenderTree.cpp:
(dump):

Canonical link: <a href="https://commits.webkit.org/257221@main">https://commits.webkit.org/257221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d7b35aba86f33c3f38794ac3764ee6ea036d5fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31285 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107599 "Updated wpe dependencies (failure)") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167863 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7842 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36118 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90740 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104195 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5892 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84737 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33023 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89474 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1318 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1279 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22409 "Found 1 new test failure: streams/readable-stream-default-controller-error.html (failure)") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4973 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6149 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41826 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->