### PR TITLE
[macOS / iOS] Limit WPT layout tests to mac-wk2 configuration in CI

### DIFF
--- a/LayoutTests/continuous-integration/TestExpectations
+++ b/LayoutTests/continuous-integration/TestExpectations
@@ -1,0 +1,5 @@
+# Skip WPT layout tests in iOS continuous integration for performance reasons.
+# These tests will continue to run in automation in the mac-wk2 configuration,
+# and they will still be able to be run locally.
+
+imported/w3c/web-platform-tests [ Skip ]

--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -152,7 +152,7 @@
                     },
                     { "name": "Apple-Ventura-Release-WK1-Tests", "factory": "TestWebKit1AllButJSCFactory",
                     "platform": "mac-ventura", "configuration": "release", "architectures": ["x86_64", "arm64"],
-                    "additionalArguments": ["--no-retry-failures"],
+                    "additionalArguments": ["--no-retry-failures", "--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
                     "workernames": ["bot212"]
                     },
                     { "name": "Apple-Ventura-Release-AppleSilicon-WK2-Tests", "factory": "TestAllButJSCFactory",
@@ -162,7 +162,7 @@
                     },
                     { "name": "Apple-Ventura-Release-AppleSilicon-WK1-Tests", "factory": "TestWebKit1AllButJSCFactory",
                     "platform": "mac-ventura", "configuration": "release", "architectures": ["x86_64", "arm64"],
-                    "additionalArguments": ["--no-retry-failures"],
+                    "additionalArguments": ["--no-retry-failures", "--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
                     "workernames": ["bot257"]
                     },
                     { "name": "Apple-Ventura-Release-WK2-Tests", "factory": "TestAllButJSCFactory",
@@ -180,7 +180,7 @@
                     },
                     { "name": "Apple-Ventura-Debug-WK1-Tests", "factory": "TestWebKit1AllButJSCFactory",
                     "platform": "mac-ventura", "configuration": "debug", "architectures": ["x86_64", "arm64"],
-                    "additionalArguments": ["--no-retry-failures"],
+                    "additionalArguments": ["--no-retry-failures", "--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
                     "workernames": ["bot216"]
                     },
                     { "name": "Apple-Ventura-Debug-WK2-Tests", "factory": "TestAllButJSCFactory",
@@ -190,7 +190,7 @@
                     },
                     { "name": "Apple-Ventura-Debug-AppleSilicon-WK1-Tests", "factory": "TestWebKit1AllButJSCFactory",
                     "platform": "mac-ventura", "configuration": "debug", "architectures": ["x86_64", "arm64"],
-                    "additionalArguments": ["--no-retry-failures"],
+                    "additionalArguments": ["--no-retry-failures", "--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
                     "workernames": ["bot260"]
                     },
                     { "name": "Apple-Ventura-Debug-AppleSilicon-WK2-Tests", "factory": "TestAllButJSCFactory",
@@ -222,7 +222,7 @@
                     },
                     { "name": "Apple-Monterey-Release-WK1-Tests", "factory": "TestWebKit1AllButJSCFactory",
                       "platform": "mac-monterey", "configuration": "release", "architectures": ["x86_64", "arm64"],
-                      "additionalArguments": ["--no-retry-failures"],
+                      "additionalArguments": ["--no-retry-failures", "--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
                       "workernames": ["bot1021"]
                     },
                     { "name": "Apple-Monterey-Release-AppleSilicon-WK2-Tests", "factory": "TestAllButJSCFactory",
@@ -232,7 +232,7 @@
                     },
                     { "name": "Apple-Monterey-Release-AppleSilicon-WK1-Tests", "factory": "TestWebKit1AllButJSCFactory",
                       "platform": "mac-monterey", "configuration": "release", "architectures": ["x86_64", "arm64"],
-                      "additionalArguments": ["--no-retry-failures"],
+                      "additionalArguments": ["--no-retry-failures", "--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
                       "workernames": ["bot138"]
                     },
                     { "name": "Apple-Monterey-Release-WK2-Tests", "factory": "TestAllButJSCFactory",
@@ -259,7 +259,7 @@
                     },
                     { "name": "Apple-Monterey-Debug-WK1-Tests", "factory": "TestWebKit1AllButJSCFactory",
                       "platform": "mac-monterey", "configuration": "debug", "architectures": ["x86_64", "arm64"],
-                      "additionalArguments": ["--no-retry-failures"],
+                      "additionalArguments": ["--no-retry-failures", "--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
                       "workernames": ["bot1025"]
                     },
                     { "name": "Apple-Monterey-Debug-WK2-Tests", "factory": "TestAllButJSCFactory",
@@ -269,7 +269,7 @@
                     },
                     { "name": "Apple-Monterey-Debug-AppleSilicon-WK1-Tests", "factory": "TestWebKit1AllButJSCFactory",
                       "platform": "mac-monterey", "configuration": "debug", "architectures": ["x86_64", "arm64"],
-                      "additionalArguments": ["--no-retry-failures"],
+                      "additionalArguments": ["--no-retry-failures", "--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
                       "workernames": ["bot139"]
                     },
                     { "name": "Apple-Monterey-Debug-AppleSilicon-WK2-Tests", "factory": "TestAllButJSCFactory",
@@ -295,7 +295,7 @@
                     },
                     { "name": "Apple-BigSur-Release-WK1-Tests", "factory": "TestWebKit1AllButJSCFactory",
                       "platform": "mac-bigsur", "configuration": "release", "architectures": ["x86_64", "arm64"],
-                      "additionalArguments": ["--no-retry-failures"],
+                      "additionalArguments": ["--no-retry-failures", "--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
                       "workernames": ["bot1020"]
                     },
                     { "name": "Apple-BigSur-Release-WK2-Tests", "factory": "TestAllButJSCFactory",
@@ -317,7 +317,7 @@
                     },
                     { "name": "Apple-BigSur-Debug-WK1-Tests", "factory": "TestWebKit1AllButJSCFactory",
                       "platform": "mac-bigsur", "configuration": "debug", "architectures": ["x86_64", "arm64"],
-                      "additionalArguments": ["--no-retry-failures"],
+                      "additionalArguments": ["--no-retry-failures", "--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
                       "workernames": ["bot1024"]
                     },
                     { "name": "Apple-BigSur-Debug-WK2-Tests", "factory": "TestAllButJSCFactory",
@@ -367,37 +367,37 @@
                     {
                       "name": "Apple-iOS-16-Simulator-Release-arm64-WK2-Tests", "factory": "TestAllButJSCFactory",
                       "platform": "ios-simulator-16", "configuration": "release", "architectures": ["x86_64", "arm64"], "device_model": "iphone",
-                      "additionalArguments": ["--no-retry-failures"],
+                      "additionalArguments": ["--no-retry-failures", "--additional-expectations=LayoutTests/continuous-integration/ios/TestExpectations"],
                       "workernames": ["bot210"]
                     },
                     {
                       "name": "Apple-iOS-16-Simulator-Release-GPUProcess-WK2-Tests", "factory": "TestAllButJSCFactory",
                       "platform": "ios-simulator-16", "configuration": "release", "architectures": ["x86_64", "arm64"], "device_model": "iphone",
-                      "additionalArguments": ["--no-retry-failures", "--use-gpu-process"],
+                      "additionalArguments": ["--no-retry-failures", "--use-gpu-process", "--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
                       "workernames": ["bot600"]
                     },
                     {
                       "name": "Apple-iOS-16-Simulator-Release-WK2-Tests", "factory": "TestAllButJSCFactory",
                       "platform": "ios-simulator-16", "configuration": "release", "architectures": ["x86_64", "arm64"], "device_model": "iphone",
-                      "additionalArguments": ["--no-retry-failures"],
+                      "additionalArguments": ["--no-retry-failures", "--additional-expectations=LayoutTests/continuous-integration/ios/TestExpectations"],
                       "workernames": ["bot651", "bot652"]
                     },
                     {
                       "name": "Apple-iOS-16-Simulator-Debug-WK2-Tests", "factory": "TestAllButJSCFactory",
                       "platform": "ios-simulator-16", "configuration": "debug", "architectures": ["x86_64"], "device_model": "iphone",
-                      "additionalArguments": ["--no-retry-failures", "--no-sample-on-timeout"],
+                      "additionalArguments": ["--no-retry-failures", "--no-sample-on-timeout", "--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
                       "workernames": ["bot653"]
                     },
                     {
                       "name": "Apple-iPadOS-16-Simulator-Release-WK2-Tests", "factory": "TestAllButJSCFactory",
                       "platform": "ios-simulator-16", "configuration": "release", "architectures": ["x86_64", "arm64"], "device_model": "ipad",
-                      "additionalArguments": ["--no-retry-failures"],
+                      "additionalArguments": ["--no-retry-failures", "--additional-expectations=LayoutTests/continuous-integration/ios/TestExpectations"],
                       "workernames": ["bot667"]
                     },
                     {
                       "name": "Apple-iPadOS-16-Simulator-Debug-WK2-Tests", "factory": "TestAllButJSCFactory",
                       "platform": "ios-simulator-16", "configuration": "debug", "architectures": ["x86_64"], "device_model": "ipad",
-                      "additionalArguments": ["--no-retry-failures", "--no-sample-on-timeout"],
+                      "additionalArguments": ["--no-retry-failures", "--no-sample-on-timeout", "--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
                       "workernames": ["bot664"]
                     },
                     {

--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -154,6 +154,7 @@
       "factory": "iOSTestsFactory", "platform": "ios-simulator-16",
       "configuration": "release", "architectures": ["x86_64"],
       "triggered_by": ["ios-16-sim-build-ews"],
+      "additionalArguments": ["--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
       "workernames": ["ews121", "ews122", "ews123", "ews124", "ews125", "ews126", "ews184", "ews185"]
     },
     {
@@ -182,6 +183,7 @@
       "factory": "macOSWK1Factory", "platform": "mac-bigsur",
       "configuration": "release", "architectures": ["x86_64"],
       "triggered_by": ["macos-bigsur-release-build-ews"],
+      "additionalArguments": ["--additional-expectations=LayoutTests/continuous-integration/TestExpectations"],
       "workernames": ["ews100", "ews101", "ews103", "ews112", "ews117", "ews129"]
     },
     {


### PR DESCRIPTION
#### 8481f74ebeefcad4cb2747a2e32f6be1ed91a410
<pre>
[macOS / iOS] Limit WPT layout tests to mac-wk2 configuration in CI
<a href="https://bugs.webkit.org/show_bug.cgi?id=248671">https://bugs.webkit.org/show_bug.cgi?id=248671</a>
rdar://102913568

Reviewed by NOBODY (OOPS!).

WPT layout tests make up for over half of the overall layout test runtime on macOS and iOS bots.
This is affecting throughput in CI, and incurs a large cost for bot watchers to maintain.
In an attempt to alleviate those issues, add a new TestExpectations file used by CI to restrict
these tests to the mac-wk2 configuration. Developers will still be able to run these tests
locally without any change in workflow, and modifying the new TestExpectations file will
force tests to run in EWS if needed for testing.

* LayoutTests/continuous-integration/TestExpectations: Added.
* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/ews-build/config.json:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8481f74ebeefcad4cb2747a2e32f6be1ed91a410

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107928 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168199 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85100 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91048 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104580 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104169 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6254 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89797 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33231 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88065 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21156 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76171 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1649 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22685 "Found 30 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html, http/tests/media/fairplay/fps-hls-key-rotation.html, http/tests/navigation/target-blank-opener-post.html, http/tests/security/contentSecurityPolicy/report-blocked-uri-cross-origin.py, http/tests/security/contentSecurityPolicy/report-blocked-uri.py, http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies-when-private-browsing-enabled.py, http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies.py, http/tests/security/contentSecurityPolicy/report-only-from-header.py, http/tests/security/contentSecurityPolicy/report-only-upgrade-insecure.py ... (failure)") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/97422 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1569 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45185 "Found 7 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html, fast/text/text-edge-property-parsing.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html, imported/w3c/web-platform-tests/css/cssom/cssom-getPropertyValue-common-checks.html, ipc/pasteboard-write-custom-data.html, media/video-inaccurate-duration-ended.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42107 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->