### PR TITLE
[MQ4] MediaQueryList API should use the new parser and evaluator

### DIFF
--- a/LayoutTests/fast/media/matchmedium-query-api-expected.txt
+++ b/LayoutTests/fast/media/matchmedium-query-api-expected.txt
@@ -5,7 +5,7 @@ Test the media interface: http://dev.w3.org/csswg/cssom-view/#the-media-interfac
 "all and (color)" evaluates to true: PASS
 "not projection and (color)" evaluates to true: PASS
 "(color)" evaluates to true: PASS
-"(color" evaluates to false: PASS
+"(color" evaluates to true: PASS
 "color" evaluates to false: PASS
 "garbage" evaluates to false: PASS
 "(min-device-width: 100px)" evaluates to true: PASS

--- a/LayoutTests/fast/media/matchmedium-query-api.html
+++ b/LayoutTests/fast/media/matchmedium-query-api.html
@@ -31,7 +31,7 @@
     testQuery('all and (color)', true);
     testQuery('not projection and (color)', true);
     testQuery('(color)', true);
-    testQuery('(color', false);
+    testQuery('(color', true);
     testQuery('color', false);
 
     testQuery('garbage', false);

--- a/LayoutTests/fast/media/media-query-list-01-expected.txt
+++ b/LayoutTests/fast/media/media-query-list-01-expected.txt
@@ -5,7 +5,7 @@ Test the MediaQueryList interface: http://dev.w3.org/csswg/cssom-view/#the-media
 "all and (color)" evaluates to true: PASS
 "not projection and (color)" evaluates to true: PASS
 "(color)" evaluates to true: PASS
-"(color" evaluates to false: PASS
+"(color" evaluates to true: PASS
 "color" evaluates to false: PASS
 "garbage" evaluates to false: PASS
 "(min-device-width: 100px)" evaluates to true: PASS

--- a/LayoutTests/fast/media/media-query-list-01.html
+++ b/LayoutTests/fast/media/media-query-list-01.html
@@ -30,7 +30,7 @@
         testQuery('all and (color)', true);
         testQuery('not projection and (color)', true);
         testQuery('(color)', true);
-        testQuery('(color', false);
+        testQuery('(color', true);
         testQuery('color', false);
 
         testQuery('garbage', false);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/dynamic-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/dynamic-range-expected.txt
@@ -1,23 +1,23 @@
 
 PASS Should be known: '(dynamic-range: standard)'
 PASS Should be known: '(dynamic-range: high)'
-FAIL Should be known: '(video-dynamic-range: standard)' assert_true: Can parse with JS expected true got false
-FAIL Should be known: '(video-dynamic-range: high)' assert_true: Can parse with JS expected true got false
-FAIL Should be parseable: '(dynamic-range)' assert_true: Can parse with JS expected true got false
-PASS Should be unknown: '(dynamic-range)'
-FAIL Should be parseable: '(dynamic-range: 0)' assert_true: Can parse with JS expected true got false
+FAIL Should be known: '(video-dynamic-range: standard)' assert_true: expected true got false
+FAIL Should be known: '(video-dynamic-range: high)' assert_true: expected true got false
+PASS Should be parseable: '(dynamic-range)'
+FAIL Should be unknown: '(dynamic-range)' assert_true: expected true got false
+PASS Should be parseable: '(dynamic-range: 0)'
 PASS Should be unknown: '(dynamic-range: 0)'
-FAIL Should be parseable: '(dynamic-range: 10px)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(dynamic-range: 10px)'
 PASS Should be unknown: '(dynamic-range: 10px)'
-FAIL Should be parseable: '(dynamic-range: invalid)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(dynamic-range: invalid)'
 PASS Should be unknown: '(dynamic-range: invalid)'
-FAIL Should be parseable: '(video-dynamic-range)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(video-dynamic-range)'
 PASS Should be unknown: '(video-dynamic-range)'
-FAIL Should be parseable: '(video-dynamic-range: 0)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(video-dynamic-range: 0)'
 PASS Should be unknown: '(video-dynamic-range: 0)'
-FAIL Should be parseable: '(video-dynamic-range: 10px)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(video-dynamic-range: 10px)'
 PASS Should be unknown: '(video-dynamic-range: 10px)'
-FAIL Should be parseable: '(video-dynamic-range: invalid)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(video-dynamic-range: invalid)'
 PASS Should be unknown: '(video-dynamic-range: invalid)'
 PASS Check that dynamic-range always matches 'standard'
 FAIL Check that video-dynamic-range always matches 'standard' assert_true: expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/forced-colors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/forced-colors-expected.txt
@@ -2,17 +2,17 @@
 PASS Should be known: '(forced-colors)'
 PASS Should be known: '(forced-colors: none)'
 PASS Should be known: '(forced-colors: active)'
-FAIL Should be parseable: '(forced-colors: 0)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(forced-colors: 0)'
 PASS Should be unknown: '(forced-colors: 0)'
-FAIL Should be parseable: '(forced-colors: no-preference)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(forced-colors: no-preference)'
 PASS Should be unknown: '(forced-colors: no-preference)'
-FAIL Should be parseable: '(forced-colors: 10px)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(forced-colors: 10px)'
 PASS Should be unknown: '(forced-colors: 10px)'
-FAIL Should be parseable: '(forced-colors: active 0)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(forced-colors: active 0)'
 PASS Should be unknown: '(forced-colors: active 0)'
-FAIL Should be parseable: '(forced-colors: none active)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(forced-colors: none active)'
 PASS Should be unknown: '(forced-colors: none active)'
-FAIL Should be parseable: '(forced-colors: active/none)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(forced-colors: active/none)'
 PASS Should be unknown: '(forced-colors: active/none)'
 PASS Check that none evaluates to false in the boolean context
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/navigation-controls.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/navigation-controls.tentative-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL Should be known: '(navigation-controls)' assert_true: Can parse with JS expected true got false
-FAIL Should be known: '(navigation-controls: none)' assert_true: Can parse with JS expected true got false
-FAIL Should be known: '(navigation-controls: back-button)' assert_true: Can parse with JS expected true got false
-FAIL Should be parseable: '(navigation-controls: none back-button)' assert_true: Can parse with JS expected true got false
+FAIL Should be known: '(navigation-controls)' assert_true: expected true got false
+FAIL Should be known: '(navigation-controls: none)' assert_true: expected true got false
+FAIL Should be known: '(navigation-controls: back-button)' assert_true: expected true got false
+PASS Should be parseable: '(navigation-controls: none back-button)'
 PASS Should be unknown: '(navigation-controls: none back-button)'
-FAIL Should be parseable: '(navigation-controls: back-button/none)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(navigation-controls: back-button/none)'
 PASS Should be unknown: '(navigation-controls: back-button/none)'
 FAIL Check that none evaluates to false in the boolean context assert_equals: expected true but got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-color-scheme-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-color-scheme-expected.txt
@@ -2,19 +2,19 @@
 PASS Should be known: '(prefers-color-scheme)'
 PASS Should be known: '(prefers-color-scheme: light)'
 PASS Should be known: '(prefers-color-scheme: dark)'
-FAIL Should be parseable: '(prefers-color-scheme: 0)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-color-scheme: 0)'
 PASS Should be unknown: '(prefers-color-scheme: 0)'
-FAIL Should be parseable: '(prefers-color-scheme: none)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-color-scheme: none)'
 PASS Should be unknown: '(prefers-color-scheme: none)'
-FAIL Should be parseable: '(prefers-color-scheme: 10px)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-color-scheme: 10px)'
 PASS Should be unknown: '(prefers-color-scheme: 10px)'
-FAIL Should be parseable: '(prefers-color-scheme: dark 0)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-color-scheme: dark 0)'
 PASS Should be unknown: '(prefers-color-scheme: dark 0)'
-FAIL Should be parseable: '(prefers-color-scheme: dark light)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-color-scheme: dark light)'
 PASS Should be unknown: '(prefers-color-scheme: dark light)'
-FAIL Should be parseable: '(prefers-color-scheme: light/dark)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-color-scheme: light/dark)'
 PASS Should be unknown: '(prefers-color-scheme: light/dark)'
-FAIL Should be parseable: '(prefers-color-scheme: no-preference)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-color-scheme: no-preference)'
 PASS Should be unknown: '(prefers-color-scheme: no-preference)'
 PASS Check that prefer-color-scheme evaluates to true in the boolean context
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-contrast-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-contrast-expected.txt
@@ -3,26 +3,26 @@ PASS Should be known: '(prefers-contrast)'
 PASS Should be known: '(prefers-contrast: no-preference)'
 PASS Should be known: '(prefers-contrast: more)'
 PASS Should be known: '(prefers-contrast: less)'
-FAIL Should be known: '(prefers-contrast: custom)' assert_true: Can parse with JS expected true got false
-FAIL Should be parseable: '(prefers-contrast: increase)' assert_true: Can parse with JS expected true got false
+FAIL Should be known: '(prefers-contrast: custom)' assert_true: expected true got false
+PASS Should be parseable: '(prefers-contrast: increase)'
 PASS Should be unknown: '(prefers-contrast: increase)'
-FAIL Should be parseable: '(prefers-contrast: none)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-contrast: none)'
 PASS Should be unknown: '(prefers-contrast: none)'
-FAIL Should be parseable: '(prefers-contrast: forced high)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-contrast: forced high)'
 PASS Should be unknown: '(prefers-contrast: forced high)'
-FAIL Should be parseable: '(prefers-contrast: forced low)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-contrast: forced low)'
 PASS Should be unknown: '(prefers-contrast: forced low)'
-FAIL Should be parseable: '(prefers-contrast > increase)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-contrast > increase)'
 PASS Should be unknown: '(prefers-contrast > increase)'
-FAIL Should be parseable: '(prefers-increased-contrast)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-increased-contrast)'
 PASS Should be unknown: '(prefers-increased-contrast)'
-FAIL Should be parseable: '(prefers-decreased-contrast)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-decreased-contrast)'
 PASS Should be unknown: '(prefers-decreased-contrast)'
-FAIL Should be parseable: '(prefers-contrast: high)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-contrast: high)'
 PASS Should be unknown: '(prefers-contrast: high)'
-FAIL Should be parseable: '(prefers-contrast: low)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-contrast: low)'
 PASS Should be unknown: '(prefers-contrast: low)'
-FAIL Should be parseable: '(prefers-contrast: forced)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-contrast: forced)'
 PASS Should be unknown: '(prefers-contrast: forced)'
 PASS Check boolean context evaluation.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-reduced-data-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-reduced-data-expected.txt
@@ -1,18 +1,18 @@
 
-FAIL Should be known: '(prefers-reduced-data)' assert_true: Can parse with JS expected true got false
-FAIL Should be known: '(prefers-reduced-data: no-preference)' assert_true: Can parse with JS expected true got false
-FAIL Should be known: '(prefers-reduced-data: reduce)' assert_true: Can parse with JS expected true got false
-FAIL Should be parseable: '(prefers-reduced-data: 0)' assert_true: Can parse with JS expected true got false
+FAIL Should be known: '(prefers-reduced-data)' assert_true: expected true got false
+FAIL Should be known: '(prefers-reduced-data: no-preference)' assert_true: expected true got false
+FAIL Should be known: '(prefers-reduced-data: reduce)' assert_true: expected true got false
+PASS Should be parseable: '(prefers-reduced-data: 0)'
 PASS Should be unknown: '(prefers-reduced-data: 0)'
-FAIL Should be parseable: '(prefers-reduced-data: none)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-reduced-data: none)'
 PASS Should be unknown: '(prefers-reduced-data: none)'
-FAIL Should be parseable: '(prefers-reduced-data: 10px)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-reduced-data: 10px)'
 PASS Should be unknown: '(prefers-reduced-data: 10px)'
-FAIL Should be parseable: '(prefers-reduced-data: no-preference reduce)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-reduced-data: no-preference reduce)'
 PASS Should be unknown: '(prefers-reduced-data: no-preference reduce)'
-FAIL Should be parseable: '(prefers-reduced-data: reduced)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-reduced-data: reduced)'
 PASS Should be unknown: '(prefers-reduced-data: reduced)'
-FAIL Should be parseable: '(prefers-reduced-data: no-preference/reduce)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-reduced-data: no-preference/reduce)'
 PASS Should be unknown: '(prefers-reduced-data: no-preference/reduce)'
 FAIL Check that no-preference evaluates to false in the boolean context assert_equals: expected true but got false
 PASS Check that invalid evaluates to false

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-reduced-motion-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-reduced-motion-expected.txt
@@ -2,17 +2,17 @@
 PASS Should be known: '(prefers-reduced-motion)'
 PASS Should be known: '(prefers-reduced-motion: no-preference)'
 PASS Should be known: '(prefers-reduced-motion: reduce)'
-FAIL Should be parseable: '(prefers-reduced-motion: 0)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-reduced-motion: 0)'
 PASS Should be unknown: '(prefers-reduced-motion: 0)'
-FAIL Should be parseable: '(prefers-reduced-motion: none)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-reduced-motion: none)'
 PASS Should be unknown: '(prefers-reduced-motion: none)'
-FAIL Should be parseable: '(prefers-reduced-motion: 10px)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-reduced-motion: 10px)'
 PASS Should be unknown: '(prefers-reduced-motion: 10px)'
-FAIL Should be parseable: '(prefers-reduced-motion: no-preference reduce)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-reduced-motion: no-preference reduce)'
 PASS Should be unknown: '(prefers-reduced-motion: no-preference reduce)'
-FAIL Should be parseable: '(prefers-reduced-motion: reduced)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-reduced-motion: reduced)'
 PASS Should be unknown: '(prefers-reduced-motion: reduced)'
-FAIL Should be parseable: '(prefers-reduced-motion: no-preference/reduce)' assert_true: Can parse with JS expected true got false
+PASS Should be parseable: '(prefers-reduced-motion: no-preference/reduce)'
 PASS Should be unknown: '(prefers-reduced-motion: no-preference/reduce)'
 PASS Check that no-preference evaluates to false in the boolean context
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
@@ -1271,8 +1271,11 @@ PASS expression_should_be_unknown: max-resolution: 0dppx
 PASS expression_should_be_parseable: max-resolution: 0x
 PASS expression_should_be_unknown: max-resolution: 0x
 PASS find_resolution
-PASS resolution is inexact: should_not_apply: (resolution: ${resolution}dpi)
-PASS resolution is inexact: should_not_apply: (resolution: ${resolution - 1}dpi)
+PASS resolution is exact: should_apply: (resolution: ${resolution}dpi)
+PASS resolution is exact: should_apply: (resolution: ${Math.floor(resolution/96)}dppx)
+PASS resolution is exact: should_apply: (resolution: ${Math.floor(resolution/96)}x)
+PASS resolution is exact: should_not_apply: (resolution: ${resolution + 1}dpi)
+PASS resolution is exact: should_not_apply: (resolution: ${resolution - 1}dpi)
 PASS should_apply: (min-resolution: ${dpi_low}dpi)
 PASS should_not_apply: not all and (min-resolution: ${dpi_low}dpi)
 PASS should_apply: not all and (min-resolution: ${dpi_high}dpi)

--- a/Source/WebCore/css/MediaQueryList.h
+++ b/Source/WebCore/css/MediaQueryList.h
@@ -21,11 +21,14 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
-#include "LegacyMediaQueryEvaluator.h"
-#include "MediaList.h"
+#include "MediaQuery.h"
 #include "MediaQueryMatcher.h"
 
 namespace WebCore {
+
+namespace MQ {
+class MediaQueryEvaluator;
+}
 
 // MediaQueryList interface is specified at https://drafts.csswg.org/cssom-view/#the-mediaquerylist-interface
 // The objects of this class are returned by window.matchMedia. They may be used to
@@ -35,7 +38,7 @@ namespace WebCore {
 class MediaQueryList final : public RefCounted<MediaQueryList>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(MediaQueryList);
 public:
-    static Ref<MediaQueryList> create(Document&, MediaQueryMatcher&, Ref<MediaQuerySet>&&, bool matches);
+    static Ref<MediaQueryList> create(Document&, MediaQueryMatcher&, MQ::MediaQueryList&&, bool matches);
     ~MediaQueryList();
 
     String media() const;
@@ -44,7 +47,7 @@ public:
     void addListener(RefPtr<EventListener>&&);
     void removeListener(RefPtr<EventListener>&&);
 
-    void evaluate(LegacyMediaQueryEvaluator&, MediaQueryMatcher::EventMode);
+    void evaluate(MQ::MediaQueryEvaluator&, MediaQueryMatcher::EventMode);
 
     void detachFromMatcher();
 
@@ -52,7 +55,7 @@ public:
     using RefCounted::deref;
 
 private:
-    MediaQueryList(Document&, MediaQueryMatcher&, Ref<MediaQuerySet>&&, bool matches);
+    MediaQueryList(Document&, MediaQueryMatcher&, MQ::MediaQueryList&&, bool matches);
 
     void setMatches(bool);
 
@@ -67,7 +70,8 @@ private:
     bool virtualHasPendingActivity() const final;
 
     RefPtr<MediaQueryMatcher> m_matcher;
-    Ref<MediaQuerySet> m_media;
+    const MQ::MediaQueryList m_mediaQueries;
+    const OptionSet<MQ::MediaQueryDynamicDependency> m_dynamicDependencies;
     unsigned m_evaluationRound; // Indicates if the query has been evaluated after the last style selector change.
     unsigned m_changeRound; // Used to know if the query has changed in the last style selector change.
     bool m_matches;

--- a/Source/WebCore/css/MediaQueryMatcher.cpp
+++ b/Source/WebCore/css/MediaQueryMatcher.cpp
@@ -24,10 +24,10 @@
 #include "EventNames.h"
 #include "Frame.h"
 #include "FrameView.h"
-#include "LegacyMediaQueryEvaluator.h"
 #include "Logging.h"
-#include "MediaList.h"
+#include "MediaQueryEvaluator.h"
 #include "MediaQueryList.h"
+#include "MediaQueryParser.h"
 #include "MediaQueryParserContext.h"
 #include "NodeRenderStyle.h"
 #include "RenderElement.h"
@@ -74,12 +74,12 @@ std::unique_ptr<RenderStyle> MediaQueryMatcher::documentElementUserAgentStyle() 
     return m_document->styleScope().resolver().styleForElement(*documentElement, { m_document->renderStyle() }, RuleMatchingBehavior::MatchOnlyUserAgentRules).renderStyle;
 }
 
-bool MediaQueryMatcher::evaluate(const MediaQuerySet& media)
+bool MediaQueryMatcher::evaluate(const MQ::MediaQueryList& queries)
 {
     auto style = documentElementUserAgentStyle();
     if (!style)
         return false;
-    return LegacyMediaQueryEvaluator { mediaType(), *m_document, style.get() }.evaluate(media);
+    return MQ::MediaQueryEvaluator { mediaType(), *m_document, style.get() }.evaluate(queries);
 }
 
 void MediaQueryMatcher::addMediaQueryList(MediaQueryList& list)
@@ -98,9 +98,9 @@ RefPtr<MediaQueryList> MediaQueryMatcher::matchMedia(const String& query)
     if (!m_document)
         return nullptr;
 
-    auto media = MediaQuerySet::create(query, MediaQueryParserContext(*m_document));
-    bool matches = evaluate(media.get());
-    return MediaQueryList::create(*m_document, *this, WTFMove(media), matches);
+    auto queries = MQ::MediaQueryParser::parse(query, MediaQueryParserContext(*m_document));
+    bool matches = evaluate(queries);
+    return MediaQueryList::create(*m_document, *this, WTFMove(queries), matches);
 }
 
 void MediaQueryMatcher::evaluateAll(EventMode eventMode)
@@ -115,7 +115,7 @@ void MediaQueryMatcher::evaluateAll(EventMode eventMode)
 
     LOG_WITH_STREAM(MediaQueries, stream << "MediaQueryMatcher::styleResolverChanged " << m_document->url());
 
-    LegacyMediaQueryEvaluator evaluator { mediaType(), *m_document, style.get() };
+    MQ::MediaQueryEvaluator evaluator { mediaType(), *m_document, style.get() };
 
     auto mediaQueryLists = m_mediaQueryLists;
     for (auto& list : mediaQueryLists) {

--- a/Source/WebCore/css/MediaQueryMatcher.h
+++ b/Source/WebCore/css/MediaQueryMatcher.h
@@ -29,10 +29,13 @@ namespace WebCore {
 
 class Document;
 class MediaQueryList;
-class LegacyMediaQueryEvaluator;
-class MediaQuerySet;
 class RenderStyle;
 class WeakPtrImplWithEventTargetData;
+
+namespace MQ {
+struct MediaQuery;
+using MediaQueryList = Vector<MediaQuery>;
+}
 
 // MediaQueryMatcher class is responsible for evaluating the queries whenever it
 // is needed and dispatch "change" event on MediaQueryLists if the corresponding
@@ -54,12 +57,13 @@ public:
     enum class EventMode : uint8_t { Schedule, DispatchNow };
     void evaluateAll(EventMode);
 
-    bool evaluate(const MediaQuerySet&);
+    bool evaluate(const MQ::MediaQueryList&);
+
+    AtomString mediaType() const;
 
 private:
     explicit MediaQueryMatcher(Document&);
     std::unique_ptr<RenderStyle> documentElementUserAgentStyle() const;
-    AtomString mediaType() const;
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     Vector<WeakPtr<MediaQueryList, WeakPtrImplWithEventTargetData>> m_mediaQueryLists;

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -52,7 +52,6 @@
 #include "Document.h"
 #include "Element.h"
 #include "FontPaletteValues.h"
-#include "LegacyMediaQueryParser.h"
 #include "MediaList.h"
 #include "MediaQueryParser.h"
 #include "MediaQueryParserContext.h"

--- a/Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp
@@ -110,12 +110,12 @@ static EvaluationResult evaluateIntegerComparison(int number, const std::optiona
     return toEvaluationResult(compare(comparison->op, left, right));
 };
 
-static EvaluationResult evaluateResolutionComparison(double resolution, const std::optional<Comparison>& comparison, Side side)
+static EvaluationResult evaluateResolutionComparison(float resolution, const std::optional<Comparison>& comparison, Side side)
 {
     if (!comparison)
         return EvaluationResult::True;
 
-    auto expressionResolution = dynamicDowncast<CSSPrimitiveValue>(comparison->value.get())->doubleValue(CSSUnitType::CSS_DPPX);
+    auto expressionResolution = dynamicDowncast<CSSPrimitiveValue>(comparison->value.get())->floatValue(CSSUnitType::CSS_DPPX);
 
     auto left = side == Side::Left ? expressionResolution : resolution;
     auto right = side == Side::Left ? resolution : expressionResolution;
@@ -203,7 +203,7 @@ EvaluationResult evaluateNumberFeature(const Feature& feature, double currentVal
     return leftResult & rightResult;
 }
 
-EvaluationResult evaluateResolutionFeature(const Feature& feature, double currentValue)
+EvaluationResult evaluateResolutionFeature(const Feature& feature, float currentValue)
 {
     if (!feature.leftComparison && !feature.rightComparison)
         return toEvaluationResult(!!currentValue);

--- a/Source/WebCore/css/query/GenericMediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/GenericMediaQueryEvaluator.h
@@ -40,7 +40,7 @@ EvaluationResult evaluateRatioFeature(const Feature&, FloatSize);
 EvaluationResult evaluateBooleanFeature(const Feature&, bool);
 EvaluationResult evaluateIntegerFeature(const Feature&, int);
 EvaluationResult evaluateNumberFeature(const Feature&, double);
-EvaluationResult evaluateResolutionFeature(const Feature&, double);
+EvaluationResult evaluateResolutionFeature(const Feature&, float);
 EvaluationResult evaluateIdentifierFeature(const Feature&, CSSValueID);
 
 template<typename ConcreteEvaluator>

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -127,7 +127,7 @@ private:
 };
 
 struct ResolutionSchema : public FeatureSchema {
-    using ValueFunction = Function<double(const FeatureEvaluationContext&)>;
+    using ValueFunction = Function<float(const FeatureEvaluationContext&)>;
 
     ResolutionSchema(const AtomString& name, ValueFunction&& valueFunction)
         : FeatureSchema(name, FeatureSchema::Type::Range, FeatureSchema::ValueType::Resolution)
@@ -168,7 +168,7 @@ private:
     ValueFunction valueFunction;
 };
 
-static double deviceScaleFactor(const FeatureEvaluationContext& context)
+static float deviceScaleFactor(const FeatureEvaluationContext& context)
 {
     auto& frame = *context.document.frame();
     auto mediaType = frame.view()->mediaType();


### PR DESCRIPTION
#### 2cf89aa97e32bfcb31d92b41d7b17875e9a5dafd
<pre>
[MQ4] MediaQueryList API should use the new parser and evaluator
<a href="https://bugs.webkit.org/show_bug.cgi?id=248530">https://bugs.webkit.org/show_bug.cgi?id=248530</a>
&lt;rdar://problem/102818616&gt;

Reviewed by Alan Baradlay.

Use the new parser and evaluator for this legacy web API.

* LayoutTests/fast/media/matchmedium-query-api-expected.txt:
* LayoutTests/fast/media/matchmedium-query-api.html:
* LayoutTests/fast/media/media-query-list-01-expected.txt:
* LayoutTests/fast/media/media-query-list-01.html:

We now allow unclosed parenthesis here per usual CSS error recovery. This matches other browsers.

* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/dynamic-range-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/forced-colors-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/navigation-controls.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-color-scheme-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-contrast-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-reduced-data-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-reduced-motion-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt:

More PASSes from new supported syntax.

* Source/WebCore/css/MediaQueryList.cpp:
(WebCore::MediaQueryList::MediaQueryList):
(WebCore::MediaQueryList::create):
(WebCore::MediaQueryList::media const):
(WebCore::MediaQueryList::evaluate):
(WebCore::MediaQueryList::matches):
* Source/WebCore/css/MediaQueryList.h:
* Source/WebCore/css/MediaQueryMatcher.cpp:
(WebCore::MediaQueryMatcher::evaluate):
(WebCore::MediaQueryMatcher::matchMedia):
(WebCore::MediaQueryMatcher::evaluateAll):
* Source/WebCore/css/MediaQueryMatcher.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
* Source/WebCore/page/FrameView.cpp:
* Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp:
(WebCore::MQ::evaluateResolutionComparison):

Make resolution comparison use floats rather than doubles. This matches the legacy behavior and gives the same accuracy
for equality comparisons. Tested by fast/media/mq-resolution.html.

(WebCore::MQ::evaluateResolutionFeature):
* Source/WebCore/css/query/GenericMediaQueryEvaluator.h:
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::deviceScaleFactor):

Canonical link: <a href="https://commits.webkit.org/257227@main">https://commits.webkit.org/257227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c092a8c5b8181626943d22a86a6e7baa8cfe9452

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107625 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167887 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7872 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36143 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90754 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104214 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5911 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84761 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33027 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89492 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1342 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1301 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22427 "Found 1 new test failure: streams/readable-stream-default-controller-error.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4978 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6175 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41849 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->