### PR TITLE
Clean up some options initialization workflow.

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.h
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.h
@@ -69,7 +69,7 @@ public:
 
     RefPtr<ExecutableMemoryHandle> allocate(size_t, JITCompilationEffort) { return nullptr; }
 
-    static void setJITEnabled(bool) { };
+    static void disableJIT() { };
     
     bool isValidExecutableMemory(const AbstractLocker&, void*) { return false; }
 
@@ -169,7 +169,7 @@ public:
     static void dumpProfile() { }
 #endif
     
-    JS_EXPORT_PRIVATE static void setJITEnabled(bool);
+    JS_EXPORT_PRIVATE static void disableJIT();
 
     RefPtr<ExecutableMemoryHandle> allocate(size_t sizeInBytes, JITCompilationEffort);
 

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3766,7 +3766,7 @@ void CommandLine::parseArguments(int argc, char** argv)
             : "All JSC runtime options:";
         JSC::Options::dumpAllOptions(dumpOptionsLevel, optionsTitle);
     }
-    JSC::Options::ensureOptionsAreCoherent();
+    JSC::Options::assertOptionsAreCoherent();
     if (needToExit)
         jscExit(EXIT_SUCCESS);
 }

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -82,7 +82,7 @@ void initialize()
             VM::computeCanUseJIT();
             if (!g_jscConfig.vm.canUseJIT) {
                 Options::useJIT() = false;
-                Options::recomputeDependentOptions();
+                Options::notifyOptionsChanged();
             } else {
 #if CPU(ARM64E) && ENABLE(JIT)
                 g_jscConfig.arm64eHashPins.initializeAtStartup();

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -478,14 +478,7 @@ static void overrideDefaults()
     }
 }
 
-static void correctOptions()
-{
-    unsigned thresholdForGlobalLexicalBindingEpoch = Options::thresholdForGlobalLexicalBindingEpoch();
-    if (thresholdForGlobalLexicalBindingEpoch == 0 || thresholdForGlobalLexicalBindingEpoch == 1)
-        Options::thresholdForGlobalLexicalBindingEpoch() = UINT_MAX;
-}
-
-static void disableAllJITOptions()
+static inline void disableAllJITOptions()
 {
     Options::useLLInt() = true;
     Options::useJIT() = false;
@@ -497,15 +490,67 @@ static void disableAllJITOptions()
     Options::useDOMJIT() = false;
     Options::useRegExpJIT() = false;
     Options::useJITCage() = false;
+    Options::useConcurrentJIT() = false;
+    Options::useSigillCrashAnalyzer() = false;
+
+    Options::useWebAssembly() = false;
+
+    Options::usePollingTraps() = true;
+    Options::useLLInt() = true;
+
+    Options::dumpDisassembly() = false;
+    Options::asyncDisassembly() = false;
+    Options::dumpDFGDisassembly() = false;
+    Options::dumpFTLDisassembly() = false;
+    Options::dumpRegExpDisassembly() = false;
+    Options::dumpWasmDisassembly() = false;
+    Options::dumpBBQDisassembly() = false;
+    Options::dumpOMGDisassembly() = false;
+    Options::needDisassemblySupport() = false;
 }
 
-void Options::recomputeDependentOptions()
+inline void Options::dumpOptionsIfNeeded()
 {
+    if (LIKELY(!Options::dumpOptions()))
+        return;
+
+    DumpLevel level = static_cast<DumpLevel>(Options::dumpOptions());
+    if (level > DumpLevel::Verbose)
+        level = DumpLevel::Verbose;
+
+    const char* title = nullptr;
+    switch (level) {
+    case DumpLevel::None:
+        break;
+    case DumpLevel::Overridden:
+        title = "Overridden JSC options:";
+        break;
+    case DumpLevel::All:
+        title = "All JSC options:";
+        break;
+    case DumpLevel::Verbose:
+        title = "All JSC options with descriptions:";
+        break;
+    }
+
+    StringBuilder builder;
+    dumpAllOptions(builder, level, title, nullptr, "   ", "\n", DumpDefaults);
+    dataLog(builder.toString());
+}
+
+void Options::notifyOptionsChanged()
+{
+    AllowUnfinalizedAccessScope scope;
+
+    unsigned thresholdForGlobalLexicalBindingEpoch = Options::thresholdForGlobalLexicalBindingEpoch();
+    if (thresholdForGlobalLexicalBindingEpoch == 0 || thresholdForGlobalLexicalBindingEpoch == 1)
+        Options::thresholdForGlobalLexicalBindingEpoch() = UINT_MAX;
+
 #if !defined(NDEBUG)
     Options::validateDFGExceptionHandling() = true;
 #endif
 #if !ENABLE(JIT)
-    disableAllJITOptions();
+    Options::useJIT() = false;
 #endif
 #if !ENABLE(CONCURRENT_JS)
     Options::useConcurrentJIT() = false;
@@ -540,98 +585,105 @@ void Options::recomputeDependentOptions()
     // At initialization time, we may decide that useJIT should be false for any
     // number of reasons (including failing to allocate JIT memory), and therefore,
     // will / should not be able to enable any JIT related services.
-    if (!Options::useJIT()) {
+    if (!Options::useJIT())
         disableAllJITOptions();
-        Options::useConcurrentJIT() = false;
-        Options::useSigillCrashAnalyzer() = false;
-        Options::useWebAssembly() = false;
-        Options::usePollingTraps() = true;
+    else {
+        if (WTF::isX86BinaryRunningOnARM()) {
+            Options::useBaselineJIT() = false;
+            Options::useDFGJIT() = false;
+            Options::useFTLJIT() = false;
+        }
+
+        if (!Options::useWebAssembly())
+            Options::useFastTLSForWasmContext() = false;
+
+        if (Options::dumpDisassembly()
+            || Options::asyncDisassembly()
+            || Options::dumpDFGDisassembly()
+            || Options::dumpFTLDisassembly()
+            || Options::dumpRegExpDisassembly()
+            || Options::dumpWasmDisassembly()
+            || Options::dumpBBQDisassembly()
+            || Options::dumpOMGDisassembly())
+            Options::needDisassemblySupport() = true;
+
+        if (Options::logJIT()
+            || Options::needDisassemblySupport()
+            || Options::dumpBytecodeAtDFGTime()
+            || Options::dumpGraphAtEachPhase()
+            || Options::dumpDFGGraphAtEachPhase()
+            || Options::dumpDFGFTLGraphAtEachPhase()
+            || Options::dumpB3GraphAtEachPhase()
+            || Options::dumpAirGraphAtEachPhase()
+            || Options::verboseCompilation()
+            || Options::verboseFTLCompilation()
+            || Options::logCompilationChanges()
+            || Options::validateGraph()
+            || Options::validateGraphAtEachPhase()
+            || Options::verboseOSR()
+            || Options::verboseCompilationQueue()
+            || Options::reportCompileTimes()
+            || Options::reportBaselineCompileTimes()
+            || Options::reportDFGCompileTimes()
+            || Options::reportFTLCompileTimes()
+            || Options::logPhaseTimes()
+            || Options::verboseCFA()
+            || Options::verboseDFGFailure()
+            || Options::verboseFTLFailure())
+            Options::alwaysComputeHash() = true;
+
+        if (Options::jitPolicyScale() != Options::jitPolicyScaleDefault())
+            scaleJITPolicy();
+
+        if (Options::forceEagerCompilation()) {
+            Options::thresholdForJITAfterWarmUp() = 10;
+            Options::thresholdForJITSoon() = 10;
+            Options::thresholdForOptimizeAfterWarmUp() = 20;
+            Options::thresholdForOptimizeAfterLongWarmUp() = 20;
+            Options::thresholdForOptimizeSoon() = 20;
+            Options::thresholdForFTLOptimizeAfterWarmUp() = 20;
+            Options::thresholdForFTLOptimizeSoon() = 20;
+            Options::maximumEvalCacheableSourceLength() = 150000;
+            Options::useConcurrentJIT() = false;
+        }
+
+        // Compute the maximum value of the reoptimization retry counter. This is simply
+        // the largest value at which we don't overflow the execute counter, when using it
+        // to left-shift the execution counter by this amount. Currently the value ends
+        // up being 18, so this loop is not so terrible; it probably takes up ~100 cycles
+        // total on a 32-bit processor.
+        Options::reoptimizationRetryCounterMax() = 0;
+        while ((static_cast<int64_t>(Options::thresholdForOptimizeAfterLongWarmUp()) << (Options::reoptimizationRetryCounterMax() + 1)) <= static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
+            Options::reoptimizationRetryCounterMax()++;
+
+        ASSERT((static_cast<int64_t>(Options::thresholdForOptimizeAfterLongWarmUp()) << Options::reoptimizationRetryCounterMax()) > 0);
+        ASSERT((static_cast<int64_t>(Options::thresholdForOptimizeAfterLongWarmUp()) << Options::reoptimizationRetryCounterMax()) <= static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+
+        // FIXME: This should be removed when we add LLint/OMG support for WASM SIMD
+        if (Options::useWebAssemblySIMD()) {
+            Options::useBBQJIT() = true;
+            Options::useOMGJIT() = false;
+            Options::webAssemblyBBQAirModeThreshold() = 0;
+            Options::webAssemblyBBQAirOptimizationLevel() = 0;
+            Options::defaultB3OptLevel() = 0;
+            Options::wasmBBQUsesAir() = true;
+            Options::useWasmLLInt() = true;
+            Options::wasmLLIntTiersUpToBBQ() = true;
+        }
     }
 
-    if (!jitEnabledByDefault() && !Options::useJIT())
-        Options::useLLInt() = true;
-
-    if (WTF::isX86BinaryRunningOnARM() && Options::useJIT()) {
-        Options::useBaselineJIT() = false;
-        Options::useDFGJIT() = false;
-        Options::useFTLJIT() = false;
-    }
-
-    if (!Options::useWebAssembly())
-        Options::useFastTLSForWasmContext() = false;
-    
-    if (Options::dumpDisassembly()
-        || Options::asyncDisassembly()
-        || Options::dumpDFGDisassembly()
-        || Options::dumpFTLDisassembly()
-        || Options::dumpRegExpDisassembly()
-        || Options::dumpWasmDisassembly()
-        || Options::dumpBBQDisassembly()
-        || Options::dumpOMGDisassembly())
-        Options::needDisassemblySupport() = true;
-
-    if (Options::logJIT()
-        || Options::needDisassemblySupport()
-        || Options::dumpBytecodeAtDFGTime()
-        || Options::dumpGraphAtEachPhase()
-        || Options::dumpDFGGraphAtEachPhase()
-        || Options::dumpDFGFTLGraphAtEachPhase()
-        || Options::dumpB3GraphAtEachPhase()
-        || Options::dumpAirGraphAtEachPhase()
-        || Options::verboseCompilation()
-        || Options::verboseFTLCompilation()
-        || Options::logCompilationChanges()
-        || Options::validateGraph()
-        || Options::validateGraphAtEachPhase()
-        || Options::verboseOSR()
-        || Options::verboseCompilationQueue()
-        || Options::reportCompileTimes()
-        || Options::reportBaselineCompileTimes()
-        || Options::reportDFGCompileTimes()
-        || Options::reportFTLCompileTimes()
-        || Options::logPhaseTimes()
-        || Options::verboseCFA()
-        || Options::verboseDFGFailure()
-        || Options::verboseFTLFailure()
-        || Options::dumpFuzzerAgentPredictions())
+    if (Options::dumpFuzzerAgentPredictions())
         Options::alwaysComputeHash() = true;
-    
+
     if (!Options::useConcurrentGC())
         Options::collectContinuously() = false;
-
-    if (Options::jitPolicyScale() != Options::jitPolicyScaleDefault())
-        scaleJITPolicy();
-    
-    if (Options::forceEagerCompilation()) {
-        Options::thresholdForJITAfterWarmUp() = 10;
-        Options::thresholdForJITSoon() = 10;
-        Options::thresholdForOptimizeAfterWarmUp() = 20;
-        Options::thresholdForOptimizeAfterLongWarmUp() = 20;
-        Options::thresholdForOptimizeSoon() = 20;
-        Options::thresholdForFTLOptimizeAfterWarmUp() = 20;
-        Options::thresholdForFTLOptimizeSoon() = 20;
-        Options::maximumEvalCacheableSourceLength() = 150000;
-        Options::useConcurrentJIT() = false;
-    }
 
     if (Options::useProfiler())
         Options::useConcurrentJIT() = false;
 
     if (Options::alwaysUseShadowChicken())
         Options::maximumInliningDepth() = 1;
-
-    // Compute the maximum value of the reoptimization retry counter. This is simply
-    // the largest value at which we don't overflow the execute counter, when using it
-    // to left-shift the execution counter by this amount. Currently the value ends
-    // up being 18, so this loop is not so terrible; it probably takes up ~100 cycles
-    // total on a 32-bit processor.
-    Options::reoptimizationRetryCounterMax() = 0;
-    while ((static_cast<int64_t>(Options::thresholdForOptimizeAfterLongWarmUp()) << (Options::reoptimizationRetryCounterMax() + 1)) <= static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
-        Options::reoptimizationRetryCounterMax()++;
-
-    ASSERT((static_cast<int64_t>(Options::thresholdForOptimizeAfterLongWarmUp()) << Options::reoptimizationRetryCounterMax()) > 0);
-    ASSERT((static_cast<int64_t>(Options::thresholdForOptimizeAfterLongWarmUp()) << Options::reoptimizationRetryCounterMax()) <= static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
-
+        
 #if !defined(NDEBUG)
     if (Options::maxSingleAllocationSize())
         fastSetMaxSingleAllocationSize(Options::maxSingleAllocationSize());
@@ -679,18 +731,6 @@ void Options::recomputeDependentOptions()
 
     if (Options::verboseVerifyGC())
         Options::verifyGC() = true;
-    
-    // FIXME: This should be removed when we add LLint/OMG support for WASM SIMD
-    if (Options::useWebAssemblySIMD()) {
-        Options::useBBQJIT() = true;
-        Options::useOMGJIT() = false;
-        Options::webAssemblyBBQAirModeThreshold() = 0;
-        Options::webAssemblyBBQAirOptimizationLevel() = 0;
-        Options::defaultB3OptLevel() = 0;
-        Options::wasmBBQUsesAir() = true;
-        Options::useWasmLLInt() = true;
-        Options::wasmLLIntTiersUpToBBQ() = true;
-    }
 
 #if ASAN_ENABLED && OS(LINUX) && ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     if (Options::useWasmFaultSignalHandler()) {
@@ -706,6 +746,17 @@ void Options::recomputeDependentOptions()
 
     if (!Options::useWasmFaultSignalHandler())
         Options::useWebAssemblyFastMemory() = false;
+
+    // Do range checks where needed and make corrections to the options:
+    ASSERT(Options::thresholdForOptimizeAfterLongWarmUp() >= Options::thresholdForOptimizeAfterWarmUp());
+    ASSERT(Options::thresholdForOptimizeAfterWarmUp() >= Options::thresholdForOptimizeSoon());
+    ASSERT(Options::thresholdForOptimizeAfterWarmUp() >= 0);
+    ASSERT(Options::criticalGCMemoryThreshold() > 0.0 && Options::criticalGCMemoryThreshold() < 1.0);
+
+    // The following should only be done at the end after all options
+    // have been initialized.
+    dumpOptionsIfNeeded();
+    assertOptionsAreCoherent();
 }
 
 inline void* Options::addressOfOption(Options::ID id)
@@ -792,59 +843,22 @@ void Options::initialize()
                 ; // Deconfuse editors that do auto indentation
 #endif
 
-            correctOptions();
-    
-            recomputeDependentOptions();
-
-            // Do range checks where needed and make corrections to the options:
-            ASSERT(Options::thresholdForOptimizeAfterLongWarmUp() >= Options::thresholdForOptimizeAfterWarmUp());
-            ASSERT(Options::thresholdForOptimizeAfterWarmUp() >= Options::thresholdForOptimizeSoon());
-            ASSERT(Options::thresholdForOptimizeAfterWarmUp() >= 0);
-            ASSERT(Options::criticalGCMemoryThreshold() > 0.0 && Options::criticalGCMemoryThreshold() < 1.0);
-
-#if HAVE(MACH_EXCEPTIONS)
-            if (Options::useMachForExceptions())
-                handleSignalsWithMach();
-#endif
-
 #if CPU(X86_64) && OS(DARWIN)
             Options::dumpZappedCellCrashData() =
                 (hwPhysicalCPUMax() >= 4) && (hwL3CacheSize() >= static_cast<int64_t>(6 * MB));
 #endif
 
-            // The following should only be done at the end after all options
-            // have been initialized.
-            dumpOptionsIfNeeded();
-            ensureOptionsAreCoherent();
+            // No more options changes after this point. notifyOptionsChanged() will
+            // do sanity checks and fix up options as needed.
+            notifyOptionsChanged();
+
+            // The code below acts on options that have been finalized.
+            // Do not change any options here.
+#if HAVE(MACH_EXCEPTIONS)
+            if (Options::useMachForExceptions())
+                handleSignalsWithMach();
+#endif
     });
-}
-
-void Options::dumpOptionsIfNeeded()
-{
-    if (Options::dumpOptions()) {
-        DumpLevel level = static_cast<DumpLevel>(Options::dumpOptions());
-        if (level > DumpLevel::Verbose)
-            level = DumpLevel::Verbose;
-            
-        const char* title = nullptr;
-        switch (level) {
-        case DumpLevel::None:
-            break;
-        case DumpLevel::Overridden:
-            title = "Overridden JSC options:";
-            break;
-        case DumpLevel::All:
-            title = "All JSC options:";
-            break;
-        case DumpLevel::Verbose:
-            title = "All JSC options with descriptions:";
-            break;
-        }
-
-        StringBuilder builder;
-        dumpAllOptions(builder, level, title, nullptr, "   ", "\n", DumpDefaults);
-        dataLog(builder.toString());
-    }
 }
 
 void Options::finalize()
@@ -929,14 +943,7 @@ bool Options::setOptions(const char* optionsStr)
         }
     }
 
-    correctOptions();
-
-    recomputeDependentOptions();
-
-    dumpOptionsIfNeeded();
-
-    ensureOptionsAreCoherent();
-
+    notifyOptionsChanged();
     WTF::fastFree(optionsStrCopy);
 
     return success;
@@ -966,8 +973,7 @@ bool Options::setOptionWithoutAlias(const char* arg)
         value = parse<OptionsStorage::type_>(valueStr);            \
         if (value) {                                               \
             name_() = value.value();                               \
-            correctOptions();                                      \
-            recomputeDependentOptions();                           \
+            notifyOptionsChanged();                                \
             return true;                                           \
         }                                                          \
         return false;                                              \
@@ -1139,7 +1145,7 @@ void Options::dumpOption(StringBuilder& builder, DumpLevel level, Options::ID id
     builder.append(footer);
 }
 
-void Options::ensureOptionsAreCoherent()
+void Options::assertOptionsAreCoherent()
 {
     AllowUnfinalizedAccessScope scope;
     bool coherent = true;

--- a/Source/JavaScriptCore/runtime/Options.h
+++ b/Source/JavaScriptCore/runtime/Options.h
@@ -116,8 +116,8 @@ public:
     JS_EXPORT_PRIVATE static void dumpAllOptions(DumpLevel, const char* title = nullptr);
     JS_EXPORT_PRIVATE static void dumpAllOptionsInALine(StringBuilder&);
 
-    JS_EXPORT_PRIVATE static void ensureOptionsAreCoherent();
-    static void recomputeDependentOptions();
+    JS_EXPORT_PRIVATE static void assertOptionsAreCoherent();
+    JS_EXPORT_PRIVATE static void notifyOptionsChanged();
 
 #define DECLARE_OPTION_ACCESSORS(type_, name_, defaultValue_, availability_, description_) \
 private: \


### PR DESCRIPTION
#### 6d72ef261e4ac4407332fa74197a5c58a554904c
<pre>
Clean up some options initialization workflow.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248682">https://bugs.webkit.org/show_bug.cgi?id=248682</a>
&lt;rdar://problem/102916238&gt;

Reviewed by Justin Michaud.

We always call correctOptions() before recomputeDependentOptions(), and often call dumpOptionsIfNeeded()
and ensureOptionsAreCoherent() after.

This patch makes things more consistent by doing the following:
1. Rename recomputeDependentOptions() to notifyOptionsChanged().
2. Rename ensureOptionsAreCoherent() to assertOptionsAreCoherent(), because &quot;ensure&quot; implies that the
   function will make them coherent.  Instead, the function asserts that they are coherent.
3. Move the body of correctOptions() (which is a tiny function) into the top of notifyOptionsChanged().
   notifyOptionsChanged() itself fixes up (i.e. corrects) options.  Hence, correctOptions() is
   redundant.
4. Call dumpOptionsIfNeeded() and assertOptionsAreCoherent() at the end of notifyOptionsChanged()
   instead of from clients.
5. Make sure clients call notifyOptionsChanged() after changing options.

Additionally:
6. Disable more JIT related options in disableAllJITOptions().
7. Refactor notifyOptionsChanged() to only process JIT related options in the JIT enabled path.
   The JIT disable path is handled by disableAllJITOptions().
8. Rename ExecutableAllocator:: setJITEnabled() to ExecutableAllocator::disableJIT().  Disabling JIT in
   this function was always a one way street, and there&apos;s no going back.  This rename makes it clear and
   explicit.

* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::ExecutableAllocator::disableJIT):
(JSC::ExecutableAllocator::setJITEnabled): Deleted.
* Source/JavaScriptCore/jit/ExecutableAllocator.h:
(JSC::ExecutableAllocatorBase::disableJIT):
(JSC::ExecutableAllocatorBase::setJITEnabled): Deleted.
* Source/JavaScriptCore/jsc.cpp:
(CommandLine::parseArguments):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::disableAllJITOptions):
(JSC::Options::dumpOptionsIfNeeded):
(JSC::Options::notifyOptionsChanged):
(JSC::Options::initialize):
(JSC::Options::setOptions):
(JSC::Options::setOptionWithoutAlias):
(JSC::Options::assertOptionsAreCoherent):
(JSC::correctOptions): Deleted.
(JSC::Options::recomputeDependentOptions): Deleted.
(JSC::Options::ensureOptionsAreCoherent): Deleted.
* Source/JavaScriptCore/runtime/Options.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h:
(WebKit::XPCServiceInitializer):

Canonical link: <a href="https://commits.webkit.org/257311@main">https://commits.webkit.org/257311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b273f833a30a9e98b410e525fe36281a9b13f54

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98532 "check-webkit-style running") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107955 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168225 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8252 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91074 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104203 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/89335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1677 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85093 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1596 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/28723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6526 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/42130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87945 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2524 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2975 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19703 "Passed tests") | 
<!--EWS-Status-Bubble-End-->