### PR TITLE
[GTK][WPE] Add WebKitWebFormManager and deprecate WebKitWebPage form related signals and WebKitDOMElement

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -202,6 +202,7 @@ set(WebKitWebExtension_HEADER_TEMPLATES
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebExtensionAutocleanups.h.in
+    ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/webkit-web-extension.h.in

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -240,6 +240,7 @@ set(WPE_WEB_EXTENSION_API_HEADER_TEMPLATES
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebExtensionAutocleanups.h.in
+    ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/webkit-web-extension.h.in

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -308,6 +308,7 @@ WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitWebEditor.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp @no-unify
+WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp @no-unify
 

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -261,6 +261,7 @@ WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitWebEditor.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp @no-unify
+WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp @no-unify
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMElement.cpp
@@ -31,6 +31,8 @@
 #include "WebKitDOMEventTarget.h"
 #endif
 
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
+
 namespace WebKit {
 
 WebKitDOMElement* kit(WebCore::Element* obj)
@@ -58,9 +60,7 @@ WebKitDOMElement* wrapElement(WebCore::Element* coreObject)
 } // namespace WebKit
 
 #if PLATFORM(GTK)
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 G_DEFINE_TYPE_WITH_CODE(WebKitDOMElement, webkit_dom_element, WEBKIT_DOM_TYPE_NODE, G_IMPLEMENT_INTERFACE(WEBKIT_DOM_TYPE_EVENT_TARGET, webkitDOMElementDOMEventTargetInit))
-G_GNUC_END_IGNORE_DEPRECATIONS;
 #else
 G_DEFINE_TYPE(WebKitDOMElement, webkit_dom_element, WEBKIT_DOM_TYPE_NODE)
 #endif
@@ -86,6 +86,8 @@ static void webkit_dom_element_init(WebKitDOMElement*)
  * Returns: whether @element has been edited by a user action.
  *
  * Since: 2.22
+ *
+ * Deprecated: 2.40: Use webkit_web_form_manager_input_element_is_user_edited() instead.
  */
 gboolean webkit_dom_element_html_input_element_is_user_edited(WebKitDOMElement* element)
 {
@@ -102,7 +104,7 @@ gboolean webkit_dom_element_html_input_element_is_user_edited(WebKitDOMElement* 
 }
 
 /**
- * webkit_dom_element_is_html_input_element_auto_filled:
+ * webkit_dom_element_html_input_element_get_auto_filled:
  * @element: a #WebKitDOMElement
  *
  * Get whether the element is an HTML input element that has been filled automatically.
@@ -110,6 +112,8 @@ gboolean webkit_dom_element_html_input_element_is_user_edited(WebKitDOMElement* 
  * Returns: whether @element has been filled automatically.
  *
  * Since: 2.22
+ *
+ * Deprecated: 2.40: Use webkit_web_form_manager_input_element_is_auto_filled() instead.
  */
 gboolean webkit_dom_element_html_input_element_get_auto_filled(WebKitDOMElement* element)
 {
@@ -131,6 +135,8 @@ gboolean webkit_dom_element_html_input_element_get_auto_filled(WebKitDOMElement*
  * If @element is not an HTML input element this function does nothing.
  *
  * Since: 2.22
+ *
+ * Deprecated: 2.40: Use webkit_web_form_manager_input_element_auto_fill() instead.
  */
 void webkit_dom_element_html_input_element_set_auto_filled(WebKitDOMElement* element, gboolean autoFilled)
 {
@@ -153,6 +159,8 @@ void webkit_dom_element_html_input_element_set_auto_filled(WebKitDOMElement* ele
  * element this function does nothing.
  *
  * Since: 2.22
+ *
+ * Deprecated: 2.40: Use webkit_web_form_manager_input_element_auto_fill() instead.
  */
 void webkit_dom_element_html_input_element_set_editing_value(WebKitDOMElement* element, const char* value)
 {
@@ -164,3 +172,5 @@ void webkit_dom_element_html_input_element_set_editing_value(WebKitDOMElement* e
 
     downcast<WebCore::HTMLInputElement>(*node).setValueForUser(String::fromUTF8(value));
 }
+
+G_GNUC_END_IGNORE_DEPRECATIONS;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2,1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebKitWebFormManager.h"
+
+#include "WebKitWebFormManagerPrivate.h"
+#include <JavaScriptCore/APICast.h>
+#include <WebCore/HTMLInputElement.h>
+#include <WebCore/HTMLTextAreaElement.h>
+#include <WebCore/JSNode.h>
+#include <jsc/JSCContextPrivate.h>
+#include <jsc/JSCValuePrivate.h>
+
+using namespace WebCore;
+
+/**
+ * WebKitWebFormManager:
+ *
+ * Form manager of a #WebKitWebPage in a #WebKitScriptWorld
+ *
+ * Since: 2.40
+ */
+
+enum {
+    FORM_CONTROLS_ASSOCIATED,
+    WILL_SEND_SUBMIT_EVENT,
+    WILL_SUBMIT_FORM,
+
+    LAST_SIGNAL
+};
+
+static guint signals[LAST_SIGNAL] = { 0, };
+
+G_DEFINE_TYPE(WebKitWebFormManager, webkit_web_form_manager, G_TYPE_OBJECT)
+
+static void webkit_web_form_manager_init(WebKitWebFormManager*)
+{
+}
+
+static void webkit_web_form_manager_class_init(WebKitWebFormManagerClass* klass)
+{
+    /**
+     * WebKitWebFormManager::form-controls-associated:
+     * @form_manager: the #WebKitWebFormManager on which the signal is emitted
+     * @frame: a #WebKitFrame
+     * @elements: (element-type JSCValue) (transfer none): a #GPtrArray of
+     *     #JSCValue with the list of forms in the page
+     *
+     * Emitted after form elements (or form associated elements) are associated to @frame.
+     * This is useful to implement form auto filling for web pages where form fields are added
+     * dynamically. This signal might be emitted multiple times for the same frame.
+     *
+     * Note that this signal could be also emitted when form controls are moved between forms. In
+     * that case, the @elements array carries the list of those elements which have moved.
+     *
+     * Clients should take a reference to the members of the @elements array if it is desired to
+     * keep them alive after the signal handler returns.
+     *
+     * Since: 2.40
+     */
+    signals[FORM_CONTROLS_ASSOCIATED] = g_signal_new(
+        "form-controls-associated",
+        G_TYPE_FROM_CLASS(klass),
+        G_SIGNAL_RUN_LAST,
+        0, 0, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_NONE, 2,
+        WEBKIT_TYPE_FRAME,
+        G_TYPE_PTR_ARRAY);
+
+    /**
+     * WebKitWebFormManager::will-send-submit-event:
+     * @form_manager: the #WebKitWebFormManager on which the signal is emitted
+     * @form: the #JSCValue to be submitted, which will always correspond to an HTMLFormElement
+     * @source_frame: the #WebKitFrame containing the form to be submitted
+     * @target_frame: the #WebKitFrame containing the form's target,
+     *     which may be the same as @source_frame if no target was specified
+     *
+     * This signal is emitted when the DOM submit event is about to be fired for @form.
+     * JavaScript code may rely on the submit event to detect that the user has clicked
+     * on a submit button, and to possibly cancel the form submission before
+     * #WebKitWebFormManager::will-submit-form signal is emitted.
+     * However, beware that, for historical reasons, the submit event is not emitted at
+     * all if the form submission is triggered by JavaScript. For these reasons,
+     * this signal may not be used to reliably detect whether a form will be submitted.
+     * Instead, use it to detect if a user has clicked on a form's submit button even if
+     * JavaScript later cancels the form submission, or to read the values of the form's
+     * fields even if JavaScript later clears certain fields before submitting. This may
+     * be needed, for example, to implement a robust browser password manager, as some
+     * misguided websites may use such techniques to attempt to thwart password managers.
+     *
+     * Since: 2.40
+     */
+    signals[WILL_SEND_SUBMIT_EVENT] = g_signal_new(
+        "will-send-submit-event",
+        G_TYPE_FROM_CLASS(klass),
+        G_SIGNAL_RUN_LAST,
+        0, 0, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_NONE, 3,
+        JSC_TYPE_VALUE,
+        WEBKIT_TYPE_FRAME,
+        WEBKIT_TYPE_FRAME);
+
+    /**
+     * WebKitWebFormManager::will-submit-form:
+     * @form_manager: the #WebKitWebFormManager on which the signal is emitted
+     * @form: the #JSCValue to be submitted, which will always correspond to an HTMLFormElement
+     * @source_frame: the #WebKitFrame containing the form to be submitted
+     * @target_frame: the #WebKitFrame containing the form's target,
+     *     which may be the same as @source_frame if no target was specified
+     *
+     * This signal is emitted when @form will imminently be submitted. It can no longer
+     * be cancelled. This event always occurs immediately before a form is submitted to
+     * its target, so use this event to reliably detect when a form is submitted. This
+     * signal is emitted after #WebKitWebFormManager::will-send-submit-event if that
+     * signal is emitted.
+     *
+     * Since: 2.40
+     */
+    signals[WILL_SUBMIT_FORM] = g_signal_new(
+        "will-submit-form",
+        G_TYPE_FROM_CLASS(klass),
+        G_SIGNAL_RUN_LAST,
+        0, 0, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_NONE, 3,
+        JSC_TYPE_VALUE,
+        WEBKIT_TYPE_FRAME,
+        WEBKIT_TYPE_FRAME);
+}
+
+WebKitWebFormManager* webkitWebFormManagerCreate()
+{
+    return WEBKIT_WEB_FORM_MANAGER(g_object_new(WEBKIT_TYPE_WEB_FORM_MANAGER, nullptr));
+}
+
+void webkitWebFormManagerDidAssociateFormControls(WebKitWebFormManager* formManager, WebKitFrame* frame, Vector<GRefPtr<JSCValue>>&& elements)
+{
+    GRefPtr<GPtrArray> formElements = adoptGRef(g_ptr_array_sized_new(elements.size()));
+    for (const auto& element : elements)
+        g_ptr_array_add(formElements.get(), element.get());
+    g_signal_emit(formManager, signals[FORM_CONTROLS_ASSOCIATED], 0, frame, formElements.get());
+}
+
+void webkitWebFormManagerWillSendSubmitEvent(WebKitWebFormManager* formManager, GRefPtr<JSCValue>&& form, WebKitFrame* sourceFrame, WebKitFrame* targetFrame)
+{
+    g_signal_emit(formManager, signals[WILL_SEND_SUBMIT_EVENT], 0, form.get(), sourceFrame, targetFrame);
+}
+
+void webkitWebFormManagerWillSubmitForm(WebKitWebFormManager* formManager, GRefPtr<JSCValue>&& form, WebKitFrame* sourceFrame, WebKitFrame* targetFrame)
+{
+    g_signal_emit(formManager, signals[WILL_SUBMIT_FORM], 0, form.get(), sourceFrame, targetFrame);
+}
+
+static Node* nodeForJSCValue(JSCValue* value)
+{
+    auto* jsObject = JSValueToObject(jscContextGetJSContext(jsc_value_get_context(value)), jscValueGetJSValue(value), nullptr);
+    return jsObject ? JSNode::toWrapped(toJS(jsObject)->vm(), toJS(jsObject)) : nullptr;
+}
+
+/**
+ * webkit_web_form_manager_input_element_is_user_edited:
+ * @element: a #JSCValue
+ *
+ * Get whether @element is an HTML text input element that has been edited by a user action.
+ *
+ * Returns: %TRUE if @element is an HTML text input element that has been edited by a user action,
+ *    or %FALSE otherwise
+ *
+ * Since: 2.40
+ */
+gboolean webkit_web_form_manager_input_element_is_user_edited(JSCValue* element)
+{
+    g_return_val_if_fail(JSC_IS_VALUE(element), FALSE);
+    g_return_val_if_fail(jsc_value_is_object(element), FALSE);
+
+    auto* node = nodeForJSCValue(element);
+    if (is<HTMLInputElement>(node))
+        return downcast<HTMLInputElement>(*node).lastChangeWasUserEdit();
+
+    if (is<HTMLTextAreaElement>(node))
+        return downcast<HTMLTextAreaElement>(*node).lastChangeWasUserEdit();
+
+    return FALSE;
+}
+
+/**
+ * webkit_web_form_manager_input_element_auto_fill:
+ * @element: a #JSCValue
+ * @value: the text to set
+ *
+ * Set the value of an HTML input element as if it had been edited by
+ * the user, triggering a change event, and set it as filled automatically.
+ * If @element is not an HTML input element this function does nothing.
+ *
+ * Since: 2.40
+ */
+void webkit_web_form_manager_input_element_auto_fill(JSCValue* element, const char* value)
+{
+    g_return_if_fail(JSC_IS_VALUE(element));
+    g_return_if_fail(jsc_value_is_object(element));
+
+    auto* node = nodeForJSCValue(element);
+    if (!is<WebCore::HTMLInputElement>(node))
+        return;
+
+    auto& inputElement = downcast<WebCore::HTMLInputElement>(*node);
+    inputElement.setAutoFilled(true);
+    inputElement.setValueForUser(String::fromUTF8(value));
+}
+
+/**
+ * webkit_web_form_manager_input_element_is_auto_filled:
+ * @element: a #JSCValue
+ *
+ * Get whether @element is an HTML input element that has been filled automatically.
+ *
+ * Returns: %TRUE if @element is an HTML input element that has been filled automatically,
+ *    or %FALSE otherwise
+ *
+ * Since: 2.40
+ */
+gboolean webkit_web_form_manager_input_element_is_auto_filled(JSCValue* element)
+{
+    g_return_val_if_fail(JSC_IS_VALUE(element), FALSE);
+    g_return_val_if_fail(jsc_value_is_object(element), FALSE);
+
+    auto* node = nodeForJSCValue(element);
+    return is<WebCore::HTMLInputElement>(node) ? downcast<WebCore::HTMLInputElement>(*node).isAutoFilled() : FALSE;
+}

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.h.in
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2,1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+@INJECTED_BUNDLE_API_SINGLE_HEADER_CHECK@
+
+#ifndef WebKitWebFormManager_h
+#define WebKitWebFormManager_h
+
+#include <glib-object.h>
+#include <jsc/jsc.h>
+#include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
+
+G_BEGIN_DECLS
+
+#define WEBKIT_TYPE_WEB_FORM_MANAGER            (webkit_web_form_manager_get_type())
+#define WEBKIT_WEB_FORM_MANAGER(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_WEB_FORM_MANAGER, WebKitWebFormManager))
+#define WEBKIT_IS_WEB_FORM_MANAGER(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_WEB_FORM_MANAGER))
+#define WEBKIT_WEB_FORM_MANAGER_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_WEB_FORM_MANAGER, WebKitWebFormManagerClass))
+#define WEBKIT_IS_WEB_FORM_MANAGER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_WEB_FORM_MANAGER))
+#define WEBKIT_WEB_FORM_MANAGER_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_WEB_FORM_MANAGER, WebKitWebFormManagerClass))
+
+typedef struct _WebKitWebFormManager        WebKitWebFormManager;
+typedef struct _WebKitWebFormManagerClass   WebKitWebFormManagerClass;
+
+struct _WebKitWebFormManager {
+    GObject parent;
+};
+
+struct _WebKitWebFormManagerClass {
+    GObjectClass parent_class;
+};
+
+WEBKIT_API GType
+webkit_web_form_manager_get_type                     (void);
+
+WEBKIT_API gboolean
+webkit_web_form_manager_input_element_is_user_edited (JSCValue             *element);
+
+WEBKIT_API void
+webkit_web_form_manager_input_element_auto_fill      (JSCValue             *element,
+                                                      const char           *value);
+
+WEBKIT_API gboolean
+webkit_web_form_manager_input_element_is_auto_filled (JSCValue             *element);
+
+G_END_DECLS
+
+#endif

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManagerPrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManagerPrivate.h
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) 2013 Igalia S.L.
+ * Copyright (C) 2022 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public
+ * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * version 2,1 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -19,15 +19,13 @@
 
 #pragma once
 
-#include "WebFrame.h"
 #include "WebKitFrame.h"
-#include "WebKitScriptWorld.h"
-#include <WebCore/Element.h>
-#include <wtf/RefPtr.h>
+#include "WebKitWebFormManager.h"
+#include <jsc/jsc.h>
 #include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
 
-WebKitFrame* webkitFrameCreate(WebKit::WebFrame*);
-WebKit::WebFrame* webkitFrameGetWebFrame(WebKitFrame*);
-GRefPtr<JSCValue> webkitFrameGetJSCValueForElementInWorld(WebKitFrame*, WebCore::Element&, WebKitScriptWorld*);
-Vector<GRefPtr<JSCValue>> webkitFrameGetJSCValuesForElementsInWorld(WebKitFrame*, const Vector<RefPtr<WebCore::Element>>&, WebKitScriptWorld*);
+WebKitWebFormManager* webkitWebFormManagerCreate();
+void webkitWebFormManagerDidAssociateFormControls(WebKitWebFormManager*, WebKitFrame*, Vector<GRefPtr<JSCValue>>&&);
+void webkitWebFormManagerWillSendSubmitEvent(WebKitWebFormManager*, GRefPtr<JSCValue>&&, WebKitFrame*, WebKitFrame*);
+void webkitWebFormManagerWillSubmitForm(WebKitWebFormManager*, GRefPtr<JSCValue>&&, WebKitFrame*, WebKitFrame*);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in
@@ -27,6 +27,7 @@
 #include <@API_INCLUDE_PREFIX@/WebKitFrame.h>
 #include <@API_INCLUDE_PREFIX@/WebKitUserMessage.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebEditor.h>
+#include <@API_INCLUDE_PREFIX@/WebKitWebFormManager.h>
 
 #if PLATFORM(GTK)
 #include <webkitdom/webkitdom.h>
@@ -61,6 +62,8 @@ typedef struct _WebKitWebEditor      WebKitWebEditor;
  * #WebKitWebPage::will-submit-form.
  *
  * Since: 2.20
+ *
+ * Deprecated: 2.40
  */
 typedef enum {
     WEBKIT_FORM_SUBMISSION_WILL_SEND_DOM_EVENT,
@@ -95,6 +98,10 @@ webkit_web_page_get_main_frame              (WebKitWebPage *web_page);
 
 WEBKIT_API WebKitWebEditor *
 webkit_web_page_get_editor                  (WebKitWebPage *web_page);
+
+WEBKIT_API WebKitWebFormManager *
+webkit_web_page_get_form_manager            (WebKitWebPage     *web_page,
+                                             WebKitScriptWorld *world);
 
 WEBKIT_API void
 webkit_web_page_send_message_to_view        (WebKitWebPage      *web_page,

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/webkit-web-extension.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/webkit-web-extension.h.in
@@ -48,6 +48,7 @@
 #include <@API_INCLUDE_PREFIX@/WebKitVersion.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebEditor.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebExtension.h>
+#include <@API_INCLUDE_PREFIX@/WebKitWebFormManager.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebHitTestResult.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebPage.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebProcessEnumTypes.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMElement.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMElement.h
@@ -45,19 +45,19 @@ struct _WebKitDOMElementClass {
     WebKitDOMNodeClass parent_class;
 };
 
-WEBKIT_API GType
+WEBKIT_DEPRECATED GType
 webkit_dom_element_get_type                             (void);
 
-WEBKIT_API gboolean
+WEBKIT_DEPRECATED_FOR(webkit_web_form_manager_input_element_is_user_edited) gboolean
 webkit_dom_element_html_input_element_is_user_edited    (WebKitDOMElement *element);
 
-WEBKIT_API gboolean
+WEBKIT_DEPRECATED_FOR(webkit_web_form_manager_input_element_is_auto_filled) gboolean
 webkit_dom_element_html_input_element_get_auto_filled   (WebKitDOMElement *element);
 
-WEBKIT_API void
+WEBKIT_DEPRECATED_FOR(webkit_web_form_manager_input_element_auto_fill) void
 webkit_dom_element_html_input_element_set_auto_filled   (WebKitDOMElement *element,
                                                          gboolean          auto_filled);
-WEBKIT_API void
+WEBKIT_DEPRECATED_FOR(webkit_web_form_manager_input_element_auto_fill) void
 webkit_dom_element_html_input_element_set_editing_value (WebKitDOMElement *element,
                                                          const char       *value);
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/wpe/DOM/WebKitDOMElement.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/wpe/DOM/WebKitDOMElement.h
@@ -48,19 +48,19 @@ struct _WebKitDOMElementClass {
     WebKitDOMNodeClass parent_class;
 };
 
-WEBKIT_API GType
+WEBKIT_DEPRECATED GType
 webkit_dom_element_get_type                             (void);
 
-WEBKIT_API gboolean
+WEBKIT_DEPRECATED_FOR(webkit_web_form_manager_input_element_is_user_edited) gboolean
 webkit_dom_element_html_input_element_is_user_edited    (WebKitDOMElement *element);
 
-WEBKIT_API gboolean
+WEBKIT_DEPRECATED_FOR(webkit_web_form_manager_input_element_is_auto_filled) gboolean
 webkit_dom_element_html_input_element_get_auto_filled   (WebKitDOMElement *element);
 
-WEBKIT_API void
+WEBKIT_DEPRECATED_FOR(webkit_web_form_manager_input_element_auto_fill) void
 webkit_dom_element_html_input_element_set_auto_filled   (WebKitDOMElement *element,
                                                          gboolean          auto_filled);
-WEBKIT_API void
+WEBKIT_DEPRECATED_FOR(webkit_web_form_manager_input_element_auto_fill) void
 webkit_dom_element_html_input_element_set_editing_value (WebKitDOMElement *element,
                                                          const char       *value);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/DOMElementTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/DOMElementTest.cpp
@@ -42,27 +42,21 @@ private:
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsInputElement.get()));
         g_assert_true(jsc_value_is_object(jsInputElement.get()));
         g_assert_true(jsc_value_object_is_instance_of(jsInputElement.get(), "HTMLInputElement"));
+        g_assert_false(webkit_web_form_manager_input_element_is_auto_filled(jsInputElement.get()));
 
-        auto* node = webkit_dom_node_for_js_value(jsInputElement.get());
-        g_assert_true(WEBKIT_DOM_IS_NODE(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
-
-        auto* element = WEBKIT_DOM_ELEMENT(node);
-        g_assert_false(webkit_dom_element_html_input_element_get_auto_filled(element));
         GRefPtr<JSCValue> value = adoptGRef(jsc_value_object_get_property(jsInputElement.get(), "value"));
         g_assert_true(JSC_IS_VALUE(value.get()));
         g_assert_true(jsc_value_is_string(value.get()));
         GUniquePtr<char> valueString(jsc_value_to_string(value.get()));
         g_assert_cmpstr(valueString.get(), ==, "");
 
-        webkit_dom_element_html_input_element_set_editing_value(element, "auto filled value");
-        webkit_dom_element_html_input_element_set_auto_filled(element, TRUE);
+        webkit_web_form_manager_input_element_auto_fill(jsInputElement.get(), "auto filled value");
         value = adoptGRef(jsc_value_object_get_property(jsInputElement.get(), "value"));
         g_assert_true(JSC_IS_VALUE(value.get()));
         g_assert_true(jsc_value_is_string(value.get()));
         valueString.reset(jsc_value_to_string(value.get()));
         g_assert_cmpstr(valueString.get(), ==, "auto filled value");
-        g_assert_true(webkit_dom_element_html_input_element_get_auto_filled(element));
+        g_assert_true(webkit_web_form_manager_input_element_is_auto_filled(jsInputElement.get()));
 
         return true;
     }

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -101,9 +101,6 @@
             "/webkit/WebKitWebExtension/form-submission-steps": {
                 "expected": {"all": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/205333"}}
             },
-            "/webkit/WebKitWebExtension/form-controls-associated-signal": {
-                "expected": {"gtk": {"status": ["FAIL", "PASS"], "bug": "webkit.org/b/205380"}}
-            },
             "/webkit/WebKitWebExtension/user-messages": {
                 "expected": {
                     "gtk": {"status": ["FAIL", "TIMEOUT", "PASS"], "bug": "webkit.org/b/211336"},


### PR DESCRIPTION
#### 81f661ea4d757aa254c322965cba2c1e7881491f
<pre>
[GTK][WPE] Add WebKitWebFormManager and deprecate WebKitWebPage form related signals and WebKitDOMElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=248657">https://bugs.webkit.org/show_bug.cgi?id=248657</a>

Reviewed by Michael Catanzaro.

Move the form signals from WebKitWebPage to WebKitWebFormManager that no longer uses WebKitDOMElement, but JSCValue.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMElement.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp:
(webkitFrameGetJSCValueForElementInWorld):
(webkitFrameGetJSCValuesForElementsInWorld):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFramePrivate.h:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp: Added.
(webkit_web_form_manager_class_init):
(webkitWebFormManagerCreate):
(webkitWebFormManagerDidAssociateFormControls):
(webkitWebFormManagerWillSendSubmitEvent):
(webkitWebFormManagerWillSubmitForm):
(nodeForJSCValue):
(webkit_web_form_manager_input_element_is_user_edited):
(webkit_web_form_manager_input_element_auto_fill):
(webkit_web_form_manager_input_element_is_auto_filled):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.h.in: Added.
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManagerPrivate.h: Added.
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp:
(worldDestroyed):
(webkitWebPageDispose):
(webkit_web_page_class_init):
(webkit_web_page_get_form_manager):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/webkit-web-extension.h.in:
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMElement.h:
* Tools/TestWebKitAPI/Tests/WebKitGLib/DOMElementTest.cpp:
(DOMElementTest::testAutoFill):
* Tools/TestWebKitAPI/Tests/WebKitGLib/FrameTest.cpp:
(WebKitFrameTest::testJavaScriptValues):
(WebKitFrameTest::willSubmitFormCallback):
(WebKitFrameTest::testSubframe):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebExtensions.cpp:
(didAssociateFormControlsCallback):
(testWebExtensionFormControlsAssociated):
* Tools/TestWebKitAPI/Tests/WebKitGLib/WebExtensionTest.cpp:
(formControlsAssociatedForFrameCallback):
(formControlsAssociatedCallback):
(willSubmitFormDeprecatedCallback):
(handleFormSubmissionCallback):
(willSendSubmitEventCallback):
(willSubmitFormCallback):
(pageCreatedCallback):
(windowObjectCleared):
(methodCallCallback):
(webkit_web_extension_initialize_with_user_data):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/257366@main">https://commits.webkit.org/257366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f1cfbbf57e8c0b0d03c59d9d2937746b995a478

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108166 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168420 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85329 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91278 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106083 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104432 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89991 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33414 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21334 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1878 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22863 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1785 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42318 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2544 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->