### PR TITLE
[Cocoa] Extend networkConnectionIntegrity with support for HTTPS-Only

### DIFF
--- a/Source/WebCore/platform/network/NetworkConnectionIntegrity.h
+++ b/Source/WebCore/platform/network/NetworkConnectionIntegrity.h
@@ -30,6 +30,7 @@ namespace WebCore {
 enum class NetworkConnectionIntegrity : uint8_t {
     Enabled = 1 << 0,
     HTTPSFirst = 1 << 1,
+    HTTPSOnly = 1 << 2,
 };
 
 }
@@ -40,7 +41,8 @@ template<> struct EnumTraits<WebCore::NetworkConnectionIntegrity> {
     using values = EnumValues<
         WebCore::NetworkConnectionIntegrity,
         WebCore::NetworkConnectionIntegrity::Enabled,
-        WebCore::NetworkConnectionIntegrity::HTTPSFirst
+        WebCore::NetworkConnectionIntegrity::HTTPSFirst,
+        WebCore::NetworkConnectionIntegrity::HTTPSOnly
     >;
 };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -609,6 +609,9 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
     if (webCorePolicy.contains(WebCore::NetworkConnectionIntegrity::HTTPSFirst))
         policy |= _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSFirst;
 
+    if (webCorePolicy.contains(WebCore::NetworkConnectionIntegrity::HTTPSOnly))
+        policy |= _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly;
+
     return policy;
 }
 
@@ -621,6 +624,9 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
     if (networkConnectionIntegrityPolicy & _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSFirst)
         webCorePolicy.add(WebCore::NetworkConnectionIntegrity::HTTPSFirst);
+
+    if (networkConnectionIntegrityPolicy & _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly)
+        webCorePolicy.add(WebCore::NetworkConnectionIntegrity::HTTPSOnly);
 
     _websitePolicies->setNetworkConnectionIntegrityPolicy(webCorePolicy);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -79,6 +79,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
     _WKWebsiteNetworkConnectionIntegrityPolicyNone = 0,
     _WKWebsiteNetworkConnectionIntegrityPolicyEnabled = 1 << 0,
     _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSFirst = 1 << 1,
+    _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly = 1 << 2,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @class _WKCustomHeaderFields;


### PR DESCRIPTION
#### 15e9e33a70d0c63d9a4954ec40d85789bf336da9
<pre>
[Cocoa] Extend networkConnectionIntegrity with support for HTTPS-Only
<a href="https://bugs.webkit.org/show_bug.cgi?id=248633">https://bugs.webkit.org/show_bug.cgi?id=248633</a>
rdar://problem/102879069

Reviewed by Wenson Hsieh.

Add another option in the NetworkConnectionIntegrity OptionSet for HTTPSOnly.

* Source/WebCore/platform/network/NetworkConnectionIntegrity.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _networkConnectionIntegrityPolicy]):
(-[WKWebpagePreferences _setNetworkConnectionIntegrityPolicy:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:

Canonical link: <a href="https://commits.webkit.org/257305@main">https://commits.webkit.org/257305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47c4cc2e16b80ff70ffc35af0db8957747ba61fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107825 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168094 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84972 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90948 "Updated gtk dependencies (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104485 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89718 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/90948 "Updated gtk dependencies (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87975 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/90948 "Updated gtk dependencies (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1540 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1474 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5030 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42017 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2834 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->