### PR TITLE
Always make ::backdrop renderers the child of the RenderView except for <dialog>

### DIFF
--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -27,6 +27,7 @@
 #include "RenderTreeUpdaterGeneratedContent.h"
 
 #include "ContentData.h"
+#include "HTMLDialogElement.h"
 #include "InspectorInstrumentation.h"
 #include "PseudoElement.h"
 #include "RenderDescendantIterator.h"
@@ -193,9 +194,11 @@ void RenderTreeUpdater::GeneratedContent::updateBackdropRenderer(RenderElement& 
         newBackdropRenderer->initializeStyle();
         renderer.setBackdropRenderer(*newBackdropRenderer.get());
 
-        // Use the renderer as parent when we can for hit-testing purposes.
-        RenderElement& parentRenderer = renderer.canHaveGeneratedChildren() ? renderer : renderer.view();
-        m_updater.m_builder.attach(parentRenderer, WTFMove(newBackdropRenderer), parentRenderer.lastChild());
+        // For hit-testing purposes, ::backdrop on <dialog> is appended as a child.
+        // FIXME: Make this consistent in webkit.org/b/248551.
+        bool shouldUseDialogAsParent = is<HTMLDialogElement>(renderer.element()) && renderer.canHaveGeneratedChildren();
+        RenderElement& parent = shouldUseDialogAsParent ? renderer : renderer.view();
+        m_updater.m_builder.attach(parent, WTFMove(newBackdropRenderer), parent.lastChild());
     }
 }
 


### PR DESCRIPTION
#### 97f84aa1984b1a3ff3e7c2d6c613fcff6f55952c
<pre>
Always make ::backdrop renderers the child of the RenderView except for &lt;dialog&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=248569">https://bugs.webkit.org/show_bug.cgi?id=248569</a>
rdar://102833504

Reviewed by NOBODY (OOPS!).

Some renderers don&apos;t expect extra children like RenderVideo, which causes the ::backdrop to not be laid out. We could fix all renderers to lay out children, but that&apos;s probably unnecessary complexity and it&apos;s likely to miss certain cases.

So let&apos;s append all ::backdrop to the RenderView whenever we can.

* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updateBackdropRenderer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97f84aa1984b1a3ff3e7c2d6c613fcff6f55952c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107677 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102162 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7928 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36195 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103874 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84814 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/90805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1395 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/1350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4966 "Found 2 new test failures: streams/readable-stream-default-controller-error.html, streams/readable-stream-tee-worker.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6229 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2687 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41894 "Failed to checkout and rebase branch from PR 6997") | | 
<!--EWS-Status-Bubble-End-->