### PR TITLE
Move masonry logic from RenderGrid to GridMasonryLayout.

### DIFF
--- a/Source/WebCore/rendering/GridMasonryLayout.h
+++ b/Source/WebCore/rendering/GridMasonryLayout.h
@@ -38,13 +38,14 @@ public:
     {
     }
 
-    void performMasonryPlacement(const HashMap<RenderBox*, GridArea>& firstTrackItems, const Vector<RenderBox*> itemsWithDefiniteGridAxisPosition, const Vector<RenderBox*> itemsWithIndefinitePosition, GridTrackSizingDirection masonryAxisDirection);
+    void performMasonryPlacement(unsigned gridAxisTracks, GridTrackSizingDirection masonryAxisDirection);
     LayoutUnit offsetForChild(const RenderBox&) const;
     LayoutUnit gridContentSize() const { return m_gridContentSize; };
 private:
 
     GridArea nextMasonryPositionForItem(const RenderBox* item);
 
+    void collectMasonryItems();
     void addItemsToFirstTrack(const HashMap<RenderBox*, GridArea>& firstTrackItems); 
     void placeItemsWithDefiniteGridAxisPosition(const Vector<RenderBox*>& itemsWithDefinitePosition);
     void placeItemsWithIndefiniteGridAxisPosition(const Vector<RenderBox*>& itemsWithIndefinitePosition);
@@ -52,20 +53,34 @@ private:
     void insertIntoGridAndLayoutItem(RenderBox*, const GridArea&);
 
     void resizeAndResetRunningPositions();
+    void allocateCapacityForMasonryVectors();
     LayoutUnit masonryAxisMarginBoxForItem(const RenderBox* child);
     void updateRunningPositions(const RenderBox* child, const GridArea&);
     void updateItemOffset(const RenderBox* child, LayoutUnit offset);
+    inline GridTrackSizingDirection gridAxisDirection() const;
+
+    bool hasDefiniteGridAxisPosition(const RenderBox* child, GridTrackSizingDirection masonryDirection) const;
+    static bool itemGridAreaStartsAtFirstLine(const GridArea& area, GridTrackSizingDirection masonryDirection)
+    {
+        return !(masonryDirection == ForRows ? area.rows.startLine() : area.columns.startLine());
+    }
 
     unsigned m_gridAxisTracksCount;
+
+    HashMap<RenderBox*, GridArea> m_firstTrackItems;
+    Vector<RenderBox*> m_itemsWithDefiniteGridAxisPosition;
+    Vector<RenderBox*> m_itemsWithIndefiniteGridAxisPosition;
+
     Vector<LayoutUnit> m_runningPositions;
     HashMap<const RenderBox*, LayoutUnit> m_itemOffsets;
     RenderGrid& m_renderGrid;
     LayoutUnit m_masonryAxisGridGap;
     LayoutUnit m_gridContentSize;
 
-    const GridSpan m_masonryAxisSpan = GridSpan::masonryAxisTranslatedDefiniteGridSpan();
     GridTrackSizingDirection m_masonryAxisDirection;
-    GridTrackSizingDirection m_gridAxisDirection;
+    const GridSpan m_masonryAxisSpan = GridSpan::masonryAxisTranslatedDefiniteGridSpan();
+    const unsigned m_masonryDefiniteItemsQuarterCapacity = 4;
+    const unsigned m_masonryIndefiniteItemsHalfCapacity = 2;
 };
 
 } // end namespace WebCore

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -156,9 +156,11 @@ private:
     GridTrackSizingDirection autoPlacementMajorAxisDirection() const;
     GridTrackSizingDirection autoPlacementMinorAxisDirection() const;
 
-    void allocateSpaceForMasonryVectors(Vector<RenderBox*>& itemsWithDefiniteGridAxisPosition, Vector<RenderBox*>& itemsWithIndefinitePosition); 
-    void collectMasonryItems(Grid&, unsigned gridAxisTracksCount, GridTrackSizingDirection masonryDirection, HashMap<RenderBox*, GridArea>& itemsOnFirstTrack, Vector<RenderBox*>& itemsWithDefiniteGridAxisPosition, Vector<RenderBox*>& itemsWithIndefinitePosition) const;
-    bool hasDefiniteGridAxisPosition(const RenderBox* child, GridTrackSizingDirection masonryDirection) const;
+    static bool itemGridAreaIsWithinImplicitGrid(const GridArea& area, unsigned gridAxisLinesCount, GridTrackSizingDirection gridAxisDirection)
+    {
+        auto itemSpan = gridAxisDirection == ForColumns ? area.columns : area.rows;
+        return itemSpan.startLine() <  gridAxisLinesCount && itemSpan.endLine() < gridAxisLinesCount;
+    }
 
     bool canPerformSimplifiedLayout() const final;
     void prepareChildForPositionedLayout(RenderBox&);
@@ -263,8 +265,6 @@ private:
     bool m_hasAspectRatioBlockSizeDependentItem { false };
     bool m_baselineItemsCached {false};
     bool m_hasAnyBaselineAlignmentItem { false };
-    const unsigned m_masonryDefiniteItemsQuarterCapacity = 4;
-    const unsigned m_masonryIndefiniteItemsHalfCapacity = 2;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/GridPositionsResolver.h
+++ b/Source/WebCore/rendering/style/GridPositionsResolver.h
@@ -94,7 +94,6 @@ public:
     static GridSpan resolveGridPositionsFromStyle(const RenderGrid& gridContainer, const RenderBox&, GridTrackSizingDirection);
     static unsigned explicitGridColumnCount(const RenderGrid&);
     static unsigned explicitGridRowCount(const RenderGrid&);
-    static inline GridTrackSizingDirection gridAxisDirection(GridTrackSizingDirection masonryAxisDirection) { return masonryAxisDirection == ForRows ? ForColumns: ForRows; }
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### ee553c43b364439656fe9eb00616b8167c8d103a
<pre>
Move masonry logic from RenderGrid to GridMasonryLayout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248621">https://bugs.webkit.org/show_bug.cgi?id=248621</a>
rdar://102871735

Reviewed by Tim Nguyen.

This is a somewhat small refactor that involes moving some masonry
specific logic from RenderGrid to GridMasonryLayout. The intial goal was
to remove only collectMasonryItems so that GridMasonryLayout could
hold onto the items directly, but it became pretty clear that some of
the other logic in the surrounding area could also be moved. This should
hopefully have 2 benefits:

1.) Make RenderGrid much more simple and easier to read when we need to
do a masonry layout (since much of the responsibility should be moved)
2.) Allow GridMasonryLayout to much more easily query the masonry item
data structures without having to pass references around everywhere.
This is especially useful if we ever need to check if an item is a
first track item.

There should be no functionality change with this patch.

* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::performMasonryPlacement):
(WebCore::GridMasonryLayout::collectMasonryItems):
(WebCore::GridMasonryLayout::allocateCapacityForMasonryVectors):
(WebCore::GridMasonryLayout::placeItemsWithDefiniteGridAxisPosition):
(WebCore::GridMasonryLayout::setItemGridAxisContainingBlockToGridArea):
(WebCore::GridMasonryLayout::nextMasonryPositionForItem):
(WebCore::GridMasonryLayout::gridAxisDirection const):
* Source/WebCore/rendering/GridMasonryLayout.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::placeItemsOnGrid):
(WebCore::RenderGrid::allocateSpaceForMasonryVectors): Deleted.
(WebCore::itemGridAreaStartsAtFirstLine): Deleted.
(WebCore::itemGridAreaIsWithinImplicitGrid): Deleted.
(WebCore::RenderGrid::collectMasonryItems const): Deleted.
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/style/GridPositionsResolver.h:
(WebCore::GridPositionsResolver::gridAxisDirection): Deleted.

Canonical link: <a href="https://commits.webkit.org/257358@main">https://commits.webkit.org/257358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/507c9d9fc8ba3d6f33ffce849abcc44d6cbb7ff5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108101 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168353 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85260 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91214 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106029 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33362 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76288 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1813 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22793 "Found 30 new test failures: http/tests/navigation/javascriptlink-basic.html, http/wpt/cache-storage/cache-quota.any.html, imported/w3c/web-platform-tests/css/css-backgrounds/background-origin-001.html, imported/w3c/web-platform-tests/css/css-flexbox/flexitem-no-margin-collapsing.html, imported/w3c/web-platform-tests/css/css-writing-modes/text-orientation-parsing-001.html, imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoundingClientRect-003.html, imported/w3c/web-platform-tests/fetch/metadata/generated/element-frame.sub.html, imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-global-scope.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/popup-same-origin-non-initial-about-blank.https.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-opener.https.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1722 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45287 "Found 2 new test failures: fast/forms/select-max-length.html, media/video-inactive-playback.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5051 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42246 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->