### PR TITLE
[SIMD] Intel support for splat

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1673,6 +1673,10 @@ VectorSplat32 U:G:32, D:F:128
     Tmp, Tmp
 VectorSplat64 U:G:64, D:F:128
     Tmp, Tmp
+x86_64: VectorSplatFloat32 U:F:32, D:F:128
+    Tmp, Tmp
+x86_64: VectorSplatFloat64 U:F:64, D:F:128
+    Tmp, Tmp
 
 CompareFloatingPointVector U:G:32, U:G:Ptr, U:F:128, U:F:128, D:F:128
     DoubleCond, SIMDInfo, Tmp, Tmp, Tmp

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
@@ -3810,34 +3810,33 @@ auto AirIRGenerator::addSIMDStore(ExpressionType value, ExpressionType pointer, 
 
 auto AirIRGenerator::addSIMDSplat(SIMDLane lane, ExpressionType scalar, ExpressionType& result) -> PartialResult
 {
-    Tmp toSplat = scalar.tmp();
-    if (scalarTypeIsFloatingPoint(lane)) {
-        Tmp gpCast = newTmp(B3::GP);
-        append(elementByteSize(lane) == 4 ? MoveFloatTo32 : MoveDoubleTo64, toSplat, gpCast);
-        toSplat = gpCast;
-    }
-
     B3::Air::Opcode op;
-    switch (elementByteSize(lane)) {
-    case 1:
+
+    switch (lane) {
+    case SIMDLane::i8x16:
         op = VectorSplat8;
         break;
-    case 2:
+    case SIMDLane::i16x8:
         op = VectorSplat16;
         break;
-    case 4:
+    case SIMDLane::i32x4:
         op = VectorSplat32;
         break;
-    case 8:
+    case SIMDLane::i64x2:
         op = VectorSplat64;
+        break;
+    case SIMDLane::f32x4:
+        op = VectorSplatFloat32;
+        break;
+    case SIMDLane::f64x2:
+        op = VectorSplatFloat64;
         break;
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }
 
     result = v128();
-    append(op, toSplat, result.tmp());
-
+    append(op, scalar, result.tmp());
     return { };
 }
 


### PR DESCRIPTION
#### 46b5fd3c0928a534c956bcda8820af4e97e9810c
<pre>
[SIMD] Intel support for splat
<a href="https://bugs.webkit.org/show_bug.cgi?id=248678">https://bugs.webkit.org/show_bug.cgi?id=248678</a>
rdar://102927968

Reviewed by Yusuke Suzuki.

Support WASM SIMD operation splat.
<a href="https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md#constant">https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md#constant</a>

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::vectorSplat):
(JSC::MacroAssemblerX86_64::vectorSplatFloat32):
(JSC::MacroAssemblerX86_64::vectorSplatFloat64):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::pshufd):
(JSC::X86Assembler::pshufb):
(JSC::X86Assembler::pshuflw):
(JSC::X86Assembler::pshufhw):
(JSC::X86Assembler::X86InstructionFormatter::SingleInstructionBufferWriter::memoryModRM):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::addSIMDSplat):

Canonical link: <a href="https://commits.webkit.org/257316@main">https://commits.webkit.org/257316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7784850bb57dcd143e07ec4a1e1081d585c5a9e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107998 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168262 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85164 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91110 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/105979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104258 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33278 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88105 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89371 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1719 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85137 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1632 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28730 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5037 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42158 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87989 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3019 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19708 "Passed tests") | 
<!--EWS-Status-Bubble-End-->