### PR TITLE
Remove unused InProcessCookieCacheEnabled feature flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -868,19 +868,6 @@ ImperativeSlotAPIEnabled:
     WebCore:
       default: true
 
-# FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely.
-InProcessCookieCacheEnabled:
-  type: bool
-  humanReadableName: "In-Process Cookie Cache"
-  humanReadableDescription: "In-Process DOM Cookie Cache"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: false
-
 InertAttributeEnabled:
   type: bool
   humanReadableName: "inert attribute"

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
@@ -97,7 +97,7 @@ static bool shouldBlockCookies(WebFrame* frame, const URL& firstPartyForCookies,
 bool WebCookieJar::isEligibleForCache(WebFrame& frame, const URL& firstPartyForCookies, const URL& resourceURL) const
 {
     auto* page = frame.page() ? frame.page()->corePage() : nullptr;
-    if (!page || !page->settings().inProcessCookieCacheEnabled())
+    if (!page)
         return false;
 
     if (!m_cache.isSupported())


### PR DESCRIPTION
#### 636481109f854272182a1540eee1a46ec9801505
<pre>
Remove unused InProcessCookieCacheEnabled feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=248680">https://bugs.webkit.org/show_bug.cgi?id=248680</a>
&lt;rdar://problem/102915771&gt;

Reviewed by Chris Dumez.

The InProcessCookieCacheEnabled flag was briefly needed while working on some multi-process
architecture changes, but has long since lost any utility. We should remove it from the
experimental feature flag set to reduce complexity.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::WebCookieJar::isEligibleForCache const):

Canonical link: <a href="https://commits.webkit.org/257387@main">https://commits.webkit.org/257387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c66faa0ec44a73df73ee42b602d7c892cdabe40e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107943 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168214 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85117 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91063 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104595 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104188 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6252 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33246 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88071 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21170 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76186 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89324 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1665 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22699 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85080 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1585 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45201 "Found 5 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-with-line-height-simple.html, fast/text/text-edge-with-margin-padding-border-simple.html, ipc/pasteboard-write-custom-data.html, media/video-inaccurate-duration-ended.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28719 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5081 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42122 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87932 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2963 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19699 "Passed tests") | 
<!--EWS-Status-Bubble-End-->