### PR TITLE
Extract StyledElementInlineStylePropertyMap from StyledElement.cpp and to its own file

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -879,6 +879,7 @@ css/query/MediaQueryEvaluator.cpp
 css/query/MediaQueryFeatures.cpp
 css/query/MediaQueryParser.cpp
 css/typedom/ComputedStylePropertyMapReadOnly.cpp
+css/typedom/InlineStylePropertyMap.cpp
 css/typedom/StylePropertyMapReadOnly.cpp
 css/typedom/CSSKeywordValue.cpp
 css/typedom/CSSStyleImageValue.cpp

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InlineStylePropertyMap.h"
+
+#include "StyledElement.h"
+
+namespace WebCore {
+
+Ref<InlineStylePropertyMap> InlineStylePropertyMap::create(StyledElement& element)
+{
+    return adoptRef(*new InlineStylePropertyMap(element));
+}
+
+InlineStylePropertyMap::InlineStylePropertyMap(StyledElement& element)
+    : m_element(&element)
+{
+}
+
+RefPtr<CSSValue> InlineStylePropertyMap::propertyValue(CSSPropertyID propertyID) const
+{
+    if (auto* inlineStyle = m_element ? m_element->inlineStyle() : nullptr)
+        return inlineStyle->getPropertyCSSValue(propertyID);
+    return nullptr;
+}
+
+String InlineStylePropertyMap::shorthandPropertySerialization(CSSPropertyID propertyID) const
+{
+    if (auto* inlineStyle = m_element ? m_element->inlineStyle() : nullptr)
+        return inlineStyle->getPropertyValue(propertyID);
+    return String();
+}
+
+RefPtr<CSSValue> InlineStylePropertyMap::customPropertyValue(const AtomString& property) const
+{
+    if (auto* inlineStyle = m_element ? m_element->inlineStyle() : nullptr)
+        return inlineStyle->getCustomPropertyCSSValue(property.string());
+    return nullptr;
+}
+
+unsigned InlineStylePropertyMap::size() const
+{
+    auto* inlineStyle = m_element ? m_element->inlineStyle() : nullptr;
+    return inlineStyle ? inlineStyle->propertyCount() : 0;
+}
+
+auto InlineStylePropertyMap::entries(ScriptExecutionContext* context) const -> Vector<StylePropertyMapEntry>
+{
+    if (!m_element || !context)
+        return { };
+
+    auto& document = downcast<Document>(*context);
+    Vector<StylePropertyMapEntry> result;
+    auto* inlineStyle = m_element->inlineStyle();
+    if (!inlineStyle)
+        return { };
+
+    result.reserveInitialCapacity(inlineStyle->propertyCount());
+    for (unsigned i = 0; i < inlineStyle->propertyCount(); ++i) {
+        auto propertyReference = inlineStyle->propertyAt(i);
+        result.uncheckedAppend(makeKeyValuePair(propertyReference.cssName(), reifyValueToVector(RefPtr<CSSValue> { propertyReference.value() }, document)));
+    }
+    return result;
+}
+
+void InlineStylePropertyMap::removeProperty(CSSPropertyID propertyID)
+{
+    if (m_element)
+        m_element->removeInlineStyleProperty(propertyID);
+}
+
+bool InlineStylePropertyMap::setShorthandProperty(CSSPropertyID propertyID, const String& value)
+{
+    if (!m_element)
+        return false;
+    bool didFailParsing = false;
+    bool important = false;
+    m_element->setInlineStyleProperty(propertyID, value, important, &didFailParsing);
+    return !didFailParsing;
+}
+
+bool InlineStylePropertyMap::setProperty(CSSPropertyID propertyID, Ref<CSSValue>&& value)
+{
+    if (!m_element)
+        return false;
+    bool didFailParsing = false;
+    bool important = false;
+    m_element->setInlineStyleProperty(propertyID, value->cssText(), important, &didFailParsing);
+    return !didFailParsing;
+}
+
+bool InlineStylePropertyMap::setCustomProperty(Document&, const AtomString& property, Ref<CSSVariableReferenceValue>&& value)
+{
+    if (!m_element)
+        return false;
+
+    auto customPropertyValue = CSSCustomPropertyValue::createUnresolved(property, WTFMove(value));
+    m_element->setInlineStyleCustomProperty(WTFMove(customPropertyValue));
+    return true;
+}
+
+void InlineStylePropertyMap::removeCustomProperty(const AtomString& property)
+{
+    if (m_element)
+        m_element->removeInlineStyleCustomProperty(property);
+}
+
+void InlineStylePropertyMap::clear()
+{
+    if (m_element)
+        m_element->removeAllInlineStyleProperties();
+}
+
+void InlineStylePropertyMap::clearElement()
+{
+    m_element = nullptr;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.h
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StylePropertyMap.h"
+
+namespace WebCore {
+
+class InlineStylePropertyMap final : public StylePropertyMap {
+public:
+    static Ref<InlineStylePropertyMap> create(StyledElement&);
+
+    RefPtr<CSSValue> propertyValue(CSSPropertyID) const final;
+    String shorthandPropertySerialization(CSSPropertyID) const final;
+    RefPtr<CSSValue> customPropertyValue(const AtomString& property) const final;
+    unsigned size() const final;
+    Vector<StylePropertyMapEntry> entries(ScriptExecutionContext*) const final;
+    void removeProperty(CSSPropertyID) final;
+    bool setShorthandProperty(CSSPropertyID, const String& value) final;
+    bool setProperty(CSSPropertyID, Ref<CSSValue>&&) final;
+    bool setCustomProperty(Document&, const AtomString& property, Ref<CSSVariableReferenceValue>&&) final;
+    void removeCustomProperty(const AtomString& property) final;
+    void clear() final;
+    void clearElement() final;
+
+private:
+    explicit InlineStylePropertyMap(StyledElement&);
+
+    StyledElement* m_element;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -41,6 +41,7 @@
 #include "HTMLElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLParserIdioms.h"
+#include "InlineStylePropertyMap.h"
 #include "InspectorInstrumentation.h"
 #include "PropertySetCSSStyleDeclaration.h"
 #include "ScriptableDocumentParser.h"
@@ -79,122 +80,10 @@ CSSStyleDeclaration& StyledElement::cssomStyle()
     return ensureMutableInlineStyle().ensureInlineCSSStyleDeclaration(*this);
 }
 
-class StyledElementInlineStylePropertyMap final : public StylePropertyMap {
-public:
-    static Ref<StylePropertyMap> create(StyledElement& element)
-    {
-        return adoptRef(*new StyledElementInlineStylePropertyMap(element));
-    }
-
-private:
-    RefPtr<CSSValue> propertyValue(CSSPropertyID propertyID) const final
-    {
-        if (auto* inlineStyle = m_element ? m_element->inlineStyle() : nullptr)
-            return inlineStyle->getPropertyCSSValue(propertyID);
-        return nullptr;
-    }
-
-    String shorthandPropertySerialization(CSSPropertyID propertyID) const final
-    {
-        if (auto* inlineStyle = m_element ? m_element->inlineStyle() : nullptr)
-            return inlineStyle->getPropertyValue(propertyID);
-        return String();
-    }
-
-    RefPtr<CSSValue> customPropertyValue(const AtomString& property) const final
-    {
-        if (auto* inlineStyle = m_element ? m_element->inlineStyle() : nullptr)
-            return inlineStyle->getCustomPropertyCSSValue(property.string());
-        return nullptr;
-    }
-
-    unsigned size() const final
-    {
-        auto* inlineStyle = m_element ? m_element->inlineStyle() : nullptr;
-        return inlineStyle ? inlineStyle->propertyCount() : 0;
-    }
-
-    Vector<StylePropertyMapEntry> entries(ScriptExecutionContext* context) const final
-    {
-        if (!m_element || !context)
-            return { };
-
-        auto& document = downcast<Document>(*context);
-        Vector<StylePropertyMapEntry> result;
-        auto* inlineStyle = m_element->inlineStyle();
-        if (!inlineStyle)
-            return { };
-
-        result.reserveInitialCapacity(inlineStyle->propertyCount());
-        for (unsigned i = 0; i < inlineStyle->propertyCount(); ++i) {
-            auto propertyReference = inlineStyle->propertyAt(i);
-            result.uncheckedAppend(makeKeyValuePair(propertyReference.cssName(), reifyValueToVector(RefPtr<CSSValue> { propertyReference.value() }, document)));
-        }
-        return result;
-    }
-
-    void removeProperty(CSSPropertyID propertyID) final
-    {
-        if (m_element)
-            m_element->removeInlineStyleProperty(propertyID);
-    }
-
-    bool setShorthandProperty(CSSPropertyID propertyID, const String& value) final
-    {
-        if (!m_element)
-            return false;
-        bool didFailParsing = false;
-        bool important = false;
-        m_element->setInlineStyleProperty(propertyID, value, important, &didFailParsing);
-        return !didFailParsing;
-    }
-
-    bool setProperty(CSSPropertyID propertyID, Ref<CSSValue>&& value) final
-    {
-        if (!m_element)
-            return false;
-        bool didFailParsing = false;
-        bool important = false;
-        m_element->setInlineStyleProperty(propertyID, value->cssText(), important, &didFailParsing);
-        return !didFailParsing;
-    }
-
-    bool setCustomProperty(Document&, const AtomString& property, Ref<CSSVariableReferenceValue>&& value) final
-    {
-        if (!m_element)
-            return false;
-
-        auto customPropertyValue = CSSCustomPropertyValue::createUnresolved(property, WTFMove(value));
-        m_element->setInlineStyleCustomProperty(WTFMove(customPropertyValue));
-        return true;
-    }
-
-    void removeCustomProperty(const AtomString& property) final
-    {
-        if (m_element)
-            m_element->removeInlineStyleCustomProperty(property);
-    }
-
-    void clear() final
-    {
-        if (m_element)
-            m_element->removeAllInlineStyleProperties();
-    }
-
-    explicit StyledElementInlineStylePropertyMap(StyledElement& element)
-        : m_element(&element)
-    {
-    }
-
-    void clearElement() override { m_element = nullptr; }
-
-    StyledElement* m_element { nullptr };
-};
-
 StylePropertyMap& StyledElement::ensureAttributeStyleMap()
 {
     if (!attributeStyleMap())
-        setAttributeStyleMap(StyledElementInlineStylePropertyMap::create(*this));
+        setAttributeStyleMap(InlineStylePropertyMap::create(*this));
     return *attributeStyleMap();
 }
 


### PR DESCRIPTION
#### 3fa92bc62217c8505831c71a5cd17dea8c207122
<pre>
Extract StyledElementInlineStylePropertyMap from StyledElement.cpp and to its own file
<a href="https://bugs.webkit.org/show_bug.cgi?id=248620">https://bugs.webkit.org/show_bug.cgi?id=248620</a>

Reviewed by Antoine Quint.

Extract StyledElementInlineStylePropertyMap from StyledElement.cpp and to its
own file. Also rename it to InlineStylePropertyMap for simplicity.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/typedom/InlineStylePropertyMap.cpp: Added.
(WebCore::InlineStylePropertyMap::create):
(WebCore::InlineStylePropertyMap::InlineStylePropertyMap):
(WebCore::InlineStylePropertyMap::propertyValue const):
(WebCore::InlineStylePropertyMap::customPropertyValue const):
(WebCore::InlineStylePropertyMap::size const):
(WebCore::InlineStylePropertyMap::entries const):
(WebCore::InlineStylePropertyMap::removeProperty):
(WebCore::InlineStylePropertyMap::setShorthandProperty):
(WebCore::InlineStylePropertyMap::setProperty):
(WebCore::InlineStylePropertyMap::setCustomProperty):
(WebCore::InlineStylePropertyMap::removeCustomProperty):
(WebCore::InlineStylePropertyMap::clear):
(WebCore::InlineStylePropertyMap::clearElement):
* Source/WebCore/css/typedom/InlineStylePropertyMap.h: Added.
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::ensureAttributeStyleMap):
(): Deleted.

Canonical link: <a href="https://commits.webkit.org/257292@main">https://commits.webkit.org/257292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa65d939c6cff52a120ee098279c522541d5de08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107889 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168159 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85062 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91010 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104545 "Hash fa65d939 for PR 7040 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104127 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33204 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88027 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1611 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1533 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42077 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2512 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->