### PR TITLE
Adopt HAVE(MACH_PORT_CALAYER_CONTENTS)

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -66,10 +66,6 @@ RemoteLayerTreeHost::~RemoteLayerTreeHost()
 
 RemoteLayerBackingStore::LayerContentsType RemoteLayerTreeHost::layerContentsType() const
 {
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
-    // CAMachPort currently does not work on macOS (or macCatalyst): rdar://problem/31247730
-    return RemoteLayerBackingStore::LayerContentsType::IOSurface;
-#else
     // If a surface will be referenced by multiple layers (as in the tile debug indicator), CAMachPort cannot be used.
     if (m_drawingArea->hasDebugIndicator())
         return RemoteLayerBackingStore::LayerContentsType::IOSurface;
@@ -78,7 +74,10 @@ RemoteLayerBackingStore::LayerContentsType RemoteLayerTreeHost::layerContentsTyp
     if (m_drawingArea->page().windowKind() == WindowKind::InProcessSnapshotting)
         return RemoteLayerBackingStore::LayerContentsType::IOSurface;
 
+#if HAVE(MACH_PORT_CALAYER_CONTENTS)
     return RemoteLayerBackingStore::LayerContentsType::CAMachPort;
+#else
+    return RemoteLayerBackingStore::LayerContentsType::IOSurface;
 #endif
 }
 


### PR DESCRIPTION
#### ee0a6a9a3b2b376d717a75b26e1710a8b5ede6e4
<pre>
Adopt HAVE(MACH_PORT_CALAYER_CONTENTS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=248563">https://bugs.webkit.org/show_bug.cgi?id=248563</a>
rdar://102831386

Reviewed by Tim Horton.

Use HAVE(MACH_PORT_CALAYER_CONTENTS) to know when we&apos;re on a build with
the fix for rdar://31247730.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::layerContentsType const):

Canonical link: <a href="https://commits.webkit.org/257257@main">https://commits.webkit.org/257257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85c6492194e2085ae1de0ec10cb755cabcafca5b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107670 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7920 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36188 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90798 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104256 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103866 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84807 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33061 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89529 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1388 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1343 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22464 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4999 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6221 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44968 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41888 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->