### PR TITLE
Resync screen-orientation tests from upstream WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/page-visibility/resources/window_state_context.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/page-visibility/resources/window_state_context.js
@@ -1,0 +1,19 @@
+function window_state_context(t) {
+    let rect = null;
+    let state = "restored";
+    t.add_cleanup(async () => {
+        if (state === "minimized")
+            await restore();
+    });
+    async function restore() {
+        state = "restored";
+        await test_driver.set_window_rect(rect);
+    }
+
+    async function minimize() {
+        state = "minimized";
+        rect = await test_driver.minimize_window();
+    }
+
+    return {minimize, restore};
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/META.yml
@@ -3,3 +3,4 @@ suggested_reviewers:
   - marcoscaceres
   - cdumez
   - michaelwasserman
+  - makotokato

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document-expected.txt
@@ -1,3 +1,8 @@
 
-PASS test locking the orientation when document is hidden
+Harness Error (FAIL), message = Test named 'hidden documents must not unlock the screen orientation' specified 3 'cleanup' functions, and 2 failed.
+
+PASS hidden documents must reject went trying to call lock or unlock
+PASS hidden documents must reject went trying to call unlock
+FAIL hidden documents must not unlock the screen orientation promise_test: Unhandled rejection with value: object "SecurityError: Locking the screen orientation is only allowed when in fullscreen"
+NOTRUN Once maximized, a minimized window can lock or unlock the screen orientation again
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document.html
@@ -1,39 +1,65 @@
 <!DOCTYPE html>
 <meta name="timeout" content="long" />
-<title>Prevent hidden documents from locking orientation</title>
+<title>
+  Prevent hidden documents from locking orientation
+</title>
 <link rel="help" href="https://github.com/w3c/screen-orientation/pull/232" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
+<script src="/page-visibility/resources/window_state_context.js"></script>
 <script type="module">
-  import { getOppositeOrientation } from "./resources/orientation-utils.js";
-  let rect;
-
-  promise_setup(async (t) => {
-    rect = await test_driver.minimize_window();
-    assert_true(document.hidden, "document must be hidden");
-  });
+  import { makeCleanup, getOppositeOrientation } from "./resources/orientation-utils.js";
 
   promise_test(async (t) => {
-    await promise_rejects_dom(
-      t,
-      "SecurityError",
-      screen.orientation.lock("landscape"),
-      "Locking orientation must reject when the document is hidden"
-    );
+    const { minimize, restore } = window_state_context(t);
+    t.add_cleanup(restore);
 
-    assert_throws_dom(
-      "SecurityError",
-      () => {
-        screen.orientation.unlock();
-      },
-      "Unlocking orientation must throw when the document is hidden"
-    );
+    await minimize();
 
-    await test_driver.set_window_rect(rect);
-    assert_false(document.hidden, "document must not be hidden");
-    // not longer throws
+    assert_equals(document.visibilityState, "hidden", "Document must be hidden");
+    await promise_rejects_dom(t, "SecurityError", screen.orientation.lock("landscape") );
+  }, "hidden documents must reject went trying to call lock or unlock");
+
+  promise_test(async (t) => {
+    const { minimize, restore } = window_state_context(t);
+    t.add_cleanup(restore);
+
+    await minimize();
+
+    assert_equals(document.visibilityState, "hidden", "Document must be hidden");
+    assert_throws_dom("SecurityError", () => screen.orientation.unlock());
+  }, "hidden documents must reject went trying to call unlock");
+
+  promise_test(async (t) => {
+    const { minimize, restore } = window_state_context(t);
+    t.add_cleanup(restore);
+    t.add_cleanup(makeCleanup());
+    await screen.orientation.lock(getOppositeOrientation());
+
+    await minimize();
+
+    assert_equals(document.visibilityState, "hidden", "Document must be hidden");
+    assert_throws_dom("SecurityError", () => screen.orientation.unlock());
+  }, "hidden documents must not unlock the screen orientation");
+
+  promise_test(async (t) => {
+    const { minimize, restore } = window_state_context(t);
+    t.add_cleanup(restore);
+    t.add_cleanup(makeCleanup());
+    await screen.orientation.lock(getOppositeOrientation());
+
+    await minimize();
+
+    assert_equals(document.visibilityState, "hidden");
+    await promise_rejects_dom(t, "SecurityError", screen.orientation.lock(getOppositeOrientation()));
+
+    // Maximize, now everything should work as expected.
+    await restore();
+
+    assert_equals(document.visibilityState, "visible");
+    await screen.orientation.lock(getOppositeOrientation());
     screen.orientation.unlock();
-  }, "test locking the orientation when document is hidden");
+  }, "Once maximized, a minimized window can lock or unlock the screen orientation again");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt
@@ -4,7 +4,7 @@ Harness Error (FAIL), message = Test named 'Test the orientations and associated
 PASS Test screen.orientation properties
 FAIL Test screen.orientation default values. assert_true: expected true got false
 PASS Test the orientations and associated angles
-FAIL Test that screen.orientation properties are not writable Attempted to assign to readonly property.
+PASS Test that screen.orientation properties are not writable
 PASS Test that screen.orientation is always the same object
 NOTRUN Test that screen.orientation values change if the orientation changes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html
@@ -90,8 +90,16 @@ test(() => {
   const type = screen.orientation.type;
   const angle = screen.orientation.angle;
 
-  screen.orientation.type = "foo";
-  screen.orientation.angle = 42;
+  try {
+    screen.orientation.type = "foo";
+  } catch (err) {
+    // implementation might throw an exception due to readonly
+  }
+  try {
+    screen.orientation.angle = 42;
+  } catch (err) {
+    // implementation might throw an exception due to readonly
+  }
 
   assert_equals(screen.orientation.type, type);
   assert_equals(screen.orientation.angle, angle);

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js
@@ -42,7 +42,7 @@ export function makeCleanup(
     }
     screen.orientation.unlock();
     requestAnimationFrame(async () => {
-      try{
+      try {
         await document.exitFullscreen();
       } catch {}
     });

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/sandboxed-iframe-locking.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/sandboxed-iframe-locking.html
@@ -24,7 +24,7 @@ test_driver.bless("request full screen", async () => {
     await document.exitFullscreen();
   } catch (error) {
     data.result = "errored";
-    data.name = "fullscreen exit failed";
+    data.name = error.name;
   }
 
   parent.window.postMessage(data, "*");

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/w3c-import.log
@@ -17,12 +17,16 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/event-before-promise.html
+/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html
+/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document.html
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/idlharness.window.js
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-bad-argument.html
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-basic.html
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html
+/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents.html
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/non-fully-active.html
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event.html
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html
+/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/unlock.html

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe-expected.txt
@@ -2,5 +2,5 @@ CONSOLE MESSAGE: Error while parsing the 'sandbox' attribute: 'allow-orientation
 
 
 FAIL Test without 'allow-orientation-lock' sandboxing directive assert_equals: screen.lockOrientation() throws a SecurityError expected "SecurityError" but got "portrait-primary"
-FAIL Test with 'allow-orientation-lock' sandboxing directive assert_equals: screen.orientation lock to portrait-primary expected "portrait-primary" but got "fullscreen exit failed"
+FAIL Test with 'allow-orientation-lock' sandboxing directive assert_equals: screen.orientation lock to portrait-primary expected "portrait-primary" but got "TypeError"
 

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -4997,6 +4997,9 @@
     "imported/w3c/web-platform-tests/resources/test/tests/unit/throwing-assertions.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/screen-orientation/hidden_document.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/scroll-to-text-fragment/find-range-from-text-directive.html": [
         "slow"
     ],


### PR DESCRIPTION
#### 32793ec47fe34a49cebf9b701cf1356e5c857ad4
<pre>
Resync screen-orientation tests from upstream WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=248624">https://bugs.webkit.org/show_bug.cgi?id=248624</a>

Reviewed by Tim Nguyen.

Resync screen-orientation tests from upstream WPT b763d6d0c6e3ede36.

* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/sandboxed-iframe-locking.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/w3c-import.log:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe-expected.txt:
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/257476@main">https://commits.webkit.org/257476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66e97f091668eee9408fc788abef291848beda24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108445 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168694 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85614 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91562 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106399 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33679 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76536 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2149 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23101 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2047 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45506 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42576 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2608 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3464 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->