### PR TITLE
Clean up enable_ifs using `if constexpr`

### DIFF
--- a/Source/JavaScriptCore/assembler/Printer.h
+++ b/Source/JavaScriptCore/assembler/Printer.h
@@ -182,18 +182,15 @@ struct Printer<RawPointer> : public PrintRecord {
     { }
 };
 
-template<typename T, typename = typename std::enable_if_t<std::is_integral<T>::value && std::numeric_limits<T>::is_signed>>
-void setPrinter(PrintRecord& record, T value, intptr_t = 0)
+template<typename T>
+std::enable_if_t<std::is_integral_v<T>>
+setPrinter(PrintRecord& record, T value, intptr_t = 0)
 {
     record.data.value = static_cast<uintptr_t>(value);
-    record.printer = printIntptr;
-}
-
-template<typename T, typename = typename std::enable_if_t<std::is_integral<T>::value && !std::numeric_limits<T>::is_signed>>
-void setPrinter(PrintRecord& record, T value, uintptr_t = 0)
-{
-    record.data.value = static_cast<uintptr_t>(value);
-    record.printer = printUintptr;
+    if constexpr (std::numeric_limits<T>::is_signed)
+        record.printer = printIntptr;
+    else
+        record.printer = printUintptr;
 }
 
 template<typename T>

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -663,28 +663,14 @@ namespace JSC {
         RegisterID* emitUnaryOp(OpcodeID, RegisterID* dst, RegisterID* src, ResultType);
 
         template<typename BinaryOp>
-        std::enable_if_t<
-            BinaryOp::opcodeID != op_add
-            && BinaryOp::opcodeID != op_mul
-            && BinaryOp::opcodeID != op_sub
-            && BinaryOp::opcodeID != op_div,
-            RegisterID*>
-        emitBinaryOp(RegisterID* dst, RegisterID* src1, RegisterID* src2, OperandTypes = OperandTypes())
+        RegisterID* emitBinaryOp(RegisterID* dst, RegisterID* src1, RegisterID* src2, OperandTypes types = { })
         {
-            BinaryOp::emit(this, dst, src1, src2);
-            return dst;
-        }
-
-        template<typename BinaryOp>
-        std::enable_if_t<
-            BinaryOp::opcodeID == op_add
-            || BinaryOp::opcodeID == op_mul
-            || BinaryOp::opcodeID == op_sub
-            || BinaryOp::opcodeID == op_div,
-            RegisterID*>
-        emitBinaryOp(RegisterID* dst, RegisterID* src1, RegisterID* src2, OperandTypes types)
-        {
-            BinaryOp::emit(this, dst, src1, src2, m_codeBlock->addBinaryArithProfile(), types);
+            if constexpr (BinaryOp::opcodeID == op_add || BinaryOp::opcodeID == op_mul || BinaryOp::opcodeID == op_sub || BinaryOp::opcodeID == op_div)
+                BinaryOp::emit(this, dst, src1, src2, m_codeBlock->addBinaryArithProfile(), types);
+            else {
+                UNUSED_PARAM(types);
+                BinaryOp::emit(this, dst, src1, src2);
+            }
             return dst;
         }
 

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -321,15 +321,14 @@ namespace JSC {
         template<typename Op>
         static inline constexpr bool isProfiledOp = std::is_same_v<decltype(Op::Metadata::m_profile), ValueProfile>;
         template<typename Op>
-        std::enable_if_t<isProfiledOp<Op>, void>
-        emitValueProfilingSiteIfProfiledOpcode(Op bytecode)
-        { // This assumes that the value to profile is in jsRegT10.
-            emitValueProfilingSite(bytecode, jsRegT10);
+        void emitValueProfilingSiteIfProfiledOpcode(Op bytecode)
+        {
+            // This assumes that the value to profile is in jsRegT10.
+            if constexpr (isProfiledOp<Op>)
+                emitValueProfilingSite(bytecode, jsRegT10);
+            else
+                UNUSED_PARAM(bytecode);
         }
-        template<typename Op>
-        std::enable_if_t<!isProfiledOp<Op>, void>
-        emitValueProfilingSiteIfProfiledOpcode(Op)
-        { }
 
         template <typename Bytecode>
         void emitArrayProfilingSiteWithCell(const Bytecode&, RegisterID cellGPR, RegisterID scratchGPR);

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2471,14 +2471,14 @@ JSC_DEFINE_HOST_FUNCTION(functionTotalCompileTime, (JSGlobalObject*, CallFrame*)
 #endif
 }
 
+IGNORE_GCC_WARNINGS_BEGIN("unused-but-set-parameter")
 template<typename ValueType>
-typename std::enable_if<!std::is_fundamental<ValueType>::value>::type addOption(VM&, JSObject*, const Identifier&, ValueType) { }
-
-template<typename ValueType>
-typename std::enable_if<std::is_fundamental<ValueType>::value>::type addOption(VM& vm, JSObject* optionsObject, const Identifier& identifier, ValueType value)
+void addOption(VM& vm, JSObject* optionsObject, const Identifier& identifier, ValueType value)
 {
-    optionsObject->putDirect(vm, identifier, JSValue(value));
+    if constexpr (std::is_fundamental_v<ValueType>)
+        optionsObject->putDirect(vm, identifier, JSValue(value));
 }
+IGNORE_GCC_WARNINGS_END
 
 JSC_DEFINE_HOST_FUNCTION(functionJSCOptions, (JSGlobalObject* globalObject, CallFrame*))
 {

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -5226,21 +5226,20 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseArgument(Tre
     return parseAssignmentExpression(context);
 }
 
-template <typename TreeBuilder, typename ParserType, typename = typename std::enable_if<std::is_same<TreeBuilder, ASTBuilder>::value>::type>
-static inline void recordCallOrApplyDepth(ParserType* parser, VM& vm, std::optional<typename ParserType::CallOrApplyDepthScope>& callOrApplyDepthScope, ExpressionNode* expression)
+IGNORE_GCC_WARNINGS_BEGIN("unused-but-set-parameter")
+template <typename TreeBuilder, typename ParserType>
+static inline void recordCallOrApplyDepth(ParserType* parser, VM& vm, std::optional<typename ParserType::CallOrApplyDepthScope>& callOrApplyDepthScope, typename TreeBuilder::Expression expression)
 {
-    if (expression->isDotAccessorNode()) {
-        DotAccessorNode* dot = static_cast<DotAccessorNode*>(expression);
-        bool isCallOrApply = dot->identifier() == vm.propertyNames->builtinNames().callPublicName() || dot->identifier() == vm.propertyNames->builtinNames().applyPublicName();
-        if (isCallOrApply)
-            callOrApplyDepthScope.emplace(parser);
+    if constexpr (std::is_same_v<TreeBuilder, ASTBuilder>) {
+        if (expression->isDotAccessorNode()) {
+            DotAccessorNode* dot = static_cast<DotAccessorNode*>(expression);
+            bool isCallOrApply = dot->identifier() == vm.propertyNames->builtinNames().callPublicName() || dot->identifier() == vm.propertyNames->builtinNames().applyPublicName();
+            if (isCallOrApply)
+                callOrApplyDepthScope.emplace(parser);
+        }
     }
 }
-
-template <typename TreeBuilder, typename ParserType, typename = typename std::enable_if<std::is_same<TreeBuilder, SyntaxChecker>::value>::type>
-static inline void recordCallOrApplyDepth(ParserType*, VM&, std::optional<typename ParserType::CallOrApplyDepthScope>&, SyntaxChecker::Expression)
-{
-}
+IGNORE_GCC_WARNINGS_END
 
 template <typename LexerType>
 template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpression(TreeBuilder& context)

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -354,39 +354,30 @@ RefPtr<SourceProvider> Decoder::provider() const
 }
 
 template<typename T>
-static std::enable_if_t<std::is_same<T, SourceType<T>>::value> encode(Encoder&, T& dst, const SourceType<T>& src)
+static void encode(Encoder& encoder, T& dst, const SourceType<T>& src)
 {
-    dst = src;
-}
-
-template<typename T>
-static std::enable_if_t<!std::is_same<T, SourceType<T>>::value> encode(Encoder& encoder, T& dst, const SourceType<T>& src)
-{
-    dst.encode(encoder, src);
+    if constexpr (std::is_same_v<T, SourceType<T>>)
+        dst = src;
+    else
+        dst.encode(encoder, src);
 }
 
 template<typename T, typename... Args>
-static std::enable_if_t<std::is_same<T, SourceType<T>>::value> decode(Decoder&, const T& src, SourceType<T>& dst, Args...)
+static void decode(Decoder& decoder, const T& src, SourceType<T>& dst, Args... args)
 {
-    dst = src;
-}
-
-template<typename T, typename... Args>
-static std::enable_if_t<!std::is_same<T, SourceType<T>>::value> decode(Decoder& decoder, const T& src, SourceType<T>& dst, Args... args)
-{
-    src.decode(decoder, dst, args...);
+    if constexpr (std::is_same_v<T, SourceType<T>>)
+        dst = src;
+    else
+        src.decode(decoder, dst, args...);
 }
 
 template<typename T>
-static std::enable_if_t<std::is_same<T, SourceType<T>>::value, T> decode(Decoder&, T src)
+static T decode(Decoder& decoder, T src)
 {
-    return src;
-}
-
-template<typename T>
-static std::enable_if_t<!std::is_same<T, SourceType<T>>::value, SourceType<T>>&& decode(Decoder& decoder, const T& src)
-{
-    return src.decode(decoder);
+    if constexpr (std::is_same_v<T, SourceType<T>>)
+        return src;
+    else
+        return src.decode(decoder);
 }
 
 template<typename Source>

--- a/Source/WTF/wtf/CrossThreadTask.h
+++ b/Source/WTF/wtf/CrossThreadTask.h
@@ -87,20 +87,18 @@ void callMemberFunctionForCrossThreadTask(C* object, MF function, ArgsTuple&& ar
     callMemberFunctionForCrossThreadTaskImpl(object, function, std::forward<ArgsTuple>(args), ArgsIndices());
 }
 
-template<typename T, typename std::enable_if<std::is_base_of<ThreadSafeRefCountedBase, T>::value, int>::type = 0, typename... Parameters, typename... Arguments>
+template<typename T, typename... Parameters, typename... Arguments>
 CrossThreadTask createCrossThreadTask(T& callee, void (T::*method)(Parameters...), const Arguments&... arguments)
 {
-    return CrossThreadTask([callee = RefPtr { &callee }, method, arguments = std::make_tuple(crossThreadCopy(arguments)...)]() mutable {
-        callMemberFunctionForCrossThreadTask(callee.get(), method, WTFMove(arguments));
-    });
-}
-
-template<typename T, typename std::enable_if<!std::is_base_of<ThreadSafeRefCountedBase, T>::value, int>::type = 0, typename... Parameters, typename... Arguments>
-CrossThreadTask createCrossThreadTask(T& callee, void (T::*method)(Parameters...), const Arguments&... arguments)
-{
-    return CrossThreadTask([callee = &callee, method, arguments = std::make_tuple(crossThreadCopy(arguments)...)]() mutable {
-        callMemberFunctionForCrossThreadTask(callee, method, WTFMove(arguments));
-    });
+    if constexpr (std::is_base_of_v<ThreadSafeRefCountedBase, T>) {
+        return CrossThreadTask([callee = RefPtr { &callee }, method, arguments = std::make_tuple(crossThreadCopy(arguments)...)]() mutable {
+            callMemberFunctionForCrossThreadTask(callee.get(), method, WTFMove(arguments));
+        });
+    } else {
+        return CrossThreadTask([callee = &callee, method, arguments = std::make_tuple(crossThreadCopy(arguments)...)]() mutable {
+            callMemberFunctionForCrossThreadTask(callee, method, WTFMove(arguments));
+        });
+    }
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/HashTraits.h
+++ b/Source/WTF/wtf/HashTraits.h
@@ -308,18 +308,14 @@ struct HashTraitHasCustomDelete {
 };
 
 template<typename Traits, typename T>
-typename std::enable_if<HashTraitHasCustomDelete<Traits, T>::value>::type
-hashTraitsDeleteBucket(T& value)
+void hashTraitsDeleteBucket(T& value)
 {
-    Traits::customDeleteBucket(value);
-}
-
-template<typename Traits, typename T>
-typename std::enable_if<!HashTraitHasCustomDelete<Traits, T>::value>::type
-hashTraitsDeleteBucket(T& value)
-{
-    value.~T();
-    Traits::constructDeletedValue(value);
+    if constexpr (HashTraitHasCustomDelete<Traits, T>::value)
+        Traits::customDeleteBucket(value);
+    else {
+        value.~T();
+        Traits::constructDeletedValue(value);
+    }
 }
 
 template<typename FirstTraitsArg, typename SecondTraitsArg>

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp
@@ -447,15 +447,14 @@ template<typename, typename = void> inline constexpr bool HasIsValid = false;
 template<typename T> inline constexpr bool HasIsValid<T, std::void_t<decltype(std::declval<T>().isValid())>> = true;
 
 template<typename Item>
-static inline typename std::enable_if_t<!HasIsValid<Item>, bool> isValid(const Item&)
+static inline bool isValid(const Item& item)
 {
-    return true;
-}
-
-template<typename Item>
-static inline typename std::enable_if_t<HasIsValid<Item>, bool> isValid(const Item& item)
-{
-    return item.isValid();
+    if constexpr (HasIsValid<Item>)
+        return item.isValid();
+    else {
+        UNUSED_PARAM(item);
+        return true;
+    }
 }
 
 template<typename Item>


### PR DESCRIPTION
#### 21e76d2cd34577a4d7d71b1c0f96ec8eab21686e
<pre>
Clean up enable_ifs using `if constexpr`
<a href="https://bugs.webkit.org/show_bug.cgi?id=248586">https://bugs.webkit.org/show_bug.cgi?id=248586</a>

Reviewed by Yusuke Suzuki.

In JSC and elsewhere, there are quite a bunch of cases where enable_if is used for a given condition and its opposite;
these are great opportunities to make use of `if constexpr` instead.

* Source/JavaScriptCore/assembler/Printer.h:
(JSC::Printer::setPrinter):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::emitBinaryOp):
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jsc.cpp:
(addOption):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::recordCallOrApplyDepth):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::encode):
(JSC::decode):
* Source/JavaScriptCore/runtime/CodeCache.h:
(JSC::CodeCacheMap::fetchFromDisk):
(): Deleted.
* Source/WTF/wtf/CrossThreadTask.h:
(WTF::createCrossThreadTask):
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::toTimeT):
(): Deleted.
* Source/WTF/wtf/HashTraits.h:
(WTF::hashTraitsDeleteBucket):
* Source/WTF/wtf/OptionSet.h:
(WTF::isValidOptionSetEnum):
(WTF::maskRawValue):
* Source/WebCore/bindings/js/JSDOMWrapperCache.h:
(WebCore::createWrapper):
* Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp:
(WebCore::DisplayList::isValid):

Canonical link: <a href="https://commits.webkit.org/257273@main">https://commits.webkit.org/257273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa13526ca94da382f8c4bf87b55c73d862630c64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98283 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107732 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168003 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7995 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36252 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90858 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104315 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6014 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84874 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33098 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89592 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89104 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1450 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84847 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1394 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22516 "Found 1 new test failure: streams/readable-stream-default-controller-error.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28659 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5013 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45015 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87693 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41940 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19659 "Passed tests") | 
<!--EWS-Status-Bubble-End-->