### PR TITLE
[WebIDL] SelectedOptions and DataListOptions collections shouldn't be invalidated on change of any attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-selectedOptions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-selectedOptions-expected.txt
@@ -7,4 +7,8 @@ PASS .selectedOptions without the 'multiple' attribute but more than one selecte
 PASS .selectedOptions should return `HTMLCollection` instance
 PASS .selectedOptions should always return the same value - [SameObject]
 PASS .selectedOptions should return the same object after selection changes - [SameObject]
+PASS .selectedOptions should return the same object after selection changes via setAttribute() - [SameObject]
+PASS .selectedOptions should return the same object after selection changes via setAttribute() on disconnected root - [SameObject]
+PASS .selectedOptions should return the same object after selection changes via removeAttribute() - [SameObject]
+PASS .selectedOptions should return the same object after selection changes via removeAttribute() on disconnected root - [SameObject]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-selectedOptions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-selectedOptions.html
@@ -58,6 +58,30 @@
   <option selected>Three</option>
 </select>
 
+<select multiple id="select-same-object-change-2">
+  <option>One</option>
+  <option>Two</option>
+  <option>Three</option>
+</select>
+
+<select multiple id="select-same-object-change-2-disconnected">
+  <option>One</option>
+  <option>Two</option>
+  <option>Three</option>
+</select>
+
+<select multiple id="select-same-object-change-3">
+  <option>One</option>
+  <option>Two</option>
+  <option selected>Three</option>
+</select>
+
+<select multiple id="select-same-object-change-3-disconnected">
+  <option>One</option>
+  <option>Two</option>
+  <option selected>Three</option>
+</select>
+
 <script>
 "use strict";
 
@@ -138,6 +162,61 @@ test(() => {
   assert_equals(after.length, 2);
 
 }, ".selectedOptions should return the same object after selection changes - [SameObject]");
+
+test(() => {
+  const select = document.getElementById("select-same-object-change-2");
+  const before = select.selectedOptions;
+  assert_equals(before.length, 0);
+
+  select.querySelector("option:nth-of-type(2)").setAttribute("selected", "");
+
+  const after = select.selectedOptions;
+
+  assert_equals(after, before);
+  assert_array_equals(Array.from(after, o => o.text), ["Two"]);
+}, ".selectedOptions should return the same object after selection changes via setAttribute() - [SameObject]");
+
+test(() => {
+  const select = document.getElementById("select-same-object-change-2-disconnected");
+  select.remove();
+  const before = select.selectedOptions;
+  assert_equals(before.length, 0);
+
+  select.querySelector("option:nth-of-type(2)").setAttribute("selected", "");
+
+  const after = select.selectedOptions;
+
+  assert_equals(after, before);
+  assert_array_equals(Array.from(after, o => o.text), ["Two"]);
+}, ".selectedOptions should return the same object after selection changes via setAttribute() on disconnected root - [SameObject]");
+
+test(() => {
+  const select = document.getElementById("select-same-object-change-3");
+  const before = select.selectedOptions;
+  assert_array_equals(Array.from(before, o => o.text), ["Three"]);
+
+  select.querySelector("option:nth-of-type(3)").removeAttribute("selected");
+
+  const after = select.selectedOptions;
+
+  assert_equals(after, before);
+  assert_equals(after.length, 0);
+}, ".selectedOptions should return the same object after selection changes via removeAttribute() - [SameObject]");
+
+test(() => {
+  const select = document.getElementById("select-same-object-change-3-disconnected");
+  select.remove();
+
+  const before = select.selectedOptions;
+  assert_array_equals(Array.from(before, o => o.text), ["Three"]);
+
+  select.querySelector("option:nth-of-type(3)").removeAttribute("selected");
+
+  const after = select.selectedOptions;
+
+  assert_equals(after, before);
+  assert_equals(after.length, 0);
+}, ".selectedOptions should return the same object after selection changes via removeAttribute() on disconnected root - [SameObject]");
 </script>
 </body>
 </html>

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -298,6 +298,7 @@ enum NodeListInvalidationType {
     InvalidateOnForTypeAttrChange,
     InvalidateForFormControls,
     InvalidateOnHRefAttrChange,
+    InvalidateOnSelectedAttrChange,
     InvalidateOnAnyAttrChange,
 };
 const int numNodeListInvalidationTypes = InvalidateOnAnyAttrChange + 1;

--- a/Source/WebCore/dom/LiveNodeList.h
+++ b/Source/WebCore/dom/LiveNodeList.h
@@ -123,6 +123,8 @@ ALWAYS_INLINE bool shouldInvalidateTypeOnAttributeChange(NodeListInvalidationTyp
             || attrName == HTMLNames::formAttr || attrName == HTMLNames::typeAttr;
     case InvalidateOnHRefAttrChange:
         return attrName == HTMLNames::hrefAttr;
+    case InvalidateOnSelectedAttrChange:
+        return attrName == HTMLNames::selectedAttr;
     case DoNotInvalidateOnAttributeChanges:
         return false;
     case InvalidateOnAnyAttrChange:

--- a/Source/WebCore/html/HTMLCollection.cpp
+++ b/Source/WebCore/html/HTMLCollection.cpp
@@ -86,13 +86,13 @@ static NodeListInvalidationType invalidationTypeExcludingIdAndNameAttributes(Col
     case TableRows:
     case TRCells:
     case SelectOptions:
+    case DataListOptions:
     case MapAreas:
         return DoNotInvalidateOnAttributeChanges;
     case DocApplets:
-    case SelectedOptions:
-    case DataListOptions:
-        // FIXME: We can do better some day.
         return InvalidateOnAnyAttrChange;
+    case SelectedOptions:
+        return InvalidateOnSelectedAttrChange;
     case ByClass:
         return InvalidateOnClassAttrChange;
     case DocAnchors:


### PR DESCRIPTION
#### 0906a10d4074d22cbf3a389bf4363c609714dda9
<pre>
[WebIDL] SelectedOptions and DataListOptions collections shouldn&apos;t be invalidated on change of any attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=239811">https://bugs.webkit.org/show_bug.cgi?id=239811</a>

Reviewed by NOBODY (OOPS!).

SelectedOptions collection matches elements based on *selectedness* [1], which is affected
only by &quot;selected&quot; content attribute and only before user interacts with &lt;select&gt;.
DataListOptions collection matches elements merely by tag name [2].

No behavior change, just a speed-up.

[1] <a href="https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-selectedness">https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-selectedness</a>
[2] <a href="https://html.spec.whatwg.org/multipage/form-elements.html#dom-datalist-options">https://html.spec.whatwg.org/multipage/form-elements.html#dom-datalist-options</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-selectedOptions-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-selectedOptions.html:
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/LiveNodeList.h:
(WebCore::shouldInvalidateTypeOnAttributeChange):
* Source/WebCore/html/HTMLCollection.cpp:
(WebCore::invalidationTypeExcludingIdAndNameAttributes):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0906a10d4074d22cbf3a389bf4363c609714dda9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107812 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168081 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84958 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90935 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104472 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33150 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87962 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21072 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/text/text-edge-property-parsing.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-030.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-031.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html, imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-margin-003.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76097 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1527 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22600 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/rendering/render-style-null-optgroup-crash.html, http/tests/cache/disk-cache/resource-becomes-uncacheable.html, http/tests/permissions/permission-status-onchange-event-dedicated-worker.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-030.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-031.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1461 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45088 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, animations/stop-animation-on-suspend.html, compositing/no-compositing-when-fulll-screen-is-present.html, css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, http/tests/navigation/fragment-navigation-policy-ignore.html, http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html, http/wpt/service-workers/fetch-service-worker-preload.https.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-030.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-031.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42009 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->