### PR TITLE
[Filters] Make ImageBuffer::filteredImage() use FilterTargetSwitcher to apply the filter

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -171,6 +171,8 @@ public:
     WEBCORE_EXPORT virtual RefPtr<NativeImage> sinkIntoNativeImage();
     WEBCORE_EXPORT RefPtr<Image> copyImage(BackingStoreCopy = CopyBackingStore, PreserveResolution = PreserveResolution::No) const;
     WEBCORE_EXPORT virtual RefPtr<Image> filteredImage(Filter&);
+    RefPtr<Image> filteredImage(Filter&, std::function<void(GraphicsContext&)> drawCallback);
+
 #if USE(CAIRO)
     WEBCORE_EXPORT RefPtr<cairo_surface_t> createCairoSurface();
 #endif

--- a/Source/WebCore/platform/graphics/filters/Filter.cpp
+++ b/Source/WebCore/platform/graphics/filters/Filter.cpp
@@ -84,31 +84,17 @@ bool Filter::clampFilterRegionIfNeeded()
 
 RenderingMode Filter::renderingMode() const
 {
-    if (m_filterRenderingMode == FilterRenderingMode::Software)
-        return RenderingMode::Unaccelerated;
-    
-    if (m_filterRenderingMode == FilterRenderingMode::Accelerated)
+    if (m_filterRenderingModes.contains(FilterRenderingMode::Accelerated))
         return RenderingMode::Accelerated;
     
-    ASSERT_NOT_REACHED();
+    ASSERT(m_filterRenderingModes.contains(FilterRenderingMode::Software));
     return RenderingMode::Unaccelerated;
 }
 
-void Filter::setFilterRenderingMode(OptionSet<FilterRenderingMode> preferredFilterRenderingModes)
+void Filter::setFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes)
 {
-    auto filterRenderingModes = preferredFilterRenderingModes & supportedFilterRenderingModes();
-
-    if (filterRenderingModes.contains(FilterRenderingMode::GraphicsContext)) {
-        setFilterRenderingMode(FilterRenderingMode::GraphicsContext);
-        return;
-    }
-
-    if (filterRenderingModes.contains(FilterRenderingMode::Accelerated)) {
-        setFilterRenderingMode(FilterRenderingMode::Accelerated);
-        return;
-    }
-
-    setFilterRenderingMode(FilterRenderingMode::Software);
+    m_filterRenderingModes = preferredFilterRenderingModes & supportedFilterRenderingModes();
+    ASSERT(m_filterRenderingModes.contains(FilterRenderingMode::Software));
 }
 
 RefPtr<FilterImage> Filter::apply(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, FilterResults& results)

--- a/Source/WebCore/platform/graphics/filters/Filter.h
+++ b/Source/WebCore/platform/graphics/filters/Filter.h
@@ -44,9 +44,8 @@ public:
 
     RenderingMode renderingMode() const;
 
-    FilterRenderingMode filterRenderingMode() const { return m_filterRenderingMode; }
-    void setFilterRenderingMode(FilterRenderingMode filterRenderingMode) { m_filterRenderingMode = filterRenderingMode; }
-    void setFilterRenderingMode(OptionSet<FilterRenderingMode> preferredFilterRenderingMode);
+    OptionSet<FilterRenderingMode> filterRenderingModes() const { return m_filterRenderingModes; }
+    WEBCORE_EXPORT void setFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes);
 
     FloatSize filterScale() const { return m_filterScale; }
     void setFilterScale(const FloatSize& filterScale) { m_filterScale = filterScale; }
@@ -82,7 +81,7 @@ protected:
     virtual FilterStyleVector createFilterStyles(const FilterStyle& sourceStyle) const = 0;
 
 private:
-    FilterRenderingMode m_filterRenderingMode { FilterRenderingMode::Software };
+    OptionSet<FilterRenderingMode> m_filterRenderingModes { FilterRenderingMode::Software };
     FloatSize m_filterScale;
     ClipOperation m_clipOperation;
     FloatRect m_filterRegion;

--- a/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
@@ -101,14 +101,11 @@ FloatRect FilterEffect::calculateImageRect(const Filter& filter, Span<const Floa
 
 std::unique_ptr<FilterEffectApplier> FilterEffect::createApplier(const Filter& filter) const
 {
-    if (filter.filterRenderingMode() == FilterRenderingMode::Accelerated)
+    if (filter.filterRenderingModes().contains(FilterRenderingMode::Accelerated))
         return createAcceleratedApplier();
 
-    if (filter.filterRenderingMode() == FilterRenderingMode::Software)
-        return createSoftwareApplier();
-
-    ASSERT_NOT_REACHED();
-    return nullptr;
+    ASSERT(filter.filterRenderingModes() == FilterRenderingMode::Software);
+    return createSoftwareApplier();
 }
 
 void FilterEffect::transformInputsColorSpace(const FilterImageVector& inputs) const

--- a/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.cpp
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-FilterStyleTargetSwitcher::FilterStyleTargetSwitcher(GraphicsContext&, Filter& filter, const FloatRect& sourceImageRect)
+FilterStyleTargetSwitcher::FilterStyleTargetSwitcher(Filter& filter, const FloatRect& sourceImageRect)
     : FilterTargetSwitcher(filter)
     , m_filterStyles(filter.createFilterStyles(sourceImageRect))
 {

--- a/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h
+++ b/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h
@@ -33,7 +33,7 @@ namespace WebCore {
 class FilterStyleTargetSwitcher : public FilterTargetSwitcher {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    FilterStyleTargetSwitcher(GraphicsContext& destinationContext, Filter&, const FloatRect &sourceImageRect);
+    FilterStyleTargetSwitcher(Filter&, const FloatRect &sourceImageRect);
 
 private:
     bool needsRedrawSourceImage() const override { return true; }

--- a/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.cpp
@@ -35,8 +35,8 @@ namespace WebCore {
 
 std::unique_ptr<FilterTargetSwitcher> FilterTargetSwitcher::create(GraphicsContext& destinationContext, Filter& filter, const FloatRect &sourceImageRect, const DestinationColorSpace& colorSpace, FilterResults* results)
 {
-    if (filter.filterRenderingMode() == FilterRenderingMode::GraphicsContext)
-        return makeUnique<FilterStyleTargetSwitcher>(destinationContext, filter, sourceImageRect);
+    if (filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext))
+        return makeUnique<FilterStyleTargetSwitcher>(filter, sourceImageRect);
     return makeUnique<FilterImageTargetSwitcher>(destinationContext, filter, sourceImageRect, colorSpace, results);
 }
 

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -56,7 +56,7 @@ RefPtr<CSSFilter> CSSFilter::create(RenderElement& renderer, const FilterOperati
 
     LOG_WITH_STREAM(Filters, stream << "CSSFilter::create built filter " << filter.get() << " for " << operations);
 
-    filter->setFilterRenderingMode(preferredFilterRenderingModes);
+    filter->setFilterRenderingModes(preferredFilterRenderingModes);
     return filter;
 }
 

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -136,12 +136,11 @@ RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const Float
     if (!sourceImage)
         return &Image::nullImage();
 
-    sourceImage->context().drawImage(*image, sourceImageRect);
+    auto filteredImage = sourceImage->filteredImage(*cssFilter, [&](GraphicsContext& context) {
+        context.drawImage(*image, sourceImageRect);
+    });
 
-    if (auto image = sourceImage->filteredImage(*cssFilter))
-        return image;
-
-    return &Image::nullImage();
+    return filteredImage ? filteredImage : &Image::nullImage();
 }
 
 bool StyleFilterImage::knownToBeOpaque(const RenderElement&) const

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -47,7 +47,7 @@ RefPtr<SVGFilter> SVGFilter::create(SVGFilterElement& filterElement, OptionSet<F
     ASSERT(!expression->isEmpty());
     filter->setExpression(WTFMove(*expression));
 
-    filter->setFilterRenderingMode(preferredFilterRenderingModes);
+    filter->setFilterRenderingModes(preferredFilterRenderingModes);
     return filter;
 }
 

--- a/Source/WebKit/Platform/IPC/FilterReference.h
+++ b/Source/WebKit/Platform/IPC/FilterReference.h
@@ -448,7 +448,7 @@ template<class Encoder>
 void FilterReference::encodeFilter(const WebCore::Filter& filter, Encoder& encoder)
 {
     encoder << filter.filterType();
-    encoder << filter.filterRenderingMode();
+    encoder << filter.filterRenderingModes();
     encoder << filter.filterScale();
     encoder << filter.clipOperation();
     encoder << filter.filterRegion();
@@ -462,9 +462,9 @@ void FilterReference::encodeFilter(const WebCore::Filter& filter, Encoder& encod
 template<class Decoder>
 RefPtr<WebCore::Filter> FilterReference::decodeFilter(Decoder& decoder, WebCore::FilterFunction::Type filterType)
 {
-    std::optional<WebCore::FilterRenderingMode> filterRenderingMode;
-    decoder >> filterRenderingMode;
-    if (!filterRenderingMode)
+    std::optional<OptionSet<WebCore::FilterRenderingMode>> filterRenderingModes;
+    decoder >> filterRenderingModes;
+    if (!filterRenderingModes)
         return nullptr;
 
     std::optional<WebCore::FloatSize> filterScale;
@@ -490,7 +490,7 @@ RefPtr<WebCore::Filter> FilterReference::decodeFilter(Decoder& decoder, WebCore:
         filter = decodeSVGFilter(decoder);
     
     if (filter) {
-        filter->setFilterRenderingMode(*filterRenderingMode);
+        filter->setFilterRenderingModes(*filterRenderingModes);
         filter->setFilterScale(*filterScale);
         filter->setClipOperation(*clipOperation);
         filter->setFilterRegion(*filterRegion);


### PR DESCRIPTION
#### 6b3eb0be454e99625e24e9453a48a66ae96ed6f2
<pre>
[Filters] Make ImageBuffer::filteredImage() use FilterTargetSwitcher to apply the filter
<a href="https://bugs.webkit.org/show_bug.cgi?id=248587">https://bugs.webkit.org/show_bug.cgi?id=248587</a>
rdar://102847191

Reviewed by Simon Fraser.

Filter needs to know all the FilterRenderingModes it can use when it applies its
functions/effects. Instead of holding a single FilterRenderingMode, Filter will
hold a OptionSet&lt;FilterRenderingMode&gt;. So implementing Filter::renderingMode()
will be a lot clearer.

A new overriding ImageBuffer::filteredImage() will be added to take a drawCallback
argument. This method will be used for clean ImageBuffers which has no drawings
yet. If FilterRenderingMode::GraphicsContext can be used, the styles transparency
layers will be begun before calling drawCallback. And they will be ended after
calling drawCallback.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::filteredImage):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/filters/Filter.cpp:
(WebCore::Filter::renderingMode const):
(WebCore::Filter::setFilterRenderingModes):
(WebCore::Filter::setFilterRenderingMode): Deleted.
* Source/WebCore/platform/graphics/filters/Filter.h:
(WebCore::Filter::filterRenderingModes const):
(WebCore::Filter::filterRenderingMode const): Deleted.
(WebCore::Filter::setFilterRenderingMode): Deleted.
* Source/WebCore/platform/graphics/filters/FilterEffect.cpp:
(WebCore::FilterEffect::createApplier const):
* Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.cpp:
(WebCore::FilterStyleTargetSwitcher::FilterStyleTargetSwitcher):
* Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h:
* Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.cpp:
(WebCore::FilterTargetSwitcher::create):
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::CSSFilter::create):
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::image const):
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::create):
* Source/WebKit/Platform/IPC/FilterReference.h:
(IPC::FilterReference::encodeFilter):
(IPC::FilterReference::decodeFilter):

Canonical link: <a href="https://commits.webkit.org/257275@main">https://commits.webkit.org/257275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2870b2d018fb8ae33914fdfe8e42e2b81497d8f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107701 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167982 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7958 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36219 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104285 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5980 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84841 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33080 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76024 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1418 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20981 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1372 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22484 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5015 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44989 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41909 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->