### PR TITLE
Make some data structures const.

### DIFF
--- a/Source/JavaScriptCore/API/tests/CustomGlobalObjectClassTest.c
+++ b/Source/JavaScriptCore/API/tests/CustomGlobalObjectClassTest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ static JSValueRef jsDoSomething(JSContextRef ctx, JSObjectRef function, JSObject
     return JSValueMakeNull(ctx);
 }
 
-static JSStaticFunction bridgedFunctions[] = {
+static const JSStaticFunction bridgedFunctions[] = {
     {"doSomething", jsDoSomething, kJSPropertyAttributeDontDelete},
     {0, 0, 0},
 };

--- a/Source/JavaScriptCore/API/tests/JSNode.c
+++ b/Source/JavaScriptCore/API/tests/JSNode.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Apple Inc.  All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -97,7 +97,7 @@ static JSValueRef JSNode_replaceChild(JSContextRef context, JSObjectRef function
     return JSValueMakeUndefined(context);
 }
 
-static JSStaticFunction JSNode_staticFunctions[] = {
+static const JSStaticFunction JSNode_staticFunctions[] = {
     { "appendChild", JSNode_appendChild, kJSPropertyAttributeDontDelete },
     { "removeChild", JSNode_removeChild, kJSPropertyAttributeDontDelete },
     { "replaceChild", JSNode_replaceChild, kJSPropertyAttributeDontDelete },
@@ -139,7 +139,7 @@ static JSValueRef JSNode_getFirstChild(JSContextRef context, JSObjectRef object,
     return JSValueMakeUndefined(context);
 }
 
-static JSStaticValue JSNode_staticValues[] = {
+static const JSStaticValue JSNode_staticValues[] = {
     { "nodeType", JSNode_getNodeType, NULL, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
     { "childNodes", JSNode_getChildNodes, NULL, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
     { "firstChild", JSNode_getFirstChild, NULL, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },

--- a/Source/JavaScriptCore/API/tests/JSNodeList.c
+++ b/Source/JavaScriptCore/API/tests/JSNodeList.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Apple Inc.  All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,7 +46,7 @@ static JSValueRef JSNodeList_item(JSContextRef context, JSObjectRef object, JSOb
     return JSValueMakeUndefined(context);
 }
 
-static JSStaticFunction JSNodeList_staticFunctions[] = {
+static const JSStaticFunction JSNodeList_staticFunctions[] = {
     { "item", JSNodeList_item, kJSPropertyAttributeDontDelete },
     { 0, 0, 0 }
 };
@@ -61,7 +61,7 @@ static JSValueRef JSNodeList_length(JSContextRef context, JSObjectRef thisObject
     return JSValueMakeNumber(context, NodeList_length(nodeList));
 }
 
-static JSStaticValue JSNodeList_staticValues[] = {
+static const JSStaticValue JSNodeList_staticValues[] = {
     { "length", JSNodeList_length, NULL, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
     { 0, 0, 0, 0 }
 };

--- a/Source/JavaScriptCore/API/tests/PingPongStackOverflowTest.cpp
+++ b/Source/JavaScriptCore/API/tests/PingPongStackOverflowTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,7 +71,7 @@ static bool PingPongStackOverflowObject_hasInstance(JSContextRef context, JSObje
     return result && JSValueToBoolean(context, result);
 }
 
-JSClassDefinition PingPongStackOverflowObject_definition = {
+static const JSClassDefinition PingPongStackOverflowObject_definition = {
     0,
     kJSClassAttributeNone,
     

--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2020 Apple Inc.  All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -407,18 +407,18 @@ static bool MyObject_set_nullGetForwardSet(JSContextRef ctx, JSObjectRef object,
     return false; // Forward to parent class.
 }
 
-static JSStaticValue evilStaticValues[] = {
+static const JSStaticValue evilStaticValues[] = {
     { "nullGetSet", 0, 0, kJSPropertyAttributeNone },
     { "nullGetForwardSet", 0, MyObject_set_nullGetForwardSet, kJSPropertyAttributeNone },
     { 0, 0, 0, 0 }
 };
 
-static JSStaticFunction evilStaticFunctions[] = {
+static const JSStaticFunction evilStaticFunctions[] = {
     { "nullCall", 0, kJSPropertyAttributeNone },
     { 0, 0, 0 }
 };
 
-JSClassDefinition MyObject_definition = {
+static const JSClassDefinition MyObject_definition = {
     0,
     kJSClassAttributeNone,
     
@@ -441,7 +441,7 @@ JSClassDefinition MyObject_definition = {
     MyObject_convertToType,
 };
 
-JSClassDefinition MyObject_convertToTypeWrapperDefinition = {
+static const JSClassDefinition MyObject_convertToTypeWrapperDefinition = {
     0,
     kJSClassAttributeNone,
     
@@ -464,7 +464,7 @@ JSClassDefinition MyObject_convertToTypeWrapperDefinition = {
     MyObject_convertToTypeWrapper,
 };
 
-JSClassDefinition MyObject_nullWrapperDefinition = {
+static const JSClassDefinition MyObject_nullWrapperDefinition = {
     0,
     kJSClassAttributeNone,
     
@@ -493,11 +493,13 @@ static JSClassRef MyObject_class(JSContextRef context)
 
     static JSClassRef jsClass;
     if (!jsClass) {
+        JSClassDefinition classDefinition = MyObject_convertToTypeWrapperDefinition;
+        JSClassDefinition nullClassDefinition = MyObject_nullWrapperDefinition;
         JSClassRef baseClass = JSClassCreate(&MyObject_definition);
-        MyObject_convertToTypeWrapperDefinition.parentClass = baseClass;
-        JSClassRef wrapperClass = JSClassCreate(&MyObject_convertToTypeWrapperDefinition);
-        MyObject_nullWrapperDefinition.parentClass = wrapperClass;
-        jsClass = JSClassCreate(&MyObject_nullWrapperDefinition);
+        classDefinition.parentClass = baseClass;
+        JSClassRef wrapperClass = JSClassCreate(&classDefinition);
+        nullClassDefinition.parentClass = wrapperClass;
+        jsClass = JSClassCreate(&nullClassDefinition);
     }
 
     return jsClass;
@@ -579,7 +581,7 @@ static void PropertyCatchalls_getPropertyNames(JSContextRef context, JSObjectRef
     JSStringRelease(propertyName);
 }
 
-JSClassDefinition PropertyCatchalls_definition = {
+static const JSClassDefinition PropertyCatchalls_definition = {
     0,
     kJSClassAttributeNone,
     
@@ -659,7 +661,7 @@ static JSValueRef EvilExceptionObject_convertToType(JSContextRef context, JSObje
     return value;
 }
 
-JSClassDefinition EvilExceptionObject_definition = {
+static const JSClassDefinition EvilExceptionObject_definition = {
     0,
     kJSClassAttributeNone,
 
@@ -693,7 +695,7 @@ static JSClassRef EvilExceptionObject_class(JSContextRef context)
     return jsClass;
 }
 
-JSClassDefinition EmptyObject_definition = {
+static const JSClassDefinition EmptyObject_definition = {
     0,
     kJSClassAttributeNone,
     
@@ -770,14 +772,14 @@ static JSValueRef Base_returnHardNull(JSContextRef ctx, JSObjectRef function, JS
     return 0; // should convert to undefined!
 }
 
-static JSStaticFunction Base_staticFunctions[] = {
+static const JSStaticFunction Base_staticFunctions[] = {
     { "baseProtoDup", NULL, kJSPropertyAttributeNone },
     { "baseProto", Base_callAsFunction, kJSPropertyAttributeNone },
     { "baseHardNull", Base_returnHardNull, kJSPropertyAttributeNone },
     { 0, 0, 0 }
 };
 
-static JSStaticValue Base_staticValues[] = {
+static const JSStaticValue Base_staticValues[] = {
     { "baseDup", Base_get, Base_set, kJSPropertyAttributeNone },
     { "baseOnly", Base_get, Base_set, kJSPropertyAttributeNone },
     { 0, 0, 0, 0 }
@@ -851,14 +853,14 @@ static JSValueRef Derived_callAsFunction(JSContextRef ctx, JSObjectRef function,
     return JSValueMakeNumber(ctx, 2); // distinguish base call from derived call
 }
 
-static JSStaticFunction Derived_staticFunctions[] = {
+static const JSStaticFunction Derived_staticFunctions[] = {
     { "protoOnly", Derived_callAsFunction, kJSPropertyAttributeNone },
     { "protoDup", NULL, kJSPropertyAttributeNone },
     { "baseProtoDup", Derived_callAsFunction, kJSPropertyAttributeNone },
     { 0, 0, 0 }
 };
 
-static JSStaticValue Derived_staticValues[] = {
+static const JSStaticValue Derived_staticValues[] = {
     { "derivedOnly", Derived_get, Derived_set, kJSPropertyAttributeNone },
     { "protoDup", Derived_get, Derived_set, kJSPropertyAttributeNone },
     { "baseDup", Derived_get, Derived_set, kJSPropertyAttributeNone },
@@ -1016,13 +1018,13 @@ static JSValueRef functionGC(JSContextRef context, JSObjectRef function, JSObjec
     return JSValueMakeUndefined(context);
 }
 
-static JSStaticValue globalObject_staticValues[] = {
+static const JSStaticValue globalObject_staticValues[] = {
     { "globalStaticValue", globalObject_get, globalObject_set, kJSPropertyAttributeNone },
     { "globalStaticValue2", globalObject_get, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontEnum },
     { 0, 0, 0, 0 }
 };
 
-static JSStaticFunction globalObject_staticFunctions[] = {
+static const JSStaticFunction globalObject_staticFunctions[] = {
     { "globalStaticFunction", globalObject_call, kJSPropertyAttributeNone },
     { "globalStaticFunction2", globalObject_call, kJSPropertyAttributeNone },
     { "globalStaticFunction3", globalObject_call, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontEnum },

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1582,12 +1582,12 @@ FloatSize PDFPlugin::pdfDocumentSizeForPrinting() const
 
 JSObjectRef PDFPlugin::makeJSPDFDoc(JSContextRef ctx)
 {
-    static JSStaticFunction jsPDFDocStaticFunctions[] = {
+    static const JSStaticFunction jsPDFDocStaticFunctions[] = {
         { "print", jsPDFDocPrint, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { 0, 0, 0 },
     };
 
-    static JSClassDefinition jsPDFDocClassDefinition = {
+    static const JSClassDefinition jsPDFDocClassDefinition = {
         0,
         kJSClassAttributeNone,
         "Doc",

--- a/Source/WebKitLegacy/mac/WebView/WebJSPDFDoc.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebJSPDFDoc.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,12 +52,12 @@ static JSValueRef jsPDFDocPrint(JSContextRef ctx, JSObjectRef function, JSObject
     return JSValueMakeUndefined(ctx);
 }
 
-static JSStaticFunction jsPDFDocStaticFunctions[] = {
+static const JSStaticFunction jsPDFDocStaticFunctions[] = {
     { "print", jsPDFDocPrint, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
     { 0, 0, 0 },
 };
 
-static JSClassDefinition jsPDFDocClassDefinition = {
+static const JSClassDefinition jsPDFDocClassDefinition = {
     0,
     kJSClassAttributeNone,
     "Doc",

--- a/Tools/DumpRenderTree/AccessibilityTextMarker.cpp
+++ b/Tools/DumpRenderTree/AccessibilityTextMarker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,16 +62,16 @@ JSObjectRef AccessibilityTextMarker::makeJSAccessibilityTextMarker(JSContextRef 
 
 JSClassRef AccessibilityTextMarker::getJSClass()
 {
-    static JSStaticValue staticValues[] = {
+    static const JSStaticValue staticValues[] = {
         { 0, 0, 0, 0 }
     };
     
-    static JSStaticFunction staticFunctions[] = {
+    static const JSStaticFunction staticFunctions[] = {
         { "isEqual", isMarkerEqualCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { 0, 0, 0 }
     };
     
-    static JSClassDefinition classDefinition = {
+    static const JSClassDefinition classDefinition = {
         0, kJSClassAttributeNone, "AccessibilityTextMarker", 0, staticValues, staticFunctions,
         0, markerFinalize, 0, 0, 0, 0, 0, 0, 0, 0, 0
     };
@@ -114,16 +114,16 @@ JSObjectRef AccessibilityTextMarkerRange::makeJSAccessibilityTextMarkerRange(JSC
 
 JSClassRef AccessibilityTextMarkerRange::getJSClass()
 {
-    static JSStaticValue staticValues[] = {
+    static const JSStaticValue staticValues[] = {
         { 0, 0, 0, 0 }
     };
     
-    static JSStaticFunction staticFunctions[] = {
+    static const JSStaticFunction staticFunctions[] = {
         { "isEqual", isMarkerRangeEqualCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { 0, 0, 0 }
     };
     
-    static JSClassDefinition classDefinition = {
+    static const JSClassDefinition classDefinition = {
         0, kJSClassAttributeNone, "AccessibilityTextMarkerRange", 0, staticValues, staticFunctions,
         0, markerRangeFinalize, 0, 0, 0, 0, 0, 0, 0, 0, 0
     };

--- a/Tools/DumpRenderTree/AccessibilityUIElement.cpp
+++ b/Tools/DumpRenderTree/AccessibilityUIElement.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008, 2009 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2008-2022 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1945,7 +1945,7 @@ JSObjectRef AccessibilityUIElement::makeJSAccessibilityUIElement(JSContextRef co
 
 JSClassRef AccessibilityUIElement::getJSClass()
 {
-    static JSStaticValue staticValues[] = {
+    static const JSStaticValue staticValues[] = {
         { "accessibilityValue", getAccessibilityValueCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "role", getRoleCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "subrole", getSubroleCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
@@ -2041,7 +2041,7 @@ JSClassRef AccessibilityUIElement::getJSClass()
         { 0, 0, 0, 0 }
     };
 
-    static JSStaticFunction staticFunctions[] = {
+    static const JSStaticFunction staticFunctions[] = {
         { "allAttributes", allAttributesCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "attributesOfLinkedUIElements", attributesOfLinkedUIElementsCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "attributesOfDocumentLinks", attributesOfDocumentLinksCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
@@ -2175,7 +2175,7 @@ JSClassRef AccessibilityUIElement::getJSClass()
         { 0, 0, 0 }
     };
 
-    static JSClassDefinition classDefinition = {
+    static const JSClassDefinition classDefinition = {
         0, kJSClassAttributeNone, "AccessibilityUIElement", 0, staticValues, staticFunctions,
         0, finalize, 0, 0, 0, 0, 0, 0, 0, 0, 0
     };

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010, 2011, 2014-2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -88,12 +88,12 @@ static JSValueRef getMenuItemChildrenCallback(JSContextRef context, JSObjectRef 
     return array;
 }
 
-static JSStaticFunction staticMenuItemFunctions[] = {
+static const JSStaticFunction staticMenuItemFunctions[] = {
     { "click", menuItemClickCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
     { 0, 0, 0 }
 };
 
-static JSStaticValue staticMenuItemValues[] = {
+static const JSStaticValue staticMenuItemValues[] = {
     { "title", getMenuItemTitleCallback, 0, kJSPropertyAttributeReadOnly },
     { "children", getMenuItemChildrenCallback, 0, kJSPropertyAttributeReadOnly },
     { "enabled", getMenuItemEnabledCallback, 0, kJSPropertyAttributeReadOnly },


### PR DESCRIPTION
#### 2c298496904ce18b232566e9677e3122e1018b88
<pre>
Make some data structures const.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248581">https://bugs.webkit.org/show_bug.cgi?id=248581</a>
&lt;rdar://problem/102839757&gt;

Reviewed by Yusuke Suzuki.

These are meant to be const global data, and should be declared as such.

* Source/JavaScriptCore/API/tests/CustomGlobalObjectClassTest.c:
* Source/JavaScriptCore/API/tests/JSNode.c:
* Source/JavaScriptCore/API/tests/JSNodeList.c:
* Source/JavaScriptCore/API/tests/PingPongStackOverflowTest.cpp:
* Source/JavaScriptCore/API/tests/testapi.c:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::makeJSPDFDoc):
* Source/WebKitLegacy/mac/WebView/WebJSPDFDoc.mm:
* Tools/DumpRenderTree/AccessibilityTextMarker.cpp:
(AccessibilityTextMarker::getJSClass):
(AccessibilityTextMarkerRange::getJSClass):
* Tools/DumpRenderTree/AccessibilityUIElement.cpp:
(AccessibilityUIElement::getJSClass):
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp:

Canonical link: <a href="https://commits.webkit.org/257249@main">https://commits.webkit.org/257249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/564566b0464b201a5f97cb48cfe677d4d1235874

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98238 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107691 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167973 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102180 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7948 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36208 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90819 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104276 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5973 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84830 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33067 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89539 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89068 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1408 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84803 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1363 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22474 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28653 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6245 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87648 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2492 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41898 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19654 "Passed tests") | 
<!--EWS-Status-Bubble-End-->