### PR TITLE
Remove GetOriginsWithPushSubscriptions

### DIFF
--- a/Source/WebCore/Modules/push-api/PushDatabase.cpp
+++ b/Source/WebCore/Modules/push-api/PushDatabase.cpp
@@ -670,26 +670,6 @@ void PushDatabase::getTopics(CompletionHandler<void(PushTopics&&)>&& completionH
     });
 }
 
-void PushDatabase::getOriginsWithPushSubscriptions(const String& bundleID, CompletionHandler<void(Vector<String>&&)>&& completionHandler)
-{
-    dispatchOnWorkQueue([this, bundleID = crossThreadCopy(bundleID), completionHandler = WTFMove(completionHandler)]() mutable {
-        auto sql = cachedStatementOnQueue(
-            "SELECT securityOrigin "
-            "FROM SubscriptionSets "
-            "WHERE bundleID = ? AND state = 0"_s);
-        if (!sql || sql->bindText(1, bundleID) != SQLITE_OK) {
-            PUSHDB_RELEASE_LOG_BIND_ERROR();
-            return completeOnMainQueue(WTFMove(completionHandler), Vector<String> { });
-        }
-
-        Vector<String> origins;
-        while (sql->step() == SQLITE_ROW)
-            origins.append(sql->columnText(0));
-
-        completeOnMainQueue(WTFMove(completionHandler), WTFMove(origins));
-    });
-}
-
 void PushDatabase::incrementSilentPushCount(const String& bundleID, const String& securityOrigin, CompletionHandler<void(unsigned)>&& completionHandler)
 {
     dispatchOnWorkQueue([this, bundleID = crossThreadCopy(bundleID), securityOrigin = crossThreadCopy(securityOrigin), completionHandler = WTFMove(completionHandler)]() mutable {

--- a/Source/WebCore/Modules/push-api/PushDatabase.h
+++ b/Source/WebCore/Modules/push-api/PushDatabase.h
@@ -96,8 +96,6 @@ public:
     WEBCORE_EXPORT void getIdentifiers(CompletionHandler<void(HashSet<PushSubscriptionIdentifier>&&)>&&);
     WEBCORE_EXPORT void getTopics(CompletionHandler<void(PushTopics&&)>&&);
 
-    WEBCORE_EXPORT void getOriginsWithPushSubscriptions(const String& bundleID, CompletionHandler<void(Vector<String>&&)>&&);
-
     WEBCORE_EXPORT void incrementSilentPushCount(const String& bundleID, const String& securityOrigin, CompletionHandler<void(unsigned)>&&);
 
     WEBCORE_EXPORT void removeRecordsByBundleIdentifier(const String& bundleID, CompletionHandler<void(Vector<RemovedPushRecord>&&)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2469,17 +2469,6 @@ void NetworkProcess::getOriginsWithPushAndNotificationPermissions(PAL::SessionID
     callback({ });
 }
 
-void NetworkProcess::getOriginsWithPushSubscriptions(PAL::SessionID sessionID, CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&& callback)
-{
-#if ENABLE(BUILT_IN_NOTIFICATIONS)
-    if (auto* session = networkSession(sessionID)) {
-        session->notificationManager().getOriginsWithPushSubscriptions(WTFMove(callback));
-        return;
-    }
-#endif
-    callback({ });
-}
-
 void NetworkProcess::hasPushSubscriptionForTesting(PAL::SessionID sessionID, URL&& scopeURL, CompletionHandler<void(bool)>&& callback)
 {
 #if ENABLE(BUILT_IN_NOTIFICATIONS)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -390,7 +390,6 @@ public:
     void setPushAndNotificationsEnabledForOrigin(PAL::SessionID, const WebCore::SecurityOriginData&, bool, CompletionHandler<void()>&&);
     void deletePushAndNotificationRegistration(PAL::SessionID, const WebCore::SecurityOriginData&, CompletionHandler<void(const String&)>&&);
     void getOriginsWithPushAndNotificationPermissions(PAL::SessionID, CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
-    void getOriginsWithPushSubscriptions(PAL::SessionID, CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
     void hasPushSubscriptionForTesting(PAL::SessionID, URL&&, CompletionHandler<void(bool)>&&);
 
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -223,7 +223,6 @@ messages -> NetworkProcess LegacyReceiver {
     SetPushAndNotificationsEnabledForOrigin(PAL::SessionID sessionID, struct WebCore::SecurityOriginData origin, bool enabled) -> ()
     DeletePushAndNotificationRegistration(PAL::SessionID sessionID, struct WebCore::SecurityOriginData origin) -> (String errorMessage)
     GetOriginsWithPushAndNotificationPermissions(PAL::SessionID sessionID) -> (Vector<WebCore::SecurityOriginData> origins)
-    GetOriginsWithPushSubscriptions(PAL::SessionID sessionID) -> (Vector<WebCore::SecurityOriginData> origins)
     HasPushSubscriptionForTesting(PAL::SessionID sessionID, URL scopeURL) -> (bool hasSubscription)
 
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -95,18 +95,6 @@ void NetworkNotificationManager::getOriginsWithPushAndNotificationPermissions(Co
     sendMessageWithReply<WebPushD::MessageType::GetOriginsWithPushAndNotificationPermissions>(WTFMove(replyHandler));
 }
 
-void NetworkNotificationManager::getOriginsWithPushSubscriptions(CompletionHandler<void(const Vector<SecurityOriginData>&)>&& completionHandler)
-{
-    CompletionHandler<void(Vector<String>&&)> replyHandler = [completionHandler = WTFMove(completionHandler)] (Vector<String> originStrings) mutable {
-        auto origins = originStrings.map([](auto& originString) {
-            return SecurityOriginData::fromURL({ { }, originString });
-        });
-        completionHandler(WTFMove(origins));
-    };
-
-    sendMessageWithReply<WebPushD::MessageType::GetOriginsWithPushSubscriptions>(WTFMove(replyHandler));
-}
-
 void NetworkNotificationManager::getPendingPushMessages(CompletionHandler<void(const Vector<WebPushMessage>&)>&& completionHandler)
 {
     CompletionHandler<void(Vector<WebPushMessage>&&)> replyHandler = [completionHandler = WTFMove(completionHandler)] (Vector<WebPushMessage>&& messages) mutable {

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -58,7 +58,6 @@ public:
     void setPushAndNotificationsEnabledForOrigin(const WebCore::SecurityOriginData&, bool, CompletionHandler<void()>&&);
     void deletePushAndNotificationRegistration(const WebCore::SecurityOriginData&, CompletionHandler<void(const String&)>&&);
     void getOriginsWithPushAndNotificationPermissions(CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
-    void getOriginsWithPushSubscriptions(CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
     void getPendingPushMessages(CompletionHandler<void(const Vector<WebPushMessage>&)>&&);
 
     void subscribeToPushService(URL&& scopeURL, Vector<uint8_t>&& applicationServerKey, CompletionHandler<void(Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&&)>&&);

--- a/Source/WebKit/Shared/WebPushDaemonConstants.h
+++ b/Source/WebKit/Shared/WebPushDaemonConstants.h
@@ -58,7 +58,6 @@ enum class MessageType : uint8_t {
     RemovePushSubscriptionsForOrigin,
     SetPublicTokenForTesting,
     SetPushAndNotificationsEnabledForOrigin,
-    GetOriginsWithPushSubscriptions,
 };
 
 enum class RawXPCMessageType : uint8_t {
@@ -84,7 +83,6 @@ inline bool messageTypeSendsReply(MessageType messageType)
     case MessageType::RemovePushSubscriptionsForOrigin:
     case MessageType::SetPublicTokenForTesting:
     case MessageType::SetPushAndNotificationsEnabledForOrigin:
-    case MessageType::GetOriginsWithPushSubscriptions:
         return true;
     case MessageType::SetDebugModeIsEnabled:
     case MessageType::UpdateConnectionConfiguration:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -928,18 +928,6 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
     });
 }
 
-- (void)_getOriginsWithPushSubscriptions:(void(^)(NSSet<WKSecurityOrigin *> *))completionHandler {
-    auto completionHandlerCopy = makeBlockPtr(completionHandler);
-    _websiteDataStore->networkProcess().getOriginsWithPushSubscriptions(_websiteDataStore->sessionID(), [completionHandlerCopy](const Vector<WebCore::SecurityOriginData>& origins) {
-        auto set = adoptNS([[NSMutableSet alloc] initWithCapacity:origins.size()]);
-        for (auto& origin : origins) {
-            auto apiOrigin = API::SecurityOrigin::create(origin);
-            [set addObject:wrapper(apiOrigin.get())];
-        }
-        completionHandlerCopy(set.get());
-    });
-}
-
 -(void)_scopeURL:(NSURL *)scopeURL hasPushSubscriptionForTesting:(void(^)(BOOL))completionHandler
 {
     auto completionHandlerCopy = makeBlockPtr(completionHandler);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -118,7 +118,6 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteDataStoreFetchOptions) {
 -(void)_processPersistentNotificationClose:(NSDictionary *)notificationDictionaryRepresentation completionHandler:(void(^)(bool))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_deletePushAndNotificationRegistration:(WKSecurityOrigin *)securityOrigin completionHandler:(void(^)(NSError *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_getOriginsWithPushAndNotificationPermissions:(void(^)(NSSet<WKSecurityOrigin *> *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
--(void)_getOriginsWithPushSubscriptions:(void(^)(NSSet<WKSecurityOrigin *> *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_scopeURL:(NSURL *)scopeURL hasPushSubscriptionForTesting:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_originDirectoryForTesting:(NSURL *)origin topOrigin:(NSURL *)topOrigin type:(NSString *)dataType completionHandler:(void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_setBackupExclusionPeriodForTesting:(double)seconds completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1783,11 +1783,6 @@ void NetworkProcessProxy::getOriginsWithPushAndNotificationPermissions(PAL::Sess
     sendWithAsyncReply(Messages::NetworkProcess::GetOriginsWithPushAndNotificationPermissions { sessionID }, WTFMove(callback));
 }
 
-void NetworkProcessProxy::getOriginsWithPushSubscriptions(PAL::SessionID sessionID, CompletionHandler<void(const Vector<SecurityOriginData>&)>&& callback)
-{
-    sendWithAsyncReply(Messages::NetworkProcess::GetOriginsWithPushSubscriptions { sessionID }, WTFMove(callback));
-}
-
 void NetworkProcessProxy::hasPushSubscriptionForTesting(PAL::SessionID sessionID, const URL& scopeURL, CompletionHandler<void(bool)>&& callback)
 {
     sendWithAsyncReply(Messages::NetworkProcess::HasPushSubscriptionForTesting { sessionID, scopeURL }, WTFMove(callback));

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -291,7 +291,6 @@ public:
     void setPushAndNotificationsEnabledForOrigin(PAL::SessionID, const WebCore::SecurityOriginData&, bool, CompletionHandler<void()>&&);
     void deletePushAndNotificationRegistration(PAL::SessionID, const WebCore::SecurityOriginData&, CompletionHandler<void(const String&)>&&);
     void getOriginsWithPushAndNotificationPermissions(PAL::SessionID, CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
-    void getOriginsWithPushSubscriptions(PAL::SessionID, CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
     void hasPushSubscriptionForTesting(PAL::SessionID, const URL&, CompletionHandler<void(bool)>&&);
 
     void dataTaskReceivedChallenge(DataTaskIdentifier, WebCore::AuthenticationChallenge&&, CompletionHandler<void(AuthenticationChallengeDisposition, WebCore::Credential&&)>&&);

--- a/Source/WebKit/webpushd/PushService.h
+++ b/Source/WebKit/webpushd/PushService.h
@@ -64,8 +64,6 @@ public:
     void subscribe(const String& bundleIdentifier, const String& scope, const Vector<uint8_t>& vapidPublicKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&&);
     void unsubscribe(const String& bundleIdentifier, const String& scope, std::optional<WebCore::PushSubscriptionIdentifier>, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&&);
 
-    void getOriginsWithPushSubscriptions(const String& bundleIdentifier, CompletionHandler<void(Vector<String>&&)>&&);
-
     void setPushesEnabledForBundleIdentifierAndOrigin(const String& bundleIdentifier, const String& securityOrigin, bool, CompletionHandler<void()>&&);
 
     void removeRecordsForBundleIdentifier(const String& bundleIdentifier, CompletionHandler<void(unsigned)>&&);

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -501,11 +501,6 @@ void PushService::didCompleteUnsubscribeRequest(UnsubscribeRequest& request)
     finishedPushServiceRequest(m_unsubscribeRequests, request);
 }
 
-void PushService::getOriginsWithPushSubscriptions(const String& bundleIdentifier, CompletionHandler<void(Vector<String>&&)>&& handler)
-{
-    m_database->getOriginsWithPushSubscriptions(bundleIdentifier, WTFMove(handler));
-}
-
 void PushService::incrementSilentPushCount(const String& bundleIdentifier, const String& securityOrigin, CompletionHandler<void(unsigned)>&& handler)
 {
     if (bundleIdentifier.isEmpty() || securityOrigin.isEmpty()) {

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -75,7 +75,6 @@ public:
     void echoTwice(ClientConnection*, const String&, CompletionHandler<void(const String&)>&& replySender);
     void requestSystemNotificationPermission(ClientConnection*, const String&, CompletionHandler<void(bool)>&& replySender);
     void getOriginsWithPushAndNotificationPermissions(ClientConnection*, CompletionHandler<void(const Vector<String>&)>&& replySender);
-    void getOriginsWithPushSubscriptions(ClientConnection*, CompletionHandler<void(Vector<String>&&)>&&);
     void setPushAndNotificationsEnabledForOrigin(ClientConnection*, const String& originString, bool, CompletionHandler<void()>&& replySender);
     void deletePushRegistration(const String&, const String&, CompletionHandler<void()>&&);
     void deletePushAndNotificationRegistration(ClientConnection*, const String& originString, CompletionHandler<void(const String&)>&& replySender);

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -69,11 +69,6 @@ ARGUMENTS()
 REPLY(const Vector<String>&)
 END
 
-FUNCTION(getOriginsWithPushSubscriptions)
-ARGUMENTS()
-REPLY(Vector<String>&&)
-END
-
 FUNCTION(setPushAndNotificationsEnabledForOrigin)
 ARGUMENTS(String, bool)
 REPLY()
@@ -171,13 +166,6 @@ WebPushD::EncodedMessage echoTwice::encodeReply(String reply)
 }
 
 WebPushD::EncodedMessage getOriginsWithPushAndNotificationPermissions::encodeReply(const Vector<String>& reply)
-{
-    WebKit::Daemon::Encoder encoder;
-    encoder << reply;
-    return encoder.takeBuffer();
-}
-
-WebPushD::EncodedMessage getOriginsWithPushSubscriptions::encodeReply(Vector<String>&& reply)
 {
     WebKit::Daemon::Encoder encoder;
     encoder << reply;
@@ -475,9 +463,6 @@ void Daemon::decodeAndHandleMessage(xpc_connection_t connection, MessageType mes
     case MessageType::GetOriginsWithPushAndNotificationPermissions:
         handleWebPushDMessageWithReply<MessageInfo::getOriginsWithPushAndNotificationPermissions>(clientConnection, encodedMessage, WTFMove(replySender));
         break;
-    case MessageType::GetOriginsWithPushSubscriptions:
-        handleWebPushDMessageWithReply<MessageInfo::getOriginsWithPushSubscriptions>(clientConnection, encodedMessage, WTFMove(replySender));
-        break;
     case MessageType::SetPushAndNotificationsEnabledForOrigin:
         handleWebPushDMessageWithReply<MessageInfo::setPushAndNotificationsEnabledForOrigin>(clientConnection, encodedMessage, WTFMove(replySender));
         break;
@@ -571,16 +556,6 @@ void Daemon::getOriginsWithPushAndNotificationPermissions(ClientConnection* conn
 #else
     RELEASE_ASSERT_NOT_REACHED();
 #endif
-}
-
-void Daemon::getOriginsWithPushSubscriptions(ClientConnection* connection, CompletionHandler<void(Vector<String>&&)>&& callback)
-{
-    runAfterStartingPushService([this, bundleIdentifier = connection->hostAppCodeSigningIdentifier(), callback = WTFMove(callback)]() mutable {
-        if (!m_pushService)
-            return callback({ });
-
-        m_pushService->getOriginsWithPushSubscriptions(bundleIdentifier, WTFMove(callback));
-    });
 }
 
 void Daemon::deletePushRegistration(const String& bundleIdentifier, const String& originString, CompletionHandler<void()>&& callback)

--- a/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
@@ -347,25 +347,6 @@ public:
         return result;
     }
 
-    Vector<String> getOriginsWithPushSubscriptions(const String& bundleID)
-    {
-        bool done = false;
-        Vector<String> result;
-
-        db->getOriginsWithPushSubscriptions(bundleID, [&done, &result](Vector<String>&& origins) mutable {
-            result = WTFMove(origins);
-            done = true;
-        });
-        Util::run(&done);
-
-        // Sort to make comparison easier.
-        std::sort(result.begin(), result.end(), [](const String& lhs, const String& rhs) {
-            return codePointCompare(lhs, rhs) < 0;
-        });
-
-        return result;
-    }
-
     void SetUp() final
     {
         db = createDatabaseSync(SQLiteDatabase::inMemoryPath());
@@ -556,32 +537,6 @@ TEST_F(PushDatabaseTest, SetPushesEnabledForOrigin)
 
     result = setPushesEnabledForOrigin("com.apple.nonexistent"_s, "https://www.apple.com"_s, false);
     EXPECT_FALSE(result);
-}
-
-TEST_F(PushDatabaseTest, GetOriginsWithPushSubscriptions)
-{
-    {
-        auto result = getOriginsWithPushSubscriptions("com.apple.webapp"_s);
-        auto expected = Vector<String> { "https://www.apple.com"_s };
-        EXPECT_EQ(result, expected);
-    }
-
-    {
-        auto result = getOriginsWithPushSubscriptions("com.apple.Safari"_s);
-        Vector<String> expected { "https://www.apple.com"_s, "https://www.webkit.org"_s };
-        EXPECT_EQ(result, expected);
-    }
-
-    {
-        bool result = setPushesEnabledForOrigin("com.apple.Safari"_s, "https://www.apple.com"_s, false);
-        EXPECT_TRUE(result);
-    }
-
-    {
-        auto result = getOriginsWithPushSubscriptions("com.apple.Safari"_s);
-        auto expected = Vector<String> { "https://www.webkit.org"_s };
-        EXPECT_EQ(result, expected);
-    }
 }
 
 TEST(PushDatabase, ManyInFlightOps)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -449,25 +449,6 @@ protected:
         return result;
     }
 
-    Vector<String> getOriginsWithPushSubscriptions()
-    {
-        __block bool done = false;
-        __block Vector<String> result;
-
-        [m_dataStore _getOriginsWithPushSubscriptions:^(NSSet<WKSecurityOrigin *> *origins) {
-            for (WKSecurityOrigin *origin in origins) {
-                if (origin.port)
-                    result.append(makeString(String(origin.protocol), "://"_s, String(origin.host), ":"_s, String::number(origin.port)));
-                else
-                    result.append(makeString(String(origin.protocol), "://"_s, String(origin.host)));
-            }
-            done = true;
-        }];
-
-        TestWebKitAPI::Util::run(&done);
-        return result;
-    }
-
     ~WebPushDTest()
     {
         cleanUpTestWebPushD(m_tempDirectory.get());
@@ -695,10 +676,6 @@ TEST_F(WebPushDTest, SubscribeTest)
     ASSERT_EQ([subscription[@"keys"][@"p256dh"] length], 87u);
 
     ASSERT_TRUE(hasPushSubscription());
-
-    auto result = getOriginsWithPushSubscriptions();
-    EXPECT_EQ(result.size(), 1u);
-    EXPECT_EQ(result.first(), m_origin);
 }
 
 TEST_F(WebPushDTest, SubscribeFailureTest)


### PR DESCRIPTION
#### ce6da4432f86313abd18d9887b70a6801a8d034d
<pre>
Remove GetOriginsWithPushSubscriptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=248565">https://bugs.webkit.org/show_bug.cgi?id=248565</a>
&lt;rdar://problem/102832536&gt;

Reviewed by Alex Christensen and Brady Eidson.

We added the GetOriginsWithPushSubscriptions IPC in bug 243347 but never ended up using it since we
ended up going with another approach to handling the interaction between ITP and Web Push (see bug
246468). This removes the unused IPC.

* Source/WebCore/Modules/push-api/PushDatabase.cpp:
(WebCore::PushDatabase::getOriginsWithPushSubscriptions): Deleted.
* Source/WebCore/Modules/push-api/PushDatabase.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::getOriginsWithPushSubscriptions): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::getOriginsWithPushSubscriptions): Deleted.
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/Shared/WebPushDaemonConstants.h:
(WebKit::WebPushD::messageTypeSendsReply):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _getOriginsWithPushSubscriptions:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::getOriginsWithPushSubscriptions): Deleted.
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/webpushd/PushService.h:
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushService::getOriginsWithPushSubscriptions): Deleted.
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::Daemon::decodeAndHandleMessage):
(WebPushD::MessageInfo::getOriginsWithPushSubscriptions::encodeReply): Deleted.
(WebPushD::Daemon::getOriginsWithPushSubscriptions): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp:
(TestWebKitAPI::PushDatabaseTest::getOriginsWithPushSubscriptions): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/257265@main">https://commits.webkit.org/257265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fefcf197d5d57b15f6284d47d245c0ae2012e33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107675 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167958 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7926 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36193 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90803 "Updated gtk dependencies (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104261 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5958 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84812 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/90803 "Updated gtk dependencies (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89533 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/90803 "Updated gtk dependencies (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1393 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1348 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22468 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5005 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44972 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2685 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41892 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->