### PR TITLE
[EME][Thunder] Prune cached sessions

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
@@ -38,6 +38,7 @@
 #include "GStreamerEMEUtilities.h"
 #include "MediaKeyStatus.h"
 #include "SharedBuffer.h"
+#include <wtf/MonotonicTime.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -51,6 +52,21 @@ struct ThunderSystemDeleter {
 using UniqueThunderSystem = std::unique_ptr<OpenCDMSystem, ThunderSystemDeleter>;
 
 } // namespace Thunder
+
+class KeyHandleThunder : public KeyHandle {
+public:
+    virtual ~KeyHandleThunder() = default;
+
+    static RefPtr<KeyHandle> create(KeyStatus status, KeyIDType&& keyID, KeyHandleValueVariant&& keyHandleValue)
+    {
+        return adoptRef(*new KeyHandleThunder(status, WTFMove(keyID), WTFMove(keyHandleValue)));
+    }
+    void pruneIfNeeded() final;
+    void markUsed() const final;
+private:
+    KeyHandleThunder(KeyStatus, KeyIDType&&, KeyHandleValueVariant&&);
+    mutable MonotonicTime m_lastUsed;
+};
 
 class CDMFactoryThunder final : public CDMFactory, public CDMProxyFactory {
     WTF_MAKE_FAST_ALLOCATED;


### PR DESCRIPTION
#### bc51803b2f9f1d544cd4b50c9dbba211041bf84d
<pre>
[EME][Thunder] Prune cached sessions
<a href="https://bugs.webkit.org/show_bug.cgi?id=248609">https://bugs.webkit.org/show_bug.cgi?id=248609</a>

Reviewed by NOBODY (OOPS!).

The framework should inform us of keys that are no longer available but it does not so we keep caching them when coming.
The problem seems to be that DRM systems run out of sessions. To avoid that we are putting in place a mechanism to allow
DRM backends to un-cache sessions we are are going to regularly check if keys are still in use or not. If they are in
use, we don&apos;t un-cache them but if they are not, we can un-cache that framework session.

We are not informing the JS app about those keys being unavailable because theoretically they still are available and we
should be able to ask the framework for a session for a certain key id again.

* Source/WebCore/platform/encryptedmedia/CDMProxy.cpp:
(WebCore::KeyHandle::takeValueIfDifferent):
(WebCore::KeyStore::KeyStore):
(WebCore::KeyStore::~KeyStore):
(WebCore::KeyStore::pruneKeysIfNeeded):
* Source/WebCore/platform/encryptedmedia/CDMProxy.h:
(WebCore::KeyHandle::value const):
(WebCore::KeyHandle::value):
(WebCore::KeyHandle::pruneIfNeeded):
(WebCore::KeyHandle::markUsed const):
(WebCore::KeyHandle::KeyHandle):
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
(WebCore::KeyHandleThunder::KeyHandleThunder):
(WebCore::KeyHandleThunder::pruneIfNeeded):
(WebCore::KeyHandleThunder::markUsed const):
(WebCore::CDMInstanceSessionThunder::keyUpdatedCallback):
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h:
(WebCore::KeyHandleThunder::create):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc51803b2f9f1d544cd4b50c9dbba211041bf84d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107761 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168028 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85026 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90885 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104378 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6086 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89634 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33119 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87921 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21026 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, css3/supports-dom-api.html, http/tests/appcache/fail-on-update-2.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-030.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-031.html, imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-margin-003.html, imported/w3c/web-platform-tests/css/css-transforms/3d-rendering-context-behavior.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/computed/computed.tentative.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76065 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1476 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22552 "Found 1 new test failure: streams/readable-stream-default-controller-error.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1420 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45137 "Found 30 new test failures: css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/forms/file/entries-api/image-no-transcode-open-panel.html, fast/rendering/render-style-null-optgroup-crash.html, fast/text/text-edge-no-half-leading-simple.html, fast/text/text-edge-property-parsing.html, http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html, http/wpt/service-workers/fetch-service-worker-preload.https.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41965 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->