### PR TITLE
Allow multiple data store and push partition identifiers per app in PushDatabase

### DIFF
--- a/Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.h
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.h
@@ -26,10 +26,33 @@
 #pragma once
 
 #include <wtf/ObjectIdentifier.h>
+#include <wtf/UUID.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 enum PushSubscriptionIdentifierType { };
 using PushSubscriptionIdentifier = ObjectIdentifier<PushSubscriptionIdentifierType>;
+
+struct PushSubscriptionSetIdentifier {
+    String bundleIdentifier;
+    String pushPartition;
+    std::optional<UUID> dataStoreIdentifier;
+
+    bool operator==(const PushSubscriptionSetIdentifier&) const = default;
+
+    PushSubscriptionSetIdentifier isolatedCopy() const &;
+    PushSubscriptionSetIdentifier isolatedCopy() &&;
+};
+
+inline PushSubscriptionSetIdentifier PushSubscriptionSetIdentifier::isolatedCopy() const &
+{
+    return { bundleIdentifier.isolatedCopy(), pushPartition.isolatedCopy(), dataStoreIdentifier };
+}
+
+inline PushSubscriptionSetIdentifier PushSubscriptionSetIdentifier::isolatedCopy() &&
+{
+    return { WTFMove(bundleIdentifier).isolatedCopy(), WTFMove(pushPartition).isolatedCopy(), dataStoreIdentifier };
+}
 
 }

--- a/Source/WebCore/platform/sql/SQLiteStatement.h
+++ b/Source/WebCore/platform/sql/SQLiteStatement.h
@@ -38,7 +38,11 @@ class SQLiteStatement {
 public:
     WEBCORE_EXPORT ~SQLiteStatement();
     WEBCORE_EXPORT SQLiteStatement(SQLiteStatement&&);
-    
+
+    // Binds multiple parameters. Returns true if all were successfully bound.
+    template<typename T, typename... Args>
+    bool bind(T, Args&&...);
+
     WEBCORE_EXPORT int bindBlob(int index, Span<const uint8_t>);
     WEBCORE_EXPORT int bindBlob(int index, const String&);
     WEBCORE_EXPORT int bindText(int index, StringView);
@@ -85,8 +89,40 @@ private:
     // Returns true if the prepared statement has been stepped at least once using step() but has neither run to completion (returned SQLITE_DONE from step()) nor been reset().
     bool hasStartedStepping();
 
+    template<typename T, typename... Args> bool bindImpl(int i, T first, Args&&... args);
+    template<typename T> bool bindImpl(int, T);
+
     SQLiteDatabase& m_database;
     sqlite3_stmt* m_statement;
 };
+
+template<typename T, typename... Args>
+inline bool SQLiteStatement::bind(T first, Args&&... args)
+{
+    return bindImpl(1, first, std::forward<Args>(args)...);
+}
+
+template<typename T, typename... Args>
+inline bool SQLiteStatement::bindImpl(int i, T first, Args&&... args)
+{
+    return bindImpl(i, first) && bindImpl(i+1, std::forward<Args>(args)...);
+}
+
+template<typename T>
+inline bool SQLiteStatement::bindImpl(int i, T value)
+{
+    if constexpr (std::is_convertible_v<T, Span<const uint8_t>>)
+        return bindBlob(i, value) == SQLITE_OK;
+    else if constexpr (std::is_convertible_v<T, StringView>)
+        return bindText(i, value) == SQLITE_OK;
+    else if constexpr (std::is_same_v<T, std::nullptr_t>)
+        return bindNull(i) == SQLITE_OK;
+    else if constexpr (std::is_floating_point_v<T>)
+        return bindDouble(i, value) == SQLITE_OK;
+    else if constexpr (std::is_same_v<T, SQLValue>)
+        return bindValue(i, value) == SQLITE_OK;
+    else
+        return bindInt64(i, value) == SQLITE_OK;
+}
 
 } // namespace WebCore


### PR DESCRIPTION
#### 0ad922bc0c9601604a6ba8ca53ea271927b768d6
<pre>
Allow multiple data store and push partition identifiers per app in PushDatabase
<a href="https://bugs.webkit.org/show_bug.cgi?id=248695">https://bugs.webkit.org/show_bug.cgi?id=248695</a>
&lt;rdar://problem/102922285&gt;

Reviewed by Brady Eidson.

This upgrades the PushDatabase schema to allow more than one data store identifier and push
partition identifier per app. Previously, a push subscription was identified by (bundleID,
serviceWorkerScopeURL). After this patch, it&apos;s identified by (bundleID, pushPartition,
dataStoreUUID, serviceWorkerScopeURL).

To do this, in this patch we:

* Create a new type PushSubscriptionSetIdentifier which is a tuple of (bundleID, pushPartition,
  dataStoreUUID).  We use this type wherever we used to use only bundleID.

* Add new columns to the SubscriptionSets table to store the pushPartition and
  dataStoreUUID. dataStoreUUID column to the SubscriptionSets table. This involves a copying the
  table and then dropping it since we are adding the columns to the middle of the table, and because
  we need to regenerate a unique index. (ALTER TABLE doesn&apos;t have the power to do either.)

* Since a lot of PushDatabase involves boilerplate around binding parameters, I added a binding
  helper method to SQLiteStatement that allows multiple parameters to be bound in one function call
  and am now using that in PushDatabase.

* Modified the API tests to also test multiple subscription set identifiers.

For now, PushService (the only user of PushDatabase) is still unaware of pushPartition and
dataStoreUUID. I&apos;ll add that support to PushService in a future patch.

* Source/WebCore/Modules/push-api/PushDatabase.cpp:
(WebCore::PushRecord::isolatedCopy const):
(WebCore::PushRecord::isolatedCopy):
(WebCore::openAndMigrateDatabase):
(WebCore::PushDatabase::bindStatementOnQueue):
(WebCore::uuidToSpan):
(WebCore::uuidFromSpan):
(WebCore::expirationTimeToValue):
(WebCore::expirationTimeFromValue):
(WebCore::PushDatabase::updatePublicToken):
(WebCore::PushDatabase::getPublicToken):
(WebCore::PushDatabase::insertRecord):
(WebCore::PushDatabase::removeRecordByIdentifier):
(WebCore::makePushRecordFromRow):
(WebCore::PushDatabase::getRecordByTopic):
(WebCore::PushDatabase::getRecordBySubscriptionSetAndScope):
(WebCore::PushDatabase::getTopics):
(WebCore::PushDatabase::incrementSilentPushCount):
(WebCore::PushDatabase::removeRecordsBySubscriptionSet):
(WebCore::PushDatabase::removeRecordsBySubscriptionSetAndSecurityOrigin):
(WebCore::PushDatabase::setPushesEnabledForOrigin):
(WebCore::bindExpirationTime): Deleted.
(WebCore::PushDatabase::getRecordByBundleIdentifierAndScope): Deleted.
(WebCore::PushDatabase::removeRecordsByBundleIdentifier): Deleted.
(WebCore::PushDatabase::removeRecordsByBundleIdentifierAndSecurityOrigin): Deleted.
* Source/WebCore/Modules/push-api/PushDatabase.h:
* Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.h:
(WebCore::PushSubscriptionSetIdentifier::isolatedCopy const):
(WebCore::PushSubscriptionSetIdentifier::isolatedCopy):
* Source/WebCore/platform/sql/SQLiteStatement.h:
(WebCore::SQLiteStatement::bind):
(WebCore::SQLiteStatement::bindImpl):
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::makeSubscriptionSet):
(WebPushD::GetSubscriptionRequest::startInternal):
(WebPushD::SubscribeRequest::startImpl):
(WebPushD::UnsubscribeRequest::startInternal):
(WebPushD::PushService::incrementSilentPushCount):
(WebPushD::PushService::setPushesEnabledForBundleIdentifierAndOrigin):
(WebPushD::PushService::removeRecordsImpl):
(WebPushD::PushService::didReceivePushMessage):
* Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp:
(WebCore::operator==):
(TestWebKitAPI::getTopicsFromRecords):
(TestWebKitAPI::getRecordBySubscriptionSetAndScopeSync):
(TestWebKitAPI::PushDatabaseTest::getRecordBySubscriptionSetAndScope):
(TestWebKitAPI::PushDatabaseTest::removeRecordsBySubscriptionSet):
(TestWebKitAPI::PushDatabaseTest::removeRecordsBySubscriptionSetAndSecurityOrigin):
(TestWebKitAPI::PushDatabaseTest::incrementSilentPushCount):
(TestWebKitAPI::PushDatabaseTest::setPushesEnabledForOrigin):
(TestWebKitAPI::TEST_F):
(TestWebKitAPI::TEST):
(TestWebKitAPI::getRecordByBundleIdentifierAndScopeSync): Deleted.
(TestWebKitAPI::PushDatabaseTest::getRecordByBundleIdentifierAndScope): Deleted.
(TestWebKitAPI::PushDatabaseTest::removeRecordsByBundleIdentifier): Deleted.
(TestWebKitAPI::PushDatabaseTest::removeRecordsByBundleIdentifierAndSecurityOrigin): Deleted.

Canonical link: <a href="https://commits.webkit.org/257521@main">https://commits.webkit.org/257521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e938383d2613d869a4726724bfe572628d9ffb76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99099 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108492 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168734 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85650 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91602 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106434 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33712 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88515 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76570 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2195 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23128 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45543 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5170 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7048 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42606 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->