### PR TITLE
Replace std::forward_like implementation with one without std::move

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -651,23 +651,13 @@ using remove_cvref_t = typename remove_cvref<T>::type;
 
 #if !(defined(__cpp_lib_forward_like) && __cpp_lib_forward_like >= 202207L)
 namespace std {
-template<typename T, typename U>
-constexpr auto&& forward_like(U&& value)
-{
-    constexpr bool is_adding_const = std::is_const_v<std::remove_reference_t<T>>;
-    if constexpr (std::is_lvalue_reference_v<T&&>) {
-        if constexpr (is_adding_const)
-            return std::as_const(value);
-        else
-            return static_cast<U&>(value);
-    } else {
-        if constexpr (is_adding_const)
-            return std::move(std::as_const(value));
-        else
-            return std::move(value);
-    }
-}
-}
+namespace detail {
+template<typename T, typename U> using copy_const = conditional_t<is_const_v<T>, const U, U>;
+template<typename T, typename U> using override_ref = conditional_t<is_rvalue_reference_v<T>, remove_reference_t<U>&&, U&>;
+template<typename T, typename U> using forward_like_impl = override_ref<T&&, copy_const<remove_reference_t<T>, remove_reference_t<U>>>;
+} // namespace detail
+template<typename T, typename U> constexpr auto forward_like(U&& value) -> detail::forward_like_impl<T, U> { return static_cast<detail::forward_like_impl<T, U>>(value); }
+} // namespace std
 #endif
 
 using WTF::GB;


### PR DESCRIPTION
#### 803459a86aca323e51d14bd2af11e6b20e14f0bd
<pre>
Replace std::forward_like implementation with one without std::move
<a href="https://bugs.webkit.org/show_bug.cgi?id=248542">https://bugs.webkit.org/show_bug.cgi?id=248542</a>

Reviewed by Kimmo Kinnunen.

It was causing some problems with the static analyzer with its last std::move,
which the static analyzer was sure needed to be std::forward instead.
Completely replace it with an unrelated implementation.

* Source/WTF/wtf/StdLibExtras.h:
(std::forward_like):

Canonical link: <a href="https://commits.webkit.org/257216@main">https://commits.webkit.org/257216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87e223c522b2bd39e40641cfe32a5e8ffcca0391

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107649 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167934 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7895 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36167 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104235 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103840 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84784 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/90777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89511 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89027 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1365 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84758 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1322 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28644 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4957 "Found 1 new test failure: streams/readable-stream-default-controller-error.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6198 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87598 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2478 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2659 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41870 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19646 "Passed tests") | 
<!--EWS-Status-Bubble-End-->