### PR TITLE
[GTK] Fix build failure in ClipboardGtk4.cpp

### DIFF
--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
@@ -34,6 +34,7 @@
 #include <WebCore/SharedBuffer.h>
 #include <gtk/gtk.h>
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GUniquePtr.h>
 
 namespace WebKit {
 


### PR DESCRIPTION
#### 285ff73b5f6d46d6e502aca30061667e41a3114b
<pre>
[GTK] Fix build failure in ClipboardGtk4.cpp
<a href="https://bugs.gentoo.org/882609">https://bugs.gentoo.org/882609</a>

Reviewed by Michael Catanzaro

* Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp:

Canonical link: <a href="https://commits.webkit.org/257364@main">https://commits.webkit.org/257364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6b8028ff267470b593e5763b285283295d6e855

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107796 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84940 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90919 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104444 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89695 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33135 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87948 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21058 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, compositing/shared-backing/shared-layer-has-blending.html, css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/text/text-edge-property-parsing.html, http/tests/media/fairplay/fps-hls-key-rotation.html, http/tests/media/fairplay/fps-hls-update-reject.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-030.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-031.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76087 "Found 4 new API test failures: /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/console-api, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/security-error, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/js-exception (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1511 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22586 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, gamepad/gamepad-polling-access.html, http/tests/appcache/fail-on-update-2.html, http/tests/privateClickMeasurement/triggering-event-with-attribution-source-through-fetch-keepalive-ephemeral.html, http/wpt/cache-storage/cache-quota.any.html, http/wpt/fetch/response-opaque-clone.html, imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.worker.html?61-80, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-030.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-031.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1447 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45079 "Found 14 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-030.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-031.html, imported/w3c/web-platform-tests/css/css-transforms/3d-rendering-context-behavior.html, imported/w3c/web-platform-tests/streams/idlharness.any.html, imported/w3c/web-platform-tests/streams/idlharness.any.serviceworker.html, imported/w3c/web-platform-tests/streams/idlharness.any.worker.html, imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any.html, imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any.serviceworker.html ... (failure)") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4996 "Found 1 new test failure: streams/readable-stream-default-reader-read.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41994 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2543 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->