### PR TITLE
Add WritableStreamDefaultController signal getter

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any-expected.txt
@@ -168,11 +168,11 @@ PASS WritableStreamDefaultController interface object name
 PASS WritableStreamDefaultController interface: existence and properties of interface prototype object
 PASS WritableStreamDefaultController interface: existence and properties of interface prototype object's "constructor" property
 PASS WritableStreamDefaultController interface: existence and properties of interface prototype object's @@unscopables property
-FAIL WritableStreamDefaultController interface: attribute signal assert_true: The prototype object must have a property "signal" expected true got false
+PASS WritableStreamDefaultController interface: attribute signal
 FAIL WritableStreamDefaultController interface: operation error(optional any) assert_equals: property has wrong .length expected 0 but got 1
 PASS WritableStreamDefaultController must be primary interface of self.writableStreamDefaultController
 PASS Stringification of self.writableStreamDefaultController
-FAIL WritableStreamDefaultController interface: self.writableStreamDefaultController must inherit property "signal" with the proper type assert_inherits: property "signal" not found in prototype chain
+PASS WritableStreamDefaultController interface: self.writableStreamDefaultController must inherit property "signal" with the proper type
 PASS WritableStreamDefaultController interface: self.writableStreamDefaultController must inherit property "error(optional any)" with the proper type
 PASS WritableStreamDefaultController interface: calling error(optional any) on self.writableStreamDefaultController with too few arguments must throw TypeError
 PASS TransformStream interface: existence and properties of interface object

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.serviceworker-expected.txt
@@ -168,11 +168,11 @@ PASS WritableStreamDefaultController interface object name
 PASS WritableStreamDefaultController interface: existence and properties of interface prototype object
 PASS WritableStreamDefaultController interface: existence and properties of interface prototype object's "constructor" property
 PASS WritableStreamDefaultController interface: existence and properties of interface prototype object's @@unscopables property
-FAIL WritableStreamDefaultController interface: attribute signal assert_true: The prototype object must have a property "signal" expected true got false
+PASS WritableStreamDefaultController interface: attribute signal
 FAIL WritableStreamDefaultController interface: operation error(optional any) assert_equals: property has wrong .length expected 0 but got 1
 PASS WritableStreamDefaultController must be primary interface of self.writableStreamDefaultController
 PASS Stringification of self.writableStreamDefaultController
-FAIL WritableStreamDefaultController interface: self.writableStreamDefaultController must inherit property "signal" with the proper type assert_inherits: property "signal" not found in prototype chain
+PASS WritableStreamDefaultController interface: self.writableStreamDefaultController must inherit property "signal" with the proper type
 PASS WritableStreamDefaultController interface: self.writableStreamDefaultController must inherit property "error(optional any)" with the proper type
 PASS WritableStreamDefaultController interface: calling error(optional any) on self.writableStreamDefaultController with too few arguments must throw TypeError
 PASS TransformStream interface: existence and properties of interface object

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.worker-expected.txt
@@ -168,11 +168,11 @@ PASS WritableStreamDefaultController interface object name
 PASS WritableStreamDefaultController interface: existence and properties of interface prototype object
 PASS WritableStreamDefaultController interface: existence and properties of interface prototype object's "constructor" property
 PASS WritableStreamDefaultController interface: existence and properties of interface prototype object's @@unscopables property
-FAIL WritableStreamDefaultController interface: attribute signal assert_true: The prototype object must have a property "signal" expected true got false
+PASS WritableStreamDefaultController interface: attribute signal
 FAIL WritableStreamDefaultController interface: operation error(optional any) assert_equals: property has wrong .length expected 0 but got 1
 PASS WritableStreamDefaultController must be primary interface of self.writableStreamDefaultController
 PASS Stringification of self.writableStreamDefaultController
-FAIL WritableStreamDefaultController interface: self.writableStreamDefaultController must inherit property "signal" with the proper type assert_inherits: property "signal" not found in prototype chain
+PASS WritableStreamDefaultController interface: self.writableStreamDefaultController must inherit property "signal" with the proper type
 PASS WritableStreamDefaultController interface: self.writableStreamDefaultController must inherit property "error(optional any)" with the proper type
 PASS WritableStreamDefaultController interface: calling error(optional any) on self.writableStreamDefaultController with too few arguments must throw TypeError
 PASS TransformStream interface: existence and properties of interface object

--- a/Source/WebCore/Modules/streams/WritableStreamDefaultController.idl
+++ b/Source/WebCore/Modules/streams/WritableStreamDefaultController.idl
@@ -29,7 +29,6 @@
     PrivateIdentifier,
     PublicIdentifier
 ] interface WritableStreamDefaultController {
-    constructor();
-
+    readonly attribute AbortSignal signal;
     undefined error(optional any e);
 };

--- a/Source/WebCore/Modules/streams/WritableStreamDefaultController.js
+++ b/Source/WebCore/Modules/streams/WritableStreamDefaultController.js
@@ -45,6 +45,17 @@ function initializeWritableStreamDefaultController()
     return this;
 }
 
+@getter
+function signal()
+{
+    "use strict";
+
+    if (@getByIdDirectPrivate(this, "abortSteps") === @undefined)
+        throw @makeThisTypeError("WritableStreamDefaultController", "signal");
+
+    return @getByIdDirectPrivate(this, "signal");
+}
+
 function error(e)
 {
     "use strict";

--- a/Source/WebCore/Modules/streams/WritableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/WritableStreamInternals.js
@@ -186,6 +186,9 @@ function writableStreamAbort(stream, reason)
     if (state === "closed" || state === "errored")
         return @Promise.@resolve();
 
+    const controller = @getByIdDirectPrivate(stream, "controller");
+    @signalAbort(@getByIdDirectPrivate(controller, "signal"), reason);
+
     const pendingAbortRequest = @getByIdDirectPrivate(stream, "pendingAbortRequest");
     if (pendingAbortRequest !== @undefined)
         return pendingAbortRequest.promise.@promise;
@@ -579,6 +582,7 @@ function setUpWritableStreamDefaultController(stream, controller, startAlgorithm
 
     @resetQueue(@getByIdDirectPrivate(controller, "queue"));
 
+    @putByIdDirectPrivate(controller, "signal", @createAbortSignal());
     @putByIdDirectPrivate(controller, "started", false);
     @putByIdDirectPrivate(controller, "strategySizeAlgorithm", sizeAlgorithm);
     @putByIdDirectPrivate(controller, "strategyHWM", highWaterMark);

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -493,6 +493,7 @@ namespace WebCore {
     macro(consumeChunk) \
     macro(controlledReadableStream) \
     macro(controller) \
+    macro(createAbortSignal) \
     macro(createImageBitmap) \
     macro(createReadableStream) \
     macro(createWritableStreamFromInternal) \
@@ -600,6 +601,8 @@ namespace WebCore {
     macro(setBodyFromInputRequest) \
     macro(setStatus) \
     macro(showModalDialog) \
+    macro(signal) \
+    macro(signalAbort) \
     macro(SpeechSynthesis) \
     macro(SpeechSynthesisErrorEvent) \
     macro(SpeechSynthesisEvent) \


### PR DESCRIPTION
#### 5815663b4091e899abd1b81a412b05d020c70d53
<pre>
Add WritableStreamDefaultController signal getter
<a href="https://bugs.webkit.org/show_bug.cgi?id=248600">https://bugs.webkit.org/show_bug.cgi?id=248600</a>
rdar://problem/102858374

Reviewed by Alex Christensen.

Add signal as attribute and signal it as aborted when stream gets aborted.
Add necessary built-in globals to interact with AbortSignal.
Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.worker-expected.txt:
* Source/WebCore/Modules/streams/WritableStreamDefaultController.idl:
* Source/WebCore/Modules/streams/WritableStreamDefaultController.js:
(getter.signal):
* Source/WebCore/Modules/streams/WritableStreamInternals.js:
(writableStreamAbort):
(setUpWritableStreamDefaultController):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSC_DEFINE_HOST_FUNCTION):
(WebCore::JSDOMGlobalObject::addBuiltinGlobals):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:

Canonical link: <a href="https://commits.webkit.org/257397@main">https://commits.webkit.org/257397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/692cb1c735638d626cb2cdc0ac3c006f00312837

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108143 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168395 "Failed to checkout and rebase branch from PR 7022") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85303 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91255 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106060 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33396 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76322 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1856 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22837 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1764 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45319 "Found 5 new test failures: imported/w3c/web-platform-tests/streams/transform-streams/patched-global.any.html, imported/w3c/web-platform-tests/streams/transform-streams/patched-global.any.serviceworker.html, imported/w3c/web-platform-tests/streams/transform-streams/patched-global.any.worker.html, ipc/webpageproxy-correctionpanel-no-crash.html, media/video-inactive-playback.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5088 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6710 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42292 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->