### PR TITLE
Add width and height content attributes to <model>

### DIFF
--- a/LayoutTests/model-element/model-element-width-height-expected.txt
+++ b/LayoutTests/model-element/model-element-width-height-expected.txt
@@ -1,0 +1,9 @@
+
+PASS HTMLModelElement has width and height properties
+PASS HTMLModelElement width and height properties reflect width and height attribute values
+PASS <model> width and height attributes reflect HTMLModelElement width and height properties
+PASS <model> has default CSS size when no width or height attribute is used
+PASS <model> width and height attributes influence automatic size
+PASS <model> width and height attributes do not win over non-auto width and height property values
+PASS <model> size computation takes aspect-ratio property into account
+

--- a/LayoutTests/model-element/model-element-width-height-visual-expected.html
+++ b/LayoutTests/model-element/model-element-width-height-visual-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<model style="width: 200px; height: 400px; background-color: blue;"></model>

--- a/LayoutTests/model-element/model-element-width-height-visual.html
+++ b/LayoutTests/model-element/model-element-width-height-visual.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<model width="200" height="400" style="background-color: blue;"></model>

--- a/LayoutTests/model-element/model-element-width-height.html
+++ b/LayoutTests/model-element/model-element-width-height.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ModelElementEnabled=true ] -->
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+test(() => {
+    const model = document.createElement("model");
+    assert_idl_attribute(model, "width", "width is defined");
+    assert_idl_attribute(model, "height", "width is defined");
+}, "HTMLModelElement has width and height properties");
+
+test(() => {
+    const model = document.createElement("model");
+    model.setAttribute("width", "100");
+    model.setAttribute("height", "200");
+    assert_equals(model.width, 100, "width attribute value is reflected by HTMLModelElement width property");
+    assert_equals(model.height, 200, "height attribute value is reflected by HTMLModelElement height property");
+}, "HTMLModelElement width and height properties reflect width and height attribute values");
+
+test(() => {
+    const model = document.createElement("model");
+    model.width = 100;
+    model.height = 200;
+    assert_equals(model.getAttribute("width"), "100", "HTMLModelElement width property value is reflected by width attribute");
+    assert_equals(model.getAttribute("height"), "200", "HTMLModelElement height property value is reflected by height attribute");
+}, "<model> width and height attributes reflect HTMLModelElement width and height properties");
+
+test(() => {
+    const model = document.createElement("model");
+    document.body.append(model);
+    assert_equals(getComputedStyle(model).width, "300px", "default width is 300");
+    assert_equals(getComputedStyle(model).height, "150px", "default height is 150");
+    model.remove();
+}, "<model> has default CSS size when no width or height attribute is used");
+
+test(() => {
+    const model = document.createElement("model");
+    model.width = "400";
+    model.height = "100";
+    document.body.append(model);
+    assert_equals(getComputedStyle(model).width, "400px", "automatic size is influenced by width attribute");
+    assert_equals(getComputedStyle(model).height, "100px", "automatic size is influenced by height attribute");
+    model.remove();
+}, "<model> width and height attributes influence automatic size");
+
+test(() => {
+    const model = document.createElement("model");
+    model.style.width = "200px";
+    model.style.height = "50px";
+    model.width = "400";
+    model.height = "100";
+    document.body.append(model);
+    assert_equals(getComputedStyle(model).width, "200px", "non-auto width value wins over width attribute");
+    assert_equals(getComputedStyle(model).height, "50px", "non-auto height value wins over height attribute");
+    model.remove();
+}, "<model> width and height attributes do not win over non-auto width and height property values");
+
+test(() => {
+    const model = document.createElement("model");
+    model.width = 200;
+    model.style.aspectRatio = "1 / 2";
+    document.body.append(model);
+    assert_equals(getComputedStyle(model).height, "400px", "aspect-ratio influences size");
+    model.remove();
+}, "<model> size computation takes aspect-ratio property into account");
+</script>

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -65,6 +65,8 @@
 
 namespace WebCore {
 
+using namespace HTMLNames;
+
 WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLModelElement);
 
 HTMLModelElement::HTMLModelElement(const QualifiedName& tagName, Document& document)
@@ -677,6 +679,25 @@ String HTMLModelElement::inlinePreviewUUIDForTesting() const
     return m_modelPlayer->inlinePreviewUUIDForTesting();
 }
 #endif
+
+void HTMLModelElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
+{
+    if (name == widthAttr) {
+        addHTMLLengthToStyle(style, CSSPropertyWidth, value);
+        applyAspectRatioFromWidthAndHeightAttributesToStyle(value, attributeWithoutSynchronization(heightAttr), style);
+    } else if (name == heightAttr) {
+        addHTMLLengthToStyle(style, CSSPropertyHeight, value);
+        applyAspectRatioFromWidthAndHeightAttributesToStyle(attributeWithoutSynchronization(widthAttr), value, style);
+    } else
+        HTMLElement::collectPresentationalHintsForAttribute(name, value, style);
+}
+
+bool HTMLModelElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
+{
+    if (name == widthAttr || name == heightAttr)
+        return true;
+    return HTMLElement::hasPresentationalHintsForAttribute(name);
+}
 
 }
 

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -134,6 +134,10 @@ private:
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 
+    // StyledElement
+    bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
+    void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
+
     // Rendering overrides.
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     void didAttachRenderers() final;

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.idl
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.idl
@@ -30,6 +30,8 @@
     Exposed=Window,
     JSGenerateToNativeObject
 ] interface HTMLModelElement : HTMLElement {
+    [CEReactions=NotNeeded, Reflect] attribute unsigned long width;
+    [CEReactions=NotNeeded, Reflect] attribute unsigned long height;
     [URL] readonly attribute USVString currentSrc;
 
     readonly attribute boolean complete;


### PR DESCRIPTION
#### cf600d68403f383e2755725ad982c2e82dc1bd27
<pre>
Add width and height content attributes to &lt;model&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=243974">https://bugs.webkit.org/show_bug.cgi?id=243974</a>
rdar://99014926

Reviewed by Antoine Quint.

For consistency with &lt;img&gt; and &lt;video&gt;, &lt;model&gt; should have width and
height content attributes that set presentational style for the width
and height properties.

* LayoutTests/model-element/model-element-width-height-expected.txt: Added.
* LayoutTests/model-element/model-element-width-height-visual-expected.html: Added.
* LayoutTests/model-element/model-element-width-height-visual.html: Added.
* LayoutTests/model-element/model-element-width-height.html: Added.
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::collectPresentationalHintsForAttribute):
(WebCore::HTMLModelElement::hasPresentationalHintsForAttribute const):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/HTMLModelElement.idl:

Canonical link: <a href="https://commits.webkit.org/257294@main">https://commits.webkit.org/257294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0902ec42e96e15644ebe519222446fe2e163d77e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107904 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168174 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102421 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85076 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91024 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104561 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104143 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33214 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88040 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1626 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1548 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5028 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42085 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->