### PR TITLE
IPC::StreamClientConnection should support sendWithAsyncReply()

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -674,7 +674,8 @@ inline std::unique_ptr<Decoder> Connection::waitForMessageForTesting(MessageName
 template<typename T, typename C>
 Connection::AsyncReplyHandler Connection::makeAsyncReplyHandler(C&& completionHandler, ThreadLikeAssertion callThread)
 {
-    // FIXME: callThread by default uses AnyThread because the API contract on invalid sends does not make sense.
+    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=248947): callThread by default uses AnyThread because the
+    // API contract on invalid sends does not make sense.
     return AsyncReplyHandler {
         {
             [completionHandler = WTFMove(completionHandler)] (Decoder* decoder) mutable {

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -273,8 +273,10 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
         return jsValueForDecodedMessage<MessageName::TestWithImageData_ReceiveImageData>(globalObject, decoder);
     case MessageName::TestWithStream_SendString:
         return jsValueForDecodedMessage<MessageName::TestWithStream_SendString>(globalObject, decoder);
-    case MessageName::TestWithStream_SendStringSynchronized:
-        return jsValueForDecodedMessage<MessageName::TestWithStream_SendStringSynchronized>(globalObject, decoder);
+    case MessageName::TestWithStream_SendStringAsync:
+        return jsValueForDecodedMessage<MessageName::TestWithStream_SendStringAsync>(globalObject, decoder);
+    case MessageName::TestWithStream_SendStringSync:
+        return jsValueForDecodedMessage<MessageName::TestWithStream_SendStringSync>(globalObject, decoder);
 #if PLATFORM(COCOA)
     case MessageName::TestWithStream_SendMachSendRight:
         return jsValueForDecodedMessage<MessageName::TestWithStream_SendMachSendRight>(globalObject, decoder);
@@ -352,8 +354,10 @@ std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject* global
         return jsValueForDecodedMessageReply<MessageName::TestWithSemaphore_ReceiveSemaphore>(globalObject, decoder);
     case MessageName::TestWithImageData_ReceiveImageData:
         return jsValueForDecodedMessageReply<MessageName::TestWithImageData_ReceiveImageData>(globalObject, decoder);
-    case MessageName::TestWithStream_SendStringSynchronized:
-        return jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringSynchronized>(globalObject, decoder);
+    case MessageName::TestWithStream_SendStringAsync:
+        return jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringAsync>(globalObject, decoder);
+    case MessageName::TestWithStream_SendStringSync:
+        return jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringSync>(globalObject, decoder);
 #if PLATFORM(COCOA)
     case MessageName::TestWithStream_ReceiveMachSendRight:
         return jsValueForDecodedMessageReply<MessageName::TestWithStream_ReceiveMachSendRight>(globalObject, decoder);
@@ -802,7 +806,11 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
         return Vector<ArgumentDescription> {
             { "url", "String", nullptr, false },
         };
-    case MessageName::TestWithStream_SendStringSynchronized:
+    case MessageName::TestWithStream_SendStringAsync:
+        return Vector<ArgumentDescription> {
+            { "url", "String", nullptr, false },
+        };
+    case MessageName::TestWithStream_SendStringSync:
         return Vector<ArgumentDescription> {
             { "url", "String", nullptr, false },
         };
@@ -924,7 +932,11 @@ std::optional<Vector<ArgumentDescription>> messageReplyArgumentDescriptions(Mess
         return Vector<ArgumentDescription> {
             { "r0", "RefPtr<WebCore::ImageData>", nullptr, false },
         };
-    case MessageName::TestWithStream_SendStringSynchronized:
+    case MessageName::TestWithStream_SendStringAsync:
+        return Vector<ArgumentDescription> {
+            { "returnValue", "int64_t", nullptr, false },
+        };
+    case MessageName::TestWithStream_SendStringSync:
         return Vector<ArgumentDescription> {
             { "returnValue", "int64_t", nullptr, false },
         };

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -88,16 +88,12 @@ const char* description(MessageName name)
         return "TestWithStreamBatched_SendString";
     case MessageName::TestWithStreamBuffer_SendStreamBuffer:
         return "TestWithStreamBuffer_SendStreamBuffer";
-    case MessageName::TestWithStream_ReceiveMachSendRight:
-        return "TestWithStream_ReceiveMachSendRight";
-    case MessageName::TestWithStream_SendAndReceiveMachSendRight:
-        return "TestWithStream_SendAndReceiveMachSendRight";
     case MessageName::TestWithStream_SendMachSendRight:
         return "TestWithStream_SendMachSendRight";
     case MessageName::TestWithStream_SendString:
         return "TestWithStream_SendString";
-    case MessageName::TestWithStream_SendStringSynchronized:
-        return "TestWithStream_SendStringSynchronized";
+    case MessageName::TestWithStream_SendStringAsync:
+        return "TestWithStream_SendStringAsync";
     case MessageName::TestWithSuperclass_LoadURL:
         return "TestWithSuperclass_LoadURL";
     case MessageName::TestWithSuperclass_TestAsyncMessage:
@@ -174,12 +170,8 @@ const char* description(MessageName name)
         return "TestWithLegacyReceiver_RunJavaScriptAlertReply";
     case MessageName::TestWithSemaphore_ReceiveSemaphoreReply:
         return "TestWithSemaphore_ReceiveSemaphoreReply";
-    case MessageName::TestWithStream_ReceiveMachSendRightReply:
-        return "TestWithStream_ReceiveMachSendRightReply";
-    case MessageName::TestWithStream_SendAndReceiveMachSendRightReply:
-        return "TestWithStream_SendAndReceiveMachSendRightReply";
-    case MessageName::TestWithStream_SendStringSynchronizedReply:
-        return "TestWithStream_SendStringSynchronizedReply";
+    case MessageName::TestWithStream_SendStringAsyncReply:
+        return "TestWithStream_SendStringAsyncReply";
     case MessageName::TestWithSuperclass_TestAsyncMessageReply:
         return "TestWithSuperclass_TestAsyncMessageReply";
     case MessageName::TestWithSuperclass_TestAsyncMessageWithConnectionReply:
@@ -200,6 +192,12 @@ const char* description(MessageName name)
         return "TestWithLegacyReceiver_GetPluginProcessConnection";
     case MessageName::TestWithLegacyReceiver_TestMultipleAttributes:
         return "TestWithLegacyReceiver_TestMultipleAttributes";
+    case MessageName::TestWithStream_ReceiveMachSendRight:
+        return "TestWithStream_ReceiveMachSendRight";
+    case MessageName::TestWithStream_SendAndReceiveMachSendRight:
+        return "TestWithStream_SendAndReceiveMachSendRight";
+    case MessageName::TestWithStream_SendStringSync:
+        return "TestWithStream_SendStringSync";
     case MessageName::TestWithSuperclass_TestSyncMessage:
         return "TestWithSuperclass_TestSyncMessage";
     case MessageName::TestWithSuperclass_TestSynchronousMessage:
@@ -254,11 +252,9 @@ ReceiverName receiverName(MessageName messageName)
         return ReceiverName::TestWithStreamBatched;
     case MessageName::TestWithStreamBuffer_SendStreamBuffer:
         return ReceiverName::TestWithStreamBuffer;
-    case MessageName::TestWithStream_ReceiveMachSendRight:
-    case MessageName::TestWithStream_SendAndReceiveMachSendRight:
     case MessageName::TestWithStream_SendMachSendRight:
     case MessageName::TestWithStream_SendString:
-    case MessageName::TestWithStream_SendStringSynchronized:
+    case MessageName::TestWithStream_SendStringAsync:
         return ReceiverName::TestWithStream;
     case MessageName::TestWithSuperclass_LoadURL:
     case MessageName::TestWithSuperclass_TestAsyncMessage:
@@ -301,9 +297,7 @@ ReceiverName receiverName(MessageName messageName)
     case MessageName::TestWithLegacyReceiver_InterpretKeyEventReply:
     case MessageName::TestWithLegacyReceiver_RunJavaScriptAlertReply:
     case MessageName::TestWithSemaphore_ReceiveSemaphoreReply:
-    case MessageName::TestWithStream_ReceiveMachSendRightReply:
-    case MessageName::TestWithStream_SendAndReceiveMachSendRightReply:
-    case MessageName::TestWithStream_SendStringSynchronizedReply:
+    case MessageName::TestWithStream_SendStringAsyncReply:
     case MessageName::TestWithSuperclass_TestAsyncMessageReply:
     case MessageName::TestWithSuperclass_TestAsyncMessageWithConnectionReply:
     case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply:
@@ -316,6 +310,10 @@ ReceiverName receiverName(MessageName messageName)
     case MessageName::TestWithLegacyReceiver_GetPluginProcessConnection:
     case MessageName::TestWithLegacyReceiver_TestMultipleAttributes:
         return ReceiverName::TestWithLegacyReceiver;
+    case MessageName::TestWithStream_ReceiveMachSendRight:
+    case MessageName::TestWithStream_SendAndReceiveMachSendRight:
+    case MessageName::TestWithStream_SendStringSync:
+        return ReceiverName::TestWithStream;
     case MessageName::TestWithSuperclass_TestSyncMessage:
     case MessageName::TestWithSuperclass_TestSynchronousMessage:
         return ReceiverName::TestWithSuperclass;
@@ -332,13 +330,14 @@ bool messageAllowedWhenWaitingForSyncReply(MessageName name)
 {
     switch (name) {
     case MessageName::TestWithStreamBatched_SendString:
-    case MessageName::TestWithStream_ReceiveMachSendRight:
-    case MessageName::TestWithStream_SendAndReceiveMachSendRight:
     case MessageName::TestWithStream_SendMachSendRight:
     case MessageName::TestWithStream_SendString:
-    case MessageName::TestWithStream_SendStringSynchronized:
+    case MessageName::TestWithStream_SendStringAsync:
     case MessageName::TestWithLegacyReceiver_GetPluginProcessConnection:
     case MessageName::TestWithLegacyReceiver_TestMultipleAttributes:
+    case MessageName::TestWithStream_ReceiveMachSendRight:
+    case MessageName::TestWithStream_SendAndReceiveMachSendRight:
+    case MessageName::TestWithStream_SendStringSync:
     case MessageName::TestWithSuperclass_TestSyncMessage:
     case MessageName::TestWithSuperclass_TestSynchronousMessage:
     case MessageName::TestWithoutAttributes_GetPluginProcessConnection:
@@ -450,20 +449,12 @@ template<> bool isValidEnum<IPC::MessageName, void>(std::underlying_type_t<IPC::
     if (messageName == IPC::MessageName::TestWithStreamBuffer_SendStreamBuffer)
         return true;
 #if PLATFORM(COCOA)
-    if (messageName == IPC::MessageName::TestWithStream_ReceiveMachSendRight)
-        return true;
-#endif
-#if PLATFORM(COCOA)
-    if (messageName == IPC::MessageName::TestWithStream_SendAndReceiveMachSendRight)
-        return true;
-#endif
-#if PLATFORM(COCOA)
     if (messageName == IPC::MessageName::TestWithStream_SendMachSendRight)
         return true;
 #endif
     if (messageName == IPC::MessageName::TestWithStream_SendString)
         return true;
-    if (messageName == IPC::MessageName::TestWithStream_SendStringSynchronized)
+    if (messageName == IPC::MessageName::TestWithStream_SendStringAsync)
         return true;
     if (messageName == IPC::MessageName::TestWithSuperclass_LoadURL)
         return true;
@@ -571,15 +562,7 @@ template<> bool isValidEnum<IPC::MessageName, void>(std::underlying_type_t<IPC::
         return true;
     if (messageName == IPC::MessageName::TestWithSemaphore_ReceiveSemaphoreReply)
         return true;
-#if PLATFORM(COCOA)
-    if (messageName == IPC::MessageName::TestWithStream_ReceiveMachSendRightReply)
-        return true;
-#endif
-#if PLATFORM(COCOA)
-    if (messageName == IPC::MessageName::TestWithStream_SendAndReceiveMachSendRightReply)
-        return true;
-#endif
-    if (messageName == IPC::MessageName::TestWithStream_SendStringSynchronizedReply)
+    if (messageName == IPC::MessageName::TestWithStream_SendStringAsyncReply)
         return true;
 #if ENABLE(TEST_FEATURE)
     if (messageName == IPC::MessageName::TestWithSuperclass_TestAsyncMessageReply)
@@ -610,6 +593,16 @@ template<> bool isValidEnum<IPC::MessageName, void>(std::underlying_type_t<IPC::
     if (messageName == IPC::MessageName::TestWithLegacyReceiver_GetPluginProcessConnection)
         return true;
     if (messageName == IPC::MessageName::TestWithLegacyReceiver_TestMultipleAttributes)
+        return true;
+#if PLATFORM(COCOA)
+    if (messageName == IPC::MessageName::TestWithStream_ReceiveMachSendRight)
+        return true;
+#endif
+#if PLATFORM(COCOA)
+    if (messageName == IPC::MessageName::TestWithStream_SendAndReceiveMachSendRight)
+        return true;
+#endif
+    if (messageName == IPC::MessageName::TestWithStream_SendStringSync)
         return true;
     if (messageName == IPC::MessageName::TestWithSuperclass_TestSyncMessage)
         return true;

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -74,11 +74,9 @@ enum class MessageName : uint16_t {
     , TestWithSemaphore_SendSemaphore
     , TestWithStreamBatched_SendString
     , TestWithStreamBuffer_SendStreamBuffer
-    , TestWithStream_ReceiveMachSendRight
-    , TestWithStream_SendAndReceiveMachSendRight
     , TestWithStream_SendMachSendRight
     , TestWithStream_SendString
-    , TestWithStream_SendStringSynchronized
+    , TestWithStream_SendStringAsync
     , TestWithSuperclass_LoadURL
     , TestWithSuperclass_TestAsyncMessage
     , TestWithSuperclass_TestAsyncMessageWithConnection
@@ -117,9 +115,7 @@ enum class MessageName : uint16_t {
     , TestWithLegacyReceiver_InterpretKeyEventReply
     , TestWithLegacyReceiver_RunJavaScriptAlertReply
     , TestWithSemaphore_ReceiveSemaphoreReply
-    , TestWithStream_ReceiveMachSendRightReply
-    , TestWithStream_SendAndReceiveMachSendRightReply
-    , TestWithStream_SendStringSynchronizedReply
+    , TestWithStream_SendStringAsyncReply
     , TestWithSuperclass_TestAsyncMessageReply
     , TestWithSuperclass_TestAsyncMessageWithConnectionReply
     , TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply
@@ -130,6 +126,9 @@ enum class MessageName : uint16_t {
     , TestWithoutAttributes_RunJavaScriptAlertReply
     , TestWithLegacyReceiver_GetPluginProcessConnection
     , TestWithLegacyReceiver_TestMultipleAttributes
+    , TestWithStream_ReceiveMachSendRight
+    , TestWithStream_SendAndReceiveMachSendRight
+    , TestWithStream_SendStringSync
     , TestWithSuperclass_TestSyncMessage
     , TestWithSuperclass_TestSynchronousMessage
     , TestWithoutAttributes_GetPluginProcessConnection

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStream.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStream.messages.in
@@ -23,10 +23,11 @@
 # Tests Stream receiver attribute.
 messages -> TestWithStream NotRefCounted Stream {
     void SendString(String url)
-    void SendStringSynchronized(String url) -> (int64_t returnValue)
+    void SendStringAsync(String url) -> (int64_t returnValue)
+    void SendStringSync(String url) -> (int64_t returnValue) Synchronous
 #if PLATFORM(COCOA)
     void SendMachSendRight(MachSendRight a1) NotStreamEncodable
-    void ReceiveMachSendRight() -> (MachSendRight r1) NotStreamEncodableReply
-    void SendAndReceiveMachSendRight(MachSendRight a1) -> (MachSendRight r1) NotStreamEncodable NotStreamEncodableReply
+    void ReceiveMachSendRight() -> (MachSendRight r1) Synchronous NotStreamEncodableReply
+    void SendAndReceiveMachSendRight(MachSendRight a1) -> (MachSendRight r1) Synchronous NotStreamEncodable NotStreamEncodableReply
 #endif
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
@@ -47,19 +47,21 @@ void TestWithStream::didReceiveStreamMessage(IPC::StreamServerConnection& connec
 {
     if (decoder.messageName() == Messages::TestWithStream::SendString::name())
         return IPC::handleMessage<Messages::TestWithStream::SendString>(connection.connection(), decoder, this, &TestWithStream::sendString);
-    if (decoder.messageName() == Messages::TestWithStream::SendStringSynchronized::name())
-        return IPC::handleMessageAsync<Messages::TestWithStream::SendStringSynchronized>(connection.connection(), decoder, this, &TestWithStream::sendStringSynchronized);
+    if (decoder.messageName() == Messages::TestWithStream::SendStringAsync::name())
+        return IPC::handleMessageAsync<Messages::TestWithStream::SendStringAsync>(connection.connection(), decoder, this, &TestWithStream::sendStringAsync);
 #if PLATFORM(COCOA)
     if (decoder.messageName() == Messages::TestWithStream::SendMachSendRight::name())
         return IPC::handleMessage<Messages::TestWithStream::SendMachSendRight>(connection.connection(), decoder, this, &TestWithStream::sendMachSendRight);
 #endif
+    if (decoder.messageName() == Messages::TestWithStream::SendStringSync::name())
+        return IPC::handleMessageSynchronous<Messages::TestWithStream::SendStringSync>(connection, decoder, this, &TestWithStream::sendStringSync);
 #if PLATFORM(COCOA)
     if (decoder.messageName() == Messages::TestWithStream::ReceiveMachSendRight::name())
-        return IPC::handleMessageAsync<Messages::TestWithStream::ReceiveMachSendRight>(connection.connection(), decoder, this, &TestWithStream::receiveMachSendRight);
+        return IPC::handleMessageSynchronous<Messages::TestWithStream::ReceiveMachSendRight>(connection, decoder, this, &TestWithStream::receiveMachSendRight);
 #endif
 #if PLATFORM(COCOA)
     if (decoder.messageName() == Messages::TestWithStream::SendAndReceiveMachSendRight::name())
-        return IPC::handleMessageAsync<Messages::TestWithStream::SendAndReceiveMachSendRight>(connection.connection(), decoder, this, &TestWithStream::sendAndReceiveMachSendRight);
+        return IPC::handleMessageSynchronous<Messages::TestWithStream::SendAndReceiveMachSendRight>(connection, decoder, this, &TestWithStream::sendAndReceiveMachSendRight);
 #endif
     UNUSED_PARAM(decoder);
     UNUSED_PARAM(connection);
@@ -80,13 +82,21 @@ template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::Tes
 {
     return jsValueForDecodedArguments<Messages::TestWithStream::SendString::Arguments>(globalObject, decoder);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_SendStringSynchronized>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_SendStringAsync>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStream::SendStringSynchronized::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStream::SendStringAsync::Arguments>(globalObject, decoder);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringSynchronized>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringAsync>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStream::SendStringSynchronized::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStream::SendStringAsync::ReplyArguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_SendStringSync>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithStream::SendStringSync::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringSync>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithStream::SendStringSync::ReplyArguments>(globalObject, decoder);
 }
 #if PLATFORM(COCOA)
 template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_SendMachSendRight>(JSC::JSGlobalObject* globalObject, Decoder& decoder)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
@@ -64,20 +64,46 @@ private:
     Arguments m_arguments;
 };
 
-class SendStringSynchronized {
+class SendStringAsync {
 public:
     using Arguments = std::tuple<const String&>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendStringSynchronized; }
+    static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendStringAsync; }
     static constexpr bool isSync = false;
     static constexpr bool isStreamEncodable = true;
     static constexpr bool isReplyStreamEncodable = true;
     static constexpr bool isStreamBatched = false;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithStream_SendStringSynchronizedReply; }
+    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithStream_SendStringAsyncReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<int64_t>;
-    explicit SendStringSynchronized(const String& url)
+    explicit SendStringAsync(const String& url)
+        : m_arguments(url)
+    {
+    }
+
+    const Arguments& arguments() const
+    {
+        return m_arguments;
+    }
+
+private:
+    Arguments m_arguments;
+};
+
+class SendStringSync {
+public:
+    using Arguments = std::tuple<const String&>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendStringSync; }
+    static constexpr bool isSync = true;
+    static constexpr bool isStreamEncodable = true;
+    static constexpr bool isReplyStreamEncodable = true;
+    static constexpr bool isStreamBatched = false;
+
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<int64_t>;
+    explicit SendStringSync(const String& url)
         : m_arguments(url)
     {
     }
@@ -122,12 +148,11 @@ public:
     using Arguments = std::tuple<>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithStream_ReceiveMachSendRight; }
-    static constexpr bool isSync = false;
+    static constexpr bool isSync = true;
     static constexpr bool isStreamEncodable = true;
     static constexpr bool isReplyStreamEncodable = false;
     static constexpr bool isStreamBatched = false;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithStream_ReceiveMachSendRightReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<MachSendRight>;
     const Arguments& arguments() const
@@ -146,12 +171,11 @@ public:
     using Arguments = std::tuple<const MachSendRight&>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendAndReceiveMachSendRight; }
-    static constexpr bool isSync = false;
+    static constexpr bool isSync = true;
     static constexpr bool isStreamEncodable = false;
     static constexpr bool isReplyStreamEncodable = false;
     static constexpr bool isStreamBatched = false;
 
-    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithStream_SendAndReceiveMachSendRightReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<MachSendRight>;
     explicit SendAndReceiveMachSendRight(const MachSendRight& a1)

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -103,6 +103,11 @@ void IPCStreamTester::syncCrashOnZero(int32_t value, CompletionHandler<void(int3
     completionHandler(value);
 }
 
+void IPCStreamTester::asyncMessage(bool value, CompletionHandler<void(bool)>&& completionHandler)
+{
+    completionHandler(!value);
+}
+
 #if USE(FOUNDATION)
 
 namespace {

--- a/Source/WebKit/Shared/IPCStreamTester.h
+++ b/Source/WebKit/Shared/IPCStreamTester.h
@@ -61,6 +61,7 @@ private:
     void syncMessageReturningSharedMemory1(uint32_t byteCount, CompletionHandler<void(SharedMemory::Handle)>&&);
     void syncCrashOnZero(int32_t, CompletionHandler<void(int32_t)>&&);
     void checkAutoreleasePool(CompletionHandler<void(int32_t)>&&);
+    void asyncMessage(bool value, CompletionHandler<void(bool)>&&);
 
     const Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     const Ref<IPC::StreamServerConnection> m_streamConnection;

--- a/Source/WebKit/Shared/IPCStreamTester.messages.in
+++ b/Source/WebKit/Shared/IPCStreamTester.messages.in
@@ -27,6 +27,7 @@ messages -> IPCStreamTester NotRefCounted Stream {
     SyncCrashOnZero(int32_t value) -> (int32_t sameValue) Synchronous
 
     CheckAutoreleasePool() -> (int32_t previousUseCount) Synchronous
+    AsyncMessage(bool value) -> (bool reply)
 }
 
 #endif

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -33,6 +33,7 @@
 #include "Utilities.h"
 #include <optional>
 #include <wtf/Lock.h>
+#include <wtf/threads/BinarySemaphore.h>
 
 namespace TestWebKitAPI {
 
@@ -47,13 +48,31 @@ struct MessageInfo {
     uint64_t destinationID;
 };
 
-struct MockTestMessage1 {
+struct MockStreamTestMessage1 {
     static constexpr bool isSync = false;
     static constexpr bool isStreamEncodable = true;
     static constexpr bool isStreamBatched = false;
     static constexpr IPC::MessageName name()  { return static_cast<IPC::MessageName>(123); }
     std::tuple<> arguments() { return { }; }
 };
+
+struct MockStreamTestMessageWithAsyncReply1 {
+    static constexpr bool isSync = false;
+    static constexpr bool isStreamEncodable = true;
+    static constexpr bool isStreamBatched = false;
+    static constexpr IPC::MessageName name()  { return static_cast<IPC::MessageName>(124); }
+    // Just using WebPage_GetBytecodeProfileReply as something that is async message name.
+    // If WebPage_GetBytecodeProfileReply is removed, just use another one.
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::WebPage_GetBytecodeProfileReply; }
+    std::tuple<uint64_t> arguments() { return { contents }; }
+    using ReplyArguments = std::tuple<uint64_t>;
+    MockStreamTestMessageWithAsyncReply1(uint64_t contents)
+        : contents(contents)
+    {
+    }
+    uint64_t contents;
+};
+
 
 class WaitForMessageMixin {
 public:
@@ -84,6 +103,8 @@ public:
     void addMessage(IPC::Decoder& decoder)
     {
         ASSERT(!m_closed);
+        if (m_asyncMessageHandler && m_asyncMessageHandler(decoder))
+            return;
         Locker locker { m_lock };
         m_messages.insert(0, { decoder.messageName(), decoder.destinationID() });
         m_continueWaitForMessage = true;
@@ -94,11 +115,18 @@ public:
         m_closed = true;
     }
 
+    // Handler returns false if the message should be just recorded.
+    void setAsyncMessageHandler(Function<bool(IPC::Decoder&)>&& handler)
+    {
+        m_asyncMessageHandler = WTFMove(handler);
+    }
+
 protected:
     Lock m_lock;
     Vector<MessageInfo> m_messages WTF_GUARDED_BY_LOCK(m_lock);
     std::atomic<bool> m_continueWaitForMessage { false };
     std::atomic<bool> m_closed { false };
+    Function<bool(IPC::Decoder&)> m_asyncMessageHandler;
 };
 
 class MockMessageReceiver : public IPC::Connection::Client, public WaitForMessageMixin {
@@ -143,17 +171,28 @@ public:
     void SetUp() override
     {
         WTF::initializeMainThread();
-        auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(1000);
+        auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(10000);
         auto serverConnection = IPC::StreamServerConnection::create(WTFMove(serverConnectionHandle), *m_workQueue);
         m_clientConnection = WTFMove(clientConnection);
         m_serverConnection = WTFMove(serverConnection);
     }
+
     void TearDown() override
     {
         m_workQueue->stopAndWaitForCompletion();
         m_clientConnection->invalidate();
         m_serverConnection->invalidate();
     }
+
+    void localReferenceBarrier()
+    {
+        BinarySemaphore workQueueWait;
+        m_workQueue->dispatch([&] {
+            workQueueWait.signal();
+        });
+        workQueueWait.wait();
+    }
+
 protected:
     MockMessageReceiver m_mockClientReceiver;
     RefPtr<IPC::StreamConnectionWorkQueue> m_workQueue;
@@ -170,29 +209,105 @@ TEST_F(StreamConnectionTest, OpenConnections)
     m_clientConnection->invalidate();
 }
 
-TEST_F(StreamConnectionTest, SendLocalMessage)
+TEST_F(StreamConnectionTest, SendMessage)
 {
     m_clientConnection->open(m_mockClientReceiver);
     m_serverConnection->open();
     RefPtr<MockStreamMessageReceiver> mockServerReceiver = adoptRef(new MockStreamMessageReceiver);
-    m_serverConnection->startReceivingMessages(*mockServerReceiver, IPC::receiverName(MockTestMessage1::name()), 77);
+    m_serverConnection->startReceivingMessages(*mockServerReceiver, IPC::receiverName(MockStreamTestMessage1::name()), 77);
     for (uint64_t i = 0u; i < 55u; ++i)
-        m_clientConnection->send(MockTestMessage1 { }, makeObjectIdentifier<TestObjectIdentifier>(77), defaultSendTimeout);
+        m_clientConnection->send(MockStreamTestMessage1 { }, makeObjectIdentifier<TestObjectIdentifier>(77), defaultSendTimeout);
     m_workQueue->dispatch([this] {
         for (uint64_t i = 100u; i < 160u; ++i)
-            m_serverConnection->send(MockTestMessage1 { }, makeObjectIdentifier<TestObjectIdentifier>(i));
+            m_serverConnection->send(MockStreamTestMessage1 { }, makeObjectIdentifier<TestObjectIdentifier>(i));
     });
     for (uint64_t i = 100u; i < 160u; ++i) {
         auto message = m_mockClientReceiver.waitForMessage();
-        EXPECT_EQ(message.messageName, MockTestMessage1::name());
+        EXPECT_EQ(message.messageName, MockStreamTestMessage1::name());
         EXPECT_EQ(message.destinationID, i);
     }
     for (uint64_t i = 0u; i < 55u; ++i) {
         auto message = mockServerReceiver->waitForMessage();
-        EXPECT_EQ(message.messageName, MockTestMessage1::name());
+        EXPECT_EQ(message.messageName, MockStreamTestMessage1::name());
         EXPECT_EQ(message.destinationID, 77u);
     }
-    m_serverConnection->stopReceivingMessages(IPC::receiverName(MockTestMessage1::name()), 77);
+    m_serverConnection->stopReceivingMessages(IPC::receiverName(MockStreamTestMessage1::name()), 77);
+}
+
+TEST_F(StreamConnectionTest, SendAsyncReplyMessage)
+{
+    m_clientConnection->open(m_mockClientReceiver);
+    m_serverConnection->open();
+    RefPtr<MockStreamMessageReceiver> mockServerReceiver = adoptRef(new MockStreamMessageReceiver);
+    mockServerReceiver->setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+        using AsyncReplyID =IPC::StreamServerConnection::AsyncReplyID;
+        auto contents = decoder.decode<uint64_t>();
+        auto asyncReplyID = decoder.decode<AsyncReplyID>();
+        ASSERT(decoder.isValid());
+        m_serverConnection->sendAsyncReply<MockStreamTestMessageWithAsyncReply1>(asyncReplyID.value_or(AsyncReplyID { }), contents.value_or(0));
+        return true;
+    });
+    m_serverConnection->startReceivingMessages(*mockServerReceiver, IPC::receiverName(MockStreamTestMessageWithAsyncReply1::name()), 77);
+
+    HashSet<uint64_t> replies;
+    for (uint64_t i = 100u; i < 155u; ++i) {
+        m_clientConnection->sendWithAsyncReply(MockStreamTestMessageWithAsyncReply1 { i }, [&, j = i] (uint64_t value) {
+            EXPECT_GE(value, 100u) << j;
+            replies.add(value);
+        }, makeObjectIdentifier<TestObjectIdentifier>(77), defaultSendTimeout);
+    }
+    while (replies.size() < 55u)
+        RunLoop::current().cycle();
+    for (uint64_t i = 100u; i < 155u; ++i)
+        EXPECT_TRUE(replies.contains(i));
+    m_serverConnection->stopReceivingMessages(IPC::receiverName(MockStreamTestMessageWithAsyncReply1::name()), 77);
+}
+
+TEST_F(StreamConnectionTest, SendAsyncReplyMessageCancel)
+{
+    m_clientConnection->open(m_mockClientReceiver);
+    m_serverConnection->open();
+    RefPtr<MockStreamMessageReceiver> mockServerReceiver = adoptRef(new MockStreamMessageReceiver);
+    mockServerReceiver->setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+        using AsyncReplyID =IPC::StreamServerConnection::AsyncReplyID;
+        auto contents = decoder.decode<uint64_t>();
+        auto asyncReplyID = decoder.decode<AsyncReplyID>();
+        ASSERT(decoder.isValid());
+        m_serverConnection->sendAsyncReply<MockStreamTestMessageWithAsyncReply1>(asyncReplyID.value_or(AsyncReplyID { }), contents.value_or(0));
+        return true;
+    });
+    m_serverConnection->startReceivingMessages(*mockServerReceiver, IPC::receiverName(MockStreamTestMessageWithAsyncReply1::name()), 77);
+
+    std::atomic<bool> waiting;
+    BinarySemaphore workQueueWait;
+    m_workQueue->dispatch([&] {
+        waiting = true;
+        workQueueWait.wait();
+    });
+    while (!waiting)
+        RunLoop::current().cycle();
+
+    HashSet<uint64_t> replies;
+    for (uint64_t i = 100u; i < 155u; ++i) {
+        auto result = m_clientConnection->sendWithAsyncReply(MockStreamTestMessageWithAsyncReply1 { i }, [&, j = i] (uint64_t value) {
+            EXPECT_EQ(value, 0u) << j; // Cancel handler returns 0 for uint64_t.
+            replies.add(j);
+        }, makeObjectIdentifier<TestObjectIdentifier>(77), defaultSendTimeout);
+        EXPECT_NE(0u, result.toUInt64());
+    }
+    m_clientConnection->invalidate();
+    workQueueWait.signal();
+    // FIXME: this should be more consistent: the async replies are asynchronous, and they cannot be invoked at the
+    // point of invalidate as that is not always guaranteed to be in safe call stack.
+    // They should be scheduled during invalidate() and ran from the event loop.
+    // EXPECT_EQ(0u, replies.size());
+
+    while (replies.size() < 55u)
+        RunLoop::current().cycle();
+    for (uint64_t i = 100u; i < 155u; ++i)
+        EXPECT_TRUE(replies.contains(i));
+    m_serverConnection->stopReceivingMessages(IPC::receiverName(MockStreamTestMessageWithAsyncReply1::name()), 77);
+    localReferenceBarrier();
 }
 
 }


### PR DESCRIPTION
#### 19a30ab35aa9d8d0ebbe7b1cd002b5573c306e81
<pre>
IPC::StreamClientConnection should support sendWithAsyncReply()
<a href="https://bugs.webkit.org/show_bug.cgi?id=235965">https://bugs.webkit.org/show_bug.cgi?id=235965</a>
rdar://problem/88636456&gt;

Reviewed by Simon Fraser and Matt Woodrow.

Implement the sending async messages by:
- Sending the message as stream message if possible
  - Otherwise send as &quot;out of stream&quot; message
- Reply comes through the dedicated Connection

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::addAsyncReplyHandler):
(IPC::Connection::sendMessageWithAsyncReply):
(IPC::Connection::dispatchMessage):
(IPC::CompletionHandler&lt;void):
(IPC::addAsyncReplyHandler): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::waitForAsyncCallbackAndDispatchImmediately):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::send):
(IPC::StreamClientConnection::trySendStream):
(IPC::StreamClientConnection::sendWithAsyncReply): Deleted.
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
(IPC::StreamServerConnection::sendAsyncReply):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::Subnamespace::StructName&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::ReturnRefClass&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::InheritsFrom&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::InheritanceGrandchild&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::jsValueForArguments):
(IPC::jsValueForReplyArguments):
(IPC::messageArgumentDescriptions):
(IPC::messageReplyArgumentDescriptions):
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
(IPC::description):
(IPC::receiverName):
(IPC::messageAllowedWhenWaitingForSyncReply):
(WTF::void&gt;):
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
* Source/WebKit/Scripts/webkit/tests/TestWithStream.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp:
(WebKit::TestWithStream::didReceiveStreamMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithStream_SendStringAsync&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithStream_SendStringAsync&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithStream_SendStringSync&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithStream_SendStringSync&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithStream_SendStringSynchronized&gt;): Deleted.
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithStream_SendStringSynchronized&gt;): Deleted.
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h:
(Messages::TestWithStream::SendStringAsync::name):
(Messages::TestWithStream::SendStringAsync::asyncMessageReplyName):
(Messages::TestWithStream::SendStringAsync::SendStringAsync):
(Messages::TestWithStream::SendStringAsync::arguments const):
(Messages::TestWithStream::SendStringSync::name):
(Messages::TestWithStream::SendStringSync::SendStringSync):
(Messages::TestWithStream::SendStringSynchronized::name): Deleted.
(Messages::TestWithStream::SendStringSynchronized::asyncMessageReplyName): Deleted.
(Messages::TestWithStream::SendStringSynchronized::SendStringSynchronized): Deleted.
(Messages::TestWithStream::SendStringSynchronized::arguments const): Deleted.
(Messages::TestWithStream::ReceiveMachSendRight::asyncMessageReplyName): Deleted.
(Messages::TestWithStream::SendAndReceiveMachSendRight::asyncMessageReplyName): Deleted.
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(IPC::StreamClientConnection::sendWithAsyncReply):
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/257735@main">https://commits.webkit.org/257735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de41fbf9cc1026d23655ac02bc8ac54e4f608f81

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109200 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169438 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86309 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92300 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107110 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105607 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90747 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34201 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/103351 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22136 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2829 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23646 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46025 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5314 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43119 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->