### PR TITLE
Masonry repeat(auto-fit) should behave as repeat(auto-fill)

### DIFF
--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -698,16 +698,6 @@ static GridArea insertIntoGrid(Grid& grid, RenderBox& child, const GridArea& are
     return clamped;
 }
 
-static inline bool isMasonryRows(const RenderStyle& style)
-{
-    return style.gridMasonryRows();
-}
-
-static inline bool isMasonryColumns(const RenderStyle& style)
-{
-    return !isMasonryRows(style) && style.gridMasonryColumns();
-}
-
 // FIXME: We shouldn't have to pass the available logical width as argument. The problem is that
 // availableLogicalWidth() does always return a value even if we cannot resolve it like when
 // computing the intrinsic size (preferred widths). That's why we pass the responsibility to the
@@ -738,9 +728,9 @@ void RenderGrid::placeItemsOnGrid(std::optional<LayoutUnit> availableLogicalWidt
 
         // Grid items should use the grid area sizes instead of the containing block (grid container)
         // sizes, we initialize the overrides here if needed to ensure it.
-        if (!child->hasOverridingContainingBlockContentLogicalWidth() && !isMasonryColumns(style()))
+        if (!child->hasOverridingContainingBlockContentLogicalWidth() && !style().gridMasonryColumns())
             child->setOverridingContainingBlockContentLogicalWidth(LayoutUnit());
-        if (!child->hasOverridingContainingBlockContentLogicalHeight() && !isMasonryRows(style()))
+        if (!child->hasOverridingContainingBlockContentLogicalHeight() && !style().gridMasonryRows())
             child->setOverridingContainingBlockContentLogicalHeight(std::nullopt);
 
         GridArea area = currentGrid().gridItemArea(*child);
@@ -798,9 +788,9 @@ void RenderGrid::placeItemsOnGrid(std::optional<LayoutUnit> availableLogicalWidt
         m_masonryLayout.performMasonryPlacement(firstTrackItems, itemsWithDefiniteGridAxisPosition, itemsWithIndefinitePosition, masonryAxisDirection);
     };
 
-    if (isMasonryRows(style())) 
+    if (style().gridMasonryRows()) 
         performMasonryPlacement(ForRows);
-    else if (isMasonryColumns(style()))
+    else if (style().gridMasonryRows())
         performMasonryPlacement(ForColumns);
     else
         performAutoPlacement();
@@ -1226,9 +1216,9 @@ void RenderGrid::layoutPositionedObject(RenderBox& child, bool relayoutChildren,
 LayoutUnit RenderGrid::gridAreaBreadthForChildIncludingAlignmentOffsets(const RenderBox& child, GridTrackSizingDirection direction) const
 {
     if (direction == ForRows) {
-        if (isMasonryRows(style()))
+        if (style().gridMasonryRows())
             return isHorizontalWritingMode() ? child.height() + child.verticalMarginExtent() : child.width() + child.horizontalMarginExtent();
-    } else if (isMasonryColumns(style()))
+    } else if (style().gridMasonryColumns())
         return isHorizontalWritingMode() ? child.width() + child.horizontalMarginExtent() : child.height() + child.verticalMarginExtent();
 
     // We need the cached value when available because Content Distribution alignment properties
@@ -1758,7 +1748,7 @@ LayoutUnit RenderGrid::columnAxisOffsetForChild(const RenderBox& child) const
     gridAreaPositionForChild(child, ForRows, startOfRow, endOfRow);
     LayoutUnit startPosition = startOfRow + marginBeforeForChild(child);
     LayoutUnit columnAxisChildSize = GridLayoutFunctions::isOrthogonalChild(*this, child) ? child.logicalWidth() + child.marginLogicalWidth() : child.logicalHeight() + child.marginLogicalHeight();
-    LayoutUnit masonryOffset = isMasonryRows(style()) ? m_masonryLayout.offsetForChild(child) : 0_lu;
+    LayoutUnit masonryOffset = style().gridMasonryRows() ? m_masonryLayout.offsetForChild(child) : 0_lu;
     auto overflow = alignSelfForChild(child).overflow();
         LayoutUnit offsetFromStartPosition = computeOverflowAlignmentOffset(overflow, endOfRow - startOfRow, columnAxisChildSize);
     if (hasAutoMarginsInColumnAxis(child))
@@ -1783,7 +1773,7 @@ LayoutUnit RenderGrid::rowAxisOffsetForChild(const RenderBox& child) const
     LayoutUnit endOfColumn;
     gridAreaPositionForChild(child, ForColumns, startOfColumn, endOfColumn);
     LayoutUnit startPosition = startOfColumn + marginStartForChild(child);
-    LayoutUnit masonryOffset = isMasonryColumns(style()) ? m_masonryLayout.offsetForChild(child) : 0_lu;
+    LayoutUnit masonryOffset = style().gridMasonryColumns() ? m_masonryLayout.offsetForChild(child) : 0_lu;
     if (hasAutoMarginsInRowAxis(child))
         return startPosition;
     GridAxisPosition axisPosition = rowAxisPositionForChild(child);

--- a/Source/WebCore/rendering/style/StyleGridData.h
+++ b/Source/WebCore/rendering/style/StyleGridData.h
@@ -117,14 +117,34 @@ public:
     const unsigned& autoRepeatColumnsInsertionPoint() const { return m_autoRepeatColumnsInsertionPoint; }
     const unsigned& autoRepeatRowsInsertionPoint() const { return m_autoRepeatRowsInsertionPoint; }
 
-    const AutoRepeatType& autoRepeatColumnsType() const { return m_autoRepeatColumnsType; }
-    const AutoRepeatType& autoRepeatRowsType() const { return m_autoRepeatRowsType; }
-
     const bool& subgridRows() const { return m_subgridRows; };
     const bool& subgridColumns() const { return m_subgridColumns; }
 
+    // Masonry Spec Section 2
+    // "If masonry is specified for both grid-template-columns and grid-template-rows, then the used value for grid-template-columns is none, 
+    // and thus the inline axis will be the grid axis."
+
     bool masonryRows() const { return m_masonryRows; }
-    bool masonryColumns() const { return m_masonryColumns; }
+    bool masonryColumns() const { return !m_masonryRows && m_masonryColumns; }
+
+    // Masonry Spec Section 2.3.1 repeat(auto-fit)
+    // "repeat(auto-fit) behaves as repeat(auto-fill) when the other axis is a masonry axis."
+    // We need to lie here that we are are really an auto-fill instead of an auto-fit.
+
+    AutoRepeatType autoRepeatColumnsType() const 
+    { 
+        if (masonryRows() && m_autoRepeatColumnsType == AutoRepeatType::Fit) 
+            return AutoRepeatType::Fill;
+        return m_autoRepeatColumnsType; 
+    }
+    
+    AutoRepeatType autoRepeatRowsType() const 
+    { 
+        if (masonryColumns() && m_autoRepeatRowsType == AutoRepeatType::Fit) 
+            return AutoRepeatType::Fill;
+        return m_autoRepeatRowsType; 
+    }
+
 
     const GridTrackList& columns() const { return m_columns; };
     const GridTrackList& rows() const { return m_rows; };


### PR DESCRIPTION
#### 7b675d00b20040b94a16d3456e40952cd1d3d0fb
<pre>
Masonry repeat(auto-fit) should behave as repeat(auto-fill)
<a href="https://bugs.webkit.org/show_bug.cgi?id=248577">https://bugs.webkit.org/show_bug.cgi?id=248577</a>

Reviewed by NOBODY (OOPS!).

Masonry repeat(auto-fit) should have the properities of repeat(auto-fill) according to the spec.
<a href="https://drafts.csswg.org/css-grid-3/#repeat-auto-fit">https://drafts.csswg.org/css-grid-3/#repeat-auto-fit</a>

This patch also cleans up checking if masonry is enabled for grid and column.

* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::placeItemsOnGrid):
(WebCore::RenderGrid::gridAreaBreadthForChildIncludingAlignmentOffsets const):
(WebCore::RenderGrid::columnAxisOffsetForChild const):
(WebCore::RenderGrid::rowAxisOffsetForChild const):
(WebCore::isMasonryRows): Deleted.
(WebCore::isMasonryColumns): Deleted.
* Source/WebCore/rendering/style/StyleGridData.h:
(WebCore::StyleGridData::masonryColumns const):
(WebCore::StyleGridData::autoRepeatColumnsType const):
(WebCore::StyleGridData::autoRepeatRowsType const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b675d00b20040b94a16d3456e40952cd1d3d0fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107687 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167969 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7939 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36204 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90815 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104272 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103885 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5967 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-align-content-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84823 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33068 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-align-content-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89537 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1404 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1359 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22472 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-align-content-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6240 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44976 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-align-content-003.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2696 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41896 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->