### PR TITLE
[fetch] Add Initiator associated with a resource request

### DIFF
--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -919,6 +919,11 @@ size_t HTMLImageElement::pendingDecodePromisesCountForTesting() const
     return m_imageLoader->pendingDecodePromisesCountForTesting();
 }
 
+bool HTMLImageElement::usesSrcsetOrPicture() const
+{
+    return !attributeWithoutSynchronization(srcsetAttr).isNull() || !!pictureElement();
+}
+
 AtomString HTMLImageElement::srcsetForBindings() const
 {
     return getAttributeForBindings(srcsetAttr);

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -141,6 +141,8 @@ public:
     AtomString srcsetForBindings() const;
     void setSrcsetForBindings(const AtomString&);
 
+    bool usesSrcsetOrPicture() const;
+
     const AtomString& loadingForBindings() const;
     void setLoadingForBindings(const AtomString&);
 

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -191,8 +191,12 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
         options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
         options.serviceWorkersMode = is<HTMLPlugInElement>(element()) ? ServiceWorkersMode::None : ServiceWorkersMode::All;
         bool isImageElement = is<HTMLImageElement>(element());
-        if (isImageElement)
-            options.referrerPolicy = downcast<HTMLImageElement>(element()).referrerPolicy();
+        if (isImageElement) {
+            auto& imageElement = downcast<HTMLImageElement>(element());
+            options.referrerPolicy = imageElement.referrerPolicy();
+            if (imageElement.usesSrcsetOrPicture())
+                options.initiator = Initiator::Imageset;
+        }
 
         auto crossOriginAttribute = element().attributeWithoutSynchronization(HTMLNames::crossoriginAttr);
 

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -113,6 +113,18 @@ enum class InitiatorContext : uint8_t {
 };
 static constexpr unsigned bitWidthOfInitiatorContext = 1;
 
+// https://fetch.spec.whatwg.org/#concept-request-initiator
+enum class Initiator : uint8_t {
+    EmptyString,
+    Download,
+    Imageset,
+    Manifest,
+    Prefetch,
+    Prerender,
+    Xslt
+};
+static constexpr unsigned bitWidthOfInitiator = 3;
+
 enum class ServiceWorkersMode : uint8_t {
     All,
     None,
@@ -171,6 +183,7 @@ struct ResourceLoaderOptions : public FetchOptions {
         , cachingPolicy(CachingPolicy::AllowCaching)
         , sameOriginDataURLFlag(SameOriginDataURLFlag::Unset)
         , initiatorContext(InitiatorContext::Document)
+        , initiator(Initiator::EmptyString)
         , serviceWorkersMode(ServiceWorkersMode::All)
         , applicationCacheMode(ApplicationCacheMode::Use)
         , clientCredentialPolicy(ClientCredentialPolicy::CannotAskClientForCredentials)
@@ -192,6 +205,7 @@ struct ResourceLoaderOptions : public FetchOptions {
         , cachingPolicy(cachingPolicy)
         , sameOriginDataURLFlag(SameOriginDataURLFlag::Unset)
         , initiatorContext(InitiatorContext::Document)
+        , initiator(Initiator::EmptyString)
         , serviceWorkersMode(ServiceWorkersMode::All)
         , applicationCacheMode(ApplicationCacheMode::Use)
         , clientCredentialPolicy(credentialPolicy)
@@ -226,6 +240,7 @@ struct ResourceLoaderOptions : public FetchOptions {
     CachingPolicy cachingPolicy : bitWidthOfCachingPolicy;
     SameOriginDataURLFlag sameOriginDataURLFlag : bitWidthOfSameOriginDataURLFlag;
     InitiatorContext initiatorContext : bitWidthOfInitiatorContext;
+    Initiator initiator : bitWidthOfInitiator;
     ServiceWorkersMode serviceWorkersMode : bitWidthOfServiceWorkersMode;
     ApplicationCacheMode applicationCacheMode : bitWidthOfApplicationCacheMode;
     ClientCredentialPolicy clientCredentialPolicy : bitWidthOfClientCredentialPolicy;

--- a/Source/WebCore/loader/ThreadableLoader.cpp
+++ b/Source/WebCore/loader/ThreadableLoader.cpp
@@ -93,6 +93,7 @@ ThreadableLoaderOptions ThreadableLoaderOptions::isolatedCopy() const
     copy.cachingPolicy = this->cachingPolicy;
     copy.sameOriginDataURLFlag = this->sameOriginDataURLFlag;
     copy.initiatorContext = this->initiatorContext;
+    copy.initiator = this->initiator;
     copy.clientCredentialPolicy = this->clientCredentialPolicy;
     copy.maxRedirectCount = this->maxRedirectCount;
     copy.preflightPolicy = this->preflightPolicy;


### PR DESCRIPTION
#### f2cf9958d49b88d049bbdcbe60abdc00731910c3
<pre>
[fetch] Add Initiator associated with a resource request
<a href="https://bugs.webkit.org/show_bug.cgi?id=248623">https://bugs.webkit.org/show_bug.cgi?id=248623</a>
rdar://problem/102872475

Reviewed by Youenn Fablet.

A resource request may have an &quot;initiator&quot; [0] associated with it. This value
is used in various situation for making security-related decisions. For
example, when loading mixed content, an image may be blocked [1] if it uses a
srcset or if it&apos;s a child of a picture element [2]. In this patch, minimal
support is added by defining ResourceLoaderOptions::Initiator and applying
ResourceLoaderOptions::Initiator::Imageset.

[0] <a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a>
[1] <a href="https://www.w3.org/TR/mixed-content/#category-upgradeable">https://www.w3.org/TR/mixed-content/#category-upgradeable</a>
[2] <a href="https://html.spec.whatwg.org/#use-srcset-or-picture">https://html.spec.whatwg.org/#use-srcset-or-picture</a>

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::usesSrcsetOrPicture const):
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement):
* Source/WebCore/loader/ResourceLoaderOptions.h:
(WebCore::ResourceLoaderOptions::ResourceLoaderOptions):
* Source/WebCore/loader/ThreadableLoader.cpp:
(WebCore::ThreadableLoaderOptions::isolatedCopy const):

Canonical link: <a href="https://commits.webkit.org/258343@main">https://commits.webkit.org/258343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbc3804268ce5dbd2dff5953c3b32d087a17db57

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108596 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168843 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85735 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91708 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106534 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33774 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76641 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2295 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23193 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45595 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42666 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5720 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3664 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->