### PR TITLE
[EWS] Include flavor (wk1/wk2) in results database request when evaluating pre-existing failures

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3266,6 +3266,11 @@ class RunWebKitTests(shell.Test, AddToLogMixin):
         if style and style in ['debug', 'release']:
             configuration['style'] = style
 
+        if self.getProperty('use-dump-render-tree', False):
+            configuration['flavor'] = 'wk1'
+        else:
+            configuration['flavor'] = 'wk2'
+
         self._addToLog('stdio', f'\nChecking Results database for failing tests. Identifier: {identifier}, configuration: {configuration}')
         for test in failing_tests:
             data = ResultsDatabase().is_test_pre_existing_failure(test, commit=identifier, configuration=configuration)


### PR DESCRIPTION
#### e2196aa0ada38bcf95c3c954d33b7d195ddbedd8
<pre>
[EWS] Include flavor (wk1/wk2) in results database request when evaluating pre-existing failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=248561">https://bugs.webkit.org/show_bug.cgi?id=248561</a>
rdar://102860227

Reviewed by Jonathan Bedard.

* Tools/CISupport/ews-build/steps.py:
(RunWebKitTests.filter_failures_using_results_db):

Canonical link: <a href="https://commits.webkit.org/257238@main">https://commits.webkit.org/257238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bf691d92c563540afdf11a52726f9a3ce4f4771

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98291 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/7499 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107741 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168011 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102234 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/8003 "Build was cancelled. Recent messages:Cleaned up git repository; Running checkout-specific-revision; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/36260 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103945 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/8003 "Build was cancelled. Recent messages:Cleaned up git repository; Running checkout-specific-revision; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/84882 "Build was cancelled. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Running checkout-specific-revision; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/90868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/8003 "Build was cancelled. Recent messages:Cleaned up git repository; Running checkout-specific-revision; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1458 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/97218 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1402 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6296 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/84882 "Build was cancelled. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Running checkout-specific-revision; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2486 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2752 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41947 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->