### PR TITLE
Remove Document.getOverrideStyle()

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -944,8 +944,6 @@ public:
     bool hasMutationObservers() const { return !m_mutationObserverTypes.isEmpty(); }
     void addMutationObserverTypes(MutationObserverOptions types) { m_mutationObserverTypes.add(types); }
 
-    CSSStyleDeclaration* getOverrideStyle(Element*, const String&) { return nullptr; }
-
     // Handles an HTTP header equivalent set by a meta tag using <meta http-equiv="..." content="...">. This is called
     // when a meta tag is encountered during document parsing, and also when a script dynamically changes or adds a meta
     // tag. This enables scripts to use meta tags to perform refreshes and set expiry dates in addition to them being

--- a/Source/WebCore/dom/Document.idl
+++ b/Source/WebCore/dom/Document.idl
@@ -88,10 +88,6 @@ typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
     attribute DOMString? xmlVersion;
     attribute boolean xmlStandalone;
 
-    // Non standard: Blink has already dropped this (https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/s3ezjTuC8ig).
-    // And it's just a stub that always returns null, so we can probably remove it some time soon.
-    CSSStyleDeclaration? getOverrideStyle(optional Element? element = null, optional DOMString pseudoElement = "undefined");
-
     // Non standard: It has been superseeded by caretPositionFromPoint which we do not implement yet.
     Range caretRangeFromPoint(optional long x = 0, optional long y = 0);
 


### PR DESCRIPTION
#### 62957ecdf469bf3acaf8b21e3eed6c539bf822c6
<pre>
Remove Document.getOverrideStyle()
<a href="https://bugs.webkit.org/show_bug.cgi?id=248439">https://bugs.webkit.org/show_bug.cgi?id=248439</a>

Reviewed by Tim Nguyen.

Removed this non-standard feature. Blink removed this function back in 2015:
<a href="https://chromium.googlesource.com/chromium/blink/+/c4295e1eb8e409eb724af535fdce94ecdc10654d">https://chromium.googlesource.com/chromium/blink/+/c4295e1eb8e409eb724af535fdce94ecdc10654d</a>

* Source/WebCore/dom/Document.h:
(WebCore::Document::getOverrideStyle): Deleted.
* Source/WebCore/dom/Document.idl:

Canonical link: <a href="https://commits.webkit.org/257318@main">https://commits.webkit.org/257318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d70d0ea6e378def8f4a21c977fc8d5aa72c4d89

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107829 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168098 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84977 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90952 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104488 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33164 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87976 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21088 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/text/text-edge-property-parsing.html, http/tests/appcache/fail-on-update-2.html, http/tests/appcache/remove-cache.html, http/tests/security/contentSecurityPolicy/script-src-star-cross-scheme.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76111 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1545 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22616 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/rendering/render-style-null-optgroup-crash.html, fast/shadow-dom/style-resolver-sharing.html, fast/text/text-edge-property-parsing.html, http/tests/appcache/fail-on-update-2.html, http/tests/security/contentSecurityPolicy/report-blocked-uri-cross-origin.py, http/tests/security/contentSecurityPolicy/report-blocked-uri.py ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1478 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45104 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, compositing/no-compositing-when-fulll-screen-is-present.html, css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/events/blur-remove-parent-crash.html, fast/rendering/render-style-null-optgroup-crash.html, fast/text/text-edge-property-parsing.html, http/tests/navigation/fragment-navigation-policy-ignore.html, http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42026 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2525 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->