### PR TITLE
Improve <textarea> validation performance

### DIFF
--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -31,6 +31,7 @@
 #include "ElementRareData.h"
 #include "Event.h"
 #include "File.h"
+#include "FileChooser.h"
 #include "FileList.h"
 #include "FormController.h"
 #include "Frame.h"
@@ -343,7 +344,7 @@ void FileInputType::applyFileChooserSettings()
     if (m_fileChooser)
         m_fileChooser->invalidate();
 
-    m_fileChooser = FileChooser::create(this, fileChooserSettings());
+    m_fileChooser = FileChooser::create(*this, fileChooserSettings());
 }
 
 bool FileInputType::allowsDirectories() const

--- a/Source/WebCore/html/FormController.cpp
+++ b/Source/WebCore/html/FormController.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "FormController.h"
 
+#include "FileChooser.h"
 #include "HTMLFormElement.h"
 #include "HTMLInputElement.h"
 #include "ScriptDisallowedScope.h"
@@ -92,8 +93,6 @@ static std::optional<FormControlState> consumeSerializedFormControlState(AtomStr
         return std::nullopt;
     return reader.consumeSubvector(parseInteger<size_t>(sizeString).value_or(0));
 }
-
-// ----------------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------
 

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -44,6 +44,7 @@
 #include "Editor.h"
 #include "ElementInlines.h"
 #include "EventNames.h"
+#include "FileChooser.h"
 #include "FileInputType.h"
 #include "FileList.h"
 #include "FormController.h"
@@ -183,11 +184,6 @@ HTMLElement* HTMLInputElement::innerBlockElement() const
 HTMLElement* HTMLInputElement::innerSpinButtonElement() const
 {
     return m_inputType->innerSpinButtonElement();
-}
-
-HTMLElement* HTMLInputElement::capsLockIndicatorElement() const
-{
-    return m_inputType->capsLockIndicatorElement();
 }
 
 HTMLElement* HTMLInputElement::autoFillButtonElement() const
@@ -1345,11 +1341,6 @@ Vector<String> HTMLInputElement::acceptFileExtensions() const
     return parseAcceptAttribute(attributeWithoutSynchronization(acceptAttr), isValidFileExtension);
 }
 
-String HTMLInputElement::accept() const
-{
-    return attributeWithoutSynchronization(acceptAttr);
-}
-
 String HTMLInputElement::alt() const
 {
     return attributeWithoutSynchronization(altAttr);
@@ -1953,14 +1944,6 @@ MediaCaptureType HTMLInputElement::mediaCaptureType() const
 }
 #endif
 
-bool HTMLInputElement::isInRequiredRadioButtonGroup()
-{
-    ASSERT(isRadioButton());
-    if (auto* buttons = radioButtonGroups())
-        return buttons->isInRequiredGroup(*this);
-    return false;
-}
-
 Vector<Ref<HTMLInputElement>> HTMLInputElement::radioButtonGroup() const
 {
     if (auto* buttons = radioButtonGroups())
@@ -2053,15 +2036,7 @@ void ListAttributeTargetObserver::idTargetChanged()
 }
 #endif
 
-ExceptionOr<void> HTMLInputElement::setRangeText(const String& replacement)
-{
-    if (!m_inputType->supportsSelectionAPI())
-        return Exception { InvalidStateError };
-
-    return HTMLTextFormControlElement::setRangeText(replacement);
-}
-
-ExceptionOr<void> HTMLInputElement::setRangeText(const String& replacement, unsigned start, unsigned end, const String& selectionMode)
+ExceptionOr<void> HTMLInputElement::setRangeText(StringView replacement, unsigned start, unsigned end, const String& selectionMode)
 {
     if (!m_inputType->supportsSelectionAPI())
         return Exception { InvalidStateError };

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -234,12 +234,12 @@ void HTMLTextFormControlElement::dispatchFormControlChangeEvent()
     setChangedSinceLastFormControlChangeEvent(false);
 }
 
-ExceptionOr<void> HTMLTextFormControlElement::setRangeText(const String& replacement)
+ExceptionOr<void> HTMLTextFormControlElement::setRangeText(StringView replacement)
 {
     return setRangeText(replacement, selectionStart(), selectionEnd(), String());
 }
 
-ExceptionOr<void> HTMLTextFormControlElement::setRangeText(const String& replacement, unsigned start, unsigned end, const String& selectionMode)
+ExceptionOr<void> HTMLTextFormControlElement::setRangeText(StringView replacement, unsigned start, unsigned end, const String& selectionMode)
 {
     if (start > end)
         return Exception { IndexSizeError };

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -77,8 +77,8 @@ public:
     WEBCORE_EXPORT void setSelectionEnd(unsigned);
     WEBCORE_EXPORT void setSelectionDirection(const String&);
     WEBCORE_EXPORT void select(SelectionRevealMode = SelectionRevealMode::DoNotReveal, const AXTextStateChangeIntent& = AXTextStateChangeIntent());
-    WEBCORE_EXPORT virtual ExceptionOr<void> setRangeText(const String& replacement);
-    WEBCORE_EXPORT virtual ExceptionOr<void> setRangeText(const String& replacement, unsigned start, unsigned end, const String& selectionMode);
+    WEBCORE_EXPORT ExceptionOr<void> setRangeText(StringView replacement);
+    WEBCORE_EXPORT virtual ExceptionOr<void> setRangeText(StringView replacement, unsigned start, unsigned end, const String& selectionMode);
     void setSelectionRange(unsigned start, unsigned end, const String& direction, const AXTextStateChangeIntent& = AXTextStateChangeIntent());
     WEBCORE_EXPORT bool setSelectionRange(unsigned start, unsigned end, TextFieldSelectionDirection = SelectionHasNoDirection, SelectionRevealMode = SelectionRevealMode::DoNotReveal, const AXTextStateChangeIntent& = AXTextStateChangeIntent());
 

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -320,7 +320,6 @@ public:
     virtual HTMLElement* innerBlockElement() const { return nullptr; }
     virtual RefPtr<TextControlInnerTextElement> innerTextElement() const;
     virtual HTMLElement* innerSpinButtonElement() const { return nullptr; }
-    virtual HTMLElement* capsLockIndicatorElement() const { return nullptr; }
     virtual HTMLElement* autoFillButtonElement() const { return nullptr; }
     virtual HTMLElement* resultsButtonElement() const { return nullptr; }
     virtual HTMLElement* cancelButtonElement() const { return nullptr; }

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -408,11 +408,6 @@ HTMLElement* TextFieldInputType::innerSpinButtonElement() const
     return m_innerSpinButton.get();
 }
 
-HTMLElement* TextFieldInputType::capsLockIndicatorElement() const
-{
-    return m_capsLockIndicator.get();
-}
-
 HTMLElement* TextFieldInputType::autoFillButtonElement() const
 {
     return m_autoFillButton.get();

--- a/Source/WebCore/html/TextFieldInputType.h
+++ b/Source/WebCore/html/TextFieldInputType.h
@@ -66,7 +66,6 @@ protected:
     HTMLElement* innerBlockElement() const final;
     RefPtr<TextControlInnerTextElement> innerTextElement() const final;
     HTMLElement* innerSpinButtonElement() const final;
-    HTMLElement* capsLockIndicatorElement() const final;
     HTMLElement* autoFillButtonElement() const final;
 #if ENABLE(DATALIST_ELEMENT)
     HTMLElement* dataListButtonElement() const final;

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -51,7 +51,6 @@
 #include "EditorClient.h"
 #include "EmptyAttachmentElementClient.h"
 #include "EmptyFrameLoaderClient.h"
-#include "FileChooser.h"
 #include "FormState.h"
 #include "Frame.h"
 #include "FrameLoaderClient.h"

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -29,8 +29,6 @@
 #include "DOMWindow.h"
 #include "Document.h"
 #include "DocumentType.h"
-#include "FileChooser.h"
-#include "FileIconLoader.h"
 #include "FileList.h"
 #include "FloatRect.h"
 #include "Frame.h"

--- a/Source/WebCore/platform/FileChooser.cpp
+++ b/Source/WebCore/platform/FileChooser.cpp
@@ -31,13 +31,13 @@
 
 namespace WebCore {
 
-FileChooser::FileChooser(FileChooserClient* client, const FileChooserSettings& settings)
-    : m_client(client)
+FileChooser::FileChooser(FileChooserClient& client, const FileChooserSettings& settings)
+    : m_client(&client)
     , m_settings(settings)
 {
 }
 
-Ref<FileChooser> FileChooser::create(FileChooserClient* client, const FileChooserSettings& settings)
+Ref<FileChooser> FileChooser::create(FileChooserClient& client, const FileChooserSettings& settings)
 {
     return adoptRef(*new FileChooser(client, settings));
 }
@@ -78,8 +78,6 @@ void FileChooser::cancelFileChoosing()
 
 #if PLATFORM(IOS_FAMILY)
 
-// FIXME: This function is almost identical to FileChooser::chooseFiles(). We should merge this function
-// with FileChooser::chooseFiles() and hence remove the PLATFORM(IOS_FAMILY)-guard.
 void FileChooser::chooseMediaFiles(const Vector<String>& filenames, const String& displayString, Icon* icon)
 {
     if (!m_client)

--- a/Source/WebCore/platform/FileChooser.h
+++ b/Source/WebCore/platform/FileChooser.h
@@ -36,14 +36,13 @@
 
 namespace WebCore {
 
+class Icon;
+
 enum class MediaCaptureType : uint8_t {
     MediaCaptureTypeNone,
     MediaCaptureTypeUser,
     MediaCaptureTypeEnvironment
 };
-
-class FileChooser;
-class Icon;
 
 struct FileChooserFileInfo {
     FileChooserFileInfo isolatedCopy() const & { return { path.isolatedCopy(), replacementPath.isolatedCopy(), displayName.isolatedCopy() }; }
@@ -70,13 +69,12 @@ public:
     virtual ~FileChooserClient() = default;
 
     virtual void filesChosen(const Vector<FileChooserFileInfo>&, const String& displayString = { }, Icon* = nullptr) = 0;
-
     virtual void fileChoosingCancelled() = 0;
 };
 
 class FileChooser : public RefCounted<FileChooser> {
 public:
-    static Ref<FileChooser> create(FileChooserClient*, const FileChooserSettings&);
+    static Ref<FileChooser> create(FileChooserClient&, const FileChooserSettings&);
     WEBCORE_EXPORT ~FileChooser();
 
     void invalidate();
@@ -84,9 +82,9 @@ public:
     WEBCORE_EXPORT void chooseFile(const String& path);
     WEBCORE_EXPORT void chooseFiles(const Vector<String>& paths, const Vector<String>& replacementPaths = { });
     WEBCORE_EXPORT void cancelFileChoosing();
+
 #if PLATFORM(IOS_FAMILY)
-    // FIXME: This function is almost identical to FileChooser::chooseFiles(). We should merge this
-    // function with FileChooser::chooseFiles() and hence remove the PLATFORM(IOS_FAMILY)-guard.
+    // FIXME: This function is almost identical to FileChooser::chooseFiles(). We should merge this in and remove this one.
     WEBCORE_EXPORT void chooseMediaFiles(const Vector<String>& paths, const String& displayString, Icon*);
 #endif
 
@@ -96,7 +94,7 @@ public:
     const FileChooserSettings& settings() const { return m_settings; }
 
 private:
-    FileChooser(FileChooserClient*, const FileChooserSettings&);
+    FileChooser(FileChooserClient&, const FileChooserSettings&);
 
     FileChooserClient* m_client { nullptr };
     FileChooserSettings m_settings;

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm
@@ -659,13 +659,13 @@
 - (void)setRangeText:(NSString *)replacement
 {
     WebCore::JSMainThreadNullState state;
-    raiseOnDOMError(IMPL->setRangeText(replacement));
+    raiseOnDOMError(IMPL->setRangeText(String { replacement }));
 }
 
 - (void)setRangeText:(NSString *)replacement start:(unsigned)start end:(unsigned)end selectionMode:(NSString *)selectionMode
 {
     WebCore::JSMainThreadNullState state;
-    raiseOnDOMError(IMPL->setRangeText(replacement, start, end, selectionMode));
+    raiseOnDOMError(IMPL->setRangeText(String { replacement }, start, end, selectionMode));
 }
 
 - (void)setSelectionRange:(int)start end:(int)end

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm
@@ -308,13 +308,13 @@ DOMHTMLTextAreaElement *kit(WebCore::HTMLTextAreaElement* value)
 - (void)setRangeText:(NSString *)replacement
 {
     WebCore::JSMainThreadNullState state;
-    raiseOnDOMError(unwrap(*self).setRangeText(replacement));
+    raiseOnDOMError(unwrap(*self).setRangeText(String { replacement }));
 }
 
 - (void)setRangeText:(NSString *)replacement start:(unsigned)start end:(unsigned)end selectionMode:(NSString *)selectionMode
 {
     WebCore::JSMainThreadNullState state;
-    raiseOnDOMError(unwrap(*self).setRangeText(replacement, start, end, selectionMode));
+    raiseOnDOMError(unwrap(*self).setRangeText(String { replacement }, start, end, selectionMode));
 }
 
 - (void)setSelectionRange:(int)start end:(int)end


### PR DESCRIPTION
#### 95861845546f13626a0ea23d6eab4e513ff6f760
<pre>
Improve &lt;textarea&gt; validation performance
<a href="https://bugs.webkit.org/show_bug.cgi?id=248447">https://bugs.webkit.org/show_bug.cgi?id=248447</a>
rdar://problem/102909909

Reviewed by Ryosuke Niwa.

Added laziness to the HTMLTextAreaElement computation of validity. Also did style
tweaks and minor reorganization of the two text form element classes.

* Source/WebCore/html/FileInputType.cpp: Added include of FileChooser.h.
(WebCore::FileInputType::applyFileChooserSettings): Update to pass reference.

* Source/WebCore/html/FormController.cpp: Added include of FileChooser.h.

* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::capsLockIndicatorElement const): Deleted.
(WebCore::HTMLInputElement::accept const): Deleted.
(WebCore::HTMLInputElement::isInRequiredRadioButtonGroup): Deleted.
(WebCore::HTMLInputElement::setRangeText): Removed unneeded overload and let
the base class version of setRangeText call the virtual one.

* Source/WebCore/html/HTMLInputElement.h: Removed unneeded includes.
Moved the functions for the IDL file to the top of the class, sorted in the
order that matches the IDL. Removed a few unused functions. Made three
public functions private. Tweaked comments.

* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::HTMLTextAreaElement): Removed the tag name argument.
(WebCore::HTMLTextAreaElement::create): Updated to not pass the tag name to the constructor.
(WebCore::HTMLTextAreaElement::formControlType const): Use textareaTag so we don&apos;t need a global.
(WebCore::HTMLTextAreaElement::collectPresentationalHintsForAttribute): Moved body of the
shouldWrapText in.
(WebCore::HTMLTextAreaElement::parseAttribute): Moved the bodies of maxLengthAttributeChanged,
and minLengthAttributeChanged in.
(WebCore::HTMLTextAreaElement::maxLengthAttributeChanged): Deleted.
(WebCore::HTMLTextAreaElement::minLengthAttributeChanged): Deleted.
(WebCore::HTMLTextAreaElement::appendFormData): Tweaked coding style.
(WebCore::HTMLTextAreaElement::hasCustomFocusLogic const): Moved to the class definition.
(WebCore::HTMLTextAreaElement::defaultTabIndex const): Ditto.
(WebCore::HTMLTextAreaElement::isKeyboardFocusable const): Ditto.
(WebCore::HTMLTextAreaElement::isMouseFocusable const): Ditto.
(WebCore::HTMLTextAreaElement::handleBeforeTextInsertedEvent const): Call maxLength. Merge in the
sanitizeUserInputValue function.
(WebCore::HTMLTextAreaElement::sanitizeUserInputValue): Deleted.
(WebCore::HTMLTextAreaElement::rendererWillBeDestroyed): Moved to the class definition.
(WebCore::HTMLTextAreaElement::validationMessage const): Call maxLength.
(WebCore::HTMLTextAreaElement::valueMissing const): Pass null string for value, so the value will
be computed lazily. In the overload that takes a StringView, get the value lazily.
(WebCore::HTMLTextAreaElement::tooShort const): Ditto.
(WebCore::HTMLTextAreaElement::tooLong const): Ditto.
(WebCore::HTMLTextAreaElement::isValidValue const): Change type to StringView.
(WebCore::HTMLTextAreaElement::shouldUseInputMethod): Moved to the class definition.
(WebCore::HTMLTextAreaElement::placeholderElement const): Ditto.
(WebCore::HTMLTextAreaElement::matchesReadWritePseudoClass const): Ditto.
(WebCore::HTMLTextAreaElement::willRespondToMouseClickEventsWithEditability const): Ditto.

* Source/WebCore/html/HTMLTextAreaElement.h: Removed unneeded include. Moved the functions for the
IDL file to the top of the class, sorted in the order that matches the IDL. Removed some functions.
Moved some function bodies here. Use StringView more often.

* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::setRangeText): Take StringView.

* Source/WebCore/html/HTMLTextFormControlElement.h: Changed setRangeText to take a StringView.
Also made the single argument form non-virtual.

* Source/WebCore/html/InputType.h:
(WebCore::InputType::capsLockIndicatorElement const): Deleted.
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::capsLockIndicatorElement const): Deleted.
* Source/WebCore/html/TextFieldInputType.h: Deleted capsLockIndicatorElement.

* Source/WebCore/loader/EmptyClients.cpp: Deleted unneeded includes.
* Source/WebCore/page/Chrome.cpp: Ditto.

* Source/WebCore/platform/FileChooser.cpp:
(WebCore::FileChooser::FileChooser): Take a reference.
(WebCore::FileChooser::create): Ditto.

* Source/WebCore/platform/FileChooser.h: Updated for the above.

* Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm:
(-[DOMHTMLInputElement setRangeText:]): Create a String explicitly since the function now
takes a StringView.
(-[DOMHTMLInputElement setRangeText:start:end:selectionMode:]): Ditto.
* Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm:
(-[DOMHTMLTextAreaElement setRangeText:]): Ditto.
(-[DOMHTMLTextAreaElement setRangeText:start:end:selectionMode:]): Ditto.

Canonical link: <a href="https://commits.webkit.org/257417@main">https://commits.webkit.org/257417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/450484e953a93cdd1a312fe88c0b9ee1a20ec53d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108362 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168615 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8710 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91480 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106332 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104650 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33622 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76471 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2062 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1968 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5103 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6928 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/42514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3376 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->