### PR TITLE
Add exports to link a shared WebCore with TestWebCore for WinCairo

### DIFF
--- a/Source/WebCore/PAL/pal/text/TextEncoding.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncoding.cpp
@@ -55,6 +55,11 @@ TextEncoding::TextEncoding(StringView name)
 {
 }
 
+TextEncoding::TextEncoding(const String& name)
+    : TextEncoding(StringView { name })
+{
+}
+
 String TextEncoding::decode(const char* data, size_t length, bool stopOnError, bool& sawError) const
 {
     if (!m_name)

--- a/Source/WebCore/PAL/pal/text/TextEncoding.h
+++ b/Source/WebCore/PAL/pal/text/TextEncoding.h
@@ -38,11 +38,7 @@ public:
     TextEncoding() = default;
     PAL_EXPORT TextEncoding(const char* name);
     PAL_EXPORT TextEncoding(StringView name);
-
-    TextEncoding(const String& name)
-        : TextEncoding(StringView { name })
-    {
-    }
+    PAL_EXPORT TextEncoding(const String& name);
 
     bool isValid() const { return m_name; }
     const char* name() const { return m_name; }

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -396,7 +396,7 @@ public:
 #endif
 
 #if PLATFORM(WIN) || (PLATFORM(GTK) && OS(WINDOWS))
-    operator XFORM() const;
+    WEBCORE_EXPORT operator XFORM() const;
 #endif
 
     bool isIdentityOrTranslation() const

--- a/Source/WebCore/platform/network/curl/CookieJarDB.h
+++ b/Source/WebCore/platform/network/curl/CookieJarDB.h
@@ -51,7 +51,7 @@ public:
         Script
     };
 
-    void open();
+    WEBCORE_EXPORT void open();
     bool isEnabled() const;
 
     void setAcceptPolicy(CookieAcceptPolicy policy) { m_acceptPolicy = policy; }
@@ -60,7 +60,7 @@ public:
     HashSet<String> allDomains();
     std::optional<Vector<Cookie>> searchCookies(const URL& firstParty, const URL& requestUrl, const std::optional<bool>& httpOnly, const std::optional<bool>& secure, const std::optional<bool>& session);
     Vector<Cookie> getAllCookies();
-    bool setCookie(const URL& firstParty, const URL&, const String& cookie, Source, std::optional<Seconds> cappedLifetime = std::nullopt);
+    WEBCORE_EXPORT bool setCookie(const URL& firstParty, const URL&, const String& cookie, Source, std::optional<Seconds> cappedLifetime = std::nullopt);
     bool setCookie(const Cookie&);
 
     bool deleteCookie(const String& url, const String& name);

--- a/Source/WebCore/platform/network/curl/OpenSSLHelper.h
+++ b/Source/WebCore/platform/network/curl/OpenSSLHelper.h
@@ -37,6 +37,6 @@ std::optional<WebCore::CertificateSummary> createSummaryInfo(const Vector<uint8_
 
 String tlsVersion(const SSL*);
 String tlsCipherName(const SSL*);
-String canonicalizeIPv6Address(Span<uint8_t, 16> data);
+WEBCORE_EXPORT String canonicalizeIPv6Address(Span<uint8_t, 16> data);
 
 } // namespace OpenSSL


### PR DESCRIPTION
#### dd21812cfbe38b05ec156b3170486d1da1e5e18b
<pre>
Add exports to link a shared WebCore with TestWebCore for WinCairo
<a href="https://bugs.webkit.org/show_bug.cgi?id=248558">https://bugs.webkit.org/show_bug.cgi?id=248558</a>

Reviewed by Myles C. Maxfield.

Add `WEBCORE_EXPORT` to the referenced code. Move a `TextEncoding`
constructor into the `.cpp` file so it will export properly.

* Source/WebCore/PAL/pal/text/TextEncoding.cpp:
* Source/WebCore/PAL/pal/text/TextEncoding.h:
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:
* Source/WebCore/platform/network/curl/CookieJarDB.h:
* Source/WebCore/platform/network/curl/OpenSSLHelper.h:

Canonical link: <a href="https://commits.webkit.org/257241@main">https://commits.webkit.org/257241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8346c2fffdf07db285a00506843670196921458

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107665 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167948 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7914 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36183 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90793 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104251 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5951 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84802 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33052 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87833 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89523 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1383 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1338 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22458 "Found 1 new test failure: streams/readable-stream-default-controller-error.html (failure)") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6216 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41882 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->