### PR TITLE
[iOS] Allow clients to override text input traits

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -117,6 +117,7 @@ typedef NS_OPTIONS(NSUInteger, _WKRectEdge) {
 #endif
 
 @class UIEventAttribution;
+@class UITextInputTraits;
 @class WKBrowsingContextHandle;
 @class WKDownload;
 @class WKFrameInfo;
@@ -632,6 +633,8 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 
 - (void)_isNavigatingToAppBoundDomain:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(ios(14.0));
 - (void)_isForcedIntoAppBoundMode:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(ios(14.0));
+
+- (UITextInputTraits *)_textInputTraits WK_API_AVAILABLE(ios(WK_IOS_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4118,6 +4118,14 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 #endif // HAVE(UIFINDINTERACTION)
 
+- (UITextInputTraits *)_textInputTraits
+{
+    if (self.usesStandardContentView)
+        return [_contentView textInputTraitsForWebView];
+
+    return nil;
+}
+
 @end // WKWebView (WKPrivateIOS)
 
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -582,6 +582,7 @@ struct ImageAnalysisContextMenuActionData {
 @property (nonatomic, readonly) UITextInputAssistantItem *inputAssistantItemForWebView;
 @property (nonatomic, readonly) UIView *inputViewForWebView;
 @property (nonatomic, readonly) UIView *inputAccessoryViewForWebView;
+@property (nonatomic, readonly) UITextInputTraits *textInputTraitsForWebView;
 @property (nonatomic, readonly) BOOL preventsPanningInXAxis;
 @property (nonatomic, readonly) BOOL preventsPanningInYAxis;
 @property (nonatomic, readonly) UIWebTouchEventsGestureRecognizer *touchEventGestureRecognizer;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5921,6 +5921,12 @@ static NSString *contentTypeFromFieldName(WebCore::AutofillFieldName fieldName)
 // Direct access to the (private) UITextInputTraits object.
 - (UITextInputTraits *)textInputTraits
 {
+    _traits = [_webView _textInputTraits];
+    return _traits.get();
+}
+
+- (UITextInputTraits *)textInputTraitsForWebView
+{
     if (!_traits)
         _traits = adoptNS([[UITextInputTraits alloc] init]);
 


### PR DESCRIPTION
#### 212b86c2035cf1570090e14605f5f12e0edaa519
<pre>
[iOS] Allow clients to override text input traits
<a href="https://bugs.webkit.org/show_bug.cgi?id=248606">https://bugs.webkit.org/show_bug.cgi?id=248606</a>
rdar://100240377

Reviewed by Wenson Hsieh.

Text input traits are provided by `WKContentView`, which clients do not have
access to. To support overriding text input traits, `WKContentView` now calls
into `-[WKWebView _textInputTraits]` to give clients the opportunity to
customize traits. The `WKWebView` implementation calls back into `WKContentView`
to return the standard set of traits.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _textInputTraits]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView textInputTraits]):
(-[WKContentView textInputTraitsForWebView]):
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(-[CustomTextInputTraitsWebView initWithFrame:keyboardType:]):
(-[CustomTextInputTraitsWebView _textInputTraits]):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/257412@main">https://commits.webkit.org/257412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ef502cca0f5a0ad6944f673001cad0705805c2f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107764 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168031 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85028 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90889 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104387 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89644 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33123 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87920 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21030 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, http/tests/appcache/fail-on-update-2.html, imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-works-on-frame-src.https.sub.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-030.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-031.html, imported/w3c/web-platform-tests/css/css-transforms/3d-rendering-context-behavior.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76069 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1479 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22556 "Found 1 new test failure: streams/readable-stream-default-controller-error.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1423 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45139 "Found 30 new test failures: css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/events/blur-remove-parent-crash.html, fast/rendering/render-style-null-optgroup-crash.html, fast/text/text-edge-no-half-leading-simple.html, fast/text/text-edge-property-parsing.html, gamepad/gamepad-polling-access.html, http/wpt/service-workers/fetch-service-worker-preload.https.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41969 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2577 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->