### PR TITLE
[content-visibility] Support content-visibility for resize/intersection observer

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-030-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-030-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL IntersectionObserver interactions assert_equals: runStep2 expected 1 but got 0
+PASS IntersectionObserver interactions
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-031-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-031-expected.txt
@@ -1,10 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: ResizeObsever should not run during while unrendered expected true but got false
 
-Harness Error (FAIL), message = Unhandled rejection: assert_equals: ResizeObsever should not run during while unrendered expected true but got false
-
-TIMEOUT ResizeObserver skipped while hidden Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: assert_equals: ResizeObsever should not run during while unrendered expected true but got false
-
-TIMEOUT ResizeObserver skipped while hidden Test timed out
+PASS ResizeObserver skipped while hidden
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8222,7 +8222,7 @@ static std::optional<IntersectionObservationState> computeIntersectionState(Fram
     FloatRect rootLocalIntersectionRect = localRootBounds;
 
     IntersectionObservationState intersectionState;
-    intersectionState.isIntersecting = rootLocalTargetRect && rootLocalIntersectionRect.edgeInclusiveIntersect(*rootLocalTargetRect);
+    intersectionState.isIntersecting = rootLocalTargetRect && rootLocalIntersectionRect.edgeInclusiveIntersect(*rootLocalTargetRect) && !targetRenderer->isSkippedContent();
     intersectionState.absoluteTargetRect = targetRenderer->localToAbsoluteQuad(FloatRect(localTargetBounds)).boundingBox();
     intersectionState.absoluteRootBounds = rootRenderer->localToAbsoluteQuad(localRootBounds).boundingBox();
 

--- a/Source/WebCore/page/ResizeObservation.h
+++ b/Source/WebCore/page/ResizeObservation.h
@@ -69,7 +69,7 @@ public:
 private:
     ResizeObservation(Element&, ResizeObserverBoxOptions);
 
-    BoxSizes computeObservedSizes() const;
+    std::optional<BoxSizes> computeObservedSizes() const;
     LayoutPoint computeTargetLocation() const;
 
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_target;


### PR DESCRIPTION
#### 56fda589ecc211863ce21915e7a9e0f0b13445ba
<pre>
[content-visibility] Support content-visibility for resize/intersection observer
<a href="https://bugs.webkit.org/show_bug.cgi?id=245776">https://bugs.webkit.org/show_bug.cgi?id=245776</a>

Reviewed by Darin Adler.

Implement restrictions to resize and intersection observers as specified in the specification:
<a href="https://w3c.github.io/csswg-drafts/css-contain/#cv-notes">https://w3c.github.io/csswg-drafts/css-contain/#cv-notes</a> (Items 1 and 2)

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-030-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-031-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::computeIntersectionState):
* Source/WebCore/page/ResizeObservation.cpp:
(WebCore::ResizeObservation::computeObservedSizes const):
(WebCore::ResizeObservation::elementSizeChanged const):
* Source/WebCore/page/ResizeObservation.h:

Canonical link: <a href="https://commits.webkit.org/257256@main">https://commits.webkit.org/257256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30ba836eccd6f7fa5db098864a99471146990981

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107755 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168022 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8018 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36273 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90879 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104362 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103958 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84896 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33113 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87906 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1470 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1414 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4995 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6308 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41960 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->