### PR TITLE
Make the debug assertion in AuxiliaryProcess::registerWithStateDumper more descriptive

### DIFF
--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -129,7 +129,7 @@ void AuxiliaryProcess::registerWithStateDumper(ASCIILiteral title)
             auto data = [NSPropertyListSerialization dataWithPropertyList:stateDictionary.get() format:NSPropertyListBinaryFormat_v1_0 options:0 error:&error];
 
             if (!data) {
-                ASSERT(data);
+                ASSERT_NOT_REACHED_WITH_MESSAGE("Failed to serialize OS state info with error: %@", error);
                 return os_state;
             }
 


### PR DESCRIPTION
#### 3f4765beb0bdcc287d626d2818c04f631cd2058b
<pre>
Make the debug assertion in AuxiliaryProcess::registerWithStateDumper more descriptive
<a href="https://bugs.webkit.org/show_bug.cgi?id=248696">https://bugs.webkit.org/show_bug.cgi?id=248696</a>

Reviewed by Simon Fraser.

Use `ASSERT_NOT_REACHED_WITH_MESSAGE` instead of a regular `ASSERT`, so that:
1. The intent (to exit immediately in debug) is more explicit, and also:
2. To include a descriptive message containing the serialization error in the crash log.

* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::registerWithStateDumper):

Canonical link: <a href="https://commits.webkit.org/257317@main">https://commits.webkit.org/257317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34745e035a368a59ae00a5da2e5a6a63ca98cb7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107982 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85149 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91095 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/105968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104238 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89831 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33265 "Found 1 new test failure: css3/supports-dom-api.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88096 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1703 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1617 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5039 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42143 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->