### PR TITLE
Add support for RegExp lookbehind assertions

### DIFF
--- a/JSTests/stress/regexp-lookbehind.js
+++ b/JSTests/stress/regexp-lookbehind.js
@@ -1,0 +1,203 @@
+// With verbose set to false, this test is successful if there is no output.  Set verbose to true to see expected matches.
+let verbose = false;
+
+function arrayToString(arr)
+{
+  let str = '';
+  arr.forEach(function(v, index) {
+    if (typeof v == "string")
+        str += "\"" + v + "\"";
+    else
+        str += v;
+
+    if (index != (arr.length - 1)) {
+      str += ',';
+    };
+  });
+  return "[" + str + "]";
+}
+
+function dumpValue(v)
+{
+    if (v === null)
+        return "<null>";
+
+    if (v === undefined)
+        return "<undefined>";
+
+    if (typeof v == "string")
+        return "\"" + v + "\"";
+
+    if (v.length)
+        return arrayToString(v);
+
+    return v;
+}
+
+function compareArray(a, b)
+{
+    if (a === null && b === null)
+        return true;
+
+    if (a === null) {
+        print("### a is null, b is not null");
+        return false;
+    }
+
+    if (b === null) {
+        print("### a is not null, b is null");
+        return false;
+    }
+
+    if (a.length !== b.length) {
+        print("### a.length: " + a.length + ", b.length: " + b.length);
+        return false;
+    }
+
+    for (var i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) {
+            print("### a[" + i + "]: \"" + a[i] + "\" !== b[" + i + "]: \"" + b[i] + "\"");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+let testNumber = 0;
+
+function testRegExp(re, str, exp)
+{
+    testNumber++;
+
+    let actual = str.match(re);
+
+    if (compareArray(exp, actual)) {
+        if (verbose)
+            print(dumpValue(str) +".match(" + re.toString() + "), passed ", dumpValue(exp));
+    } else
+        print(dumpValue(str) +".match(" + re.toString() + "), FAILED test #" + testNumber + ", Expected ", dumpValue(exp), " got ", dumpValue(actual));
+}
+
+// Test 1
+testRegExp(/(?<= )Dog/, " Dog", ["Dog"]);
+testRegExp(/(?<=A )Dog/, "Walk A Dog", ["Dog"]);
+testRegExp(/(?<=A )Dog/, "It's A Dog", ["Dog"]);
+testRegExp(/((?<=A ))Dog/, "A Dog", ["Dog", ""]);
+testRegExp(/((?<=A ))Dog/, "B Dog", null);
+
+// Test 6
+testRegExp(/(?<=(\w*) )Dog/, "Big Dog", ["Dog", "Big"]);
+testRegExp(/(?<=(\w*) )Dog/, " B i g Dog", ["Dog", "g"]);
+testRegExp(/Dog/, "Brown Dog", ["Dog"]);
+testRegExp(/(?<=(\w{3}) )Dog/, "Brown Dog", ["Dog", "own"]);
+testRegExp(/(?<=.*)Dog/, "Big Dog", ["Dog"]);
+
+// Test 11
+testRegExp(/(?<=(Big) )Dog/, "Big Dog", ["Dog", "Big"]);
+testRegExp(/^.(?<=a)/, "a" , ["a"]);
+testRegExp(/A (?<=A )Dog/, "A Dog", ["A Dog"]);  //  FAILS
+testRegExp(/(?<=(b*))c/, "abbbbbbc", ["c", "bbbbbb"]);
+testRegExp(/(?<=(b+))c/, "abbbbbbc", ["c", "bbbbbb"]);
+
+// Test 16
+testRegExp(/(?<=(b\d+))c/, "ab1234c", ["c", "b1234"]);
+testRegExp(/(?<=((?:b\d{2})*))c/, "ab12b23b34c", ["c", "b12b23b34"]);
+testRegExp(/(?<=((?:b\d{2})+))c/, "ab12b23b34c", ["c", "b12b23b34"]);
+testRegExp(/.*(?<=(..|...|....))(.*)/, "xabcd", ["xabcd", "cd", ""]);
+testRegExp(/.*(?<=(....|...|..))(.*)/, "xabcd", ["xabcd", "abcd", ""]);
+
+// Test 21
+testRegExp(/.*(?<=(xx|...|....))(.*)/, "xabcd", ["xabcd", "bcd", ""]);
+testRegExp(/.*(?<=(xx|...))(.*)/, "xxabcd", ["xxabcd", "bcd", ""]);
+testRegExp(/(?<=^abc)def/, "abcdef", ["def"]);
+testRegExp(/(?<=([abc]+)).\1/, "abcdbc", null);
+testRegExp(/(.)(?<=(\1\1))/, "abb", ["b", "b", "bb"]);
+
+// Test 26
+testRegExp(/(.)(?<=(\1\1))/i, "abB", ["B", "B", "bB"]);
+testRegExp(/(?<=\1([abx]))d/, "abxxd", ["d", "x"]);
+testRegExp(/((\w)\w)(?<=\1\2\1)/i, "aabAaBa", ["aB", "aB", "a"]);
+testRegExp(/(?<=\1(\w+))c/, "ababc", ["c", "ab"]);
+testRegExp(/(?<=\1(\w+))c/, "ababbc", ["c", "b"]);
+
+// Test 31
+testRegExp(/(?<=\1(\w+))c/, "ababdc", null);
+testRegExp(/(?<=(\w+)\1)c/, "ababc", ["c", "abab"]);
+testRegExp(/(?<=(\w){3})def/, "abcdef", ["def", "a"]);
+testRegExp(/(?<=\b)[d-f]{3}/,"abc def", ["def"]);
+testRegExp(/(?<=\B)\w{3}/, "ab cdef" , ["def"]);
+
+// Test 36
+testRegExp(/(?<=\B)(?<=c(?<=\w))\w{3}/, "ab cdef", ["def"]);
+testRegExp(/(?<=\b)[d-f]{3}/, "abcdef", null);
+testRegExp(/(?<!abc)\w\w\w/, "abcdef", ["abc"]);
+testRegExp(/(?<!a.c)\w\w\w/, "abcdef", ["abc"]);
+testRegExp(/(?<!a\wc)\w\w\w/, "abcdef", ["abc"]);
+
+// Test 41
+testRegExp(/(?<!a[a-z])\w\w\w/, "abcdef", ["abc"]);
+testRegExp(/(?<!a[a-z]{2})\w\w\w/, "abcdef", ["abc"]);
+testRegExp(/(?<!abc)def/, "abcdef", null);
+testRegExp(/(?<!a.c)def/, "abcdef", null);
+testRegExp(/(?<=ab\wd)\w\w/, "abcdef", ["ef"]);
+
+// Test 46
+testRegExp(/(?<=ab(?=c)\wd)\w\w/, "abcdef", ["ef"]);
+testRegExp(/(?<=a\w{3})\w\w/, "abcdef", ["ef"]);
+testRegExp(/(?<=a(?=([^a]{2})d)\w{3})\w\w/, "abcdef", ["ef", "bc"]);
+testRegExp(/(?<=a(?=([bc]{2}(?<!a{2}))d)\w{3})\w\w/, "abcdef", ["ef", "bc"]);
+testRegExp(/^faaao?(?<=^f[oa]+(?=o))/, "faaao", ["faaa"]);
+
+// Test 51
+testRegExp(/(?<=a(?=([bc]{2}(?<!a*))d)\w{3})\w\w/, "abcdef", null);
+testRegExp(/(?<!abc)\w\w\w/, "abcdef", ["abc"]);
+testRegExp(/(?<=^[^a-c]{3})def/, "abcdef", null);
+testRegExp(/^(f)oo(?<=^\1o+)$/i, "foo", ["foo", "f"]);
+testRegExp(/\w+(?<=$)/gm, "ab\ncd\nefg", ["ab", "cd", "efg"]);
+
+// Test 56
+testRegExp(/(?<=(bb*))c/, "abbbbbbc", ["c", "bbbbbb"]);
+testRegExp(/(?<=(b*?))c/, "abbbbbbc", ["c", ""]);
+testRegExp(/(?<=(b*?))c/, "abbbbbbc", ["c", ""]);
+testRegExp(/(?<=(ab*?))c/, "abbbbbbc", ["c", "abbbbbb"]);
+testRegExp(/(?<=(bb*?))c/, "abbbbbbc", ["c", "b"]);
+
+// Test 61
+testRegExp(/(?<=(b*?))c/i, "abbbbbbc", ["c", ""]);
+testRegExp(/(?<=(b*?))c/i, "abbbbbbc", ["c", ""]);
+testRegExp(/(?<=(ab*?))c/i, "abbbbbbc", ["c", "abbbbbb"]);
+testRegExp(/(?<=(bb*?))c/i, "abbbbbbc", ["c", "b"]);
+testRegExp(/(?<=(\u{10000}|\u{10400}|\u{10429}))x/u, "\u{10400}x", ["x", "\u{10400}"]);
+
+// Test 66
+testRegExp(/(?<=(\u{10000}|\u{10400}{2}|\u{10429}))x/u, "\u{10400}x", null);
+testRegExp(/(?<=(\u{10000}|\u{10400}|\u{10429}))x/ui, "\u{10400}x", ["x", "\u{10400}"]);
+testRegExp(/(?<=([^\u{10000}\u{10429}]))x/u, "\u{10400}x", ["x", "\u{10400}"]);
+testRegExp(/(?<=([^\u{10000}\u{10429}]))x/ui, "\u{10400}x", ["x", "\u{10400}"]);
+testRegExp(/(?<=([^\u{10000}\u{10429}]*))x/u, "\u{10400}\u{10406}x", ["x", "\u{10400}\u{10406}"]);
+
+// Test 71
+testRegExp(/(?<=([^\u{10000}\u{10429}]*))x/ui, "\u{10400}\u{10406}x", ["x", "\u{10400}\u{10406}"]);
+testRegExp(/(?<=([^\u{10000}\u{10429}]*))x/u, "\u{10401}\u{10400}\u{10406}x", ["x", "\u{10401}\u{10400}\u{10406}"]);
+testRegExp(/(?<=([^\u{10000}\u{10429}]*))x/ui, "\u{10401}\u{10400}\u{10406}x", ["x", "\u{10400}\u{10406}"]);
+testRegExp(/(?<=([^\u{10000}\u{10429}]*))x/u, "\u{10401}A\u{10400}\u{10406}x", ["x", "\u{10401}A\u{10400}\u{10406}"]);
+testRegExp(/(?<=([^\u{10000}\u{10429}]*))x/ui, "\u{10401}A\u{10400}\u{10406}x", ["x", "A\u{10400}\u{10406}"]);
+
+// Test 76
+testRegExp(/(?<=(A[^\u{10000}\u{10429}]*))x/u, "A\u{10400}\u{10406}x", ["x", "A\u{10400}\u{10406}"]);
+testRegExp(/(?<=(A[^\u{10000}\u{10429}]*))x/ui, "A\u{10400}\u{10406}x", ["x", "A\u{10400}\u{10406}"]);
+testRegExp(/(?<=([\u{10401}\u{10402}\u{10403}\u{10404}\u{10405}\u{10406}\u{10407}\u{10408}\u{10409}\u{1040a}]))x/u, "\u{10408}x", ["x", "\u{10408}"]);
+testRegExp(/(?<=([\u{10428}\u{1042a}\u{1042c}\u{1042e}]))x/ui, "\u{10404}x", ["x", "\u{10404}"]);
+testRegExp(/(?<=(A[\u{10401}\u{10402}\u{10403}\u{10404}\u{10405}\u{10406}\u{10407}\u{10408}\u{10409}\u{1040a}]*))x/u, "A\u{10408}\u{10406}x", ["x", "A\u{10408}\u{10406}"]);
+
+ // Test 81
+testRegExp(/(?<=(A[\u{10428}\u{1042a}\u{1042c}\u{1042e}]*))x/ui, "A\u{10404}\u{10406}x", ["x", "A\u{10404}\u{10406}"]);
+testRegExp(/(?<=(^[^\u{10000}\u{10429}]*))x/u, "\u{10401}A\u{10400}\u{10406}x", ["x", "\u{10401}A\u{10400}\u{10406}"]);
+testRegExp(/(?<=((?:A|\u{10400})*))x/u, "\u{10400}A\u{10400}x", ["x", "\u{10400}A\u{10400}"]);
+testRegExp(/(?<=((?:A|\u{10400}|\u{10401}|\u{10406})*))x/u, "\u{10401}A\u{10400}\u{10406}x", ["x", "\u{10401}A\u{10400}\u{10406}"]);
+testRegExp(/(?<=(^(?:A|\u{10400}|\u{10401}|\u{10406})*))x/u, "\u{10401}A\u{10400}\u{10406}x", ["x", "\u{10401}A\u{10400}\u{10406}"]);
+
+// Test 86
+testRegExp(/(?<=(\d{2})(\d{2}))X/, "34121234X", ["X", "12", "34"]);
+testRegExp(/(?<=\2\1(\d{2})(\d{2}))X/, "34121234X", ["X", "12", "34"]);

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -11,8 +11,6 @@ flags:
   resizable-arraybuffer: useArrayBufferTransfer
 skip:
   features:
-    # https://bugs.webkit.org/show_bug.cgi?id=174931
-    - regexp-lookbehind
     - regexp-v-flag
     - callable-boundary-realms
     - FinalizationRegistry.prototype.cleanupSome

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -249,6 +249,7 @@ void RegExp::compile(VM* vm, Yarr::CharSize charSize)
 #if !ENABLE(YARR_JIT_BACKREFERENCES)
         && !pattern.m_containsBackreferences
 #endif
+        && !pattern.m_containsLookbehinds
         ) {
         auto& jitCode = ensureRegExpJITCode();
         Yarr::jitCompile(pattern, m_patternString, charSize, vm, jitCode, Yarr::JITCompileMode::IncludeSubpatterns);
@@ -261,8 +262,7 @@ void RegExp::compile(VM* vm, Yarr::CharSize charSize)
     UNUSED_PARAM(charSize);
 #endif
 
-    if (Options::dumpCompiledRegExpPatterns())
-        dataLog("Can't JIT this regular expression: \"", m_patternString, "\"\n");
+    dataLogLnIf(Options::dumpCompiledRegExpPatterns(), "Can't JIT this regular expression: \"/", m_patternString, "/\"");
 
     m_state = ByteCode;
     m_regExpBytecode = byteCodeCompilePattern(vm, pattern, m_constructionErrorCode);
@@ -313,6 +313,7 @@ void RegExp::compileMatchOnly(VM* vm, Yarr::CharSize charSize)
 #if !ENABLE(YARR_JIT_BACKREFERENCES)
         && !pattern.m_containsBackreferences
 #endif
+        && !pattern.m_containsLookbehinds
         ) {
         auto& jitCode = ensureRegExpJITCode();
         Yarr::jitCompile(pattern, m_patternString, charSize, vm, jitCode, Yarr::JITCompileMode::MatchOnly);
@@ -325,8 +326,7 @@ void RegExp::compileMatchOnly(VM* vm, Yarr::CharSize charSize)
     UNUSED_PARAM(charSize);
 #endif
 
-    if (Options::dumpCompiledRegExpPatterns())
-        dataLog("Can't JIT this regular expression: \"", m_patternString, "\"\n");
+    dataLogLnIf(Options::dumpCompiledRegExpPatterns(), "Can't JIT this regular expression: \"/", m_patternString, "/\"");
 
     m_state = ByteCode;
     m_regExpBytecode = byteCodeCompilePattern(vm, pattern, m_constructionErrorCode);

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -4182,6 +4182,11 @@ public:
                 return;
         }
 
+        if (m_pattern.m_containsLookbehinds) {
+            codeBlock.setFallBackWithFailureReason(JITFailureReason::Lookbehind);
+            return;
+        }
+
         // We need to compile before generating code since we set flags based on compilation that
         // are used during generation.
         opCompileBody(m_pattern.m_body);
@@ -4714,6 +4719,9 @@ static void dumpCompileFailure(JITFailureReason failure)
         break;
     case JITFailureReason::ForwardReference:
         dataLog("Can't JIT a pattern containing forward references\n");
+        break;
+    case JITFailureReason::Lookbehind:
+        dataLog("Can't JIT a pattern containing lookbehinds\n");
         break;
     case JITFailureReason::VariableCountedParenthesisWithNonZeroMinimum:
         dataLog("Can't JIT a pattern containing a variable counted parenthesis with a non-zero minimum\n");

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -57,6 +57,7 @@ enum class JITFailureReason : uint8_t {
     DecodeSurrogatePair,
     BackReference,
     ForwardReference,
+    Lookbehind,
     VariableCountedParenthesisWithNonZeroMinimum,
     ParenthesizedSubpattern,
     FixedCountParenthesizedSubpattern,

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -631,12 +631,12 @@ private:
                 break;
             
             case '=':
-                m_delegate.atomParentheticalAssertionBegin();
+                m_delegate.atomParentheticalAssertionBegin(false, Forward);
                 type = ParenthesesType::Assertion;
                 break;
 
             case '!':
-                m_delegate.atomParentheticalAssertionBegin(true);
+                m_delegate.atomParentheticalAssertionBegin(true, Forward);
                 type = ParenthesesType::Assertion;
                 break;
 
@@ -656,8 +656,20 @@ private:
                         m_delegate.atomParenthesesSubpatternBegin(true, groupName);
                     else
                         m_errorCode = ErrorCode::DuplicateGroupName;
-                } else
+                } else {
+                    if (tryConsume('=')) {
+                        m_delegate.atomParentheticalAssertionBegin(false, Backward);
+                        type = ParenthesesType::Assertion;
+                        break;
+                    }
+
+                    if (tryConsume('!')) {
+                        m_delegate.atomParentheticalAssertionBegin(true, Backward);
+                        type = ParenthesesType::Assertion;
+                        break;
+                    }
                     m_errorCode = ErrorCode::InvalidGroupName;
+                }
 
                 break;
             }
@@ -1245,7 +1257,7 @@ private:
  *    void atomCharacterClassBuiltIn(BuiltInCharacterClassID classID, bool invert)
  *    void atomCharacterClassEnd()
  *    void atomParenthesesSubpatternBegin(bool capture = true, std::optional<String> groupName);
- *    void atomParentheticalAssertionBegin(bool invert = false);
+ *    void atomParentheticalAssertionBegin(bool invert, MatchDirection matchDirection);
  *    void atomParenthesesEnd();
  *    void atomBackReference(unsigned subpatternId);
  *    void atomNamedBackReference(const String& subpatternName);

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -128,6 +128,12 @@ enum class QuantifierType : uint8_t {
     NonGreedy,
 };
 
+enum MatchDirection : uint8_t {
+    // The code assumes that Forward is 0 and Backward is 1.
+    Forward = 0,
+    Backward = 1
+};
+
 struct PatternTerm {
     enum class Type : uint8_t {
         AssertionBOL,
@@ -142,8 +148,9 @@ struct PatternTerm {
         DotStarEnclosure,
     };
     Type type;
-    bool m_capture :1;
-    bool m_invert :1;
+    bool m_capture : 1;
+    bool m_invert : 1;
+    MatchDirection m_matchDirection : 1;
     QuantifierType quantityType;
     Checked<unsigned> quantityMinCount;
     Checked<unsigned> quantityMaxCount;
@@ -155,8 +162,8 @@ struct PatternTerm {
             PatternDisjunction* disjunction;
             unsigned subpatternId;
             unsigned lastSubpatternId;
-            bool isCopy;
-            bool isTerminal;
+            bool isCopy : 1;
+            bool isTerminal : 1;
         } parentheses;
         struct {
             bool bolAnchor : 1;
@@ -166,30 +173,33 @@ struct PatternTerm {
     unsigned inputPosition;
     unsigned frameLocation;
 
-    PatternTerm(UChar32 ch)
+    PatternTerm(UChar32 ch, MatchDirection matchDirection = Forward)
         : type(PatternTerm::Type::PatternCharacter)
         , m_capture(false)
         , m_invert(false)
+        , m_matchDirection(matchDirection)
     {
         patternCharacter = ch;
         quantityType = QuantifierType::FixedCount;
         quantityMinCount = quantityMaxCount = 1;
     }
 
-    PatternTerm(CharacterClass* charClass, bool invert)
+    PatternTerm(CharacterClass* charClass, bool invert, MatchDirection matchDirection = Forward)
         : type(PatternTerm::Type::CharacterClass)
         , m_capture(false)
         , m_invert(invert)
+        , m_matchDirection(matchDirection)
     {
         characterClass = charClass;
         quantityType = QuantifierType::FixedCount;
         quantityMinCount = quantityMaxCount = 1;
     }
 
-    PatternTerm(Type type, unsigned subpatternId, PatternDisjunction* disjunction, bool capture = false, bool invert = false)
+    PatternTerm(Type type, unsigned subpatternId, PatternDisjunction* disjunction, bool capture = false, bool invert = false, MatchDirection matchDirection = Forward)
         : type(type)
         , m_capture(capture)
         , m_invert(invert)
+        , m_matchDirection(matchDirection)
     {
         parentheses.disjunction = disjunction;
         parentheses.subpatternId = subpatternId;
@@ -203,6 +213,7 @@ struct PatternTerm {
         : type(type)
         , m_capture(false)
         , m_invert(invert)
+        , m_matchDirection(Forward)
     {
         quantityType = QuantifierType::FixedCount;
         quantityMinCount = quantityMaxCount = 1;
@@ -212,6 +223,7 @@ struct PatternTerm {
         : type(Type::BackReference)
         , m_capture(false)
         , m_invert(false)
+        , m_matchDirection(Forward)
     {
         backReferenceSubpatternId = spatternId;
         quantityType = QuantifierType::FixedCount;
@@ -222,6 +234,7 @@ struct PatternTerm {
         : type(Type::DotStarEnclosure)
         , m_capture(false)
         , m_invert(false)
+        , m_matchDirection(Forward)
     {
         anchors.bolAnchor = bolAnchor;
         anchors.eolAnchor = eolAnchor;
@@ -248,10 +261,26 @@ struct PatternTerm {
     {
         return PatternTerm(Type::AssertionWordBoundary, invert);
     }
-    
+
+    void convertToBackreference()
+    {
+        ASSERT(type == Type::ForwardReference);
+        type = Type::BackReference;
+    }
+
     bool invert() const
     {
         return m_invert;
+    }
+
+    void setMatchDirection(MatchDirection matchDirection)
+    {
+        m_matchDirection = matchDirection;
+    }
+
+    MatchDirection matchDirection() const
+    {
+        return m_matchDirection;
     }
 
     bool capture()
@@ -294,8 +323,9 @@ struct PatternTerm {
 struct PatternAlternative {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    PatternAlternative(PatternDisjunction* disjunction)
+    PatternAlternative(PatternDisjunction* disjunction, MatchDirection matchDirection = Forward)
         : m_parent(disjunction)
+        , m_direction(matchDirection)
         , m_onceThrough(false)
         , m_hasFixedSize(false)
         , m_startsWithBOL(false)
@@ -325,11 +355,17 @@ public:
         return m_onceThrough;
     }
 
+    MatchDirection matchDirection() const
+    {
+        return m_direction;
+    }
+
     void dump(PrintStream&, YarrPattern*, unsigned);
 
     Vector<PatternTerm> m_terms;
     PatternDisjunction* m_parent;
     unsigned m_minimumSize;
+    MatchDirection m_direction;
     bool m_onceThrough : 1;
     bool m_hasFixedSize : 1;
     bool m_startsWithBOL : 1;
@@ -345,9 +381,9 @@ public:
     {
     }
     
-    PatternAlternative* addNewAlternative()
+    PatternAlternative* addNewAlternative(MatchDirection matchDirection = Forward)
     {
-        m_alternatives.append(makeUnique<PatternAlternative>(this));
+        m_alternatives.append(makeUnique<PatternAlternative>(this, matchDirection));
         return static_cast<PatternAlternative*>(m_alternatives.last().get());
     }
 
@@ -396,6 +432,7 @@ struct YarrPattern {
 
         m_containsBackreferences = false;
         m_containsBOL = false;
+        m_containsLookbehinds = false;
         m_containsUnsignedLengthPattern = false;
         m_hasCopiedParenSubexpressions = false;
         m_saveInitialStartValue = false;
@@ -532,6 +569,7 @@ struct YarrPattern {
 
     bool m_containsBackreferences : 1;
     bool m_containsBOL : 1;
+    bool m_containsLookbehinds : 1;
     bool m_containsUnsignedLengthPattern : 1;
     bool m_hasCopiedParenSubexpressions : 1;
     bool m_saveInitialStartValue : 1;
@@ -627,3 +665,5 @@ private:
     };
 
 } } // namespace JSC::Yarr
+
+using JSC::Yarr::MatchDirection;

--- a/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
+++ b/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
@@ -44,7 +44,7 @@ public:
     void atomCharacterClassBuiltIn(BuiltInCharacterClassID, bool) { }
     void atomCharacterClassEnd() { }
     void atomParenthesesSubpatternBegin(bool = true, std::optional<String> = std::nullopt) { }
-    void atomParentheticalAssertionBegin(bool = false) { }
+    void atomParentheticalAssertionBegin(bool, MatchDirection) { }
     void atomParenthesesEnd() { }
     void atomBackReference(unsigned) { }
     void atomNamedBackReference(const String&) { }

--- a/Source/WTF/wtf/PrintStream.cpp
+++ b/Source/WTF/wtf/PrintStream.cpp
@@ -144,6 +144,11 @@ void printInternal(PrintStream& out, unsigned char value)
     out.printf("%u", static_cast<unsigned>(value));
 }
 
+void printInternal(PrintStream& out, char16_t value)
+{
+    out.printf("%lc", value);
+}
+
 void printInternal(PrintStream& out, short value)
 {
     out.printf("%d", static_cast<int>(value));

--- a/Source/WTF/wtf/PrintStream.h
+++ b/Source/WTF/wtf/PrintStream.h
@@ -119,6 +119,7 @@ inline void printInternal(PrintStream& out, UniquedStringImpl& value) { printInt
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, bool);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, signed char); // NOTE: this prints as a number, not as a character; use CharacterDump if you want the character
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, unsigned char); // NOTE: see above.
+WTF_EXPORT_PRIVATE void printInternal(PrintStream&, char16_t);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, short);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, unsigned short);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, int);

--- a/Source/WebCore/contentextensions/URLFilterParser.cpp
+++ b/Source/WebCore/contentextensions/URLFilterParser.cpp
@@ -223,7 +223,7 @@ public:
         m_openGroups.append(Term(Term::GroupTerm));
     }
 
-    void atomParentheticalAssertionBegin(bool = false)
+    void atomParentheticalAssertionBegin(bool, MatchDirection)
     {
         fail(URLFilterParser::Group);
     }


### PR DESCRIPTION
#### 46e6b3f97425a4a7bb16fc175288903a5f74d5f2
<pre>
Add support for RegExp lookbehind assertions
<a href="https://bugs.webkit.org/show_bug.cgi?id=174931">https://bugs.webkit.org/show_bug.cgi?id=174931</a>
rdar://33183185

This change implements RegExp lookbehind in the Yarr interpreter.

This change introduces the notion of match direction, either forward or backward.
The forward match direction is the way the current code works, matching disjunciton terms and the subject
string in a right to left manner.  Lookbehind assertions, as defined in the EcmaScript spec, process disjunctions
terms right to left matching the correspondding subject string right to left as well.

Except for the Yarr JIT, almost all of the Yarr code has been touched to account for this backward matching.
An additional Byteterm has been added, HaveCheckedInput, which checks that there is at least as many characters
available in the input stream, but it doesn&apos;t move the input stream position.  This is basically a CheckInput,
without moving the input position.  For variable counted terms, we still need to check that we won&apos;t try to access
characters beyond the first character of the subject string.  For functions like readSurrogatePairChecked(),
we check for input before calling the funcion.  For new input functions with a try prefix like tryReadBackward,
the function itselfs checks for available input.  After these checks prove that it is safe to access an offset
to the left of the current input position, the actual matching can be performed.

The Yarr parser, parses regular expression in left to right order.  It also computes character offest in forward
order.  When we Byteterm compile, we process backward matching disjunctions right to left.  The parser also has
special handling of forward references within a backward matching parenthetical group.  All such forward references
are saved for that parenthetical group and are processed at the end of the group.  Every one of these forward
reference are check to see if a capture to the right of the forward reference was found, if so the forward
reference is converted to a back reference.

As part of this work, the ByteTerm dumping code was significantly updated to allow for not only dumping of the
ByteCode after it has been generated, but to dump ByteCode while it is being interpreted.  This ByteTerm dumping
while interpreting is enabled with the Interpreter::verbose compile time constant.

Reviewed by Yusuke Suzuki.

* JSTests/stress/regexp-lookbehind.js: New tests.
(arrayToString):
(dumpValue):
(compareArray):
(testRegExp):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::compile):
(JSC::RegExp::compileMatchOnly):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::ByteTermDumper::ByteTermDumper):
(JSC::Yarr::ByteTermDumper::unicode):
(JSC::Yarr::Interpreter::InputStream::readForCharacterDump):
(JSC::Yarr::Interpreter::InputStream::tryReadBackward):
(JSC::Yarr::Interpreter::InputStream::tryUncheckInput):
(JSC::Yarr::Interpreter::InputStream::isValidNegativeInputOffset):
(JSC::Yarr::Interpreter::InputStream::dump const):
(JSC::Yarr::Interpreter::checkCharacter):
(JSC::Yarr::Interpreter::checkSurrogatePair):
(JSC::Yarr::Interpreter::checkCasedCharacter):
(JSC::Yarr::Interpreter::checkCharacterClass):
(JSC::Yarr::Interpreter::checkCharacterClassDontAdvanceInputForNonBMP):
(JSC::Yarr::Interpreter::tryConsumeBackReference):
(JSC::Yarr::Interpreter::matchAssertionWordBoundary):
(JSC::Yarr::Interpreter::backtrackPatternCharacter):
(JSC::Yarr::Interpreter::backtrackPatternCasedCharacter):
(JSC::Yarr::Interpreter::matchCharacterClass):
(JSC::Yarr::Interpreter::backtrackCharacterClass):
(JSC::Yarr::Interpreter::matchBackReference):
(JSC::Yarr::Interpreter::backtrackBackReference):
(JSC::Yarr::Interpreter::recordParenthesesMatch):
(JSC::Yarr::Interpreter::matchParenthesesOnceBegin):
(JSC::Yarr::Interpreter::matchParenthesesOnceEnd):
(JSC::Yarr::Interpreter::backtrackParenthesesOnceEnd):
(JSC::Yarr::Interpreter::matchParentheticalAssertionBegin):
(JSC::Yarr::Interpreter::backtrackParentheticalAssertionBegin):
(JSC::Yarr::Interpreter::matchDisjunction):
(JSC::Yarr::ByteCompiler::compile):
(JSC::Yarr::ByteCompiler::haveCheckedInput):
(JSC::Yarr::ByteCompiler::assertionWordBoundary):
(JSC::Yarr::ByteCompiler::atomPatternCharacter):
(JSC::Yarr::ByteCompiler::atomCharacterClass):
(JSC::Yarr::ByteCompiler::atomBackReference):
(JSC::Yarr::ByteCompiler::atomParenthesesOnceBegin):
(JSC::Yarr::ByteCompiler::atomParenthesesTerminalBegin):
(JSC::Yarr::ByteCompiler::atomParenthesesSubpatternBegin):
(JSC::Yarr::ByteCompiler::atomParentheticalAssertionBegin):
(JSC::Yarr::ByteCompiler::atomParentheticalAssertionEnd):
(JSC::Yarr::ByteCompiler::atomParenthesesSubpatternEnd):
(JSC::Yarr::ByteCompiler::atomParenthesesOnceEnd):
(JSC::Yarr::ByteCompiler::atomParenthesesTerminalEnd):
(JSC::Yarr::ByteCompiler::emitDisjunction):
(JSC::Yarr::ByteCompiler::isSafeToRecurse):
(JSC::Yarr::ByteTermDumper::dumpTerm):
(JSC::Yarr::ByteTermDumper::dumpDisjunction):
(JSC::Yarr::Interpreter::InputStream::readPair): Deleted.
(JSC::Yarr::ByteCompiler::dumpDisjunction): Deleted.
* Source/JavaScriptCore/yarr/YarrInterpreter.h:
(JSC::Yarr::ByteTerm::ByteTerm):
(JSC::Yarr::ByteTerm::HaveCheckedInput):
(JSC::Yarr::ByteTerm::WordBoundary):
(JSC::Yarr::ByteTerm::BackReference):
(JSC::Yarr::ByteTerm::isCharacterType):
(JSC::Yarr::ByteTerm::isCasedCharacterType):
(JSC::Yarr::ByteTerm::isCharacterClass):
(JSC::Yarr::ByteTerm::matchDirection):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::dumpCompileFailure):
* Source/JavaScriptCore/yarr/YarrJIT.h:
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::parseParenthesesBegin):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::resetForReparsing):
(JSC::Yarr::YarrPatternConstructor::assertionBOL):
(JSC::Yarr::YarrPatternConstructor::atomPatternCharacter):
(JSC::Yarr::YarrPatternConstructor::atomBuiltInCharacterClass):
(JSC::Yarr::YarrPatternConstructor::atomParenthesesSubpatternBegin):
(JSC::Yarr::YarrPatternConstructor::atomParentheticalAssertionBegin):
(JSC::Yarr::YarrPatternConstructor::atomParenthesesEnd):
(JSC::Yarr::YarrPatternConstructor::atomBackReference):
(JSC::Yarr::YarrPatternConstructor::copyDisjunction):
(JSC::Yarr::YarrPatternConstructor::quantifyAtom):
(JSC::Yarr::YarrPatternConstructor::disjunction):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::SavedContext::SavedContext):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::SavedContext::restore):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::ParenthesisContext):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::push):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::pop):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::setInvert):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::invert const):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::setMatchDirection):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::matchDirection const):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::reset):
(JSC::Yarr::YarrPatternConstructor::pushParenthesisContext):
(JSC::Yarr::YarrPatternConstructor::popParenthesisContext):
(JSC::Yarr::YarrPatternConstructor::setParenthesisInvert):
(JSC::Yarr::YarrPatternConstructor::parenthesisInvert const):
(JSC::Yarr::YarrPatternConstructor::setParenthesisMatchDirection):
(JSC::Yarr::YarrPatternConstructor::parenthesisMatchDirection const):
(JSC::Yarr::YarrPattern::YarrPattern):
(JSC::Yarr::dumpCharacterClass):
(JSC::Yarr::PatternTerm::dump):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::PatternTerm::PatternTerm):
(JSC::Yarr::PatternTerm::convertToBackreference):
(JSC::Yarr::PatternTerm::setMatchDirection):
(JSC::Yarr::PatternTerm::matchDirection const):
(JSC::Yarr::PatternAlternative::PatternAlternative):
(JSC::Yarr::PatternAlternative::matchDirection const):
(JSC::Yarr::PatternDisjunction::addNewAlternative):
(JSC::Yarr::YarrPattern::resetForReparsing):
* Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp:
(JSC::Yarr::SyntaxChecker::atomParentheticalAssertionBegin):
* Source/WTF/wtf/PrintStream.cpp:
(WTF::printInternal):
* Source/WTF/wtf/PrintStream.h:
* Source/WebCore/contentextensions/URLFilterParser.cpp:
(WebCore::ContentExtensions::PatternParser::atomParentheticalAssertionBegin):

Canonical link: <a href="https://commits.webkit.org/257823@main">https://commits.webkit.org/257823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52844d018234f70d16597910045cd35d33352f5f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100129 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109463 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169698 "Failed to checkout and rebase branch from PR 7109") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10181 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92560 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107353 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105898 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34406 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90710 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3066 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23890 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86674 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/497 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3038 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29050 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43375 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89555 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5374 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4876 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20023 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->