### PR TITLE
Extract HashMapStylePropertyMap from CustomPaintImage and into its own file

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -891,6 +891,7 @@ css/typedom/CSSUnitValue.cpp
 css/typedom/CSSUnparsedValue.cpp
 css/typedom/CSSOMVariableReferenceValue.cpp
 css/typedom/DeclaredStylePropertyMap.cpp
+css/typedom/HashMapStylePropertyMapReadOnly.cpp
 css/typedom/MainThreadStylePropertyMapReadOnly.cpp
 css/typedom/StylePropertyMap.cpp
 css/typedom/color/CSSColor.cpp

--- a/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "HashMapStylePropertyMapReadOnly.h"
+
+namespace WebCore {
+
+Ref<HashMapStylePropertyMapReadOnly> HashMapStylePropertyMapReadOnly::create(HashMap<AtomString, RefPtr<CSSValue>>&& map)
+{
+    return adoptRef(*new HashMapStylePropertyMapReadOnly(WTFMove(map)));
+}
+
+HashMapStylePropertyMapReadOnly::HashMapStylePropertyMapReadOnly(HashMap<AtomString, RefPtr<CSSValue>>&& map)
+    : m_map(WTFMove(map))
+{
+}
+
+HashMapStylePropertyMapReadOnly::~HashMapStylePropertyMapReadOnly() = default;
+
+RefPtr<CSSValue> HashMapStylePropertyMapReadOnly::propertyValue(CSSPropertyID propertyID) const
+{
+    return m_map.get(nameString(propertyID));
+}
+
+String HashMapStylePropertyMapReadOnly::shorthandPropertySerialization(CSSPropertyID) const
+{
+    // FIXME: Not supported.
+    return { };
+}
+
+RefPtr<CSSValue> HashMapStylePropertyMapReadOnly::customPropertyValue(const AtomString& property) const
+{
+    return m_map.get(property);
+}
+
+unsigned HashMapStylePropertyMapReadOnly::size() const
+{
+    return m_map.size();
+}
+
+auto HashMapStylePropertyMapReadOnly::entries(ScriptExecutionContext* context) const -> Vector<StylePropertyMapEntry>
+{
+    auto* document = context ? documentFromContext(*context) : nullptr;
+    if (!document)
+        return { };
+
+    Vector<StylePropertyMapEntry> result;
+    result.reserveInitialCapacity(m_map.size());
+    for (auto& [propertyName, cssValue] : m_map)
+        result.uncheckedAppend(makeKeyValuePair(propertyName,  Vector<RefPtr<CSSStyleValue>> { reifyValue(cssValue.get(), *document) }));
+    return result;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MainThreadStylePropertyMapReadOnly.h"
+#include <wtf/HashMap.h>
+#include <wtf/text/AtomStringHash.h>
+
+namespace WebCore {
+
+class HashMapStylePropertyMapReadOnly final : public MainThreadStylePropertyMapReadOnly {
+public:
+    static Ref<HashMapStylePropertyMapReadOnly> create(HashMap<AtomString, RefPtr<CSSValue>>&&);
+    ~HashMapStylePropertyMapReadOnly();
+
+    RefPtr<CSSValue> propertyValue(CSSPropertyID) const final;
+    String shorthandPropertySerialization(CSSPropertyID) const final;
+    RefPtr<CSSValue> customPropertyValue(const AtomString& property) const final;
+    unsigned size() const final;
+    Vector<StylePropertyMapEntry> entries(ScriptExecutionContext*) const final;
+
+private:
+    HashMapStylePropertyMapReadOnly(HashMap<AtomString, RefPtr<CSSValue>>&&);
+
+    HashMap<AtomString, RefPtr<CSSValue>> m_map;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/html/CustomPaintImage.cpp
+++ b/Source/WebCore/html/CustomPaintImage.cpp
@@ -38,6 +38,7 @@
 #include "CSSUnparsedValue.h"
 #include "CustomPaintCanvas.h"
 #include "GraphicsContext.h"
+#include "HashMapStylePropertyMapReadOnly.h"
 #include "ImageBitmap.h"
 #include "ImageBuffer.h"
 #include "JSCSSPaintCallback.h"
@@ -74,67 +75,6 @@ static RefPtr<CSSValue> extractComputedProperty(const AtomString& name, Element&
     return extractor.propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::No);
 }
 
-class HashMapStylePropertyMap final : public MainThreadStylePropertyMapReadOnly {
-public:
-    static Ref<HashMapStylePropertyMap> create(HashMap<AtomString, RefPtr<CSSValue>>&& map)
-    {
-        return adoptRef(*new HashMapStylePropertyMap(WTFMove(map)));
-    }
-
-    static RefPtr<CSSValue> extractComputedProperty(const AtomString& name, Element& element)
-    {
-        ComputedStyleExtractor extractor(&element);
-
-        if (isCustomPropertyName(name))
-            return extractor.customPropertyValue(name);
-
-        CSSPropertyID propertyID = cssPropertyID(name);
-        if (!propertyID)
-            return nullptr;
-
-        return extractor.propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::No);
-    }
-
-private:
-    HashMapStylePropertyMap(HashMap<AtomString, RefPtr<CSSValue>>&& map)
-        : m_map(WTFMove(map))
-    {
-    }
-
-    RefPtr<CSSValue> propertyValue(CSSPropertyID propertyID) const final
-    {
-        return m_map.get(nameString(propertyID));
-    }
-
-    String shorthandPropertySerialization(CSSPropertyID) const final
-    {
-        // FIXME: Not supported.
-        return { };
-    }
-
-    RefPtr<CSSValue> customPropertyValue(const AtomString& property) const final
-    {
-        return m_map.get(property);
-    }
-
-    unsigned size() const final { return m_map.size(); }
-
-    Vector<StylePropertyMapEntry> entries(ScriptExecutionContext* context) const final
-    {
-        auto* document = context ? documentFromContext(*context) : nullptr;
-        if (!document)
-            return { };
-
-        Vector<StylePropertyMapEntry> result;
-        result.reserveInitialCapacity(m_map.size());
-        for (auto& [propertyName, cssValue] : m_map)
-            result.uncheckedAppend(makeKeyValuePair(propertyName,  Vector<RefPtr<CSSStyleValue>> { reifyValue(cssValue.get(), *document) }));
-        return result;
-    }
-
-    HashMap<AtomString, RefPtr<CSSValue>> m_map;
-};
-
 ImageDrawResult CustomPaintImage::doCustomPaint(GraphicsContext& destContext, const FloatSize& destSize)
 {
     if (!m_element || !m_element->element() || !m_paintDefinition)
@@ -164,7 +104,7 @@ ImageDrawResult CustomPaintImage::doCustomPaint(GraphicsContext& destContext, co
     }
 
     auto size = CSSPaintSize::create(destSize.width(), destSize.height());
-    Ref<StylePropertyMapReadOnly> propertyMap = HashMapStylePropertyMap::create(WTFMove(propertyValues));
+    Ref<StylePropertyMapReadOnly> propertyMap = HashMapStylePropertyMapReadOnly::create(WTFMove(propertyValues));
 
     auto& vm = paintConstructor.getObject()->vm();
     JSC::JSLockHolder lock(vm);


### PR DESCRIPTION
#### ca9cbcaf34069404b8868b20307805f184122c34
<pre>
Extract HashMapStylePropertyMap from CustomPaintImage and into its own file
<a href="https://bugs.webkit.org/show_bug.cgi?id=248622">https://bugs.webkit.org/show_bug.cgi?id=248622</a>

Reviewed by Antoine Quint.

Extract HashMapStylePropertyMap from CustomPaintImage and into its own file.
Also rename to HashMapStylePropertyMapReadOnly for clarity.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp: Added.
(WebCore::HashMapStylePropertyMapReadOnly::create):
(WebCore::HashMapStylePropertyMapReadOnly::HashMapStylePropertyMapReadOnly):
(WebCore::HashMapStylePropertyMapReadOnly::propertyValue const):
(WebCore::HashMapStylePropertyMapReadOnly::customPropertyValue const):
(WebCore::HashMapStylePropertyMapReadOnly::size const):
(WebCore::HashMapStylePropertyMapReadOnly::entries const):
* Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.h: Added.
* Source/WebCore/html/CustomPaintImage.cpp:
(WebCore::CustomPaintImage::doCustomPaint):
(): Deleted.

Canonical link: <a href="https://commits.webkit.org/257299@main">https://commits.webkit.org/257299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ad494db15a41af404372008e897728a323c861d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107914 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168186 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85086 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91035 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104153 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88046 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1636 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1558 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42092 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2516 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->