### PR TITLE
Add _WKWebExtensionControllerConfiguration to control extension storage.

### DIFF
--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -53,6 +53,7 @@ extern "C" {
     M(DiskPersistency) \
     M(DragAndDrop) \
     M(EME) \
+    M(Extensions) \
     M(Fullscreen) \
     M(Gamepad) \
     M(IPC) \

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -78,7 +78,4 @@ NSString *escapeCharactersInString(NSString *, NSString *charactersToEscape);
 NSDate *toAPI(const WallTime&);
 WallTime toImpl(NSDate *);
 
-NSUUID *toAPI(const UUID&);
-UUID toImpl(NSUUID *);
-
 } // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -213,24 +213,6 @@ NSString *escapeCharactersInString(NSString *string, NSString *charactersToEscap
     return result;
 }
 
-NSUUID *toAPI(const UUID& uuid)
-{
-    if (!uuid)
-        return nil;
-
-    return [[NSUUID alloc] initWithUUIDBytes:uuid.toSpan().data()];
-}
-
-UUID toImpl(NSUUID *uuid)
-{
-    if (!uuid)
-        return UUID(UInt128 { 0 });
-
-    uuid_t bytes;
-    [uuid getUUIDBytes:bytes];
-    return UUID(bytes);
-}
-
 NSDate *toAPI(const WallTime& time)
 {
     if (std::isnan(time))

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -175,6 +175,7 @@ public:
         WebExtension,
         WebExtensionContext,
         WebExtensionController,
+        WebExtensionControllerConfiguration,
         WebExtensionMatchPattern,
 #endif
         WebResourceLoadStatisticsManager,
@@ -429,6 +430,7 @@ template<> struct EnumTraits<API::Object::Type> {
         API::Object::Type::WebExtension,
         API::Object::Type::WebExtensionContext,
         API::Object::Type::WebExtensionController,
+        API::Object::Type::WebExtensionControllerConfiguration,
         API::Object::Type::WebExtensionMatchPattern,
 #endif
         API::Object::Type::WebResourceLoadStatisticsManager,

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -106,6 +106,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 #import "_WKWebExtensionContextInternal.h"
+#import "_WKWebExtensionControllerConfigurationInternal.h"
 #import "_WKWebExtensionControllerInternal.h"
 #import "_WKWebExtensionInternal.h"
 #import "_WKWebExtensionMatchPatternInternal.h"
@@ -409,6 +410,10 @@ void* Object::newObject(size_t size, Type type)
 
     case Type::WebExtensionController:
         wrapper = [_WKWebExtensionController alloc];
+        break;
+
+    case Type::WebExtensionControllerConfiguration:
+        wrapper = [_WKWebExtensionControllerConfiguration alloc];
         break;
 
     case Type::WebExtensionMatchPattern:

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -543,6 +543,7 @@ UIProcess/Downloads/DownloadProxyMap.cpp
 
 UIProcess/Extensions/WebExtensionContext.cpp
 UIProcess/Extensions/WebExtensionController.cpp
+UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
 
 UIProcess/Gamepad/UIGamepad.cpp
 UIProcess/Gamepad/UIGamepadProvider.cpp

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -121,7 +121,7 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     LazyInitialized<RetainPtr<WKPreferences>> _preferences;
     LazyInitialized<RetainPtr<WKUserContentController>> _userContentController;
 #if ENABLE(WK_WEB_EXTENSIONS)
-    LazyInitialized<RetainPtr<_WKWebExtensionController>> _webExtensionController;
+    RetainPtr<_WKWebExtensionController> _webExtensionController;
     WeakObjCPtr<_WKWebExtensionController> _weakWebExtensionController;
 #endif
     LazyInitialized<RetainPtr<_WKVisitedLinkStore>> _visitedLinkStore;
@@ -393,7 +393,7 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
 #endif
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-    if (auto *controller = self->_webExtensionController.peek())
+    if (auto *controller = self->_webExtensionController.get())
         configuration._webExtensionController = controller;
 
     if (auto controller = self->_weakWebExtensionController.get())
@@ -506,27 +506,25 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
 - (_WKWebExtensionController *)_strongWebExtensionController
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
-    return _webExtensionController.peek();
+    return _webExtensionController.get();
 #else
-    return nullptr;
+    return nil;
 #endif
 }
 
 - (_WKWebExtensionController *)_webExtensionController
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
-    return self._weakWebExtensionController ?: _webExtensionController.get([] {
-        return adoptNS([[_WKWebExtensionController alloc] init]);
-    });
+    return self._weakWebExtensionController ?: _webExtensionController.get();
 #else
-    return nullptr;
+    return nil;
 #endif
 }
 
 - (void)_setWebExtensionController:(_WKWebExtensionController *)webExtensionController
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
-    _webExtensionController.set(webExtensionController);
+    _webExtensionController = webExtensionController;
 #endif
 }
 
@@ -535,7 +533,7 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
 #if ENABLE(WK_WEB_EXTENSIONS)
     return _weakWebExtensionController.getAutoreleased();
 #else
-    return nullptr;
+    return nil;
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
@@ -29,6 +29,7 @@
 
 @class _WKWebExtension;
 @class _WKWebExtensionContext;
+@class _WKWebExtensionControllerConfiguration;
 @protocol _WKWebExtensionControllerDelegate;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -41,8 +42,34 @@ NS_ASSUME_NONNULL_BEGIN
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @interface _WKWebExtensionController : NSObject
 
+/*!
+ @abstract Returns a web extension controller initialized with the default configuration.
+ @result An initialized web extension controller, or nil if the object could not be initialized.
+ @discussion This is a designated initializer. You can use @link -initWithConfiguration: @/link to
+ initialize an instance with a configuration.
+ @seealso initWithConfiguration:
+*/
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+/*!
+ @abstract Returns a web extension controller initialized with the specified configuration.
+ @param configuration The configuration for the new web extension controller.
+ @result An initialized web extension controller, or nil if the object could not be initialized.
+ @discussion This is a designated initializer. You can use @link -init: @/link to initialize an
+ instance with the default configuration. The initializer copies the specified configuration, so mutating
+ the configuration after invoking the initializer has no effect on the web extension controller.
+ @seealso init
+*/
+- (instancetype)initWithConfiguration:(_WKWebExtensionControllerConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
+
 /*! @abstract The extension controller delegate. */
 @property (nonatomic, weak) id <_WKWebExtensionControllerDelegate> delegate;
+
+/*!
+ @abstract A copy of the configuration with which the web extension controller was initialized.
+ @discussion Mutating the configuration has no effect on the web extension controller.
+*/
+@property (nonatomic, readonly, copy) _WKWebExtensionControllerConfiguration *configuration;
 
 /*!
  @abstract Loads the specified extension context.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
@@ -32,6 +32,7 @@
 
 #import "WebExtensionController.h"
 #import "_WKWebExtensionContextInternal.h"
+#import "_WKWebExtensionControllerConfigurationInternal.h"
 #import "_WKWebExtensionInternal.h"
 #import <WebCore/WebCoreObjCExtras.h>
 
@@ -44,7 +45,19 @@
     if (!(self = [super init]))
         return nil;
 
-    API::Object::constructInWrapper<WebKit::WebExtensionController>(self);
+    API::Object::constructInWrapper<WebKit::WebExtensionController>(self, WebKit::WebExtensionControllerConfiguration::createDefault());
+
+    return self;
+}
+
+- (instancetype)initWithConfiguration:(_WKWebExtensionControllerConfiguration *)configuration
+{
+    NSParameterAssert(configuration);
+
+    if (!(self = [super init]))
+        return nil;
+
+    API::Object::constructInWrapper<WebKit::WebExtensionController>(self, configuration._webExtensionControllerConfiguration.copy());
 
     return self;
 }
@@ -55,6 +68,11 @@
         return;
 
     _webExtensionController->~WebExtensionController();
+}
+
+- (_WKWebExtensionControllerConfiguration *)configuration
+{
+    return _webExtensionController->configuration().copy()->wrapper();
 }
 
 - (BOOL)loadExtensionContext:(_WKWebExtensionContext *)extensionContext
@@ -132,6 +150,21 @@ static inline NSSet *toAPI(const T& inputSet)
 }
 
 #else // ENABLE(WK_WEB_EXTENSIONS)
+
+- (instancetype)init
+{
+    return nil;
+}
+
+- (instancetype)initWithConfiguration:(_WKWebExtensionControllerConfiguration *)configuration
+{
+    return nil;
+}
+
+- (_WKWebExtensionControllerConfiguration *)configuration
+{
+    return nil;
+}
 
 - (BOOL)loadExtensionContext:(_WKWebExtensionContext *)extensionContext
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*!
+ @abstract A `WKWebExtensionControllerConfiguration` object with which to initialize a web extension controller.
+ @discussion Contains properties used to configure a @link WKWebExtensionController @/link.
+*/
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+@interface _WKWebExtensionControllerConfiguration : NSObject <NSSecureCoding, NSCopying>
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+/*!
+ @abstract Returns a new default configuration that is persistent and not unique.
+ @discussion If a @link WKWebExtensionController @/link is associated with a persistent configuration,
+ data will be written to the file system in a common location. When using multiple extension controllers, each
+ controller should use a unique configuration to avoid conflicts.
+ @seealso configurationWithIdentifier:
+*/
++ (instancetype)defaultConfiguration;
+
+/*!
+ @abstract Returns a new non-persistent configuration.
+ @discussion If a @link WKWebExtensionController @/link is associated with a non-persistent configuration,
+ no data will be written to the file system. This is useful for extensions in "private browsing" situations.
+*/
++ (instancetype)nonPersistentConfiguration;
+
+/*!
+ @abstract Returns a new configuration that is persistent and unique for the specified identifier.
+ @discussion If a @link WKWebExtensionController @/link is associated with a unique persistent configuration,
+ data will be written to the file system in a unique location based on the specified identifier.
+ @seealso defaultConfiguration
+*/
++ (instancetype)configurationWithIdentifier:(NSUUID *)identifier;
+
+@property (nonatomic, readonly, getter=isPersistent) BOOL persistent WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+@property (nonatomic, nullable, readonly) NSUUID *identifier WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "_WKWebExtensionControllerConfigurationInternal.h"
+
+#import "WebExtensionControllerConfiguration.h"
+#import <WebCore/WebCoreObjCExtras.h>
+
+static constexpr NSString *persistentCodingKey = @"persistent";
+static constexpr NSString *identifierCodingKey = @"identifier";
+
+@implementation _WKWebExtensionControllerConfiguration
+
++ (BOOL)supportsSecureCoding
+{
+    return YES;
+}
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
++ (instancetype)defaultConfiguration
+{
+    return WebKit::WebExtensionControllerConfiguration::createDefault()->wrapper();
+}
+
++ (instancetype)nonPersistentConfiguration
+{
+    return WebKit::WebExtensionControllerConfiguration::createNonPersistent()->wrapper();
+}
+
++ (instancetype)configurationWithIdentifier:(NSUUID *)identifier
+{
+    NSParameterAssert(identifier);
+
+    return WebKit::WebExtensionControllerConfiguration::create(identifier)->wrapper();
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+    NSParameterAssert(coder);
+
+    [coder encodeObject:self.identifier forKey:identifierCodingKey];
+    [coder encodeBool:self.persistent forKey:persistentCodingKey];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+    NSParameterAssert(coder);
+
+    if (!(self = [super init]))
+        return nil;
+
+    using IsPersistent = WebKit::WebExtensionControllerConfiguration::IsPersistent;
+
+    NSUUID *identifier = [coder decodeObjectOfClass:NSUUID.class forKey:identifierCodingKey];
+    BOOL persistent = [coder decodeBoolForKey:persistentCodingKey];
+
+    if (identifier)
+        API::Object::constructInWrapper<WebKit::WebExtensionControllerConfiguration>(self, identifier);
+    else
+        API::Object::constructInWrapper<WebKit::WebExtensionControllerConfiguration>(self, persistent ? IsPersistent::Yes : IsPersistent::No);
+
+    return self;
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    return _webExtensionControllerConfiguration->copy()->wrapper();
+}
+
+- (void)dealloc
+{
+    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebExtensionControllerConfiguration.class, self))
+        return;
+
+    _webExtensionControllerConfiguration->~WebExtensionControllerConfiguration();
+}
+
+- (BOOL)isEqual:(id)object
+{
+    if (self == object)
+        return YES;
+
+    auto *other = dynamic_objc_cast<_WKWebExtensionControllerConfiguration>(object);
+    if (!other)
+        return NO;
+
+    return *_webExtensionControllerConfiguration == *other->_webExtensionControllerConfiguration;
+}
+
+- (NSString *)debugDescription
+{
+    return [NSString stringWithFormat:@"<%@: %p; persistent = %@; identifier = %@>", NSStringFromClass(self.class), self, self.persistent ? @"YES" : @"NO", self.identifier];
+}
+
+- (NSUUID *)identifier
+{
+    if (auto identifier = _webExtensionControllerConfiguration->identifier())
+        return identifier.value();
+    return nil;
+}
+
+- (BOOL)isPersistent
+{
+    return _webExtensionControllerConfiguration->isPersistent();
+}
+
+#pragma mark WKObject protocol implementation
+
+- (API::Object&)_apiObject
+{
+    return *_webExtensionControllerConfiguration;
+}
+
+- (WebKit::WebExtensionControllerConfiguration&)_webExtensionControllerConfiguration
+{
+    return *_webExtensionControllerConfiguration;
+}
+
+#else // ENABLE(WK_WEB_EXTENSIONS)
+
++ (instancetype)defaultConfiguration
+{
+    return nil;
+}
+
++ (instancetype)nonPersistentConfiguration
+{
+    return nil;
+}
+
++ (instancetype)configurationWithIdentifier:(NSUUID *)identifier
+{
+    return nil;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+    return nil;
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    return nil;
+}
+
+- (NSUUID *)identifier
+{
+    return nil;
+}
+
+- (BOOL)isPersistent
+{
+    return NO;
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationInternal.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "_WKWebExtensionControllerConfigurationPrivate.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "WKObject.h"
+#import "WebExtensionControllerConfiguration.h"
+
+namespace WebKit {
+template<> struct WrapperTraits<WebExtensionControllerConfiguration> {
+    using WrapperClass = _WKWebExtensionControllerConfiguration;
+};
+}
+
+@interface _WKWebExtensionControllerConfiguration () <WKObject> {
+@package
+    API::ObjectStorage<WebKit::WebExtensionControllerConfiguration> _webExtensionControllerConfiguration;
+}
+
+@property (nonatomic, readonly) WebKit::WebExtensionControllerConfiguration& _webExtensionControllerConfiguration;
+
+@end
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationPrivate.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/_WKWebExtensionControllerConfiguration.h>
+
+@interface _WKWebExtensionControllerConfiguration ()
+
+@end

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfiguration.mm
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionControllerConfiguration.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "SandboxUtilities.h"
+#import <wtf/FileSystem.h>
+
+namespace WebKit {
+
+String WebExtensionControllerConfiguration::createStorageDirectoryPath(std::optional<UUID> identifier)
+{
+    static NeverDestroyed<String> defaultStoragePath;
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+        String libraryPath = [NSFileManager.defaultManager URLForDirectory:NSLibraryDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:NO error:nullptr].path;
+        if (libraryPath.isEmpty())
+            RELEASE_ASSERT_NOT_REACHED();
+
+        String identiferPath = identifier ? identifier->toString() : "Default"_s;
+
+        if (processHasContainer()) {
+            defaultStoragePath.get() = FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, "WebExtensions"_s, identiferPath });
+            return;
+        }
+
+        String appDirectoryName = [NSBundle mainBundle].bundleIdentifier ?: [NSProcessInfo processInfo].processName;
+        defaultStoragePath.get() = FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, appDirectoryName, "WebExtensions"_s, identiferPath });
+    });
+
+    return defaultStoragePath.get();
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -48,8 +48,9 @@ WebExtensionController* WebExtensionController::get(WebExtensionControllerIdenti
     return webExtensionControllers().get(identifier).get();
 }
 
-WebExtensionController::WebExtensionController()
-    : m_identifier(WebExtensionControllerIdentifier::generate())
+WebExtensionController::WebExtensionController(Ref<WebExtensionControllerConfiguration> configuration)
+    : m_configuration(configuration)
+    , m_identifier(WebExtensionControllerIdentifier::generate())
 {
     ASSERT(!webExtensionControllers().contains(m_identifier));
     webExtensionControllers().add(m_identifier, this);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebExtensionControllerConfiguration.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+namespace WebKit {
+
+WebExtensionControllerConfiguration::WebExtensionControllerConfiguration(IsPersistent persistent)
+    : m_storageDirectory(persistent == IsPersistent::Yes ? createStorageDirectoryPath() : nullString())
+{
+}
+
+WebExtensionControllerConfiguration::WebExtensionControllerConfiguration(const UUID& identifier)
+    : m_identifier(identifier)
+    , m_storageDirectory(createStorageDirectoryPath(identifier))
+{
+}
+
+Ref<WebExtensionControllerConfiguration> WebExtensionControllerConfiguration::copy() const
+{
+    if (m_identifier)
+        return create(m_identifier.value());
+    if (isPersistent())
+        return createDefault();
+    return createNonPersistent();
+}
+
+bool WebExtensionControllerConfiguration::operator==(const WebExtensionControllerConfiguration& other) const
+{
+    if (this == &other)
+        return true;
+
+    if (m_storageDirectory != other.m_storageDirectory)
+        return false;
+
+    if (m_identifier != other.m_identifier)
+        return false;
+
+    return true;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "APIObject.h"
+#include <wtf/Forward.h>
+#include <wtf/UUID.h>
+
+OBJC_CLASS _WKWebExtensionControllerConfiguration;
+
+namespace WebKit {
+
+class WebExtensionControllerConfiguration : public API::ObjectImpl<API::Object::Type::WebExtensionControllerConfiguration> {
+    WTF_MAKE_NONCOPYABLE(WebExtensionControllerConfiguration);
+
+public:
+    enum class IsPersistent : bool { No, Yes };
+
+    static Ref<WebExtensionControllerConfiguration> createDefault() { return adoptRef(*new WebExtensionControllerConfiguration(IsPersistent::Yes)); }
+    static Ref<WebExtensionControllerConfiguration> createNonPersistent() { return adoptRef(*new WebExtensionControllerConfiguration(IsPersistent::No)); }
+    static Ref<WebExtensionControllerConfiguration> create(const UUID& identifier) { return adoptRef(*new WebExtensionControllerConfiguration(identifier)); }
+
+    Ref<WebExtensionControllerConfiguration> copy() const;
+
+    explicit WebExtensionControllerConfiguration(IsPersistent);
+    explicit WebExtensionControllerConfiguration(const UUID&);
+
+    std::optional<UUID> identifier() const { return m_identifier; }
+
+    bool isPersistent() const { return !m_storageDirectory.isEmpty(); }
+    String storageDirectory() const { return m_storageDirectory; }
+
+    bool operator==(const WebExtensionControllerConfiguration&) const;
+    bool operator!=(const WebExtensionControllerConfiguration& other) const { return !(this == &other); }
+
+#ifdef __OBJC__
+    _WKWebExtensionControllerConfiguration *wrapper() const { return (_WKWebExtensionControllerConfiguration *)API::ObjectImpl<API::Object::Type::WebExtensionControllerConfiguration>::wrapper(); }
+#endif
+
+private:
+    static String createStorageDirectoryPath(std::optional<UUID> = std::nullopt);
+
+    std::optional<UUID> m_identifier;
+    String m_storageDirectory;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -392,6 +392,10 @@
 		1C15497F2926C073001B9E5B /* JSWebExtensionAPITest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C1549822926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C1549842926F091001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1549832926F04E001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C1549D229381BA0001B9E5B /* WebExtensionControllerConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1549D129381B9F001B9E5B /* WebExtensionControllerConfiguration.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C1549D729381DFF001B9E5B /* _WKWebExtensionControllerConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1549D429381DFE001B9E5B /* _WKWebExtensionControllerConfiguration.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C1549D829382062001B9E5B /* _WKWebExtensionControllerConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1549D329381DFE001B9E5B /* _WKWebExtensionControllerConfiguration.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C1549D92938206A001B9E5B /* _WKWebExtensionControllerConfigurationPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1549D629381DFF001B9E5B /* _WKWebExtensionControllerConfigurationPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C1CE96D288DF46D0098D3A1 /* WebExtensionMatchPatternCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C1CE972288DF5030098D3A1 /* _WKWebExtensionMatchPattern.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1CE96E288DF5020098D3A1 /* _WKWebExtensionMatchPattern.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C1CE973288DF5030098D3A1 /* _WKWebExtensionMatchPatternInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1CE96F288DF5020098D3A1 /* _WKWebExtensionMatchPatternInternal.h */; };
@@ -3544,6 +3548,13 @@
 		1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPITest.mm; sourceTree = "<group>"; };
 		1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPITestCocoa.mm; sourceTree = "<group>"; };
 		1C1549832926F04E001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionControllerDelegatePrivate.h; sourceTree = "<group>"; };
+		1C1549CE293812F8001B9E5B /* WebExtensionControllerConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionControllerConfiguration.h; sourceTree = "<group>"; };
+		1C1549CF293817FE001B9E5B /* WebExtensionControllerConfiguration.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionControllerConfiguration.cpp; sourceTree = "<group>"; };
+		1C1549D129381B9F001B9E5B /* WebExtensionControllerConfiguration.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionControllerConfiguration.mm; sourceTree = "<group>"; };
+		1C1549D329381DFE001B9E5B /* _WKWebExtensionControllerConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionControllerConfiguration.h; sourceTree = "<group>"; };
+		1C1549D429381DFE001B9E5B /* _WKWebExtensionControllerConfiguration.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionControllerConfiguration.mm; sourceTree = "<group>"; };
+		1C1549D529381DFF001B9E5B /* _WKWebExtensionControllerConfigurationInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionControllerConfigurationInternal.h; sourceTree = "<group>"; };
+		1C1549D629381DFF001B9E5B /* _WKWebExtensionControllerConfigurationPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionControllerConfigurationPrivate.h; sourceTree = "<group>"; };
 		1C1CE96A288DF31E0098D3A1 /* WebExtensionMatchPattern.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionMatchPattern.h; sourceTree = "<group>"; };
 		1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionMatchPatternCocoa.mm; sourceTree = "<group>"; };
 		1C1CE96E288DF5020098D3A1 /* _WKWebExtensionMatchPattern.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionMatchPattern.mm; sourceTree = "<group>"; };
@@ -8840,6 +8851,7 @@
 				1C627477288A1DDE00CED3A2 /* WebExtensionCocoa.mm */,
 				1C0234DB28A0268B00AC1E5B /* WebExtensionContextCocoa.mm */,
 				1CBEE26F28F4DDA0006D1A02 /* WebExtensionControllerCocoa.mm */,
+				1C1549D129381B9F001B9E5B /* WebExtensionControllerConfiguration.mm */,
 				1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */,
 				1CAB9B8528F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm */,
 			);
@@ -9217,6 +9229,8 @@
 				1CC23B1D288732A800D0A65A /* WebExtensionController.cpp */,
 				1CC23B1C288732A800D0A65A /* WebExtensionController.h */,
 				1CC23B1B288732A800D0A65A /* WebExtensionController.messages.in */,
+				1C1549CF293817FE001B9E5B /* WebExtensionControllerConfiguration.cpp */,
+				1C1549CE293812F8001B9E5B /* WebExtensionControllerConfiguration.h */,
 				1C1CE96A288DF31E0098D3A1 /* WebExtensionMatchPattern.h */,
 				1CAB9B8428F7427F00E6C77E /* WebExtensionURLSchemeHandler.h */,
 			);
@@ -10223,6 +10237,10 @@
 				1C0234D528A013D900AC1E5B /* _WKWebExtensionContextPrivate.h */,
 				1C3BEB5728875CE400E66E38 /* _WKWebExtensionController.h */,
 				1C3BEB5528875CE400E66E38 /* _WKWebExtensionController.mm */,
+				1C1549D329381DFE001B9E5B /* _WKWebExtensionControllerConfiguration.h */,
+				1C1549D429381DFE001B9E5B /* _WKWebExtensionControllerConfiguration.mm */,
+				1C1549D529381DFF001B9E5B /* _WKWebExtensionControllerConfigurationInternal.h */,
+				1C1549D629381DFF001B9E5B /* _WKWebExtensionControllerConfigurationPrivate.h */,
 				1C04983B289AFF9B0010308B /* _WKWebExtensionControllerDelegate.h */,
 				1C1549832926F04E001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h */,
 				1C3BEB5628875CE400E66E38 /* _WKWebExtensionControllerInternal.h */,
@@ -14497,6 +14515,8 @@
 				1C0234D828A013D900AC1E5B /* _WKWebExtensionContextInternal.h in Headers */,
 				1C0234D728A013D900AC1E5B /* _WKWebExtensionContextPrivate.h in Headers */,
 				1C3BEB5B28875CE500E66E38 /* _WKWebExtensionController.h in Headers */,
+				1C1549D829382062001B9E5B /* _WKWebExtensionControllerConfiguration.h in Headers */,
+				1C1549D92938206A001B9E5B /* _WKWebExtensionControllerConfigurationPrivate.h in Headers */,
 				1C04983F289AFF9B0010308B /* _WKWebExtensionControllerDelegate.h in Headers */,
 				1C1549842926F091001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h in Headers */,
 				1C3BEB5A28875CE500E66E38 /* _WKWebExtensionControllerInternal.h in Headers */,
@@ -17729,6 +17749,7 @@
 				1C627479288B2F7400CED3A2 /* _WKWebExtension.mm in Sources */,
 				1C0234D428A0135600AC1E5B /* _WKWebExtensionContext.mm in Sources */,
 				1C62747A288B2F7400CED3A2 /* _WKWebExtensionController.mm in Sources */,
+				1C1549D729381DFF001B9E5B /* _WKWebExtensionControllerConfiguration.mm in Sources */,
 				1C1CE972288DF5030098D3A1 /* _WKWebExtensionMatchPattern.mm in Sources */,
 				1C049838289AF5AD0010308B /* _WKWebExtensionPermission.mm in Sources */,
 				572EBBDA2538F6B4000552B3 /* AppAttestInternalSoftLink.mm in Sources */,
@@ -18097,6 +18118,7 @@
 				1C0234CD28A00FE400AC1E5B /* WebExtensionContextMessageReceiver.cpp in Sources */,
 				1C0234CE28A00FE600AC1E5B /* WebExtensionContextProxyMessageReceiver.cpp in Sources */,
 				1CBEE27028F4DDA1006D1A02 /* WebExtensionControllerCocoa.mm in Sources */,
+				1C1549D229381BA0001B9E5B /* WebExtensionControllerConfiguration.mm in Sources */,
 				1C3BEB522887492F00E66E38 /* WebExtensionControllerMessageReceiver.cpp in Sources */,
 				1C3D0AC1291AE6210093F67E /* WebExtensionControllerProxyCocoa.mm in Sources */,
 				1C3BEB532887492F00E66E38 /* WebExtensionControllerProxyMessageReceiver.cpp in Sources */,

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -285,6 +285,7 @@ Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
 Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
 Tests/WebKitCocoa/WKWebExtensionContext.mm
 Tests/WebKitCocoa/WKWebExtensionController.mm
+Tests/WebKitCocoa/WKWebExtensionControllerConfiguration.mm
 Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
 Tests/WebKitCocoa/WKWebViewAlwaysShowsScroller.mm
 Tests/WebKitCocoa/WKWebViewCandidateTests.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2002,6 +2002,7 @@
 		1C15498E2926F701001B9E5B /* WebExtensionUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WebExtensionUtilities.mm; path = cocoa/WebExtensionUtilities.mm; sourceTree = "<group>"; };
 		1C15498F2926F944001B9E5B /* WebExtensionUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebExtensionUtilities.h; path = cocoa/WebExtensionUtilities.h; sourceTree = "<group>"; };
 		1C1549A2292ADB64001B9E5B /* WKWebExtensionAPIExtension.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIExtension.mm; sourceTree = "<group>"; };
+		1C1549DA293A6D7F001B9E5B /* WKWebExtensionControllerConfiguration.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionControllerConfiguration.mm; sourceTree = "<group>"; };
 		1C24DEEC263001DE00450D07 /* TextStyleFontSize.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextStyleFontSize.mm; sourceTree = "<group>"; };
 		1C2B817E1C891E4200A5529F /* CancelFontSubresource.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CancelFontSubresource.mm; sourceTree = "<group>"; };
 		1C2B81811C891EFA00A5529F /* CancelFontSubresourcePlugIn.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CancelFontSubresourcePlugIn.mm; sourceTree = "<group>"; };
@@ -4074,6 +4075,7 @@
 				1C1549852926F4CA001B9E5B /* WKWebExtensionAPIRuntime.mm */,
 				1CBEE26228F47FA9006D1A02 /* WKWebExtensionContext.mm */,
 				1CAB9B7128F5E08900E6C77E /* WKWebExtensionController.mm */,
+				1C1549DA293A6D7F001B9E5B /* WKWebExtensionControllerConfiguration.mm */,
 				1CFAA40928974405009F894D /* WKWebExtensionMatchPattern.mm */,
 				5C7148942123A40700FDE3C5 /* WKWebsiteDatastore.mm */,
 				371195AA1FE5797700A1FB92 /* WKWebViewAlwaysShowsScroller.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
@@ -39,6 +39,24 @@
 
 namespace TestWebKitAPI {
 
+TEST(WKWebExtensionController, Configuration)
+{
+    _WKWebExtensionController *testController = [[_WKWebExtensionController alloc] init];
+    EXPECT_TRUE(testController.configuration.persistent);
+    EXPECT_NULL(testController.configuration.identifier);
+
+    testController = [[_WKWebExtensionController alloc] initWithConfiguration:_WKWebExtensionControllerConfiguration.nonPersistentConfiguration];
+    EXPECT_FALSE(testController.configuration.persistent);
+    EXPECT_NULL(testController.configuration.identifier);
+
+    NSUUID *identifier = [NSUUID UUID];
+    _WKWebExtensionControllerConfiguration *configuration = [_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier];
+
+    testController = [[_WKWebExtensionController alloc] initWithConfiguration:configuration];
+    EXPECT_TRUE(testController.configuration.persistent);
+    EXPECT_NS_EQUAL(testController.configuration.identifier, identifier);
+}
+
 TEST(WKWebExtensionController, LoadingAndUnloadingContexts)
 {
     _WKWebExtensionController *testController = [[_WKWebExtensionController alloc] init];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionControllerConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionControllerConfiguration.mm
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "TestCocoa.h"
+#import <WebKit/WKFoundation.h>
+#import <WebKit/_WKWebExtensionControllerConfigurationPrivate.h>
+
+namespace TestWebKitAPI {
+
+TEST(WKWebExtensionControllerConfiguration, Initialization)
+{
+    auto *configuration = _WKWebExtensionControllerConfiguration.defaultConfiguration;
+
+    EXPECT_TRUE(configuration.persistent);
+    EXPECT_NULL(configuration.identifier);
+    EXPECT_NE(configuration, _WKWebExtensionControllerConfiguration.defaultConfiguration);
+    EXPECT_NS_EQUAL(configuration, _WKWebExtensionControllerConfiguration.defaultConfiguration);
+
+    configuration = _WKWebExtensionControllerConfiguration.nonPersistentConfiguration;
+
+    EXPECT_FALSE(configuration.persistent);
+    EXPECT_NULL(configuration.identifier);
+    EXPECT_NE(configuration, _WKWebExtensionControllerConfiguration.nonPersistentConfiguration);
+    EXPECT_NS_EQUAL(configuration, _WKWebExtensionControllerConfiguration.nonPersistentConfiguration);
+
+    auto *identifier = [NSUUID UUID];
+    configuration = [_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier];
+
+    EXPECT_TRUE(configuration.persistent);
+    EXPECT_NS_EQUAL(configuration.identifier, identifier);
+    EXPECT_NE(configuration, [_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier]);
+    EXPECT_NS_EQUAL(configuration, [_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier]);
+}
+
+TEST(WKWebExtensionControllerConfiguration, SecureCoding)
+{
+    NSError *error = nil;
+    auto *configuration = _WKWebExtensionControllerConfiguration.defaultConfiguration;
+    auto *data = [NSKeyedArchiver archivedDataWithRootObject:configuration requiringSecureCoding:YES error:&error];
+    _WKWebExtensionControllerConfiguration *result = [NSKeyedUnarchiver unarchivedObjectOfClass:_WKWebExtensionControllerConfiguration.class fromData:data error:&error];
+
+    EXPECT_NULL(error);
+    EXPECT_TRUE(result.persistent);
+    EXPECT_NULL(result.identifier);
+    EXPECT_NE(configuration, result);
+    EXPECT_NS_EQUAL(configuration, result);
+
+    configuration = _WKWebExtensionControllerConfiguration.nonPersistentConfiguration;
+    data = [NSKeyedArchiver archivedDataWithRootObject:configuration requiringSecureCoding:YES error:&error];
+    result = [NSKeyedUnarchiver unarchivedObjectOfClass:_WKWebExtensionControllerConfiguration.class fromData:data error:&error];
+
+    EXPECT_NULL(error);
+    EXPECT_FALSE(result.persistent);
+    EXPECT_NULL(result.identifier);
+    EXPECT_NE(configuration, result);
+    EXPECT_NS_EQUAL(configuration, result);
+
+    auto *identifier = [NSUUID UUID];
+    configuration = [_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier];
+    data = [NSKeyedArchiver archivedDataWithRootObject:configuration requiringSecureCoding:YES error:&error];
+    result = [NSKeyedUnarchiver unarchivedObjectOfClass:_WKWebExtensionControllerConfiguration.class fromData:data error:&error];
+
+    EXPECT_NULL(error);
+    EXPECT_TRUE(result.persistent);
+    EXPECT_NS_EQUAL(result.identifier, identifier);
+    EXPECT_NE(configuration, result);
+    EXPECT_NS_EQUAL(configuration, result);
+}
+
+TEST(WKWebExtensionControllerConfiguration, Copying)
+{
+    auto *configuration = _WKWebExtensionControllerConfiguration.defaultConfiguration;
+    _WKWebExtensionControllerConfiguration *copy = [configuration copy];
+
+    EXPECT_TRUE(copy.persistent);
+    EXPECT_NULL(copy.identifier);
+    EXPECT_NE(configuration, copy);
+    EXPECT_NS_EQUAL(configuration, copy);
+
+    configuration = _WKWebExtensionControllerConfiguration.nonPersistentConfiguration;
+    copy = [configuration copy];
+
+    EXPECT_FALSE(copy.persistent);
+    EXPECT_NULL(copy.identifier);
+    EXPECT_NE(configuration, copy);
+    EXPECT_NS_EQUAL(configuration, copy);
+
+    auto *identifier = [NSUUID UUID];
+    configuration = [_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier];
+    copy = [configuration copy];
+
+    EXPECT_TRUE(copy.persistent);
+    EXPECT_NS_EQUAL(copy.identifier, identifier);
+    EXPECT_NE(configuration, copy);
+    EXPECT_NS_EQUAL(configuration, copy);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -29,6 +29,7 @@
 #include "Utilities.h"
 #include "WTFTestUtilities.h"
 #include <WebKit/_WKWebExtensionContextPrivate.h>
+#include <WebKit/_WKWebExtensionControllerConfigurationPrivate.h>
 #include <WebKit/_WKWebExtensionControllerDelegatePrivate.h>
 #include <WebKit/_WKWebExtensionControllerPrivate.h>
 #include <WebKit/_WKWebExtensionPrivate.h>

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -44,7 +44,7 @@
 
     _extension = extension;
     _context = [[_WKWebExtensionContext alloc] initWithExtension:extension];
-    _controller = [[_WKWebExtensionController alloc] init];
+    _controller = [[_WKWebExtensionController alloc] initWithConfiguration:_WKWebExtensionControllerConfiguration.nonPersistentConfiguration];
 
     _context._testingMode = YES;
 


### PR DESCRIPTION
#### 3bd3d318889c814347c566a45b349c96f078720b
<pre>
Add _WKWebExtensionControllerConfiguration to control extension storage.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248665">https://bugs.webkit.org/show_bug.cgi?id=248665</a>

Reviewed by Brian Weinstein.

_WKWebExtensionControllerConfiguration allows for default persistent storage, non-persistent,
and identifier based storage. With this, we can now store state for extension contexts and have
a directory structure to store extension data in the future (like local storage, etc).

Default storage is placed at: ~/Library/WebKit/&lt;app-id&gt;/WebExtensions/Default/&lt;extension-id&gt;
Non-persistent storage is placed at: ~/Library/WebKit/&lt;app-id&gt;/WebExtensions/&lt;identifier&gt;/&lt;extension-id&gt;
Non-persistent storage is not saved to disk.

Only extension contexts that have a custom uniqueIdentifier will be persistent as well, since the default
uniqueIdentifier is a random UUID, persisting those would cause state to be saved under random IDs that
can&apos;t be reused later.

* Source/WebKit/Platform/Logging.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.h: Removed UUID helpers since UUID has Cocoa conversions now.
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm: Ditto.
* Source/WebKit/Shared/API/APIObject.h:
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration copyWithZone:]): Adjust access to _webExtensionController now that it is RetainPtr.
(-[WKWebViewConfiguration _strongWebExtensionController]): Ditto.
(-[WKWebViewConfiguration _webExtensionController]): Don&apos;t use a LazyInitialized since we don&apos;t require a
webExtensionController to be set and we don&apos;t want to assume the default configuration.
(-[WKWebViewConfiguration _setWebExtensionController:]): Use nil instead of nullptr.
(-[WKWebViewConfiguration _weakWebExtensionController]): Ditto.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm:
(-[_WKWebExtensionController init]): Use default configuration.
(-[_WKWebExtensionController initWithConfiguration:]): Added.
(-[_WKWebExtensionController configuration]): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm: Added.
(+[_WKWebExtensionControllerConfiguration supportsSecureCoding]):
(+[_WKWebExtensionControllerConfiguration defaultConfiguration]):
(+[_WKWebExtensionControllerConfiguration nonPersistentConfiguration]):
(+[_WKWebExtensionControllerConfiguration configurationWithIdentifier:]):
(-[_WKWebExtensionControllerConfiguration encodeWithCoder:]):
(-[_WKWebExtensionControllerConfiguration initWithCoder:]):
(-[_WKWebExtensionControllerConfiguration copyWithZone:]):
(-[_WKWebExtensionControllerConfiguration dealloc]):
(-[_WKWebExtensionControllerConfiguration isEqual:]):
(-[_WKWebExtensionControllerConfiguration debugDescription]):
(-[_WKWebExtensionControllerConfiguration identifier]):
(-[_WKWebExtensionControllerConfiguration isPersistent]):
(-[_WKWebExtensionControllerConfiguration _apiObject]):
(-[_WKWebExtensionControllerConfiguration _webExtensionControllerConfiguration]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationInternal.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationPrivate.h: Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::WebExtensionContext):
(WebKit::WebExtensionContext::load): Added a storageDirectory param. Call readStateFromStorage().
(WebKit::WebExtensionContext::unload): Call writeStateToStorage().
(WebKit::WebExtensionContext::stateFilePath const): Added.
(WebKit::WebExtensionContext::currentState const): Added.
(WebKit::WebExtensionContext::readStateFromStorage): Added.
(WebKit::WebExtensionContext::writeStateToStorage const): Added.
(WebKit::WebExtensionContext::setBaseURL): Use makeString() instead of StringBuilder.
(WebKit::WebExtensionContext::setUniqueIdentifier): Don&apos;t use baseURL&apos;s host, use a UUID for empty.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::storageDirectory const): Added.
(WebKit::WebExtensionController::load): Pass a storageDirectory to the loaded context.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfiguration.mm: Added.
(WebKit::WebExtensionControllerConfiguration::createStorageDirectoryPath):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::isPersistent const): Added.
(WebKit::WebExtensionContext::hasCustomUniqueIdentifier const): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::WebExtensionController):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::create):
(WebKit::WebExtensionController::configuration const):
(WebKit::WebExtensionController::isPersistent const):
(WebKit::WebExtensionController::hasLoadedContexts const):
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp: Added.
(WebKit::WebExtensionControllerConfiguration::WebExtensionControllerConfiguration):
(WebKit::WebExtensionControllerConfiguration::copy const):
(WebKit::WebExtensionControllerConfiguration::operator== const):
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h: Added.
(WebKit::WebExtensionControllerConfiguration::createDefault):
(WebKit::WebExtensionControllerConfiguration::createNonPersistent):
(WebKit::WebExtensionControllerConfiguration::create):
(WebKit::WebExtensionControllerConfiguration::identifier const):
(WebKit::WebExtensionControllerConfiguration::isPersistent const):
(WebKit::WebExtensionControllerConfiguration::storageDirectory const):
(WebKit::WebExtensionControllerConfiguration::operator!= const):
(WebKit::WebExtensionControllerConfiguration::wrapper const):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionControllerConfiguration.mm: Added.
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initWithExtension:]):

Canonical link: <a href="https://commits.webkit.org/257310@main">https://commits.webkit.org/257310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fb471a5e324ec6c7fb3fd30355158abaa17c262

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98493 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107922 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168193 "Failed to checkout and rebase branch from PR 7077") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85094 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91042 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104575 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104162 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89791 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33228 "Found 2 new test failures: fast/text/text-edge-property-parsing.html, imported/w3c/web-platform-tests/css/cssom/cssom-getPropertyValue-common-checks.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88054 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1643 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1564 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6489 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42101 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2523 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2941 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->