### PR TITLE
Resync WPT tests for contain-intrinsic-size

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4724,6 +4724,7 @@ webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/
 
 # contain-intrinsic-size
 webkit.org/b/246338 imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007.html [ Skip ]
+webkit.org/b/246338 imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-009.html [ Skip ]
 webkit.org/b/246283 imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003.html [ Skip ]
 
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/image-fractional-height-with-wide-aspect-ratio.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-011-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-011-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL contain:size does not prevent recording last remembered size assert_equals: Using last remembered size - clientWidth expected 20 but got 2
+FAIL contain:inline-size does not prevent recording last remembered inline size assert_equals: Size containment for inline axis - clientWidth expected 20 but got 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-011.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-011.html
@@ -5,9 +5,9 @@
 <link rel="help" href="https://drafts.csswg.org/css-sizing-4/#last-remembered">
 <link rel="help" href="https://drafts.csswg.org/css-sizing-4/#intrinsic-size-override">
 <link rel="help" href="https://drafts.csswg.org/css-contain-2/#content-visibility">
-<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7529">
-<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7516">
-<meta name="assert" content="Tests that the last remembered size is tracked independently for each axis." />
+<link rel="help" href="https://drafts.csswg.org/css-contain-3/#containment-inline-size">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7807">
+<meta name="assert" content="Tests that the last remembered size can be updated when the element has size containment but doesn't skip its contents." />
 
 <style>
 #target {
@@ -25,6 +25,12 @@
 }
 .content-skip {
   content-visibility: hidden;
+}
+.contain-size {
+  contain: size;
+}
+.contain-inline-size {
+  contain: inline-size;
 }
 .ciw-auto-2 {
   contain-intrinsic-width: auto 2px;
@@ -61,20 +67,28 @@ function nextRendering() {
 }
 
 promise_test(async function() {
-  target.className = "content-100-50 ciw-auto-20";
+  target.className = "content-100-50";
   checkSize(100, 50, "Sizing normally");
 
   await nextRendering();
+  target.className = "content-100-50 ciw-auto-20 cih-auto-10 contain-size";
+  checkSize(20, 10, "Size containment");
+
+  await nextRendering();
   target.className = "content-skip ciw-auto-2 cih-auto-1";
-  checkSize(100, 1, "Using last remembered inline size");
-}, "Only recording last remembered inline size");
+  checkSize(20, 10, "Using last remembered size");
+}, "contain:size does not prevent recording last remembered size");
 
 promise_test(async function() {
-  target.className = "content-100-50 cih-auto-10";
+  target.className = "content-100-50";
   checkSize(100, 50, "Sizing normally");
 
   await nextRendering();
+  target.className = "content-100-50 ciw-auto-20 cih-auto-10 contain-inline-size";
+  checkSize(20, 50, "Size containment for inline axis");
+
+  await nextRendering();
   target.className = "content-skip ciw-auto-2 cih-auto-1";
-  checkSize(2, 50, "Using last remembered block size");
-}, "Only recording last remembered block size");
+  checkSize(20, 50, "Using last remembered block size");
+}, "contain:inline-size does not prevent recording last remembered inline size");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-012-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-012-expected.txt
@@ -1,0 +1,9 @@
+
+PASS Sizing normally
+PASS Sizing with c-i-s fallback
+PASS Still sizing with c-i-s fallback
+PASS Sizing with last remembered size
+FAIL Still sizing with last remembered size assert_equals: clientWidth expected 100 but got 150
+PASS Sizing with new c-i-s fallback
+FAIL Sizing with new last remembered size assert_equals: clientWidth expected 150 but got 200
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-012.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-012.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Last remembered size</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#last-remembered">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#intrinsic-size-override">
+<link rel="help" href="https://drafts.csswg.org/css-contain-2/#content-visibility">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7807">
+<meta name="assert" content="Tests that content-visibility:auto, contain:size and contain-intrinsic-size:auto do not result in instable size." />
+
+<style>
+#target {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 100px auto 101px;
+  width: max-content;
+  height: max-content;
+  border: 1px solid;
+}
+#target::before {
+  content: "";
+  display: block;
+  width: 50px;
+  height: 51px;
+}
+</style>
+
+<div id="log"></div>
+
+<div id="spacer"></div>
+<div id="target"></div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const target = document.getElementById("target");
+const spacer = document.getElementById("spacer");
+
+function checkSize(expectedWidth, expectedHeight, msg) {
+  test(function() {
+    assert_equals(target.clientWidth, expectedWidth, "clientWidth");
+    assert_equals(target.clientHeight, expectedHeight, "clientHeight");
+  }, msg);
+}
+
+function nextRendering() {
+  return new Promise(resolve => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  });
+}
+
+setup({explicit_done: true});
+
+(async function() {
+  // Size normally.
+  await nextRendering();
+  checkSize(50, 51, "Sizing normally");
+  await nextRendering();
+
+  // The last remembered size is 50x51, but the element is not skipping
+  // its contents, so the fallback size will be used instead.
+  target.style.contain = "size";
+  checkSize(100, 101, "Sizing with c-i-s fallback");
+  await nextRendering();
+
+  // The last remembered size is now 100x101, but still not using it.
+  spacer.style.height = "10000vh";
+  checkSize(100, 101, "Still sizing with c-i-s fallback");
+  await nextRendering();
+
+  // The element went off-screen, using last remembered size now.
+  // It's important that this is the same as in previous step!
+  checkSize(100, 101, "Sizing with last remembered size");
+  await nextRendering();
+
+  // Change the c-i-s fallback to prove last remembered size is used.
+  target.style.containIntrinsicSize = "auto 150px auto 151px";
+  checkSize(100, 101, "Still sizing with last remembered size");
+
+  // Move the element on-screen. Switch to using c-i-s fallback, and
+  // update the last remembered size.
+  spacer.style.height = "0px";
+  await nextRendering();
+  checkSize(150, 151, "Sizing with new c-i-s fallback");
+  await nextRendering();
+
+  // Move off-screen again. Same size as in previous step!
+  spacer.style.height = "10000vh";
+  await nextRendering();
+  target.style.containIntrinsicSize = "auto 200px auto 201px";
+  checkSize(150, 151, "Sizing with new last remembered size");
+
+  done();
+})();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-033-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-033-expected.txt
@@ -1,0 +1,64 @@
+
+PASS .test 1
+PASS .test 2
+PASS .test 3
+PASS .test 4
+PASS .test 5
+PASS .test 6
+PASS .test 7
+PASS .test 8
+PASS .test 9
+PASS .test 10
+PASS .test 11
+PASS .test 12
+PASS .test 13
+PASS .test 14
+PASS .test 15
+PASS .test 16
+PASS .test 17
+PASS .test 18
+FAIL .test 19 assert_equals:
+<img src="resources/dice.png" class="test ci-width" data-expected-client-width="10" data-expected-client-height="0">
+clientWidth expected 10 but got 0
+PASS .test 20
+FAIL .test 21 assert_equals:
+<img src="resources/dice.png" class="test ci-both" data-expected-client-width="10" data-expected-client-height="20">
+clientWidth expected 10 but got 0
+FAIL .test 22 assert_equals:
+<svg class="test ci-width" data-expected-client-width="10" data-expected-client-height="0"></svg>
+clientWidth expected 10 but got 0
+PASS .test 23
+FAIL .test 24 assert_equals:
+<svg class="test ci-both" data-expected-client-width="10" data-expected-client-height="20"></svg>
+clientWidth expected 10 but got 0
+FAIL .test 25 assert_equals:
+<canvas class="test ci-width" data-expected-client-width="10" data-expected-client-height="0"></canvas>
+clientWidth expected 10 but got 0
+PASS .test 26
+FAIL .test 27 assert_equals:
+<canvas class="test ci-both" data-expected-client-width="10" data-expected-client-height="20"></canvas>
+clientWidth expected 10 but got 0
+FAIL .test 28 assert_equals:
+<iframe class="test ci-width" data-expected-client-width="10" data-expected-client-height="0"></iframe>
+clientWidth expected 10 but got 0
+PASS .test 29
+FAIL .test 30 assert_equals:
+<iframe class="test ci-both" data-expected-client-width="10" data-expected-client-height="20"></iframe>
+clientWidth expected 10 but got 0
+FAIL .test 31 assert_equals:
+<video class="test ci-width" data-expected-client-width="10" data-expected-client-height="0"></video>
+clientWidth expected 10 but got 0
+PASS .test 32
+FAIL .test 33 assert_equals:
+<video class="test ci-both" data-expected-client-width="10" data-expected-client-height="20"></video>
+clientWidth expected 10 but got 0
+PASS .test 34
+PASS .test 35
+PASS .test 36
+PASS .test 37
+PASS .test 38
+PASS .test 39
+PASS .test 40
+PASS .test 41
+PASS .test 42
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-033.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-033.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CIS + content-visibility:hidden and contain:size</title>
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-sizing-4/#explicit-intrinsic-inner-size">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-contain-2/#size-containment">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-contain-2/#using-cv-hidden">
+<meta name="assert"
+    content="Tests that CIS + content-visibility:hidden should be same to CIS + contain:size" />
+
+<style>
+    .test {
+        width: max-content;
+        height: max-content;
+        border: 1px solid;
+    }
+
+    .test::before {
+        content: "";
+        display: block;
+        width: 320px;
+        height: 240px;
+    }
+
+    .contain-size {
+        contain: size;
+    }
+
+    .ci-width {
+        contain-intrinsic-width: 10px;
+    }
+
+    .ci-height {
+        contain-intrinsic-height: 20px;
+    }
+
+    .ci-both {
+        contain-intrinsic-size: 10px 20px;
+    }
+
+    .skip-contents .test {
+        content-visibility: hidden;
+    }
+
+</style>
+
+<div id="log"></div>
+
+<div id="tests">
+
+    <div></div>
+    <div class="scroll"></div>
+    <div class="columns"></div>
+    <div class="grid"></div>
+    <div class="flex"></div>
+    <fieldset></fieldset>
+    <img src="resources/dice.png">
+    <svg></svg>
+    <canvas></canvas>
+    <iframe></iframe>
+    <video></video>
+    <button></button>
+    <select>
+        <option>Lorem ipsum</option>
+    </select>
+    <select multiple>
+        <option>Lorem ipsum</option>
+    </select>
+
+</div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script>
+addEventListener("load", async function() {
+  const wrapper = document.getElementById("tests");
+  const tests = new DocumentFragment();
+  for (let template of wrapper.children) {
+    template.classList.add("test");
+
+    const containIntrinsicWidthTest = template.cloneNode(true);
+    const containIntrinsicHeightTest = template.cloneNode(true);
+    const containIntrinsicSizeTest = template.cloneNode(true);
+    containIntrinsicWidthTest.classList.add("ci-width");
+    containIntrinsicHeightTest.classList.add("ci-height");
+    containIntrinsicSizeTest.classList.add("ci-both");
+
+    template.classList.add("contain-size");
+    const containSizeWidth = template.clientWidth;
+    const containSizeHeight = template.clientHeight;
+    template.classList.add("ci-both");
+    const CISWidth = template.clientWidth;;
+    const CISHeight = template.clientHeight;
+
+    containIntrinsicWidthTest.dataset.expectedClientWidth = CISWidth;
+    containIntrinsicWidthTest.dataset.expectedClientHeight = containSizeHeight;
+    containIntrinsicHeightTest.dataset.expectedClientWidth = containSizeWidth;
+    containIntrinsicHeightTest.dataset.expectedClientHeight = CISHeight;
+    containIntrinsicSizeTest.dataset.expectedClientWidth = CISWidth;
+    containIntrinsicSizeTest.dataset.expectedClientHeight = CISHeight;
+
+    tests.append(containIntrinsicWidthTest, containIntrinsicHeightTest, containIntrinsicSizeTest);
+  }
+  wrapper.textContent = "";
+  wrapper.appendChild(tests);
+
+  wrapper.classList.add("skip-contents");
+  checkLayout(".test");
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/w3c-import.log
@@ -24,6 +24,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-008.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-009.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-010.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-011.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-012.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-001-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-001-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-001.html
@@ -107,6 +109,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-030.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-031.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-032.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-033.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-001-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-002-expected.html


### PR DESCRIPTION
#### 5ec07d1125db2d13bd0cde752cf580d87d7ff9f7
<pre>
Resync WPT tests for contain-intrinsic-size
<a href="https://bugs.webkit.org/show_bug.cgi?id=248679">https://bugs.webkit.org/show_bug.cgi?id=248679</a>

Reviewed by Rob Buis.

Resnc the WPT test in css/css-sizing/contain-intrinsic-size/ to commit 15aaa7c3c9467.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-009.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-011-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-011.html: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-009.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-012-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-012.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-033-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-033.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/257350@main">https://commits.webkit.org/257350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6bfcb9f7ada63ee2136234223be0850c9bf5ed9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98580 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7790 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108002 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168266 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85168 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91114 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/105982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104262 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6291 "Found 1 new test failure: fast/text/text-edge-no-half-leading-with-line-height-simple.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33287 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88109 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21203 "Found 1 new test failure: fast/text/text-edge-no-half-leading-with-line-height-simple.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76221 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1723 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22732 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/cache-storage/cross-partition.https.tentative.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1636 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5049 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6574 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42162 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->