### PR TITLE
Add support for the Web Extensions Event API in the WebProcess.

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -308,6 +308,7 @@ $(PROJECT_DIR)/WebProcess/Cache/WebCacheStorageConnection.messages.in
 $(PROJECT_DIR)/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.messages.in
 $(PROJECT_DIR)/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
 $(PROJECT_DIR)/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
+$(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIEvent.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIExtension.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -45,6 +45,9 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverMessagesReplies.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIEvent.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIEvent.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIExtension.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIExtension.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINamespace.h

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -593,6 +593,7 @@ BINDINGS_SCRIPTS = \
 #
 
 EXTENSION_INTERFACES = \
+    WebExtensionAPIEvent \
     WebExtensionAPIExtension \
     WebExtensionAPINamespace \
     WebExtensionAPIRuntime \

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -349,6 +349,7 @@ def types_that_cannot_be_forward_declared():
         'WebKit::TransactionID',
         'WebKit::WCLayerTreeHostIdentifier',
         'WebKit::WCContentBufferIdentifier',
+        'WebKit::WebExtensionEventListenerType',
         'WebKit::XRDeviceIdentifier',
     ] + serialized_identifiers())
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+namespace WebKit {
+
+enum class WebExtensionEventListenerType : uint8_t {
+    Unknown = 0,
+    ActionOnClicked,
+    AlarmsOnAlarm,
+    CommandsOnCommand,
+    ContextMenusOnClicked,
+    CookiesOnChanged,
+    DevToolsElementsPanelOnSelectionChanged,
+    DevToolsExtensionPanelOnShown,
+    DevToolsExtensionPanelOnHidden,
+    DevToolsExtensionSidebarPaneOnShown,
+    DevToolsExtensionSidebarPaneOnHidden,
+    DevToolsExtensionPanelOnSearch,
+    DevToolsNetworkOnNavigated,
+    DevToolsNetworkOnRequestFinished,
+    DevToolsPanelsOnThemeChanged,
+    NotificationsOnButtonClicked,
+    NotificationsOnClicked,
+    PermissionsOnAdded,
+    PermissionsOnRemoved,
+    PortOnDisconnect,
+    PortOnMessage,
+    RuntimeOnConnect,
+    RuntimeOnConnectExternal,
+    RuntimeOnInstalled,
+    RuntimeOnMessage,
+    RuntimeOnMessageExternal,
+    RuntimeOnStartup,
+    StorageOnChanged,
+    TabsOnActivated,
+    TabsOnAttached,
+    TabsOnCreated,
+    TabsOnDetached,
+    TabsOnHighlighted,
+    TabsOnMoved,
+    TabsOnRemoved,
+    TabsOnReplaced,
+    TabsOnUpdated,
+    WebNavigationOnBeforeNavigate,
+    WebNavigationOnCommitted,
+    WebNavigationOnCompleted,
+    WebNavigationOnDOMContentLoaded,
+    WebNavigationOnErrorOccurred,
+    WebRequestOnAuthRequired,
+    WebRequestOnBeforeRedirect,
+    WebRequestOnBeforeRequest,
+    WebRequestOnBeforeSendHeaders,
+    WebRequestOnCompleted,
+    WebRequestOnErrorOccurred,
+    WebRequestOnHeadersReceived,
+    WebRequestOnResponseStarted,
+    WebRequestOnSendHeaders,
+    WindowsOnCreated,
+    WindowsOnFocusChanged,
+    WindowsOnRemoved,
+    DevToolsInspectedWindowOnResourceAdded,
+    DownloadsOnCreated,
+    DownloadsOnChanged,
+};
+
+} // namespace WebKit
+
+namespace WTF {
+
+template<> struct EnumTraits<WebKit::WebExtensionEventListenerType> {
+    using values = EnumValues<
+    WebKit::WebExtensionEventListenerType,
+    WebKit::WebExtensionEventListenerType::Unknown,
+    WebKit::WebExtensionEventListenerType::ActionOnClicked,
+    WebKit::WebExtensionEventListenerType::AlarmsOnAlarm,
+    WebKit::WebExtensionEventListenerType::CommandsOnCommand,
+    WebKit::WebExtensionEventListenerType::ContextMenusOnClicked,
+    WebKit::WebExtensionEventListenerType::CookiesOnChanged,
+    WebKit::WebExtensionEventListenerType::DevToolsElementsPanelOnSelectionChanged,
+    WebKit::WebExtensionEventListenerType::DevToolsExtensionPanelOnShown,
+    WebKit::WebExtensionEventListenerType::DevToolsExtensionPanelOnHidden,
+    WebKit::WebExtensionEventListenerType::DevToolsExtensionSidebarPaneOnShown,
+    WebKit::WebExtensionEventListenerType::DevToolsExtensionSidebarPaneOnHidden,
+    WebKit::WebExtensionEventListenerType::DevToolsExtensionPanelOnSearch,
+    WebKit::WebExtensionEventListenerType::DevToolsNetworkOnNavigated,
+    WebKit::WebExtensionEventListenerType::DevToolsNetworkOnRequestFinished,
+    WebKit::WebExtensionEventListenerType::DevToolsPanelsOnThemeChanged,
+    WebKit::WebExtensionEventListenerType::NotificationsOnButtonClicked,
+    WebKit::WebExtensionEventListenerType::NotificationsOnClicked,
+    WebKit::WebExtensionEventListenerType::PermissionsOnAdded,
+    WebKit::WebExtensionEventListenerType::PermissionsOnRemoved,
+    WebKit::WebExtensionEventListenerType::PortOnDisconnect,
+    WebKit::WebExtensionEventListenerType::PortOnMessage,
+    WebKit::WebExtensionEventListenerType::RuntimeOnConnect,
+    WebKit::WebExtensionEventListenerType::RuntimeOnConnectExternal,
+    WebKit::WebExtensionEventListenerType::RuntimeOnInstalled,
+    WebKit::WebExtensionEventListenerType::RuntimeOnMessage,
+    WebKit::WebExtensionEventListenerType::RuntimeOnMessageExternal,
+    WebKit::WebExtensionEventListenerType::RuntimeOnStartup,
+    WebKit::WebExtensionEventListenerType::StorageOnChanged,
+    WebKit::WebExtensionEventListenerType::TabsOnActivated,
+    WebKit::WebExtensionEventListenerType::TabsOnAttached,
+    WebKit::WebExtensionEventListenerType::TabsOnCreated,
+    WebKit::WebExtensionEventListenerType::TabsOnDetached,
+    WebKit::WebExtensionEventListenerType::TabsOnHighlighted,
+    WebKit::WebExtensionEventListenerType::TabsOnMoved,
+    WebKit::WebExtensionEventListenerType::TabsOnRemoved,
+    WebKit::WebExtensionEventListenerType::TabsOnReplaced,
+    WebKit::WebExtensionEventListenerType::TabsOnUpdated,
+    WebKit::WebExtensionEventListenerType::WebNavigationOnBeforeNavigate,
+    WebKit::WebExtensionEventListenerType::WebNavigationOnCommitted,
+    WebKit::WebExtensionEventListenerType::WebNavigationOnCompleted,
+    WebKit::WebExtensionEventListenerType::WebNavigationOnDOMContentLoaded,
+    WebKit::WebExtensionEventListenerType::WebNavigationOnErrorOccurred,
+    WebKit::WebExtensionEventListenerType::WebRequestOnAuthRequired,
+    WebKit::WebExtensionEventListenerType::WebRequestOnBeforeRedirect,
+    WebKit::WebExtensionEventListenerType::WebRequestOnBeforeRequest,
+    WebKit::WebExtensionEventListenerType::WebRequestOnBeforeSendHeaders,
+    WebKit::WebExtensionEventListenerType::WebRequestOnCompleted,
+    WebKit::WebExtensionEventListenerType::WebRequestOnErrorOccurred,
+    WebKit::WebExtensionEventListenerType::WebRequestOnHeadersReceived,
+    WebKit::WebExtensionEventListenerType::WebRequestOnResponseStarted,
+    WebKit::WebExtensionEventListenerType::WebRequestOnSendHeaders,
+    WebKit::WebExtensionEventListenerType::WindowsOnCreated,
+    WebKit::WebExtensionEventListenerType::WindowsOnFocusChanged,
+    WebKit::WebExtensionEventListenerType::WindowsOnRemoved,
+    WebKit::WebExtensionEventListenerType::DevToolsInspectedWindowOnResourceAdded,
+    WebKit::WebExtensionEventListenerType::DownloadsOnCreated,
+    WebKit::WebExtensionEventListenerType::DownloadsOnChanged
+    >;
+};
+
+} // namespace WTF
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
@@ -23,12 +23,31 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WK_WEB_EXTENSIONS,
-] interface WebExtensionAPIEvent {
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
 
-    [NeedsPage] void addListener([CallbackHandler] function listener);
-    [NeedsPage] void removeListener([CallbackHandler] function listener);
-    boolean hasListener([CallbackHandler] function listener);
+#import "config.h"
+#import "WebExtensionContext.h"
 
-};
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "WebExtensionController.h"
+#import "_WKWebExtensionControllerDelegatePrivate.h"
+#import "_WKWebExtensionControllerInternal.h"
+
+namespace WebKit {
+
+void WebExtensionContext::addListener(WebPageProxyIdentifier identifier, WebExtensionEventListenerType type)
+{
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=248684.
+}
+
+void WebExtensionContext::removeListener(WebPageProxyIdentifier identifier, WebExtensionEventListenerType type)
+{
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=248684
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -35,8 +35,11 @@
 #include "WebExtension.h"
 #include "WebExtensionContextIdentifier.h"
 #include "WebExtensionController.h"
+#include "WebExtensionEventListenerType.h"
 #include "WebExtensionMatchPattern.h"
+#include "WebPageProxyIdentifier.h"
 #include <wtf/Forward.h>
+#include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/ListHashSet.h>
@@ -91,6 +94,8 @@ public:
     using MatchPatternSet = WebExtension::MatchPatternSet;
     using InjectedContentData = WebExtension::InjectedContentData;
     using InjectedContentVector = WebExtension::InjectedContentVector;
+
+    using EventListenterTypeCountedSet = HashCountedSet<WebExtensionEventListenerType, WTF::IntHash<WebKit::WebExtensionEventListenerType>, WTF::StrongEnumHashTraits<WebKit::WebExtensionEventListenerType>>;
 
     enum class EqualityOnly : bool { No, Yes };
 
@@ -258,6 +263,10 @@ private:
     void testYielded(String message, String sourceURL, unsigned lineNumber);
     void testFinished(bool result, String message, String sourceURL, unsigned lineNumber);
 
+    // Event APIs
+    void addListener(WebPageProxyIdentifier, WebExtensionEventListenerType);
+    void removeListener(WebPageProxyIdentifier, WebExtensionEventListenerType);
+
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
@@ -293,6 +302,8 @@ private:
 #else
     bool m_testingMode { true };
 #endif
+
+    EventListenterTypeCountedSet m_backgroundPageListeners;
 
     RetainPtr<WKWebView> m_backgroundWebView;
     RetainPtr<_WKWebExtensionContextDelegate> m_delegate;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -32,6 +32,10 @@ messages -> WebExtensionContext {
     TestMessage(String message, String sourceURL, unsigned lineNumber);
     TestYielded(String message, String sourceURL, unsigned lineNumber);
     TestFinished(bool result, String message, String sourceURL, unsigned lineNumber);
+
+    // Event APIs
+    AddListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type);
+    RemoveListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type);
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1725,7 +1725,12 @@
 		A7D792D81767CCA300881CBE /* ActivityAssertion.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D792D41767CB0900881CBE /* ActivityAssertion.h */; };
 		AAB145E6223F931200E489D8 /* PrefetchCache.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB145E4223F931200E489D8 /* PrefetchCache.h */; };
 		AAFA634F234F7C6400FFA864 /* AsyncRevalidation.h in Headers */ = {isa = PBXBuildFile; fileRef = AAFA634E234F7C6300FFA864 /* AsyncRevalidation.h */; };
+		B6114A7F29394A1600380B1B /* JSWebExtensionAPIEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6114A7D29394A1500380B1B /* JSWebExtensionAPIEvent.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B6114A8C293AE06800380B1B /* WebExtensionEventListenerType.h in Headers */ = {isa = PBXBuildFile; fileRef = B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */; };
 		B62E7312143047B00069EC35 /* WKHitTestResult.h in Headers */ = {isa = PBXBuildFile; fileRef = B62E7311143047B00069EC35 /* WKHitTestResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B6544F932937E45100034EB0 /* WebExtensionAPIEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = B6544F912937E45000034EB0 /* WebExtensionAPIEvent.h */; };
+		B6544F972937E46900034EB0 /* WebExtensionAPIEventCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6544F952937E46900034EB0 /* WebExtensionAPIEventCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B6544F9F2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6544F9E2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B878B615133428DC006888E9 /* CorrectionPanel.h in Headers */ = {isa = PBXBuildFile; fileRef = B878B613133428DC006888E9 /* CorrectionPanel.h */; };
 		BC017D0716260FF4007054F5 /* WKDOMDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = BC017CFF16260FF4007054F5 /* WKDOMDocument.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC017D0916260FF4007054F5 /* WKDOMElement.h in Headers */ = {isa = PBXBuildFile; fileRef = BC017D0116260FF4007054F5 /* WKDOMElement.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -6409,11 +6414,17 @@
 		AB2750C024859B1A00F1C9D8 /* PepperUICoreSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PepperUICoreSPI.h; sourceTree = "<group>"; };
 		ABB6C809249180DB00C50D9A /* ClockKitSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ClockKitSPI.h; sourceTree = "<group>"; };
 		B396EA5512E0ED2D00F4FEB7 /* config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
+		B6114A7C2939498000380B1B /* JSWebExtensionAPIEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIEvent.h; sourceTree = "<group>"; };
+		B6114A7D29394A1500380B1B /* JSWebExtensionAPIEvent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIEvent.mm; sourceTree = "<group>"; };
+		B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionEventListenerType.h; sourceTree = "<group>"; };
 		B62E730F143047A60069EC35 /* WKHitTestResult.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKHitTestResult.cpp; sourceTree = "<group>"; };
 		B62E7311143047B00069EC35 /* WKHitTestResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKHitTestResult.h; sourceTree = "<group>"; };
 		B63403F814910D57001070B5 /* APIObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = APIObject.cpp; sourceTree = "<group>"; };
 		B6544F76293560B000034EB0 /* WebExtensionAPIPermissions.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebExtensionAPIPermissions.idl; sourceTree = "<group>"; };
 		B6544F7C29357B1B00034EB0 /* WebExtensionAPIEvent.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebExtensionAPIEvent.idl; sourceTree = "<group>"; };
+		B6544F912937E45000034EB0 /* WebExtensionAPIEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIEvent.h; sourceTree = "<group>"; };
+		B6544F952937E46900034EB0 /* WebExtensionAPIEventCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIEventCocoa.mm; sourceTree = "<group>"; };
+		B6544F9E2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIEventCocoa.mm; sourceTree = "<group>"; };
 		B878B613133428DC006888E9 /* CorrectionPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorrectionPanel.h; sourceTree = "<group>"; };
 		B878B614133428DC006888E9 /* CorrectionPanel.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CorrectionPanel.mm; sourceTree = "<group>"; };
 		BC017CFF16260FF4007054F5 /* WKDOMDocument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDOMDocument.h; sourceTree = "<group>"; };
@@ -8206,6 +8217,7 @@
 				5C1579F82717AF2200ED5280 /* Daemon */,
 				51E351C2180F2C8500E53BE9 /* Databases */,
 				BC82836816B3587900A278FE /* EntryPointUtilities */,
+				B6114A8A293AE03600380B1B /* Extensions */,
 				E170877216D6CFEC00F99226 /* FileAPI */,
 				515BE1AE1D59003400DD7C68 /* Gamepad */,
 				2DA944961884E4DA00ED86DB /* ios */,
@@ -8778,6 +8790,7 @@
 		1C1549802926E7CC001B9E5B /* API */ = {
 			isa = PBXGroup;
 			children = (
+				B6544F9E2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm */,
 				1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */,
 			);
 			path = API;
@@ -8795,6 +8808,7 @@
 			isa = PBXGroup;
 			children = (
 				1C5DC4502908A9D00061EC62 /* Cocoa */,
+				B6544F912937E45000034EB0 /* WebExtensionAPIEvent.h */,
 				1C5DC468290B239C0061EC62 /* WebExtensionAPIExtension.h */,
 				1C5DC44F290888140061EC62 /* WebExtensionAPINamespace.h */,
 				1C5DC44E29087E7F0061EC62 /* WebExtensionAPIObject.h */,
@@ -8807,6 +8821,7 @@
 		1C5DC4502908A9D00061EC62 /* Cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				B6544F952937E46900034EB0 /* WebExtensionAPIEventCocoa.mm */,
 				1C5DC465290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm */,
 				1C5DC4512908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm */,
 				1C5DC464290B23890061EC62 /* WebExtensionAPIRuntimeCocoa.mm */,
@@ -12040,6 +12055,14 @@
 			path = watchos;
 			sourceTree = "<group>";
 		};
+		B6114A8A293AE03600380B1B /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		BC017D1016260FFD007054F5 /* DOM */ = {
 			isa = PBXGroup;
 			children = (
@@ -13412,6 +13435,8 @@
 				0F5562DE27EE28D000953585 /* GPUProcessMessages.h */,
 				0F5562E827EE28D200953585 /* GPUProcessProxyMessageReceiver.cpp */,
 				0F5562E427EE28D100953585 /* GPUProcessProxyMessages.h */,
+				B6114A7C2939498000380B1B /* JSWebExtensionAPIEvent.h */,
+				B6114A7D29394A1500380B1B /* JSWebExtensionAPIEvent.mm */,
 				1C5DC462290B1C470061EC62 /* JSWebExtensionAPIExtension.h */,
 				1C5DC460290B1C440061EC62 /* JSWebExtensionAPIExtension.mm */,
 				1C5DC4532908AC260061EC62 /* JSWebExtensionAPINamespace.h */,
@@ -15419,6 +15444,7 @@
 				BC111B5D112F629800337BAB /* WebEventFactory.h in Headers */,
 				86DD519028EF28E800DF2A58 /* WebEventModifier.h in Headers */,
 				DDA0A41727E67039005E086E /* WebEventRegion.h in Headers */,
+				B6544F932937E45100034EB0 /* WebExtensionAPIEvent.h in Headers */,
 				1C5DC46D290B271E0061EC62 /* WebExtensionAPIExtension.h in Headers */,
 				1C5DC46C290B271E0061EC62 /* WebExtensionAPINamespace.h in Headers */,
 				1C5DC46B290B271E0061EC62 /* WebExtensionAPIObject.h in Headers */,
@@ -15434,6 +15460,7 @@
 				1C3BEB7B2888A00B00E66E38 /* WebExtensionControllerParameters.h in Headers */,
 				1C3BEB7D2888A01600E66E38 /* WebExtensionControllerProxy.h in Headers */,
 				1C3BEB512887492F00E66E38 /* WebExtensionControllerProxyMessages.h in Headers */,
+				B6114A8C293AE06800380B1B /* WebExtensionEventListenerType.h in Headers */,
 				1CAB9B8728F746AA00E6C77E /* WebExtensionURLSchemeHandler.h in Headers */,
 				DDA0A35D27E55E4F005E086E /* WebFeature.h in Headers */,
 				9354242C2703BDCB005CA72C /* WebFileSystemStorageConnection.h in Headers */,
@@ -17787,6 +17814,7 @@
 				51E9049727BCB3D900929E7E /* ICAppBundle.mm in Sources */,
 				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
 				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
+				B6114A7F29394A1600380B1B /* JSWebExtensionAPIEvent.mm in Sources */,
 				1C5DC471290B33A20061EC62 /* JSWebExtensionAPIExtension.mm in Sources */,
 				1C5DC4552908AC900061EC62 /* JSWebExtensionAPINamespace.mm in Sources */,
 				1C5DC472290B33A60061EC62 /* JSWebExtensionAPIRuntime.mm in Sources */,
@@ -18108,11 +18136,13 @@
 				E3866B0B2399A2DD00F88FE9 /* WebDeviceOrientationUpdateProviderMessageReceiver.cpp in Sources */,
 				E3866AE52397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm in Sources */,
 				E3866B092399A2D500F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessageReceiver.cpp in Sources */,
+				B6544F972937E46900034EB0 /* WebExtensionAPIEventCocoa.mm in Sources */,
 				1C5DC467290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm in Sources */,
 				1C5DC4522908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm in Sources */,
 				1C5DC466290B23890061EC62 /* WebExtensionAPIRuntimeCocoa.mm in Sources */,
 				1C15497A2926BF03001B9E5B /* WebExtensionAPITestCocoa.mm in Sources */,
 				1C627478288A1E1D00CED3A2 /* WebExtensionCocoa.mm in Sources */,
+				B6544F9F2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm in Sources */,
 				1C1549822926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm in Sources */,
 				1C0234DC28A0268C00AC1E5B /* WebExtensionContextCocoa.mm in Sources */,
 				1C0234CD28A00FE400AC1E5B /* WebExtensionContextMessageReceiver.cpp in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionAPIEvent.h"
+
+#import "WebExtensionContextMessages.h"
+#import "WebPageProxy.h"
+#import "WebProcess.h"
+#import <JavaScriptCore/APICast.h>
+#import <JavaScriptCore/ScriptCallStack.h>
+#import <JavaScriptCore/ScriptCallStackFactory.h>
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+namespace WebKit {
+
+class JSWebExtensionWrappable;
+
+void WebExtensionAPIEvent::invokeListeners()
+{
+    if (m_listeners.isEmpty())
+        return;
+
+    for (auto& listener : m_listeners)
+        listener->call();
+}
+
+void WebExtensionAPIEvent::invokeListenersWithArgument(id argument1)
+{
+    if (m_listeners.isEmpty())
+        return;
+
+    for (auto& listener : m_listeners)
+        listener->call(argument1);
+}
+
+void WebExtensionAPIEvent::invokeListenersWithArgument(id argument1, id argument2)
+{
+    if (m_listeners.isEmpty())
+        return;
+
+    for (auto& listener : m_listeners)
+        listener->call(argument1, argument2);
+}
+
+void WebExtensionAPIEvent::invokeListenersWithArgument(id argument1, id argument2, id argument3)
+{
+    if (m_listeners.isEmpty())
+        return;
+
+    for (auto& listener : m_listeners)
+        listener->call(argument1, argument2, argument3);
+}
+
+void WebExtensionAPIEvent::addListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener)
+{
+    m_listeners.append(listener);
+
+    if (!page)
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(page->webPageProxyIdentifier(), m_type));
+}
+
+void WebExtensionAPIEvent::removeListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener)
+{
+    m_listeners.removeAllMatching([&](auto& entry) {
+        return entry->callbackFunction() == listener->callbackFunction();
+    });
+
+    if (!page)
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(page->webPageProxyIdentifier(), m_type));
+}
+
+bool WebExtensionAPIEvent::hasListener(RefPtr<WebExtensionCallbackHandler> listener)
+{
+    return m_listeners.containsIf([&](auto& entry) {
+        return entry->callbackFunction() == listener->callbackFunction();
+    });
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
@@ -23,12 +23,42 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WK_WEB_EXTENSIONS,
-] interface WebExtensionAPIEvent {
+#pragma once
 
-    [NeedsPage] void addListener([CallbackHandler] function listener);
-    [NeedsPage] void removeListener([CallbackHandler] function listener);
-    boolean hasListener([CallbackHandler] function listener);
+#if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "JSWebExtensionAPIEvent.h"
+#include "JSWebExtensionWrappable.h"
+#include "WebExtensionAPIObject.h"
+#include "WebExtensionEventListenerType.h"
+#include "WebPage.h"
+
+OBJC_CLASS JSValue;
+
+namespace WebKit {
+
+class WebExtensionAPIEvent : public WebExtensionAPIObject, public JSWebExtensionWrappable {
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIEvent, event);
+
+public:
+    using ListenerVector = Vector<RefPtr<WebExtensionCallbackHandler>>;
+
+    void invokeListeners();
+    void invokeListenersWithArgument(id argument);
+    void invokeListenersWithArgument(id argument1, id argument2);
+    void invokeListenersWithArgument(id argument1, id argument2, id argument3);
+
+    const ListenerVector& listeners() const { return m_listeners; }
+
+    void addListener(WebPage*, RefPtr<WebExtensionCallbackHandler>);
+    void removeListener(WebPage*, RefPtr<WebExtensionCallbackHandler>);
+    bool hasListener(RefPtr<WebExtensionCallbackHandler>);
+
+private:
+    WebExtensionEventListenerType m_type;
+    ListenerVector m_listeners;
 };
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -1252,7 +1252,6 @@ sub _platformTypeVariableDeclaration
 
     return "$platformType$variableName = $condition && $constructor;" if $condition && $platformType eq "bool ";
     return "$platformType$variableName = $condition ? $constructor : $nullValue;" if $condition;
-    return "$platformType$variableName;" if $platformType =~ /^RefPtr</;
     return "$platformType$variableName = $constructor;" if $constructor;
     return "$platformType$variableName = $nullValue;";
 }


### PR DESCRIPTION
#### f14203440c9ccb1f09af72288eec9fb1b75f235d
<pre>
Add support for the Web Extensions Event API in the WebProcess.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248684">https://bugs.webkit.org/show_bug.cgi?id=248684</a>

Reviewed by Timothy Hatcher.

This patch adds support for the Web Extensions Event API in the WebProcess. This includes support
for adding, removing, and invoking event listeners.

Testing:
Using a test extension, I added a &apos;testEvent&apos; property to the WebExtensionTest API, and I called
&quot;browser.test.testEvent.addListener()&quot; in the background page of the extension. Using the debugger,
I confirmed that the code path for adding the listener hits and a call to
Messages::WebExtensionContext::AddListener is made.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:

* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):
Add WebKit::WebExtensionEventListenerType to types that cannot be forward declared so that the
correct type will be used in WebExtensionMessageReceiver.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
Copied from Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in.
(WebKit::WebExtensionContext::addListener):
(WebKit::WebExtensionContext::removeListener):
Methods for adding and removing event listeners for extensions in the UIProcess.
Implementation being tracked in <a href="https://bugs.webkit.org/show_bug.cgi?id=248684.">https://bugs.webkit.org/show_bug.cgi?id=248684.</a>

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm: Added.
(WebKit::WebExtensionAPIEvent::invokeListeners):
(WebKit::WebExtensionAPIEvent::invokeListenersWithArgument):
(WebKit::WebExtensionAPIEvent::addListener):
(WebKit::WebExtensionAPIEvent::removeListener):
(WebKit::WebExtensionAPIEvent::hasListener):

* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_platformTypeVariableDeclaration):
Remove this line of code so that the generated code in JSWebExtensionAPIEvent::addListener can
successfully set the listener. With this line, RefPtr&lt;WebExtensionCallbackHandler&gt; listener
never gets set.

* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIEvent.idl:
Use [NeedsPage] instead of NeedsPageWithCallbackHandler since hasListeners doesn&apos;t need the WebPage.

Canonical link: <a href="https://commits.webkit.org/257375@main">https://commits.webkit.org/257375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad401b4be2a7ddb5795fe56264832d8d1d8cd37a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107991 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85157 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91103 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/105975 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104251 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6282 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89838 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33277 "Found 1 new test failure: fast/text/text-edge-no-half-leading-simple.html (failure)") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/102108 "Found 1 webkitpy python2 test failure: webkitpy.port.server_process_unittest.TestServerProcess.test_broken_pipe") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88100 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21197 "Found 4 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html, fast/text/text-edge-no-half-leading-with-line-height-simple.html, fast/text/text-edge-with-margin-padding-border-simple.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76210 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1712 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22726 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-with-margin-padding-border-simple.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1625 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45224 "Found 3 new test failures: fast/text/text-edge-with-margin-padding-border-simple.html, imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection.html, media/video-inaccurate-duration-ended.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42151 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2554 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3012 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->