### PR TITLE
Update TransformStream options getters to check for undefined

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transform-streams/patched-global.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transform-streams/patched-global.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL TransformStream constructor should not call setters for highWaterMark or size highWaterMark value is negative or not a number
+PASS TransformStream constructor should not call setters for highWaterMark or size
 PASS TransformStream should use the original value of ReadableStream and WritableStream
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transform-streams/patched-global.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transform-streams/patched-global.any.serviceworker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL TransformStream constructor should not call setters for highWaterMark or size highWaterMark value is negative or not a number
+PASS TransformStream constructor should not call setters for highWaterMark or size
 PASS TransformStream should use the original value of ReadableStream and WritableStream
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transform-streams/patched-global.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transform-streams/patched-global.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL TransformStream constructor should not call setters for highWaterMark or size highWaterMark value is negative or not a number
+PASS TransformStream constructor should not call setters for highWaterMark or size
 PASS TransformStream should use the original value of ReadableStream and WritableStream
 

--- a/Source/WebCore/Modules/streams/StreamInternals.js
+++ b/Source/WebCore/Modules/streams/StreamInternals.js
@@ -170,7 +170,11 @@ function extractSizeAlgorithm(strategy)
 {
     if (!("size" in strategy))
         return () => 1;
+
     const sizeAlgorithm = strategy["size"];
+    if (sizeAlgorithm === @undefined)
+        return () => 1;
+
     if (typeof sizeAlgorithm !== "function")
         @throwTypeError("strategy.size must be a function");
 
@@ -181,7 +185,11 @@ function extractHighWaterMark(strategy, defaultHWM)
 {
     if (!("highWaterMark" in strategy))
         return defaultHWM;
+
     const highWaterMark = strategy["highWaterMark"];
+    if (highWaterMark === @undefined)
+        return defaultHWM;
+
     if (@isNaN(highWaterMark) || highWaterMark < 0)
         @throwRangeError("highWaterMark value is negative or not a number");
 


### PR DESCRIPTION
#### 7994b8b934686b39f6f2bcf5a7655fe1a8ee8bbd
<pre>
Update TransformStream options getters to check for undefined
<a href="https://bugs.webkit.org/show_bug.cgi?id=248599">https://bugs.webkit.org/show_bug.cgi?id=248599</a>
rdar://problem/102858309

Reviewed by Alex Christensen.

Make sure to handle the case where a member value is underfined is equivalent to no member at all.

* LayoutTests/imported/w3c/web-platform-tests/streams/transform-streams/patched-global.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/transform-streams/patched-global.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/transform-streams/patched-global.any.worker-expected.txt:
* Source/WebCore/Modules/streams/StreamInternals.js:
(extractSizeAlgorithm):
(extractHighWaterMark):

Canonical link: <a href="https://commits.webkit.org/257361@main">https://commits.webkit.org/257361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11a6a4d44cb7ac444274db2b3969e69dbf12eac7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107738 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168008 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85016 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90864 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104325 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89590 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33108 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76052 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1455 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22527 "Found 1 new test failure: streams/readable-stream-default-controller-error.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1399 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45126 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, animations/stop-animation-on-suspend.html, css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/rendering/render-style-null-optgroup-crash.html, fast/text/text-edge-property-parsing.html, http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html, http/wpt/service-workers/fetch-service-worker-preload-download.https.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html ... (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5054 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41944 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->