### PR TITLE
Add an iterator for the StyleProperties family of classes

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -1786,7 +1786,7 @@ struct Mapper {
         Vector<DestinationItemType> result;
         // FIXME: Use std::size when available on all compilers.
         result.reserveInitialCapacity(source.size());
-        for (auto& item : source)
+        for (auto&& item : source)
             result.uncheckedAppend(mapFunction(item));
         return result;
     }
@@ -1844,7 +1844,7 @@ struct CompactMapper {
     static Vector<DestinationItemType> compactMap(const SourceType& source, const MapFunction& mapFunction)
     {
         Vector<DestinationItemType> result;
-        for (auto& item : source) {
+        for (auto&& item : source) {
             auto itemResult = mapFunction(item);
             if (CompactMapTraits<ResultItemType>::hasValue(itemResult))
                 result.append(CompactMapTraits<ResultItemType>::extractValue(WTFMove(itemResult)));
@@ -1885,7 +1885,7 @@ inline auto copyToVectorSpecialization(const Collection& collection) -> Destinat
     DestinationVector result;
     // FIXME: Use std::size when available on all compilers.
     result.reserveInitialCapacity(collection.size());
-    for (auto& item : collection)
+    for (auto&& item : collection)
         result.uncheckedAppend(item);
     return result;
 }

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2271,8 +2271,8 @@ void KeyframeEffect::computeHasImplicitKeyframeForAcceleratedProperty()
             HashSet<CSSPropertyID> explicitZeroProperties;
             HashSet<CSSPropertyID> explicitOneProperties;
             auto styleProperties = keyframe.style;
-            for (unsigned i = 0; i < styleProperties->propertyCount(); ++i) {
-                auto property = styleProperties->propertyAt(i).id();
+            for (auto propertyReference : styleProperties.get()) {
+                auto property = propertyReference.id();
                 // All properties may end up being implicit.
                 implicitProperties.add(property);
                 if (!keyframe.computedOffset)
@@ -2324,9 +2324,8 @@ void KeyframeEffect::computeHasKeyframeComposingAcceleratedProperty()
             if (keyframe.composite != CompositeOperationOrAuto::Add && keyframe.composite != CompositeOperationOrAuto::Accumulate)
                 continue;
             auto styleProperties = keyframe.style;
-            for (unsigned i = 0; i < styleProperties->propertyCount(); ++i) {
-                auto property = styleProperties->propertyAt(i).id();
-                if (CSSPropertyAnimation::animationOfPropertyIsAccelerated(property))
+            for (auto property : styleProperties.get()) {
+                if (CSSPropertyAnimation::animationOfPropertyIsAccelerated(property.id()))
                     return true;
             }
         }

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -96,8 +96,8 @@ String StyleRuleKeyframe::cssText() const
 
 bool StyleRuleKeyframe::containsCSSVariableReferences() const
 {
-    for (unsigned i = 0; i < m_properties->propertyCount(); ++i) {
-        if (auto* cssValue = m_properties->propertyAt(i).value()) {
+    for (auto property : m_properties.get()) {
+        if (auto* cssValue = property.value()) {
             if (cssValue->hasVariableReferences())
                 return true;
         }

--- a/Source/WebCore/css/CSSValueList.cpp
+++ b/Source/WebCore/css/CSSValueList.cpp
@@ -37,25 +37,33 @@ CSSValueList::CSSValueList(ValueSeparator listSeparator)
     m_valueSeparator = listSeparator;
 }
 
-bool CSSValueList::removeAll(CSSValue* value)
+bool CSSValueList::removeAll(CSSValue& value)
 {
-    // FIXME: Why even take a pointer?
-    if (!value)
-        return false;
-
-    return m_values.removeAllMatching([value](auto& current) {
-        return current->equals(*value);
+    return m_values.removeAllMatching([&value](auto& current) {
+        return current->equals(value);
     }) > 0;
 }
 
-bool CSSValueList::hasValue(CSSValue* val) const
+bool CSSValueList::removeAll(CSSValueID value)
 {
-    // FIXME: Why even take a pointer?
-    if (!val)
-        return false;
+    return m_values.removeAllMatching([value](auto& current) {
+        return isValueID(current, value);
+    }) > 0;
+}
 
-    for (unsigned i = 0, size = m_values.size(); i < size; ++i) {
-        if (m_values[i].get().equals(*val))
+bool CSSValueList::hasValue(CSSValue& otherValue) const
+{
+    for (auto& value : m_values) {
+        if (value->equals(otherValue))
+            return true;
+    }
+    return false;
+}
+
+bool CSSValueList::hasValue(CSSValueID otherValue) const
+{
+    for (auto& value : m_values) {
+        if (isValueID(value, otherValue))
             return true;
     }
     return false;

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "CSSValue.h"
+#include "CSSValueKeywords.h"
 #include <wtf/Function.h>
 #include <wtf/Vector.h>
 
@@ -44,6 +45,8 @@ public:
         return adoptRef(*new CSSValueList(SlashSeparator));
     }
 
+    Ref<CSSValueList> copy();
+
     size_t length() const { return m_values.size(); }
     CSSValue* item(size_t index) { return index < m_values.size() ? m_values[index].ptr() : nullptr; }
     const CSSValue* item(size_t index) const { return index < m_values.size() ? m_values[index].ptr() : nullptr; }
@@ -58,9 +61,10 @@ public:
 
     void append(Ref<CSSValue>&&);
     void prepend(Ref<CSSValue>&&);
-    bool removeAll(CSSValue*);
-    bool hasValue(CSSValue*) const;
-    Ref<CSSValueList> copy();
+    bool removeAll(CSSValue&);
+    bool removeAll(CSSValueID);
+    bool hasValue(CSSValue&) const;
+    bool hasValue(CSSValueID) const;
 
     String customCSSText() const;
     bool equals(const CSSValueList&) const;

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2283,10 +2283,9 @@ static Ref<CSSValue> fontStyle(const RenderStyle& style)
 Ref<CSSValue> ComputedStyleExtractor::fontVariantShorthandValue()
 {
     auto list = CSSValueList::createSpaceSeparated();
-    auto shorthand = fontVariantShorthand();
-    for (size_t i = 0; i < shorthand.length(); ++i) {
-        auto value = propertyValue(shorthand.properties()[i], UpdateLayout::No);
-        if (is<CSSPrimitiveValue>(value) && downcast<CSSPrimitiveValue>(*value).valueID() == CSSValueNormal)
+    for (auto longhand : fontVariantShorthand()) {
+        auto value = propertyValue(longhand, UpdateLayout::No);
+        if (isValueID(value, CSSValueNormal))
             continue;
         list->append(value.releaseNonNull());
     }
@@ -4318,8 +4317,8 @@ bool ComputedStyleExtractor::propertyMatches(CSSPropertyID propertyID, const CSS
 Ref<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesForShorthandProperties(const StylePropertyShorthand& shorthand)
 {
     auto list = CSSValueList::createSpaceSeparated();
-    for (size_t i = 0; i < shorthand.length(); ++i)
-        list->append(propertyValue(shorthand.properties()[i], UpdateLayout::No).releaseNonNull());
+    for (auto longhand : shorthand)
+        list->append(propertyValue(longhand, UpdateLayout::No).releaseNonNull());
     return list;
 }
 
@@ -4376,8 +4375,8 @@ RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor4SidesShorth
 Ref<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesForGridShorthand(const StylePropertyShorthand& shorthand)
 {
     auto list = CSSValueList::createSlashSeparated();
-    for (size_t i = 0; i < shorthand.length(); ++i)
-        list->append(propertyValue(shorthand.properties()[i], UpdateLayout::No).releaseNonNull());
+    for (auto longhand : shorthand)
+        list->append(propertyValue(longhand, UpdateLayout::No).releaseNonNull());
     return list;
 }
 

--- a/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
+++ b/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
@@ -152,8 +152,8 @@ void PropertySetCSSStyleDeclaration::deref()
 unsigned PropertySetCSSStyleDeclaration::length() const
 {
     unsigned exposed = 0;
-    for (unsigned i = 0; i < m_propertySet->propertyCount(); i++) {
-        if (isExposed(m_propertySet->propertyAt(i).id()))
+    for (auto property : *m_propertySet) {
+        if (isExposed(property.id()))
             exposed++;
     }
     return exposed;

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -83,11 +83,38 @@ public:
         const CSSValue* m_value;
     };
 
+    template<typename T>
+    struct Iterator {
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = PropertyReference;
+        using difference_type = ptrdiff_t;
+        using pointer = PropertyReference;
+        using reference = PropertyReference;
+
+        Iterator(const T& properties)
+            : properties { properties }
+        {
+        }
+
+        PropertyReference operator*() const { return properties.propertyAt(index); }
+        Iterator& operator++() { ++index; return *this; }
+        bool operator==(std::nullptr_t) const { return index >= properties.propertyCount(); }
+        bool operator!=(std::nullptr_t) const { return index < properties.propertyCount(); }
+
+    private:
+        const T& properties;
+        unsigned index { 0 };
+    };
+
     StylePropertiesType type() const { return static_cast<StylePropertiesType>(m_type); }
 
     unsigned propertyCount() const;
     bool isEmpty() const { return !propertyCount(); }
     PropertyReference propertyAt(unsigned) const;
+
+    Iterator<StyleProperties> begin() const { return { *this }; }
+    static constexpr std::nullptr_t end() { return nullptr; }
+    unsigned size() const { return propertyCount(); }
 
     WEBCORE_EXPORT RefPtr<CSSValue> getPropertyCSSValue(CSSPropertyID) const;
     WEBCORE_EXPORT String getPropertyValue(CSSPropertyID) const;
@@ -188,6 +215,10 @@ public:
     bool isEmpty() const { return !propertyCount(); }
     PropertyReference propertyAt(unsigned index) const;
 
+    Iterator<ImmutableStyleProperties> begin() const { return { *this }; }
+    static constexpr std::nullptr_t end() { return nullptr; }
+    unsigned size() const { return propertyCount(); }
+
     int findPropertyIndex(CSSPropertyID) const;
     int findCustomPropertyIndex(const String& propertyName) const;
     
@@ -221,6 +252,10 @@ public:
     unsigned propertyCount() const { return m_propertyVector.size(); }
     bool isEmpty() const { return !propertyCount(); }
     PropertyReference propertyAt(unsigned index) const;
+
+    Iterator<MutableStyleProperties> begin() const { return { *this }; }
+    static constexpr std::nullptr_t end() { return nullptr; }
+    unsigned size() const { return propertyCount(); }
 
     PropertySetCSSStyleDeclaration* cssStyleDeclaration();
 

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -5627,16 +5627,15 @@ RefPtr<CSSValue> consumeClip(CSSParserTokenRange& range, CSSParserMode cssParser
 
 RefPtr<CSSValue> consumeTouchAction(CSSParserTokenRange& range)
 {
-    CSSValueID id = range.peek().id();
-    if (id == CSSValueNone || id == CSSValueAuto || id == CSSValueManipulation)
-        return consumeIdent(range);
+    if (auto ident = consumeIdent<CSSValueNone, CSSValueAuto, CSSValueManipulation>(range))
+        return ident;
 
     auto list = CSSValueList::createSpaceSeparated();
     while (true) {
         auto ident = consumeIdent<CSSValuePanX, CSSValuePanY, CSSValuePinchZoom>(range);
         if (!ident)
             break;
-        if (list->hasValue(ident.get()))
+        if (list->hasValue(*ident))
             return nullptr;
         list->append(ident.releaseNonNull());
     }
@@ -5892,12 +5891,12 @@ RefPtr<CSSValue> consumeTextDecorationLine(CSSParserTokenRange& range)
     if (id == CSSValueNone)
         return consumeIdent(range);
 
-    RefPtr<CSSValueList> list = CSSValueList::createSpaceSeparated();
+    auto list = CSSValueList::createSpaceSeparated();
     while (true) {
-        RefPtr<CSSPrimitiveValue> ident = consumeIdent<CSSValueBlink, CSSValueUnderline, CSSValueOverline, CSSValueLineThrough>(range);
+        auto ident = consumeIdent<CSSValueBlink, CSSValueUnderline, CSSValueOverline, CSSValueLineThrough>(range);
         if (!ident)
             break;
-        if (list->hasValue(ident.get()))
+        if (list->hasValue(*ident))
             return nullptr;
         list->append(ident.releaseNonNull());
     }

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
@@ -63,14 +63,9 @@ auto DeclaredStylePropertyMap::entries(ScriptExecutionContext* context) const ->
         return { };
 
     auto& document = downcast<Document>(*context);
-    Vector<StylePropertyMapEntry> result;
-    auto& declaredStyleSet = styleRule->properties();
-    result.reserveInitialCapacity(declaredStyleSet.propertyCount());
-    for (unsigned i = 0; i < declaredStyleSet.propertyCount(); ++i) {
-        auto propertyReference = declaredStyleSet.propertyAt(i);
-        result.uncheckedAppend(makeKeyValuePair(propertyReference.cssName(), reifyValueToVector(RefPtr<CSSValue> { propertyReference.value() }, document)));
-    }
-    return result;
+    return map(styleRule->properties(), [&] (auto propertyReference) {
+        return StylePropertyMapEntry { propertyReference.cssName(), reifyValueToVector(RefPtr<CSSValue> { propertyReference.value() }, document) };
+    });
 }
 
 RefPtr<CSSValue> DeclaredStylePropertyMap::propertyValue(CSSPropertyID propertyID) const

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
@@ -72,18 +72,14 @@ auto InlineStylePropertyMap::entries(ScriptExecutionContext* context) const -> V
     if (!m_element || !context)
         return { };
 
-    auto& document = downcast<Document>(*context);
-    Vector<StylePropertyMapEntry> result;
     auto* inlineStyle = m_element->inlineStyle();
     if (!inlineStyle)
         return { };
 
-    result.reserveInitialCapacity(inlineStyle->propertyCount());
-    for (unsigned i = 0; i < inlineStyle->propertyCount(); ++i) {
-        auto propertyReference = inlineStyle->propertyAt(i);
-        result.uncheckedAppend(makeKeyValuePair(propertyReference.cssName(), reifyValueToVector(RefPtr<CSSValue> { propertyReference.value() }, document)));
-    }
-    return result;
+    auto& document = downcast<Document>(*context);
+    return map(*inlineStyle, [&document] (auto property) {
+        return StylePropertyMapEntry(property.cssName(), reifyValueToVector(RefPtr<CSSValue> { property.value() }, document));
+    });
 }
 
 void InlineStylePropertyMap::removeProperty(CSSPropertyID propertyID)

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -253,10 +253,12 @@ public:
         auto change = changeInStyle(style);
         if (change != TextDecorationChange::None)
             return change == TextDecorationChange::Add;
-        RefPtr<CSSValue> styleValue = style.m_mutableStyle->getPropertyCSSValue(CSSPropertyWebkitTextDecorationsInEffect);
+        auto styleValue = style.m_mutableStyle->getPropertyCSSValue(CSSPropertyWebkitTextDecorationsInEffect);
         if (!styleValue)
             styleValue = style.m_mutableStyle->getPropertyCSSValue(CSSPropertyTextDecorationLine);
-        return is<CSSValueList>(styleValue) && downcast<CSSValueList>(*styleValue).hasValue(m_primitiveValue.get());
+        if (!m_primitiveValue)
+            return false;
+        return is<CSSValueList>(styleValue) && downcast<CSSValueList>(*styleValue).hasValue(*m_primitiveValue);
     }
 
 private:
@@ -268,7 +270,7 @@ private:
     bool m_isUnderline;
 };
 
-static bool fontWeightIsBold(CSSValue& fontWeight)
+static bool fontWeightValueIsBold(CSSValue& fontWeight)
 {
     if (!is<CSSPrimitiveValue>(fontWeight))
         return false;
@@ -306,7 +308,7 @@ private:
     bool valueIsPresentInStyle(Element& element, const EditingStyle& style) const
     {
         RefPtr<CSSValue> value = style.m_mutableStyle->getPropertyCSSValue(m_propertyID);
-        return matches(element) && value && fontWeightIsBold(*value);
+        return matches(element) && value && fontWeightValueIsBold(*value);
     }
 };
 
@@ -659,7 +661,7 @@ static void applyTextDecorationChangeToValueList(CSSValueList& valueList, TextDe
         valueList.append(WTFMove(value));
         break;
     case TextDecorationChange::Remove:
-        valueList.removeAll(&value.get());
+        valueList.removeAll(value);
         break;
     }
 }
@@ -758,10 +760,10 @@ void EditingStyle::removeStyleAddedByNode(Node* node)
 {
     if (!node || !node->parentNode())
         return;
-    RefPtr<MutableStyleProperties> parentStyle = copyPropertiesFromComputedStyle(node->parentNode(), EditingPropertiesInEffect);
-    RefPtr<MutableStyleProperties> nodeStyle = copyPropertiesFromComputedStyle(node, EditingPropertiesInEffect);
-    removeEquivalentProperties(*parentStyle);
-    removeEquivalentProperties(*nodeStyle);
+    auto parentStyle = copyPropertiesFromComputedStyle(node->parentNode(), EditingPropertiesInEffect);
+    auto nodeStyle = copyPropertiesFromComputedStyle(node, EditingPropertiesInEffect);
+    removeEquivalentProperties(parentStyle.get());
+    removeEquivalentProperties(nodeStyle.get());
 }
 
 void EditingStyle::removeStyleConflictingWithStyleOfNode(Node& node)
@@ -769,14 +771,12 @@ void EditingStyle::removeStyleConflictingWithStyleOfNode(Node& node)
     if (!node.parentNode() || !m_mutableStyle)
         return;
 
-    RefPtr<MutableStyleProperties> parentStyle = copyPropertiesFromComputedStyle(node.parentNode(), EditingPropertiesInEffect);
+    auto parentStyle = copyPropertiesFromComputedStyle(node.parentNode(), EditingPropertiesInEffect);
     auto nodeStyle = EditingStyle::create(&node, EditingPropertiesInEffect);
-    nodeStyle->removeEquivalentProperties(*parentStyle);
+    nodeStyle->removeEquivalentProperties(parentStyle.get());
 
-    MutableStyleProperties* style = nodeStyle->style();
-    unsigned propertyCount = style->propertyCount();
-    for (unsigned i = 0; i < propertyCount; ++i)
-        m_mutableStyle->removeProperty(style->propertyAt(i).id());
+    for (auto property : *nodeStyle->style())
+        m_mutableStyle->removeProperty(property.id());
 }
 
 void EditingStyle::collapseTextDecorationProperties()
@@ -817,7 +817,7 @@ TriState EditingStyle::triStateOfStyle(T& styleToCompare, ShouldIgnoreTextOnlyPr
     if (!m_mutableStyle)
         return TriState::True;
 
-    RefPtr<MutableStyleProperties> difference = getPropertiesNotIn(*m_mutableStyle, styleToCompare);
+    auto difference = getPropertiesNotIn(*m_mutableStyle, styleToCompare);
 
     if (shouldIgnoreTextOnlyProperties == IgnoreTextOnlyProperties)
         difference->removePropertiesInSet(textOnlyProperties, WTF_ARRAY_LENGTH(textOnlyProperties));
@@ -887,20 +887,18 @@ bool EditingStyle::conflictsWithInlineStyleOfElement(StyledElement& element, Ref
             auto newValueList = valueList->copy();
             auto extractedValueList = CSSValueList::createSpaceSeparated();
 
-            Ref<CSSPrimitiveValue> underline = CSSValuePool::singleton().createIdentifierValue(CSSValueUnderline);
-            if (shouldRemoveUnderline && valueList->hasValue(underline.ptr())) {
+            if (shouldRemoveUnderline && valueList->hasValue(CSSValueUnderline)) {
                 if (!newInlineStyle)
                     return true;
-                newValueList->removeAll(underline.ptr());
-                extractedValueList->append(WTFMove(underline));
+                newValueList->removeAll(CSSValueUnderline);
+                extractedValueList->append(CSSValuePool::singleton().createIdentifierValue(CSSValueUnderline));
             }
 
-            Ref<CSSPrimitiveValue> lineThrough = CSSValuePool::singleton().createIdentifierValue(CSSValueLineThrough);
-            if (shouldRemoveStrikeThrough && valueList->hasValue(lineThrough.ptr())) {
+            if (shouldRemoveStrikeThrough && valueList->hasValue(CSSValueLineThrough)) {
                 if (!newInlineStyle)
                     return true;
-                newValueList->removeAll(lineThrough.ptr());
-                extractedValueList->append(WTFMove(lineThrough));
+                newValueList->removeAll(CSSValueLineThrough);
+                extractedValueList->append(CSSValuePool::singleton().createIdentifierValue(CSSValueLineThrough));
             }
 
             if (extractedValueList->length()) {
@@ -918,9 +916,11 @@ bool EditingStyle::conflictsWithInlineStyleOfElement(StyledElement& element, Ref
         }
     }
 
-    unsigned propertyCount = m_mutableStyle ? m_mutableStyle->propertyCount() : 0;
-    for (unsigned i = 0; i < propertyCount; ++i) {
-        CSSPropertyID propertyID = m_mutableStyle->propertyAt(i).id();
+    if (!m_mutableStyle)
+        return conflicts;
+
+    for (auto property : *m_mutableStyle) {
+        auto propertyID = property.id();
 
         // We don't override whitespace property of a tab span because that would collapse the tab into a space.
         if (propertyID == CSSPropertyWhiteSpace && isTabSpanNode(&element))
@@ -1061,10 +1061,9 @@ bool EditingStyle::styleIsPresentInComputedStyleOfNode(Node& node) const
         bool hasLineThrough = false;
         if (RefPtr<CSSValue> value = computedStyle.propertyValue(CSSPropertyTextDecorationLine)) {
             if (value->isValueList()) {
-                auto& cssValuePool = CSSValuePool::singleton();
                 const CSSValueList& valueList = downcast<CSSValueList>(*value);
-                hasUnderline = valueList.hasValue(cssValuePool.createIdentifierValue(CSSValueUnderline).ptr());
-                hasLineThrough = valueList.hasValue(cssValuePool.createIdentifierValue(CSSValueLineThrough).ptr());
+                hasUnderline = valueList.hasValue(CSSValueUnderline);
+                hasLineThrough = valueList.hasValue(CSSValueLineThrough);
             }
         }
         if ((shouldAddUnderline && !hasUnderline) || (shouldAddLineThrough && !hasLineThrough))
@@ -1104,10 +1103,9 @@ bool EditingStyle::elementIsStyledSpanOrHTMLEquivalent(const HTMLElement& elemen
         matchedAttributes++;
 
     if (element.hasAttribute(HTMLNames::styleAttr)) {
-        if (const StyleProperties* style = element.inlineStyle()) {
-            unsigned propertyCount = style->propertyCount();
-            for (unsigned i = 0; i < propertyCount; ++i) {
-                if (!isEditingProperty(style->propertyAt(i).id()))
+        if (const auto* style = element.inlineStyle()) {
+            for (auto property : *style) {
+                if (!isEditingProperty(property.id()))
                     return false;
             }
         }
@@ -1267,14 +1265,12 @@ Ref<EditingStyle> EditingStyle::wrappingStyleForSerialization(Node& context, boo
 static void mergeTextDecorationValues(CSSValueList& mergedValue, const CSSValueList& valueToMerge)
 {
     auto& cssValuePool = CSSValuePool::singleton();
-    Ref<CSSPrimitiveValue> underline = cssValuePool.createIdentifierValue(CSSValueUnderline);
-    Ref<CSSPrimitiveValue> lineThrough = cssValuePool.createIdentifierValue(CSSValueLineThrough);
 
-    if (valueToMerge.hasValue(underline.ptr()) && !mergedValue.hasValue(underline.ptr()))
-        mergedValue.append(WTFMove(underline));
+    if (valueToMerge.hasValue(CSSValueUnderline) && !mergedValue.hasValue(CSSValueUnderline))
+        mergedValue.append(cssValuePool.createIdentifierValue(CSSValueUnderline));
 
-    if (valueToMerge.hasValue(lineThrough.ptr()) && !mergedValue.hasValue(lineThrough.ptr()))
-        mergedValue.append(WTFMove(lineThrough));
+    if (valueToMerge.hasValue(CSSValueLineThrough) && !mergedValue.hasValue(CSSValueLineThrough))
+        mergedValue.append(cssValuePool.createIdentifierValue(CSSValueLineThrough));
 }
 
 void EditingStyle::mergeStyle(const StyleProperties* style, CSSPropertyOverrideMode mode)
@@ -1287,10 +1283,8 @@ void EditingStyle::mergeStyle(const StyleProperties* style, CSSPropertyOverrideM
         return;
     }
 
-    unsigned propertyCount = style->propertyCount();
-    for (unsigned i = 0; i < propertyCount; ++i) {
-        StyleProperties::PropertyReference property = style->propertyAt(i);
-        RefPtr<CSSValue> value = m_mutableStyle->getPropertyCSSValue(property.id());
+    for (auto property : *style) {
+        auto value = m_mutableStyle->getPropertyCSSValue(property.id());
 
         // text decorations never override values.
         if ((property.id() == CSSPropertyTextDecorationLine || property.id() == CSSPropertyWebkitTextDecorationsInEffect)
@@ -1324,15 +1318,14 @@ static Ref<MutableStyleProperties> styleFromMatchedRulesForElement(Element& elem
 
 void EditingStyle::mergeStyleFromRules(StyledElement& element)
 {
-    RefPtr<MutableStyleProperties> styleFromMatchedRules = styleFromMatchedRulesForElement(element,
-        Style::Resolver::AuthorCSSRules);
+    auto styleFromMatchedRules = styleFromMatchedRulesForElement(element, Style::Resolver::AuthorCSSRules);
     // Styles from the inline style declaration, held in the variable "style", take precedence 
     // over those from matched rules.
     if (m_mutableStyle)
         styleFromMatchedRules->mergeAndOverrideOnConflict(*m_mutableStyle);
 
     clear();
-    m_mutableStyle = styleFromMatchedRules;
+    m_mutableStyle = WTFMove(styleFromMatchedRules);
 }
 
 static String familyNameFromCSSPrimitiveValue(const CSSPrimitiveValue& primitiveValue)
@@ -1369,10 +1362,8 @@ void EditingStyle::mergeStyleFromRulesForSerialization(StyledElement& element, S
 
     bool shouldRemoveFontFamily = false;
     {
-        unsigned propertyCount = m_mutableStyle->propertyCount();
-        for (unsigned i = 0; i < propertyCount; ++i) {
-            StyleProperties::PropertyReference property = m_mutableStyle->propertyAt(i);
-            CSSValue& value = *property.value();
+        for (auto property : *m_mutableStyle) {
+            auto& value = *property.value();
             if (property.id() == CSSPropertyFontFamily) {
                 auto familyName = loneFontFamilyName(value);
                 if (FontCache::isSystemFontForbiddenForEditing(familyName)
@@ -1395,14 +1386,11 @@ void EditingStyle::mergeStyleFromRulesForSerialization(StyledElement& element, S
     m_mutableStyle->mergeAndOverrideOnConflict(fromComputedStyle.get());
 }
 
-static void removePropertiesInStyle(MutableStyleProperties* styleToRemovePropertiesFrom, MutableStyleProperties* style)
+static void removePropertiesInStyle(MutableStyleProperties& styleToRemovePropertiesFrom, MutableStyleProperties& style)
 {
-    unsigned propertyCount = style->propertyCount();
-    Vector<CSSPropertyID> propertiesToRemove(propertyCount);
-    for (unsigned i = 0; i < propertyCount; ++i)
-        propertiesToRemove[i] = style->propertyAt(i).id();
+    auto propertiesToRemove = map(style, [] (auto property) { return property.id(); });
 
-    styleToRemovePropertiesFrom->removePropertiesInSet(propertiesToRemove.data(), propertiesToRemove.size());
+    styleToRemovePropertiesFrom.removePropertiesInSet(propertiesToRemove.data(), propertiesToRemove.size());
 }
 
 void EditingStyle::removeStyleFromRulesAndContext(StyledElement& element, Node* context)
@@ -1411,9 +1399,9 @@ void EditingStyle::removeStyleFromRulesAndContext(StyledElement& element, Node* 
         return;
 
     // 1. Remove style from matched rules because style remain without repeating it in inline style declaration
-    RefPtr<MutableStyleProperties> styleFromMatchedRules = styleFromMatchedRulesForElement(element, Style::Resolver::AllButEmptyCSSRules);
-    if (styleFromMatchedRules && !styleFromMatchedRules->isEmpty())
-        m_mutableStyle = getPropertiesNotIn(*m_mutableStyle, *styleFromMatchedRules);
+    auto styleFromMatchedRules = styleFromMatchedRulesForElement(element, Style::Resolver::AllButEmptyCSSRules);
+    if (!styleFromMatchedRules->isEmpty())
+        m_mutableStyle = getPropertiesNotIn(*m_mutableStyle, styleFromMatchedRules.get());
 
     // 2. Remove style present in context and not overridden by matched rules.
     auto computedStyle = EditingStyle::create(context, EditingPropertiesInEffect);
@@ -1445,7 +1433,7 @@ void EditingStyle::removeStyleFromRulesAndContext(StyledElement& element, Node* 
         replaceSemanticColorWithComputedValue(CSSPropertyCaretColor);
         replaceSemanticColorWithComputedValue(CSSPropertyBackgroundColor);
 
-        removePropertiesInStyle(computedStyle->m_mutableStyle.get(), styleFromMatchedRules.get());
+        removePropertiesInStyle(*computedStyle->m_mutableStyle, styleFromMatchedRules.get());
         m_mutableStyle = getPropertiesNotIn(*m_mutableStyle, *computedStyle->m_mutableStyle);
     }
 
@@ -1464,9 +1452,9 @@ void EditingStyle::removePropertiesInElementDefaultStyle(Element& element)
     if (!m_mutableStyle || m_mutableStyle->isEmpty())
         return;
 
-    RefPtr<MutableStyleProperties> defaultStyle = styleFromMatchedRulesForElement(element, Style::Resolver::UAAndUserCSSRules);
+    auto defaultStyle = styleFromMatchedRulesForElement(element, Style::Resolver::UAAndUserCSSRules);
 
-    removePropertiesInStyle(m_mutableStyle.get(), defaultStyle.get());
+    removePropertiesInStyle(*m_mutableStyle, defaultStyle.get());
 }
 
 template<typename T>
@@ -1695,21 +1683,21 @@ Ref<EditingStyle> EditingStyle::inverseTransformColorIfNeeded(Element& element)
     return styleWithInvertedColors;
 }
 
-static void reconcileTextDecorationProperties(MutableStyleProperties* style)
+static void reconcileTextDecorationProperties(MutableStyleProperties& style)
 {    
-    RefPtr<CSSValue> textDecorationsInEffect = style->getPropertyCSSValue(CSSPropertyWebkitTextDecorationsInEffect);
-    RefPtr<CSSValue> textDecoration = style->getPropertyCSSValue(CSSPropertyTextDecorationLine);
+    auto textDecorationsInEffect = style.getPropertyCSSValue(CSSPropertyWebkitTextDecorationsInEffect);
+    auto textDecoration = style.getPropertyCSSValue(CSSPropertyTextDecorationLine);
     // We shouldn't have both text-decoration and -webkit-text-decorations-in-effect because that wouldn't make sense.
     ASSERT(!textDecorationsInEffect || !textDecoration);
     if (textDecorationsInEffect) {
-        style->setProperty(CSSPropertyTextDecorationLine, textDecorationsInEffect->cssText());
-        style->removeProperty(CSSPropertyWebkitTextDecorationsInEffect);
+        style.setProperty(CSSPropertyTextDecorationLine, textDecorationsInEffect->cssText());
+        style.removeProperty(CSSPropertyWebkitTextDecorationsInEffect);
         textDecoration = textDecorationsInEffect;
     }
 
     // If text-decoration is set to "none", remove the property because we don't want to add redundant "text-decoration: none".
     if (textDecoration && !textDecoration->isValueList())
-        style->removeProperty(CSSPropertyTextDecorationLine);
+        style.removeProperty(CSSPropertyTextDecorationLine);
 }
 
 StyleChange::StyleChange(EditingStyle* style, const Position& position)
@@ -1731,13 +1719,12 @@ StyleChange::StyleChange(EditingStyle* style, const Position& position)
     ComputedStyleExtractor computedStyle(node);
 
     // FIXME: take care of background-color in effect
-    RefPtr<MutableStyleProperties> mutableStyle = style->style() ?
-        getPropertiesNotIn(*style->style(), computedStyle) : MutableStyleProperties::create();
+    auto mutableStyle = style->style() ? getPropertiesNotIn(*style->style(), computedStyle) : MutableStyleProperties::create();
 
     reconcileTextDecorationProperties(mutableStyle.get());
     bool shouldStyleWithCSS = document->editor().shouldStyleWithCSS();
     if (!shouldStyleWithCSS)
-        extractTextStyles(*document, *mutableStyle, computedStyle.useFixedFontDefaultSize());
+        extractTextStyles(*document, mutableStyle.get(), computedStyle.useFixedFontDefaultSize());
 
     bool shouldAddUnderline = style->underlineChange() == TextDecorationChange::Add;
     bool shouldAddStrikeThrough = style->strikeThroughChange() == TextDecorationChange::Add;
@@ -1751,18 +1738,15 @@ StyleChange::StyleChange(EditingStyle* style, const Position& position)
             valueList = downcast<CSSValueList>(value.get());
 
         auto& cssValuePool = CSSValuePool::singleton();
-        Ref<CSSValue> underline = cssValuePool.createIdentifierValue(CSSValueUnderline);
-        bool hasUnderline = valueList && valueList->hasValue(underline.ptr());
-
-        Ref<CSSValue> lineThrough = cssValuePool.createIdentifierValue(CSSValueLineThrough);
-        bool hasLineThrough = valueList && valueList->hasValue(lineThrough.ptr());
+        bool hasUnderline = valueList && valueList->hasValue(CSSValueUnderline);
+        bool hasLineThrough = valueList && valueList->hasValue(CSSValueLineThrough);
 
         if (shouldStyleWithCSS) {
             valueList = valueList ? valueList->copy() : CSSValueList::createSpaceSeparated();
             if (shouldAddUnderline && !hasUnderline)
-                valueList->append(WTFMove(underline));
+                valueList->append(cssValuePool.createIdentifierValue(CSSValueUnderline));
             if (shouldAddStrikeThrough && !hasLineThrough)
-                valueList->append(WTFMove(lineThrough));
+                valueList->append(cssValuePool.createIdentifierValue(CSSValueLineThrough));
             mutableStyle->setProperty(CSSPropertyTextDecorationLine, valueList.get());
         } else {
             m_applyUnderline = shouldAddUnderline && !hasUnderline;
@@ -1780,7 +1764,7 @@ StyleChange::StyleChange(EditingStyle* style, const Position& position)
         mutableStyle->setProperty(CSSPropertyDirection, style->style()->getPropertyValue(CSSPropertyDirection));
 
     if (!mutableStyle->isEmpty())
-        m_cssStyle = mutableStyle;
+        m_cssStyle = WTFMove(mutableStyle);
 }
 
 bool StyleChange::operator==(const StyleChange& other)
@@ -1800,10 +1784,10 @@ bool StyleChange::operator==(const StyleChange& other)
         || (m_cssStyle && other.m_cssStyle && m_cssStyle->asText() == other.m_cssStyle->asText());
 }
 
-static void setTextDecorationProperty(MutableStyleProperties& style, const CSSValueList* newTextDecoration, CSSPropertyID propertyID)
+static void setTextDecorationProperty(MutableStyleProperties& style, const CSSValueList& newTextDecoration, CSSPropertyID propertyID)
 {
-    if (newTextDecoration->length())
-        style.setProperty(propertyID, newTextDecoration->cssText(), style.propertyIsImportant(propertyID));
+    if (newTextDecoration.length())
+        style.setProperty(propertyID, newTextDecoration.cssText(), style.propertyIsImportant(propertyID));
     else {
         // text-decoration: none is redundant since it does not remove any text decorations.
         style.removeProperty(propertyID);
@@ -1825,16 +1809,12 @@ void StyleChange::extractTextStyles(Document& document, MutableStyleProperties& 
 
     // Assuming reconcileTextDecorationProperties has been called, there should not be -webkit-text-decorations-in-effect
     // Furthermore, text-decoration: none has been trimmed so that text-decoration property is always a CSSValueList.
-    RefPtr<CSSValue> textDecoration = style.getPropertyCSSValue(CSSPropertyTextDecorationLine);
+    auto textDecoration = style.getPropertyCSSValue(CSSPropertyTextDecorationLine);
     if (is<CSSValueList>(textDecoration)) {
-        auto& cssValuePool = CSSValuePool::singleton();
-        RefPtr<CSSPrimitiveValue> underline = cssValuePool.createIdentifierValue(CSSValueUnderline);
-        RefPtr<CSSPrimitiveValue> lineThrough = cssValuePool.createIdentifierValue(CSSValueLineThrough);
-
-        RefPtr<CSSValueList> newTextDecoration = downcast<CSSValueList>(*textDecoration).copy();
-        if (newTextDecoration->removeAll(underline.get()))
+        auto newTextDecoration = downcast<CSSValueList>(*textDecoration).copy();
+        if (newTextDecoration->removeAll(CSSValueUnderline))
             m_applyUnderline = true;
-        if (newTextDecoration->removeAll(lineThrough.get()))
+        if (newTextDecoration->removeAll(CSSValueLineThrough))
             m_applyLineThrough = true;
 
         // If trimTextDecorations, delete underline and line-through
@@ -1878,14 +1858,14 @@ void StyleChange::extractTextStyles(Document& document, MutableStyleProperties& 
 
 static void diffTextDecorations(MutableStyleProperties& style, CSSPropertyID propertID, CSSValue* refTextDecoration)
 {
-    RefPtr<CSSValue> textDecoration = style.getPropertyCSSValue(propertID);
+    auto textDecoration = style.getPropertyCSSValue(propertID);
     if (!is<CSSValueList>(textDecoration) || !is<CSSValueList>(refTextDecoration))
         return;
 
-    RefPtr<CSSValueList> newTextDecoration = downcast<CSSValueList>(*textDecoration).copy();
+    auto newTextDecoration = downcast<CSSValueList>(*textDecoration).copy();
 
     for (auto& value :  downcast<CSSValueList>(*refTextDecoration))
-        newTextDecoration->removeAll(&value.get());
+        newTextDecoration->removeAll(value);
 
     setTextDecorationProperty(style, newTextDecoration.get(), propertID);
 }
@@ -1894,7 +1874,7 @@ template<typename T>
 static bool fontWeightIsBold(T& style)
 {
     RefPtr<CSSValue> fontWeight = extractPropertyValue(style, CSSPropertyFontWeight);
-    return fontWeight && fontWeightIsBold(*fontWeight);
+    return fontWeight && fontWeightValueIsBold(*fontWeight);
 }
 
 template<typename T>
@@ -1903,26 +1883,25 @@ static Ref<MutableStyleProperties> extractPropertiesNotIn(StyleProperties& style
     auto result = EditingStyle::create(&styleWithRedundantProperties);
     result->removeEquivalentProperties(baseStyle);
     ASSERT(result->style());
-    Ref<MutableStyleProperties> mutableStyle = *result->style();
+    Ref mutableStyle = *result->style();
 
-    RefPtr<CSSValue> baseTextDecorationsInEffect = extractPropertyValue(baseStyle, CSSPropertyWebkitTextDecorationsInEffect);
-    diffTextDecorations(mutableStyle, CSSPropertyTextDecorationLine, baseTextDecorationsInEffect.get());
-    diffTextDecorations(mutableStyle, CSSPropertyWebkitTextDecorationsInEffect, baseTextDecorationsInEffect.get());
+    auto baseTextDecorationsInEffect = extractPropertyValue(baseStyle, CSSPropertyWebkitTextDecorationsInEffect);
+    diffTextDecorations(mutableStyle.get(), CSSPropertyTextDecorationLine, baseTextDecorationsInEffect.get());
+    diffTextDecorations(mutableStyle.get(), CSSPropertyWebkitTextDecorationsInEffect, baseTextDecorationsInEffect.get());
 
-    if (extractPropertyValue(baseStyle, CSSPropertyFontWeight) && fontWeightIsBold(mutableStyle) == fontWeightIsBold(baseStyle))
+    if (extractPropertyValue(baseStyle, CSSPropertyFontWeight) && fontWeightIsBold(mutableStyle.get()) == fontWeightIsBold(baseStyle))
         mutableStyle->removeProperty(CSSPropertyFontWeight);
 
-    if (extractPropertyValue(baseStyle, CSSPropertyColor) && equalIgnoringSemanticColor(textColorFromStyle(mutableStyle), textColorFromStyle(baseStyle)))
+    if (extractPropertyValue(baseStyle, CSSPropertyColor) && equalIgnoringSemanticColor(textColorFromStyle(mutableStyle.get()), textColorFromStyle(baseStyle)))
         mutableStyle->removeProperty(CSSPropertyColor);
 
-    if (extractPropertyValue(baseStyle, CSSPropertyCaretColor) && equalIgnoringSemanticColor(caretColorFromStyle(mutableStyle), caretColorFromStyle(baseStyle)))
+    if (extractPropertyValue(baseStyle, CSSPropertyCaretColor) && equalIgnoringSemanticColor(caretColorFromStyle(mutableStyle.get()), caretColorFromStyle(baseStyle)))
         mutableStyle->removeProperty(CSSPropertyCaretColor);
 
-    if (extractPropertyValue(baseStyle, CSSPropertyTextAlign)
-        && textAlignResolvingStartAndEnd(mutableStyle) == textAlignResolvingStartAndEnd(baseStyle))
+    if (extractPropertyValue(baseStyle, CSSPropertyTextAlign) && textAlignResolvingStartAndEnd(mutableStyle.get()) == textAlignResolvingStartAndEnd(baseStyle))
         mutableStyle->removeProperty(CSSPropertyTextAlign);
 
-    if (extractPropertyValue(baseStyle, CSSPropertyBackgroundColor) && equalIgnoringSemanticColor(backgroundColorFromStyle(mutableStyle), backgroundColorFromStyle(baseStyle)))
+    if (extractPropertyValue(baseStyle, CSSPropertyBackgroundColor) && equalIgnoringSemanticColor(backgroundColorFromStyle(mutableStyle.get()), backgroundColorFromStyle(baseStyle)))
         mutableStyle->removeProperty(CSSPropertyBackgroundColor);
 
     return mutableStyle;

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4172,10 +4172,10 @@ FontAttributes Editor::fontAttributesAtSelectionStart()
     if (typingStyle && typingStyle->style()) {
         auto value = typingStyle->style()->getPropertyCSSValue(CSSPropertyWebkitTextDecorationsInEffect);
         if (value && value->isValueList()) {
-            CSSValueList& valueList = downcast<CSSValueList>(*value);
-            if (valueList.hasValue(CSSValuePool::singleton().createIdentifierValue(CSSValueLineThrough).ptr()))
+            auto& valueList = downcast<CSSValueList>(*value);
+            if (valueList.hasValue(CSSValueLineThrough))
                 attributes.hasStrikeThrough = true;
-            if (valueList.hasValue(CSSValuePool::singleton().createIdentifierValue(CSSValueUnderline).ptr()))
+            if (valueList.hasValue(CSSValueUnderline))
                 attributes.hasUnderline = true;
         }
     } else {

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -306,9 +306,8 @@ void PageSerializer::retrieveResourcesForProperties(const StyleProperties* style
     // The background-image and list-style-image (for ul or ol) are the CSS properties
     // that make use of images. We iterate to make sure we include any other
     // image properties there might be.
-    unsigned propertyCount = styleDeclaration->propertyCount();
-    for (unsigned i = 0; i < propertyCount; ++i) {
-        RefPtr<CSSValue> cssValue = styleDeclaration->propertyAt(i).value();
+    for (auto property : *styleDeclaration) {
+        auto cssValue = property.value();
         if (!is<CSSImageValue>(*cssValue))
             continue;
 

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -655,14 +655,12 @@ void ElementRuleCollector::addMatchedProperties(MatchedProperties&& matchedPrope
         if (matchedProperties.styleScopeOrdinal != ScopeOrdinal::Element)
             return false;
 
-        auto& properties = *matchedProperties.properties;
-        for (unsigned i = 0, count = properties.propertyCount(); i < count; ++i) {
+        for (auto current : *matchedProperties.properties) {
             // Currently the property cache only copy the non-inherited values and resolve
             // the inherited ones.
             // Here we define some exception were we have to resolve some properties that are not inherited
             // by default. If those exceptions become too common on the web, it should be possible
             // to build a list of exception to resolve instead of completely disabling the cache.
-            StyleProperties::PropertyReference current = properties.propertyAt(i);
             if (current.isInherited())
                 continue;
 

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -185,13 +185,10 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
     if (m_maximumCascadeLayerPriorityForRollback && !includePropertiesForRollback())
         return false;
 
-    auto& styleProperties = *matchedProperties.properties;
     auto propertyAllowlist = matchedProperties.allowlistType;
     bool hasImportantProperties = false;
 
-    for (unsigned i = 0, count = styleProperties.propertyCount(); i < count; ++i) {
-        auto current = styleProperties.propertyAt(i);
-
+    for (auto current : *matchedProperties.properties) {
         if (current.isImportant())
             hasImportantProperties = true;
         if (important != current.isImportant())
@@ -203,7 +200,7 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
             ASSERT(!current.value()->isInheritValue());
             continue;
         }
-        CSSPropertyID propertyID = current.id();
+        auto propertyID = current.id();
 
 #if ENABLE(VIDEO)
         if (propertyAllowlist == PropertyAllowlist::Cue && !isValidCueStyleProperty(propertyID))
@@ -243,8 +240,8 @@ bool PropertyCascade::addNormalMatches(CascadeLevel cascadeLevel)
 
 static bool hasImportantProperties(const StyleProperties& properties)
 {
-    for (unsigned i = 0, count = properties.propertyCount(); i < count; ++i) {
-        if (properties.propertyAt(i).isImportant())
+    for (auto property : properties) {
+        if (property.isImportant())
             return true;
     }
     return false;

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -276,10 +276,8 @@ ElementStyle Resolver::styleForElement(const Element& element, const ResolutionC
 std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, const StyleRuleKeyframe& keyframe, KeyframeValue& keyframeValue)
 {
     // Add all the animating properties to the keyframe.
-    unsigned propertyCount = keyframe.properties().propertyCount();
     bool hasRevert = false;
-    for (unsigned i = 0; i < propertyCount; ++i) {
-        auto propertyReference = keyframe.properties().propertyAt(i);
+    for (auto propertyReference : keyframe.properties()) {
         auto unresolvedProperty = propertyReference.id();
         auto resolvedProperty = CSSProperty::resolveDirectionAwareProperty(unresolvedProperty, elementStyle.direction(), elementStyle.writingMode());
         // The animation-composition and animation-timing-function within keyframes are special


### PR DESCRIPTION
#### bd076ef181ed44bc115636d4c4fa1fe70b2f0348
<pre>
Add an iterator for the StyleProperties family of classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=248546">https://bugs.webkit.org/show_bug.cgi?id=248546</a>
rdar://102823936

Reviewed by Antoine Quint.

Add iterator support for StyleProperties, ImmutableStyleProperties
and MutableStyleProperties to allow iterating through the stored
properties using for-in as well generic algorithms.

* Source/WTF/wtf/Vector.h:
(WTF::Mapper::map):
(WTF::CompactMapper::compactMap):
(WTF::copyToVectorSpecialization):
Use a universal reference to allow iterators that return temporaries
(like the one for StyleProperties) to work with the mapping code.

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computeHasImplicitKeyframeForAcceleratedProperty):
(WebCore::KeyframeEffect::computeHasKeyframeComposingAcceleratedProperty):
Adopt range-based for loop using the new iterator.

* Source/WebCore/css/CSSValueList.cpp:
(WebCore::CSSValueList::removeAll):
(WebCore::CSSValueList::hasValue const):
* Source/WebCore/css/CSSValueList.h:
Remove versions of removeAll() and hasValue() taking a nullable CSSValue*,
and replace them with overloads that take either a CSSValue&amp; or a CSSValueID.
The CSSValueID allows us to check use without allocation or pool lookup.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::fontVariantShorthandValue):
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesForShorthandProperties):
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesForGridShorthand):
Adopt range-based for loop using existing shorthand iterator support. Use
isValueID helper to simplify a condition.

* Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp:
(WebCore::PropertySetCSSStyleDeclaration::length const):
Adopt range-based for loop using the new iterator.

* Source/WebCore/css/StyleProperties.cpp:
(WebCore::MutableStyleProperties::MutableStyleProperties):
(WebCore::StyleProperties::commonShorthandChecks const):
(WebCore::StyleProperties::asTextInternal const):
(WebCore::MutableStyleProperties::mergeAndOverrideOnConflict):
(WebCore::StyleProperties::traverseSubresources const):
* Source/WebCore/css/StyleProperties.h:
(WebCore::StyleProperties::Iterator::Iterator):
(WebCore::StyleProperties::Iterator::operator* const):
(WebCore::StyleProperties::Iterator::operator++):
(WebCore::StyleProperties::Iterator::operator== const):
(WebCore::StyleProperties::Iterator::operator!= const):
(WebCore::StyleProperties::begin const):
(WebCore::StyleProperties::end):
(WebCore::StyleProperties::size const):
Adds and adopts iterator support. The two subclasses of StyleProperties
overload begin() to allow specialization when the concrete type is known.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeTouchAction):
(WebCore::CSSPropertyParserHelpers::consumeTextDecorationLine):
Adopt template consumeIdent and update for new reference taking hasValue().

* Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp:
(WebCore::DeclaredStylePropertyMap::entries const):
Adopt WTF::map() now that it can be used due to iterator for StyleProperties.

* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::applyTextDecorationChangeToValueList):
Update for new hasValue/removeValue interfaces.

(WebCore::EditingStyle::removeStyleAddedByNode):
Use auto (which is going to infer Ref now rather than RefPtr) and update
uses to pass non-null references.

(WebCore::EditingStyle::removeStyleConflictingWithStyleOfNode):
Adopt range-based for loop using the new iterator.

(WebCore::EditingStyle::conflictsWithInlineStyleOfElement const):
Adopt range-based for loop using the new iterator.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::fontAttributesAtSelectionStart):
Adopt new CSSValueID overloads of hasValue.

* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::retrieveResourcesForProperties):
Adopt range-based for loop using the new iterator.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::addMatchedProperties):
Adopt range-based for loop using the new iterator.

* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::addMatch):
(WebCore::Style::hasImportantProperties):
Adopt range-based for loop using the new iterator.

* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe):
Adopt range-based for loop using the new iterator.

Canonical link: <a href="https://commits.webkit.org/257356@main">https://commits.webkit.org/257356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62c3aa9910a4e355d7a2c2fd14abbfcd5f694159

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98652 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108073 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168335 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85239 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91189 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6337 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89907 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33359 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88162 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21254 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76285 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89435 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1794 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22783 "Found 30 new test failures: http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/uri/assign-path-with-leading-slash.html, http/wpt/fetch/response-opaque-clone.html, imported/w3c/web-platform-tests/content-security-policy/reporting/report-original-url-on-mixed-content-frame.https.sub.html, imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-report-only-policy-works-with-external-hash-policy.html, imported/w3c/web-platform-tests/css/css-flexbox/intrinsic-size/row-005.html, imported/w3c/web-platform-tests/fetch/api/request/request-cache-only-if-cached.any.html, imported/w3c/web-platform-tests/fetch/http-cache/vary.any.sharedworker.html, imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-load-from-cache-storage.https.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-popup.https.html ... (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85210 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1704 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45273 "Found 1 new test failure: media/video-inactive-playback.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28747 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5047 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6645 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42230 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88062 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2542 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3093 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19723 "Passed tests") | 
<!--EWS-Status-Bubble-End-->