### PR TITLE
[JSC] Make BaselineCallLinkInfo more compact

### DIFF
--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
@@ -207,13 +207,6 @@ ExecutableBase* CallLinkInfo::executable()
     return jsCast<ExecutableBase*>(m_lastSeenCalleeOrExecutable.get());
 }
 
-void CallLinkInfo::setMaxArgumentCountIncludingThis(unsigned value)
-{
-    RELEASE_ASSERT(isDirect());
-    RELEASE_ASSERT(value);
-    m_maxArgumentCountIncludingThis = value;
-}
-
 void CallLinkInfo::visitWeak(VM& vm)
 {
     auto handleSpecificCallee = [&] (JSFunction* callee) {
@@ -229,7 +222,7 @@ void CallLinkInfo::visitWeak(VM& vm)
             if (!stub()->visitWeak(vm)) {
                 if (UNLIKELY(Options::verboseOSR())) {
                     dataLog(
-                        "At ", m_codeOrigin, ", ", RawPointer(this), ": clearing call stub to ",
+                        "At ", codeOrigin(), ", ", RawPointer(this), ": clearing call stub to ",
                         listDump(stub()->variants()), ", stub routine ", RawPointer(stub()),
                         ".\n");
                 }
@@ -322,7 +315,7 @@ void BaselineCallLinkInfo::initialize(VM& vm, CallType callType, BytecodeIndex b
     ASSERT(Type::Baseline == type());
     m_useDataIC = static_cast<unsigned>(UseDataIC::Yes);
     ASSERT(UseDataIC::Yes == useDataIC());
-    m_codeOrigin = CodeOrigin(bytecodeIndex);
+    m_bytecodeIndex = bytecodeIndex;
     m_callType = callType;
     if (LIKELY(Options::useLLIntICs()))
         setSlowPathCallDestination(vm.getCTILinkCall().code());
@@ -590,6 +583,13 @@ void OptimizingCallLinkInfo::setDirectCallTarget(CodeBlock* codeBlock, CodeLocat
 
     MacroAssembler::repatchNearCall(m_callLocation, target);
     MacroAssembler::repatchPointer(u.codeIC.m_codeBlockLocation, codeBlock);
+}
+
+void OptimizingCallLinkInfo::setDirectCallMaxArgumentCountIncludingThis(unsigned value)
+{
+    RELEASE_ASSERT(isDirect());
+    RELEASE_ASSERT(value);
+    m_maxArgumentCountIncludingThisForDirectCall = value;
 }
 
 #if ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.h
@@ -59,6 +59,8 @@ class CallLinkInfo : public PackedRawSentinelNode<CallLinkInfo> {
 public:
     friend class LLIntOffsetsExtractor;
 
+    static constexpr uint8_t maxProfiledArgumentCountIncludingThisForVarargs = UINT8_MAX;
+
     enum class Type : uint8_t {
         Baseline,
         Optimizing,
@@ -291,21 +293,20 @@ public:
         return static_cast<CallType>(m_callType);
     }
 
-    static ptrdiff_t offsetOfMaxArgumentCountIncludingThis()
+    static ptrdiff_t offsetOfMaxArgumentCountIncludingThisForVarargs()
     {
-        return OBJECT_OFFSETOF(CallLinkInfo, m_maxArgumentCountIncludingThis);
+        return OBJECT_OFFSETOF(CallLinkInfo, m_maxArgumentCountIncludingThisForVarargs);
     }
 
-    uint32_t maxArgumentCountIncludingThis()
+    uint32_t maxArgumentCountIncludingThisForVarargs()
     {
-        return m_maxArgumentCountIncludingThis;
+        return m_maxArgumentCountIncludingThisForVarargs;
     }
     
-    void setMaxArgumentCountIncludingThis(unsigned);
-    void updateMaxArgumentCountIncludingThis(unsigned argumentCountIncludingThis)
+    void updateMaxArgumentCountIncludingThisForVarargs(unsigned argumentCountIncludingThisForVarargs)
     {
-        if (m_maxArgumentCountIncludingThis < argumentCountIncludingThis)
-            m_maxArgumentCountIncludingThis = argumentCountIncludingThis;
+        if (m_maxArgumentCountIncludingThisForVarargs < argumentCountIncludingThisForVarargs)
+            m_maxArgumentCountIncludingThisForVarargs = std::min<unsigned>(argumentCountIncludingThisForVarargs, maxProfiledArgumentCountIncludingThisForVarargs);
     }
 
     static ptrdiff_t offsetOfSlowPathCount()
@@ -343,10 +344,7 @@ public:
         return m_slowPathCount;
     }
 
-    CodeOrigin codeOrigin()
-    {
-        return m_codeOrigin;
-    }
+    CodeOrigin codeOrigin() const;
 
     template<typename Functor>
     void forEachDependentCell(const Functor& functor) const
@@ -373,9 +371,8 @@ public:
     Type type() const { return static_cast<Type>(m_type); }
 
 protected:
-    CallLinkInfo(Type type, CodeOrigin codeOrigin, UseDataIC useDataIC)
-        : m_codeOrigin(codeOrigin)
-        , m_hasSeenShouldRepatch(false)
+    CallLinkInfo(Type type, UseDataIC useDataIC)
+        : m_hasSeenShouldRepatch(false)
         , m_hasSeenClosure(false)
         , m_clearedByGC(false)
         , m_clearedByVirtual(false)
@@ -388,11 +385,7 @@ protected:
         ASSERT(useDataIC == this->useDataIC());
     }
 
-#if ENABLE(JIT)
-    void setCallLinkInfoGPR(GPRReg);
-#endif
-
-    uint32_t m_maxArgumentCountIncludingThis { 0 }; // For varargs: the profiled maximum number of arguments. For direct: the number of stack slots allocated for arguments.
+    uint32_t m_slowPathCount { 0 };
     CodeLocationLabel<JSInternalPtrTag> m_doneLocation;
     CodePtr<JSEntryPtrTag> m_slowPathCallDestination;
     union UnionType {
@@ -416,7 +409,6 @@ protected:
 #if ENABLE(JIT)
     RefPtr<PolymorphicCallStubRoutine> m_stub;
 #endif
-    CodeOrigin m_codeOrigin;
     bool m_hasSeenShouldRepatch : 1;
     bool m_hasSeenClosure : 1;
     bool m_clearedByGC : 1;
@@ -425,17 +417,13 @@ protected:
     unsigned m_callType : 4; // CallType
     unsigned m_useDataIC : 1; // UseDataIC
     unsigned m_type : 1; // Type
-#if ENABLE(JIT)
-    GPRReg m_calleeGPR { InvalidGPRReg };
-    GPRReg m_callLinkInfoGPR { InvalidGPRReg };
-#endif
-    uint32_t m_slowPathCount { 0 };
+    uint8_t m_maxArgumentCountIncludingThisForVarargs { 0 }; // For varargs: the profiled maximum number of arguments. For direct: the number of stack slots allocated for arguments.
 };
 
 class BaselineCallLinkInfo final : public CallLinkInfo {
 public:
     BaselineCallLinkInfo()
-        : CallLinkInfo(Type::Baseline, CodeOrigin { }, UseDataIC::Yes)
+        : CallLinkInfo(Type::Baseline, UseDataIC::Yes)
     {
     }
 
@@ -446,11 +434,15 @@ public:
         m_doneLocation = doneLocation;
     }
 
+    CodeOrigin codeOrigin() const { return CodeOrigin { m_bytecodeIndex }; }
+
 #if ENABLE(JIT)
     static constexpr GPRReg calleeGPR() { return BaselineJITRegisters::Call::calleeGPR; }
     static constexpr GPRReg callLinkInfoGPR() { return BaselineJITRegisters::Call::callLinkInfoGPR; }
-    void setCallLinkInfoGPR(GPRReg callLinkInfoGPR) { RELEASE_ASSERT(callLinkInfoGPR == BaselineJITRegisters::Call::callLinkInfoGPR); }
 #endif
+
+private:
+    BytecodeIndex m_bytecodeIndex { };
 };
 
 inline CodeOrigin getCallLinkInfoCodeOrigin(CallLinkInfo& callLinkInfo)
@@ -483,12 +475,13 @@ public:
     friend class CallLinkInfo;
 
     OptimizingCallLinkInfo()
-        : CallLinkInfo(Type::Optimizing, { }, UseDataIC::Yes)
+        : CallLinkInfo(Type::Optimizing, UseDataIC::Yes)
     {
     }
 
     OptimizingCallLinkInfo(CodeOrigin codeOrigin, UseDataIC useDataIC)
-        : CallLinkInfo(Type::Optimizing, codeOrigin, useDataIC)
+        : CallLinkInfo(Type::Optimizing, useDataIC)
+        , m_codeOrigin(codeOrigin)
     {
     }
 
@@ -518,6 +511,8 @@ public:
     void emitDirectTailCallFastPath(CCallHelpers&, ScopedLambda<void()>&& prepareForTailCall);
     void initializeDirectCall();
     void setDirectCallTarget(CodeBlock*, CodeLocationLabel<JSEntryPtrTag>);
+    void setDirectCallMaxArgumentCountIncludingThis(unsigned);
+    unsigned maxArgumentCountIncludingThisForDirectCall() const { return m_maxArgumentCountIncludingThisForDirectCall; }
     void emitSlowPath(VM&, CCallHelpers&);
 
     void setFrameShuffleData(const CallFrameShuffleData&);
@@ -527,13 +522,19 @@ public:
         return m_frameShuffleData.get();
     }
 
+    CodeOrigin codeOrigin() const { return m_codeOrigin; }
+
     void initializeFromDFGUnlinkedCallLinkInfo(VM&, const DFG::UnlinkedCallLinkInfo&);
 
 private:
     MacroAssembler::JumpList emitFastPath(CCallHelpers&, GPRReg calleeGPR, GPRReg callLinkInfoGPR) WARN_UNUSED_RETURN;
     MacroAssembler::JumpList emitTailCallFastPath(CCallHelpers&, GPRReg calleeGPR, GPRReg callLinkInfoGPR, ScopedLambda<void()>&& prepareForTailCall) WARN_UNUSED_RETURN;
 
-    CodeLocationNearCall<JSInternalPtrTag> m_callLocation;
+    CodeOrigin m_codeOrigin;
+    CodeLocationNearCall<JSInternalPtrTag> m_callLocation NO_UNIQUE_ADDRESS;
+    GPRReg m_calleeGPR { InvalidGPRReg };
+    GPRReg m_callLinkInfoGPR { InvalidGPRReg };
+    unsigned m_maxArgumentCountIncludingThisForDirectCall { 0 };
     CodeLocationLabel<JSInternalPtrTag> m_slowPathStart;
     CodeLocationLabel<JSInternalPtrTag> m_fastPathStart;
     std::unique_ptr<CallFrameShuffleData> m_frameShuffleData;
@@ -561,16 +562,21 @@ inline GPRReg CallLinkInfo::callLinkInfoGPR() const
     return InvalidGPRReg;
 }
 
-inline void CallLinkInfo::setCallLinkInfoGPR(GPRReg callLinkInfoGPR)
+#endif
+
+inline CodeOrigin CallLinkInfo::codeOrigin() const
 {
     switch (type()) {
     case Type::Baseline:
-        return static_cast<BaselineCallLinkInfo*>(this)->setCallLinkInfoGPR(callLinkInfoGPR);
+        return static_cast<const BaselineCallLinkInfo*>(this)->codeOrigin();
     case Type::Optimizing:
-        return static_cast<OptimizingCallLinkInfo*>(this)->setCallLinkInfoGPR(callLinkInfoGPR);
-    }
-}
-
+#if ENABLE(JIT)
+        return static_cast<const OptimizingCallLinkInfo*>(this)->codeOrigin();
+#else
+        return { };
 #endif
+    }
+    return { };
+}
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
@@ -128,7 +128,7 @@ CallLinkStatus CallLinkStatus::computeFor(
     UNUSED_PARAM(profiledBlock);
     
     CallLinkStatus result = computeFromCallLinkInfo(locker, callLinkInfo);
-    result.m_maxArgumentCountIncludingThis = callLinkInfo.maxArgumentCountIncludingThis();
+    result.m_maxArgumentCountIncludingThisForVarargs = callLinkInfo.maxArgumentCountIncludingThisForVarargs();
     return result;
 }
 
@@ -444,8 +444,8 @@ void CallLinkStatus::dump(PrintStream& out) const
     if (!m_variants.isEmpty())
         out.print(comma, listDump(m_variants));
     
-    if (m_maxArgumentCountIncludingThis)
-        out.print(comma, "maxArgumentCountIncludingThis = ", m_maxArgumentCountIncludingThis);
+    if (m_maxArgumentCountIncludingThisForVarargs)
+        out.print(comma, "maxArgumentCountIncludingThisForVarargs = ", m_maxArgumentCountIncludingThisForVarargs);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.h
@@ -104,7 +104,7 @@ public:
 
     bool isClosureCall() const; // Returns true if any callee is a closure call.
     
-    unsigned maxArgumentCountIncludingThis() const { return m_maxArgumentCountIncludingThis; }
+    unsigned maxArgumentCountIncludingThisForVarargs() const { return m_maxArgumentCountIncludingThisForVarargs; }
     
     bool finalize(VM&);
     
@@ -128,7 +128,7 @@ private:
     bool m_couldTakeSlowPath { false };
     bool m_isProved { false };
     bool m_isBasedOnStub { false };
-    unsigned m_maxArgumentCountIncludingThis { 0 };
+    uint8_t m_maxArgumentCountIncludingThisForVarargs { 0 }; // More than UINT8_MAX will be recorded as UINT8_MAX.
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -1978,7 +1978,7 @@ bool ByteCodeParser::handleVarargsInlining(Node* callTargetNode, Operand result,
         VERBOSE_LOG("Bailing inlining (compiler thread stack overflow eminent).\nStack: ", currentCodeOrigin(), "\n");
         return false;
     }
-    if (callLinkStatus.maxArgumentCountIncludingThis() > Options::maximumVarargsForInlining()) {
+    if (callLinkStatus.maxArgumentCountIncludingThisForVarargs() > Options::maximumVarargsForInlining()) {
         VERBOSE_LOG("Bailing inlining: too many arguments for varargs inlining.\n");
         return false;
     }
@@ -1996,7 +1996,7 @@ bool ByteCodeParser::handleVarargsInlining(Node* callTargetNode, Operand result,
         mandatoryMinimum = 0;
     
     // includes "this"
-    unsigned maxArgumentCountIncludingThis = std::max(callLinkStatus.maxArgumentCountIncludingThis(), mandatoryMinimum + 1);
+    unsigned maxArgumentCountIncludingThis = std::max(callLinkStatus.maxArgumentCountIncludingThisForVarargs(), mandatoryMinimum + 1);
 
     CodeSpecializationKind specializationKind = InlineCallFrame::specializationKindFor(kind);
     if (inliningCost(callVariant, maxArgumentCountIncludingThis, kind) > getInliningBalance(callLinkStatus, specializationKind)) {

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3910,7 +3910,7 @@ JSC_DEFINE_JIT_OPERATION(operationLinkDirectCall, void, (OptimizingCallLinkInfo*
         functionExecutable->prepareForExecution<FunctionExecutable>(vm, callee, scope, kind, codeBlock);
         RETURN_IF_EXCEPTION(throwScope, void());
 
-        unsigned argumentStackSlots = callLinkInfo->maxArgumentCountIncludingThis();
+        unsigned argumentStackSlots = callLinkInfo->maxArgumentCountIncludingThisForDirectCall();
         if (argumentStackSlots < static_cast<size_t>(codeBlock->numParameters()))
             codePtr = functionExecutable->entrypointFor(kind, MustCheckArity);
         else

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -862,7 +862,7 @@ void SpeculativeJIT::emitCall(Node* node)
     if (isDirect) {
         auto* info = std::get<OptimizingCallLinkInfo*>(callLinkInfo);
         info->setExecutableDuringCompilation(executable);
-        info->setMaxArgumentCountIncludingThis(numAllocatedArgs);
+        info->setDirectCallMaxArgumentCountIncludingThis(numAllocatedArgs);
 
         if (isTail) {
             RELEASE_ASSERT(node->op() == DirectTailCall);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -1007,7 +1007,7 @@ void SpeculativeJIT::emitCall(Node* node)
         ASSERT(!m_graph.m_plan.isUnlinked());
         auto* linkedCallLinkInfo = std::get<OptimizingCallLinkInfo*>(callLinkInfo);
         linkedCallLinkInfo->setExecutableDuringCompilation(executable);
-        linkedCallLinkInfo->setMaxArgumentCountIncludingThis(numAllocatedArgs);
+        linkedCallLinkInfo->setDirectCallMaxArgumentCountIncludingThis(numAllocatedArgs);
 
         if (isTail) {
             RELEASE_ASSERT(node->op() == DirectTailCall);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -10686,7 +10686,7 @@ IGNORE_CLANG_WARNINGS_END
                     jit.jump().linkTo(mainPath, &jit);
                     callLinkInfo->setExecutableDuringCompilation(executable);
                     if (numAllocatedArgs > numPassedArgs)
-                        callLinkInfo->setMaxArgumentCountIncludingThis(numAllocatedArgs);
+                        callLinkInfo->setDirectCallMaxArgumentCountIncludingThis(numAllocatedArgs);
                     
                     jit.addLinkTask([=] (LinkBuffer& linkBuffer) {
                         callLinkInfo->setCodeLocations(
@@ -10711,7 +10711,7 @@ IGNORE_CLANG_WARNINGS_END
                 
                 callLinkInfo->setExecutableDuringCompilation(executable);
                 if (numAllocatedArgs > numPassedArgs)
-                    callLinkInfo->setMaxArgumentCountIncludingThis(numAllocatedArgs);
+                    callLinkInfo->setDirectCallMaxArgumentCountIncludingThis(numAllocatedArgs);
                 
                 params.addLatePath(
                     [=] (CCallHelpers& jit) {

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2060,7 +2060,7 @@ inline SlowPathReturnType varargsSetup(CallFrame* callFrame, const JSInstruction
     calleeFrame->uncheckedR(VirtualRegister(CallFrameSlot::callee)) = calleeAsValue;
     callFrame->setCurrentVPC(pc);
 
-    metadata.m_callLinkInfo.updateMaxArgumentCountIncludingThis(argumentCountIncludingThis);
+    metadata.m_callLinkInfo.updateMaxArgumentCountIncludingThisForVarargs(argumentCountIncludingThis);
 
     auto* callerSP = calleeFrame + CallerFrameAndPC::sizeInRegisters;
     LLINT_RETURN_TWO(pc, callerSP);


### PR DESCRIPTION
#### 349d9d98217583326815bc41d75d96f16bb47c0b
<pre>
[JSC] Make BaselineCallLinkInfo more compact
<a href="https://bugs.webkit.org/show_bug.cgi?id=248704">https://bugs.webkit.org/show_bug.cgi?id=248704</a>
rdar://102929204

Reviewed by Mark Lam.

This patch makes BaselineCallLinkInfo more compact by reducing size of m_maxArgumentCountIncludingThis from unsigned to uint8_t.
This is OK since this data is profiling information and only meaningful value is under 100 (since varargs call inlining threshold
is 100). We also store BytecodeIndex for BaselineCallLinkInfo instead of CodeOrigin. By doing them, we can make
sizeof(BaselineCallLinkInfo) from 88 to 80 with the other reordering.

* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
(JSC::OptimizingCallLinkInfo::setDirectCallMaxArgumentCountIncludingThis):
(JSC::CallLinkInfo::visitWeak):
(JSC::BaselineCallLinkInfo::initialize):
(JSC::CallLinkInfo::setMaxArgumentCountIncludingThis): Deleted.
* Source/JavaScriptCore/bytecode/CallLinkInfo.h:
(JSC::CallLinkInfo::offsetOfMaxArgumentCountIncludingThisForVarargs):
(JSC::CallLinkInfo::maxArgumentCountIncludingThisForVarargs):
(JSC::CallLinkInfo::updateMaxArgumentCountIncludingThisForVarargs):
(JSC::CallLinkInfo::CallLinkInfo):
(JSC::CallLinkInfo::codeOrigin const):
(JSC::CallLinkInfo::offsetOfMaxArgumentCountIncludingThis): Deleted.
(JSC::CallLinkInfo::maxArgumentCountIncludingThis): Deleted.
(JSC::CallLinkInfo::updateMaxArgumentCountIncludingThis): Deleted.
(JSC::CallLinkInfo::codeOrigin): Deleted.
(JSC::CallLinkInfo::setCallLinkInfoGPR): Deleted.
* Source/JavaScriptCore/bytecode/CallLinkStatus.cpp:
(JSC::CallLinkStatus::computeFor):
(JSC::CallLinkStatus::dump const):
* Source/JavaScriptCore/bytecode/CallLinkStatus.h:
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleVarargsInlining):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::compileSetupFrame):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::varargsSetup):

Canonical link: <a href="https://commits.webkit.org/257325@main">https://commits.webkit.org/257325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d12043077110dd21c8a1b4729ab982726752975a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108014 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168276 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85180 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91127 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/105988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104274 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33295 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88117 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76227 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89382 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1735 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85152 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1646 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28737 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6586 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42175 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88004 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2529 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3035 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19714 "Passed tests") | 
<!--EWS-Status-Bubble-End-->