### PR TITLE
Avoid code duplication between ComputedStylePropertyMapReadOnly and MainThreadStylePropertyMapReadOnly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-expected.txt
@@ -9,9 +9,9 @@ PASS Setting 'background' to a flexible length throws TypeError
 FAIL Setting 'background' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'background' to a URL throws TypeError
 PASS Setting 'background' to a transform throws TypeError
-FAIL 'background' does not supported 'green' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'background' does not supported 'green'
 PASS 'background' does not supported 'content-box radial-gradient(crimson, skyblue)'
 PASS 'background' does not supported 'no-repeat url("http://foo.com")'
-FAIL 'background' does not supported 'left 5% / 15% 60% repeat-x url("http://foo.com")' Bad value for shorthand CSS property
-FAIL 'background' does not supported 'center / contain no-repeat url("foo.com"), red' Bad value for shorthand CSS property
+PASS 'background' does not supported 'left 5% / 15% 60% repeat-x url("http://foo.com")'
+PASS 'background' does not supported 'center / contain no-repeat url("foo.com"), red'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt
@@ -41,6 +41,6 @@ PASS Setting 'border-bottom-right-radius' to a URL throws TypeError
 PASS Setting 'border-bottom-right-radius' to a transform throws TypeError
 PASS 'border-radius' does not supported '30px'
 PASS 'border-radius' does not supported '25% 10%'
-FAIL 'border-radius' does not supported '10% / 50%' Bad value for shorthand CSS property
-FAIL 'border-radius' does not supported '50% 20% / 10% 40%' Bad value for shorthand CSS property
+PASS 'border-radius' does not supported '10% / 50%'
+PASS 'border-radius' does not supported '50% 20% / 10% 40%'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-flow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-flow-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL 'flex-flow' does not supported 'row' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'flex-flow' does not supported 'row'
 PASS 'flex-flow' does not supported 'column wrap'
 PASS 'flex-flow' does not supported 'row-reverse wrap-reverse'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL 'font' does not supported '1.2em "Fira Sans", sans-serif' Bad value for shorthand CSS property
-FAIL 'font' does not supported 'italic 1.2em "Fira Sans", serif' Bad value for shorthand CSS property
-FAIL 'font' does not supported 'italic small-caps bold 16px/2 cursive' Bad value for shorthand CSS property
-FAIL 'font' does not supported 'small-caps bold 24px/1 sans-serif' Bad value for shorthand CSS property
-FAIL 'font' does not supported 'caption' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS 'font' does not supported '1.2em "Fira Sans", sans-serif'
+PASS 'font' does not supported 'italic 1.2em "Fira Sans", serif'
+PASS 'font' does not supported 'italic small-caps bold 16px/2 cursive'
+PASS 'font' does not supported 'small-caps bold 24px/1 sans-serif'
+PASS 'font' does not supported 'caption'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-synthesis-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-synthesis-expected.txt
@@ -35,7 +35,7 @@ PASS Setting 'font-synthesis-small-caps' to a flexible length throws TypeError
 PASS Setting 'font-synthesis-small-caps' to a number throws TypeError
 PASS Setting 'font-synthesis-small-caps' to a URL throws TypeError
 PASS Setting 'font-synthesis-small-caps' to a transform throws TypeError
-FAIL 'font-synthesis' does not supported 'weight style' Bad value for shorthand CSS property
-FAIL 'font-synthesis' does not supported 'style small-caps' Bad value for shorthand CSS property
-FAIL 'font-synthesis' does not supported 'small-caps weight style' Bad value for shorthand CSS property
+PASS 'font-synthesis' does not supported 'weight style'
+PASS 'font-synthesis' does not supported 'style small-caps'
+PASS 'font-synthesis' does not supported 'small-caps weight style'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL 'font-variant' does not supported 'normal' Bad value for shorthand CSS property
+PASS 'font-variant' does not supported 'normal'
 PASS 'font-variant' does not supported 'no-common-ligatures proportional-nums'
 PASS 'font-variant' does not supported 'common-ligatures tabular-nums'
-FAIL 'font-variant' does not supported 'small-caps slashed-zero' Bad value for shorthand CSS property
+PASS 'font-variant' does not supported 'small-caps slashed-zero'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-area-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-area-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL 'grid-area' does not supported 'a' Bad value for shorthand CSS property
-FAIL 'grid-area' does not supported 'a / a' Bad value for shorthand CSS property
-FAIL 'grid-area' does not supported 'auto' Bad value for shorthand CSS property
-FAIL 'grid-area' does not supported 'auto / auto' Bad value for shorthand CSS property
-FAIL 'grid-area' does not supported '2 / 1 / 2' Bad value for shorthand CSS property
-FAIL 'grid-area' does not supported 'span 3' Bad value for shorthand CSS property
-FAIL 'grid-area' does not supported '2 span / a span' Bad value for shorthand CSS property
+PASS 'grid-area' does not supported 'a'
+PASS 'grid-area' does not supported 'a / a'
+PASS 'grid-area' does not supported 'auto'
+PASS 'grid-area' does not supported 'auto / auto'
+PASS 'grid-area' does not supported '2 / 1 / 2'
+PASS 'grid-area' does not supported 'span 3'
+PASS 'grid-area' does not supported '2 span / a span'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL 'grid' does not supported 'auto-flow / 1fr 1fr 1fr' Bad value for shorthand CSS property
-FAIL 'grid' does not supported 'auto-flow dense / 40px 40px 1fr' Bad value for shorthand CSS property
-FAIL 'grid' does not supported 'repeat(3, 80px) / auto-flow' Bad value for shorthand CSS property
+PASS 'grid' does not supported 'auto-flow / 1fr 1fr 1fr'
+PASS 'grid' does not supported 'auto-flow dense / 40px 40px 1fr'
+PASS 'grid' does not supported 'repeat(3, 80px) / auto-flow'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL 'grid-template' does not supported 'none' Bad value for shorthand CSS property
-FAIL 'grid-template' does not supported '100px 1fr / 50px 1fr' Bad value for shorthand CSS property
-FAIL 'grid-template' does not supported '[linename] 100px / [columnname1] 30% [columname2] 70%' Bad value for shorthand CSS property
-FAIL 'grid-template' does not supported 'fit-content(100px) / fit-content(40%)' Bad value for shorthand CSS property
-FAIL 'grid-template' does not supported '"a a a" "b b b"' Bad value for shorthand CSS property
-FAIL 'grid-template' does not supported '[header-top] "a a a" [header-bottom] [main-top] "b b b" 1fr [main-bottom] / auto 1fr auto' Bad value for shorthand CSS property
+PASS 'grid-template' does not supported 'none'
+PASS 'grid-template' does not supported '100px 1fr / 50px 1fr'
+PASS 'grid-template' does not supported '[linename] 100px / [columnname1] 30% [columname2] 70%'
+PASS 'grid-template' does not supported 'fit-content(100px) / fit-content(40%)'
+PASS 'grid-template' does not supported '"a a a" "b b b"'
+PASS 'grid-template' does not supported '[header-top] "a a a" [header-bottom] [main-top] "b b b" 1fr [main-bottom] / auto 1fr auto'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/marker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/marker-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL 'marker' does not supported 'none' Bad value for shorthand CSS property
-FAIL 'marker' does not supported 'url(#m1)' Bad value for shorthand CSS property
+PASS 'marker' does not supported 'none'
+PASS 'marker' does not supported 'url(#m1)'
 PASS Can set 'marker-start' to CSS-wide keywords
 FAIL Can set 'marker-start' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'marker-start' to the 'none' keyword

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL 'mask' does not supported 'none' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'mask' does not supported 'url(mask.png)' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSImageValue]"
+PASS 'mask' does not supported 'none'
+PASS 'mask' does not supported 'url(mask.png)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL 'offset' does not supported 'auto' Bad value for shorthand CSS property
-FAIL 'offset' does not supported '10px 30px' Bad value for shorthand CSS property
-FAIL 'offset' does not supported 'none' Bad value for shorthand CSS property
-FAIL 'offset' does not supported 'ray(45deg closest-side)' Bad value for shorthand CSS property
-FAIL 'offset' does not supported 'path("M 100 100 L 300 100 L 200 300 z")' Bad value for shorthand CSS property
-FAIL 'offset' does not supported 'ray(45deg closest-side) / 40px 20px' Bad value for shorthand CSS property
+PASS 'offset' does not supported 'auto'
+PASS 'offset' does not supported '10px 30px'
+PASS 'offset' does not supported 'none'
+PASS 'offset' does not supported 'ray(45deg closest-side)'
+PASS 'offset' does not supported 'path("M 100 100 L 300 100 L 200 300 z")'
+PASS 'offset' does not supported 'ray(45deg closest-side) / 40px 20px'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL 'text-decoration' does not supported 'underline' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'text-decoration' does not supported 'underline'
 FAIL 'text-decoration' does not supported 'underline dotted #ff3028' assert_not_equals: Unsupported value must not be null got disallowed value null
 FAIL 'text-decoration' does not supported 'green wavy underline' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-expected.txt
@@ -1,5 +1,5 @@
 
-PASS Can set 'text-decoration-skip' to CSS-wide keywords
+FAIL Can set 'text-decoration-skip' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'text-decoration-skip' to var() references assert_equals: expected 2 but got 1
 FAIL Can set 'text-decoration-skip' to the 'none' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'text-decoration-skip' to the 'objects' keyword Bad value for shorthand CSS property

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-expected.txt
@@ -2,5 +2,5 @@
 PASS 'transition' does not supported 'none'
 FAIL 'transition' does not supported 'none, none' assert_not_equals: Unsupported value must not be null got disallowed value null
 PASS 'transition' does not supported 'margin-right 4s'
-FAIL 'transition' does not supported 'all 0.5s ease-out, color 1s' assert_equals: Unsupported value can be set on different element expected "all 0.5s ease-out 0s, color 1s ease 0s" but got "all 0s ease 0s, color 0.5s ease 0s, all 1s ease-out 0s, all 0s ease 0s, all 0s ease 0s"
+PASS 'transition' does not supported 'all 0.5s ease-out, color 1s'
 

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.h
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.h
@@ -45,7 +45,7 @@ class CSSStyleValueFactory {
 public:
     static ExceptionOr<Ref<CSSStyleValue>> reifyValue(Ref<CSSValue>, Document* = nullptr);
     static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseStyleValue(const AtomString&, const String&, bool);
-    static ExceptionOr<RefPtr<CSSStyleValue>> constructStyleValueForShorthandProperty(CSSPropertyID, const Function<RefPtr<CSSValue>(CSSPropertyID)>& propertyValue, Document* = nullptr);
+    static RefPtr<CSSStyleValue> constructStyleValueForShorthandSerialization(const String&);
     static ExceptionOr<Vector<Ref<CSSStyleValue>>> vectorFromStyleValuesOrStrings(const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values);
 
 protected:

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -47,50 +47,20 @@ ComputedStylePropertyMapReadOnly::ComputedStylePropertyMapReadOnly(Element& elem
 {
 }
 
-ExceptionOr<RefPtr<CSSStyleValue>> ComputedStylePropertyMapReadOnly::get(ScriptExecutionContext&, const AtomString& property) const
+RefPtr<CSSValue> ComputedStylePropertyMapReadOnly::propertyValue(CSSPropertyID propertyID) const
 {
-    // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-get
-    if (isCustomPropertyName(property))
-        return StylePropertyMapReadOnly::reifyValue(ComputedStyleExtractor(m_element.ptr()).customPropertyValue(property), m_element->document());
-
-    auto propertyID = cssPropertyID(property);
-    if (!isExposed(propertyID, &m_element->document().settings()))
-        return Exception { TypeError, makeString("Invalid property ", property) };
-
-    if (isShorthandCSSProperty(propertyID)) {
-        auto value = ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed);
-        return CSSStyleValue::create(WTFMove(value), String(property)).ptr();
-    }
-
-    return StylePropertyMapReadOnly::reifyValue(ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed), m_element->document());
+    return ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed);
 }
 
-ExceptionOr<Vector<RefPtr<CSSStyleValue>>> ComputedStylePropertyMapReadOnly::getAll(ScriptExecutionContext&, const AtomString& property) const
+String ComputedStylePropertyMapReadOnly::shorthandPropertySerialization(CSSPropertyID propertyID) const
 {
-    // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-getall
-    if (isCustomPropertyName(property))
-        return StylePropertyMapReadOnly::reifyValueToVector(ComputedStyleExtractor(m_element.ptr()).customPropertyValue(property), m_element->document());
-
-    auto propertyID = cssPropertyID(property);
-    if (!isExposed(propertyID, &m_element->document().settings()))
-        return Exception { TypeError, makeString("Invalid property ", property) };
-
-    if (isShorthandCSSProperty(propertyID)) {
-        auto value = ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed);
-        return Vector<RefPtr<CSSStyleValue>> { CSSStyleValue::create(WTFMove(value), String(property)) };
-    }
-
-    return StylePropertyMapReadOnly::reifyValueToVector(ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed), m_element->document());
+    auto value = propertyValue(propertyID);
+    return value ? value->cssText() : String();
 }
 
-ExceptionOr<bool> ComputedStylePropertyMapReadOnly::has(ScriptExecutionContext& context, const AtomString& property) const
+RefPtr<CSSValue> ComputedStylePropertyMapReadOnly::customPropertyValue(const AtomString& property) const
 {
-    // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-has
-    auto result = get(context, property);
-    if (result.hasException())
-        return result.releaseException();
-
-    return !!result.releaseReturnValue();
+    return ComputedStyleExtractor(m_element.ptr()).customPropertyValue(property);
 }
 
 unsigned ComputedStylePropertyMapReadOnly::size() const

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h
@@ -25,21 +25,21 @@
 
 #pragma once
 
-#include "StylePropertyMapReadOnly.h"
+#include "MainThreadStylePropertyMapReadOnly.h"
 
 namespace WebCore {
 class Element;
 
-class ComputedStylePropertyMapReadOnly final : public StylePropertyMapReadOnly {
+class ComputedStylePropertyMapReadOnly final : public MainThreadStylePropertyMapReadOnly {
 public:
     static Ref<ComputedStylePropertyMapReadOnly> create(Element&);
 
 private:
     explicit ComputedStylePropertyMapReadOnly(Element&);
 
-    ExceptionOr<RefPtr<CSSStyleValue>> get(ScriptExecutionContext&, const AtomString&) const final;
-    ExceptionOr<Vector<RefPtr<CSSStyleValue>>> getAll(ScriptExecutionContext&, const AtomString&) const final;
-    ExceptionOr<bool> has(ScriptExecutionContext&, const AtomString&) const final;
+    RefPtr<CSSValue> propertyValue(CSSPropertyID) const final;
+    String shorthandPropertySerialization(CSSPropertyID) const final;
+    RefPtr<CSSValue> customPropertyValue(const AtomString&) const final;
     unsigned size() const final;
     Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> entries(ScriptExecutionContext*) const final;
 

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
@@ -81,6 +81,14 @@ RefPtr<CSSValue> DeclaredStylePropertyMap::propertyValue(CSSPropertyID propertyI
     return styleRule->properties().getPropertyCSSValue(propertyID);
 }
 
+String DeclaredStylePropertyMap::shorthandPropertySerialization(CSSPropertyID propertyID) const
+{
+    auto* styleRule = this->styleRule();
+    if (!styleRule)
+        return { };
+    return styleRule->properties().getPropertyValue(propertyID);
+}
+
 RefPtr<CSSValue> DeclaredStylePropertyMap::customPropertyValue(const AtomString& propertyName) const
 {
     auto* styleRule = this->styleRule();

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.h
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.h
@@ -48,6 +48,7 @@ private:
 
     void clear() final;
     RefPtr<CSSValue> propertyValue(CSSPropertyID) const final;
+    String shorthandPropertySerialization(CSSPropertyID) const final;
     RefPtr<CSSValue> customPropertyValue(const AtomString&) const final;
     void removeProperty(CSSPropertyID) final;
     void removeCustomProperty(const AtomString&) final;

--- a/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.h
@@ -43,10 +43,8 @@ protected:
     static Document* documentFromContext(ScriptExecutionContext&);
 
     virtual RefPtr<CSSValue> propertyValue(CSSPropertyID) const = 0;
+    virtual String shorthandPropertySerialization(CSSPropertyID) const = 0;
     virtual RefPtr<CSSValue> customPropertyValue(const AtomString&) const = 0;
-
-private:
-    RefPtr<CSSStyleValue> shorthandPropertyValue(Document&, CSSPropertyID) const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -94,6 +94,13 @@ private:
         return nullptr;
     }
 
+    String shorthandPropertySerialization(CSSPropertyID propertyID) const final
+    {
+        if (auto* inlineStyle = m_element ? m_element->inlineStyle() : nullptr)
+            return inlineStyle->getPropertyValue(propertyID);
+        return String();
+    }
+
     RefPtr<CSSValue> customPropertyValue(const AtomString& property) const final
     {
         if (auto* inlineStyle = m_element ? m_element->inlineStyle() : nullptr)

--- a/Source/WebCore/html/CustomPaintImage.cpp
+++ b/Source/WebCore/html/CustomPaintImage.cpp
@@ -106,6 +106,12 @@ private:
         return m_map.get(nameString(propertyID));
     }
 
+    String shorthandPropertySerialization(CSSPropertyID) const final
+    {
+        // FIXME: Not supported.
+        return { };
+    }
+
     RefPtr<CSSValue> customPropertyValue(const AtomString& property) const final
     {
         return m_map.get(property);


### PR DESCRIPTION
#### 95de65d6299743f9aa53a547a5b17f0e28ad7898
<pre>
Avoid code duplication between ComputedStylePropertyMapReadOnly and MainThreadStylePropertyMapReadOnly
<a href="https://bugs.webkit.org/show_bug.cgi?id=248583">https://bugs.webkit.org/show_bug.cgi?id=248583</a>

Reviewed by Antti Koivisto.

Avoid code duplication between ComputedStylePropertyMapReadOnly and
MainThreadStylePropertyMapReadOnly by having ComputedStylePropertyMapReadOnly
subclass MainThreadStylePropertyMapReadOnly instead of the more generic
StylePropertyMapReadOnly.

Doing so exposed a bug in the way we serialize shorthand property values in
MainThreadStylePropertyMapReadOnly and caused some test failures. To address
the issue, we now avoid doing the serialization ourselves and rely on
StyleProperties::getPropertyValue() instead. Fixing this actually caused quite
a few tests to pass.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-flow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-synthesis-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-area-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/marker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-expected.txt:
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::constructStyleValueForShorthandSerialization):
(WebCore::CSSStyleValueFactory::extractShorthandCSSValues):
(WebCore::CSSStyleValueFactory::constructStyleValueForShorthandProperty): Deleted.
* Source/WebCore/css/typedom/CSSStyleValueFactory.h:
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
(WebCore::ComputedStylePropertyMapReadOnly::propertyValue const):
(WebCore::ComputedStylePropertyMapReadOnly::shorthandPropertySerialization const):
(WebCore::ComputedStylePropertyMapReadOnly::customPropertyValue const):
(WebCore::ComputedStylePropertyMapReadOnly::get const): Deleted.
(WebCore::ComputedStylePropertyMapReadOnly::getAll const): Deleted.
(WebCore::ComputedStylePropertyMapReadOnly::has const): Deleted.
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h:
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp:
(WebCore::DeclaredStylePropertyMap::shorthandPropertySerialization const):
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.h:
* Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp:
(WebCore::MainThreadStylePropertyMapReadOnly::get const):
(WebCore::MainThreadStylePropertyMapReadOnly::getAll const):
(WebCore::MainThreadStylePropertyMapReadOnly::shorthandPropertyValue const): Deleted.
* Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.h:
* Source/WebCore/dom/StyledElement.cpp:
* Source/WebCore/html/CustomPaintImage.cpp:

Canonical link: <a href="https://commits.webkit.org/257284@main">https://commits.webkit.org/257284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/083f7c7aee1dab7b754ba663b393a715a36281e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107694 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167976 "Hash 083f7c7a for PR 7006 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7951 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36211 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90822 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104279 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5975 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84833 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33072 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76017 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1411 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20976 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1366 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22479 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44983 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2506 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41903 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->