### PR TITLE
Interaction regions for passwords and search fields are incorrect

### DIFF
--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -147,8 +147,17 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
         bounds.inflate(regionRenderer.document().settings().interactionRegionInlinePadding());
 
     float borderRadius = 0;
-    if (const auto& renderBox = dynamicDowncast<RenderBox>(renderer))
+    if (auto* renderBox = dynamicDowncast<RenderBox>(renderer)) {
         borderRadius = renderBox->borderRadii().minimumRadius();
+
+        auto* input = dynamicDowncast<HTMLInputElement>(element);
+        if (input && input->containerElement()) {
+            auto borderBoxRect = renderBox->borderBoxRect();
+            auto contentBoxRect = renderBox->contentBoxRect();
+            bounds.move(IntSize(borderBoxRect.location() - contentBoxRect.location()));
+            bounds.expand(IntSize(borderBoxRect.size() - contentBoxRect.size()));
+        }
+    }
 
     Region boundsRegion;
     boundsRegion.unite(bounds);


### PR DESCRIPTION
#### 1a9b607d44610188073e437cd7fc45a730beb29f
<pre>
Interaction regions for passwords and search fields are incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=248047">https://bugs.webkit.org/show_bug.cgi?id=248047</a>
&lt;radar://102158222&gt;

Reviewed by Dean Jackson.

Expand the interaction region by the difference of the contentBoxRect
and the borderBoxRect, when an input element contains a containerElement,
as the container element did not take into account the border regions.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):

Canonical link: <a href="https://commits.webkit.org/257999@main">https://commits.webkit.org/257999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c38709e0a971939918bcaa2e288204c8fedef821

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109782 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170030 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/184 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92873 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107635 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34612 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77574 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3342 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24138 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3334 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/283 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/source-list-parsing-05.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43628 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5149 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2864 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->