### PR TITLE
Show thumbnail when navigating to a USDZ file

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm
@@ -55,7 +55,7 @@
         [self registerProvider:[WKPDFView class] forMIMEType:@(type.characters())];
 #endif
 
-#if USE(SYSTEM_PREVIEW) && !HAVE(UIKIT_WEBKIT_INTERNALS)
+#if USE(SYSTEM_PREVIEW)
     if (configuration._systemPreviewEnabled && !configuration.preferences._modelDocumentEnabled) {
         for (auto& type : WebCore::MIMETypeRegistry::usdMIMETypes())
             [self registerProvider:[WKUSDPreviewView class] forMIMEType:@(type.characters())];

--- a/Source/WebKit/UIProcess/ios/WKUSDPreviewView.h
+++ b/Source/WebKit/UIProcess/ios/WKUSDPreviewView.h
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if USE(SYSTEM_PREVIEW) && !HAVE(UIKIT_WEBKIT_INTERNALS)
+#if USE(SYSTEM_PREVIEW)
 
 #import "WKApplicationStateTrackingView.h"
 #import "WKWebViewContentProvider.h"

--- a/Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm
+++ b/Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm
@@ -26,7 +26,7 @@
 #import "config.h"
 #import "WKUSDPreviewView.h"
 
-#if USE(SYSTEM_PREVIEW) && !HAVE(UIKIT_WEBKIT_INTERNALS)
+#if USE(SYSTEM_PREVIEW)
 
 #import "APIFindClient.h"
 #import "APIUIClient.h"


### PR DESCRIPTION
#### ef3a06e1f3c35d4776583f03ec9688f6e9f9152c
<pre>
Show thumbnail when navigating to a USDZ file
<a href="https://bugs.webkit.org/show_bug.cgi?id=248574">https://bugs.webkit.org/show_bug.cgi?id=248574</a>
rdar://102780167

Reviewed by Tim Horton.

ASVThumbnailView is available again, so use it.

* Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm:
(-[WKWebViewContentProviderRegistry initWithConfiguration:]):
* Source/WebKit/UIProcess/ios/WKUSDPreviewView.h:
* Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm:

Canonical link: <a href="https://commits.webkit.org/257206@main">https://commits.webkit.org/257206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55dd70b50dc7eba9297c9b7432c4bafd9ecdfbd2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98228 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/7438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/31368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/107684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7936 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/36201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103882 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/84820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/90812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/31368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/1401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/31368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/1356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/31368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/6237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/84820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2477 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/2693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/31368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->