### PR TITLE
Get subscrollers working with macOS UI-side compositing

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -106,7 +106,10 @@ bool RemoteScrollingCoordinatorProxy::handleWheelEvent(const PlatformWheelEvent&
     if (m_scrollingTree->willWheelEventStartSwipeGesture(wheelEvent))
         return false;
 
-    auto result = m_scrollingTree->handleWheelEvent(wheelEvent);
+    m_scrollingTree->willProcessWheelEvent();
+
+    auto filteredEvent = filteredWheelEvent(wheelEvent);
+    auto result = m_scrollingTree->handleWheelEvent(filteredEvent);
     didReceiveWheelEvent(result.wasHandled);
     return result.wasHandled;
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -93,6 +93,8 @@ public:
     // FIXME: expose the tree and pass this to that?
     bool handleWheelEvent(const WebCore::PlatformWheelEvent&);
     void handleMouseEvent(const WebCore::PlatformMouseEvent&);
+    
+    virtual WebCore::PlatformWheelEvent filteredWheelEvent(const WebCore::PlatformWheelEvent& wheelEvent) { return wheelEvent; }
 
     WebCore::ScrollingNodeID rootScrollingNodeID() const;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -29,6 +29,10 @@
 
 #include "RemoteScrollingCoordinatorProxy.h"
 
+namespace WebCore {
+class WheelEventDeltaFilter;
+}
+
 namespace WebKit {
 
 class RemoteScrollingCoordinatorProxyMac final : public RemoteScrollingCoordinatorProxy {
@@ -36,6 +40,8 @@ public:
     explicit RemoteScrollingCoordinatorProxyMac(WebPageProxy&);
 
 private:
+    WebCore::PlatformWheelEvent filteredWheelEvent(const WebCore::PlatformWheelEvent&) override;
+
     void didReceiveWheelEvent(bool) override;
     bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) override;
     void hasNodeWithAnimatedScrollChanged(bool) override;
@@ -43,6 +49,8 @@ private:
 
     void connectStateNodeLayers(WebCore::ScrollingStateTree&, const RemoteLayerTreeHost&) override;
     void establishLayerTreeScrollingRelations(const RemoteLayerTreeHost&) override;
+
+    std::unique_ptr<WebCore::WheelEventDeltaFilter> m_recentWheelEventDeltaFilter;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -38,13 +38,28 @@
 #import <WebCore/ScrollingTreeOverflowScrollProxyNode.h>
 #import <WebCore/ScrollingTreeOverflowScrollingNode.h>
 #import <WebCore/ScrollingTreePositionedNode.h>
+#import <WebCore/WheelEventDeltaFilter.h>
 
 namespace WebKit {
 using namespace WebCore;
 
 RemoteScrollingCoordinatorProxyMac::RemoteScrollingCoordinatorProxyMac(WebPageProxy& webPageProxy)
     : RemoteScrollingCoordinatorProxy(webPageProxy)
+    , m_recentWheelEventDeltaFilter(WheelEventDeltaFilter::create())
 {
+}
+
+PlatformWheelEvent RemoteScrollingCoordinatorProxyMac::filteredWheelEvent(const WebCore::PlatformWheelEvent& wheelEvent)
+{
+    m_recentWheelEventDeltaFilter->updateFromEvent(wheelEvent);
+
+    auto filteredEvent = wheelEvent;
+    if (WheelEventDeltaFilter::shouldApplyFilteringForEvent(wheelEvent))
+        filteredEvent = m_recentWheelEventDeltaFilter->eventCopyWithFilteredDeltas(wheelEvent);
+    else if (WheelEventDeltaFilter::shouldIncludeVelocityForEvent(wheelEvent))
+        filteredEvent = m_recentWheelEventDeltaFilter->eventCopyWithVelocity(wheelEvent);
+
+    return filteredEvent;
 }
 
 void RemoteScrollingCoordinatorProxyMac::didReceiveWheelEvent(bool /* wasHandled */)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -50,6 +50,8 @@ public:
 
 private:
     void handleWheelEventPhase(WebCore::ScrollingNodeID, WebCore::PlatformWheelEventPhase) final;
+    RefPtr<WebCore::ScrollingTreeNode> scrollingNodeForPoint(WebCore::FloatPoint) final;
+
     void hasNodeWithAnimatedScrollChanged(bool) final;
     void displayDidRefresh(WebCore::PlatformDisplayID) final;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -28,10 +28,16 @@
 
 #if PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)
 
+#import "Logging.h"
+#import "RemoteLayerTreeNode.h"
 #import "RemoteScrollingCoordinatorProxy.h"
 #import "ScrollingTreeFrameScrollingNodeRemoteMac.h"
 #import "ScrollingTreeOverflowScrollingNodeRemoteMac.h"
 #import <WebCore/ScrollingTreeFixedNodeCocoa.h>
+#import <WebCore/ScrollingTreeOverflowScrollProxyNode.h>
+#import <WebCore/ScrollingTreePositionedNode.h>
+#import <WebCore/WebCoreCALayerExtras.h>
+#import <wtf/text/TextStream.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -90,6 +96,91 @@ void RemoteScrollingTreeMac::handleMouseEvent(const WebCore::PlatformMouseEvent&
     if (!rootNode())
         return;
     static_cast<ScrollingTreeFrameScrollingNodeRemoteMac&>(*rootNode()).handleMouseEvent(event);
+}
+
+static ScrollingNodeID scrollingNodeIDForLayer(CALayer *layer)
+{
+    auto* layerTreeNode = RemoteLayerTreeNode::forCALayer(layer);
+    if (!layerTreeNode)
+        return 0;
+
+    return layerTreeNode->scrollingNodeID();
+}
+
+static bool isScrolledBy(const ScrollingTree& tree, ScrollingNodeID scrollingNodeID, CALayer *hitLayer)
+{
+    for (CALayer *layer = hitLayer; layer; layer = [layer superlayer]) {
+        auto nodeID = scrollingNodeIDForLayer(layer);
+        if (nodeID == scrollingNodeID)
+            return true;
+
+        auto* scrollingNode = tree.nodeForID(nodeID);
+        if (is<ScrollingTreeOverflowScrollProxyNode>(scrollingNode)) {
+            ScrollingNodeID actingOverflowScrollingNodeID = downcast<ScrollingTreeOverflowScrollProxyNode>(*scrollingNode).overflowScrollingNodeID();
+            if (actingOverflowScrollingNodeID == scrollingNodeID)
+                return true;
+        }
+
+        if (is<ScrollingTreePositionedNode>(scrollingNode)) {
+            if (downcast<ScrollingTreePositionedNode>(*scrollingNode).relatedOverflowScrollingNodes().contains(scrollingNodeID))
+                return false;
+        }
+    }
+
+    return false;
+}
+
+static bool layerEventRegionContainsPoint(CALayer *layer, CGPoint localPoint)
+{
+    auto* layerTreeNode = RemoteLayerTreeNode::forCALayer(layer);
+    if (!layerTreeNode)
+        return false;
+
+    // Scrolling changes boundsOrigin on the scroll container layer, but we computed its event region ignoring scroll position, so factor out bounds origin.
+    FloatPoint boundsOrigin = layer.bounds.origin;
+    FloatPoint originRelativePoint = localPoint - toFloatSize(boundsOrigin);
+    auto& eventRegion = layerTreeNode->eventRegion();
+    return eventRegion.contains(roundedIntPoint(originRelativePoint));
+}
+
+RefPtr<ScrollingTreeNode> RemoteScrollingTreeMac::scrollingNodeForPoint(FloatPoint point)
+{
+    auto* rootScrollingNode = rootNode();
+    if (!rootScrollingNode)
+        return nullptr;
+
+    RetainPtr scrolledContentsLayer { static_cast<CALayer*>(rootScrollingNode->scrolledContentsLayer()) };
+    auto scrollPosition = rootScrollingNode->currentScrollPosition();
+    auto pointInContentsLayer = point;
+    pointInContentsLayer.moveBy(scrollPosition);
+
+    Vector<LayerAndPoint, 16> layersAtPoint;
+    collectDescendantLayersAtPoint(layersAtPoint, scrolledContentsLayer.get(), pointInContentsLayer, layerEventRegionContainsPoint);
+
+    LOG_WITH_STREAM(UIHitTesting, stream << "RemoteScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " found " << layersAtPoint.size() << " layers");
+#if !LOG_DISABLED
+    for (auto [layer, point] : WTF::makeReversedRange(layersAtPoint))
+        LOG_WITH_STREAM(UIHitTesting, stream << " layer " << [layer description] << " scrolling node " << scrollingNodeIDForLayer(layer));
+#endif
+
+    if (layersAtPoint.size()) {
+        auto* frontmostLayer = layersAtPoint.last().first;
+        for (auto [layer, point] : WTF::makeReversedRange(layersAtPoint)) {
+            auto nodeID = scrollingNodeIDForLayer(layer);
+
+            auto* scrollingNode = nodeForID(nodeID);
+            if (!is<ScrollingTreeScrollingNode>(scrollingNode))
+                continue;
+
+            if (isScrolledBy(*this, nodeID, frontmostLayer)) {
+                LOG_WITH_STREAM(UIHitTesting, stream << "RemoteScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " found scrolling node " << nodeID);
+                return scrollingNode;
+            }
+        }
+    }
+
+    LOG_WITH_STREAM(UIHitTesting, stream << "RemoteScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " found no scrollable layers; using root node");
+    return rootScrollingNode;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
@@ -74,9 +74,9 @@ void ScrollingTreeFrameScrollingNodeRemoteMac::repositionRelatedLayers()
 
 WheelEventHandlingResult ScrollingTreeFrameScrollingNodeRemoteMac::handleWheelEvent(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting)
 {
-    ScrollingTreeFrameScrollingNodeMac::handleWheelEvent(wheelEvent, eventTargeting);
-
-    return WheelEventHandlingResult::result(m_scrollerPair->handleWheelEvent(wheelEvent));
+    auto result = ScrollingTreeFrameScrollingNodeMac::handleWheelEvent(wheelEvent, eventTargeting);
+    m_scrollerPair->handleWheelEvent(wheelEvent);
+    return result;
 }
 
 bool ScrollingTreeFrameScrollingNodeRemoteMac::handleMouseEvent(const PlatformMouseEvent& mouseEvent)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
@@ -74,9 +74,9 @@ void ScrollingTreeOverflowScrollingNodeRemoteMac::repositionRelatedLayers()
 
 WheelEventHandlingResult ScrollingTreeOverflowScrollingNodeRemoteMac::handleWheelEvent(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting)
 {
-    ScrollingTreeOverflowScrollingNodeMac::handleWheelEvent(wheelEvent, eventTargeting);
-
-    return WheelEventHandlingResult::result(m_scrollerPair->handleWheelEvent(wheelEvent));
+    auto result = ScrollingTreeOverflowScrollingNodeMac::handleWheelEvent(wheelEvent, eventTargeting);
+    m_scrollerPair->handleWheelEvent(wheelEvent);
+    return result;
 }
 
 bool ScrollingTreeOverflowScrollingNodeRemoteMac::handleMouseEvent(const PlatformMouseEvent& mouseEvent)


### PR DESCRIPTION
#### 135ae5c3f9a058abed14a56fa91afdbe8c69951f
<pre>
Get subscrollers working with macOS UI-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=248540">https://bugs.webkit.org/show_bug.cgi?id=248540</a>
rdar://102820156

Reviewed by Tim Horton.

Get basic subscroller scrolling (overflow and iframes) working with UI-side compositing on macOS.
This required the following changes:

Implement `RemoteScrollingTreeMac::scrollingNodeForPoint()` to find the correct scrolling
tree node by hit-testing through CALayers. We need to adjust the point to take the current
scroll position into account. Taking scroll origin into account for RTL content isn&apos;t necessary
here.

Fix `ScrollingTreeOverflowScrollingNodeRemoteMac` and `ScrollingTreeFrameScrollingNodeRemoteMac`
`handleWheelEvent` implementations to return the result of handling the event in the base class,
rather than whatever `m_scrollerPair` does (it&apos;s unclear if we should have a `m_scrollerPair` here
at all).

Implement wheel event delta filtering, as EventDispatcher does, via a `WheelEventDeltaFilter`
on `RemoteScrollingCoordinatorProxyMac`. This is necessary to avoid small X deltas preventing
scrolls in Y, which is very common with trackpad interaction.

Call `m_scrollingTree-&gt;willProcessWheelEvent()` in `RemoteScrollingCoordinatorProxy::handleWheelEvent()`
so that scroll latching works correctly.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::handleWheelEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::filteredWheelEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::RemoteScrollingCoordinatorProxyMac):
(WebKit::RemoteScrollingCoordinatorProxyMac::filteredWheelEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::scrollingNodeIDForLayer):
(WebKit::isScrolledBy):
(WebKit::layerEventRegionContainsPoint):
(WebKit::RemoteScrollingTreeMac::scrollingNodeForPoint):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp:
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::handleWheelEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp:
(WebKit::ScrollingTreeOverflowScrollingNodeRemoteMac::handleWheelEvent):

Canonical link: <a href="https://commits.webkit.org/257259@main">https://commits.webkit.org/257259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77df9804790c2a38181dee7be9eaaca632944862

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107630 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7877 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36148 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90759 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104219 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5917 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84766 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33029 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75968 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1347 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1306 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22486 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5000 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44887 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41911 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->