### PR TITLE
ReadableStream.pipeTo should reuse AbortSignal reason when needed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any-expected.txt
@@ -7,18 +7,18 @@ PASS a signal argument 'true' should cause pipeTo() to reject
 PASS a signal argument '-1' should cause pipeTo() to reject
 PASS a signal argument '[object AbortSignal]' should cause pipeTo() to reject
 PASS an aborted signal should cause the writable stream to reject with an AbortError
-FAIL (reason: 'null') all the error objects should be the same object promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw null
-FAIL (reason: 'undefined') all the error objects should be the same object assert_equals: signal.reason should be error expected object "AbortError: abort pipeTo from signal" but got object "AbortError: The operation was aborted."
-FAIL (reason: 'error1: error1') all the error objects should be the same object promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw object "error1: error1"
+PASS (reason: 'null') all the error objects should be the same object
+PASS (reason: 'undefined') all the error objects should be the same object
+PASS (reason: 'error1: error1') all the error objects should be the same object
 PASS preventCancel should prevent canceling the readable
 PASS preventAbort should prevent aborting the readable
 PASS preventCancel and preventAbort should prevent canceling the readable and aborting the readable
-FAIL (reason: 'null') abort should prevent further reads promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw null
-FAIL (reason: 'undefined') abort should prevent further reads assert_equals: signal.reason should be error expected object "AbortError: abort pipeTo from signal" but got object "AbortError: The operation was aborted."
-FAIL (reason: 'error1: error1') abort should prevent further reads promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw object "error1: error1"
-FAIL (reason: 'null') all pending writes should complete on abort promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw null
-FAIL (reason: 'undefined') all pending writes should complete on abort assert_equals: signal.reason should be error expected object "AbortError: abort pipeTo from signal" but got object "AbortError: The operation was aborted."
-FAIL (reason: 'error1: error1') all pending writes should complete on abort promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw object "error1: error1"
+PASS (reason: 'null') abort should prevent further reads
+PASS (reason: 'undefined') abort should prevent further reads
+PASS (reason: 'error1: error1') abort should prevent further reads
+PASS (reason: 'null') all pending writes should complete on abort
+PASS (reason: 'undefined') all pending writes should complete on abort
+PASS (reason: 'error1: error1') all pending writes should complete on abort
 PASS a rejection from underlyingSource.cancel() should be returned by pipeTo()
 PASS a rejection from underlyingSink.abort() should be returned by pipeTo()
 PASS a rejection from underlyingSink.abort() should be preferred to one from underlyingSource.cancel()

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.serviceworker-expected.txt
@@ -7,18 +7,18 @@ PASS a signal argument 'true' should cause pipeTo() to reject
 PASS a signal argument '-1' should cause pipeTo() to reject
 PASS a signal argument '[object AbortSignal]' should cause pipeTo() to reject
 PASS an aborted signal should cause the writable stream to reject with an AbortError
-FAIL (reason: 'null') all the error objects should be the same object promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw null
-FAIL (reason: 'undefined') all the error objects should be the same object assert_equals: signal.reason should be error expected object "AbortError: abort pipeTo from signal" but got object "AbortError: The operation was aborted."
-FAIL (reason: 'error1: error1') all the error objects should be the same object promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw object "error1: error1"
+PASS (reason: 'null') all the error objects should be the same object
+PASS (reason: 'undefined') all the error objects should be the same object
+PASS (reason: 'error1: error1') all the error objects should be the same object
 PASS preventCancel should prevent canceling the readable
 PASS preventAbort should prevent aborting the readable
 PASS preventCancel and preventAbort should prevent canceling the readable and aborting the readable
-FAIL (reason: 'null') abort should prevent further reads promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw null
-FAIL (reason: 'undefined') abort should prevent further reads assert_equals: signal.reason should be error expected object "AbortError: abort pipeTo from signal" but got object "AbortError: The operation was aborted."
-FAIL (reason: 'error1: error1') abort should prevent further reads promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw object "error1: error1"
-FAIL (reason: 'null') all pending writes should complete on abort promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw null
-FAIL (reason: 'undefined') all pending writes should complete on abort assert_equals: signal.reason should be error expected object "AbortError: abort pipeTo from signal" but got object "AbortError: The operation was aborted."
-FAIL (reason: 'error1: error1') all pending writes should complete on abort promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw object "error1: error1"
+PASS (reason: 'null') abort should prevent further reads
+PASS (reason: 'undefined') abort should prevent further reads
+PASS (reason: 'error1: error1') abort should prevent further reads
+PASS (reason: 'null') all pending writes should complete on abort
+PASS (reason: 'undefined') all pending writes should complete on abort
+PASS (reason: 'error1: error1') all pending writes should complete on abort
 PASS a rejection from underlyingSource.cancel() should be returned by pipeTo()
 PASS a rejection from underlyingSink.abort() should be returned by pipeTo()
 PASS a rejection from underlyingSink.abort() should be preferred to one from underlyingSource.cancel()

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.worker-expected.txt
@@ -7,18 +7,18 @@ PASS a signal argument 'true' should cause pipeTo() to reject
 PASS a signal argument '-1' should cause pipeTo() to reject
 PASS a signal argument '[object AbortSignal]' should cause pipeTo() to reject
 PASS an aborted signal should cause the writable stream to reject with an AbortError
-FAIL (reason: 'null') all the error objects should be the same object promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw null
-FAIL (reason: 'undefined') all the error objects should be the same object assert_equals: signal.reason should be error expected object "AbortError: abort pipeTo from signal" but got object "AbortError: The operation was aborted."
-FAIL (reason: 'error1: error1') all the error objects should be the same object promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw object "error1: error1"
+PASS (reason: 'null') all the error objects should be the same object
+PASS (reason: 'undefined') all the error objects should be the same object
+PASS (reason: 'error1: error1') all the error objects should be the same object
 PASS preventCancel should prevent canceling the readable
 PASS preventAbort should prevent aborting the readable
 PASS preventCancel and preventAbort should prevent canceling the readable and aborting the readable
-FAIL (reason: 'null') abort should prevent further reads promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw null
-FAIL (reason: 'undefined') abort should prevent further reads assert_equals: signal.reason should be error expected object "AbortError: abort pipeTo from signal" but got object "AbortError: The operation was aborted."
-FAIL (reason: 'error1: error1') abort should prevent further reads promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw object "error1: error1"
-FAIL (reason: 'null') all pending writes should complete on abort promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw null
-FAIL (reason: 'undefined') all pending writes should complete on abort assert_equals: signal.reason should be error expected object "AbortError: abort pipeTo from signal" but got object "AbortError: The operation was aborted."
-FAIL (reason: 'error1: error1') all pending writes should complete on abort promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw object "error1: error1"
+PASS (reason: 'null') abort should prevent further reads
+PASS (reason: 'undefined') abort should prevent further reads
+PASS (reason: 'error1: error1') abort should prevent further reads
+PASS (reason: 'null') all pending writes should complete on abort
+PASS (reason: 'undefined') all pending writes should complete on abort
+PASS (reason: 'error1: error1') all pending writes should complete on abort
 PASS a rejection from underlyingSource.cancel() should be returned by pipeTo()
 PASS a rejection from underlyingSink.abort() should be returned by pipeTo()
 PASS a rejection from underlyingSink.abort() should be preferred to one from underlyingSource.cancel()

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/streams/piping/abort.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/streams/piping/abort.any-expected.txt
@@ -10,18 +10,18 @@ PASS a signal argument 'true' should cause pipeTo() to reject
 PASS a signal argument '-1' should cause pipeTo() to reject
 PASS a signal argument '[object AbortSignal]' should cause pipeTo() to reject
 PASS an aborted signal should cause the writable stream to reject with an AbortError
-FAIL (reason: 'null') all the error objects should be the same object promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw null
-FAIL (reason: 'undefined') all the error objects should be the same object assert_equals: signal.reason should be error expected object "AbortError: abort pipeTo from signal" but got object "AbortError: The operation was aborted."
-FAIL (reason: 'error1: error1') all the error objects should be the same object promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw object "error1: error1"
+PASS (reason: 'null') all the error objects should be the same object
+PASS (reason: 'undefined') all the error objects should be the same object
+PASS (reason: 'error1: error1') all the error objects should be the same object
 PASS preventCancel should prevent canceling the readable
 PASS preventAbort should prevent aborting the readable
 PASS preventCancel and preventAbort should prevent canceling the readable and aborting the readable
-FAIL (reason: 'null') abort should prevent further reads promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw null
-FAIL (reason: 'undefined') abort should prevent further reads assert_equals: signal.reason should be error expected object "AbortError: abort pipeTo from signal" but got object "AbortError: The operation was aborted."
-FAIL (reason: 'error1: error1') abort should prevent further reads promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw object "error1: error1"
-FAIL (reason: 'null') all pending writes should complete on abort promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw null
-FAIL (reason: 'undefined') all pending writes should complete on abort assert_equals: signal.reason should be error expected object "AbortError: abort pipeTo from signal" but got object "AbortError: The operation was aborted."
-FAIL (reason: 'error1: error1') all pending writes should complete on abort promise_rejects_exactly: pipeTo rejects with abort reason function "function () { throw e }" threw object "AbortError: abort pipeTo from signal" but we expected it to throw object "error1: error1"
+PASS (reason: 'null') abort should prevent further reads
+PASS (reason: 'undefined') abort should prevent further reads
+PASS (reason: 'error1: error1') abort should prevent further reads
+PASS (reason: 'null') all pending writes should complete on abort
+PASS (reason: 'undefined') all pending writes should complete on abort
+PASS (reason: 'error1: error1') all pending writes should complete on abort
 PASS a rejection from underlyingSource.cancel() should be returned by pipeTo()
 PASS a rejection from underlyingSink.abort() should be returned by pipeTo()
 PASS a rejection from underlyingSink.abort() should be preferred to one from underlyingSource.cancel()

--- a/Source/WebCore/Modules/streams/ReadableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/ReadableStreamInternals.js
@@ -163,15 +163,13 @@ function readableStreamPipeToWritableStream(source, destination, preventClose, p
     pipeState.pendingWritePromise = @Promise.@resolve();
 
     if (signal !== @undefined) {
-        const algorithm = () => {
-            const error = @makeDOMException("AbortError", "abort pipeTo from signal");
-
+        const algorithm = (reason) => {
             @pipeToShutdownWithAction(pipeState, () => {
                 const shouldAbortDestination = !pipeState.preventAbort && @getByIdDirectPrivate(pipeState.destination, "state") === "writable";
-                const promiseDestination = shouldAbortDestination ? @writableStreamAbort(pipeState.destination, error) : @Promise.@resolve();
+                const promiseDestination = shouldAbortDestination ? @writableStreamAbort(pipeState.destination, reason) : @Promise.@resolve();
 
                 const shouldAbortSource = !pipeState.preventCancel && @getByIdDirectPrivate(pipeState.source, "state") === @streamReadable;
-                const promiseSource = shouldAbortSource ? @readableStreamCancel(pipeState.source, error) : @Promise.@resolve();
+                const promiseSource = shouldAbortSource ? @readableStreamCancel(pipeState.source, reason) : @Promise.@resolve();
 
                 let promiseCapability = @newPromiseCapability(@Promise);
                 let shouldWait = true;
@@ -188,7 +186,7 @@ function readableStreamPipeToWritableStream(source, destination, preventClose, p
                 promiseDestination.@then(handleResolvedPromise, handleRejectedPromise);
                 promiseSource.@then(handleResolvedPromise, handleRejectedPromise);
                 return promiseCapability.@promise;
-            }, error);
+            }, reason);
         };
         pipeState.abortAlgorithmIdentifier = @addAbortAlgorithmToSignal(signal, algorithm)
         if (!pipeState.abortAlgorithmIdentifier)

--- a/Source/WebCore/dom/AbortAlgorithm.h
+++ b/Source/WebCore/dom/AbortAlgorithm.h
@@ -29,13 +29,17 @@
 #include "CallbackResult.h"
 #include <wtf/ThreadSafeRefCounted.h>
 
+namespace JSC {
+class JSValue;
+} // namespace JSC
+
 namespace WebCore {
 
 class AbortAlgorithm : public ThreadSafeRefCounted<AbortAlgorithm>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
-    virtual CallbackResult<void> handleEvent() = 0;
+    virtual CallbackResult<void> handleEvent(JSC::JSValue) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/AbortAlgorithm.idl
+++ b/Source/WebCore/dom/AbortAlgorithm.idl
@@ -23,4 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-callback AbortAlgorithm = undefined ();
+callback AbortAlgorithm = undefined (any value);

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -137,11 +137,11 @@ void AbortSignal::eventListenersDidChange()
 uint32_t AbortSignal::addAbortAlgorithmToSignal(AbortSignal& signal, Ref<AbortAlgorithm>&& algorithm)
 {
     if (signal.aborted()) {
-        algorithm->handleEvent();
+        algorithm->handleEvent(signal.m_reason.getValue());
         return 0;
     }
-    return signal.addAlgorithm([algorithm = WTFMove(algorithm)](JSC::JSValue) mutable {
-        algorithm->handleEvent();
+    return signal.addAlgorithm([algorithm = WTFMove(algorithm)](JSC::JSValue value) mutable {
+        algorithm->handleEvent(value);
     });
 }
 


### PR DESCRIPTION
#### 2ce995ef5fcb3664bca39f318d6581e97eb943e7
<pre>
ReadableStream.pipeTo should reuse AbortSignal reason when needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=248591">https://bugs.webkit.org/show_bug.cgi?id=248591</a>
rdar://problem/102849934

Reviewed by Alex Christensen.

Makr the AbortAlgorithm take the abort reason.
Use this value in ReadableStream code.
Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.js:
(Object.create):
(promise_test.t.string_appeared_here.then):
(async promise_test):
(const.reason.of.null.promise_test.async t): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/streams/piping/abort.any-expected.txt:
* Source/WebCore/Modules/streams/ReadableStreamInternals.js:
(readableStreamPipeToWritableStream):
(readableStreamReaderGenericRelease):
* Source/WebCore/dom/AbortAlgorithm.h:
* Source/WebCore/dom/AbortAlgorithm.idl:
* Source/WebCore/dom/AbortSignal.cpp:
(WebCore::AbortSignal::addAbortAlgorithmToSignal):

Canonical link: <a href="https://commits.webkit.org/257464@main">https://commits.webkit.org/257464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4585874cc9d8fa59cdd4389cdecc5bd2292db4f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108308 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168564 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85468 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106288 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33594 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21480 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76447 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2014 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23006 "Found 30 new test failures: editing/input/page-up-down-scrolls.html, http/tests/cache/disk-cache/disk-cache-vary-no-body.html, http/tests/xmlhttprequest/response-access-on-error.html, http/wpt/cache-storage/cache-quota.any.html, http/wpt/cache-storage/quota-third-party.https.html, http/wpt/fetch/response-opaque-clone.html, http/wpt/service-workers/use-element.https.html, imported/w3c/web-platform-tests/css/css-flexbox/flex-basis-009.html, imported/w3c/web-platform-tests/fetch/http-cache/cache-mode.any.sharedworker.html, imported/w3c/web-platform-tests/fetch/http-cache/cache-mode.any.worker.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1923 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45455 "Found 1 new test failure: media/video-inactive-playback.html (failure)") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5139 "'git push ...'") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42470 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->