### PR TITLE
WebDriver: [Cocoa] [Actions] [Key] Right-hand modifier keys report as their left-hand counterpart

### DIFF
--- a/Source/WebKit/UIProcess/Automation/Automation.json
+++ b/Source/WebKit/UIProcess/Automation/Automation.json
@@ -157,6 +157,7 @@
                 "Meta",
                 "MetaRight",
                 "Command",
+                "CommandRight",
                 "Cancel",
                 "Help",
                 "Backspace",

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -2079,6 +2079,8 @@ static VirtualKey normalizedVirtualKey(VirtualKey key)
         return Inspector::Protocol::Automation::VirtualKey::Alternate;
     case Inspector::Protocol::Automation::VirtualKey::MetaRight:
         return Inspector::Protocol::Automation::VirtualKey::Meta;
+    case Inspector::Protocol::Automation::VirtualKey::CommandRight:
+        return Inspector::Protocol::Automation::VirtualKey::Command;
     case Inspector::Protocol::Automation::VirtualKey::DownArrowRight:
         return Inspector::Protocol::Automation::VirtualKey::DownArrow;
     case Inspector::Protocol::Automation::VirtualKey::UpArrowRight:

--- a/Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
+++ b/Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
@@ -100,10 +100,15 @@ std::optional<unichar> WebAutomationSession::charCodeForVirtualKey(Inspector::Pr
 {
     switch (key) {
     case Inspector::Protocol::Automation::VirtualKey::Shift:
+    case Inspector::Protocol::Automation::VirtualKey::ShiftRight:
     case Inspector::Protocol::Automation::VirtualKey::Control:
+    case Inspector::Protocol::Automation::VirtualKey::ControlRight:
     case Inspector::Protocol::Automation::VirtualKey::Alternate:
+    case Inspector::Protocol::Automation::VirtualKey::AlternateRight:
     case Inspector::Protocol::Automation::VirtualKey::Meta:
+    case Inspector::Protocol::Automation::VirtualKey::MetaRight:
     case Inspector::Protocol::Automation::VirtualKey::Command:
+    case Inspector::Protocol::Automation::VirtualKey::CommandRight:
         return std::nullopt;
     case Inspector::Protocol::Automation::VirtualKey::Help:
         return NSHelpFunctionKey;

--- a/Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp
+++ b/Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp
@@ -139,6 +139,7 @@ static int keyCodeForVirtualKey(Inspector::Protocol::Automation::VirtualKey key)
     case Inspector::Protocol::Automation::VirtualKey::MetaRight:
         return GDK_KEY_Meta_R;
     case Inspector::Protocol::Automation::VirtualKey::Command:
+    case Inspector::Protocol::Automation::VirtualKey::CommandRight:
         return GDK_KEY_Execute;
     case Inspector::Protocol::Automation::VirtualKey::Help:
         return GDK_KEY_Help;

--- a/Source/WebKit/UIProcess/Automation/ios/WebAutomationSessionIOS.mm
+++ b/Source/WebKit/UIProcess/Automation/ios/WebAutomationSessionIOS.mm
@@ -87,18 +87,23 @@ void WebAutomationSession::platformSimulateKeyboardInteraction(WebPageProxy& pag
 
             switch (virtualKey) {
             case VirtualKey::Shift:
+            case VirtualKey::ShiftRight:
                 changedModifiers |= WebEventFlagMaskShiftKey;
                 break;
             case VirtualKey::Control:
+            case VirtualKey::ControlRight:
                 changedModifiers |= WebEventFlagMaskControlKey;
                 break;
             case VirtualKey::Alternate:
+            case VirtualKey::AlternateRight:
                 changedModifiers |= WebEventFlagMaskOptionKey;
                 break;
             case VirtualKey::Meta:
+            case VirtualKey::MetaRight:
                 // The 'meta' key does not exist on Apple keyboards and is usually
                 // mapped to the Command key when using third-party keyboards.
             case VirtualKey::Command:
+            case VirtualKey::CommandRight:
                 changedModifiers |= WebEventFlagMaskCommandKey;
                 break;
             default:

--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp
@@ -188,6 +188,7 @@ static uint32_t keyCodeForVirtualKey(Inspector::Protocol::Automation::VirtualKey
     case Inspector::Protocol::Automation::VirtualKey::MetaRight:
         return WPE_KEY_Meta_R;
     case Inspector::Protocol::Automation::VirtualKey::Command:
+    case Inspector::Protocol::Automation::VirtualKey::CommandRight:
         return WPE_KEY_Execute;
     case Inspector::Protocol::Automation::VirtualKey::Help:
         return WPE_KEY_Help;

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -265,10 +265,15 @@ static bool virtualKeyHasStickyModifier(VirtualKey key)
     // Returns whether the key's modifier flags should affect other events while pressed down.
     switch (key) {
     case VirtualKey::Shift:
+    case VirtualKey::ShiftRight:
     case VirtualKey::Control:
+    case VirtualKey::ControlRight:
     case VirtualKey::Alternate:
+    case VirtualKey::AlternateRight:
     case VirtualKey::Meta:
+    case VirtualKey::MetaRight:
     case VirtualKey::Command:
+    case VirtualKey::CommandRight:
         return true;
 
     default:
@@ -432,11 +437,12 @@ static int keyCodeForVirtualKey(VirtualKey key)
     case VirtualKey::AlternateRight:
         return kVK_RightOption;
     case VirtualKey::Meta:
-        // The 'meta' key does not exist on Apple keyboards and is usually
-        // mapped to the Command key when using third-party keyboards.
+        // The 'meta' keys (left and right) do not exist on Apple keyboards and are usually
+        // mapped to the Command keys when using third-party keyboards.
     case VirtualKey::Command:
         return kVK_Command;
     case VirtualKey::MetaRight:
+    case VirtualKey::CommandRight:
         return kVK_RightCommand;
     case VirtualKey::Help:
         return kVK_Help;
@@ -565,18 +571,23 @@ static NSEventModifierFlags eventModifierFlagsForVirtualKey(VirtualKey key)
     // The mapping from keys to modifiers is specified in the documentation for NSEvent.
     switch (key) {
     case VirtualKey::Shift:
+    case VirtualKey::ShiftRight:
         return NSEventModifierFlagShift;
 
     case VirtualKey::Control:
+    case VirtualKey::ControlRight:
         return NSEventModifierFlagControl;
 
     case VirtualKey::Alternate:
+    case VirtualKey::AlternateRight:
         return NSEventModifierFlagOption;
 
     case VirtualKey::Meta:
-        // The 'meta' key does not exist on Apple keyboards and is usually
-        // mapped to the Command key when using third-party keyboards.
+    case VirtualKey::MetaRight:
+        // The 'meta' keys (left and right) do not exist on Apple keyboards and are usually
+        // mapped to the Command keys when using third-party keyboards.
     case VirtualKey::Command:
+    case VirtualKey::CommandRight:
         return NSEventModifierFlagCommand;
 
     case VirtualKey::Help:


### PR DESCRIPTION
#### 9aaabd386a2fd8d1c1689cae9c4d3716ec8cc71a
<pre>
WebDriver: [Cocoa] [Actions] [Key] Right-hand modifier keys report as their left-hand counterpart
<a href="https://bugs.webkit.org/show_bug.cgi?id=248674">https://bugs.webkit.org/show_bug.cgi?id=248674</a>
rdar://100588604

Reviewed by BJ Burg.

Add support to the Cocoa ports for properly handling right-hand modifiers which, when paired with safaridriver changes,
will allow the left and right modifier keys to be distiguished from one another. Most of the support is already done,
this just adds the missing `CommandRight` virtual key to the automation protocol and adds handling so that these keys
are properly considered to be a modifier key when combined with other subsequent actions.

This progresses the following WPT test cases:
webdriver/tests/perform_actions/key_events.py::test_modifier_key_sends_correct_events[\ue052-R_ALT]
webdriver/tests/perform_actions/key_events.py::test_modifier_key_sends_correct_events[\ue051-R_CONTROL]
webdriver/tests/perform_actions/key_events.py::test_modifier_key_sends_correct_events[\ue050-R_SHIFT]
webdriver/tests/perform_actions/key_events.py::test_special_key_sends_keydown[R_ALT-expected48]
webdriver/tests/perform_actions/key_events.py::test_special_key_sends_keydown[R_CONTROL-expected53]
webdriver/tests/perform_actions/key_events.py::test_special_key_sends_keydown[R_SHIFT-expected61]

* Source/WebKit/UIProcess/Automation/Automation.json:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::normalizedVirtualKey):
* Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm:
(WebKit::WebAutomationSession::charCodeForVirtualKey const):
* Source/WebKit/UIProcess/Automation/ios/WebAutomationSessionIOS.mm:
(WebKit::WebAutomationSession::platformSimulateKeyboardInteraction):
* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::virtualKeyHasStickyModifier):
(WebKit::keyCodeForVirtualKey):
(WebKit::eventModifierFlagsForVirtualKey):
* Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp:
(WebKit::keyCodeForVirtualKey):
* Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp:
(WebKit::keyCodeForVirtualKey):

Canonical link: <a href="https://commits.webkit.org/257406@main">https://commits.webkit.org/257406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/926eb4639f9b2e3d6da85f512339c4a8dc90fa33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108186 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85349 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91299 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106103 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33433 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88283 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76357 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1898 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22889 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1805 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45362 "Found 1 new test failure: media/video-inactive-playback.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5096 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42344 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->