### PR TITLE
[WebAssembly SIMD] Support integer and floating-point arithmetic on Intel

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.cpp
@@ -817,11 +817,15 @@ void MacroAssemblerX86Common::collectCPUFeatures()
             size_t valSize = sizeof(val);
             int rc = sysctlbyname("hw.optional.bmi1", &val, &valSize, nullptr, 0);
             s_bmi1CheckState = (rc >= 0 && val) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
+
+            rc = sysctlbyname("hw.optional.avx2_0", &val, &valSize, nullptr, 0);
+            s_avx2CheckState = (rc >= 0 && val) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
         }
 #else
         {
             CPUID cpuid = getCPUID(0x7);
             s_bmi1CheckState = (cpuid[2] & (1 << 3)) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
+            s_avx2CheckState = (cpuid[2] & (1 << 5)) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
         }
 #endif
         {
@@ -836,6 +840,7 @@ MacroAssemblerX86Common::CPUIDCheckState MacroAssemblerX86Common::s_supplemental
 MacroAssemblerX86Common::CPUIDCheckState MacroAssemblerX86Common::s_sse4_1CheckState = CPUIDCheckState::NotChecked;
 MacroAssemblerX86Common::CPUIDCheckState MacroAssemblerX86Common::s_sse4_2CheckState = CPUIDCheckState::NotChecked;
 MacroAssemblerX86Common::CPUIDCheckState MacroAssemblerX86Common::s_avxCheckState = CPUIDCheckState::NotChecked;
+MacroAssemblerX86Common::CPUIDCheckState MacroAssemblerX86Common::s_avx2CheckState = CPUIDCheckState::NotChecked;
 MacroAssemblerX86Common::CPUIDCheckState MacroAssemblerX86Common::s_lzcntCheckState = CPUIDCheckState::NotChecked;
 MacroAssemblerX86Common::CPUIDCheckState MacroAssemblerX86Common::s_bmi1CheckState = CPUIDCheckState::NotChecked;
 MacroAssemblerX86Common::CPUIDCheckState MacroAssemblerX86Common::s_popcntCheckState = CPUIDCheckState::NotChecked;

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -4013,6 +4013,20 @@ public:
         return false;
     }
 
+    static bool supportsAVXForSIMD()
+    {
+        if (s_avxCheckState == CPUIDCheckState::NotChecked)
+            collectCPUFeatures();
+        return s_avxCheckState == CPUIDCheckState::Set;
+    }
+
+    static bool supportsAVX2()
+    {
+        if (s_avx2CheckState == CPUIDCheckState::NotChecked)
+            collectCPUFeatures();
+        return s_avx2CheckState == CPUIDCheckState::Set;
+    }
+
     void lfence()
     {
         m_assembler.lfence();
@@ -4300,6 +4314,7 @@ private:
     JS_EXPORT_PRIVATE static CPUIDCheckState s_sse4_1CheckState;
     JS_EXPORT_PRIVATE static CPUIDCheckState s_sse4_2CheckState;
     JS_EXPORT_PRIVATE static CPUIDCheckState s_avxCheckState;
+    JS_EXPORT_PRIVATE static CPUIDCheckState s_avx2CheckState;
     JS_EXPORT_PRIVATE static CPUIDCheckState s_lzcntCheckState;
     JS_EXPORT_PRIVATE static CPUIDCheckState s_bmi1CheckState;
     JS_EXPORT_PRIVATE static CPUIDCheckState s_popcntCheckState;

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -341,7 +341,26 @@ private:
         OP2_PADDSW_VdqWdq               = 0xED,
         OP2_PMAXSW_VdqWdq               = 0xEE,
         OP2_PXOR_VdqWdq                 = 0xEF,
+        OP2_PADDB_VdqWdq                = 0xFC,
+        OP2_PADDW_VdqWdq                = 0xFD,
+        OP2_PADDD_VdqWdq                = 0xFE,
+        OP2_PADDQ_VdqWdq                = 0xD4,
+        OP2_PSUBB_VdqWdq                = 0xF8,
+        OP2_PSUBW_VdqWdq                = 0xF9,
+        OP2_PSUBD_VdqWdq                = 0xFA,
         OP2_PSUBQ_VdqWdq                = 0xFB,
+        OP2_PMULLW_VdqWdq               = 0xD5,
+        OP2_ADDPS_VpsWps                = 0x58,
+        OP2_ADDPD_VpdWpd                = 0x58,
+        OP2_SUBPS_VpsWps                = 0x5C,
+        OP2_SUBPD_VpdWpd                = 0x5C,
+        OP2_MULPS_VpsWps                = 0x59,
+        OP2_MULPD_VpdWpd                = 0x59,
+        OP2_DIVPS_VpsWps                = 0x5E,
+        OP2_DIVPD_VpdWpd                = 0x5E,
+        OP2_SQRTPS_VpsWps               = 0x51,
+        OP2_SQRTPD_VpdWpd               = 0x51,
+        OP2_PMADDWD_VdqWdq              = 0xF5
     } TwoByteOpcodeID;
     
     typedef enum {
@@ -355,8 +374,8 @@ private:
         OP3_PABSB_VdqWdq        = 0x1C,
         OP3_PABSW_VdqWdq        = 0x1D,
         OP3_PABSD_VdqWdq        = 0x1E,
-        OP3_PINSRB              = 0x20,
         OP3_INSERTPS_VpsUpsIb   = 0x21,
+        OP3_PINSRB              = 0x20,
         OP3_PINSRD              = 0x22,
         OP3_PMINSB_VdqWdq       = 0x38,
         OP3_PMINSD_VdqWdq       = 0x39,
@@ -370,6 +389,9 @@ private:
         OP3_LFENCE              = 0xE8,
         OP3_MFENCE              = 0xF0,
         OP3_SFENCE              = 0xF8,
+        OP3_ROUNDPS_VpsWpsIb    = 0x08,
+        OP3_ROUNDPD_VpdWpdIb    = 0x09,
+        OP3_PMULLD_VdqWdq       = 0x40
     } ThreeByteOpcodeID;
 
     struct VexPrefix {
@@ -378,6 +400,7 @@ private:
             ThreeBytes = 0xC4
         };
     };
+
     enum class VexImpliedBytes : uint8_t {
         TwoBytesOp = 1,
         ThreeBytesOp38 = 2,
@@ -3086,6 +3109,120 @@ public:
         m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PCMPEQW_VdqWdq, (RegisterID)xmm1, (RegisterID)xmm3, (RegisterID)xmm2);
     }
 
+    void vaddps_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp((OneByteOpcodeID)0, OP2_ADDPS_VpsWps, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vaddpd_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_ADDPD_VpdWpd, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vpaddb_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_PADDB_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vpaddw_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_PADDW_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vpaddd_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_PADDD_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vpaddq_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_PADDQ_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vsubps_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp((OneByteOpcodeID)0, OP2_SUBPS_VpsWps, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vsubpd_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_SUBPD_VpdWpd, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vpsubb_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_OPERAND_SIZE, OP2_PSUBB_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vpsubw_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_OPERAND_SIZE, OP2_PSUBW_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vpsubd_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_OPERAND_SIZE, OP2_PSUBD_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vpsubq_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_OPERAND_SIZE, OP2_PSUBQ_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vmulps_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp((OneByteOpcodeID)0, OP2_MULPS_VpsWps, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vmulpd_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_MULPD_VpdWpd, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vpmullw_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_PMULLW_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vpmulld_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_OPERAND_SIZE, VexImpliedBytes::ThreeBytesOp38, OP3_PMULLD_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vdivps_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp((OneByteOpcodeID)0, OP2_DIVPS_VpsWps, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vdivpd_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_DIVPD_VpdWpd, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    enum class RoundingType : uint8_t {
+        ToNearestWithTiesToEven = 0,
+        TowardNegativeInfiniti = 1,
+        TowardInfiniti = 2,
+        TowardZero = 3
+    };
+
+    void vroundps_rr(FPRegisterID src, FPRegisterID dest, RoundingType rounding)
+    {
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_OPERAND_SIZE, VexImpliedBytes::ThreeBytesOp3A, OP3_ROUNDPS_VpsWpsIb, (RegisterID)dest, (RegisterID)0, (RegisterID)src);
+        m_formatter.immediate8(static_cast<uint8_t>(rounding));
+    }
+
+    void vroundpd_rr(FPRegisterID src, FPRegisterID dest, RoundingType rounding)
+    {
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_OPERAND_SIZE, VexImpliedBytes::ThreeBytesOp3A, OP3_ROUNDPD_VpdWpdIb, (RegisterID)dest, (RegisterID)0, (RegisterID)src);
+        m_formatter.immediate8(static_cast<uint8_t>(rounding));
+    }
+
+    void vpmaddwd_rrr(FPRegisterID a, FPRegisterID b, FPRegisterID dest)
+    {
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_PMADDWD_VdqWdq, (RegisterID)dest, (RegisterID)a, (RegisterID)b);
+    }
+
     void movl_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.oneByteOp(OP_MOV_EvGv, src, dst);
@@ -4289,13 +4426,6 @@ public:
         m_formatter.twoByteOp(OP2_SQRTSD_VsdWsd, (RegisterID)dst, base, offset);
     }
 
-    enum class RoundingType : uint8_t {
-        ToNearestWithTiesToEven = 0,
-        TowardNegativeInfiniti = 1,
-        TowardInfiniti = 2,
-        TowardZero = 3
-    };
-
     void roundss_rr(XMMRegisterID src, XMMRegisterID dst, RoundingType rounding)
     {
         m_formatter.prefix(PRE_SSE_66);
@@ -5362,6 +5492,17 @@ private:
             writer.threeBytesVex(isVEX256, simdPrefix, impliedBytes, isW1, reg, (RegisterID)0, rm, vvvv);
             writer.putByteUnchecked(opcode);
             writer.registerModRM(reg, rm);
+        }
+
+        void vexNdsLigWigThreeByteOp(OneByteOpcodeID simdPrefix, VexImpliedBytes opcodePrefix, ThreeByteOpcodeID opcode, RegisterID dest, RegisterID a, RegisterID b)
+        {
+            SingleInstructionBufferWriter writer(m_buffer);
+            if (opcodePrefix != VexImpliedBytes::TwoBytesOp || regRequiresRex(b))
+                writer.threeBytesVexNds(simdPrefix, VexImpliedBytes::TwoBytesOp, dest, a, b);
+            else
+                writer.twoBytesVex(simdPrefix, a, dest);
+            writer.putByteUnchecked(opcode);
+            writer.registerModRM(dest, b);
         }
 
         void threeByteOp(TwoByteOpcodeID twoBytePrefix, ThreeByteOpcodeID opcode)

--- a/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
@@ -121,7 +121,7 @@ void lowerMacros(Code& code)
             };
 
             auto handleVectorMul = [&] {
-                if (!isARM64() || inst.args[0].simdInfo().lane != SIMDLane::i64x2)
+                if (inst.args[0].simdInfo().lane != SIMDLane::i64x2)
                     return;
 
                 Tmp lhs = inst.args[1].tmp();

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1764,7 +1764,7 @@ arm64: VectorExtractPair U:G:Ptr, U:G:8, U:F:128, U:F:128, D:F:128
 VectorAbs U:G:Ptr, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp
 
-VectorNeg U:G:Ptr, U:F:128, D:F:128
+arm64: VectorNeg U:G:Ptr, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp
 
 VectorPopcnt U:G:Ptr, U:F:128, D:F:128
@@ -1857,8 +1857,11 @@ arm64: VectorMulSat U:F:128, U:F:128, D:F:128
 x86_64: VectorMulSat U:F:128, U:F:128, D:F:128, S:G:64, S:F:128
     Tmp, Tmp, Tmp, Tmp, Tmp
 
-VectorDotProductInt32 U:F:128, U:F:128, D:F:128, S:F:128
+arm64: VectorDotProductInt32 U:F:128, U:F:128, D:F:128, S:F:128
     Tmp, Tmp, Tmp, Tmp
+
+x86_64: VectorDotProductInt32 U:F:128, U:F:128, D:F:128
+    Tmp, Tmp, Tmp
 
 VectorSwizzle U:F:128, U:F:128, D:F:128
     Tmp, Tmp, Tmp


### PR DESCRIPTION
#### 155740a50205d47608751bd4745d562202bca427
<pre>
[WebAssembly SIMD] Support integer and floating-point arithmetic on Intel
<a href="https://bugs.webkit.org/show_bug.cgi?id=248549">https://bugs.webkit.org/show_bug.cgi?id=248549</a>

Reviewed by Justin Michaud.

Adds support for basic SIMD integer arithmetic and floating-point arithmetic
instructions on Intel.

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::vectorAdd):
(JSC::MacroAssemblerX86_64::vectorSub):
(JSC::MacroAssemblerX86_64::vectorMul):
(JSC::MacroAssemblerX86_64::vectorDiv):
(JSC::MacroAssemblerX86_64::vectorCeil):
(JSC::MacroAssemblerX86_64::vectorFloor):
(JSC::MacroAssemblerX86_64::vectorTrunc):
(JSC::MacroAssemblerX86_64::vectorNearest):
(JSC::MacroAssemblerX86_64::vectorDotProductInt32):
(JSC::MacroAssemblerX86_64::vectorNeg): Deleted.
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::vectorFadd):
(JSC::X86Assembler::vectorAdd):
(JSC::X86Assembler::vectorFsub):
(JSC::X86Assembler::vectorSub):
(JSC::X86Assembler::vectorFmul):
(JSC::X86Assembler::vectorMul):
(JSC::X86Assembler::vectorFdiv):
(JSC::X86Assembler::vroundps_rr):
(JSC::X86Assembler::vroundpd_rr):
(JSC::X86Assembler::vpmaddwd_rrr):
(JSC::X86Assembler::X86InstructionFormatter::SingleInstructionBufferWriter::memoryModRM):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::addSIMDV_V):

Canonical link: <a href="https://commits.webkit.org/257511@main">https://commits.webkit.org/257511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61f605b9f0c4ff6118eeabecdc80e8f8b6ebeb83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8418 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/32339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108599 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168852 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/8970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104964 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/8970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/32339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/91711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/8970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/32339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89914 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/32339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85745 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2189 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28863 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/7242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/32339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88609 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2628 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/3667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19828 "Passed tests") | 
<!--EWS-Status-Bubble-End-->