### PR TITLE
Playback stops although the progress bar moves

### DIFF
--- a/LayoutTests/http/tests/media/video-play-stall-expected.txt
+++ b/LayoutTests/http/tests/media/video-play-stall-expected.txt
@@ -4,11 +4,10 @@ Test that a stalled event is sent when media loading stalls.
 EVENT(durationchange)
 EVENT(loadedmetadata)
 EVENT(loadeddata)
-EVENT(canplay)
-RUN(video.play())
 EVENT(stalled)
-EXPECTED (video.currentTime != '0') OK
+TEST(video.currentTime <= bufferedend) OK
+TEST(gotCanplay ? video.paused == false : video.paused == true) OK
 EXPECTED (video.playbackRate === '1') OK
-EXPECTED (video.paused === 'false') OK
+TEST(video.duration > bufferedend) OK
 END OF TEST
 

--- a/LayoutTests/http/tests/media/video-play-stall.html
+++ b/LayoutTests/http/tests/media/video-play-stall.html
@@ -4,36 +4,45 @@
         <title>'stalled' event test</title>
         <script src=../../media-resources/media-file.js></script>
         <script src=../../media-resources/video-test.js></script>
+        <script src=../../media-resources/utilities.js></script>
         <script>
 
-            var playCount = 0;
+            var bufferedend = 0;
+            var gotCanplay = false;
 
-            function start() 
+            function start()
             {
                 findMediaElement();
                 waitForEvent('durationchange');
                 waitForEvent('loadedmetadata');
                 waitForEvent('loadeddata');
 
-                mediaElement.addEventListener('canplay', function () {
-                    // 'stalled' takes three seconds to fire, so 'canplay' may fire more than once
-                    // depending on how the engine parses incoming media data.
-                    if (++playCount > 1)
-                        return;
-                    consoleWrite("EVENT(canplay)");
-                    run("video.play()");
-                } );
+                once(mediaElement, 'canplay', () => {
+                    video.play()
+                    gotCanplay = true;
+                });
 
                 waitForEvent('stalled', function () {
-                    testExpected("video.currentTime", 0, "!=");
+                    // The test simulates a load stalled by blocking the http server for several seconds.
+                    // Under loads, it is possible that we failed to retrieve any content at all.
+                    // The aim of the test being that we do emit the stalled event and that currentTime
+                    // didn't progress we output data that would pass the expectations under both conditions.
+                    if (video.buffered.length > 0)
+                        bufferedend = video.buffered.end(0);
+                    test("video.currentTime <= bufferedend", false);
+                    // If we loaded some content, playback has started
+                    test("gotCanplay ? video.paused == false : video.paused == true");
                     testExpected("video.playbackRate", 1, "===");
-                    testExpected("video.paused", false, "===");
+                    test("video.duration > bufferedend", false);
+                    // TestRunner waits for the complete frame download before finishing, so having the video load stalled
+                    // prevents TestRunner from finishing. Changing the src will abort the download and let the test finish.
+                    video.src = "";
                     endTest();
                 } );
 
                 var mediaFile = findMediaFile("video", "../../../../media/content/long-test");
                 var mimeType = mimeTypeForFile(mediaFile);
-                video.src = "http://127.0.0.1:8000/media/resources/serve_video.py?name=" + mediaFile + "&type=" + mimeType + "&stallOffset=1000000&stallDuration=60&chunkSize=1024";
+                video.src = "http://127.0.0.1:8000/media/resources/serve_video.py?name=" + mediaFile + "&type=" + mimeType + "&stallOffset=50000&stallDuration=20&chunkSize=1024";
             }
 
         </script>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3873,7 +3873,7 @@ void HTMLMediaElement::setPlaybackRate(double rate)
 void HTMLMediaElement::updatePlaybackRate()
 {
     double requestedRate = requestedPlaybackRate();
-    if (m_player && potentiallyPlaying() && m_player->effectiveRate() != requestedRate)
+    if (m_player && potentiallyPlaying() && m_player->rate() != requestedRate)
         m_player->setRate(requestedRate);
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -524,7 +524,7 @@ void MediaPlayerPrivateAVFoundation::updateStates()
         // -loadValuesAsynchronouslyForKeys:completionHandler: has invoked its handler; test status of keys and determine state.
         AssetStatus assetStatus = this->assetStatus();
         ItemStatus itemStatus = playerItemStatus();
-        
+
         m_assetIsPlayable = (assetStatus == MediaPlayerAVAssetStatusPlayable);
         if (m_readyState < MediaPlayer::ReadyState::HaveMetadata && assetStatus > MediaPlayerAVAssetStatusLoading) {
             if (m_assetIsPlayable) {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1687,7 +1687,7 @@ double MediaPlayerPrivateAVFoundationObjC::effectiveRate() const
     if (!metaDataAvailable())
         return 0;
 
-    return m_cachedRate;
+    return m_cachedTimeControlStatus == AVPlayerTimeControlStatusWaitingToPlayAtSpecifiedRate ? 0.0 : m_cachedRate;
 }
 
 double MediaPlayerPrivateAVFoundationObjC::seekableTimeRangesLastModifiedTime() const


### PR DESCRIPTION
#### 384fb5b098b89ed16edca08da12f59edd924a952
<pre>
Playback stops although the progress bar moves
<a href="https://bugs.webkit.org/show_bug.cgi?id=248585">https://bugs.webkit.org/show_bug.cgi?id=248585</a>
rdar://102846199

Reviewed by Eric Carlson.

When playback has stalled due to insufficient data being buffered, the effective rate
should be 0 as time is no longer progressing.
While the GPU process would indicate that the rate has changed once the player has
stalled, the effective rate reported would remain the same causing the current time
position to continue moving as it&apos;s estimated based on the effective rate.

Fly-By fix: set the new rate in HTMLMediaElement if previously the requested rate
is different.

* LayoutTests/http/tests/media/video-play-stall.html: Update test to ensure currentTime doesn&apos;t progress
(WebCore::HTMLMediaElement::updatePlaybackRate):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::updateStates):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::effectiveRate const):

Canonical link: <a href="https://commits.webkit.org/257403@main">https://commits.webkit.org/257403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4638b3e3bdd73bbe87913d2633931f362315dbfd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108301 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168557 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85461 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91419 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106281 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104577 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33583 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76437 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2007 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1916 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5093 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42458 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3316 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->