### PR TITLE
Masonry repeat(auto-fit) should behave as repeat(auto-fill)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html
@@ -77,7 +77,7 @@ test_computed_value("grid-template-columns", '[] 150px [] 1fr []', '150px 150px'
 // <auto-repeat> = repeat( [ auto-fill | auto-fit ] , [ <line-names>? <fixed-size> ]+ <line-names>? )
 test_computed_value("grid-template-columns", 'repeat(auto-fill, 200px)', '200px');
 test_computed_value("grid-template-columns", 'repeat(auto-fit, [one] 20%)',
-                    '[one] 60px [one] 0px [one] 0px [one] 0px [one] 0px');
+                    '[one] 60px [one] 60px [one] 60px [one] 60px [one] 60px');
 test_computed_value("grid-template-columns", 'repeat(auto-fill, minmax(100px, 5fr) [two])',
                     '100px [two] 100px [two] 100px [two]');
 test_computed_value("grid-template-columns", 'repeat(auto-fit, [three] minmax(max-content, 6em) [four])',

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -233,6 +233,11 @@ private:
 
     bool computeGridPositionsForOutOfFlowChild(const RenderBox&, GridTrackSizingDirection, int&, bool&, int&, bool&) const;
 
+    bool isMasonryRows() const;
+    bool isMasonryColumns() const;
+    AutoRepeatType autoRepeatColumnsType() const;
+    AutoRepeatType autoRepeatRowsType() const;
+
     class GridWrapper {
         Grid m_layoutGrid;
     public:


### PR DESCRIPTION
#### f91e41a89ed67eb51626018c4c485931375876f5
<pre>
Masonry repeat(auto-fit) should behave as repeat(auto-fill)
<a href="https://bugs.webkit.org/show_bug.cgi?id=248577">https://bugs.webkit.org/show_bug.cgi?id=248577</a>

Reviewed by Brent Fulgham.

Masonry repeat(auto-fit) should have the properities of repeat(auto-fill) according to the spec.
<a href="https://drafts.csswg.org/css-grid-3/#repeat-auto-fit">https://drafts.csswg.org/css-grid-3/#repeat-auto-fit</a>

Update WPT test case for auto-fit to behave the same as auto-fill.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::computeEmptyTracksForAutoRepeat const):
(WebCore::RenderGrid::isMasonryRows const):
(WebCore::RenderGrid::isMasonryColumns const):
(WebCore::RenderGrid::autoRepeatColumnsType const):
(WebCore::RenderGrid::autoRepeatRowsType const):
(WebCore::RenderGrid::placeItemsOnGrid):
(WebCore::RenderGrid::gridAreaBreadthForChildIncludingAlignmentOffsets const):
(WebCore::RenderGrid::columnAxisOffsetForChild const):
(WebCore::RenderGrid::rowAxisOffsetForChild const):
(WebCore::isMasonryRows): Deleted.
(WebCore::isMasonryColumns): Deleted.
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/257300@main">https://commits.webkit.org/257300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29d0fc882cc740220565d6cdc56a2a0baf62e46f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107898 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168168 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85070 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104556 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104136 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89777 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33211 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88036 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1620 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1542 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5027 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42086 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2917 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->