### PR TITLE
[Live Range Selection] editing/mac/pasteboard/paste-and-match-style-selector-event.html fails

### DIFF
--- a/LayoutTests/editing/mac/pasteboard/paste-and-match-style-selector-event-expected.txt
+++ b/LayoutTests/editing/mac/pasteboard/paste-and-match-style-selector-event-expected.txt
@@ -1,2 +1,3 @@
-This tests that sending the pasteAsPlainText selector, which is what happens when you paste and match style, fires the onpaste event.
+This tests pasting as plain text, which is what happens when you paste and match style, fires the onpaste event.
+To manually test, select & cut "FAILURE" below and "paste and match style" from menu.
 SUCCESS

--- a/LayoutTests/editing/mac/pasteboard/paste-and-match-style-selector-event.html
+++ b/LayoutTests/editing/mac/pasteboard/paste-and-match-style-selector-event.html
@@ -8,21 +8,20 @@
                     testRunner.dumpAsText();
 
                 var result = document.getElementById("result");
-                window.getSelection().setBaseAndExtent(result, 0, result, 7);
+                window.getSelection().setBaseAndExtent(result, 0, result, 1);
                 document.execCommand("Cut");
-                if (window.textInputController) {
-                    textInputController.doCommand("pasteAsPlainText:");
-                    if (onPasteEventFired)
-                        result.innerText = "SUCCESS";
-                }
+                if (window.testRunner)
+                    testRunner.execCommand('PasteAsPlainText');
             }
             function onpastehandler(event) {
-                onPasteEventFired = true;
+                event.preventDefault();
+                result.innerText = 'SUCCESS';
             }
         </script>
     </head>
     <body onload="test()" onpaste="onpastehandler(event)" contenteditable>
-        This tests that sending the pasteAsPlainText selector, which is what happens when you paste and match style, fires the onpaste event.
+        This tests pasting as plain text, which is what happens when you paste and match style, fires the onpaste event.<br>
+        To manually test, select & cut "FAILURE" below and "paste and match style" from menu.
         <div id="result">FAILURE</div>
     </body>
 </html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -654,7 +654,6 @@ editing/mac/input/text-input-controller.html
 editing/mac/input/text-input-controller-no-editable-no-crash.html
 editing/mac/input/wrapped-line-char-rect.html
 editing/mac/input/NSBackgroundColor-transparent.html
-editing/mac/pasteboard/paste-and-match-style-selector-event.html
 editing/mac/selection/25228.html
 
 # WebKitTestRunner needs testRunner.setCallCloseOnWebViews


### PR DESCRIPTION
#### f95f47e14f715cc9979c8b7dd3a042bc7de18bac
<pre>
[Live Range Selection] editing/mac/pasteboard/paste-and-match-style-selector-event.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248672">https://bugs.webkit.org/show_bug.cgi?id=248672</a>

Reviewed by Darin Adler.

Fix the test to use correct offset and also updated the test to work in WebKit2.

* LayoutTests/editing/mac/pasteboard/paste-and-match-style-selector-event-expected.txt:
* LayoutTests/editing/mac/pasteboard/paste-and-match-style-selector-event.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/257329@main">https://commits.webkit.org/257329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dbf2d13c8e3f8af84829aa76dcd99f74e4ba6e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107930 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168201 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85102 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91050 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104582 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89796 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33230 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88059 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21155 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76170 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1651 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22684 "Found 30 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html, gamepad/gamepad-polling-access.html, http/wpt/fetch/response-opaque-clone.html, imported/w3c/web-platform-tests/css/css-fonts/font-style-angle.html, imported/w3c/web-platform-tests/css/css-pseudo/before-in-display-none-thcrash.html, imported/w3c/web-platform-tests/fetch/api/basic/stream-safe-creation.any.html, imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/window-name-after-cross-origin-sub-frame-navigation.sub.html, imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_after_load.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-popup.https.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1571 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45184 "Found 5 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html, http/wpt/service-workers/fetch-service-worker-preload.https.html, ipc/pasteboard-write-custom-data.html, media/video-inaccurate-duration-ended.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42106 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2530 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->