### PR TITLE
Start porting graphics related WebCore objects to the new IPC serialization format

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h
@@ -31,13 +31,13 @@
 
 namespace WebCore {
 
-enum class GraphicsContextGLPowerPreference {
+enum class GraphicsContextGLPowerPreference : uint8_t {
     Default,
     LowPower,
     HighPerformance
 };
 
-enum class GraphicsContextGLWebGLVersion {
+enum class GraphicsContextGLWebGLVersion : uint8_t {
     WebGL1,
 #if ENABLE(WEBGL2)
     WebGL2
@@ -84,126 +84,8 @@ struct GraphicsContextGLAttributes {
             return PowerPreference::HighPerformance;
         return powerPreference;
     }
-
-#if ENABLE(GPU_PROCESS)
-    template<typename Encoder> void encode(Encoder&) const;
-    template<typename Decoder> static std::optional<GraphicsContextGLAttributes> decode(Decoder&);
-#endif
-};
-
-#if ENABLE(GPU_PROCESS)
-
-template<typename Encoder>
-void GraphicsContextGLAttributes::encode(Encoder& encoder) const
-{
-    encoder << alpha
-        << depth
-        << stencil
-        << antialias
-        << premultipliedAlpha
-        << preserveDrawingBuffer
-        << failIfMajorPerformanceCaveat
-        << powerPreference
-        << shareResources
-        << noExtensions
-        << devicePixelRatio
-        << initialPowerPreference
-        << webGLVersion
-        << forceRequestForHighPerformanceGPU;
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
-    encoder << windowGPUID;
-#endif
-#if PLATFORM(COCOA)
-    encoder << useMetal;
-#endif
-#if ENABLE(WEBXR)
-    encoder << xrCompatible;
-#endif
-}
-
-template<typename Decoder>
-std::optional<WebCore::GraphicsContextGLAttributes> GraphicsContextGLAttributes::decode(Decoder& decoder)
-{
-    auto alpha = decoder.template decode<bool>();
-    auto depth = decoder.template decode<bool>();
-    auto stencil = decoder.template decode<bool>();
-    auto antialias = decoder.template decode<bool>();
-    auto premultipliedAlpha = decoder.template decode<bool>();
-    auto preserveDrawingBuffer = decoder.template decode<bool>();
-    auto failIfMajorPerformanceCaveat = decoder.template decode<bool>();
-    auto powerPreference = decoder.template decode<PowerPreference>();
-    auto shareResources = decoder.template decode<bool>();
-    auto noExtensions = decoder.template decode<bool>();
-    auto devicePixelRatio = decoder.template decode<float>();
-    auto initialPowerPreference = decoder.template decode<PowerPreference>();
-    auto webGLVersion = decoder.template decode<WebGLVersion>();
-    auto forceRequestForHighPerformanceGPU = decoder.template decode<bool>();
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
-    auto windowGPUID = decoder.template decode<PlatformGPUID>();
-#endif
-#if PLATFORM(COCOA)
-    auto useMetal = decoder.template decode<bool>();
-#endif
-#if ENABLE(WEBXR)
-    auto xrCompatible = decoder.template decode<bool>();
-#endif
-    if (!decoder.isValid())
-        return std::nullopt;
-    return GraphicsContextGLAttributes {
-        *alpha,
-        *depth,
-        *stencil,
-        *antialias,
-        *premultipliedAlpha,
-        *preserveDrawingBuffer,
-        *failIfMajorPerformanceCaveat,
-        *powerPreference,
-        *shareResources,
-        *noExtensions,
-        *devicePixelRatio,
-        *initialPowerPreference,
-        *webGLVersion,
-        *forceRequestForHighPerformanceGPU,
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
-        *windowGPUID,
-#endif
-#if PLATFORM(COCOA)
-        *useMetal,
-#endif
-#if ENABLE(WEBXR)
-        *xrCompatible
-#endif
-    };
-}
-
-#endif
-
-}
-
-#if ENABLE(GPU_PROCESS)
-namespace WTF {
-
-template <> struct EnumTraits<WebCore::GraphicsContextGLPowerPreference> {
-    using values = EnumValues<
-    WebCore::GraphicsContextGLPowerPreference,
-    WebCore::GraphicsContextGLPowerPreference::Default,
-    WebCore::GraphicsContextGLPowerPreference::LowPower,
-    WebCore::GraphicsContextGLPowerPreference::HighPerformance
-    >;
-};
-
-template <> struct EnumTraits<WebCore::GraphicsContextGLWebGLVersion> {
-    using values = EnumValues<
-    WebCore::GraphicsContextGLWebGLVersion,
-    WebCore::GraphicsContextGLWebGLVersion::WebGL1
-#if ENABLE(WEBGL2)
-    , WebCore::GraphicsContextGLWebGLVersion::WebGL2
-#endif
-    >;
 };
 
 }
-
-#endif
 
 #endif // ENABLE(WEBGL)

--- a/Source/WebCore/platform/graphics/Pattern.h
+++ b/Source/WebCore/platform/graphics/Pattern.h
@@ -55,8 +55,6 @@ public:
             , repeatY(repeatY)
         {
         }
-        template<class Encoder> void encode(Encoder&) const;
-        template<class Decoder> static std::optional<Parameters> decode(Decoder&);
         AffineTransform patternSpaceTransform;
         bool repeatX;
         bool repeatY;
@@ -80,66 +78,11 @@ public:
     bool repeatX() const { return m_parameters.repeatX; }
     bool repeatY() const { return m_parameters.repeatY; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<Ref<Pattern>> decode(Decoder&);
-
 private:
     Pattern(SourceImage&&, const Parameters&);
 
     SourceImage m_tileImage;
     Parameters m_parameters;
 };
-
-template<class Encoder>
-void Pattern::Parameters::encode(Encoder& encoder) const
-{
-    encoder << patternSpaceTransform;
-    encoder << repeatX;
-    encoder << repeatY;
-}
-
-template<class Decoder>
-std::optional<Pattern::Parameters> Pattern::Parameters::decode(Decoder& decoder)
-{
-    std::optional<AffineTransform> patternSpaceTransform;
-    decoder >> patternSpaceTransform;
-    if (!patternSpaceTransform)
-        return std::nullopt;
-
-    std::optional<bool> repeatX;
-    decoder >> repeatX;
-    if (!repeatX)
-        return std::nullopt;
-
-    std::optional<bool> repeatY;
-    decoder >> repeatY;
-    if (!repeatY)
-        return std::nullopt;
-
-    return {{ *repeatX, *repeatY, *patternSpaceTransform }};
-}
-
-template<class Encoder>
-void Pattern::encode(Encoder& encoder) const
-{
-    encoder << m_tileImage;
-    encoder << m_parameters;
-}
-
-template<class Decoder>
-std::optional<Ref<Pattern>> Pattern::decode(Decoder& decoder)
-{
-    std::optional<SourceImage> tileImage;
-    decoder >> tileImage;
-    if (!tileImage)
-        return std::nullopt;
-
-    std::optional<Parameters> parameters;
-    decoder >> parameters;
-    if (!parameters)
-        return std::nullopt;
-
-    return Pattern::create(WTFMove(*tileImage), *parameters);
-}
 
 } //namespace

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -1280,12 +1280,13 @@ std::optional<FillRectWithGradient> FillRectWithGradient::decode(Decoder& decode
     decoder >> rect;
     if (!rect)
         return std::nullopt;
-
-    auto gradient = Gradient::decode(decoder);
+    
+    std::optional<Ref<Gradient>> gradient;
+    decoder >> gradient;
     if (!gradient)
         return std::nullopt;
 
-    return {{ *rect, gradient->get() }};
+    return { { *rect, WTFMove(*gradient) } };
 }
 
 class FillCompositedRect {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1824,3 +1824,97 @@ header: <WebCore/ScrollingConstraints.h>
 class WebCore::TransformOperations {
     Vector<RefPtr<WebCore::TransformOperation>> operations();
 }
+
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::Gradient::LinearData {
+    WebCore::FloatPoint point0;
+    WebCore::FloatPoint point1;
+};
+
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::Gradient::RadialData {
+    WebCore::FloatPoint point0;
+    WebCore::FloatPoint point1;
+    float startRadius;
+    float endRadius;
+    float aspectRatio;
+};
+
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::Gradient::ConicData {
+    WebCore::FloatPoint point0;
+    float angleRadians;
+};
+
+[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::Gradient {
+    std::variant<WebCore::Gradient::LinearData, WebCore::Gradient::RadialData, WebCore::Gradient::ConicData> data();
+    WebCore::ColorInterpolationMethod colorInterpolationMethod();
+    WebCore::GradientSpreadMethod spreadMethod();
+    WebCore::GradientColorStops stops();
+}
+
+[Nested, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SourceBrush::Brush::LogicalGradient {
+    Ref<WebCore::Gradient> gradient;
+    WebCore::AffineTransform spaceTransform;
+}
+
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::Pattern::Parameters {
+    bool repeatX;
+    bool repeatY;
+    WebCore::AffineTransform patternSpaceTransform;
+}
+
+[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::Pattern {
+    WebCore::SourceImage tileImage();
+    WebCore::Pattern::Parameters parameters();
+}
+
+[Nested, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SourceBrush::Brush {
+    std::variant<WebCore::SourceBrush::Brush::LogicalGradient, Ref<WebCore::Pattern>> brush;
+}
+
+[AdditionalEncoder=StreamConnectionEncoder] class WebCore::SourceBrush {
+    WebCore::Color color();
+    std::optional<WebCore::SourceBrush::Brush> brush();
+}
+
+#if ENABLE(GPU_PROCESS)
+
+header: <WebCore/GraphicsContextGLAttributes.h>
+[CustomHeader] enum class WebCore::GraphicsContextGLPowerPreference : uint8_t {
+    Default,
+    LowPower,
+    HighPerformance
+};
+
+header: <WebCore/GraphicsContextGLAttributes.h>
+[CustomHeader] enum class WebCore::GraphicsContextGLWebGLVersion : uint8_t {
+    WebGL1,
+#if ENABLE(WEBGL2)
+    WebGL2
+#endif
+};
+
+struct WebCore::GraphicsContextGLAttributes {
+    bool alpha;
+    bool depth;
+    bool stencil;
+    bool antialias;
+    bool premultipliedAlpha;
+    bool preserveDrawingBuffer;
+    bool failIfMajorPerformanceCaveat;
+    WebCore::GraphicsContextGLPowerPreference powerPreference;
+    bool shareResources;
+    bool noExtensions;
+    float devicePixelRatio;
+    WebCore::GraphicsContextGLPowerPreference initialPowerPreference;
+    WebCore::GraphicsContextGLWebGLVersion webGLVersion;
+    bool forceRequestForHighPerformanceGPU;
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+    uint64_t windowGPUID;
+#endif
+#if PLATFORM(COCOA)
+    bool useMetal;
+#endif
+#if ENABLE(WEBXR)
+    bool xrCompatible;
+#endif
+};
+#endif


### PR DESCRIPTION
#### d3222ec80fa20cc9e0fc3947acbecd2a75ae5c3d
<pre>
Start porting graphics related WebCore objects to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=248616">https://bugs.webkit.org/show_bug.cgi?id=248616</a>
rdar://102869400

Reviewed by Alex Christensen.

Start moving some of the graphics related serializable types over to the
new CoreIPC serialization mechanism. This includes:
    - WebCore::Gradient::LinearData
    - WebCore::Gradient::RadialData
    - WebCore::Gradient::ConicData
    - WebCore::Gradient
    - WebCore::SourceBrush::LogicalGradient
    - WebCore::Pattern::Parameters
    - WebCore::Pattern
    - WebCore::SourceBrush::Brush
    - WebCore::SourceBrush
    - WebCore::GraphicsContextGLPowerPreference
    - WebCore::GraphicsContextGLWebGLVersion
    - WebCore::GraphicsContextGLAttributes

* Source/WebCore/platform/graphics/Gradient.h:
(WebCore::Gradient::colorInterpolationMethod const):
(WebCore::Gradient::LinearData::encode const): Deleted.
(WebCore::Gradient::LinearData::decode): Deleted.
(WebCore::Gradient::RadialData::encode const): Deleted.
(WebCore::Gradient::RadialData::decode): Deleted.
(WebCore::Gradient::ConicData::encode const): Deleted.
(WebCore::Gradient::ConicData::decode): Deleted.
(WebCore::Gradient::encode const): Deleted.
(WebCore::Gradient::decode): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h:
(WebCore::GraphicsContextGLAttributes::effectivePowerPreference const):
(WebCore::GraphicsContextGLAttributes::encode const): Deleted.
(WebCore::GraphicsContextGLAttributes::decode): Deleted.
* Source/WebCore/platform/graphics/Pattern.h:
(WebCore::Pattern::Parameters::encode const): Deleted.
(WebCore::Pattern::Parameters::decode): Deleted.
(WebCore::Pattern::encode const): Deleted.
(WebCore::Pattern::decode): Deleted.
* Source/WebCore/platform/graphics/SourceBrush.cpp:
(WebCore::SourceBrush::gradientSpaceTransform const):
(WebCore::SourceBrush::gradient const):
(WebCore::SourceBrush::setGradient):
* Source/WebCore/platform/graphics/SourceBrush.h:
(WebCore::operator==):
(WebCore::operator!=):
(WebCore::SourceBrush::Brush::LogicalGradient::encode const): Deleted.
(WebCore::SourceBrush::Brush::LogicalGradient::decode): Deleted.
(WebCore::SourceBrush::Brush::encode const): Deleted.
(WebCore::SourceBrush::Brush::decode): Deleted.
(WebCore::SourceBrush::encode const): Deleted.
(WebCore::SourceBrush::decode): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::FillRectWithGradient::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/257559@main">https://commits.webkit.org/257559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6883e52dd48eda410bf9ea7760a691cc2a26f00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108689 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168936 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85821 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91794 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106616 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105062 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90390 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33830 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21736 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2380 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23253 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2278 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5199 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42732 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->