### PR TITLE
[WK2] Flaky ASSERTION FAILED: m_gamepads.isEmpty() on gamepad/gamepad-polling-access.html

### DIFF
--- a/LayoutTests/gamepad/gamepad-polling-access-expected.txt
+++ b/LayoutTests/gamepad/gamepad-polling-access-expected.txt
@@ -1,164 +1,285 @@
 Initial gamepads length: 0
 Connecting 20 different gamepads
 Connecting gamepad:
-[object Gamepad]
 Name: 0
 Index: 0
 Mapping:
 Axes:
 Buttons:
-onconnectedgamepad event fired (1).
+ongamepadconnected event fired (1).
+Name: 0
+Index: 0
+Mapping:
+Axes:
+Buttons:
+gamepadconnected event fired (1).
+[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad]
 Name: 1
 Index: 1
 Mapping:
 Axes: 0
 Buttons: false-0
-onconnectedgamepad event fired (2).
+ongamepadconnected event fired (2).
+Name: 1
+Index: 1
+Mapping:
+Axes: 0
+Buttons: false-0
+gamepadconnected event fired (2).
+[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 2
 Index: 2
 Mapping:
 Axes: 0,0
 Buttons: false-0 false-0
-onconnectedgamepad event fired (3).
+ongamepadconnected event fired (3).
+Name: 2
+Index: 2
+Mapping:
+Axes: 0,0
+Buttons: false-0 false-0
+gamepadconnected event fired (3).
+[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 3
 Index: 3
 Mapping:
 Axes: 0,0,0
 Buttons: false-0 false-0 false-0
-onconnectedgamepad event fired (4).
+ongamepadconnected event fired (4).
+Name: 3
+Index: 3
+Mapping:
+Axes: 0,0,0
+Buttons: false-0 false-0 false-0
+gamepadconnected event fired (4).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 4
 Index: 4
 Mapping:
 Axes: 0,0,0,0
 Buttons: false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (5).
+ongamepadconnected event fired (5).
+Name: 4
+Index: 4
+Mapping:
+Axes: 0,0,0,0
+Buttons: false-0 false-0 false-0 false-0
+gamepadconnected event fired (5).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 5
 Index: 5
 Mapping:
 Axes: 0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (6).
+ongamepadconnected event fired (6).
+Name: 5
+Index: 5
+Mapping:
+Axes: 0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (6).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 6
 Index: 6
 Mapping:
 Axes: 0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (7).
+ongamepadconnected event fired (7).
+Name: 6
+Index: 6
+Mapping:
+Axes: 0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (7).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 7
 Index: 7
 Mapping:
 Axes: 0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (8).
+ongamepadconnected event fired (8).
+Name: 7
+Index: 7
+Mapping:
+Axes: 0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (8).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 8
 Index: 8
 Mapping:
 Axes: 0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (9).
+ongamepadconnected event fired (9).
+Name: 8
+Index: 8
+Mapping:
+Axes: 0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (9).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 9
 Index: 9
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (10).
+ongamepadconnected event fired (10).
+Name: 9
+Index: 9
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (10).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 10
 Index: 10
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (11).
+ongamepadconnected event fired (11).
+Name: 10
+Index: 10
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (11).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 11
 Index: 11
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (12).
+ongamepadconnected event fired (12).
+Name: 11
+Index: 11
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (12).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 12
 Index: 12
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (13).
+ongamepadconnected event fired (13).
+Name: 12
+Index: 12
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (13).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 13
 Index: 13
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (14).
+ongamepadconnected event fired (14).
+Name: 13
+Index: 13
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (14).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 14
 Index: 14
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (15).
+ongamepadconnected event fired (15).
+Name: 14
+Index: 14
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (15).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 15
 Index: 15
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (16).
+ongamepadconnected event fired (16).
+Name: 15
+Index: 15
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (16).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 16
 Index: 16
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (17).
+ongamepadconnected event fired (17).
+Name: 16
+Index: 16
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (17).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 17
 Index: 17
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (18).
+ongamepadconnected event fired (18).
+Name: 17
+Index: 17
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (18).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 18
 Index: 18
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
-onconnectedgamepad event fired (19).
+ongamepadconnected event fired (19).
+Name: 18
+Index: 18
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (19).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Connecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 19
 Index: 19
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+ongamepadconnected event fired (20).
+Name: 19
+Index: 19
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepadconnected event fired (20).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Verifying there are 20 connected gamepads in the set of all gamepads
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 0
@@ -262,73 +383,205 @@ Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
 Disconnecting gamepads in reverse order, making sure gamepads array remains as expected
-onconnectedgamepad event fired (20).
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],
-ondisconnectedgamepad event fired (19).
+ongamepaddisconnected event fired (19).
+Name: 19
+Index: 19
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (19).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,
-ondisconnectedgamepad event fired (18).
+ongamepaddisconnected event fired (18).
+Name: 18
+Index: 18
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (18).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,
-ondisconnectedgamepad event fired (17).
+ongamepaddisconnected event fired (17).
+Name: 17
+Index: 17
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (17).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,
-ondisconnectedgamepad event fired (16).
+ongamepaddisconnected event fired (16).
+Name: 16
+Index: 16
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (16).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,
-ondisconnectedgamepad event fired (15).
+ongamepaddisconnected event fired (15).
+Name: 15
+Index: 15
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (15).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,
-ondisconnectedgamepad event fired (14).
+ongamepaddisconnected event fired (14).
+Name: 14
+Index: 14
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (14).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,
-ondisconnectedgamepad event fired (13).
+ongamepaddisconnected event fired (13).
+Name: 13
+Index: 13
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (13).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,
-ondisconnectedgamepad event fired (12).
+ongamepaddisconnected event fired (12).
+Name: 12
+Index: 12
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (12).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,
-ondisconnectedgamepad event fired (11).
+ongamepaddisconnected event fired (11).
+Name: 11
+Index: 11
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (11).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,
-ondisconnectedgamepad event fired (10).
+ongamepaddisconnected event fired (10).
+Name: 10
+Index: 10
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (10).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,,
-ondisconnectedgamepad event fired (9).
+ongamepaddisconnected event fired (9).
+Name: 9
+Index: 9
+Mapping:
+Axes: 0,0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (9).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,,,
-ondisconnectedgamepad event fired (8).
+ongamepaddisconnected event fired (8).
+Name: 8
+Index: 8
+Mapping:
+Axes: 0,0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (8).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,,,,
-ondisconnectedgamepad event fired (7).
+ongamepaddisconnected event fired (7).
+Name: 7
+Index: 7
+Mapping:
+Axes: 0,0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (7).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,,,,,
-ondisconnectedgamepad event fired (6).
+ongamepaddisconnected event fired (6).
+Name: 6
+Index: 6
+Mapping:
+Axes: 0,0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (6).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,,,,,,
-ondisconnectedgamepad event fired (5).
+ongamepaddisconnected event fired (5).
+Name: 5
+Index: 5
+Mapping:
+Axes: 0,0,0,0,0
+Buttons: false-0 false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (5).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,,,,,,,
-ondisconnectedgamepad event fired (4).
+ongamepaddisconnected event fired (4).
+Name: 4
+Index: 4
+Mapping:
+Axes: 0,0,0,0
+Buttons: false-0 false-0 false-0 false-0
+gamepaddisconnected event fired (4).
+[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,,,,,,,,
-ondisconnectedgamepad event fired (3).
+ongamepaddisconnected event fired (3).
+Name: 3
+Index: 3
+Mapping:
+Axes: 0,0,0
+Buttons: false-0 false-0 false-0
+gamepaddisconnected event fired (3).
+[object Gamepad],[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],[object Gamepad],,,,,,,,,,,,,,,,,,
-ondisconnectedgamepad event fired (2).
+ongamepaddisconnected event fired (2).
+Name: 2
+Index: 2
+Mapping:
+Axes: 0,0
+Buttons: false-0 false-0
+gamepaddisconnected event fired (2).
+[object Gamepad],[object Gamepad]
 Disconnecting gamepad:
-[object Gamepad],,,,,,,,,,,,,,,,,,,
-ondisconnectedgamepad event fired (1).
+ongamepaddisconnected event fired (1).
+Name: 1
+Index: 1
+Mapping:
+Axes: 0
+Buttons: false-0
+gamepaddisconnected event fired (1).
+[object Gamepad]
 Disconnecting gamepad:
-,,,,,,,,,,,,,,,,,,,
+ongamepaddisconnected event fired (0).
+Name: 0
+Index: 0
+Mapping:
+Axes:
+Buttons:
+gamepaddisconnected event fired (0).
+
 Checking non-zero'ed details for a gamepad
-ondisconnectedgamepad event fired (0).
-Connecting gamepad:
-,,,,,,,,,,[object Gamepad],,,,,,,,,
 Name: Awesome Joystick 5000
 Index: 10
 Mapping: standard
 Axes: 0.7,-0.9,1,-1
 Buttons: true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1
+ongamepadconnected event fired (1).
+Name: Awesome Joystick 5000
+Index: 10
+Mapping: standard
+Axes: 0.7,-0.9,1,-1
+Buttons: true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1
+gamepadconnected event fired (1).
+Disconnecting final gamepad
+ongamepaddisconnected event fired (0).
+Name: Awesome Joystick 5000
+Index: 10
+Mapping: standard
+Axes: 0.7,-0.9,1,-1
+Buttons: true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1 true-1
+gamepaddisconnected event fired (0).
 

--- a/LayoutTests/gamepad/gamepad-polling-access.html
+++ b/LayoutTests/gamepad/gamepad-polling-access.html
@@ -1,117 +1,124 @@
 <head>
 <script>
+testRunner.dumpAsText();
+testRunner.waitUntilDone();
 
-if (window.testRunner) {
-    testRunner.dumpAsText();
-    testRunner.waitUntilDone();
-}
-
-function log(msg)
-{
+function log(msg) {
     document.getElementById("logger").innerHTML += msg + "<br>";
 }
 
-function finishTest()
-{
-    if (testRunner)
-        testRunner.notifyDone();
+/**
+ * @param {Event} evt
+ * @param {string} type
+ */
+function logEvent(evt, type = evt.type) {
+    const { length } = navigator.getGamepads().filter((g) => g);
+    // don't bother printing ongamepadconnected & disconnected
+    if (!type.startsWith("on") || !type.includes("disconnected"))
+        logGamepad(evt.gamepad);
+    log(`${type ?? evt.type} event fired (${length}).`);
 }
 
-function onconnectedEventHandler(evt)
-{
-    const {length} = navigator.getGamepads();
-    log(`onconnectedgamepad event fired (${length}).`);
-}
-
-function ondisconnectedEventHandler(evt)
-{
-    const {length} = navigator.getGamepads().filter(g => g);
-    log(`ondisconnectedgamepad event fired (${length}).`);
-}
-
-function handleGamepadConnect(evt)
-{
-    log("Connecting gamepad:");
-    log(navigator.getGamepads());
-    logGamepad(evt.gamepad);
-    testGenerator.next();
-}
-
-function handleGamepadDisconnect(evt)
-{
-    log("Disconnecting gamepad:");
-    log(navigator.getGamepads());
-    testGenerator.next();
-}
-
-
-function logGamepad(gp)
-{
+function logGamepad(gp) {
     log("Name: " + gp.id);
     log("Index: " + gp.index);
     log("Mapping: " + gp.mapping);
     log("Axes: " + gp.axes);
-    
+
     var buttonString = "";
     for (button in gp.buttons) {
-        buttonString += gp.buttons[button].pressed + "-" + gp.buttons[button].value + " ";
+        buttonString +=
+            gp.buttons[button].pressed +
+            "-" +
+            gp.buttons[button].value +
+            " ";
     }
-    
+
     log("Buttons: " + buttonString);
 }
 
-function* testSteps() {
-    addEventListener("gamepadconnected", handleGamepadConnect);
-    addEventListener("gamepaddisconnected", handleGamepadDisconnect);
+function makeHandlerListenerPair(eventType) {
+    const pHandler = new Promise((resolve) => {
+        const attribute = `ongamepad${eventType}`;
+        const handler = (event) => {
+            logEvent(event, attribute);
+            window[attribute] = null;
+            resolve();
+        };
+        window[attribute] = handler;
+    });
+    const pListener = new Promise((resolve) => {
+        const handler = (event) => {
+            logEvent(event);
+            resolve();
+        };
+        window.addEventListener(`gamepad${eventType}`, handler, {
+            once: true,
+        });
+    });
+    return Promise.all([pListener, pHandler]);
+}
 
-    window.ongamepadconnected = onconnectedEventHandler;
-    window.ongamepaddisconnected = ondisconnectedEventHandler;
-
+async function runTest() {
     log("Initial gamepads length: " + navigator.getGamepads().length);
     log("Connecting 20 different gamepads");
+    // do one at a time...
     for (var i = 0; i < 20; ++i) {
+        const p = makeHandlerListenerPair("connected");
         testRunner.setMockGamepadDetails(i, i, "", i, i);
+        log("Connecting gamepad:");
         testRunner.connectMockGamepad(i);
-        yield;
+        await p;
+        log(navigator.getGamepads().filter((x) => x));
     }
-    
-    log("Verifying there are 20 connected gamepads in the set of all gamepads");
+
+    log(
+        "Verifying there are 20 connected gamepads in the set of all gamepads"
+    );
     var gamepads = navigator.getGamepads();
     log(gamepads);
     for (i in gamepads) {
         logGamepad(gamepads[i]);
     }
 
-    log("Disconnecting gamepads in reverse order, making sure gamepads array remains as expected");
+    log(
+        "Disconnecting gamepads in reverse order, making sure gamepads array remains as expected"
+    );
     for (var i = 19; i >= 0; --i) {
+        const p = makeHandlerListenerPair("disconnected");
+        log("Disconnecting gamepad:");
         testRunner.disconnectMockGamepad(i);
-        yield;
+        await p;
+        log(navigator.getGamepads().filter((x) => x));
     }
 
     log("Checking non-zero'ed details for a gamepad");
 
-    testRunner.setMockGamepadDetails(10, "Awesome Joystick 5000", "standard", 4, 16);
+    testRunner.setMockGamepadDetails(
+        10,
+        "Awesome Joystick 5000",
+        "standard",
+        4,
+        16
+    );
     testRunner.setMockGamepadAxisValue(10, 0, 0.7);
     testRunner.setMockGamepadAxisValue(10, 1, -0.9);
     testRunner.setMockGamepadAxisValue(10, 2, 1.0);
     testRunner.setMockGamepadAxisValue(10, 3, -1.0);
     for (var i = 0; i < 16; ++i)
         testRunner.setMockGamepadButtonValue(10, i, 1.0);
-        
+
+    const p = makeHandlerListenerPair("connected");
     testRunner.connectMockGamepad(10);
-    yield;
-
-    finishTest();
+    await p;
+    const p2 = makeHandlerListenerPair("disconnected");
+    log("Disconnecting final gamepad");
+    testRunner.disconnectMockGamepad(10);
+    await p2;
+    testRunner.notifyDone();
 }
-
-function runTest()
-{
-    testGenerator = testSteps();
-    testGenerator.next();
-}
-
 </script>
 </head>
-<body onload="runTest();">
+<body onload="runTest()">
 <div id="logger"></div>
 </body>

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -387,6 +387,10 @@
 #include "ImageControlsMac.h"
 #endif
 
+#if ENABLE(GAMEPAD)
+#include "MockGamepadProvider.h"
+#endif
+
 using JSC::CallData;
 using JSC::CodeBlock;
 using JSC::FunctionExecutable;
@@ -713,6 +717,10 @@ Internals::Internals(Document& document)
     VP9TestingOverrides::singleton().setHardwareDecoderDisabled(std::nullopt);
     VP9TestingOverrides::singleton().setVP9DecoderDisabled(std::nullopt);
     VP9TestingOverrides::singleton().setVP9ScreenSizeAndScale(std::nullopt);
+#endif
+
+#if ENABLE(GAMEPAD)
+    MockGamepadProvider::singleton().clearMockGamepads();
 #endif
 }
 

--- a/Source/WebCore/testing/MockGamepadProvider.cpp
+++ b/Source/WebCore/testing/MockGamepadProvider.cpp
@@ -149,6 +149,16 @@ void MockGamepadProvider::gamepadInputActivity()
     });
 }
 
+void MockGamepadProvider::clearMockGamepads()
+{
+    // Disconnect any remaining connected gamepads.
+    for (size_t i = 0; i < m_connectedGamepadVector.size(); ++i) {
+        if (m_connectedGamepadVector[i])
+            disconnectMockGamepad(i);
+    }
+    m_mockGamepadVector.clear();
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/testing/MockGamepadProvider.h
+++ b/Source/WebCore/testing/MockGamepadProvider.h
@@ -49,6 +49,7 @@ public:
     bool setMockGamepadButtonValue(unsigned index, unsigned buttonIndex, double value);
     bool connectMockGamepad(unsigned index);
     bool disconnectMockGamepad(unsigned index);
+    void clearMockGamepads();
 
 private:
     MockGamepadProvider();


### PR DESCRIPTION
#### a53135c21ca451c30ae8fe5dfeb3dc7f05377304
<pre>
[WK2] Flaky ASSERTION FAILED: m_gamepads.isEmpty() on gamepad/gamepad-polling-access.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=245051">https://bugs.webkit.org/show_bug.cgi?id=245051</a>
rdar://99802167

Reviewed by Brady Eidson and Chris Dumez.

The MockGamepadProvider was keeping mock gamepads alive after the test
was done, which caused the ASSERT.

This patch makes the MockGamepadProvider clear its list of mock gamepads
when each test is done.

Also modernized the gamepad-polling-access.html test at bit to use
promises when waiting on the events.

* LayoutTests/gamepad/gamepad-polling-access-expected.txt:
* LayoutTests/gamepad/gamepad-polling-access.html:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::Internals):
* Source/WebCore/testing/MockGamepadProvider.cpp:
(WebCore::MockGamepadProvider::clearMockGamepads):
* Source/WebCore/testing/MockGamepadProvider.h:

Canonical link: <a href="https://commits.webkit.org/257345@main">https://commits.webkit.org/257345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/546c91f656dc198dabbd93abb5f373121d185087

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108108 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168360 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85267 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91221 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104369 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33370 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88185 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1820 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1729 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5048 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6674 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42256 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3121 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->