### PR TITLE
StylePropertyMap.set() should wrap value in a calc() if outside the allowed range

### DIFF
--- a/LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value-expected.txt
+++ b/LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value-expected.txt
@@ -1,0 +1,13 @@
+Checks that calling StylePropertyMap.set() with a negative value wraps it into a calc.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS target.attributeStyleMap.set('width', new CSSUnitValue(-3.14, 'percent')) did not throw exception.
+PASS target.style.width is "calc(-3.14%)"
+PASS target.attributeStyleMap.set('perspective', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.perspective is "calc(-32px)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value.html
+++ b/LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<div id="target"></div>
+<script>
+description("Checks that calling StylePropertyMap.set() with a negative value wraps it into a calc.");
+
+target = document.getElementById("target");
+shouldNotThrow("target.attributeStyleMap.set('width', new CSSUnitValue(-3.14, 'percent'))");
+shouldBeEqualToString("target.style.width", "calc(-3.14%)");
+
+shouldNotThrow("target.attributeStyleMap.set('perspective', new CSSUnitValue(-32, 'px'))");
+shouldBeEqualToString("target.style.perspective", "calc(-32px)");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt
@@ -2,8 +2,8 @@
 PASS Can set 'block-size' to CSS-wide keywords
 FAIL Can set 'block-size' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'block-size' to the 'auto' keyword
-FAIL Can set 'block-size' to a percent Invalid values
-FAIL Can set 'block-size' to a length Invalid values
+FAIL Can set 'block-size' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'block-size' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'block-size' to a time throws TypeError
 PASS Setting 'block-size' to an angle throws TypeError
 PASS Setting 'block-size' to a flexible length throws TypeError
@@ -12,8 +12,8 @@ PASS Setting 'block-size' to a URL throws TypeError
 PASS Setting 'block-size' to a transform throws TypeError
 PASS Can set 'min-block-size' to CSS-wide keywords
 FAIL Can set 'min-block-size' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'min-block-size' to a percent Invalid values
-FAIL Can set 'min-block-size' to a length Invalid values
+FAIL Can set 'min-block-size' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'min-block-size' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'min-block-size' to a time throws TypeError
 PASS Setting 'min-block-size' to an angle throws TypeError
 PASS Setting 'min-block-size' to a flexible length throws TypeError
@@ -23,8 +23,8 @@ PASS Setting 'min-block-size' to a transform throws TypeError
 PASS Can set 'max-block-size' to CSS-wide keywords
 FAIL Can set 'max-block-size' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'max-block-size' to the 'none' keyword
-FAIL Can set 'max-block-size' to a percent Invalid values
-FAIL Can set 'max-block-size' to a length Invalid values
+FAIL Can set 'max-block-size' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'max-block-size' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'max-block-size' to a time throws TypeError
 PASS Setting 'max-block-size' to an angle throws TypeError
 PASS Setting 'max-block-size' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-count-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-count-expected.txt
@@ -2,7 +2,7 @@
 PASS Can set 'column-count' to CSS-wide keywords
 FAIL Can set 'column-count' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'column-count' to the 'auto' keyword
-FAIL Can set 'column-count' to a number Invalid values
+FAIL Can set 'column-count' to a number assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
 PASS Setting 'column-count' to a length throws TypeError
 PASS Setting 'column-count' to a percent throws TypeError
 PASS Setting 'column-count' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt
@@ -4,7 +4,7 @@ FAIL Can set 'column-rule-width' to var() references assert_equals: expected 2 b
 PASS Can set 'column-rule-width' to the 'thin' keyword
 PASS Can set 'column-rule-width' to the 'medium' keyword
 PASS Can set 'column-rule-width' to the 'thick' keyword
-FAIL Can set 'column-rule-width' to a length Invalid values
+FAIL Can set 'column-rule-width' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'column-rule-width' to a percent throws TypeError
 PASS Setting 'column-rule-width' to a time throws TypeError
 PASS Setting 'column-rule-width' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'flex-grow' to CSS-wide keywords
 FAIL Can set 'flex-grow' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'flex-grow' to a number Invalid values
+FAIL Can set 'flex-grow' to a number assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Setting 'flex-grow' to a length throws TypeError
 PASS Setting 'flex-grow' to a percent throws TypeError
 PASS Setting 'flex-grow' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'flex-shrink' to CSS-wide keywords
 FAIL Can set 'flex-shrink' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'flex-shrink' to a number Invalid values
+FAIL Can set 'flex-shrink' to a number assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Setting 'flex-shrink' to a length throws TypeError
 PASS Setting 'flex-shrink' to a percent throws TypeError
 PASS Setting 'flex-shrink' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt
@@ -2,7 +2,7 @@
 PASS Can set 'font-size-adjust' to CSS-wide keywords
 FAIL Can set 'font-size-adjust' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'font-size-adjust' to the 'none' keyword
-FAIL Can set 'font-size-adjust' to a number Invalid values
+FAIL Can set 'font-size-adjust' to a number assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Setting 'font-size-adjust' to a length throws TypeError
 PASS Setting 'font-size-adjust' to a percent throws TypeError
 PASS Setting 'font-size-adjust' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt
@@ -10,8 +10,8 @@ PASS Can set 'font-size' to the 'x-large' keyword
 PASS Can set 'font-size' to the 'xx-large' keyword
 PASS Can set 'font-size' to the 'larger' keyword
 PASS Can set 'font-size' to the 'smaller' keyword
-FAIL Can set 'font-size' to a length Invalid values
-FAIL Can set 'font-size' to a percent Invalid values
+FAIL Can set 'font-size' to a length assert_equals: expected "px" but got "em"
+FAIL Can set 'font-size' to a percent assert_equals: expected 2 but got 1
 PASS Setting 'font-size' to a time throws TypeError
 PASS Setting 'font-size' to an angle throws TypeError
 PASS Setting 'font-size' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt
@@ -10,7 +10,7 @@ FAIL Can set 'font-stretch' to the 'semi-expanded' keyword assert_equals: expect
 FAIL Can set 'font-stretch' to the 'expanded' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'font-stretch' to the 'extra-expanded' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'font-stretch' to the 'ultra-expanded' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'font-stretch' to a percent Invalid values
+FAIL Can set 'font-stretch' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Setting 'font-stretch' to a length throws TypeError
 PASS Setting 'font-stretch' to a time throws TypeError
 PASS Setting 'font-stretch' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt
@@ -2,8 +2,8 @@
 PASS Can set 'height' to CSS-wide keywords
 FAIL Can set 'height' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'height' to the 'auto' keyword
-FAIL Can set 'height' to a percent Invalid values
-FAIL Can set 'height' to a length Invalid values
+FAIL Can set 'height' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'height' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'height' to a time throws TypeError
 PASS Setting 'height' to an angle throws TypeError
 PASS Setting 'height' to a flexible length throws TypeError
@@ -12,8 +12,8 @@ PASS Setting 'height' to a URL throws TypeError
 PASS Setting 'height' to a transform throws TypeError
 PASS Can set 'min-height' to CSS-wide keywords
 FAIL Can set 'min-height' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'min-height' to a percent Invalid values
-FAIL Can set 'min-height' to a length Invalid values
+FAIL Can set 'min-height' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'min-height' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'min-height' to a time throws TypeError
 PASS Setting 'min-height' to an angle throws TypeError
 PASS Setting 'min-height' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt
@@ -2,8 +2,8 @@
 PASS Can set 'inline-size' to CSS-wide keywords
 FAIL Can set 'inline-size' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'inline-size' to the 'auto' keyword
-FAIL Can set 'inline-size' to a percent Invalid values
-FAIL Can set 'inline-size' to a length Invalid values
+FAIL Can set 'inline-size' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'inline-size' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'inline-size' to a time throws TypeError
 PASS Setting 'inline-size' to an angle throws TypeError
 PASS Setting 'inline-size' to a flexible length throws TypeError
@@ -12,8 +12,8 @@ PASS Setting 'inline-size' to a URL throws TypeError
 PASS Setting 'inline-size' to a transform throws TypeError
 PASS Can set 'min-inline-size' to CSS-wide keywords
 FAIL Can set 'min-inline-size' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'min-inline-size' to a percent Invalid values
-FAIL Can set 'min-inline-size' to a length Invalid values
+FAIL Can set 'min-inline-size' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'min-inline-size' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'min-inline-size' to a time throws TypeError
 PASS Setting 'min-inline-size' to an angle throws TypeError
 PASS Setting 'min-inline-size' to a flexible length throws TypeError
@@ -23,8 +23,8 @@ PASS Setting 'min-inline-size' to a transform throws TypeError
 PASS Can set 'max-inline-size' to CSS-wide keywords
 FAIL Can set 'max-inline-size' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'max-inline-size' to the 'none' keyword
-FAIL Can set 'max-inline-size' to a percent Invalid values
-FAIL Can set 'max-inline-size' to a length Invalid values
+FAIL Can set 'max-inline-size' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'max-inline-size' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'max-inline-size' to a time throws TypeError
 PASS Setting 'max-inline-size' to an angle throws TypeError
 PASS Setting 'max-inline-size' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
@@ -121,8 +121,8 @@ PASS Setting 'inset-inline' to a URL throws TypeError
 PASS Setting 'inset-inline' to a transform throws TypeError
 PASS Can set 'padding-block-start' to CSS-wide keywords
 FAIL Can set 'padding-block-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-block-start' to a percent Invalid values
-FAIL Can set 'padding-block-start' to a length Invalid values
+FAIL Can set 'padding-block-start' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'padding-block-start' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'padding-block-start' to a time throws TypeError
 PASS Setting 'padding-block-start' to an angle throws TypeError
 PASS Setting 'padding-block-start' to a flexible length throws TypeError
@@ -131,8 +131,8 @@ PASS Setting 'padding-block-start' to a URL throws TypeError
 PASS Setting 'padding-block-start' to a transform throws TypeError
 PASS Can set 'padding-block-end' to CSS-wide keywords
 FAIL Can set 'padding-block-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-block-end' to a percent Invalid values
-FAIL Can set 'padding-block-end' to a length Invalid values
+FAIL Can set 'padding-block-end' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'padding-block-end' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'padding-block-end' to a time throws TypeError
 PASS Setting 'padding-block-end' to an angle throws TypeError
 PASS Setting 'padding-block-end' to a flexible length throws TypeError
@@ -141,8 +141,8 @@ PASS Setting 'padding-block-end' to a URL throws TypeError
 PASS Setting 'padding-block-end' to a transform throws TypeError
 PASS Can set 'padding-inline-start' to CSS-wide keywords
 FAIL Can set 'padding-inline-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-inline-start' to a percent Invalid values
-FAIL Can set 'padding-inline-start' to a length Invalid values
+FAIL Can set 'padding-inline-start' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'padding-inline-start' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'padding-inline-start' to a time throws TypeError
 PASS Setting 'padding-inline-start' to an angle throws TypeError
 PASS Setting 'padding-inline-start' to a flexible length throws TypeError
@@ -151,8 +151,8 @@ PASS Setting 'padding-inline-start' to a URL throws TypeError
 PASS Setting 'padding-inline-start' to a transform throws TypeError
 PASS Can set 'padding-inline-end' to CSS-wide keywords
 FAIL Can set 'padding-inline-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-inline-end' to a percent Invalid values
-FAIL Can set 'padding-inline-end' to a length Invalid values
+FAIL Can set 'padding-inline-end' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'padding-inline-end' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'padding-inline-end' to a time throws TypeError
 PASS Setting 'padding-inline-end' to an angle throws TypeError
 PASS Setting 'padding-inline-end' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'orphans' to CSS-wide keywords
 FAIL Can set 'orphans' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'orphans' to a number Invalid values
+FAIL Can set 'orphans' to a number assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
 PASS Setting 'orphans' to a length throws TypeError
 PASS Setting 'orphans' to a percent throws TypeError
 PASS Setting 'orphans' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Can set 'padding-top' to CSS-wide keywords
 FAIL Can set 'padding-top' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-top' to a percent Invalid values
-FAIL Can set 'padding-top' to a length Invalid values
+FAIL Can set 'padding-top' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'padding-top' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'padding-top' to a time throws TypeError
 PASS Setting 'padding-top' to an angle throws TypeError
 PASS Setting 'padding-top' to a flexible length throws TypeError
@@ -11,8 +11,8 @@ PASS Setting 'padding-top' to a URL throws TypeError
 PASS Setting 'padding-top' to a transform throws TypeError
 PASS Can set 'padding-left' to CSS-wide keywords
 FAIL Can set 'padding-left' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-left' to a percent Invalid values
-FAIL Can set 'padding-left' to a length Invalid values
+FAIL Can set 'padding-left' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'padding-left' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'padding-left' to a time throws TypeError
 PASS Setting 'padding-left' to an angle throws TypeError
 PASS Setting 'padding-left' to a flexible length throws TypeError
@@ -21,8 +21,8 @@ PASS Setting 'padding-left' to a URL throws TypeError
 PASS Setting 'padding-left' to a transform throws TypeError
 PASS Can set 'padding-right' to CSS-wide keywords
 FAIL Can set 'padding-right' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-right' to a percent Invalid values
-FAIL Can set 'padding-right' to a length Invalid values
+FAIL Can set 'padding-right' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'padding-right' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'padding-right' to a time throws TypeError
 PASS Setting 'padding-right' to an angle throws TypeError
 PASS Setting 'padding-right' to a flexible length throws TypeError
@@ -31,8 +31,8 @@ PASS Setting 'padding-right' to a URL throws TypeError
 PASS Setting 'padding-right' to a transform throws TypeError
 PASS Can set 'padding-bottom' to CSS-wide keywords
 FAIL Can set 'padding-bottom' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-bottom' to a percent Invalid values
-FAIL Can set 'padding-bottom' to a length Invalid values
+FAIL Can set 'padding-bottom' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'padding-bottom' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'padding-bottom' to a time throws TypeError
 PASS Setting 'padding-bottom' to an angle throws TypeError
 PASS Setting 'padding-bottom' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt
@@ -2,7 +2,7 @@
 PASS Can set 'perspective' to CSS-wide keywords
 FAIL Can set 'perspective' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'perspective' to the 'none' keyword
-FAIL Can set 'perspective' to a length Invalid values
+FAIL Can set 'perspective' to a length assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSKeywordValue]"
 PASS Setting 'perspective' to a percent throws TypeError
 PASS Setting 'perspective' to a time throws TypeError
 PASS Setting 'perspective' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Can set 'r' to CSS-wide keywords
 FAIL Can set 'r' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'r' to a percent Invalid values
-FAIL Can set 'r' to a length Invalid values
+FAIL Can set 'r' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'r' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'r' to a time throws TypeError
 PASS Setting 'r' to an angle throws TypeError
 PASS Setting 'r' to a flexible length throws TypeError
@@ -12,8 +12,8 @@ PASS Setting 'r' to a transform throws TypeError
 PASS Can set 'rx' to CSS-wide keywords
 FAIL Can set 'rx' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'rx' to the 'auto' keyword
-FAIL Can set 'rx' to a percent Invalid values
-FAIL Can set 'rx' to a length Invalid values
+FAIL Can set 'rx' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'rx' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'rx' to a time throws TypeError
 PASS Setting 'rx' to an angle throws TypeError
 PASS Setting 'rx' to a flexible length throws TypeError
@@ -23,8 +23,8 @@ PASS Setting 'rx' to a transform throws TypeError
 PASS Can set 'ry' to CSS-wide keywords
 FAIL Can set 'ry' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'ry' to the 'auto' keyword
-FAIL Can set 'ry' to a percent Invalid values
-FAIL Can set 'ry' to a length Invalid values
+FAIL Can set 'ry' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'ry' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'ry' to a time throws TypeError
 PASS Setting 'ry' to an angle throws TypeError
 PASS Setting 'ry' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Can set 'shape-margin' to CSS-wide keywords
 FAIL Can set 'shape-margin' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'shape-margin' to a length Invalid values
-FAIL Can set 'shape-margin' to a percent Invalid values
+FAIL Can set 'shape-margin' to a length assert_equals: expected "px" but got "em"
+FAIL Can set 'shape-margin' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Setting 'shape-margin' to a time throws TypeError
 PASS Setting 'shape-margin' to an angle throws TypeError
 PASS Setting 'shape-margin' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/tab-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/tab-size-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Can set 'tab-size' to CSS-wide keywords
 FAIL Can set 'tab-size' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'tab-size' to a number Invalid values
-FAIL Can set 'tab-size' to a length Invalid values
+FAIL Can set 'tab-size' to a number assert_equals: expected 2 but got 1
+FAIL Can set 'tab-size' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'tab-size' to a percent throws TypeError
 PASS Setting 'tab-size' to a time throws TypeError
 PASS Setting 'tab-size' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'widows' to CSS-wide keywords
 FAIL Can set 'widows' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'widows' to a number Invalid values
+FAIL Can set 'widows' to a number assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
 PASS Setting 'widows' to a length throws TypeError
 PASS Setting 'widows' to a percent throws TypeError
 PASS Setting 'widows' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt
@@ -2,8 +2,8 @@
 PASS Can set 'width' to CSS-wide keywords
 FAIL Can set 'width' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'width' to the 'auto' keyword
-FAIL Can set 'width' to a percent Invalid values
-FAIL Can set 'width' to a length Invalid values
+FAIL Can set 'width' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'width' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'width' to a time throws TypeError
 PASS Setting 'width' to an angle throws TypeError
 PASS Setting 'width' to a flexible length throws TypeError
@@ -12,8 +12,8 @@ PASS Setting 'width' to a URL throws TypeError
 PASS Setting 'width' to a transform throws TypeError
 PASS Can set 'min-width' to CSS-wide keywords
 FAIL Can set 'min-width' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'min-width' to a percent Invalid values
-FAIL Can set 'min-width' to a length Invalid values
+FAIL Can set 'min-width' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'min-width' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'min-width' to a time throws TypeError
 PASS Setting 'min-width' to an angle throws TypeError
 PASS Setting 'min-width' to a flexible length throws TypeError

--- a/Source/WebCore/css/calc/CSSCalcExpressionNode.h
+++ b/Source/WebCore/css/calc/CSSCalcExpressionNode.h
@@ -61,6 +61,8 @@ public:
     virtual void collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>&) const = 0;
     virtual bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const = 0;
 
+    bool shouldForceEnclosingCalcInCSSText() const { return m_shouldForceEnclosingCalcInCSSText; }
+    void setShouldForceEnclosingCalcInCSSText() { m_shouldForceEnclosingCalcInCSSText = true; }
 
     CalculationCategory category() const { return m_category; }
 
@@ -74,6 +76,7 @@ protected:
 
 private:
     CalculationCategory m_category;
+    bool m_shouldForceEnclosingCalcInCSSText { false };
 };
 
 TextStream& operator<<(TextStream&, const CSSCalcExpressionNode&);

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -1085,6 +1085,8 @@ bool CSSCalcOperationNode::convertingToLengthRequiresNonNullStyle(int lengthConv
 void CSSCalcOperationNode::buildCSSText(const CSSCalcExpressionNode& node, StringBuilder& builder)
 {
     auto shouldOutputEnclosingCalc = [](const CSSCalcExpressionNode& rootNode) {
+        if (rootNode.shouldForceEnclosingCalcInCSSText())
+            return true;
         if (is<CSSCalcOperationNode>(rootNode)) {
             auto& operationNode = downcast<CSSCalcOperationNode>(rootNode);
             return operationNode.isCalcSumNode() || operationNode.isCalcProductNode();

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -49,7 +49,7 @@
 
 namespace WebCore {
 
-static inline bool isSimpleLengthPropertyID(CSSPropertyID propertyId, bool& acceptsNegativeNumbers)
+bool CSSParserFastPaths::isSimpleLengthPropertyID(CSSPropertyID propertyId, bool& acceptsNegativeNumbers)
 {
     switch (propertyId) {
     case CSSPropertyFontSize:
@@ -158,7 +158,7 @@ static RefPtr<CSSValue> parseSimpleLengthValue(CSSPropertyID propertyId, StringV
     bool acceptsNegativeNumbers = false;
 
     // In @viewport, width and height are shorthands, not simple length values.
-    if (isCSSViewportParsingEnabledForMode(cssParserMode) || !isSimpleLengthPropertyID(propertyId, acceptsNegativeNumbers))
+    if (isCSSViewportParsingEnabledForMode(cssParserMode) || !CSSParserFastPaths::isSimpleLengthPropertyID(propertyId, acceptsNegativeNumbers))
         return nullptr;
 
     unsigned length = string.length();

--- a/Source/WebCore/css/parser/CSSParserFastPaths.h
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.h
@@ -54,6 +54,8 @@ public:
     static std::optional<SRGBA<uint8_t>> parseSimpleColor(StringView, bool strict = false);
     static std::optional<SRGBA<uint8_t>> parseHexColor(StringView); // Hex colors of length 3, 4, 6, or 8, without leading "#".
     static std::optional<SRGBA<uint8_t>> parseNamedColor(StringView);
+
+    static bool isSimpleLengthPropertyID(CSSPropertyID, bool& acceptsNegativeNumbers);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/CSSStyleValue.h
+++ b/Source/WebCore/css/typedom/CSSStyleValue.h
@@ -123,6 +123,7 @@ IGNORE_GCC_WARNINGS_END
     static Ref<CSSStyleValue> create();
 
     virtual RefPtr<CSSValue> toCSSValue() const { return m_propertyValue; }
+    virtual RefPtr<CSSValue> toCSSValueWithProperty(CSSPropertyID) const { return toCSSValue(); }
 
 protected:
     CSSStyleValue(RefPtr<CSSValue>&&, String&& = String());

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -31,8 +31,11 @@
 #include "CSSUnitValue.h"
 
 #include "CSSCalcPrimitiveValueNode.h"
+#include "CSSCalcValue.h"
+#include "CSSParserFastPaths.h"
 #include "CSSParserToken.h"
 #include "CSSPrimitiveValue.h"
+#include <cmath>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -184,6 +187,60 @@ bool CSSUnitValue::equals(const CSSNumericValue& other) const
 RefPtr<CSSValue> CSSUnitValue::toCSSValue() const
 {
     return CSSPrimitiveValue::create(m_value, m_unit);
+}
+
+static bool isValueOutOfRangeForProperty(CSSPropertyID propertyID, double value, CSSUnitType unit)
+{
+    bool acceptsNegativeNumbers = true;
+    if (CSSParserFastPaths::isSimpleLengthPropertyID(propertyID, acceptsNegativeNumbers) && !acceptsNegativeNumbers && value < 0)
+        return true;
+
+    switch (propertyID) {
+    case CSSPropertyOrder:
+    case CSSPropertyZIndex:
+        return round(value) != value;
+    case CSSPropertyTabSize:
+        return value < 0 || (unit == CSSUnitType::CSS_NUMBER && round(value) != value);
+    case CSSPropertyOrphans:
+    case CSSPropertyWidows:
+    case CSSPropertyColumnCount:
+        return round(value) != value || value < 1;
+    case CSSPropertyBlockSize:
+    case CSSPropertyColumnRuleWidth:
+    case CSSPropertyFlexGrow:
+    case CSSPropertyFlexShrink:
+    case CSSPropertyFontSize:
+    case CSSPropertyFontSizeAdjust:
+    case CSSPropertyFontStretch:
+    case CSSPropertyInlineSize:
+    case CSSPropertyMaxBlockSize:
+    case CSSPropertyMaxInlineSize:
+    case CSSPropertyMinBlockSize:
+    case CSSPropertyMinInlineSize:
+    case CSSPropertyPerspective:
+    case CSSPropertyR:
+    case CSSPropertyRx:
+    case CSSPropertyRy:
+        return value < 0;
+    case CSSPropertyFontWeight:
+        return value < 0 || value > 1000;
+    default:
+        return false;
+    }
+}
+
+RefPtr<CSSValue> CSSUnitValue::toCSSValueWithProperty(CSSPropertyID propertyID) const
+{
+    if (isValueOutOfRangeForProperty(propertyID, m_value, m_unit)) {
+        // Wrap out of range values with a calc.
+        auto node = toCalcExpressionNode();
+        ASSERT(node);
+        // By default, cssText() will drop the enclosing `calc()` for simple expressions. However, it is important we
+        // keep it here or setting the value will fail.
+        node->setShouldForceEnclosingCalcInCSSText();
+        return CSSCalcValue::create(node.releaseNonNull(), true /* allowsNegativePercentage */);
+    }
+    return toCSSValue();
 }
 
 RefPtr<CSSCalcExpressionNode> CSSUnitValue::toCalcExpressionNode() const

--- a/Source/WebCore/css/typedom/CSSUnitValue.h
+++ b/Source/WebCore/css/typedom/CSSUnitValue.h
@@ -52,6 +52,7 @@ public:
     static CSSUnitType parseUnit(const String& unit);
 
     RefPtr<CSSValue> toCSSValue() const final;
+    RefPtr<CSSValue> toCSSValueWithProperty(CSSPropertyID) const final;
     RefPtr<CSSCalcExpressionNode> toCalcExpressionNode() const final;
 
 private:

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -42,11 +42,17 @@ static RefPtr<CSSValue> cssValueFromStyleValues(std::optional<CSSPropertyID> pro
 {
     if (values.isEmpty())
         return nullptr;
+
+    auto toCSSValue = [propertyID](CSSStyleValue& styleValue) {
+        if (propertyID)
+            return styleValue.toCSSValueWithProperty(*propertyID);
+        return styleValue.toCSSValue();
+    };
     if (values.size() == 1)
-        return values[0]->toCSSValue();
+        return toCSSValue(values[0]);
     auto list = propertyID ? CSSProperty::createListForProperty(*propertyID) : CSSValueList::createCommaSeparated();
     for (auto&& value : WTFMove(values)) {
-        if (auto cssValue = value->toCSSValue())
+        if (auto cssValue = toCSSValue(value))
             list->append(cssValue.releaseNonNull());
     }
     return list;


### PR DESCRIPTION
#### 2a77eefbdefdfe3b450259a8b108f6a79f457d7a
<pre>
StylePropertyMap.set() should wrap value in a calc() if outside the allowed range
<a href="https://bugs.webkit.org/show_bug.cgi?id=248547">https://bugs.webkit.org/show_bug.cgi?id=248547</a>

Reviewed by Antti Koivisto.

StylePropertyMap.set() should wrap value in a calc() if outside the allowed
range for the given property, instead of throwing.

This is the behavior expected by WPT tests and it matches what Blink is doing,
though I cannot find a reference to this in the specification:
- <a href="https://github.com/w3c/css-houdini-drafts/issues/1081">https://github.com/w3c/css-houdini-drafts/issues/1081</a>

This is covered by a lot of WPT tests. Sadly, those WPT tests still don&apos;t pass
because we fail a following subtest (which I&apos;ll investigate next).

For clarity, I extracted this separate check into its own test:
- fast/css/css-typed-om/style-property-map-set-negative-value.html

* LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value-expected.txt: Added.
* LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-count-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/tab-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt:
* Source/WebCore/css/calc/CSSCalcExpressionNode.h:
(WebCore::CSSCalcExpressionNode::shouldForceEnclosingCalcInCSSText const):
(WebCore::CSSCalcExpressionNode::setShouldForceEnclosingCalcInCSSText):
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::CSSCalcOperationNode::buildCSSText):
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::CSSParserFastPaths::isSimpleLengthPropertyID):
(WebCore::parseSimpleLengthValue):
(WebCore::isSimpleLengthPropertyID): Deleted.
* Source/WebCore/css/parser/CSSParserFastPaths.h:
* Source/WebCore/css/typedom/CSSStyleValue.h:
(WebCore::CSSStyleValue::toCSSValueWithProperty const):
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::isValueOutOfRangeForProperty):
(WebCore::CSSUnitValue::toCSSValueWithProperty const):
* Source/WebCore/css/typedom/CSSUnitValue.h:
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::cssValueFromStyleValues):

Canonical link: <a href="https://commits.webkit.org/257485@main">https://commits.webkit.org/257485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05c67dbb7aa7616467cd9a78d34b6317ed871d8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108446 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168695 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103013 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85615 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91563 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106400 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33678 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76533 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2150 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23104 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2048 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45514 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42579 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2614 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3465 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->