### PR TITLE
Rename request initiator and initiatorName to initiatorType

### DIFF
--- a/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -27,7 +27,7 @@
 #include "DOMCache.h"
 
 #include "CacheQueryOptions.h"
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "EventLoop.h"
 #include "FetchResponse.h"
 #include "HTTPParsers.h"
@@ -322,7 +322,7 @@ void DOMCache::addAll(Vector<RequestInfo>&& infos, DOMPromiseDeferred<void>&& pr
                 else
                     taskHandler->addResponseBody(recordPosition, response, data.takeAsContiguous());
             });
-        }, cachedResourceRequestInitiators().fetch);
+        }, cachedResourceRequestInitiatorTypes().fetch);
     }
 }
 

--- a/Source/WebCore/Modules/fetch/FetchLoader.cpp
+++ b/Source/WebCore/Modules/fetch/FetchLoader.cpp
@@ -30,7 +30,7 @@
 #include "FetchLoader.h"
 
 #include "BlobURL.h"
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "ContentSecurityPolicy.h"
 #include "FetchBody.h"
 #include "FetchBodyConsumer.h"

--- a/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
+++ b/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "WindowOrWorkerGlobalScopeFetch.h"
 
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "DOMWindow.h"
 #include "Document.h"
 #include "EventLoop.h"
@@ -64,7 +64,7 @@ static void doFetch(ScriptExecutionContext& scope, FetchRequest::Info&& input, F
             UserGestureIndicator gestureIndicator(userGestureToken, UserGestureToken::GestureScope::MediaOnly, UserGestureToken::IsPropagatedFromFetch::Yes);
             promise.settle(WTFMove(result));
         });
-    }, cachedResourceRequestInitiators().fetch);
+    }, cachedResourceRequestInitiatorTypes().fetch);
 }
 
 void WindowOrWorkerGlobalScopeFetch::fetch(DOMWindow& window, FetchRequest::Info&& input, FetchRequest::Init&& init, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -62,7 +62,7 @@ void ArtworkImageLoader::requestImageResource()
     options.contentSecurityPolicyImposition = m_document.isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
 
     CachedResourceRequest request(ResourceRequest(m_document.completeURL(m_src)), options);
-    request.setInitiator(AtomString { m_document.documentURI() });
+    request.setInitiatorType(AtomString { m_document.documentURI() });
     m_cachedImage = m_document.cachedResourceLoader().requestImage(WTFMove(request)).value_or(nullptr);
 
     if (m_cachedImage)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1742,7 +1742,7 @@ loader/cache/CachedResource.cpp
 loader/cache/CachedResourceHandle.cpp
 loader/cache/CachedResourceLoader.cpp
 loader/cache/CachedResourceRequest.cpp
-loader/cache/CachedResourceRequestInitiators.cpp
+loader/cache/CachedResourceRequestInitiatorTypes.cpp
 loader/cache/CachedSVGDocument.cpp
 loader/cache/CachedSVGDocumentReference.cpp
 loader/cache/CachedSVGFont.cpp

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
@@ -64,8 +64,8 @@ CachedResourceHandle<CachedScript> CachedScriptFetcher::requestScriptWithCache(D
     request.upgradeInsecureRequestIfNeeded(document);
     request.setCharset(m_charset);
     request.setPriority(WTFMove(resourceLoadPriority));
-    if (!m_initiatorName.isNull())
-        request.setInitiator(m_initiatorName);
+    if (!m_initiatorType.isNull())
+        request.setInitiatorType(m_initiatorType);
 
     return document.cachedResourceLoader().requestScript(WTFMove(request)).value_or(nullptr);
 }

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.h
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.h
@@ -43,10 +43,10 @@ public:
     static Ref<CachedScriptFetcher> create(const String& charset);
 
 protected:
-    CachedScriptFetcher(const String& nonce, ReferrerPolicy referrerPolicy, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree)
+    CachedScriptFetcher(const String& nonce, ReferrerPolicy referrerPolicy, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
         : m_nonce(nonce)
         , m_charset(charset)
-        , m_initiatorName(initiatorName)
+        , m_initiatorType(initiatorType)
         , m_isInUserAgentShadowTree(isInUserAgentShadowTree)
         , m_referrerPolicy(referrerPolicy)
     {
@@ -62,7 +62,7 @@ protected:
 private:
     String m_nonce;
     String m_charset;
-    AtomString m_initiatorName;
+    AtomString m_initiatorType;
     bool m_isInUserAgentShadowTree { false };
     ReferrerPolicy m_referrerPolicy { ReferrerPolicy::EmptyString };
 };

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -31,7 +31,7 @@
 #include "CachedFontLoadRequest.h"
 #include "CachedResourceLoader.h"
 #include "CachedResourceRequest.h"
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "FontCustomPlatformData.h"
 #include "SVGFontFaceElement.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -27,7 +27,7 @@
 #include "CachedImage.h"
 #include "CachedResourceLoader.h"
 #include "CachedResourceRequest.h"
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "DeprecatedCSSOMPrimitiveValue.h"
 #include "Document.h"
 #include "Element.h"
@@ -36,22 +36,22 @@
 
 namespace WebCore {
 
-CSSImageValue::CSSImageValue(ResolvedURL&& location, LoadedFromOpaqueSource loadedFromOpaqueSource, AtomString&& initiatorName)
+CSSImageValue::CSSImageValue(ResolvedURL&& location, LoadedFromOpaqueSource loadedFromOpaqueSource, AtomString&& initiatorType)
     : CSSValue(ImageClass)
     , m_location(WTFMove(location))
-    , m_initiatorName(WTFMove(initiatorName))
+    , m_initiatorType(WTFMove(initiatorType))
     , m_loadedFromOpaqueSource(loadedFromOpaqueSource)
 {
 }
 
-Ref<CSSImageValue> CSSImageValue::create(ResolvedURL location, LoadedFromOpaqueSource loadedFromOpaqueSource, AtomString initiatorName)
+Ref<CSSImageValue> CSSImageValue::create(ResolvedURL location, LoadedFromOpaqueSource loadedFromOpaqueSource, AtomString initiatorType)
 {
-    return adoptRef(*new CSSImageValue(WTFMove(location), loadedFromOpaqueSource, WTFMove(initiatorName)));
+    return adoptRef(*new CSSImageValue(WTFMove(location), loadedFromOpaqueSource, WTFMove(initiatorType)));
 }
 
-Ref<CSSImageValue> CSSImageValue::create(URL imageURL, LoadedFromOpaqueSource loadedFromOpaqueSource, AtomString initiatorName)
+Ref<CSSImageValue> CSSImageValue::create(URL imageURL, LoadedFromOpaqueSource loadedFromOpaqueSource, AtomString initiatorType)
 {
-    return create(makeResolvedURL(WTFMove(imageURL)), loadedFromOpaqueSource, WTFMove(initiatorName));
+    return create(makeResolvedURL(WTFMove(imageURL)), loadedFromOpaqueSource, WTFMove(initiatorType));
 }
 
 CSSImageValue::~CSSImageValue() = default;
@@ -81,7 +81,7 @@ RefPtr<StyleImage> CSSImageValue::createStyleImage(Style::BuilderState& state) c
         return StyleCachedImage::create(const_cast<CSSImageValue&>(*this));
     auto result = create(WTFMove(location), m_loadedFromOpaqueSource);
     result->m_cachedImage = m_cachedImage;
-    result->m_initiatorName = m_initiatorName;
+    result->m_initiatorType = m_initiatorType;
     result->m_unresolvedValue = const_cast<CSSImageValue*>(this);
     return StyleCachedImage::create(WTFMove(result));
 }
@@ -92,10 +92,10 @@ CachedImage* CSSImageValue::loadImage(CachedResourceLoader& loader, const Resour
         ResourceLoaderOptions loadOptions = options;
         loadOptions.loadedFromOpaqueSource = m_loadedFromOpaqueSource;
         CachedResourceRequest request(ResourceRequest(reresolvedURL(*loader.document())), loadOptions);
-        if (m_initiatorName.isEmpty())
-            request.setInitiator(cachedResourceRequestInitiators().css);
+        if (m_initiatorType.isEmpty())
+            request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
         else
-            request.setInitiator(m_initiatorName);
+            request.setInitiatorType(m_initiatorType);
         if (options.mode == FetchOptions::Mode::Cors) {
             ASSERT(loader.document());
             request.updateForAccessControl(*loader.document());

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -72,7 +72,7 @@ private:
 
     ResolvedURL m_location;
     std::optional<CachedResourceHandle<CachedImage>> m_cachedImage;
-    AtomString m_initiatorName;
+    AtomString m_initiatorType;
     LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
     RefPtr<CSSImageValue> m_unresolvedValue;
 };

--- a/Source/WebCore/css/StyleRuleImport.cpp
+++ b/Source/WebCore/css/StyleRuleImport.cpp
@@ -26,7 +26,7 @@
 #include "CachedCSSStyleSheet.h"
 #include "CachedResourceLoader.h"
 #include "CachedResourceRequest.h"
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "Document.h"
 #include "MediaList.h"
 #include "MediaQueryParserContext.h"
@@ -132,7 +132,7 @@ void StyleRuleImport::requestStyleSheet()
     // FIXME: Skip Content Security Policy check when stylesheet is in a user agent shadow tree.
     // See <https://bugs.webkit.org/show_bug.cgi?id=146663>.
     CachedResourceRequest request(absURL, CachedResourceLoader::defaultCachedResourceOptions(), std::nullopt, String(m_parentStyleSheet->charset()));
-    request.setInitiator(cachedResourceRequestInitiators().css);
+    request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
     if (m_cachedSheet)
         m_cachedSheet->removeClient(m_styleSheetClient);
     if (m_parentStyleSheet->isUserStyleSheet()) {

--- a/Source/WebCore/dom/DocumentFontLoader.cpp
+++ b/Source/WebCore/dom/DocumentFontLoader.cpp
@@ -32,7 +32,7 @@
 #include "CachedFont.h"
 #include "CachedResourceLoader.h"
 #include "CachedResourceRequest.h"
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "Frame.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
@@ -57,7 +57,7 @@ CachedFont* DocumentFontLoader::cachedFont(URL&& url, bool isSVG, bool isInitiat
     options.loadedFromOpaqueSource = loadedFromOpaqueSource;
 
     CachedResourceRequest request(ResourceRequest(WTFMove(url)), options);
-    request.setInitiator(cachedResourceRequestInitiators().css);
+    request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
     return m_document.cachedResourceLoader().requestFont(WTFMove(request), isSVG).value_or(nullptr).get();
 }
 

--- a/Source/WebCore/dom/InlineClassicScript.cpp
+++ b/Source/WebCore/dom/InlineClassicScript.cpp
@@ -43,8 +43,8 @@ Ref<InlineClassicScript> InlineClassicScript::create(ScriptElement& scriptElemen
         element.isInUserAgentShadowTree()));
 }
 
-InlineClassicScript::InlineClassicScript(const AtomString& nonce, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree)
-    : ScriptElementCachedScriptFetcher(nonce, ReferrerPolicy::EmptyString, crossOriginMode, charset, initiatorName, isInUserAgentShadowTree)
+InlineClassicScript::InlineClassicScript(const AtomString& nonce, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+    : ScriptElementCachedScriptFetcher(nonce, ReferrerPolicy::EmptyString, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
 {
 }
 

--- a/Source/WebCore/dom/InlineClassicScript.h
+++ b/Source/WebCore/dom/InlineClassicScript.h
@@ -38,7 +38,7 @@ public:
     ScriptType scriptType() const final { return ScriptType::Classic; }
 
 private:
-    InlineClassicScript(const AtomString& nonce, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree);
+    InlineClassicScript(const AtomString& nonce, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
 };
 
 }

--- a/Source/WebCore/dom/LoadableClassicScript.cpp
+++ b/Source/WebCore/dom/LoadableClassicScript.cpp
@@ -38,8 +38,8 @@
 
 namespace WebCore {
 
-LoadableNonModuleScriptBase::LoadableNonModuleScriptBase(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree, bool isAsync)
-    : LoadableScript(nonce, policy, crossOriginMode, charset, initiatorName, isInUserAgentShadowTree)
+LoadableNonModuleScriptBase::LoadableNonModuleScriptBase(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
+    : LoadableScript(nonce, policy, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
     , m_integrity(integrity)
     , m_isAsync(isAsync)
 {
@@ -157,13 +157,13 @@ bool LoadableNonModuleScriptBase::load(Document& document, const URL& sourceURL)
     return true;
 }
 
-Ref<LoadableClassicScript> LoadableClassicScript::create(const AtomString& nonce, const AtomString& integrityMetadata, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree, bool isAsync)
+Ref<LoadableClassicScript> LoadableClassicScript::create(const AtomString& nonce, const AtomString& integrityMetadata, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
 {
-    return adoptRef(*new LoadableClassicScript(nonce, integrityMetadata, policy, crossOriginMode, charset, initiatorName, isInUserAgentShadowTree, isAsync));
+    return adoptRef(*new LoadableClassicScript(nonce, integrityMetadata, policy, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree, isAsync));
 }
 
-LoadableClassicScript::LoadableClassicScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree, bool isAsync)
-    : LoadableNonModuleScriptBase(nonce, integrity, policy, crossOriginMode, charset, initiatorName, isInUserAgentShadowTree, isAsync)
+LoadableClassicScript::LoadableClassicScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
+    : LoadableNonModuleScriptBase(nonce, integrity, policy, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree, isAsync)
 {
 }
 

--- a/Source/WebCore/dom/LoadableClassicScript.h
+++ b/Source/WebCore/dom/LoadableClassicScript.h
@@ -57,7 +57,7 @@ public:
     const AtomString& integrity() const { return m_integrity; }
 
 protected:
-    LoadableNonModuleScriptBase(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree, bool isAsync);
+    LoadableNonModuleScriptBase(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
 
 private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
@@ -73,14 +73,14 @@ protected:
 
 class LoadableClassicScript final : public LoadableNonModuleScriptBase {
 public:
-    static Ref<LoadableClassicScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree, bool isAsync);
+    static Ref<LoadableClassicScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
 
     ScriptType scriptType() const final { return ScriptType::Classic; }
 
     void execute(ScriptElement&) final;
 
 private:
-    LoadableClassicScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree, bool isAsync);
+    LoadableClassicScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
 };
 
 }

--- a/Source/WebCore/dom/LoadableImportMap.cpp
+++ b/Source/WebCore/dom/LoadableImportMap.cpp
@@ -36,13 +36,13 @@
 
 namespace WebCore {
 
-Ref<LoadableImportMap> LoadableImportMap::create(const AtomString& nonce, const AtomString& integrityMetadata, ReferrerPolicy policy, const AtomString& crossOriginMode, const AtomString& initiatorName, bool isInUserAgentShadowTree, bool isAsync)
+Ref<LoadableImportMap> LoadableImportMap::create(const AtomString& nonce, const AtomString& integrityMetadata, ReferrerPolicy policy, const AtomString& crossOriginMode, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
 {
-    return adoptRef(*new LoadableImportMap(nonce, integrityMetadata, policy, crossOriginMode, initiatorName, isInUserAgentShadowTree, isAsync));
+    return adoptRef(*new LoadableImportMap(nonce, integrityMetadata, policy, crossOriginMode, initiatorType, isInUserAgentShadowTree, isAsync));
 }
 
-LoadableImportMap::LoadableImportMap(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const AtomString& initiatorName, bool isInUserAgentShadowTree, bool isAsync)
-    : LoadableNonModuleScriptBase(nonce, integrity, policy, crossOriginMode, "utf-8"_s, initiatorName, isInUserAgentShadowTree, isAsync)
+LoadableImportMap::LoadableImportMap(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync)
+    : LoadableNonModuleScriptBase(nonce, integrity, policy, crossOriginMode, "utf-8"_s, initiatorType, isInUserAgentShadowTree, isAsync)
 {
 }
 

--- a/Source/WebCore/dom/LoadableImportMap.h
+++ b/Source/WebCore/dom/LoadableImportMap.h
@@ -40,14 +40,14 @@ namespace WebCore {
 // destroyed in order to guarantee that the data buffer will not be purged.
 class LoadableImportMap final : public LoadableNonModuleScriptBase {
 public:
-    static Ref<LoadableImportMap> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const AtomString& initiatorName, bool isInUserAgentShadowTree, bool isAsync);
+    static Ref<LoadableImportMap> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
 
     ScriptType scriptType() const final { return ScriptType::ImportMap; }
 
     void execute(ScriptElement&) final;
 
 private:
-    LoadableImportMap(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const AtomString& initiatorName, bool isInUserAgentShadowTree, bool isAsync);
+    LoadableImportMap(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const AtomString& initiatorType, bool isInUserAgentShadowTree, bool isAsync);
 };
 
 }

--- a/Source/WebCore/dom/LoadableModuleScript.cpp
+++ b/Source/WebCore/dom/LoadableModuleScript.cpp
@@ -34,13 +34,13 @@
 
 namespace WebCore {
 
-Ref<LoadableModuleScript> LoadableModuleScript::create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree)
+Ref<LoadableModuleScript> LoadableModuleScript::create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
 {
-    return adoptRef(*new LoadableModuleScript(nonce, integrity, policy, crossOriginMode, charset, initiatorName, isInUserAgentShadowTree));
+    return adoptRef(*new LoadableModuleScript(nonce, integrity, policy, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree));
 }
 
-LoadableModuleScript::LoadableModuleScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree)
-    : LoadableScript(nonce, policy, crossOriginMode, charset, initiatorName, isInUserAgentShadowTree)
+LoadableModuleScript::LoadableModuleScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+    : LoadableScript(nonce, policy, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
     , m_parameters(ModuleFetchParameters::create(JSC::ScriptFetchParameters::Type::JavaScript, integrity, /* isTopLevelModule */ true))
 {
 }

--- a/Source/WebCore/dom/LoadableModuleScript.h
+++ b/Source/WebCore/dom/LoadableModuleScript.h
@@ -38,7 +38,7 @@ class LoadableModuleScript final : public LoadableScript {
 public:
     virtual ~LoadableModuleScript();
 
-    static Ref<LoadableModuleScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree);
+    static Ref<LoadableModuleScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
 
     bool isLoaded() const final;
     bool hasError() const final;
@@ -58,7 +58,7 @@ public:
     ModuleFetchParameters& parameters() { return m_parameters.get(); }
 
 private:
-    LoadableModuleScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree);
+    LoadableModuleScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
 
     Ref<ModuleFetchParameters> m_parameters;
     RefPtr<UniquedStringImpl> m_moduleKey;

--- a/Source/WebCore/dom/LoadableScript.h
+++ b/Source/WebCore/dom/LoadableScript.h
@@ -58,8 +58,8 @@ public:
     void removeClient(LoadableScriptClient&);
 
 protected:
-    LoadableScript(const AtomString& nonce, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree)
-        : ScriptElementCachedScriptFetcher(nonce, policy, crossOriginMode, charset, initiatorName, isInUserAgentShadowTree)
+    LoadableScript(const AtomString& nonce, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+        : ScriptElementCachedScriptFetcher(nonce, policy, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
     {
     }
 

--- a/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
+++ b/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
@@ -44,8 +44,8 @@ public:
     const String& crossOriginMode() const { return m_crossOriginMode; }
 
 protected:
-    ScriptElementCachedScriptFetcher(const AtomString& nonce, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorName, bool isInUserAgentShadowTree)
-        : CachedScriptFetcher(nonce, policy, charset, initiatorName, isInUserAgentShadowTree)
+    ScriptElementCachedScriptFetcher(const AtomString& nonce, ReferrerPolicy policy, const AtomString& crossOriginMode, const String& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+        : CachedScriptFetcher(nonce, policy, charset, initiatorType, isInUserAgentShadowTree)
         , m_crossOriginMode(crossOriginMode)
     {
     }

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -65,7 +65,7 @@ CachedResourceRequest PreloadRequest::resourceRequest(Document& document)
     if (m_resourceType == CachedResource::Type::Script || m_resourceType == CachedResource::Type::ImageResource)
         options.referrerPolicy = m_referrerPolicy;
     auto request = createPotentialAccessControlRequest(completeURL(document), WTFMove(options), document, crossOriginMode);
-    request.setInitiator(m_initiator);
+    request.setInitiatorType(m_initiatorType);
 
     if (m_scriptIsAsync && m_resourceType == CachedResource::Type::Script && m_scriptType == ScriptType::Classic)
         request.setPriority(DefaultResourceLoadPriority::asyncScript);

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.h
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.h
@@ -34,8 +34,8 @@ namespace WebCore {
 class PreloadRequest {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    PreloadRequest(ASCIILiteral initiator, const String& resourceURL, const URL& baseURL, CachedResource::Type resourceType, const String& mediaAttribute, ScriptType scriptType, const ReferrerPolicy& referrerPolicy)
-        : m_initiator(initiator)
+    PreloadRequest(ASCIILiteral initiatorType, const String& resourceURL, const URL& baseURL, CachedResource::Type resourceType, const String& mediaAttribute, ScriptType scriptType, const ReferrerPolicy& referrerPolicy)
+        : m_initiatorType(initiatorType)
         , m_resourceURL(resourceURL)
         , m_baseURL(baseURL.isolatedCopy())
         , m_resourceType(resourceType)
@@ -58,7 +58,7 @@ public:
 private:
     URL completeURL(Document&);
 
-    ASCIILiteral m_initiator;
+    ASCIILiteral m_initiatorType;
     String m_resourceURL;
     URL m_baseURL;
     String m_charset;

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -36,7 +36,7 @@
 #include "CachedRawResource.h"
 #include "CachedResource.h"
 #include "CachedResourceLoader.h"
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "CachedScript.h"
 #include "CertificateInfo.h"
 #include "CertificateSummary.h"
@@ -719,10 +719,10 @@ void InspectorNetworkAgent::didReceiveScriptResponse(ResourceLoaderIdentifier id
 
 void InspectorNetworkAgent::didReceiveThreadableLoaderResponse(ResourceLoaderIdentifier identifier, DocumentThreadableLoader& documentThreadableLoader)
 {
-    String initiator = documentThreadableLoader.options().initiator;
-    if (initiator == cachedResourceRequestInitiators().fetch)
+    String initiatorType = documentThreadableLoader.options().initiatorType;
+    if (initiatorType == cachedResourceRequestInitiatorTypes().fetch)
         m_resourcesData->setResourceType(IdentifiersFactory::requestId(identifier.toUInt64()), InspectorPageAgent::FetchResource);
-    else if (initiator == cachedResourceRequestInitiators().xmlhttprequest)
+    else if (initiatorType == cachedResourceRequestInitiatorTypes().xmlhttprequest)
         m_resourcesData->setResourceType(IdentifiersFactory::requestId(identifier.toUInt64()), InspectorPageAgent::XHRResource);
 }
 

--- a/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -31,7 +31,7 @@
 #include "CachedApplicationManifest.h"
 #include "CachedResourceLoader.h"
 #include "CachedResourceRequest.h"
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "DocumentLoader.h"
 #include "Frame.h"
 #include "FrameDestructionObserverInlines.h"

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -123,7 +123,7 @@ void CrossOriginPreflightChecker::startPreflight()
     options.initiatorContext = m_loader.options().initiatorContext;
 
     CachedResourceRequest preflightRequest(createAccessControlPreflightRequest(m_request, m_loader.securityOrigin(), m_loader.referrer()), options);
-    preflightRequest.setInitiator(AtomString { m_loader.options().initiator });
+    preflightRequest.setInitiatorType(AtomString { m_loader.options().initiatorType });
 
     ASSERT(!m_resource);
     m_resource = m_loader.document().cachedResourceLoader().requestRawResource(WTFMove(preflightRequest)).value_or(nullptr);

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -317,7 +317,7 @@ std::unique_ptr<LinkPreloadResourceClient> LinkLoader::preloadIfNeeded(const Lin
     options.nonce = params.nonce;
     auto linkRequest = createPotentialAccessControlRequest(url, WTFMove(options), document, params.crossOrigin);
     linkRequest.setPriority(DefaultResourceLoadPriority::forResourceType(type.value()));
-    linkRequest.setInitiator("link"_s);
+    linkRequest.setInitiatorType("link"_s);
     linkRequest.setIgnoreForRequestCount(true);
     linkRequest.setIsLinkPreload();
 

--- a/Source/WebCore/loader/ResourceTiming.cpp
+++ b/Source/WebCore/loader/ResourceTiming.cpp
@@ -51,9 +51,9 @@ ResourceTiming ResourceTiming::fromSynchronousLoad(const URL& url, const String&
     return ResourceTiming(url, initiator, loadTiming, networkLoadMetrics, response, securityOrigin);
 }
 
-ResourceTiming::ResourceTiming(const URL& url, const String& initiator, const ResourceLoadTiming& timing, const NetworkLoadMetrics& networkLoadMetrics, const ResourceResponse& response, const SecurityOrigin& origin)
+ResourceTiming::ResourceTiming(const URL& url, const String& initiatorType, const ResourceLoadTiming& timing, const NetworkLoadMetrics& networkLoadMetrics, const ResourceResponse& response, const SecurityOrigin& origin)
     : m_url(url)
-    , m_initiator(initiator)
+    , m_initiatorType(initiatorType)
     , m_resourceLoadTiming(timing)
     , m_networkLoadMetrics(networkLoadMetrics)
     , m_serverTiming(ServerTimingParser::parseServerTiming(response.httpHeaderField(HTTPHeaderName::ServerTiming)))
@@ -83,7 +83,7 @@ ResourceTiming ResourceTiming::isolatedCopy() const &
 {
     return ResourceTiming {
         m_url.isolatedCopy(),
-        m_initiator.isolatedCopy(),
+        m_initiatorType.isolatedCopy(),
         m_resourceLoadTiming.isolatedCopy(),
         m_networkLoadMetrics.isolatedCopy(),
         crossThreadCopy(m_serverTiming)
@@ -94,7 +94,7 @@ ResourceTiming ResourceTiming::isolatedCopy() &&
 {
     return ResourceTiming {
         WTFMove(m_url).isolatedCopy(),
-        WTFMove(m_initiator).isolatedCopy(),
+        WTFMove(m_initiatorType).isolatedCopy(),
         WTFMove(m_resourceLoadTiming).isolatedCopy(),
         WTFMove(m_networkLoadMetrics).isolatedCopy(),
         crossThreadCopy(WTFMove(m_serverTiming))

--- a/Source/WebCore/loader/ResourceTiming.h
+++ b/Source/WebCore/loader/ResourceTiming.h
@@ -46,7 +46,7 @@ public:
     static ResourceTiming fromSynchronousLoad(const URL&, const String& initiator, const ResourceLoadTiming&, const NetworkLoadMetrics&, const ResourceResponse&, const SecurityOrigin&);
 
     const URL& url() const { return m_url; }
-    const String& initiator() const { return m_initiator; }
+    const String& initiatorType() const { return m_initiatorType; }
     const ResourceLoadTiming& resourceLoadTiming() const { return m_resourceLoadTiming; }
     const NetworkLoadMetrics& networkLoadMetrics() const { return m_networkLoadMetrics; }
     NetworkLoadMetrics& networkLoadMetrics() { return m_networkLoadMetrics; }
@@ -55,14 +55,14 @@ public:
     ResourceTiming isolatedCopy() const &;
     ResourceTiming isolatedCopy() &&;
 
-    void overrideInitiatorName(const String& name) { m_initiator = name; }
+    void overrideInitiatorType(const String& type) { m_initiatorType = type; }
     bool isLoadedFromServiceWorker() const { return m_isLoadedFromServiceWorker; }
 
 private:
     ResourceTiming(const URL&, const String& initiator, const ResourceLoadTiming&, const NetworkLoadMetrics&, const ResourceResponse&, const SecurityOrigin&);
-    ResourceTiming(URL&& url, String&& initiator, const ResourceLoadTiming& resourceLoadTiming, NetworkLoadMetrics&& networkLoadMetrics, Vector<ServerTiming>&& serverTiming)
+    ResourceTiming(URL&& url, String&& initiatorType, const ResourceLoadTiming& resourceLoadTiming, NetworkLoadMetrics&& networkLoadMetrics, Vector<ServerTiming>&& serverTiming)
         : m_url(WTFMove(url))
-        , m_initiator(WTFMove(initiator))
+        , m_initiatorType(WTFMove(initiatorType))
         , m_resourceLoadTiming(resourceLoadTiming)
         , m_networkLoadMetrics(WTFMove(networkLoadMetrics))
         , m_serverTiming(WTFMove(serverTiming))
@@ -70,7 +70,7 @@ private:
     }
 
     URL m_url;
-    String m_initiator;
+    String m_initiatorType;
     ResourceLoadTiming m_resourceLoadTiming;
     NetworkLoadMetrics m_networkLoadMetrics;
     Vector<ServerTiming> m_serverTiming;

--- a/Source/WebCore/loader/ResourceTimingInformation.cpp
+++ b/Source/WebCore/loader/ResourceTimingInformation.cpp
@@ -68,7 +68,7 @@ void ResourceTimingInformation::addResourceTiming(CachedResource& resource, Docu
     if (!initiatorWindow)
         return;
 
-    resourceTiming.overrideInitiatorName(info.name);
+    resourceTiming.overrideInitiatorType(info.type);
 
     initiatorWindow->performance().addResourceTiming(WTFMove(resourceTiming));
 
@@ -80,7 +80,7 @@ void ResourceTimingInformation::removeResourceTiming(CachedResource& resource)
     m_initiatorMap.remove(&resource);
 }
 
-void ResourceTimingInformation::storeResourceTimingInitiatorInformation(const CachedResourceHandle<CachedResource>& resource, const AtomString& initiatorName, Frame* frame)
+void ResourceTimingInformation::storeResourceTimingInitiatorInformation(const CachedResourceHandle<CachedResource>& resource, const AtomString& initiatorType, Frame* frame)
 {
     ASSERT(resource.get());
 
@@ -92,7 +92,7 @@ void ResourceTimingInformation::storeResourceTimingInitiatorInformation(const Ca
             m_initiatorMap.add(resource.get(), info);
         }
     } else {
-        InitiatorInfo info = { initiatorName, NotYetAdded };
+        InitiatorInfo info = { initiatorType, NotYetAdded };
         m_initiatorMap.add(resource.get(), info);
     }
 }

--- a/Source/WebCore/loader/ResourceTimingInformation.h
+++ b/Source/WebCore/loader/ResourceTimingInformation.h
@@ -47,7 +47,7 @@ public:
 private:
     enum AlreadyAdded { NotYetAdded, Added };
     struct InitiatorInfo {
-        AtomString name;
+        AtomString type;
         AlreadyAdded added;
     };
     // FIXME: This shoudn't use raw pointer as identifier (though it is not dereferenced).

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -898,7 +898,7 @@ void SubresourceLoader::reportResourceTiming(const NetworkLoadMetrics& networkLo
         return;
 
     SecurityOrigin& origin = m_origin ? *m_origin : document->securityOrigin();
-    auto resourceTiming = ResourceTiming::fromLoad(*m_resource, m_resource->resourceRequest().url(), m_resource->initiatorName(), m_loadTiming, networkLoadMetrics, origin);
+    auto resourceTiming = ResourceTiming::fromLoad(*m_resource, m_resource->resourceRequest().url(), m_resource->initiatorType(), m_loadTiming, networkLoadMetrics, origin);
 
     // Worker resources loaded here are all CachedRawResources loaded through WorkerThreadableLoader.
     // Pass the ResourceTiming information on so that WorkerThreadableLoader may add them to the

--- a/Source/WebCore/loader/ThreadableLoader.cpp
+++ b/Source/WebCore/loader/ThreadableLoader.cpp
@@ -32,7 +32,7 @@
 #include "config.h"
 #include "ThreadableLoader.h"
 
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "DocumentThreadableLoader.h"
@@ -57,10 +57,10 @@ ThreadableLoaderOptions::ThreadableLoaderOptions(FetchOptions&& baseOptions)
 {
 }
 
-ThreadableLoaderOptions::ThreadableLoaderOptions(const ResourceLoaderOptions& baseOptions, ContentSecurityPolicyEnforcement contentSecurityPolicyEnforcement, String&& initiator, ResponseFilteringPolicy filteringPolicy)
+ThreadableLoaderOptions::ThreadableLoaderOptions(const ResourceLoaderOptions& baseOptions, ContentSecurityPolicyEnforcement contentSecurityPolicyEnforcement, String&& initiatorType, ResponseFilteringPolicy filteringPolicy)
     : ResourceLoaderOptions(baseOptions)
     , contentSecurityPolicyEnforcement(contentSecurityPolicyEnforcement)
-    , initiator(WTFMove(initiator))
+    , initiatorType(WTFMove(initiatorType))
     , filteringPolicy(filteringPolicy)
 {
 }
@@ -100,7 +100,7 @@ ThreadableLoaderOptions ThreadableLoaderOptions::isolatedCopy() const
 
     // ThreadableLoaderOptions
     copy.contentSecurityPolicyEnforcement = this->contentSecurityPolicyEnforcement;
-    copy.initiator = this->initiator.isolatedCopy();
+    copy.initiatorType = this->initiatorType.isolatedCopy();
     copy.filteringPolicy = this->filteringPolicy;
 
     return copy;
@@ -134,7 +134,7 @@ void ThreadableLoader::loadResourceSynchronously(ScriptExecutionContext& context
     context.didLoadResourceSynchronously(resourceURL);
 }
 
-void ThreadableLoader::logError(ScriptExecutionContext& context, const ResourceError& error, const String& initiator)
+void ThreadableLoader::logError(ScriptExecutionContext& context, const ResourceError& error, const String& initiatorType)
 {
     if (error.isCancellation())
         return;
@@ -149,11 +149,11 @@ void ThreadableLoader::logError(ScriptExecutionContext& context, const ResourceE
         return;
 
     const char* messageStart;
-    if (initiator == cachedResourceRequestInitiators().eventsource)
+    if (initiatorType == cachedResourceRequestInitiatorTypes().eventsource)
         messageStart = "EventSource cannot load ";
-    else if (initiator == cachedResourceRequestInitiators().fetch)
+    else if (initiatorType == cachedResourceRequestInitiatorTypes().fetch)
         messageStart = "Fetch API cannot load ";
-    else if (initiator == cachedResourceRequestInitiators().xmlhttprequest)
+    else if (initiatorType == cachedResourceRequestInitiatorTypes().xmlhttprequest)
         messageStart = "XMLHttpRequest cannot load ";
     else
         messageStart = "Cannot load ";

--- a/Source/WebCore/loader/ThreadableLoader.h
+++ b/Source/WebCore/loader/ThreadableLoader.h
@@ -58,13 +58,13 @@ namespace WebCore {
     struct ThreadableLoaderOptions : ResourceLoaderOptions {
         ThreadableLoaderOptions();
         explicit ThreadableLoaderOptions(FetchOptions&&);
-        ThreadableLoaderOptions(const ResourceLoaderOptions&, ContentSecurityPolicyEnforcement, String&& initiator, ResponseFilteringPolicy);
+        ThreadableLoaderOptions(const ResourceLoaderOptions&, ContentSecurityPolicyEnforcement, String&& initiatorType, ResponseFilteringPolicy);
         ~ThreadableLoaderOptions();
 
         ThreadableLoaderOptions isolatedCopy() const;
 
         ContentSecurityPolicyEnforcement contentSecurityPolicyEnforcement { ContentSecurityPolicyEnforcement::EnforceConnectSrcDirective };
-        String initiator; // This cannot be an AtomString, as isolatedCopy() wouldn't create an object that's safe for passing to another thread.
+        String initiatorType; // This cannot be an AtomString, as isolatedCopy() wouldn't create an object that's safe for passing to another thread.
         ResponseFilteringPolicy filteringPolicy { ResponseFilteringPolicy::Disable };
     };
 

--- a/Source/WebCore/loader/WorkerThreadableLoader.cpp
+++ b/Source/WebCore/loader/WorkerThreadableLoader.cpp
@@ -56,7 +56,7 @@
 namespace WebCore {
 
 WorkerThreadableLoader::WorkerThreadableLoader(WorkerOrWorkletGlobalScope& workerOrWorkletGlobalScope, ThreadableLoaderClient& client, const String& taskMode, ResourceRequest&& request, const ThreadableLoaderOptions& options, const String& referrer)
-    : m_workerClientWrapper(ThreadableLoaderClientWrapper::create(client, options.initiator))
+    : m_workerClientWrapper(ThreadableLoaderClientWrapper::create(client, options.initiatorType))
     , m_bridge(*new MainThreadBridge(m_workerClientWrapper.get(), workerOrWorkletGlobalScope.workerOrWorkletThread()->workerLoaderProxy(), workerOrWorkletGlobalScope.identifier(), taskMode, WTFMove(request), options, referrer.isEmpty() ? workerOrWorkletGlobalScope.url().strippedForUseAsReferrer() : referrer, workerOrWorkletGlobalScope))
 {
 }
@@ -285,7 +285,7 @@ void WorkerThreadableLoader::MainThreadBridge::didFinishTiming(const ResourceTim
     m_networkLoadMetrics = resourceTiming.networkLoadMetrics();
     ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_contextIdentifier, [protectedWorkerClientWrapper = Ref { *m_workerClientWrapper }, resourceTiming = resourceTiming.isolatedCopy()] (ScriptExecutionContext& context) mutable {
         ASSERT(context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
-        ASSERT(!resourceTiming.initiator().isEmpty());
+        ASSERT(!resourceTiming.initiatorType().isEmpty());
 
         // No need to notify clients, just add the performance timing entry.
         if (is<WorkerGlobalScope>(context))

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -92,7 +92,7 @@ CachedResource::CachedResource(CachedResourceRequest&& request, Type type, PAL::
     , m_responseTimestamp(WallTime::now())
     , m_fragmentIdentifierForRequest(request.releaseFragmentIdentifier())
     , m_origin(request.releaseOrigin())
-    , m_initiatorName(request.initiatorName())
+    , m_initiatorType(request.initiatorType())
     , m_type(type)
     , m_preloadResult(PreloadResult::PreloadNotReferenced)
     , m_responseTainting(ResourceResponse::Tainting::Basic)

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -235,7 +235,7 @@ public:
 
     const SecurityOrigin* origin() const { return m_origin.get(); }
     SecurityOrigin* origin() { return m_origin.get(); }
-    AtomString initiatorName() const { return m_initiatorName; }
+    AtomString initiatorType() const { return m_initiatorType; }
 
     bool canDelete() const { return !hasClients() && !m_loader && !m_preloadCount && !m_handleCount && !m_resourceToRevalidate && !m_proxyResource; }
     bool hasOneHandle() const { return m_handleCount == 1; }
@@ -371,7 +371,7 @@ private:
 
     ResourceError m_error;
     RefPtr<SecurityOrigin> m_origin;
-    AtomString m_initiatorName;
+    AtomString m_initiatorType;
 
     unsigned m_encodedSize { 0 };
     unsigned m_decodedSize { 0 };

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1149,13 +1149,13 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
                 // for this document because it may have been speculatively preloaded.
                 if (auto metricsFromResource = resource->takeNetworkLoadMetrics(); metricsFromResource && documentLoader && metricsFromResource->redirectStart >= documentLoader->timing().timeOrigin())
                     metrics = WTFMove(metricsFromResource);
-                auto resourceTiming = ResourceTiming::fromMemoryCache(url, request.initiatorName(), loadTiming, resource->response(), metrics ? *metrics : NetworkLoadMetrics::emptyMetrics(), *request.origin());
+                auto resourceTiming = ResourceTiming::fromMemoryCache(url, request.initiatorType(), loadTiming, resource->response(), metrics ? *metrics : NetworkLoadMetrics::emptyMetrics(), *request.origin());
                 if (initiatorContext == InitiatorContext::Worker) {
                     ASSERT(is<CachedRawResource>(resource.get()));
                     downcast<CachedRawResource>(resource.get())->finishedTimingForWorkerLoad(WTFMove(resourceTiming));
                 } else {
                     ASSERT(initiatorContext == InitiatorContext::Document);
-                    m_resourceTimingInfo.storeResourceTimingInitiatorInformation(resource, request.initiatorName(), &frame);
+                    m_resourceTimingInfo.storeResourceTimingInitiatorInformation(resource, request.initiatorType(), &frame);
                     m_resourceTimingInfo.addResourceTiming(*resource.get(), *document(), WTFMove(resourceTiming));
                 }
             }
@@ -1233,7 +1233,7 @@ CachedResourceHandle<CachedResource> CachedResourceLoader::revalidateResource(Ca
     memoryCache.remove(resource);
     memoryCache.add(*newResource);
 
-    m_resourceTimingInfo.storeResourceTimingInitiatorInformation(newResource, newResource->initiatorName(), frame());
+    m_resourceTimingInfo.storeResourceTimingInitiatorInformation(newResource, newResource->initiatorType(), frame());
 
     return newResource;
 }
@@ -1251,7 +1251,7 @@ CachedResourceHandle<CachedResource> CachedResourceLoader::loadResource(CachedRe
     if (resource->allowsCaching())
         memoryCache.add(*resource);
 
-    m_resourceTimingInfo.storeResourceTimingInitiatorInformation(resource, resource->initiatorName(), frame());
+    m_resourceTimingInfo.storeResourceTimingInitiatorInformation(resource, resource->initiatorType(), frame());
 
     return resource;
 }

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -64,23 +64,23 @@ String CachedResourceRequest::splitFragmentIdentifierFromRequestURL(ResourceRequ
 void CachedResourceRequest::setInitiator(Element& element)
 {
     ASSERT(!m_initiatorElement);
-    ASSERT(m_initiatorName.isEmpty());
+    ASSERT(m_initiatorType.isEmpty());
     m_initiatorElement = &element;
 }
 
-void CachedResourceRequest::setInitiator(const AtomString& name)
+void CachedResourceRequest::setInitiatorType(const AtomString& type)
 {
     ASSERT(!m_initiatorElement);
-    ASSERT(m_initiatorName.isEmpty());
-    m_initiatorName = name;
+    ASSERT(m_initiatorType.isEmpty());
+    m_initiatorType = type;
 }
 
-const AtomString& CachedResourceRequest::initiatorName() const
+const AtomString& CachedResourceRequest::initiatorType() const
 {
     if (m_initiatorElement)
         return m_initiatorElement->localName();
-    if (!m_initiatorName.isEmpty())
-        return m_initiatorName;
+    if (!m_initiatorType.isEmpty())
+        return m_initiatorType;
 
     static MainThreadNeverDestroyed<const AtomString> defaultName("other"_s);
     return defaultName;

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -64,8 +64,8 @@ public:
     void setPriority(std::optional<ResourceLoadPriority>&& priority) { m_priority = WTFMove(priority); }
 
     void setInitiator(Element&);
-    void setInitiator(const AtomString& name);
-    const AtomString& initiatorName() const;
+    void setInitiatorType(const AtomString&);
+    const AtomString& initiatorType() const;
 
     bool allowsCaching() const { return m_options.cachingPolicy == CachingPolicy::AllowCaching; }
     void setCachingPolicy(CachingPolicy policy) { m_options.cachingPolicy = policy;  }
@@ -118,7 +118,7 @@ private:
     ResourceLoaderOptions m_options;
     std::optional<ResourceLoadPriority> m_priority;
     RefPtr<Element> m_initiatorElement;
-    AtomString m_initiatorName;
+    AtomString m_initiatorType;
     RefPtr<SecurityOrigin> m_origin;
     String m_fragmentIdentifier;
     bool m_isLinkPreload { false };

--- a/Source/WebCore/loader/cache/CachedResourceRequestInitiatorTypes.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequestInitiatorTypes.cpp
@@ -23,30 +23,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include "ThreadGlobalData.h"
-#include <wtf/text/AtomString.h>
+#include "config.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 
 namespace WebCore {
 
-struct CachedResourceRequestInitiators {
-    CachedResourceRequestInitiators();
-
-    const AtomString css;
-    const AtomString eventsource;
-    const AtomString fetch;
-    const AtomString icon;
-    const AtomString navigation;
-    const AtomString xmlhttprequest;
-    WTF_MAKE_NONCOPYABLE(CachedResourceRequestInitiators); WTF_MAKE_FAST_ALLOCATED;
-private:
-    friend class ThreadGlobalData;
-};
-
-inline const CachedResourceRequestInitiators& cachedResourceRequestInitiators()
+CachedResourceRequestInitiatorTypes::CachedResourceRequestInitiatorTypes()
+    : css("css"_s)
+    , eventsource("eventsource"_s)
+    , fetch("fetch"_s)
+    , icon("icon"_s)
+    , navigation("navigation"_s)
+    , xmlhttprequest("xmlhttprequest"_s)
 {
-    return threadGlobalData().cachedResourceRequestInitiators();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedResourceRequestInitiatorTypes.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequestInitiatorTypes.h
@@ -23,19 +23,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "CachedResourceRequestInitiators.h"
+#pragma once
+
+#include "ThreadGlobalData.h"
+#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
-CachedResourceRequestInitiators::CachedResourceRequestInitiators()
-    : css("css"_s)
-    , eventsource("eventsource"_s)
-    , fetch("fetch"_s)
-    , icon("icon"_s)
-    , navigation("navigation"_s)
-    , xmlhttprequest("xmlhttprequest"_s)
+struct CachedResourceRequestInitiatorTypes {
+    CachedResourceRequestInitiatorTypes();
+
+    const AtomString css;
+    const AtomString eventsource;
+    const AtomString fetch;
+    const AtomString icon;
+    const AtomString navigation;
+    const AtomString xmlhttprequest;
+    WTF_MAKE_NONCOPYABLE(CachedResourceRequestInitiatorTypes); WTF_MAKE_FAST_ALLOCATED;
+private:
+    friend class ThreadGlobalData;
+};
+
+inline const CachedResourceRequestInitiatorTypes& cachedResourceRequestInitiatorTypes()
 {
+    return threadGlobalData().cachedResourceRequestInitiatorTypes();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp
@@ -29,7 +29,7 @@
 #include "CachedResourceHandle.h"
 #include "CachedResourceLoader.h"
 #include "CachedResourceRequest.h"
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "CachedSVGDocument.h"
 
 namespace WebCore {
@@ -55,7 +55,7 @@ void CachedSVGDocumentReference::load(CachedResourceLoader& loader, const Resour
     auto fetchOptions = options;
     fetchOptions.mode = FetchOptions::Mode::SameOrigin;
     CachedResourceRequest request(ResourceRequest(loader.document()->completeURL(m_url)), fetchOptions);
-    request.setInitiator(cachedResourceRequestInitiators().css);
+    request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
     m_document = loader.requestSVGDocument(WTFMove(request)).value_or(nullptr);
     if (m_document)
         m_document->addClient(*this);

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -29,7 +29,7 @@
 #include "CachedRawResource.h"
 #include "CachedResourceLoader.h"
 #include "CachedResourceRequest.h"
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "Frame.h"
@@ -86,7 +86,7 @@ void IconLoader::startLoading()
         DefersLoadingPolicy::AllowDefersLoading,
         CachingPolicy::AllowCaching));
 
-    request.setInitiator(cachedResourceRequestInitiators().icon);
+    request.setInitiatorType(cachedResourceRequestInitiatorTypes().icon);
 
     auto cachedResource = frame->document()->cachedResourceLoader().requestIcon(WTFMove(request));
     m_resource = cachedResource.value_or(nullptr);

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -33,7 +33,7 @@
 #include "config.h"
 #include "EventSource.h"
 
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "ContentSecurityPolicy.h"
 #include "EventNames.h"
 #include "MessageEvent.h"
@@ -110,7 +110,7 @@ void EventSource::connect()
     options.cache = FetchOptions::Cache::NoStore;
     options.dataBufferingPolicy = DataBufferingPolicy::DoNotBufferData;
     options.contentSecurityPolicyEnforcement = scriptExecutionContext()->shouldBypassMainWorldContentSecurityPolicy() ? ContentSecurityPolicyEnforcement::DoNotEnforce : ContentSecurityPolicyEnforcement::EnforceConnectSrcDirective;
-    options.initiator = cachedResourceRequestInitiators().eventsource;
+    options.initiatorType = cachedResourceRequestInitiatorTypes().eventsource;
 
     ASSERT(scriptExecutionContext());
     m_loader = ThreadableLoader::create(*scriptExecutionContext(), *this, WTFMove(request), options);

--- a/Source/WebCore/page/PerformanceResourceTiming.h
+++ b/Source/WebCore/page/PerformanceResourceTiming.h
@@ -46,7 +46,7 @@ class PerformanceResourceTiming : public PerformanceEntry {
 public:
     static Ref<PerformanceResourceTiming> create(MonotonicTime timeOrigin, ResourceTiming&&);
 
-    const String& initiatorType() const { return m_resourceTiming.initiator(); }
+    const String& initiatorType() const { return m_resourceTiming.initiatorType(); }
     const String& nextHopProtocol() const;
 
     double workerStart() const;

--- a/Source/WebCore/platform/ThreadGlobalData.cpp
+++ b/Source/WebCore/platform/ThreadGlobalData.cpp
@@ -27,7 +27,7 @@
 #include "config.h"
 #include "ThreadGlobalData.h"
 
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "EventNames.h"
 #include "FontCache.h"
 #include "MIMETypeRegistry.h"
@@ -106,10 +106,10 @@ ThreadGlobalData& threadGlobalData()
 
 #endif
 
-void ThreadGlobalData::initializeCachedResourceRequestInitiators()
+void ThreadGlobalData::initializeCachedResourceRequestInitiatorTypes()
 {
-    ASSERT(!m_cachedResourceRequestInitiators);
-    m_cachedResourceRequestInitiators = makeUnique<CachedResourceRequestInitiators>();
+    ASSERT(!m_cachedResourceRequestInitiatorTypes);
+    m_cachedResourceRequestInitiatorTypes = makeUnique<CachedResourceRequestInitiatorTypes>();
 }
 
 void ThreadGlobalData::initializeEventNames()

--- a/Source/WebCore/platform/ThreadGlobalData.h
+++ b/Source/WebCore/platform/ThreadGlobalData.h
@@ -41,7 +41,7 @@ class FontCache;
 class QualifiedNameCache;
 class ThreadTimers;
 
-struct CachedResourceRequestInitiators;
+struct CachedResourceRequestInitiatorTypes;
 struct EventNames;
 struct MIMETypeRegistryThreadGlobalData;
 
@@ -53,12 +53,12 @@ public:
     WEBCORE_EXPORT ~ThreadGlobalData();
     void destroy(); // called on workers to clean up the ThreadGlobalData before the thread exits.
 
-    const CachedResourceRequestInitiators& cachedResourceRequestInitiators()
+    const CachedResourceRequestInitiatorTypes& cachedResourceRequestInitiatorTypes()
     {
         ASSERT(!m_destroyed);
-        if (UNLIKELY(!m_cachedResourceRequestInitiators))
-            initializeCachedResourceRequestInitiators();
-        return *m_cachedResourceRequestInitiators;
+        if (UNLIKELY(!m_cachedResourceRequestInitiatorTypes))
+            initializeCachedResourceRequestInitiatorTypes();
+        return *m_cachedResourceRequestInitiatorTypes;
     }
     EventNames& eventNames()
     {
@@ -108,13 +108,13 @@ public:
 private:
     bool m_destroyed { false };
 
-    WEBCORE_EXPORT void initializeCachedResourceRequestInitiators();
+    WEBCORE_EXPORT void initializeCachedResourceRequestInitiatorTypes();
     WEBCORE_EXPORT void initializeEventNames();
     WEBCORE_EXPORT void initializeQualifiedNameCache();
     WEBCORE_EXPORT void initializeMimeTypeRegistryThreadGlobalData();
     WEBCORE_EXPORT void initializeFontCache();
 
-    std::unique_ptr<CachedResourceRequestInitiators> m_cachedResourceRequestInitiators;
+    std::unique_ptr<CachedResourceRequestInitiatorTypes> m_cachedResourceRequestInitiatorTypes;
     std::unique_ptr<EventNames> m_eventNames;
     std::unique_ptr<ThreadTimers> m_threadTimers;
     std::unique_ptr<QualifiedNameCache> m_qualifiedNameCache;

--- a/Source/WebCore/workers/service/FetchEvent.cpp
+++ b/Source/WebCore/workers/service/FetchEvent.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "FetchEvent.h"
 
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "EventNames.h"
 #include "FetchRequest.h"
 #include "JSDOMPromise.h"
@@ -193,7 +193,7 @@ void FetchEvent::navigationPreloadIsReady(ResourceResponse&& response)
     // We postpone the load to leave some time for the service worker to use the preload before loading it.
     context->postTask([fetchResponse = WTFMove(fetchResponse), request = WTFMove(request)](auto& context) {
         if (!fetchResponse->isUsedForPreload())
-            fetchResponse->startLoader(context, request.get(), cachedResourceRequestInitiators().navigation);
+            fetchResponse->startLoader(context, request.get(), cachedResourceRequestInitiatorTypes().navigation);
     });
 }
 

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -24,7 +24,7 @@
 #include "XMLHttpRequest.h"
 
 #include "Blob.h"
-#include "CachedResourceRequestInitiators.h"
+#include "CachedResourceRequestInitiatorTypes.h"
 #include "ContentSecurityPolicy.h"
 #include "CrossOriginAccessControl.h"
 #include "DOMFormData.h"
@@ -624,7 +624,7 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
     options.credentials = m_includeCredentials ? FetchOptions::Credentials::Include : FetchOptions::Credentials::SameOrigin;
     options.mode = FetchOptions::Mode::Cors;
     options.contentSecurityPolicyEnforcement = scriptExecutionContext()->shouldBypassMainWorldContentSecurityPolicy() ? ContentSecurityPolicyEnforcement::DoNotEnforce : ContentSecurityPolicyEnforcement::EnforceConnectSrcDirective;
-    options.initiator = cachedResourceRequestInitiators().xmlhttprequest;
+    options.initiatorType = cachedResourceRequestInitiatorTypes().xmlhttprequest;
     options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
     options.filteringPolicy = ResponseFilteringPolicy::Enable;
     options.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::Disable;


### PR DESCRIPTION
#### 7d03a4356c054b53d53b2572a3ba57ea1a8df076
<pre>
Rename request initiator and initiatorName to initiatorType
<a href="https://bugs.webkit.org/show_bug.cgi?id=248566">https://bugs.webkit.org/show_bug.cgi?id=248566</a>
rdar://problem/102832673

Reviewed by Darin Adler.

Resource requests have an &quot;initiator&quot; which is a string that represents &quot;what
triggered this request&quot;. That string may be an element type or a script method
(e.g., &quot;fetch&quot;). Internally, &quot;initiator&quot; and &quot;initiatorName&quot; were used
interchangably, and the ResourceTiming API exposes this information as
&quot;initiatorType&quot;. This change aligns the internal naming with the spec and
renames uses of &quot;initiator&quot; and &quot;initiatorName&quot; to &quot;initiatorType&quot;.

* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::DOMCache::addAll):
* Source/WebCore/Modules/fetch/FetchLoader.cpp:
* Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp:
(WebCore::doFetch):
* Source/WebCore/Modules/mediasession/MediaMetadata.cpp:
(WebCore::ArtworkImageLoader::requestImageResource):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/CachedScriptFetcher.cpp:
(WebCore::CachedScriptFetcher::requestScriptWithCache const):
* Source/WebCore/bindings/js/CachedScriptFetcher.h:
(WebCore::CachedScriptFetcher::CachedScriptFetcher):
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
* Source/WebCore/css/CSSImageValue.cpp:
(WebCore::CSSImageValue::CSSImageValue):
(WebCore::CSSImageValue::create):
(WebCore::CSSImageValue::createStyleImage const):
(WebCore::CSSImageValue::loadImage):
* Source/WebCore/css/CSSImageValue.h:
* Source/WebCore/css/StyleRuleImport.cpp:
(WebCore::StyleRuleImport::requestStyleSheet):
* Source/WebCore/dom/DocumentFontLoader.cpp:
(WebCore::DocumentFontLoader::cachedFont):
* Source/WebCore/dom/InlineClassicScript.cpp:
(WebCore::InlineClassicScript::InlineClassicScript):
* Source/WebCore/dom/InlineClassicScript.h:
* Source/WebCore/dom/LoadableClassicScript.cpp:
(WebCore::LoadableNonModuleScriptBase::LoadableNonModuleScriptBase):
(WebCore::LoadableClassicScript::create):
(WebCore::LoadableClassicScript::LoadableClassicScript):
* Source/WebCore/dom/LoadableClassicScript.h:
* Source/WebCore/dom/LoadableImportMap.cpp:
(WebCore::LoadableImportMap::create):
(WebCore::LoadableImportMap::LoadableImportMap):
* Source/WebCore/dom/LoadableImportMap.h:
* Source/WebCore/dom/LoadableModuleScript.cpp:
(WebCore::LoadableModuleScript::create):
(WebCore::LoadableModuleScript::LoadableModuleScript):
* Source/WebCore/dom/LoadableModuleScript.h:
* Source/WebCore/dom/LoadableScript.h:
(WebCore::LoadableScript::LoadableScript):
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.h:
(WebCore::ScriptElementCachedScriptFetcher::ScriptElementCachedScriptFetcher):
* Source/WebCore/html/parser/HTMLResourcePreloader.cpp:
(WebCore::PreloadRequest::resourceRequest):
* Source/WebCore/html/parser/HTMLResourcePreloader.h:
(WebCore::PreloadRequest::PreloadRequest):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::didReceiveThreadableLoaderResponse):
* Source/WebCore/loader/ApplicationManifestLoader.cpp:
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::startPreflight):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::redirectReceived):
(WebCore::DocumentThreadableLoader::didFail):
(WebCore::DocumentThreadableLoader::preflightFailure):
(WebCore::DocumentThreadableLoader::loadRequest):
(WebCore::DocumentThreadableLoader::logErrorAndFail):
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::preloadIfNeeded):
* Source/WebCore/loader/ResourceTiming.cpp:
(WebCore::ResourceTiming::ResourceTiming):
(WebCore::ResourceTiming::isolatedCopy const):
(WebCore::ResourceTiming::isolatedCopy):
* Source/WebCore/loader/ResourceTiming.h:
(WebCore::ResourceTiming::initiatorType const):
(WebCore::ResourceTiming::overrideInitiatorType):
(WebCore::ResourceTiming::ResourceTiming):
(WebCore::ResourceTiming::initiator const): Deleted.
(WebCore::ResourceTiming::overrideInitiatorName): Deleted.
* Source/WebCore/loader/ResourceTimingInformation.cpp:
(WebCore::ResourceTimingInformation::addResourceTiming):
(WebCore::ResourceTimingInformation::storeResourceTimingInitiatorInformation):
* Source/WebCore/loader/ResourceTimingInformation.h:
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::reportResourceTiming):
* Source/WebCore/loader/ThreadableLoader.cpp:
(WebCore::ThreadableLoaderOptions::ThreadableLoaderOptions):
(WebCore::ThreadableLoaderOptions::isolatedCopy const):
(WebCore::ThreadableLoader::logError):
* Source/WebCore/loader/ThreadableLoader.h:
* Source/WebCore/loader/WorkerThreadableLoader.cpp:
(WebCore::WorkerThreadableLoader::WorkerThreadableLoader):
(WebCore::WorkerThreadableLoader::MainThreadBridge::didFinishTiming):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::CachedResource):
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::initiatorType const):
(WebCore::CachedResource::initiatorName const): Deleted.
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
(WebCore::CachedResourceLoader::revalidateResource):
(WebCore::CachedResourceLoader::loadResource):
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::CachedResourceRequest::setInitiator):
(WebCore::CachedResourceRequest::setInitiatorType):
(WebCore::CachedResourceRequest::initiatorType const):
(WebCore::CachedResourceRequest::initiatorName const): Deleted.
* Source/WebCore/loader/cache/CachedResourceRequest.h:
* Source/WebCore/loader/cache/CachedResourceRequestInitiatorTypes.cpp: Renamed from Source/WebCore/loader/cache/CachedResourceRequestInitiators.cpp.
(WebCore::CachedResourceRequestInitiatorTypes::CachedResourceRequestInitiatorTypes):
* Source/WebCore/loader/cache/CachedResourceRequestInitiatorTypes.h: Renamed from Source/WebCore/loader/cache/CachedResourceRequestInitiators.h.
(WebCore::cachedResourceRequestInitiatorTypes):
* Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp:
(WebCore::CachedSVGDocumentReference::load):
* Source/WebCore/loader/icon/IconLoader.cpp:
(WebCore::IconLoader::startLoading):
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::connect):
* Source/WebCore/page/PerformanceResourceTiming.h:
(WebCore::PerformanceResourceTiming::initiatorType const):
* Source/WebCore/platform/ThreadGlobalData.cpp:
(WebCore::ThreadGlobalData::initializeCachedResourceRequestInitiatorTypes):
(WebCore::ThreadGlobalData::initializeCachedResourceRequestInitiators): Deleted.
* Source/WebCore/platform/ThreadGlobalData.h:
(WebCore::ThreadGlobalData::cachedResourceRequestInitiatorTypes):
(WebCore::ThreadGlobalData::cachedResourceRequestInitiators): Deleted.
* Source/WebCore/workers/service/FetchEvent.cpp:
(WebCore::FetchEvent::navigationPreloadIsReady):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::createRequest):

Canonical link: <a href="https://commits.webkit.org/257374@main">https://commits.webkit.org/257374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54c05641b589d674f69c6e0cd2d88b0c19640ba8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107740 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168010 "Found 1 new test failure: js/dom/Promise-reject-large-string.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102233 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85018 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90866 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104336 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89599 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33104 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87897 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21013 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, http/tests/appcache/fail-on-update-2.html, imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-works-on-frame-src.https.sub.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html, imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-parsing.html, imported/w3c/web-platform-tests/css/css-contain/container-queries/container-name-parsing.html, imported/w3c/web-platform-tests/css/css-contain/container-queries/container-parsing.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-030.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-031.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76048 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1457 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22531 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1401 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45128 "Found 30 new test failures: animations/stop-animation-on-suspend.html, css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/rendering/render-style-null-optgroup-crash.html, fast/text/text-edge-property-parsing.html, http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html, http/wpt/service-workers/fetch-service-worker-preload-download.https.html, http/wpt/service-workers/fetch-service-worker-preload.https.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html ... (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5070 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6295 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41946 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2751 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->