### PR TITLE
[JSC] Fix race condition in Atomics.{wait,waitAsync}

### DIFF
--- a/JSTests/stress/waitasync-waiter-list-order.js
+++ b/JSTests/stress/waitasync-waiter-list-order.js
@@ -1,5 +1,3 @@
-//@ skip
-// Temporarily skip the test until https://github.com/WebKit/WebKit/pull/7048 fixes the race condition.
 const TOTAL_WAITER_COUNT = 10;
 const WAIT_INDEX = TOTAL_WAITER_COUNT * 2 - 1;
 

--- a/Source/JavaScriptCore/runtime/AtomicsObject.cpp
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.cpp
@@ -455,8 +455,7 @@ JSValue atomicsWaitImpl(JSGlobalObject* globalObject, JSArrayType* typedArray, u
         return { };
     }
 
-    AtomicsWaitValidation validation = WTF::atomicLoad(ptr) == expectedValue ? AtomicsWaitValidation::Pass : AtomicsWaitValidation::Fail;
-    return WaiterListManager::singleton().wait(globalObject, vm, ptr, validation, timeout, type);
+    return WaiterListManager::singleton().wait(globalObject, vm, ptr, expectedValue, timeout, type);
 }
 
 JSC_DEFINE_HOST_FUNCTION(atomicsFuncWait, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/WaiterListManager.h
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.h
@@ -208,9 +208,8 @@ class WaiterListManager {
 public:
     static WaiterListManager& singleton();
 
-    JS_EXPORT_PRIVATE JSValue wait(JSGlobalObject*, VM&, void* ptr, AtomicsWaitValidation, Seconds timeout, AtomicsWaitType);
-
-    void addAsyncWaiter(void* ptr, JSPromise*, Seconds timeout);
+    JS_EXPORT_PRIVATE JSValue wait(JSGlobalObject*, VM&, int32_t* ptr, int32_t expected, Seconds timeout, AtomicsWaitType);
+    JS_EXPORT_PRIVATE JSValue wait(JSGlobalObject*, VM&, int64_t* ptr, int64_t expected, Seconds timeout, AtomicsWaitType);
 
     enum class ResolveResult : uint8_t { Ok, Timeout };
     unsigned notifyWaiter(void* ptr, unsigned count);
@@ -222,9 +221,12 @@ public:
     void unregisterSharedArrayBuffer(uint8_t* arrayPtr, size_t);
 
 private:
+    template <typename ValueType>
+    JSValue waitImpl(JSGlobalObject*, VM&, ValueType* ptr, ValueType expectedValue, Seconds timeout, AtomicsWaitType);
+
     void notifyWaiterImpl(const AbstractLocker&, Ref<Waiter>&&, const ResolveResult);
 
-    void timeoutAsyncWaiter(void* ptr, Waiter* target);
+    void timeoutAsyncWaiter(void* ptr, Ref<Waiter>&&);
 
     void cancelAsyncWaiter(const AbstractLocker&, Waiter*);
 


### PR DESCRIPTION
#### bb3be5c8f260f4dbdece34885f9de06dd5254b6d
<pre>
[JSC] Fix race condition in Atomics.{wait,waitAsync}
<a href="https://bugs.webkit.org/show_bug.cgi?id=248631">https://bugs.webkit.org/show_bug.cgi?id=248631</a>

Reviewed by Yusuke Suzuki.

At the moment, this is manifesting as intermittent timeouts in the arm32 linux
test runner, for example: <a href="https://build.webkit.org/#/builders/24/builds/17430">https://build.webkit.org/#/builders/24/builds/17430</a>

After investigation, this is the test `stress/waitasync-waiter-list-order.js`
hanging; this manifests as some of the workers hanging on the initial
`Atomic.wait` call in that test--using a debugger to examine the memory being
waited on reveals that they should all have woken up and moved on.

The implementation of both `Atomics.wait` and `Atomics.waitAsync` begin by
atomically reading from the array and comparing the result to the expected
value, then obtaining a lock on the list of waiters and proceeding from
there--this is contrary to the spec [1], which requires that the atomic read
happens while the list of waiters is exclusively locked and allows a race where
the following interleaving results in A hanging indefinitely if no other calls
to Atomic.notify on that address occur:

    thread A: begin Atomic.wait(buffer, idx, expected_value)
    thread A: read buffer[idx], get expected_value

    thread B: perform Atomic.store(buffer, idx, unexpected_value)
    thread B: perform Atomic.notify(buffer, idx) [nothing is notified since the list of waiters is empty]

    thread A: lock list of waiters, wait on condition variable, hang waiting for next notify

----

This is fixed by delaying the atomic read until the lock on the list of waiters
is held

[1] <a href="https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.wait">https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.wait</a>

* Source/JavaScriptCore/runtime/AtomicsObject.cpp:
(JSC::atomicsWaitImpl):
* Source/JavaScriptCore/runtime/WaiterListManager.cpp:
(JSC::WaiterListManager::waitImpl):
(JSC::WaiterListManager::wait):
(JSC::WaiterListManager::timeoutAsyncWaiter):
(JSC::WaiterListManager::addAsyncWaiter): Deleted.
* Source/JavaScriptCore/runtime/WaiterListManager.h:

Canonical link: <a href="https://commits.webkit.org/257423@main">https://commits.webkit.org/257423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/698248f6519bb13180c5081c517d9ce9177d82ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108376 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168629 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8726 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91494 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106344 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104671 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33637 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89698 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2076 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85509 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1982 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28815 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42528 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88364 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2584 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3391 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19777 "Passed tests") | 
<!--EWS-Status-Bubble-End-->