### PR TITLE
[ANGLE] Remove "Adjust ANGLE Paths" build rule

### DIFF
--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -3569,7 +3569,6 @@
 				31CDFDF22491819E00486F27 /* Frameworks */,
 				31CD00CE2491974C00486F27 /* CopyFiles */,
 				31CD00CF2491976800486F27 /* CopyFiles */,
-				31CD00D2249197FD00486F27 /* Adjust ANGLE Paths */,
 				6517572227CEED7200D9FE40 /* Copy Frameworks to Secondary Path */,
 			);
 			buildRules = (
@@ -3640,24 +3639,6 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		31CD00D2249197FD00486F27 /* Adjust ANGLE Paths */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Adjust ANGLE Paths";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ \"${XCODE_VERSION_ACTUAL}\" -ge \"1140\" -a \"${WK_USE_NEW_BUILD_SYSTEM}\" = \"YES\" ]; then\n    # In this configuration, post-processing is performed at the same time as copying in the postprocess-header-rule script, so there's no need for this separate step.\n    exit 0\nfi\n\nexec \"$SRCROOT/adjust-angle-include-paths.py\"\n";
-		};
 		6517572227CEED7200D9FE40 /* Copy Frameworks to Secondary Path */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 8;


### PR DESCRIPTION
#### 1845d4d0fcd5d08a95a2110b0e23f2f125492e74
<pre>
[ANGLE] Remove &quot;Adjust ANGLE Paths&quot; build rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=248560">https://bugs.webkit.org/show_bug.cgi?id=248560</a>
rdar://102830463

Reviewed by NOBODY (OOPS!).

Xcode prints a warning that &quot;Adjust ANGLE Paths&quot; runs on every build invocation
because no outputPaths are provided. This Build Phase is no longer needed, so
removing it to eliminate warning.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1845d4d0fcd5d08a95a2110b0e23f2f125492e74

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107818 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168087 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84965 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90941 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104478 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89715 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33154 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87967 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21077 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/text/text-edge-property-parsing.html, http/tests/appcache/fail-on-update-2.html, http/tests/appcache/remove-cache.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76101 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1533 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22605 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, css3/supports-dom-api.html, editing/input/page-up-down-scrolls.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/rendering/render-style-null-optgroup-crash.html, http/wpt/cache-storage/cache-quota.any.html, http/wpt/fetch/response-opaque-clone.html, http/wpt/service-workers/fetch-service-worker-preload.https.html, imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any.worker.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1467 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45093 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/rendering/render-style-null-optgroup-crash.html, http/tests/navigation/fragment-navigation-policy-ignore.html, http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html, http/wpt/service-workers/fetch-service-worker-preload-download.https.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42014 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->