### PR TITLE
[SIMD] Intel support for replace_lane and extract_lane

### DIFF
--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -322,9 +322,11 @@ private:
         OP3_MFENCE           = 0xF0,
         OP3_SFENCE           = 0xF8,
         OP3_PEXTRB           = 0x14,
+        OP3_PEXTRW           = 0x15,
         OP3_PEXTRD           = 0x16,
         OP3_EXTRACTPS        = 0x17,
         OP3_PINSRB           = 0x20,
+        OP3_PINSRW           = 0xC4,
         OP3_PINSRD           = 0x22,
     } ThreeByteOpcodeID;
 
@@ -2370,31 +2372,12 @@ public:
     
     void pinsr(XMMRegisterID vd, RegisterID rn, SIMDLane lane, uint8_t laneIndex)
     {
-        m_formatter.prefix(PRE_OPERAND_SIZE);
-
-        if (lane == SIMDLane::i64x2) {
-            RELEASE_ASSERT(laneIndex < 2);
-            m_formatter.threeByteOp64(OP2_3BYTE_ESCAPE_3A, OP3_PINSRD, (RegisterID) vd, rn);
-        } else
-            RELEASE_ASSERT_NOT_REACHED();
-
-        m_formatter.immediate8((uint8_t) laneIndex);
+        m_formatter.pinsr((RegisterID) vd, rn, lane, laneIndex);
     }
-    
+
     void pextr(RegisterID rd, XMMRegisterID vn, SIMDLane lane, uint8_t laneIndex)
     {
-        m_formatter.prefix(PRE_OPERAND_SIZE);
-
-        if (lane == SIMDLane::i8x16) {
-            ASSERT(laneIndex < 16);
-            m_formatter.threeByteOp64(OP2_3BYTE_ESCAPE_3A, OP3_PEXTRB, (RegisterID) vn, rd);
-        } else if (lane == SIMDLane::i32x4) {
-            ASSERT(laneIndex < 4);
-            m_formatter.threeByteOp64(OP2_3BYTE_ESCAPE_3A, OP3_PEXTRD, (RegisterID) vn, rd);
-        } else
-            RELEASE_ASSERT_NOT_REACHED();
-
-        m_formatter.immediate8((uint8_t) laneIndex);
+        m_formatter.pextr(rd, (RegisterID) vn, lane, laneIndex);
     }
 
     void vextractps(FPRegisterID rd, XMMRegisterID vn, SIMDLane lane, uint8_t laneIndex)
@@ -2412,7 +2395,18 @@ public:
 
     void shufps(XMMRegisterID vd, XMMRegisterID vn, uint8_t controlBits)
     {
-        m_formatter.twoByteOp(OP2_SHUFPS, (RegisterID) vn, (RegisterID) vd);
+        // https://www.felixcloutier.com/x86/shufps
+        // NP 0F C6 /r ib SHUFPS xmm1, xmm3/m128, imm8
+        m_formatter.twoByteOp(OP2_SHUFPS, (RegisterID) vd, (RegisterID) vn);
+        m_formatter.immediate8((uint8_t) controlBits);
+    }
+
+    void shufpd(XMMRegisterID vd, XMMRegisterID vn, uint8_t controlBits)
+    {
+        // https://www.felixcloutier.com/x86/shufpd
+        // 66 0F C6 /r ib SHUFPD xmm1, xmm2/m128, imm8
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_SHUFPS, (RegisterID) vd, (RegisterID) vn);
         m_formatter.immediate8((uint8_t) controlBits);
     }
 
@@ -4390,6 +4384,27 @@ private:
                 thirdByte |= (~inOpReg & 0xf) << 3;
                 putByteUnchecked(thirdByte);
             }
+
+            ALWAYS_INLINE void threeBytesVex(bool isVEX256, OneByteOpcodeID simdPrefix, VexImpliedBytes impliedBytes, bool isW1, RegisterID r, RegisterID x, RegisterID b)
+            {
+                uint8_t firstByte = VexPrefix::ThreeBytes;        // 0xC4
+
+                uint8_t secondByte = 0;
+                secondByte |= !regRequiresRex(r) << 7;            // R
+                secondByte |= !regRequiresRex(x) << 6;            // X
+                secondByte |= !regRequiresRex(b) << 5;            // B
+                secondByte |= static_cast<uint8_t>(impliedBytes); // m-mmmm
+
+                uint8_t thirdByte = 0;
+                thirdByte |= isW1 << 7;                           // W
+                thirdByte |= 0b1111 << 3;                         // vvvv
+                thirdByte |= isVEX256 << 2;                       // L
+                thirdByte |= vexEncodeSIMDPrefix(simdPrefix);     // pp
+
+                putByteUnchecked(firstByte);
+                putByteUnchecked(secondByte);
+                putByteUnchecked(thirdByte);
+            }
         private:
             uint8_t vexEncodeSIMDPrefix(OneByteOpcodeID simdPrefix)
             {
@@ -4586,6 +4601,85 @@ private:
                 writer.twoBytesVex(simdPrefix, a, dest);
             writer.putByteUnchecked(opcode);
             writer.memoryModRM(dest, base, index, scale, offset);
+        }
+
+        void pinsr(RegisterID reg, RegisterID rm, SIMDLane lane, uint8_t laneIndex)
+        {
+            SingleInstructionBufferWriter writer(m_buffer);
+
+            bool isVEX256 = false;
+            OneByteOpcodeID simdPrefix = PRE_OPERAND_SIZE;
+            VexImpliedBytes impliedBytes = VexImpliedBytes::ThreeBytesOp3A;
+            bool isW1 = false;
+
+            if (lane == SIMDLane::i8x16) {
+                ASSERT(laneIndex < 16);
+                // https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
+                // VEX.128.66.0F3A.W0 20 /r ib VPINSRB xmm1, xmm2, r32/m8, imm8
+                writer.threeBytesVex(isVEX256, simdPrefix, impliedBytes, isW1, reg, (RegisterID) 0, rm);
+                writer.putByteUnchecked(OP3_PINSRB);
+            } else if (lane == SIMDLane::i16x8) {
+                ASSERT(laneIndex < 8);
+                // https://www.felixcloutier.com/x86/pextrw
+                // VEX.128.66.0F.W0 C4 /r ib VPINSRW xmm1, xmm2, r32/m16, imm8
+                impliedBytes = VexImpliedBytes::TwoBytesOp;
+                writer.threeBytesVex(isVEX256, simdPrefix, impliedBytes, isW1, reg, (RegisterID) 0, rm);
+                writer.putByteUnchecked(OP3_PINSRW);
+            } else if (lane == SIMDLane::i32x4 || lane == SIMDLane::f32x4) {
+                ASSERT(laneIndex < 4);
+                // VEX.128.66.0F3A.W0 22 /r ib VPINSRD xmm1, xmm2, r/m32, imm8                
+                writer.threeBytesVex(isVEX256, simdPrefix, impliedBytes, isW1, reg, (RegisterID) 0, rm);
+                writer.putByteUnchecked(OP3_PINSRD);
+            } else if (lane == SIMDLane::i64x2 || lane == SIMDLane::f64x2) {
+                ASSERT(laneIndex < 2);
+                // VEX.128.66.0F3A.W1 22 /r ib VPINSRQ xmm1, xmm2, r/m64, imm8
+                isW1 = true;
+                writer.threeBytesVex(isVEX256, simdPrefix, impliedBytes, isW1, reg, (RegisterID) 0, rm);
+                writer.putByteUnchecked(OP3_PINSRD);
+            } else
+                RELEASE_ASSERT_NOT_REACHED();
+
+            writer.registerModRM(reg, rm);
+            writer.putByteUnchecked((uint8_t) laneIndex);
+        }
+
+        void pextr(RegisterID rm, RegisterID reg, SIMDLane lane, uint8_t laneIndex)
+        {
+            SingleInstructionBufferWriter writer(m_buffer);
+
+            bool isVEX256 = false;
+            OneByteOpcodeID simdPrefix = PRE_OPERAND_SIZE;
+            VexImpliedBytes impliedBytes = VexImpliedBytes::ThreeBytesOp3A;
+            bool isW1 = false;
+
+            if (lane == SIMDLane::i8x16) {
+                ASSERT(laneIndex < 16);
+                // https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
+                // VEX.128.66.0F3A.W0 14 /r ib VPEXTRB reg/m8, xmm2, imm8
+                writer.threeBytesVex(isVEX256, simdPrefix, impliedBytes, isW1, reg, (RegisterID) 0, rm);
+                writer.putByteUnchecked(OP3_PEXTRB);
+            } else if (lane == SIMDLane::i16x8) {
+                ASSERT(laneIndex < 8);
+                // https://www.felixcloutier.com/x86/pextrw
+                // VEX.128.66.0F3A.W0 15 /r ib VPEXTRW reg/m16, xmm2, imm8
+                writer.threeBytesVex(isVEX256, simdPrefix, impliedBytes, isW1, reg, (RegisterID) 0, rm);
+                writer.putByteUnchecked(OP3_PEXTRW);
+            } else if (lane == SIMDLane::i32x4) {
+                ASSERT(laneIndex < 4);
+                // VEX.128.66.0F3A.W0 16 /r ib VPEXTRD r32/m32, xmm2, imm8
+                writer.threeBytesVex(isVEX256, simdPrefix, impliedBytes, isW1, reg, (RegisterID) 0, rm);
+                writer.putByteUnchecked(OP3_PEXTRD);
+            } else if (lane == SIMDLane::i64x2) {
+                ASSERT(laneIndex < 2);
+                // VEX.128.66.0F3A.W1 16 /r ib VPEXTRQ r64/m64, xmm2, imm8
+                isW1 = true;
+                writer.threeBytesVex(isVEX256, simdPrefix, impliedBytes, isW1, reg, (RegisterID) 0, rm);
+                writer.putByteUnchecked(OP3_PEXTRD);
+            } else
+                RELEASE_ASSERT_NOT_REACHED();
+
+            writer.registerModRM(reg, rm);
+            writer.putByteUnchecked((uint8_t) laneIndex);
         }
 
         void threeByteOp(TwoByteOpcodeID twoBytePrefix, ThreeByteOpcodeID opcode)

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1639,9 +1639,13 @@ VectorReplaceLaneInt16 U:G:8, U:G:16, UD:F:128
     Imm, Tmp, Tmp
 VectorReplaceLaneInt8 U:G:8, U:G:8, UD:F:128
     Imm, Tmp, Tmp
-VectorReplaceLaneFloat64 U:G:8, U:F:64, UD:F:128
+x86_64: VectorReplaceLaneFloat64 U:G:8, U:F:64, UD:F:128, S:G:64
+    Imm, Tmp, Tmp, Tmp
+arm64: VectorReplaceLaneFloat64 U:G:8, U:F:64, UD:F:128
     Imm, Tmp, Tmp
-VectorReplaceLaneFloat32 U:G:8, U:F:32, UD:F:128
+x86_64: VectorReplaceLaneFloat32 U:G:8, U:F:32, UD:F:128, S:G:32
+    Imm, Tmp, Tmp, Tmp
+arm64: VectorReplaceLaneFloat32 U:G:8, U:F:32, UD:F:128
     Imm, Tmp, Tmp
 
 VectorExtractLaneInt64 U:G:8, U:F:128, D:G:64

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
@@ -505,7 +505,10 @@ public:
         auto airOp = airOpForSIMDReplaceLane(info);
         result = tmpForType(Types::V128);
         append(MoveVector, v, result);
-        append(airOp, Arg::imm(imm), s, result);
+        if (isValidForm(airOp, Arg::Imm, Arg::Tmp, Arg::Tmp, Arg::Tmp))
+            append(airOp, Arg::imm(imm), s, result, airOp == VectorReplaceLaneFloat64 ? tmpForType(Types::I64) : tmpForType(Types::I32));
+        else
+            append(airOp, Arg::imm(imm), s, result);
         return { };
     }
 


### PR DESCRIPTION
#### c0ff6b0854d6f0e3bcdaf11829d67dea3c5d88e5
<pre>
[SIMD] Intel fix operation shuffle
<a href="https://bugs.webkit.org/show_bug.cgi?id=249073">https://bugs.webkit.org/show_bug.cgi?id=249073</a>
rdar://problem/10321491

Reviewed by NOBODY (OOPS!).

Fix WASM SIMD operation i8x16.shuffle.

* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::addSIMDShuffle):
</pre>