### PR TITLE
Support ::backdrop renderers on all elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection.html
@@ -58,11 +58,11 @@ promise_test(async function() {
 }, "Clicking on backdrop doesn't select text");
 
 promise_test(async function() {
-  dialog.style.userSelect = "none";
+  dialog.style.webkitUserSelect = "none";
 
   await selectSomeText();
   assert_equals(getSelection().toString(), "");
 
-  dialog.style.userSelect = "";
+  dialog.style.webkitUserSelect = "";
 }, "'user-select: none' prevents text from being selected");
 </script>

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection-expected.txt
@@ -1,6 +1,6 @@
 123456789A
 
-FAIL By default, text inside a modal dialog can be selected assert_equals: expected "345678" but got "123456789A"
+FAIL By default, text inside a modal dialog can be selected assert_equals: expected "345678" but got ""
 PASS Clicking on backdrop doesn't select text
 PASS 'user-select: none' prevents text from being selected
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2033,6 +2033,19 @@ bool RenderBlock::isPointInOverflowControl(HitTestResult& result, const LayoutPo
 
 Node* RenderBlock::nodeForHitTest() const
 {
+    // If we're a ::backdrop pseudo-element, we should hit-test to the element that generated it.
+    // This matches the behavior that other browsers have.
+    if (style().styleType() == PseudoId::Backdrop) {
+        for (auto& element : document().topLayerElements()) {
+            if (!element->renderer())
+                continue;
+            ASSERT(element->renderer()->backdropRenderer());
+            if (element->renderer()->backdropRenderer() == this)
+                return element.ptr();
+        }
+        ASSERT_NOT_REACHED();
+    }
+
     // If we are in the margins of block elements that are part of a
     // continuation we're actually still inside the enclosing element
     // that was split. Use the appropriate inner node.

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -175,9 +175,6 @@ void RenderTreeUpdater::GeneratedContent::updatePseudoElement(Element& current, 
 
 void RenderTreeUpdater::GeneratedContent::updateBackdropRenderer(RenderElement& renderer)
 {
-    if (!renderer.canHaveGeneratedChildren())
-        return;
-
     auto destroyBackdropIfNeeded = [&renderer, this]() {
         if (WeakPtr backdropRenderer = renderer.backdropRenderer())
             m_updater.m_builder.destroy(*backdropRenderer);
@@ -203,7 +200,7 @@ void RenderTreeUpdater::GeneratedContent::updateBackdropRenderer(RenderElement& 
         auto newBackdropRenderer = WebCore::createRenderer<RenderBlockFlow>(renderer.document(), WTFMove(newStyle));
         newBackdropRenderer->initializeStyle();
         renderer.setBackdropRenderer(*newBackdropRenderer.get());
-        m_updater.m_builder.attach(renderer, WTFMove(newBackdropRenderer), renderer.firstChild());
+        m_updater.m_builder.attach(renderer.view(), WTFMove(newBackdropRenderer));
     }
 }
 


### PR DESCRIPTION
#### fc7f34162f2456c11091af902071437be8911450
<pre>
Support ::backdrop renderers on all elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=248569">https://bugs.webkit.org/show_bug.cgi?id=248569</a>
rdar://102833504

Reviewed by Darin Adler.

The fullscreen API needs to display ::backdrop pseudo elements for _all_ elements, with no exception.

- Add custom code in RenderBlock::nodeForHitTest to get correct handling for hit-testing
- Append backdrop renderers as children of RenderView, since not all individual renderers support children. RenderView is guaranteed to exist and it now centralizes all ::backdrop in one place.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection.html:
This was imported when we unprefixed -webkit-user-select, however this was reverted. The import script usually adds prefixes as necessary.
This didn&apos;t fail before, since the test selected nothing both with or without user-select.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection-expected.txt: Added.
The new results are due to the hit-testing change, which now causes us to start a selection when we mousedown on the backdrop.
They pass properly on WebDriver, since the WKTR testdriver is incorrect, the mouse selection should start at the 3rd character, end at the 6th, not start outside of the backdrop.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::nodeForHitTest const): Lookup associated renderer in top layer in case of ::backdrop to match behavior tested by backdrop-receives-element-events.html, common to other browsers.
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updateBackdropRenderer):

Canonical link: <a href="https://commits.webkit.org/257337@main">https://commits.webkit.org/257337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/786e2cfb96d847eeffd176b799805c52f8ca6f4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108027 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168290 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85194 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91142 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/105992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104287 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6306 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33306 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21222 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76232 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1748 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1659 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42190 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2534 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3048 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->