### PR TITLE
[macOS] Data detector highlights are broken with UI-side compositing

### DIFF
--- a/Source/WebCore/platform/mac/DataDetectorHighlight.h
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.h
@@ -29,6 +29,7 @@
 
 #import "GraphicsLayerClient.h"
 #import "SimpleRange.h"
+#import "Timer.h"
 #import <wtf/RefCounted.h>
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>
@@ -88,6 +89,8 @@ private:
     void paintContents(const GraphicsLayer*, GraphicsContext&, const FloatRect& inClip, GraphicsLayerPaintBehavior) override;
     float deviceScaleFactor() const override;
 
+    void fadeAnimationTimerFired();
+    void startFadeAnimation();
     void didFinishFadeOutAnimation();
 
     WeakPtr<DataDetectorHighlightClient> m_client;
@@ -96,6 +99,12 @@ private:
     SimpleRange m_range;
     Ref<GraphicsLayer> m_graphicsLayer;
     Type m_type { Type::None };
+
+    Timer m_fadeAnimationTimer;
+    WallTime m_fadeAnimationStartTime;
+
+    enum class FadeAnimationState : uint8_t { NotAnimating, FadingIn, FadingOut };
+    FadeAnimationState m_fadeAnimationState { FadeAnimationState::NotAnimating };
 };
 
 bool areEquivalent(const DataDetectorHighlight*, const DataDetectorHighlight*);


### PR DESCRIPTION
#### dc20f61c73d1c88b51f1d6d9811c8a068df04d67
<pre>
[macOS] Data detector highlights are broken with UI-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=248548">https://bugs.webkit.org/show_bug.cgi?id=248548</a>
rdar://101664503

Reviewed by Simon Fraser.

Data detector highlights are currently broken when with UI-side compositing
and DOM rendering using the GPU process for two reasons:

1. There is no platform graphics context in the web process, which means
   highlights cannot be painted by simply using CG drawing commands.
2. CALayer&apos;s are no longer accessible in the web process, which means the
   existing fade in/out animation no longer works.

Both these problems could be solved by moving all highlight rendering logic
into the UI process. However, that solution was not chosen, as it would be a
complex refactoring, and would make scrolling highlights difficult.

To fix (1), highlights are now drawn into a local image buffer, which is then
drawn into the graphics context using a display list command. An alternative
approach to fix (1) would be to add a new display list drawing command to draw
Data Detector highlights. However, that solution introduces unnecessary
complexity. Furthermore, this drawing command does not really make sense for
other platforms.

To fix (2), the fade animation is now performed using a timer, similar to the
animation of PageOverlay. An alternative approach to fix (2) would be to add
animations to the GraphicsLayer itself. However, the current animation
infrastructure lacks the ability to specify a single &quot;to&quot; animation, and does
not provide a clean way to detect completion. Given the short duration of the
animation, and the fact that Data Detector highlights are not a hot codepath, a
simple Timer-based animation is used instead.

* Source/WebCore/platform/mac/DataDetectorHighlight.h:
* Source/WebCore/platform/mac/DataDetectorHighlight.mm:
(WebCore::DataDetectorHighlight::DataDetectorHighlight):
(WebCore::DataDetectorHighlight::invalidate):
(WebCore::DataDetectorHighlight::paintContents):
(WebCore::DataDetectorHighlight::fadeAnimationTimerFired):
(WebCore::DataDetectorHighlight::fadeIn):
(WebCore::DataDetectorHighlight::fadeOut):
(WebCore::DataDetectorHighlight::startFadeAnimation):

Canonical link: <a href="https://commits.webkit.org/257261@main">https://commits.webkit.org/257261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfbce49f1b4db486b3a0804bf20cec722865a009

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107655 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167937 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7901 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36173 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90783 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104241 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5938 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84790 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33045 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89517 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75982 "Found 3 new API test failures: /WebKitGTK/TestWebKitUserContentFilterStore:/webkit/WebKitUserContentFilterStore/filter-save-load, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/close-quickly, /WebKitGTK/TestWebKitUserContentFilterStore:/webkit/WebKitUserContentFilterStore/filter-persistence (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1371 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20949 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1328 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22452 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5003 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6204 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44937 "Found 2 new test failures: fast/images/animated-heics-verify.html, http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41876 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->