### PR TITLE
[Live Range Selection] editing/pasteboard/cleanup-on-move.html fails

### DIFF
--- a/LayoutTests/editing/pasteboard/cleanup-on-move.html
+++ b/LayoutTests/editing/pasteboard/cleanup-on-move.html
@@ -13,7 +13,7 @@
 Markup.description('This test drags a selection of a couple of <li> and drops them after another <li> in the same list. It verifies that no empty <li> (actually with a <br> inside) are left after the moving operation.');
 
 if (window.testRunner) {
-    selectListItems("two", "three", 5);
+    selectListItems("two", "three", 1);
     Markup.dump("test", "The original list looks like this. 'two' and 'three' are selected and are going to be dropped after 'four'");
     dragSelectionToTarget("two", "four");
     Markup.dump("test", "'two' and 'three' should appear as <li> after 'four' and no empty <li> (nor a <br> placeholder) should be there");


### PR DESCRIPTION
#### fc72928b66d943febf0a19941ced1d2b2e8f3496
<pre>
[Live Range Selection] editing/pasteboard/cleanup-on-move.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248673">https://bugs.webkit.org/show_bug.cgi?id=248673</a>

Reviewed by Darin Adler.

Use the correct offset for the selection end. Unfortunately, this test still doesn&apos;t work in WebKit2 :(

* LayoutTests/editing/pasteboard/cleanup-on-move.html:

Canonical link: <a href="https://commits.webkit.org/257331@main">https://commits.webkit.org/257331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3de96eede99b3faa8deef5a16cb00a0d4753b024

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107934 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168205 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85108 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91054 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104586 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104177 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6248 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33234 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88067 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21157 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76174 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1656 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22686 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1576 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45189 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6502 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42108 "Passed tests") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2531 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2954 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->