### PR TITLE
Calling StylePropertyMap.set() with a `calc()` ends up dropping the calc

### DIFF
--- a/LayoutTests/fast/css/css-typed-om/style-property-map-set-CSSMathSum-value-expected.txt
+++ b/LayoutTests/fast/css/css-typed-om/style-property-map-set-CSSMathSum-value-expected.txt
@@ -1,0 +1,11 @@
+Checks that calling StylePropertyMap.set() with a CSSMathSum value.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS target.attributeStyleMap.set('width', new CSSMathSum(new CSSUnitValue(1, 'percent'), new CSSUnitValue(2, 'percent'))) did not throw exception.
+PASS target.style.width == 'calc(3%)' || target.style.width == 'calc(1% + 2%)' is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html
+++ b/LayoutTests/fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<div id="target"></div>
+<script>
+description("Checks that calling StylePropertyMap.set() with a CSSMathSum value.");
+
+target = document.getElementById("target");
+shouldNotThrow("target.attributeStyleMap.set('width', new CSSMathSum(new CSSUnitValue(1, 'percent'), new CSSUnitValue(2, 'percent')))");
+shouldBeTrue("target.style.width == 'calc(3%)' || target.style.width == 'calc(1% + 2%)'");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'animation-delay' to CSS-wide keywords
 FAIL Can set 'animation-delay' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'animation-delay' to a time assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'animation-delay' to a time
 PASS Setting 'animation-delay' to a length throws TypeError
 PASS Setting 'animation-delay' to a percent throws TypeError
 PASS Setting 'animation-delay' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'baseline-shift' to CSS-wide keywords
 FAIL Can set 'baseline-shift' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'baseline-shift' to the 'sub' keyword
 PASS Can set 'baseline-shift' to the 'super' keyword
-FAIL Can set 'baseline-shift' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'baseline-shift' to a percent
 FAIL Can set 'baseline-shift' to a length assert_equals: unit expected "px" but got "em"
 PASS Setting 'baseline-shift' to a time throws TypeError
 PASS Setting 'baseline-shift' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/bottom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/bottom-expected.txt
@@ -2,8 +2,8 @@
 PASS Can set 'bottom' to CSS-wide keywords
 FAIL Can set 'bottom' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'bottom' to the 'auto' keyword
-FAIL Can set 'bottom' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'bottom' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'bottom' to a percent
+PASS Can set 'bottom' to a length
 PASS Setting 'bottom' to a time throws TypeError
 PASS Setting 'bottom' to an angle throws TypeError
 PASS Setting 'bottom' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Can set 'cx' to CSS-wide keywords
 FAIL Can set 'cx' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'cx' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'cx' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'cx' to a percent
+PASS Can set 'cx' to a length
 PASS Setting 'cx' to a time throws TypeError
 PASS Setting 'cx' to an angle throws TypeError
 PASS Setting 'cx' to a flexible length throws TypeError
@@ -11,8 +11,8 @@ PASS Setting 'cx' to a URL throws TypeError
 PASS Setting 'cx' to a transform throws TypeError
 PASS Can set 'cy' to CSS-wide keywords
 FAIL Can set 'cy' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'cy' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'cy' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'cy' to a percent
+PASS Can set 'cy' to a length
 PASS Setting 'cy' to a time throws TypeError
 PASS Setting 'cy' to an angle throws TypeError
 PASS Setting 'cy' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Can set 'x' to CSS-wide keywords
 FAIL Can set 'x' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'x' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'x' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'x' to a percent
+PASS Can set 'x' to a length
 PASS Setting 'x' to a time throws TypeError
 PASS Setting 'x' to an angle throws TypeError
 PASS Setting 'x' to a flexible length throws TypeError
@@ -11,8 +11,8 @@ PASS Setting 'x' to a URL throws TypeError
 PASS Setting 'x' to a transform throws TypeError
 PASS Can set 'y' to CSS-wide keywords
 FAIL Can set 'y' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'y' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'y' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'y' to a percent
+PASS Can set 'y' to a length
 PASS Setting 'y' to a time throws TypeError
 PASS Setting 'y' to an angle throws TypeError
 PASS Setting 'y' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'fill-opacity' to CSS-wide keywords
 FAIL Can set 'fill-opacity' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'fill-opacity' to a number assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'fill-opacity' to a number
 PASS Setting 'fill-opacity' to a length throws TypeError
 FAIL Setting 'fill-opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'fill-opacity' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'flood-opacity' to CSS-wide keywords
 FAIL Can set 'flood-opacity' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'flood-opacity' to a number assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'flood-opacity' to a number
 PASS Setting 'flood-opacity' to a length throws TypeError
 FAIL Setting 'flood-opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'flood-opacity' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/left-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/left-expected.txt
@@ -2,8 +2,8 @@
 PASS Can set 'left' to CSS-wide keywords
 FAIL Can set 'left' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'left' to the 'auto' keyword
-FAIL Can set 'left' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'left' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'left' to a percent
+PASS Can set 'left' to a length
 PASS Setting 'left' to a time throws TypeError
 PASS Setting 'left' to an angle throws TypeError
 PASS Setting 'left' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Can set 'margin-block-start' to CSS-wide keywords
 FAIL Can set 'margin-block-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'margin-block-start' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'margin-block-start' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'margin-block-start' to a percent
+PASS Can set 'margin-block-start' to a length
 PASS Setting 'margin-block-start' to a time throws TypeError
 PASS Setting 'margin-block-start' to an angle throws TypeError
 PASS Setting 'margin-block-start' to a flexible length throws TypeError
@@ -11,8 +11,8 @@ PASS Setting 'margin-block-start' to a URL throws TypeError
 PASS Setting 'margin-block-start' to a transform throws TypeError
 PASS Can set 'margin-block-end' to CSS-wide keywords
 FAIL Can set 'margin-block-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'margin-block-end' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'margin-block-end' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'margin-block-end' to a percent
+PASS Can set 'margin-block-end' to a length
 PASS Setting 'margin-block-end' to a time throws TypeError
 PASS Setting 'margin-block-end' to an angle throws TypeError
 PASS Setting 'margin-block-end' to a flexible length throws TypeError
@@ -21,8 +21,8 @@ PASS Setting 'margin-block-end' to a URL throws TypeError
 PASS Setting 'margin-block-end' to a transform throws TypeError
 PASS Can set 'margin-inline-start' to CSS-wide keywords
 FAIL Can set 'margin-inline-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'margin-inline-start' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'margin-inline-start' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'margin-inline-start' to a percent
+PASS Can set 'margin-inline-start' to a length
 PASS Setting 'margin-inline-start' to a time throws TypeError
 PASS Setting 'margin-inline-start' to an angle throws TypeError
 PASS Setting 'margin-inline-start' to a flexible length throws TypeError
@@ -31,8 +31,8 @@ PASS Setting 'margin-inline-start' to a URL throws TypeError
 PASS Setting 'margin-inline-start' to a transform throws TypeError
 PASS Can set 'margin-inline-end' to CSS-wide keywords
 FAIL Can set 'margin-inline-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'margin-inline-end' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'margin-inline-end' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'margin-inline-end' to a percent
+PASS Can set 'margin-inline-end' to a length
 PASS Setting 'margin-inline-end' to a time throws TypeError
 PASS Setting 'margin-inline-end' to an angle throws TypeError
 PASS Setting 'margin-inline-end' to a flexible length throws TypeError
@@ -61,8 +61,8 @@ PASS Setting 'margin-inline' to a URL throws TypeError
 PASS Setting 'margin-inline' to a transform throws TypeError
 PASS Can set 'inset-block-start' to CSS-wide keywords
 FAIL Can set 'inset-block-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'inset-block-start' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'inset-block-start' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'inset-block-start' to a percent
+PASS Can set 'inset-block-start' to a length
 PASS Setting 'inset-block-start' to a time throws TypeError
 PASS Setting 'inset-block-start' to an angle throws TypeError
 PASS Setting 'inset-block-start' to a flexible length throws TypeError
@@ -71,8 +71,8 @@ PASS Setting 'inset-block-start' to a URL throws TypeError
 PASS Setting 'inset-block-start' to a transform throws TypeError
 PASS Can set 'inset-block-end' to CSS-wide keywords
 FAIL Can set 'inset-block-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'inset-block-end' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'inset-block-end' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'inset-block-end' to a percent
+PASS Can set 'inset-block-end' to a length
 PASS Setting 'inset-block-end' to a time throws TypeError
 PASS Setting 'inset-block-end' to an angle throws TypeError
 PASS Setting 'inset-block-end' to a flexible length throws TypeError
@@ -81,8 +81,8 @@ PASS Setting 'inset-block-end' to a URL throws TypeError
 PASS Setting 'inset-block-end' to a transform throws TypeError
 PASS Can set 'inset-inline-start' to CSS-wide keywords
 FAIL Can set 'inset-inline-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'inset-inline-start' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'inset-inline-start' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'inset-inline-start' to a percent
+PASS Can set 'inset-inline-start' to a length
 PASS Setting 'inset-inline-start' to a time throws TypeError
 PASS Setting 'inset-inline-start' to an angle throws TypeError
 PASS Setting 'inset-inline-start' to a flexible length throws TypeError
@@ -91,8 +91,8 @@ PASS Setting 'inset-inline-start' to a URL throws TypeError
 PASS Setting 'inset-inline-start' to a transform throws TypeError
 PASS Can set 'inset-inline-end' to CSS-wide keywords
 FAIL Can set 'inset-inline-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'inset-inline-end' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'inset-inline-end' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'inset-inline-end' to a percent
+PASS Can set 'inset-inline-end' to a length
 PASS Setting 'inset-inline-end' to a time throws TypeError
 PASS Setting 'inset-inline-end' to an angle throws TypeError
 PASS Setting 'inset-inline-end' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/margin-expected.txt
@@ -2,8 +2,8 @@
 PASS Can set 'margin-top' to CSS-wide keywords
 FAIL Can set 'margin-top' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'margin-top' to the 'auto' keyword
-FAIL Can set 'margin-top' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'margin-top' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'margin-top' to a percent
+PASS Can set 'margin-top' to a length
 PASS Setting 'margin-top' to a time throws TypeError
 PASS Setting 'margin-top' to an angle throws TypeError
 PASS Setting 'margin-top' to a flexible length throws TypeError
@@ -13,8 +13,8 @@ PASS Setting 'margin-top' to a transform throws TypeError
 PASS Can set 'margin-left' to CSS-wide keywords
 FAIL Can set 'margin-left' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'margin-left' to the 'auto' keyword
-FAIL Can set 'margin-left' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'margin-left' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'margin-left' to a percent
+PASS Can set 'margin-left' to a length
 PASS Setting 'margin-left' to a time throws TypeError
 PASS Setting 'margin-left' to an angle throws TypeError
 PASS Setting 'margin-left' to a flexible length throws TypeError
@@ -24,8 +24,8 @@ PASS Setting 'margin-left' to a transform throws TypeError
 PASS Can set 'margin-right' to CSS-wide keywords
 FAIL Can set 'margin-right' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'margin-right' to the 'auto' keyword
-FAIL Can set 'margin-right' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'margin-right' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'margin-right' to a percent
+PASS Can set 'margin-right' to a length
 PASS Setting 'margin-right' to a time throws TypeError
 PASS Setting 'margin-right' to an angle throws TypeError
 PASS Setting 'margin-right' to a flexible length throws TypeError
@@ -35,8 +35,8 @@ PASS Setting 'margin-right' to a transform throws TypeError
 PASS Can set 'margin-bottom' to CSS-wide keywords
 FAIL Can set 'margin-bottom' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'margin-bottom' to the 'auto' keyword
-FAIL Can set 'margin-bottom' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'margin-bottom' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'margin-bottom' to a percent
+PASS Can set 'margin-bottom' to a length
 PASS Setting 'margin-bottom' to a time throws TypeError
 PASS Setting 'margin-bottom' to an angle throws TypeError
 PASS Setting 'margin-bottom' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-distance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-distance-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Can set 'offset-distance' to CSS-wide keywords
 FAIL Can set 'offset-distance' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'offset-distance' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'offset-distance' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'offset-distance' to a length
+PASS Can set 'offset-distance' to a percent
 PASS Setting 'offset-distance' to a time throws TypeError
 PASS Setting 'offset-distance' to an angle throws TypeError
 PASS Setting 'offset-distance' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'opacity' to CSS-wide keywords
 FAIL Can set 'opacity' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'opacity' to a number assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'opacity' to a number
 PASS Setting 'opacity' to a length throws TypeError
 FAIL Setting 'opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'opacity' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-offset-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'outline-offset' to CSS-wide keywords
 FAIL Can set 'outline-offset' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'outline-offset' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'outline-offset' to a length
 PASS Setting 'outline-offset' to a percent throws TypeError
 PASS Setting 'outline-offset' to a time throws TypeError
 PASS Setting 'outline-offset' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/right-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/right-expected.txt
@@ -2,8 +2,8 @@
 PASS Can set 'right' to CSS-wide keywords
 FAIL Can set 'right' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'right' to the 'auto' keyword
-FAIL Can set 'right' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'right' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'right' to a percent
+PASS Can set 'right' to a length
 PASS Setting 'right' to a time throws TypeError
 PASS Setting 'right' to an angle throws TypeError
 PASS Setting 'right' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-margin-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'scroll-margin-top' to CSS-wide keywords
 FAIL Can set 'scroll-margin-top' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-margin-top' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'scroll-margin-top' to a length
 PASS Setting 'scroll-margin-top' to a percent throws TypeError
 PASS Setting 'scroll-margin-top' to a time throws TypeError
 PASS Setting 'scroll-margin-top' to an angle throws TypeError
@@ -11,7 +11,7 @@ PASS Setting 'scroll-margin-top' to a URL throws TypeError
 PASS Setting 'scroll-margin-top' to a transform throws TypeError
 PASS Can set 'scroll-margin-left' to CSS-wide keywords
 FAIL Can set 'scroll-margin-left' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-margin-left' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'scroll-margin-left' to a length
 PASS Setting 'scroll-margin-left' to a percent throws TypeError
 PASS Setting 'scroll-margin-left' to a time throws TypeError
 PASS Setting 'scroll-margin-left' to an angle throws TypeError
@@ -21,7 +21,7 @@ PASS Setting 'scroll-margin-left' to a URL throws TypeError
 PASS Setting 'scroll-margin-left' to a transform throws TypeError
 PASS Can set 'scroll-margin-right' to CSS-wide keywords
 FAIL Can set 'scroll-margin-right' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-margin-right' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'scroll-margin-right' to a length
 PASS Setting 'scroll-margin-right' to a percent throws TypeError
 PASS Setting 'scroll-margin-right' to a time throws TypeError
 PASS Setting 'scroll-margin-right' to an angle throws TypeError
@@ -31,7 +31,7 @@ PASS Setting 'scroll-margin-right' to a URL throws TypeError
 PASS Setting 'scroll-margin-right' to a transform throws TypeError
 PASS Can set 'scroll-margin-bottom' to CSS-wide keywords
 FAIL Can set 'scroll-margin-bottom' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-margin-bottom' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'scroll-margin-bottom' to a length
 PASS Setting 'scroll-margin-bottom' to a percent throws TypeError
 PASS Setting 'scroll-margin-bottom' to a time throws TypeError
 PASS Setting 'scroll-margin-bottom' to an angle throws TypeError
@@ -41,7 +41,7 @@ PASS Setting 'scroll-margin-bottom' to a URL throws TypeError
 PASS Setting 'scroll-margin-bottom' to a transform throws TypeError
 PASS Can set 'scroll-margin-inline-start' to CSS-wide keywords
 FAIL Can set 'scroll-margin-inline-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-margin-inline-start' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'scroll-margin-inline-start' to a length
 PASS Setting 'scroll-margin-inline-start' to a percent throws TypeError
 PASS Setting 'scroll-margin-inline-start' to a time throws TypeError
 PASS Setting 'scroll-margin-inline-start' to an angle throws TypeError
@@ -51,7 +51,7 @@ PASS Setting 'scroll-margin-inline-start' to a URL throws TypeError
 PASS Setting 'scroll-margin-inline-start' to a transform throws TypeError
 PASS Can set 'scroll-margin-block-start' to CSS-wide keywords
 FAIL Can set 'scroll-margin-block-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-margin-block-start' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'scroll-margin-block-start' to a length
 PASS Setting 'scroll-margin-block-start' to a percent throws TypeError
 PASS Setting 'scroll-margin-block-start' to a time throws TypeError
 PASS Setting 'scroll-margin-block-start' to an angle throws TypeError
@@ -61,7 +61,7 @@ PASS Setting 'scroll-margin-block-start' to a URL throws TypeError
 PASS Setting 'scroll-margin-block-start' to a transform throws TypeError
 PASS Can set 'scroll-margin-inline-end' to CSS-wide keywords
 FAIL Can set 'scroll-margin-inline-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-margin-inline-end' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'scroll-margin-inline-end' to a length
 PASS Setting 'scroll-margin-inline-end' to a percent throws TypeError
 PASS Setting 'scroll-margin-inline-end' to a time throws TypeError
 PASS Setting 'scroll-margin-inline-end' to an angle throws TypeError
@@ -71,7 +71,7 @@ PASS Setting 'scroll-margin-inline-end' to a URL throws TypeError
 PASS Setting 'scroll-margin-inline-end' to a transform throws TypeError
 PASS Can set 'scroll-margin-block-end' to CSS-wide keywords
 FAIL Can set 'scroll-margin-block-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-margin-block-end' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'scroll-margin-block-end' to a length
 PASS Setting 'scroll-margin-block-end' to a percent throws TypeError
 PASS Setting 'scroll-margin-block-end' to a time throws TypeError
 PASS Setting 'scroll-margin-block-end' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-image-threshold-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-image-threshold-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'shape-image-threshold' to CSS-wide keywords
 FAIL Can set 'shape-image-threshold' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'shape-image-threshold' to a number assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'shape-image-threshold' to a number
 PASS Setting 'shape-image-threshold' to a length throws TypeError
 PASS Setting 'shape-image-threshold' to a percent throws TypeError
 PASS Setting 'shape-image-threshold' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'stop-opacity' to CSS-wide keywords
 FAIL Can set 'stop-opacity' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'stop-opacity' to a number assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'stop-opacity' to a number
 PASS Setting 'stop-opacity' to a length throws TypeError
 FAIL Setting 'stop-opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'stop-opacity' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Can set 'stroke-dashoffset' to CSS-wide keywords
 FAIL Can set 'stroke-dashoffset' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'stroke-dashoffset' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'stroke-dashoffset' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'stroke-dashoffset' to a length
+PASS Can set 'stroke-dashoffset' to a percent
 PASS Setting 'stroke-dashoffset' to a time throws TypeError
 PASS Setting 'stroke-dashoffset' to an angle throws TypeError
 PASS Setting 'stroke-dashoffset' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'stroke-opacity' to CSS-wide keywords
 FAIL Can set 'stroke-opacity' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'stroke-opacity' to a number assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'stroke-opacity' to a number
 PASS Setting 'stroke-opacity' to a length throws TypeError
 FAIL Setting 'stroke-opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'stroke-opacity' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-thickness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-thickness-expected.txt
@@ -2,7 +2,7 @@
 PASS Can set 'text-decoration-thickness' to CSS-wide keywords
 FAIL Can set 'text-decoration-thickness' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'text-decoration-thickness' to the 'auto' keyword
-FAIL Can set 'text-decoration-thickness' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'text-decoration-thickness' to a length
 FAIL Can set 'text-decoration-thickness' to a percent Invalid values
 PASS Setting 'text-decoration-thickness' to a time throws TypeError
 PASS Setting 'text-decoration-thickness' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Can set 'text-indent' to CSS-wide keywords
 FAIL Can set 'text-indent' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'text-indent' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'text-indent' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'text-indent' to a length
+PASS Can set 'text-indent' to a percent
 PASS Setting 'text-indent' to a time throws TypeError
 PASS Setting 'text-indent' to an angle throws TypeError
 PASS Setting 'text-indent' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt
@@ -2,7 +2,7 @@
 PASS Can set 'text-underline-offset' to CSS-wide keywords
 FAIL Can set 'text-underline-offset' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'text-underline-offset' to the 'auto' keyword
-FAIL Can set 'text-underline-offset' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'text-underline-offset' to a length
 FAIL Can set 'text-underline-offset' to a percent Invalid values
 PASS Setting 'text-underline-offset' to a time throws TypeError
 PASS Setting 'text-underline-offset' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/top-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/top-expected.txt
@@ -2,8 +2,8 @@
 PASS Can set 'top' to CSS-wide keywords
 FAIL Can set 'top' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'top' to the 'auto' keyword
-FAIL Can set 'top' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'top' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'top' to a percent
+PASS Can set 'top' to a length
 PASS Setting 'top' to a time throws TypeError
 PASS Setting 'top' to an angle throws TypeError
 PASS Setting 'top' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-delay-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-delay-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'transition-delay' to CSS-wide keywords
 FAIL Can set 'transition-delay' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'transition-delay' to a time assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'transition-delay' to a time
 PASS Setting 'transition-delay' to a length throws TypeError
 PASS Setting 'transition-delay' to a percent throws TypeError
 PASS Setting 'transition-delay' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vertical-align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vertical-align-expected.txt
@@ -2,8 +2,8 @@
 PASS Can set 'vertical-align' to CSS-wide keywords
 FAIL Can set 'vertical-align' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'vertical-align' to the 'baseline' keyword
-FAIL Can set 'vertical-align' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'vertical-align' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'vertical-align' to a length
+PASS Can set 'vertical-align' to a percent
 PASS Setting 'vertical-align' to a time throws TypeError
 PASS Setting 'vertical-align' to an angle throws TypeError
 PASS Setting 'vertical-align' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-spacing-expected.txt
@@ -2,8 +2,8 @@
 PASS Can set 'word-spacing' to CSS-wide keywords
 FAIL Can set 'word-spacing' to var() references assert_equals: expected 2 but got 1
 FAIL Can set 'word-spacing' to the 'normal' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'word-spacing' to a length assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
-FAIL Can set 'word-spacing' to a percent assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSUnitValue]"
+PASS Can set 'word-spacing' to a length
+PASS Can set 'word-spacing' to a percent
 PASS Setting 'word-spacing' to a time throws TypeError
 PASS Setting 'word-spacing' to an angle throws TypeError
 PASS Setting 'word-spacing' to a flexible length throws TypeError

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4410,6 +4410,7 @@ imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-
 css-custom-properties-api [ Skip ]
 fast/css-custom-paint [ Skip ]
 css-typedom [ Skip ]
+fast/css/css-typed-om [ Skip ]
 
 editing/pasteboard/drag-and-drop-color-input-events.html [ Skip ]
 

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -147,11 +147,12 @@ static ExceptionOr<Ref<CSSNumericValue>> reifyMathExpression(const CSSCalcOperat
     Vector<Ref<CSSNumericValue>> values;
     const CSSCalcExpressionNode* currentNode = &root;
     do {
-        auto* binaryOperation = downcast<CSSCalcOperationNode>(currentNode);
-        ASSERT(binaryOperation->children().size() == 2);
-        CSS_NUMERIC_RETURN_IF_EXCEPTION(value, CSSNumericValue::reifyMathExpression(binaryOperation->children()[1].get()));
-        values.append(negateOrInvertIfRequired(binaryOperation->calcOperator(), WTFMove(value)));
-        currentNode = binaryOperation->children()[0].ptr();
+        auto* operationNode = downcast<CSSCalcOperationNode>(currentNode);
+        if (operationNode->children().size() == 2) {
+            CSS_NUMERIC_RETURN_IF_EXCEPTION(value, CSSNumericValue::reifyMathExpression(operationNode->children()[1].get()));
+            values.append(negateOrInvertIfRequired(operationNode->calcOperator(), WTFMove(value)));
+        }
+        currentNode = operationNode->children()[0].ptr();
     } while (canCombineNodes(root, *currentNode));
 
     ASSERT(currentNode);

--- a/Source/WebCore/css/typedom/numeric/CSSMathValue.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathValue.h
@@ -26,10 +26,10 @@
 #pragma once
 
 #include "CSSCalcExpressionNode.h"
+#include "CSSCalcValue.h"
 #include "CSSMathOperator.h"
 #include "CSSNumericArray.h"
 #include "CSSNumericValue.h"
-#include "CSSPrimitiveValue.h"
 #include "CSSStyleValue.h"
 
 namespace WebCore {
@@ -68,7 +68,7 @@ public:
         auto node = toCalcExpressionNode();
         if (!node)
             return nullptr;
-        return CSSPrimitiveValue::create(node->doubleValue(node->primitiveType()), node->primitiveType());
+        return CSSCalcValue::create(node.releaseNonNull());
     }
 };
 


### PR DESCRIPTION
#### f53b8be5211fa670849428e727ab301fe42f1720
<pre>
Calling StylePropertyMap.set() with a `calc()` ends up dropping the calc
<a href="https://bugs.webkit.org/show_bug.cgi?id=248559">https://bugs.webkit.org/show_bug.cgi?id=248559</a>

Reviewed by Geoffrey Garen.

When calling StylePropertyMap.set() with a CSSMathValue, we would call
CSSMathValue::toCSSValue() to convert it to a CSSValue. We would expect to get
a CSSCalcValue as a result. However, our implementation was trying to resolve
the `calc()` and would return a CSSPrimitiveValue instead.

* LayoutTests/fast/css/css-typed-om/style-property-map-set-CSSMathSum-value-expected.txt: Added.
* LayoutTests/fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html: Added.
* Source/WebCore/css/typedom/numeric/CSSMathValue.h:

Canonical link: <a href="https://commits.webkit.org/257291@main">https://commits.webkit.org/257291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80c08f72550eb64df346390d2ed380329f07aafc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107815 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168084 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84962 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90938 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104475 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33153 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87966 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76100 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1530 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1464 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42010 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2511 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2824 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->