### PR TITLE
[iOS] Flaky crash under ScreenOrientationProvider::screenOrientationDidChange()

### DIFF
--- a/Source/WebCore/platform/ScreenOrientationProvider.cpp
+++ b/Source/WebCore/platform/ScreenOrientationProvider.cpp
@@ -39,7 +39,7 @@ ScreenOrientationProvider::ScreenOrientationProvider() = default;
 
 ScreenOrientationProvider::~ScreenOrientationProvider()
 {
-    platformDestroy();
+    platformStopListeningForChanges();
 }
 
 void ScreenOrientationProvider::addObserver(Observer& observer)
@@ -92,10 +92,6 @@ void ScreenOrientationProvider::platformStartListeningForChanges()
 }
 
 void ScreenOrientationProvider::platformStopListeningForChanges()
-{
-}
-
-void ScreenOrientationProvider::platformDestroy()
 {
 }
 #endif

--- a/Source/WebCore/platform/ScreenOrientationProvider.h
+++ b/Source/WebCore/platform/ScreenOrientationProvider.h
@@ -67,7 +67,6 @@ private:
     ScreenOrientationType platformCurrentOrientation();
     void platformStartListeningForChanges();
     void platformStopListeningForChanges();
-    void platformDestroy();
 
     WeakHashSet<Observer> m_observers;
     std::optional<ScreenOrientationType> m_currentOrientation;

--- a/Source/WebCore/platform/ios/ScreenOrientationProviderIOS.mm
+++ b/Source/WebCore/platform/ios/ScreenOrientationProviderIOS.mm
@@ -96,6 +96,10 @@ void ScreenOrientationProvider::platformStartListeningForChanges()
 
 void ScreenOrientationProvider::platformStopListeningForChanges()
 {
+    if (!m_systemObserver)
+        return;
+
+    m_systemObserver.get().provider = nullptr;
     m_systemObserver = nullptr;
 }
 
@@ -103,12 +107,6 @@ void ScreenOrientationProvider::setWindow(UIWindow *window)
 {
     m_window = window;
     screenOrientationDidChange();
-}
-
-void ScreenOrientationProvider::platformDestroy()
-{
-    if (m_systemObserver)
-        m_systemObserver.get().provider = nullptr;
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 2065c26bcce50d3cca791ffe95229237895ad79e
<pre>
[iOS] Flaky crash under ScreenOrientationProvider::screenOrientationDidChange()
<a href="https://bugs.webkit.org/show_bug.cgi?id=248632">https://bugs.webkit.org/show_bug.cgi?id=248632</a>
rdar://102697580

Reviewed by Wenson Hsieh.

ScreenOrientationProvider::platformStopListeningForChanges() was clearing
m_systemObserver without clearing the system&apos;s observer&apos;s pointer to the
provider. Upon destruction, ScreenOrientationProvider::platformDestroy() would
attempt to clear this pointer but it wouldn&apos;t work in the case where
platformStopListeningForChanges() was previously called, since m_systemObserver
is already gone.

* Source/WebCore/platform/ScreenOrientationProvider.cpp:
(WebCore::ScreenOrientationProvider::~ScreenOrientationProvider):
(WebCore::ScreenOrientationProvider::platformStopListeningForChanges):
(WebCore::ScreenOrientationProvider::platformDestroy): Deleted.
* Source/WebCore/platform/ScreenOrientationProvider.h:
* Source/WebCore/platform/ios/ScreenOrientationProviderIOS.mm:
(WebCore::ScreenOrientationProvider::platformStopListeningForChanges):
(WebCore::ScreenOrientationProvider::platformDestroy): Deleted.

Canonical link: <a href="https://commits.webkit.org/257303@main">https://commits.webkit.org/257303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9596bbd9970fb542de3a97a8f542153454e7e65e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107814 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168083 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84961 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90937 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104474 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33151 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87961 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76098 "Found 1 new API test failure: /WebKitGTK/TestWebExtensions:/webkit/WebKitWebExtension/page-id (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1529 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22602 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1463 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45092 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, http/tests/navigation/fragment-navigation-policy-ignore.html, http/tests/xmlhttprequest/chunked-progress-event-expectedLength.html, http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html, http/wpt/service-workers/fetch-service-worker-preload-download.https.html, http/wpt/service-workers/fetch-service-worker-preload.https.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42011 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2519 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->