### PR TITLE
Remove the unused DisableMediaExperiencePIDInheritance experimental feature

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -678,19 +678,6 @@ DirPseudoEnabled:
     WebCore:
       default: true
 
-# FIXME: Starting the preference name with "Disable" is inconsistent with most other preferences and should be changed.
-DisableMediaExperiencePIDInheritance:
-  type: bool
-  webcoreBinding: DeprecatedGlobalSettings
-  humanReadableName: "Disable Media Experience PID Inheritance"
-  humanReadableDescription: "Disable Media Experience PID Inheritance"
-  condition: HAVE(CELESTIAL)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-
 DisallowSyncXHRDuringPageDismissalEnabled:
   type: bool
   humanReadableName: "Disallow sync XHR during page dismissal"

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -239,11 +239,6 @@ public:
     static bool webMParserEnabled() { return shared().m_webMParserEnabled; }
 #endif
 
-#if HAVE(CELESTIAL)
-    static void setDisableMediaExperiencePIDInheritance(bool isDisabled) { shared().m_disableMediaExperiencePIDInheritance = isDisabled; }
-    static bool disableMediaExperiencePIDInheritance() { return shared().m_disableMediaExperiencePIDInheritance; }
-#endif
-
 #if ENABLE(VORBIS)
     WEBCORE_EXPORT static void setVorbisDecoderEnabled(bool isEnabled);
     static bool vorbisDecoderEnabled() { return shared().m_vorbisDecoderEnabled; }
@@ -408,10 +403,6 @@ private:
 
 #if ENABLE(MEDIA_SOURCE)
     bool m_webMParserEnabled { false };
-#endif
-
-#if HAVE(CELESTIAL)
-    bool m_disableMediaExperiencePIDInheritance { false };
 #endif
 
 #if ENABLE(VORBIS)

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -258,9 +258,6 @@ void MediaSessionHelperiOS::providePresentingApplicationPID(int pid)
 
     m_presentedApplicationPID = pid;
 
-    if (DeprecatedGlobalSettings::disableMediaExperiencePIDInheritance())
-        return;
-
     if (!canLoadAVSystemController_PIDToInheritApplicationStateFrom())
         return;
 


### PR DESCRIPTION
#### f782290b5c30d8f763fb1a498222e3fa19e5fcbb
<pre>
Remove the unused DisableMediaExperiencePIDInheritance experimental feature
<a href="https://bugs.webkit.org/show_bug.cgi?id=248562">https://bugs.webkit.org/show_bug.cgi?id=248562</a>
&lt;rdar://problem/102831157&gt;

Reviewed by Eric Carlson.

We no longer need the ability to toggle DisableMediaExperiencePIDInheritance, and should
remove this unused feature flag to reduce complexity and build time.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setDisableMediaExperiencePIDInheritance): Deleted.
(WebCore::DeprecatedGlobalSettings::disableMediaExperiencePIDInheritance): Deleted.
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(MediaSessionHelperiOS::providePresentingApplicationPID):

Canonical link: <a href="https://commits.webkit.org/257260@main">https://commits.webkit.org/257260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fd94d0a471aa9852f4bae2503362c53afd603f6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107669 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167952 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7918 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36187 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90797 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104255 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5953 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84806 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33057 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89527 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89047 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1387 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84778 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1342 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22462 "Found 1 new test failure: streams/readable-stream-default-controller-error.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28649 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5001 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44966 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87620 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41886 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19650 "Passed tests") | 
<!--EWS-Status-Bubble-End-->