### PR TITLE
IPC::Connection per instance async reply handler map is not accessible to stream connections

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -299,25 +299,6 @@ HashMap<IPC::Connection::UniqueID, Connection*>& Connection::connectionMap()
     return map;
 }
 
-static Lock asyncReplyHandlerMapLock;
-static HashMap<uintptr_t, HashMap<uint64_t, CompletionHandler<void(Decoder*)>>>& asyncReplyHandlerMap() WTF_REQUIRES_LOCK(asyncReplyHandlerMapLock)
-{
-    ASSERT(asyncReplyHandlerMapLock.isHeld());
-    static NeverDestroyed<HashMap<uintptr_t, HashMap<uint64_t, CompletionHandler<void(Decoder*)>>>> map;
-    return map.get();
-}
-
-static void addAsyncReplyHandler(Connection& connection, uint64_t identifier, CompletionHandler<void(Decoder*)> completionHandler)
-{
-    Locker locker { asyncReplyHandlerMapLock };
-    auto result = asyncReplyHandlerMap().ensure(reinterpret_cast<uintptr_t>(&connection), [] {
-        return HashMap<uint64_t, CompletionHandler<void(Decoder*)>>();
-    }).iterator->value.add(identifier, WTFMove(completionHandler));
-    ASSERT_UNUSED(result, result.isNewEntry);
-}
-
-static void clearAsyncReplyHandlers(const Connection&);
-
 Connection::Connection(Identifier identifier, bool isServer)
     : m_uniqueID(UniqueID::generate())
     , m_isServer(isServer)
@@ -340,7 +321,7 @@ Connection::~Connection()
         connectionMap().remove(m_uniqueID);
     }
 
-    clearAsyncReplyHandlers(*this);
+    cancelAsyncReplyHandlers();
 }
 
 RefPtr<Connection> Connection::connection(UniqueID uniqueID)
@@ -492,7 +473,7 @@ void Connection::invalidate()
         return WTFMove(m_syncState);
     }();
 
-    clearAsyncReplyHandlers(*this);
+    cancelAsyncReplyHandlers();
 
     m_connectionQueue->dispatch([protectedThis = Ref { *this }]() mutable {
         protectedThis->platformInvalidate();
@@ -576,11 +557,11 @@ bool Connection::sendMessageWithAsyncReply(UniqueRef<Encoder>&& encoder, AsyncRe
     ASSERT(replyHandler.completionHandler);
     auto replyID = replyHandler.replyID;
     encoder.get() << replyID;
-    addAsyncReplyHandler(*this, replyID, WTFMove(replyHandler.completionHandler));
+    addAsyncReplyHandler(WTFMove(replyHandler));
     if (sendMessage(WTFMove(encoder), sendOptions, qos))
         return true;
     // replyHandlerToCancel might be already cancelled if invalidate() happened in-between.
-    if (auto replyHandlerToCancel = takeAsyncReplyHandler(*this, replyID)) {
+    if (auto replyHandlerToCancel = takeAsyncReplyHandler(replyID)) {
         // FIXME: Current contract is that completionHandler is called on the connection run loop.
         // This does not make sense. However, this needs a change that is done later.
         RunLoop::main().dispatch([completionHandler = WTFMove(replyHandlerToCancel)]() mutable {
@@ -1167,7 +1148,7 @@ void Connection::dispatchMessage(Decoder& decoder)
     assertIsCurrent(dispatcher());
     RELEASE_ASSERT(m_client);
     if (decoder.messageReceiverName() == ReceiverName::AsyncReply) {
-        auto handler = takeAsyncReplyHandler(*this, decoder.destinationID());
+        auto handler = takeAsyncReplyHandler(makeObjectIdentifier<AsyncReplyIDType>(decoder.destinationID()));
         if (!handler) {
             markCurrentlyDispatchedMessageAsInvalid();
 #if ENABLE(IPC_TESTING_API)
@@ -1359,18 +1340,19 @@ void Connection::dispatchIncomingMessages()
     }
 }
 
-uint64_t nextAsyncReplyHandlerID()
+void Connection::addAsyncReplyHandler(AsyncReplyHandler&& handler)
 {
-    static std::atomic<uint64_t> identifier { 0 };
-    return ++identifier;
+    Locker locker { m_incomingMessagesLock };
+    auto result = m_asyncReplyHandlers.add(handler.replyID, WTFMove(handler.completionHandler));
+    ASSERT_UNUSED(result, result.isNewEntry);
 }
 
-void clearAsyncReplyHandlers(const Connection& connection)
+void Connection::cancelAsyncReplyHandlers()
 {
-    HashMap<uint64_t, CompletionHandler<void(Decoder*)>> map;
+    AsyncReplyHandlerMap map;
     {
-        Locker locker { asyncReplyHandlerMapLock };
-        map = asyncReplyHandlerMap().take(reinterpret_cast<uintptr_t>(&connection));
+        Locker locker { m_incomingMessagesLock };
+        map.swap(m_asyncReplyHandlers);
     }
 
     for (auto& handler : map.values()) {
@@ -1379,16 +1361,12 @@ void clearAsyncReplyHandlers(const Connection& connection)
     }
 }
 
-CompletionHandler<void(Decoder*)> takeAsyncReplyHandler(Connection& connection, uint64_t identifier)
+CompletionHandler<void(Decoder*)> Connection::takeAsyncReplyHandler(AsyncReplyID replyID)
 {
-    Locker locker { asyncReplyHandlerMapLock };
-    auto& map = asyncReplyHandlerMap();
-    auto iterator = map.find(reinterpret_cast<uintptr_t>(&connection));
-    if (iterator == map.end())
+    Locker locker { m_incomingMessagesLock };
+    if (!m_asyncReplyHandlers.isValidKey(replyID))
         return nullptr;
-    if (!iterator->value.isValidKey(identifier))
-        return nullptr;
-    return iterator->value.take(identifier);
+    return m_asyncReplyHandlers.take(replyID);
 }
 
 void Connection::wakeUpRunLoop()

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -124,12 +124,13 @@ template<typename AsyncReplyResult> struct AsyncReplyError {
 class MachMessage;
 class UnixMessage;
 class WorkQueueMessageReceiver;
-uint64_t nextAsyncReplyHandlerID();
 
 class Connection : public ThreadSafeRefCounted<Connection, WTF::DestructionThread::MainRunLoop>, public CanMakeWeakPtr<Connection> {
 public:
     enum SyncRequestIDType { };
     using SyncRequestID = ObjectIdentifier<SyncRequestIDType>;
+    enum AsyncReplyIDType { };
+    using AsyncReplyID = ObjectIdentifier<AsyncReplyIDType>;
 
     class Client : public MessageReceiver {
     public:
@@ -220,7 +221,7 @@ public:
     void setOnlySendMessagesAsDispatchWhenWaitingForSyncReplyWhenProcessingSuchAMessage(bool);
     void setShouldExitOnSyncMessageSendFailure(bool);
 
-    // The set callback will be called on the connection work queue when the connection is closed, 
+    // The set callback will be called on the connection work queue when the connection is closed,
     // before didCall is called on the client thread. Must be called before the connection is opened.
     // In the future we might want a more generic way to handle sync or async messages directly
     // on the work queue, for example if we want to handle them on some other thread we could avoid
@@ -253,7 +254,7 @@ public:
     void invalidate();
     void markCurrentlyDispatchedMessageAsInvalid();
 
-    template<typename T, typename C> uint64_t sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID = 0, OptionSet<SendOption> = { }); // Thread-safe.
+    template<typename T, typename C> AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID = 0, OptionSet<SendOption> = { }); // Thread-safe.
     template<typename T> bool send(T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt); // Thread-safe.
     template<typename T> static bool send(UniqueID, T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt); // Thread-safe.
 
@@ -289,15 +290,15 @@ public:
     template<typename T> SendSyncResult<T> sendSync(T&& message, uint64_t destinationID, Timeout = Timeout::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { }); // Main thread only.
 
     template<typename> bool waitForAndDispatchImmediately(uint64_t destinationID, Timeout, OptionSet<WaitForOption> waitForOptions = { }); // Main thread only.
-    template<typename> bool waitForAsyncCallbackAndDispatchImmediately(uint64_t callbackID, Timeout); // Main thread only.
+    template<typename> bool waitForAsyncReplyAndDispatchImmediately(AsyncReplyID, Timeout); // Main thread only.
 
     // Thread-safe.
     template<typename T, typename C, typename U>
-    uint64_t sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifier<U> destinationID = { }, OptionSet<SendOption> sendOptions = { })
+    AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifier<U> destinationID = { }, OptionSet<SendOption> sendOptions = { })
     {
         return sendWithAsyncReply<T, C>(WTFMove(message), WTFMove(completionHandler), destinationID.toUInt64(), sendOptions);
     }
-    
+
     // Thread-safe.
     template<typename T, typename U>
     bool send(T&& message, ObjectIdentifier<U> destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt)
@@ -311,7 +312,7 @@ public:
     {
         return sendSync<T>(WTFMove(message), destinationID.toUInt64(), timeout, sendSyncOptions);
     }
-    
+
     // Main thread only.
     template<typename T, typename U>
     bool waitForAndDispatchImmediately(ObjectIdentifier<U> destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions = { })
@@ -323,7 +324,7 @@ public:
 
     struct AsyncReplyHandler {
         CompletionHandler<void(Decoder*)> completionHandler;
-        uint64_t replyID;
+        AsyncReplyID replyID;
     };
     bool sendMessageWithAsyncReply(UniqueRef<Encoder>&&, AsyncReplyHandler, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> = std::nullopt);
     UniqueRef<Encoder> createSyncMessageEncoder(MessageName, uint64_t destinationID, SyncRequestID&);
@@ -384,7 +385,7 @@ private:
     bool isIncomingMessagesThrottlingEnabled() const { return m_incomingMessagesThrottlingLevel.has_value(); }
 
     static HashMap<IPC::Connection::UniqueID, Connection*>& connectionMap() WTF_REQUIRES_LOCK(s_connectionMapLock);
-    
+
     std::unique_ptr<Decoder> waitForMessage(MessageName, uint64_t destinationID, Timeout, OptionSet<WaitForOption>);
 
     SyncRequestID makeSyncRequestID() { return SyncRequestID::generateThreadSafe(); }
@@ -403,7 +404,7 @@ private:
     void sendOutgoingMessages();
     bool sendOutgoingMessage(UniqueRef<Encoder>&&);
     void connectionDidClose();
-    
+
     // Called on the connection run loop.
     void dispatchSyncStateMessages();
     void dispatchOneIncomingMessage();
@@ -441,6 +442,9 @@ private:
     struct SyncMessageStateRelease {
         void operator()(SyncMessageState*) const;
     };
+    void addAsyncReplyHandler(AsyncReplyHandler&&);
+    CompletionHandler<void(Decoder*)> takeAsyncReplyHandler(AsyncReplyID);
+    void cancelAsyncReplyHandlers();
 
     static Lock s_connectionMapLock;
     Client* m_client { nullptr };
@@ -491,6 +495,9 @@ private:
     HashMap<uint64_t, WTF::Function<void()>> m_incomingSyncMessageCallbacks WTF_GUARDED_BY_LOCK(m_incomingSyncMessageCallbackLock);
     RefPtr<WorkQueue> m_incomingSyncMessageCallbackQueue WTF_GUARDED_BY_LOCK(m_incomingSyncMessageCallbackLock);
     uint64_t m_nextIncomingSyncMessageCallbackID WTF_GUARDED_BY_LOCK(m_incomingSyncMessageCallbackLock) { 0 };
+
+    using AsyncReplyHandlerMap = HashMap<AsyncReplyID, CompletionHandler<void(Decoder*)>>;
+    AsyncReplyHandlerMap m_asyncReplyHandlers WTF_GUARDED_BY_LOCK(m_incomingMessagesLock);
 
 #if ENABLE(IPC_TESTING_API)
     Vector<WeakPtr<MessageObserver>> m_messageObservers;
@@ -571,7 +578,7 @@ bool Connection::send(T&& message, uint64_t destinationID, OptionSet<SendOption>
 
     auto encoder = makeUniqueRef<Encoder>(T::name(), destinationID);
     encoder.get() << message.arguments();
-    
+
     return sendMessage(WTFMove(encoder), sendOptions, qos);
 }
 
@@ -585,10 +592,8 @@ bool Connection::send(UniqueID connectionID, T&& message, uint64_t destinationID
     return connection->send(WTFMove(message), destinationID, sendOptions, qos);
 }
 
-CompletionHandler<void(Decoder*)> takeAsyncReplyHandler(Connection&, uint64_t);
-
 template<typename T, typename C>
-uint64_t Connection::sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption> sendOptions)
+Connection::AsyncReplyID Connection::sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption> sendOptions)
 {
     static_assert(!T::isSync, "Async message expected");
     auto handler = makeAsyncReplyHandler<T>(WTFMove(completionHandler));
@@ -597,7 +602,7 @@ uint64_t Connection::sendWithAsyncReply(T&& message, C&& completionHandler, uint
     encoder.get() << message.arguments();
     if (sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(handler), sendOptions))
         return replyID;
-    return 0;
+    return { };
 }
 
 template<typename T> Connection::SendSyncResult<T> Connection::sendSync(T&& message, uint64_t destinationID, Timeout timeout, OptionSet<SendSyncOption> sendSyncOptions)
@@ -639,15 +644,15 @@ template<typename T> bool Connection::waitForAndDispatchImmediately(uint64_t des
     return true;
 }
 
-template<typename T> bool Connection::waitForAsyncCallbackAndDispatchImmediately(uint64_t destinationID, Timeout timeout)
+template<typename T> bool Connection::waitForAsyncReplyAndDispatchImmediately(AsyncReplyID replyID, Timeout timeout)
 {
-    std::unique_ptr<Decoder> decoder = waitForMessage(T::asyncMessageReplyName(), destinationID, timeout, { });
+    std::unique_ptr<Decoder> decoder = waitForMessage(T::asyncMessageReplyName(), replyID.toUInt64(), timeout, { });
     if (!decoder)
         return false;
 
     ASSERT(decoder->messageReceiverName() == ReceiverName::AsyncReply);
-    ASSERT(decoder->destinationID() == destinationID);
-    auto handler = takeAsyncReplyHandler(*this, decoder->destinationID());
+    ASSERT(decoder->destinationID() == replyID.toUInt64());
+    auto handler = takeAsyncReplyHandler(makeObjectIdentifier<AsyncReplyIDType>(decoder->destinationID()));
     if (!handler) {
         ASSERT_NOT_REACHED();
         return false;
@@ -676,7 +681,7 @@ Connection::AsyncReplyHandler Connection::makeAsyncReplyHandler(C&& completionHa
                     cancelReply<T>(WTFMove(completionHandler));
             }, callThread
         },
-        nextAsyncReplyHandlerID()
+        AsyncReplyID::generateThreadSafe()
     };
 }
 

--- a/Source/WebKit/Platform/IPC/HandleMessage.h
+++ b/Source/WebKit/Platform/IPC/HandleMessage.h
@@ -292,7 +292,7 @@ void handleMessageAsync(Connection& connection, Decoder& decoder, T* object, MF 
     auto arguments = decoder.decode<typename CodingType<typename MessageType::Arguments>::Type>();
     if (UNLIKELY(!arguments))
         return;
-    auto replyID = decoder.decode<uint64_t>();
+    auto replyID = decoder.decode<Connection::AsyncReplyID>();
     if (UNLIKELY(!replyID))
         return;
 
@@ -302,7 +302,7 @@ void handleMessageAsync(Connection& connection, Decoder& decoder, T* object, MF 
     logMessage(connection, MessageType::name(), object, *arguments);
     callMemberFunction(object, function, WTFMove(*arguments),
         CompletionHandlerFromMF { [replyID = *replyID, connection = Ref { connection }] (auto&&... args) mutable {
-            auto encoder = makeUniqueRef<Encoder>(MessageType::asyncMessageReplyName(), replyID);
+            auto encoder = makeUniqueRef<Encoder>(MessageType::asyncMessageReplyName(), replyID.toUInt64());
             logReply(connection, MessageType::name(), args...);
             (encoder.get() << ... << std::forward<decltype(args)>(args));
             connection->sendSyncReply(WTFMove(encoder));
@@ -315,7 +315,7 @@ void handleMessageAsyncWantsConnection(Connection& connection, Decoder& decoder,
     auto arguments = decoder.decode<typename CodingType<typename MessageType::Arguments>::Type>();
     if (UNLIKELY(!arguments))
         return;
-    auto replyID = decoder.decode<uint64_t>();
+    auto replyID = decoder.decode<Connection::AsyncReplyID>();
     if (UNLIKELY(!replyID))
         return;
 
@@ -325,7 +325,7 @@ void handleMessageAsyncWantsConnection(Connection& connection, Decoder& decoder,
     logMessage(connection, MessageType::name(), object, *arguments);
     callMemberFunction(object, function, connection, WTFMove(*arguments),
         CompletionHandlerFromMF { [replyID = *replyID, connection = Ref { connection }] (auto&&... args) mutable {
-            auto encoder = makeUniqueRef<Encoder>(MessageType::asyncMessageReplyName(), replyID);
+            auto encoder = makeUniqueRef<Encoder>(MessageType::asyncMessageReplyName(), replyID.toUInt64());
             logReply(connection, MessageType::name(), args...);
             (encoder.get() << ... << std::forward<decltype(args)>(args));
             connection->sendSyncReply(WTFMove(encoder));

--- a/Source/WebKit/Platform/IPC/MessageSender.h
+++ b/Source/WebKit/Platform/IPC/MessageSender.h
@@ -80,14 +80,16 @@ public:
         return sendSync<T>(std::forward<T>(message), destinationID.toUInt64(), timeout, sendSyncOptions);
     }
 
+    using AsyncReplyID = Connection::AsyncReplyID;
+
     template<typename T, typename C>
-    uint64_t sendWithAsyncReply(T&& message, C&& completionHandler, OptionSet<SendOption> sendOptions = { })
+    AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, OptionSet<SendOption> sendOptions = { })
     {
         return sendWithAsyncReply(WTFMove(message), WTFMove(completionHandler), messageSenderDestinationID(), sendOptions);
     }
 
     template<typename T, typename C>
-    uint64_t sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption> sendOptions = { })
+    AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption> sendOptions = { })
     {
         static_assert(!T::isSync, "Async message expected");
 
@@ -97,7 +99,7 @@ public:
         auto replyID = asyncHandler.replyID;
         if (sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(asyncHandler), sendOptions))
             return replyID;
-        return 0;
+        return { };
     }
 
     virtual bool sendMessage(UniqueRef<Encoder>&&, OptionSet<SendOption>);

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -66,7 +66,8 @@ public:
     template<typename T> SendSyncResult<T> sendSync(T&& message, uint64_t destinationID, IPC::Timeout = 1_s, OptionSet<IPC::SendSyncOption> sendSyncOptions = { });
 
     enum class ShouldStartProcessThrottlerActivity : bool { No, Yes };
-    template<typename T, typename C> uint64_t sendWithAsyncReply(T&&, C&&, uint64_t destinationID = 0, OptionSet<IPC::SendOption> = { }, ShouldStartProcessThrottlerActivity = ShouldStartProcessThrottlerActivity::Yes);
+    using AsyncReplyID = IPC::Connection::AsyncReplyID;
+    template<typename T, typename C> AsyncReplyID sendWithAsyncReply(T&&, C&&, uint64_t destinationID = 0, OptionSet<IPC::SendOption> = { }, ShouldStartProcessThrottlerActivity = ShouldStartProcessThrottlerActivity::Yes);
     
     template<typename T, typename U>
     bool send(T&& message, ObjectIdentifier<U> destinationID, OptionSet<IPC::SendOption> sendOptions = { })
@@ -240,7 +241,7 @@ AuxiliaryProcessProxy::SendSyncResult<T> AuxiliaryProcessProxy::sendSync(T&& mes
 }
 
 template<typename T, typename C>
-uint64_t AuxiliaryProcessProxy::sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<IPC::SendOption> sendOptions, ShouldStartProcessThrottlerActivity shouldStartProcessThrottlerActivity)
+AuxiliaryProcessProxy::AsyncReplyID AuxiliaryProcessProxy::sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<IPC::SendOption> sendOptions, ShouldStartProcessThrottlerActivity shouldStartProcessThrottlerActivity)
 {
     static_assert(!T::isSync, "Async message expected");
 
@@ -250,7 +251,7 @@ uint64_t AuxiliaryProcessProxy::sendWithAsyncReply(T&& message, C&& completionHa
     auto replyID = handler.replyID;
     if (sendMessage(WTFMove(encoder), sendOptions, WTFMove(handler), shouldStartProcessThrottlerActivity))
         return replyID;
-    return 0;
+    return { };
 }
     
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9466,7 +9466,7 @@ void WebPageProxy::endPrinting()
         send(Messages::WebPage::EndPrinting());
 }
 
-uint64_t WebPageProxy::computePagesForPrinting(FrameIdentifier frameID, const PrintInfo& printInfo, CompletionHandler<void(const Vector<WebCore::IntRect>&, double, const WebCore::FloatBoxExtent&)>&& callback)
+IPC::Connection::AsyncReplyID WebPageProxy::computePagesForPrinting(FrameIdentifier frameID, const PrintInfo& printInfo, CompletionHandler<void(const Vector<WebCore::IntRect>&, double, const WebCore::FloatBoxExtent&)>&& callback)
 {
     m_isInPrintingMode = true;
     if (m_isPerformingDOMPrintOperation)
@@ -9475,14 +9475,14 @@ uint64_t WebPageProxy::computePagesForPrinting(FrameIdentifier frameID, const Pr
 }
 
 #if PLATFORM(COCOA)
-uint64_t WebPageProxy::drawRectToImage(WebFrameProxy* frame, const PrintInfo& printInfo, const IntRect& rect, const WebCore::IntSize& imageSize, CompletionHandler<void(const WebKit::ShareableBitmapHandle&)>&& callback)
+IPC::Connection::AsyncReplyID WebPageProxy::drawRectToImage(WebFrameProxy* frame, const PrintInfo& printInfo, const IntRect& rect, const WebCore::IntSize& imageSize, CompletionHandler<void(const WebKit::ShareableBitmapHandle&)>&& callback)
 {
     if (m_isPerformingDOMPrintOperation)
         return sendWithAsyncReply(Messages::WebPage::DrawRectToImageDuringDOMPrintOperation(frame->frameID(), printInfo, rect, imageSize), WTFMove(callback), IPC::SendOption::DispatchMessageEvenWhenWaitingForUnboundedSyncReply);
     return sendWithAsyncReply(Messages::WebPage::DrawRectToImage(frame->frameID(), printInfo, rect, imageSize), WTFMove(callback));
 }
 
-uint64_t WebPageProxy::drawPagesToPDF(WebFrameProxy* frame, const PrintInfo& printInfo, uint32_t first, uint32_t count, CompletionHandler<void(API::Data*)>&& callback)
+IPC::Connection::AsyncReplyID WebPageProxy::drawPagesToPDF(WebFrameProxy* frame, const PrintInfo& printInfo, uint32_t first, uint32_t count, CompletionHandler<void(API::Data*)>&& callback)
 {
     if (m_isPerformingDOMPrintOperation)
         return sendWithAsyncReply(Messages::WebPage::DrawPagesToPDFDuringDOMPrintOperation(frame->frameID(), printInfo, first, count), toAPIDataSharedBufferCallback(WTFMove(callback)), IPC::SendOption::DispatchMessageEvenWhenWaitingForUnboundedSyncReply);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1451,15 +1451,15 @@ public:
 
     void beginPrinting(WebFrameProxy*, const PrintInfo&);
     void endPrinting();
-    uint64_t computePagesForPrinting(WebCore::FrameIdentifier, const PrintInfo&, CompletionHandler<void(const Vector<WebCore::IntRect>&, double, const WebCore::FloatBoxExtent&)>&&);
+    IPC::Connection::AsyncReplyID computePagesForPrinting(WebCore::FrameIdentifier, const PrintInfo&, CompletionHandler<void(const Vector<WebCore::IntRect>&, double, const WebCore::FloatBoxExtent&)>&&);
     void getPDFFirstPageSize(WebCore::FrameIdentifier, CompletionHandler<void(WebCore::FloatSize)>&&);
 #if PLATFORM(COCOA)
-    uint64_t drawRectToImage(WebFrameProxy*, const PrintInfo&, const WebCore::IntRect&, const WebCore::IntSize&, CompletionHandler<void(const WebKit::ShareableBitmapHandle&)>&&);
-    uint64_t drawPagesToPDF(WebFrameProxy*, const PrintInfo&, uint32_t first, uint32_t count, CompletionHandler<void(API::Data*)>&&);
+    IPC::Connection::AsyncReplyID drawRectToImage(WebFrameProxy*, const PrintInfo&, const WebCore::IntRect&, const WebCore::IntSize&, CompletionHandler<void(const WebKit::ShareableBitmapHandle&)>&&);
+    IPC::Connection::AsyncReplyID drawPagesToPDF(WebFrameProxy*, const PrintInfo&, uint32_t first, uint32_t count, CompletionHandler<void(API::Data*)>&&);
     void drawToPDF(WebCore::FrameIdentifier, const std::optional<WebCore::FloatRect>&, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
 #if PLATFORM(IOS_FAMILY)
     size_t computePagesForPrintingiOS(WebCore::FrameIdentifier, const PrintInfo&);
-    uint64_t drawToPDFiOS(WebCore::FrameIdentifier, const PrintInfo&, size_t pageCount, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
+    IPC::Connection::AsyncReplyID drawToPDFiOS(WebCore::FrameIdentifier, const PrintInfo&, size_t pageCount, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
 #endif
 #elif PLATFORM(GTK)
     void drawPagesForPrinting(WebFrameProxy*, const PrintInfo&, CompletionHandler<void(std::optional<SharedMemory::Handle>&&, WebCore::ResourceError&&)>&&);

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1075,11 +1075,11 @@ size_t WebPageProxy::computePagesForPrintingiOS(FrameIdentifier frameID, const P
     return pageCount;
 }
 
-uint64_t WebPageProxy::drawToPDFiOS(FrameIdentifier frameID, const PrintInfo& printInfo, size_t pageCount, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&& completionHandler)
+IPC::Connection::AsyncReplyID WebPageProxy::drawToPDFiOS(FrameIdentifier frameID, const PrintInfo& printInfo, size_t pageCount, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&& completionHandler)
 {
     if (!hasRunningProcess()) {
         completionHandler({ });
-        return 0;
+        return { };
     }
 
     return sendWithAsyncReply(Messages::WebPage::DrawToPDFiOS(frameID, printInfo, pageCount), WTFMove(completionHandler));

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.h
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.h
@@ -25,6 +25,7 @@
 
 #if PLATFORM(MAC)
 
+#import "Connection.h"
 #import <WebCore/IntRectHash.h>
 #import <condition_variable>
 #import <wtf/Condition.h>
@@ -57,10 +58,10 @@ class WebFrameProxy;
     RetainPtr<PDFDocument> _printedPagesPDFDocument;
     Vector<Vector<RetainPtr<PDFDestination>>> _linkDestinationsPerPage;
 
-    uint64_t _expectedComputedPagesCallback;
-    HashMap<uint64_t, WebCore::IntRect> _expectedPreviewCallbacks;
-    uint64_t _latestExpectedPreviewCallback;
-    uint64_t _expectedPrintCallback;
+    IPC::Connection::AsyncReplyID _expectedComputedPagesCallback;
+    HashMap<IPC::Connection::AsyncReplyID, WebCore::IntRect> _expectedPreviewCallbacks;
+    IPC::Connection::AsyncReplyID _latestExpectedPreviewCallback;
+    IPC::Connection::AsyncReplyID _expectedPrintCallback;
 
     BOOL _isPrintingFromSecondaryThread;
     Lock _printingCallbackMutex;

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -158,7 +158,7 @@ template<typename U> bool WebNotificationManager::sendNotificationMessage(U&& me
 template<typename U> bool WebNotificationManager::sendNotificationMessageWithAsyncReply(U&& message, WebPage* page, CompletionHandler<void()>&& callback)
 {
     return sendMessage(page, [&] (auto& connection, auto destinationIdentifier) {
-        return connection.sendWithAsyncReply(WTFMove(message), WTFMove(callback), destinationIdentifier);
+        return !!connection.sendWithAsyncReply(WTFMove(message), WTFMove(callback), destinationIdentifier);
     });
 }
 #endif // ENABLE(NOTIFICATIONS)

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -487,7 +487,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
                 JSValueUnprotect(context, resolve);
                 JSGlobalContextRelease(JSContextGetGlobalContext(context));
             },
-            IPC::nextAsyncReplyHandlerID()
+            IPC::Connection::AsyncReplyID::generateThreadSafe()
         };
         connection.sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(handler), { });
     } else
@@ -2906,8 +2906,8 @@ JSC::JSObject* JSMessageListener::jsDescriptionFromDecoder(JSC::JSGlobalObject* 
     }
 
     if (!decoder.isSyncMessage() && messageReplyArgumentDescriptions(decoder.messageName())) {
-        if (uint64_t asyncReplyID = 0; decoder.decode(asyncReplyID)) {
-            jsResult->putDirect(vm, JSC::Identifier::fromString(vm, "listenerID"_s), JSC::JSValue(asyncReplyID));
+        if (IPC::Connection::AsyncReplyID asyncReplyID; decoder.decode(asyncReplyID)) {
+            jsResult->putDirect(vm, JSC::Identifier::fromString(vm, "listenerID"_s), JSC::JSValue(asyncReplyID.toUInt64()));
             RETURN_IF_EXCEPTION(scope, nullptr);
         }
     }


### PR DESCRIPTION
#### 0fea03a077b9e700898f706dd3c9d57981e371ff
<pre>
IPC::Connection per instance async reply handler map is not accessible to stream connections
<a href="https://bugs.webkit.org/show_bug.cgi?id=248611">https://bugs.webkit.org/show_bug.cgi?id=248611</a>
rdar://problem/102865370

Reviewed by Alex Christensen.

Expose the functions to maintain async reply handlers in Connection private
section. The StreamClientConnection is a friend and will use the internal
implementation to implement the feature for stream connections. The async
replies will be delivered by the dedicated Connection of StreamClientConnection.

At the same time, do two clarifying changes:
- Before, the async reply id was uint64_t. Make it a AsyncReplyID type object
  identifier type.
- Before, the handler map was stored in hash map that was stored
  per-connection in a global hash map. Instead, make the map a normal instance
  variable.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::~Connection):
(IPC::Connection::invalidate):
(IPC::Connection::sendMessageWithAsyncReply):
(IPC::Connection::dispatchMessage):
(IPC::Connection::addAsyncReplyHandler):
(IPC::Connection::cancelAsyncReplyHandlers):
(IPC::CompletionHandler&lt;void):
(IPC::WTF_REQUIRES_LOCK): Deleted.
(IPC::addAsyncReplyHandler): Deleted.
(IPC::nextAsyncReplyHandlerID): Deleted.
(IPC::clearAsyncReplyHandlers): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendWithAsyncReply):
(IPC::Connection::waitForAsyncCallbackAndDispatchImmediately):
(IPC::Connection::makeAsyncReplyHandler):
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessageAsync):
(IPC::handleMessageAsyncWantsConnection):
* Source/WebKit/Platform/IPC/MessageSender.h:
(IPC::MessageSender::sendWithAsyncReply):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::sendWithAsyncReply):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::computePagesForPrinting):
(WebKit::WebPageProxy::drawRectToImage):
(WebKit::WebPageProxy::drawPagesToPDF):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _resetPrintingState]):
(-[WKContentView _wk_pageCountForPrintFormatter:]):
(-[WKContentView _waitForDrawToPDFCallbackForPrintFormatterIfNeeded:]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::drawToPDFiOS):
* Source/WebKit/UIProcess/mac/WKPrintingView.h:
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView _expectedPreviewCallbackForRect:]):
(pageDidDrawToImage):
(-[WKPrintingView _preparePDFDataForPrintingOnSecondaryThread]):
(pageDidComputePageRects):
(-[WKPrintingView _drawPreview:]):
(-[WKPrintingView endDocument]):
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::WebNotificationManager::sendNotificationMessageWithAsyncReply):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::sendMessageWithJSArguments):
(WebKit::IPCTestingAPI::JSMessageListener::jsDescriptionFromDecoder):

Canonical link: <a href="https://commits.webkit.org/257458@main">https://commits.webkit.org/257458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/290ec5ea6921bffe3db2915d093badce5ff878c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108213 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85376 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91327 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106128 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90037 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33448 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21379 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76372 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1921 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22910 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1830 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45377 "Found 1 new test failure: media/video-inactive-playback.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5136 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6786 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42365 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->