### PR TITLE
Make ::backdrop renderers use background layers when possible

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6176,9 +6176,6 @@ imported/w3c/web-platform-tests/xhr/send-after-setting-document-domain.htm [ Ski
 fast/text/text-edge-no-half-leading-simple.html [ Skip ]
 fast/text/text-edge-no-half-leading-with-line-height-simple.html [ Skip ]
 
-# This test isn't working as expected, it will be fixed in webkit.org/b/248148.
-webkit.org/b/248148 fullscreen/full-screen-layer-dump.html [ Failure ]
-
 # CSS Nesting
 imported/w3c/web-platform-tests/css/css-nesting/conditional-properties.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-nesting/conditional-rules.html [ ImageOnlyFailure ]

--- a/LayoutTests/compositing/no-compositing-when-full-screen-is-present-expected.txt
+++ b/LayoutTests/compositing/no-compositing-when-full-screen-is-present-expected.txt
@@ -1,4 +1,4 @@
-Test that only elements in fullscreen subtree get layer backed.
+Test that only elements in fullscreen subtree and the associated backdrop get layer backed.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -17,7 +17,28 @@ foobar
       (bounds 800.00 600.00)
       (contentsOpaque 1)
       (backingStoreAttached 1)
-      (children 1
+      (children 2
+        (GraphicsLayer
+          (preserves3D 1)
+          (backingStoreAttached 0)
+          (children 1
+            (GraphicsLayer
+              (bounds 800.00 600.00)
+              (backingStoreAttached 1)
+              (children 2
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 800.00 600.00)
+                  (backingStoreAttached 1)
+                )
+                (GraphicsLayer
+                  (bounds 800.00 600.00)
+                  (backingStoreAttached 1)
+                )
+              )
+            )
+          )
+        )
         (GraphicsLayer
           (preserves3D 1)
           (backingStoreAttached 0)

--- a/LayoutTests/compositing/no-compositing-when-full-screen-is-present.html
+++ b/LayoutTests/compositing/no-compositing-when-full-screen-is-present.html
@@ -9,7 +9,7 @@
 <script src="../resources/js-test.js"></script>
 <script>
 
-description("Test that only elements in fullscreen subtree get layer backed.");
+description("Test that only elements in fullscreen subtree and the associated backdrop get layer backed.");
 
 function goFullscreen() {
     host.webkitRequestFullscreen();

--- a/LayoutTests/fullscreen/full-screen-layer-dump-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-layer-dump-expected.txt
@@ -1,3 +1,5 @@
+Test passes if you see a contents layer 3x the size and with a negative offset equal to the size:
+
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -5,17 +7,33 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 1
+      (children 2
         (GraphicsLayer
           (preserves3D 1)
           (children 1
             (GraphicsLayer
               (bounds 800.00 600.00)
-              (contentsOpaque 1)
-              (contents layer (background color)
-                (position 0.00 0.00)
-                (bounds 800.00 600.00)
+              (children 2
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 800.00 600.00)
+                  (contents layer (background color)
+                    (position -800.00 -600.00)
+                    (bounds 2400.00 1800.00)
+                  )
+                )
+                (GraphicsLayer
+                  (bounds 800.00 600.00)
+                )
               )
+            )
+          )
+        )
+        (GraphicsLayer
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 800.00 600.00)
             )
           )
         )

--- a/LayoutTests/fullscreen/full-screen-layer-dump.html
+++ b/LayoutTests/fullscreen/full-screen-layer-dump.html
@@ -23,7 +23,8 @@ body {
         document.addEventListener('webkitfullscreenchange', event => {
             if (document.webkitIsFullScreen) {
                 setTimeout(() => {
-                    out.innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS);
+                    out.innerText = "Test passes if you see a contents layer 3x the size and with a negative offset equal to the size:\n\n";
+                    out.innerText += internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS);
                     document.webkitCancelFullScreen();
                 }, 0)
             } else 

--- a/LayoutTests/platform/gtk/compositing/no-compositing-when-full-screen-is-present-expected.txt
+++ b/LayoutTests/platform/gtk/compositing/no-compositing-when-full-screen-is-present-expected.txt
@@ -1,4 +1,4 @@
-Test that only elements in fullscreen subtree get layer backed.
+Test that only elements in fullscreen subtree and the associated backdrop get layer backed.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -17,7 +17,28 @@ foobar
       (bounds 800.00 600.00)
       (contentsOpaque 1)
       (backingStoreAttached 1)
-      (children 1
+      (children 2
+        (GraphicsLayer
+          (preserves3D 1)
+          (backingStoreAttached 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 800.00 600.00)
+              (backingStoreAttached 1)
+              (children 2
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 800.00 600.00)
+                  (backingStoreAttached 1)
+                )
+                (GraphicsLayer
+                  (bounds 800.00 600.00)
+                  (backingStoreAttached 1)
+                )
+              )
+            )
+          )
+        )
         (GraphicsLayer
           (preserves3D 1)
           (backingStoreAttached 1)

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -757,11 +757,6 @@ void RenderElement::propagateStyleToAnonymousChildren(StylePropagationType propa
         if (propagationType == PropagateToBlockChildrenOnly && !is<RenderBlock>(elementChild))
             continue;
 
-#if ENABLE(FULLSCREEN_API)
-        if (elementChild.isRenderFullScreen() || elementChild.isRenderFullScreenPlaceholder())
-            continue;
-#endif
-
         // RenderFragmentedFlows are updated through the RenderView::styleDidChange function.
         if (is<RenderFragmentedFlow>(elementChild))
             continue;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -205,10 +205,24 @@ RenderLayerBacking::RenderLayerBacking(RenderLayer& layer)
         m_isMainFrameRenderViewLayer = renderer().frame().isMainFrame();
         m_isFrameLayerWithTiledBacking = renderer().page().chrome().client().shouldUseTiledBackingForFrameView(renderer().view().frameView());
     }
-    
+
     createPrimaryGraphicsLayer();
 #if ENABLE(FULLSCREEN_API)
-    setRequiresBackgroundLayer(layer.renderer().isRenderFullScreen());
+    auto isFullsizeBackdrop = [](const RenderElement& renderer) -> bool {
+        auto& style = renderer.style();
+        if (style.styleType() != PseudoId::Backdrop || style.position() != PositionType::Fixed)
+            return false;
+
+        if (style.hasTransform() || style.hasClip() || style.hasMask())
+            return false;
+
+        if (!is<RenderBox>(renderer))
+            return false;
+
+        auto rendererRect = downcast<RenderBox>(renderer).frameRect();
+        return rendererRect == renderer.view().frameRect();
+    };
+    setRequiresBackgroundLayer(isFullsizeBackdrop(layer.renderer()));
 #endif
 
     if (auto* tiledBacking = this->tiledBacking()) {

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2670,6 +2670,10 @@ static FullScreenDescendant isDescendantOfFullScreenLayer(const RenderLayer& lay
     if (!fullScreenRenderer || !fullScreenLayer)
         return FullScreenDescendant::NotApplicable;
 
+    auto backdropRenderer = fullScreenRenderer->backdropRenderer();
+    if (backdropRenderer && backdropRenderer.get() == &layer.renderer())
+        return FullScreenDescendant::Yes;
+
     return layer.isDescendantOf(*fullScreenLayer) ? FullScreenDescendant::Yes : FullScreenDescendant::No;
 }
 #endif

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -263,10 +263,6 @@ public:
 #if ENABLE(ATTACHMENT_ELEMENT)
     virtual bool isAttachment() const { return false; }
 #endif
-#if ENABLE(FULLSCREEN_API)
-    virtual bool isRenderFullScreen() const { return false; }
-    virtual bool isRenderFullScreenPlaceholder() const { return false; }
-#endif
     virtual bool isRenderGrid() const { return false; }
 
     virtual bool isMultiColumnBlockFlow() const { return false; }
@@ -1159,10 +1155,6 @@ inline bool RenderObject::isAnonymousBlock() const
         && (style().display() == DisplayType::Block || style().display() == DisplayType::Box)
         && style().styleType() == PseudoId::None
         && isRenderBlock()
-#if ENABLE(FULLSCREEN_API)
-        && !isRenderFullScreen()
-        && !isRenderFullScreenPlaceholder()
-#endif
 #if ENABLE(MATHML)
         && !isRenderMathMLBlock()
 #endif


### PR DESCRIPTION
#### 2a5bd0ff38736fcfe4df01b8098012b8d0a1fbff
<pre>
Make ::backdrop renderers use background layers when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=248148">https://bugs.webkit.org/show_bug.cgi?id=248148</a>
rdar://102566049

Reviewed by Simon Fraser.

Right now, when rotating in fullscreen on iPad, there are white gaps around the edges. This was avoided by RenderFullscreen using
&quot;background layers&quot; that are 3x the size with a negative offset. Now that RenderFullscreen is gone, we need to target ::backdrop
pseudo elements that have:

- The same rect as the RenderView
- position: fixed, since position: absolute can allow scrolling away from the ::backdrop, since the containing block is the ICB
- No transforms/clips/masks (since they intentionally do not cover the whole screen)

Also clean up remainders of RenderFullscreen which has been removed in 255641@main.

* LayoutTests/compositing/no-compositing-when-full-screen-is-present-expected.txt:
* LayoutTests/compositing/no-compositing-when-full-screen-is-present.html:
* LayoutTests/platform/gtk/compositing/no-compositing-when-full-screen-is-present-expected.txt:
Update test expectations to reflect that ::backdrop is now layer backed in fullscreen.

* LayoutTests/TestExpectations:
* LayoutTests/fullscreen/full-screen-layer-dump-expected.txt:
* LayoutTests/fullscreen/full-screen-layer-dump.html:
Make test expectation more clear in the description to avoid regressing this test again, and update test expectation to reflect that &quot;background layers&quot; now work again.

* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::propagateStyleToAnonymousChildren):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::RenderLayerBacking):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::isDescendantOfFullScreenLayer):
Consider the fullscreen element&apos;s associated ::backdrop as fullscreen layer, otherwise the renderer is never layer-backed meaning we can&apos;t use &quot;background layers&quot;.
We avoid backing non-fullscreen layers to optimize for power usage.

* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isAttachment const):
(WebCore::RenderObject::isAnonymousBlock const):
(WebCore::RenderObject::isRenderFullScreen const): Deleted.
(WebCore::RenderObject::isRenderFullScreenPlaceholder const): Deleted.

Canonical link: <a href="https://commits.webkit.org/257538@main">https://commits.webkit.org/257538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a08277f2cc5f0ff411ab12b9d06d8d48b377290

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108485 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168727 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85644 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91595 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106429 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90262 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33703 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88509 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21607 "Found 30 new test failures: http/tests/media/fairplay/fps-hls-key-rotation.html, http/tests/media/fairplay/fps-hls-update-reject.html, http/tests/media/fairplay/fps-hls.html, http/tests/media/fairplay/fps-init-data-cenc.html, http/tests/media/fairplay/fps-init-data-sinf.html, http/tests/media/fairplay/fps-init-data-skd.html, http/tests/media/fairplay/fps-mse-play-while-not-in-dom.html, http/tests/media/fairplay/fps-mse-unmuxed-key-renewal.html, http/tests/media/media-source/mediasource-play-then-seek-back-with-remote-control.html, http/tests/media/media-source/mediasource-rvfc.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76561 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2188 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23123 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45537 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5180 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7043 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42599 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3496 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->