### PR TITLE
Align WEBGL_provoking_vertex parameter name with the spec

### DIFF
--- a/Source/WebCore/html/canvas/WebGLProvokingVertex.cpp
+++ b/Source/WebCore/html/canvas/WebGLProvokingVertex.cpp
@@ -52,13 +52,13 @@ bool WebGLProvokingVertex::supported(GraphicsContextGL& context)
     return context.supportsExtension("GL_ANGLE_provoking_vertex"_s);
 }
 
-void WebGLProvokingVertex::provokingVertexWEBGL(GCGLenum mode)
+void WebGLProvokingVertex::provokingVertexWEBGL(GCGLenum provokeMode)
 {
     auto context = WebGLExtensionScopedContext(this);
     if (context.isLost())
         return;
 
-    context->graphicsContextGL()->provokingVertexANGLE(mode);
+    context->graphicsContextGL()->provokingVertexANGLE(provokeMode);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLProvokingVertex.h
+++ b/Source/WebCore/html/canvas/WebGLProvokingVertex.h
@@ -39,7 +39,7 @@ public:
 
     static bool supported(GraphicsContextGL&);
 
-    void provokingVertexWEBGL(GCGLenum mode);
+    void provokingVertexWEBGL(GCGLenum provokeMode);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLProvokingVertex.idl
+++ b/Source/WebCore/html/canvas/WebGLProvokingVertex.idl
@@ -32,5 +32,5 @@
     const unsigned long LAST_VERTEX_CONVENTION_WEBGL  = 0x8E4E;
     const unsigned long PROVOKING_VERTEX_WEBGL        = 0x8E4F;
 
-    undefined provokingVertexWEBGL(unsigned long mode);
+    undefined provokingVertexWEBGL(unsigned long provokeMode);
 };

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1465,7 +1465,7 @@ public:
     virtual void multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLsizei, const GCGLsizei, const GCGLsizei, const GCGLint, const GCGLuint> countsOffsetsInstanceCountsBaseVerticesAndBaseInstances, GCGLenum type) = 0;
 
     // GL_ANGLE_provoking_vertex
-    virtual void provokingVertexANGLE(GCGLenum mode) = 0;
+    virtual void provokingVertexANGLE(GCGLenum provokeMode) = 0;
 
     // ========== Other functions.
     GCGLfloat getFloat(GCGLenum pname);

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -3049,12 +3049,12 @@ void GraphicsContextGLANGLE::multiDrawElementsInstancedBaseVertexBaseInstanceANG
     checkGPUStatus();
 }
 
-void GraphicsContextGLANGLE::provokingVertexANGLE(GCGLenum mode)
+void GraphicsContextGLANGLE::provokingVertexANGLE(GCGLenum provokeMode)
 {
     if (!makeContextCurrent())
         return;
 
-    GL_ProvokingVertexANGLE(mode);
+    GL_ProvokingVertexANGLE(provokeMode);
 }
 
 bool GraphicsContextGLANGLE::waitAndUpdateOldestFrame()

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -323,7 +323,7 @@ public:
     void drawElementsInstancedBaseVertexBaseInstanceANGLE(GCGLenum mode, GCGLsizei count, GCGLenum type, GCGLintptr offset, GCGLsizei instanceCount, GCGLint baseVertex, GCGLuint baseInstance) final;
     void multiDrawArraysInstancedBaseInstanceANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLint, const GCGLsizei, const GCGLsizei, const GCGLuint> firstsCountsInstanceCountsAndBaseInstances) final;
     void multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLsizei, const GCGLsizei, const GCGLsizei, const GCGLint, const GCGLuint> countsOffsetsInstanceCountsBaseVerticesAndBaseInstances, GCGLenum type) final;
-    void provokingVertexANGLE(GCGLenum mode) final;
+    void provokingVertexANGLE(GCGLenum provokeMode) final;
 
     PlatformGLObject createBuffer() final;
     PlatformGLObject createFramebuffer() final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -305,7 +305,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void ColorMaskiOES(uint32_t buf, bool red, bool green, bool blue, bool alpha)
     void DrawArraysInstancedBaseInstanceANGLE(uint32_t mode, int32_t first, int32_t count, int32_t instanceCount, uint32_t baseInstance)
     void DrawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, int32_t count, uint32_t type, uint64_t offset, int32_t instanceCount, int32_t baseVertex, uint32_t baseInstance)
-    void ProvokingVertexANGLE(uint32_t mode)
+    void ProvokingVertexANGLE(uint32_t provokeMode)
     void GetInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, uint64_t paramsSize) -> (IPC::ArrayReference<int32_t> params) Synchronous
     void SetDrawingBufferColorSpace(WebCore::DestinationColorSpace arg0)
     void PaintRenderingResultsToPixelBuffer() -> (RefPtr<WebCore::PixelBuffer> returnValue) Synchronous

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -1385,10 +1385,10 @@
         assertIsCurrent(workQueue());
         m_context->drawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, static_cast<GCGLintptr>(offset), instanceCount, baseVertex, baseInstance);
     }
-    void provokingVertexANGLE(uint32_t mode)
+    void provokingVertexANGLE(uint32_t provokeMode)
     {
         assertIsCurrent(workQueue());
-        m_context->provokingVertexANGLE(mode);
+        m_context->provokingVertexANGLE(provokeMode);
     }
     void getInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, uint64_t paramsSize, CompletionHandler<void(IPC::ArrayReference<int32_t>)>&& completionHandler)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -334,7 +334,7 @@ public:
     void colorMaskiOES(GCGLuint buf, GCGLboolean red, GCGLboolean green, GCGLboolean blue, GCGLboolean alpha) final;
     void drawArraysInstancedBaseInstanceANGLE(GCGLenum mode, GCGLint first, GCGLsizei count, GCGLsizei instanceCount, GCGLuint baseInstance) final;
     void drawElementsInstancedBaseVertexBaseInstanceANGLE(GCGLenum mode, GCGLsizei count, GCGLenum type, GCGLintptr offset, GCGLsizei instanceCount, GCGLint baseVertex, GCGLuint baseInstance) final;
-    void provokingVertexANGLE(GCGLenum mode) final;
+    void provokingVertexANGLE(GCGLenum provokeMode) final;
     void getInternalformativ(GCGLenum target, GCGLenum internalformat, GCGLenum pname, GCGLSpan<GCGLint> params) final;
     void setDrawingBufferColorSpace(const WebCore::DestinationColorSpace&) final;
     RefPtr<WebCore::PixelBuffer> paintRenderingResultsToPixelBuffer() final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -2861,11 +2861,11 @@ void RemoteGraphicsContextGLProxy::drawElementsInstancedBaseVertexBaseInstanceAN
     }
 }
 
-void RemoteGraphicsContextGLProxy::provokingVertexANGLE(GCGLenum mode)
+void RemoteGraphicsContextGLProxy::provokingVertexANGLE(GCGLenum provokeMode)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ProvokingVertexANGLE(mode));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ProvokingVertexANGLE(provokeMode));
     if (!sendResult) {
         markContextLost();
         return;


### PR DESCRIPTION
#### 7b45cc012ccef09352d1102f0093ff8c88b3dd27
<pre>
Align WEBGL_provoking_vertex parameter name with the spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=248589">https://bugs.webkit.org/show_bug.cgi?id=248589</a>

Reviewed by Kimmo Kinnunen.

* Source/WebCore/html/canvas/WebGLProvokingVertex.cpp:
(WebCore::WebGLProvokingVertex::provokingVertexWEBGL):
* Source/WebCore/html/canvas/WebGLProvokingVertex.h:
* Source/WebCore/html/canvas/WebGLProvokingVertex.idl:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::provokingVertexANGLE):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(provokingVertexANGLE):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::provokingVertexANGLE):

Canonical link: <a href="https://commits.webkit.org/257405@main">https://commits.webkit.org/257405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/207b116dc8a5f94b873820cf324a7308597cebac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107756 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168023 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102248 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85023 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90880 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104364 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33116 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87910 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21017 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, css3/supports-dom-api.html, http/tests/appcache/fail-on-update-2.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-030.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-031.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/scrollIntoView-with-focus-target-with-contents-hidden.html, imported/w3c/web-platform-tests/css/css-transforms/3d-rendering-context-behavior.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/computed/computed.tentative.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76060 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1471 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22543 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1415 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45134 "Found 30 new test failures: css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/forms/file/entries-api/image-no-transcode-open-panel.html, fast/rendering/render-style-null-optgroup-crash.html, fast/text/text-edge-property-parsing.html, http/tests/permissions/permission-status-onchange-event-dedicated-worker.html, http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html, http/wpt/service-workers/fetch-service-worker-preload-download.https.html, http/wpt/service-workers/fetch-service-worker-preload.https.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html ... (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5095 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41956 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->