### PR TITLE
Implementing CounterStyle representation from StyleRuleCounterStyle

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -593,6 +593,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     crypto/SerializedCryptoKeyWrap.h
 
     css/CSSConditionRule.h
+    css/CSSCounterStyle.h
+    css/CSSCounterStyleDescriptors.h
+    css/CSSCounterStyleRule.h
     css/CSSCustomPropertyValue.h
     css/CSSFontFaceRule.h
     css/CSSFontPaletteValuesRule.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -742,6 +742,8 @@ css/CSSComputedStyleDeclaration.cpp
 css/CSSConditionRule.cpp
 css/CSSContainerRule.cpp
 css/CSSContentDistributionValue.cpp
+css/CSSCounterStyle.cpp
+css/CSSCounterStyleDescriptors.cpp
 css/CSSCounterStyleRule.cpp
 css/CSSCrossfadeValue.cpp
 css/CSSCursorImageValue.cpp

--- a/Source/WebCore/css/CSSCounterStyle.cpp
+++ b/Source/WebCore/css/CSSCounterStyle.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSCounterStyle.h"
+
+#include "CSSCounterStyleDescriptors.h"
+#include "CSSCounterStyleRule.h"
+#include "CSSPrimitiveValue.h"
+#include "CSSValuePair.h"
+
+namespace WebCore {
+
+String CSSCounterStyle::counterForSystemCyclic(int)
+{
+    // FIXME: implement counter for system rdar://103648354
+    return ""_s;
+}
+String CSSCounterStyle::counterForSystemFixed(int)
+{
+    // FIXME: implement counter for system rdar://103648354
+    return ""_s;
+}
+String CSSCounterStyle::counterForSystemSymbolic(int)
+{
+    // FIXME: implement counter for system rdar://103648354
+    return ""_s;
+}
+String CSSCounterStyle::counterForSystemAlphabetic(int)
+{
+    // FIXME: implement counter for system rdar://103648354
+    return ""_s;
+}
+String CSSCounterStyle::counterForSystemNumeric(int)
+{
+    // FIXME: implement counter for system rdar://103648354
+    return ""_s;
+}
+String CSSCounterStyle::counterForSystemAdditive(int)
+{
+    // FIXME: implement counter for system rdar://103648354
+    return ""_s;
+}
+String CSSCounterStyle::initialRepresentation(int)
+{
+    // FIXME: implement counter initial representation rdar://103648354
+    return ""_s;
+}
+String CSSCounterStyle::text(int value)
+{
+// FIXME: implement text representation for CounterStyle rdar://103648354.
+    return String::number(value);
+}
+bool CSSCounterStyle::isInRange(int value) const
+{
+    if (isAutoRange()) {
+        switch (system()) {
+        case CSSCounterStyleDescriptors::System::Cyclic:
+        case CSSCounterStyleDescriptors::System::Numeric:
+        case CSSCounterStyleDescriptors::System::Fixed:
+            return true;
+        case CSSCounterStyleDescriptors::System::Alphabetic:
+        case CSSCounterStyleDescriptors::System::Symbolic:
+            return value >= 1;
+        case CSSCounterStyleDescriptors::System::Additive:
+            return value >= 0;
+        case CSSCounterStyleDescriptors::System::Extends:
+            ASSERT_NOT_REACHED();
+            return true;
+        }
+    }
+
+    for (const auto& [lowerBound, higherBound] : ranges()) {
+        if (value >= lowerBound && value <= higherBound)
+            return true;
+    }
+    return false;
+}
+
+CSSCounterStyle::CSSCounterStyle(const CSSCounterStyleDescriptors& descriptors, bool isPredefinedCounterStyle)
+    : m_descriptors { descriptors },
+    m_predefinedCounterStyle { isPredefinedCounterStyle }
+{
+}
+
+Ref<CSSCounterStyle> CSSCounterStyle::create(const CSSCounterStyleDescriptors& descriptors, bool isPredefinedCounterStyle)
+{
+    return adoptRef(*new CSSCounterStyle(descriptors, isPredefinedCounterStyle));
+}
+
+Ref<CSSCounterStyle> CSSCounterStyle::createCounterStyleDecimal()
+{
+    Vector<CSSCounterStyleDescriptors::Symbol> symbols { "0"_s, "1"_s, "2"_s, "3"_s, "4"_s, "5"_s, "6"_s, "7"_s, "8"_s, "9"_s };
+    CSSCounterStyleDescriptors descriptors {
+        .m_name = "decimal"_s,
+        .m_system = CSSCounterStyleDescriptors::System::Numeric,
+        .m_negativeSymbols = { },
+        .m_prefix = { },
+        .m_suffix = { },
+        .m_ranges = { },
+        .m_pad = { },
+        .m_fallbackName = { },
+        .m_symbols = WTFMove(symbols),
+        .m_additiveSymbols = { },
+        .m_speakAs = CSSCounterStyleDescriptors::SpeakAs::Auto,
+        .m_extendsName = { },
+        .m_fixedSystemFirstSymbolValue = 0,
+        .m_explicitlySetDescriptors = { }
+    };
+    return adoptRef(*new CSSCounterStyle(descriptors, true));
+}
+
+void CSSCounterStyle::setFallbackReference(RefPtr<CSSCounterStyle>&& fallback)
+{
+    m_fallbackReference = WeakPtr { fallback };
+}
+
+// The counter's system value is promoted to the value of the counter we are extending.
+void CSSCounterStyle::extendAndResolve(const CSSCounterStyle& extendedCounterStyle)
+{
+    m_isExtendedUnresolved = false;
+
+    setSystem(extendedCounterStyle.system());
+
+    if (!explicitlySetDescriptors().contains(CSSCounterStyleDescriptors::ExplicitlySetDescriptors::Negative))
+        setNegative(extendedCounterStyle.negative());
+    if (!explicitlySetDescriptors().contains(CSSCounterStyleDescriptors::ExplicitlySetDescriptors::Prefix))
+        setPrefix(extendedCounterStyle.prefix());
+    if (!explicitlySetDescriptors().contains(CSSCounterStyleDescriptors::ExplicitlySetDescriptors::Suffix))
+        setSuffix(extendedCounterStyle.suffix());
+    if (!explicitlySetDescriptors().contains(CSSCounterStyleDescriptors::ExplicitlySetDescriptors::Range))
+        setRanges(extendedCounterStyle.ranges());
+    if (!explicitlySetDescriptors().contains(CSSCounterStyleDescriptors::ExplicitlySetDescriptors::Pad))
+        setPad(extendedCounterStyle.pad());
+    if (!explicitlySetDescriptors().contains(CSSCounterStyleDescriptors::ExplicitlySetDescriptors::Fallback)) {
+        setFallbackName(extendedCounterStyle.fallbackName());
+        m_fallbackReference = extendedCounterStyle.m_fallbackReference;
+    }
+    if (!explicitlySetDescriptors().contains(CSSCounterStyleDescriptors::ExplicitlySetDescriptors::Symbols))
+        setSymbols(extendedCounterStyle.symbols());
+    if (!explicitlySetDescriptors().contains(CSSCounterStyleDescriptors::ExplicitlySetDescriptors::AdditiveSymbols))
+        setAdditiveSymbols(extendedCounterStyle.additiveSymbols());
+    if (!explicitlySetDescriptors().contains(CSSCounterStyleDescriptors::ExplicitlySetDescriptors::SpeakAs))
+        setSpeakAs(extendedCounterStyle.speakAs());
+}
+
+}

--- a/Source/WebCore/css/CSSCounterStyle.h
+++ b/Source/WebCore/css/CSSCounterStyle.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSCounterStyleDescriptors.h"
+#include <wtf/Forward.h>
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+
+class StyleRuleCounterStyle;
+
+class CSSCounterStyle : public RefCounted<CSSCounterStyle>, public CanMakeWeakPtr<CSSCounterStyle> {
+public:
+    static Ref<CSSCounterStyle> create(const CSSCounterStyleDescriptors&, bool isPredefinedCounterStyle);
+    static Ref<CSSCounterStyle> createCounterStyleDecimal();
+
+    bool operator==(const CSSCounterStyle& other) const
+    {
+        return m_descriptors == other.m_descriptors
+            && m_predefinedCounterStyle == other.m_predefinedCounterStyle;
+    }
+
+    String text(int);
+    const CSSCounterStyleDescriptors::Name& name() const { return m_descriptors.m_name; }
+    CSSCounterStyleDescriptors::System system() const { return m_descriptors.m_system; }
+    const CSSCounterStyleDescriptors::NegativeSymbols& negative() const { return m_descriptors.m_negativeSymbols; }
+    const CSSCounterStyleDescriptors::Symbol& prefix() const { return m_descriptors.m_prefix; }
+    const CSSCounterStyleDescriptors::Symbol& suffix() const { return m_descriptors.m_suffix; }
+    const CSSCounterStyleDescriptors::Ranges& ranges() const { return m_descriptors.m_ranges; }
+    const CSSCounterStyleDescriptors::Pad& pad() const { return m_descriptors.m_pad; }
+    const CSSCounterStyleDescriptors::Name& fallbackName() const { return m_descriptors.m_fallbackName; }
+    const Vector<CSSCounterStyleDescriptors::Symbol>& symbols() const { return m_descriptors.m_symbols; }
+    const CSSCounterStyleDescriptors::AdditiveSymbols& additiveSymbols() const { return m_descriptors.m_additiveSymbols; }
+    CSSCounterStyleDescriptors::SpeakAs speakAs() const { return m_descriptors.m_speakAs; }
+    const CSSCounterStyleDescriptors::Name extendsName() const { return m_descriptors.m_extendsName; }
+    int firstSymbolValueForFixedSystem() const { return m_descriptors.m_fixedSystemFirstSymbolValue; }
+    const OptionSet<CSSCounterStyleDescriptors::ExplicitlySetDescriptors>& explicitlySetDescriptors() const { return m_descriptors.m_explicitlySetDescriptors; }
+
+    void setSystem(CSSCounterStyleDescriptors::System system) { m_descriptors.m_system = system; }
+    void setNegative(const CSSCounterStyleDescriptors::NegativeSymbols& negative) { m_descriptors.m_negativeSymbols = negative; }
+    void setPrefix(const CSSCounterStyleDescriptors::Symbol& prefix) { m_descriptors.m_prefix = prefix; }
+    void setSuffix(const CSSCounterStyleDescriptors::Symbol& suffix) { m_descriptors.m_suffix = suffix; }
+    void setRanges(const CSSCounterStyleDescriptors::Ranges& ranges) { m_descriptors.m_ranges = ranges; }
+    void setPad(const CSSCounterStyleDescriptors::Pad& pad) { m_descriptors.m_pad = pad; }
+    void setFallbackName(const CSSCounterStyleDescriptors::Name& fallbackName) { m_descriptors.m_fallbackName = fallbackName; }
+    void setSymbols(const Vector<CSSCounterStyleDescriptors::Symbol>& symbols) { m_descriptors.m_symbols = symbols; }
+    void setAdditiveSymbols(const CSSCounterStyleDescriptors::AdditiveSymbols& additiveSymbols) { m_descriptors.m_additiveSymbols = additiveSymbols; }
+    void setSpeakAs(CSSCounterStyleDescriptors::SpeakAs speakAs) { m_descriptors.m_speakAs = speakAs; }
+
+    void setFallbackReference(RefPtr<CSSCounterStyle>&&);
+    bool isFallbackUnresolved() { return !m_fallbackReference; }
+    bool isExtendsUnresolved() { return m_isExtendedUnresolved; };
+    bool isExtendsSystem() const { return system() == CSSCounterStyleDescriptors::System::Extends; }
+    void extendAndResolve(const CSSCounterStyle&);
+private:
+    CSSCounterStyle(const CSSCounterStyleDescriptors&, bool isPredefinedCounterStyle);
+
+    // https://www.w3.org/TR/css-counter-styles-3/#counter-style-range
+    bool isInRange(int) const;
+    // https://www.w3.org/TR/css-counter-styles-3/#counter-style-negative
+    bool usesNegativeSign();
+    bool shouldApplyNegativeSymbols(int);
+    // https://www.w3.org/TR/css-counter-styles-3/#counter-style-fallback
+    Ref<CSSCounterStyle> fallback();
+    // Generates a CounterStyle object as it was defined by a 'decimal' descriptor. It is used as a last-resource in case we can't resolve fallback references.
+    void applyPadSymbols(String&);
+    void applyNegativeSymbols(String&);
+    // Initial text representation for the counter, before applying pad and/or negative symbols. Suffix and Prefix are also not considered as described by https://www.w3.org/TR/css-counter-styles-3/#counter-styles.
+    String initialRepresentation(int);
+
+    String counterForSystemCyclic(int);
+    String counterForSystemFixed(int);
+    String counterForSystemSymbolic(int);
+    String counterForSystemAlphabetic(int);
+    String counterForSystemNumeric(int);
+    String counterForSystemAdditive(int);
+
+    bool isPredefinedCounterStyle() const { return m_predefinedCounterStyle; }
+    bool isAutoRange() const { return ranges().isEmpty(); }
+
+    // Fixed and Extends system can/must have extra data in the system descriptor (https://www.w3.org/TR/css-counter-styles-3/#fixed-system and https://www.w3.org/TR/css-counter-styles-3/#extends-system).
+    void extractDataFromSystemDescriptor(const StyleRuleCounterStyle&);
+
+    CSSCounterStyleDescriptors m_descriptors;
+    bool m_predefinedCounterStyle { false };
+    CSSCounterStyleDescriptors::Name m_fallbackName;
+    WeakPtr<const CSSCounterStyle> m_fallbackReference { nullptr };
+    WeakPtr<const CSSCounterStyle> m_extendsReference { nullptr };
+    bool m_isFallingBack { false };
+    bool m_isExtendedUnresolved { true };
+};
+} // namespace WebCore

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSCounterStyleDescriptors.h"
+
+#include "StyleProperties.h"
+
+#include <utility>
+
+namespace WebCore {
+
+static CSSCounterStyleDescriptors::Ranges translateRangeFromStyleProperties(const StyleProperties& properties)
+{
+    auto ranges = properties.getPropertyCSSValue(CSSPropertySystem).get();
+    // auto range will return an empty Ranges
+    if (!ranges || !is<CSSValueList>(ranges))
+        return { };
+    auto& list = downcast<CSSValueList>(*ranges);
+    CSSCounterStyleDescriptors::Ranges result;
+    for (auto& rangeValue : list) {
+        ASSERT(rangeValue->isPrimitiveValue());
+        if (!rangeValue->isPrimitiveValue())
+            return { };
+        auto& bounds = downcast<CSSPrimitiveValue>(rangeValue.get());
+        ASSERT(bounds.isPair());
+        if (!bounds.isPair())
+            return { };
+        auto boundsPair = bounds.pairValue();
+        if (!boundsPair)
+            return { };
+        auto low = boundsPair->first();
+        auto high = boundsPair->second();
+        if (!low || !high)
+            return { };
+        int convertedLow { std::numeric_limits<int>::min() };
+        int convertedHigh { std::numeric_limits<int>::max() };
+        if (low->isInteger())
+            convertedLow = low->intValue();
+        if (high->isInteger())
+            convertedHigh = high->intValue();
+        std::pair<int, int> newRange { convertedLow, convertedHigh };
+        result.append(newRange);
+    }
+    return result;
+}
+
+static String symbolToString(const CSSValue* value)
+{
+    if (!value || !value->isPrimitiveValue())
+        return String();
+
+    auto& primitiveValue = downcast<CSSPrimitiveValue>(*value);
+    return primitiveValue.stringValue();
+}
+
+static CSSCounterStyleDescriptors::Pad translatePadFromStyleProperties(const StyleProperties& properties)
+{
+    auto pad = properties.getPropertyCSSValue(CSSPropertyPad).get();
+    if (!pad || !is<CSSValueList>(pad))
+        return CSSCounterStyleDescriptors::Pad();
+
+    auto& list = downcast<CSSValueList>(*pad);
+    ASSERT(list.size() == 2);
+    auto length = downcast<CSSPrimitiveValue>(list.item(0));
+    if (!length)
+        return CSSCounterStyleDescriptors::Pad();
+    auto lengthValue = length->intValue();
+    ASSERT(lengthValue >= 0);
+    return { static_cast<unsigned>(std::max(0, lengthValue)), symbolToString(list.item(1)) };
+}
+
+static CSSCounterStyleDescriptors::NegativeSymbols translateNegativeSymbolsFromStyleProperties(const StyleProperties& properties)
+{
+    auto negative = properties.getPropertyCSSValue(CSSPropertyNegative).get();
+    if (!negative || !is<CSSValueList>(negative))
+        return CSSCounterStyleDescriptors::NegativeSymbols();
+
+    auto& list = downcast<CSSValueList>(*negative);
+    ASSERT(list.size() == 1 || list.size() == 2);
+    CSSCounterStyleDescriptors::NegativeSymbols result;
+    if (list.size() >= 1)
+        result.m_prefix = symbolToString(list.item(0));
+    else if (list.size() == 2)
+        result.m_suffix = symbolToString(list.item(1));
+    else {
+        ASSERT_NOT_REACHED();
+        return CSSCounterStyleDescriptors::NegativeSymbols();
+    }
+    return result;
+}
+
+static Vector<CSSCounterStyleDescriptors::Symbol> translateSymbolsFromStyleProperties(const StyleProperties& properties)
+{
+    auto symbolsValues = properties.getPropertyCSSValue(CSSPropertySymbols).get();
+    if (!symbolsValues || !is<CSSValueList>(symbolsValues))
+        return { };
+
+    Vector<CSSCounterStyleDescriptors::Symbol> result;
+    auto& list = downcast<CSSValueList>(*symbolsValues);
+    for (auto& symbolValue : list) {
+        auto symbolString = symbolToString(&symbolValue.get());
+        if (!symbolString.isNull())
+            result.append((symbolString));
+    }
+    return result;
+}
+
+static CSSCounterStyleDescriptors::Name translateFallbackNameFromStyleProperties(const StyleProperties& properties)
+{
+    auto fallback = properties.getPropertyCSSValue(CSSPropertyFallback).get();
+    if (!fallback)
+        return "decimal"_s;
+    return makeAtomString(symbolToString(fallback));
+}
+
+static CSSCounterStyleDescriptors::Symbol translatePrefixFromStyleProperties(const StyleProperties& properties)
+{
+    auto prefix = properties.getPropertyCSSValue(CSSPropertyPrefix).get();
+    if (!prefix)
+        return ""_s;
+    return symbolToString(prefix);
+}
+
+static CSSCounterStyleDescriptors::Symbol translateSuffixFromStyleProperties(const StyleProperties& properties)
+{
+    auto suffix = properties.getPropertyCSSValue(CSSPropertySuffix).get();
+    // https://www.w3.org/TR/css-counter-styles-3/#counter-style-suffix
+    // ("." full stop followed by a space)
+    if (!suffix)
+        return "\2E\20"_s;
+    return symbolToString(suffix);
+}
+
+static std::pair<CSSCounterStyleDescriptors::Name, int> extractDataFromSystemDescriptor(const StyleProperties& properties, CSSCounterStyleDescriptors::System system)
+{
+    auto systemValue = properties.getPropertyCSSValue(CSSPropertySystem).get();
+    // If no value is provided after `fixed`, the first synbol value is implicitly 1 (https://www.w3.org/TR/css-counter-styles-3/#first-symbol-value).
+    if (!systemValue || !systemValue->isPrimitiveValue())
+        return { "decimal"_s, 1 };
+
+    std::pair<CSSCounterStyleDescriptors::Name, int> result;
+
+    auto& primitiveSystemValue = downcast<CSSPrimitiveValue>(*systemValue);
+    ASSERT(primitiveSystemValue.isValueID() || primitiveSystemValue.isPair());
+    if (auto* pair = primitiveSystemValue.pairValue()) {
+        // This value must be `fixed` or `extends`, both of which can or must have an additional component.
+        auto secondValue = pair->second();
+        if (system == CSSCounterStyleDescriptors::System::Extends) {
+            ASSERT(secondValue && secondValue->isCustomIdent());
+            result.first = secondValue && secondValue->isCustomIdent() ? makeAtomString(secondValue->stringValue()) : makeAtomString("decimal"_s);
+        } else if (system == CSSCounterStyleDescriptors::System::Fixed) {
+            ASSERT(secondValue && secondValue->isInteger());
+            result.second = secondValue && secondValue->isInteger() ? secondValue->intValue() : 1;
+        }
+    }
+    return result;
+}
+
+void CSSCounterStyleDescriptors::setExplicitlySetDescriptors(const StyleProperties& properties)
+{
+    auto getPropertyCSSValue = [&](CSSPropertyID id) -> RefPtr<CSSValue> {
+        return properties.getPropertyCSSValue(id);
+    };
+
+    if (getPropertyCSSValue(CSSPropertySystem))
+        m_explicitlySetDescriptors.add(ExplicitlySetDescriptors::System);
+    if (getPropertyCSSValue(CSSPropertyNegative))
+        m_explicitlySetDescriptors.add(ExplicitlySetDescriptors::Negative);
+    if (getPropertyCSSValue(CSSPropertyPrefix))
+        m_explicitlySetDescriptors.add(ExplicitlySetDescriptors::Prefix);
+    if (getPropertyCSSValue(CSSPropertySuffix))
+        m_explicitlySetDescriptors.add(ExplicitlySetDescriptors::Suffix);
+    if (getPropertyCSSValue(CSSPropertyRange))
+        m_explicitlySetDescriptors.add(ExplicitlySetDescriptors::Range);
+    if (getPropertyCSSValue(CSSPropertyPad))
+        m_explicitlySetDescriptors.add(ExplicitlySetDescriptors::Pad);
+    if (getPropertyCSSValue(CSSPropertyFallback))
+        m_explicitlySetDescriptors.add(ExplicitlySetDescriptors::Fallback);
+    if (getPropertyCSSValue(CSSPropertyAdditiveSymbols))
+        m_explicitlySetDescriptors.add(ExplicitlySetDescriptors::AdditiveSymbols);
+    if (getPropertyCSSValue(CSSPropertySpeakAs))
+        m_explicitlySetDescriptors.add(ExplicitlySetDescriptors::SpeakAs);
+}
+
+CSSCounterStyleDescriptors CSSCounterStyleDescriptors::create(AtomString name, const StyleProperties& properties)
+{
+    auto system = toCounterStyleSystemEnum(properties.getPropertyCSSValue(CSSPropertySystem).get());
+    auto systemData = extractDataFromSystemDescriptor(properties, system);
+    CSSCounterStyleDescriptors descriptors {
+        .m_name = name,
+        .m_system = system,
+        .m_negativeSymbols = translateNegativeSymbolsFromStyleProperties(properties),
+        .m_prefix = translatePrefixFromStyleProperties(properties),
+        .m_suffix = translateSuffixFromStyleProperties(properties),
+        .m_ranges = translateRangeFromStyleProperties(properties),
+        .m_pad = translatePadFromStyleProperties(properties),
+        .m_fallbackName = translateFallbackNameFromStyleProperties(properties),
+        .m_symbols = translateSymbolsFromStyleProperties(properties),
+        .m_additiveSymbols = { },
+        .m_speakAs = SpeakAs::Auto,
+        .m_extendsName = systemData.first,
+        .m_fixedSystemFirstSymbolValue = systemData.second,
+        .m_explicitlySetDescriptors = { }
+    };
+    descriptors.setExplicitlySetDescriptors(properties);
+    return descriptors;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.h
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+
+class StyleProperties;
+
+struct CSSCounterStyleDescriptors {
+    using Name = AtomString;
+    using Symbol = String;
+    using Ranges = Vector<std::pair<int, int>>;
+    using AdditiveSymbols = Vector<std::pair<Symbol, unsigned>>;
+    // The keywords that can be used as values for the counter-style `system` descriptor.
+    // https://www.w3.org/TR/css-counter-styles-3/#counter-style-system
+    enum class System : uint8_t {
+        Cyclic,
+        Numeric,
+        Alphabetic,
+        Symbolic,
+        Additive,
+        Fixed,
+        Extends
+    };
+    enum class SpeakAs : uint8_t {
+        Auto,
+        Bullets,
+        Numbers,
+        Words,
+        SpellOut,
+        CounterStyleNameReference,
+    };
+    struct Pad {
+        unsigned m_padMinimumLength = 0;
+        Symbol m_padSymbol = "-"_s;
+        bool operator==(const Pad& other) const = default;
+    };
+    struct NegativeSymbols {
+        Symbol m_prefix = "-"_s;
+        Symbol m_suffix;
+        bool operator==(const NegativeSymbols& other) const = default;
+    };
+    enum class ExplicitlySetDescriptors: uint16_t {
+        System = 1 << 0,
+        Negative = 1 << 1,
+        Prefix = 1 << 2,
+        Suffix = 1 << 3,
+        Range = 1 << 4,
+        Pad = 1 << 5,
+        Fallback = 1 << 6,
+        Symbols = 1 << 7,
+        AdditiveSymbols = 1 << 8,
+        SpeakAs = 1 << 9
+    };
+
+    // create() is prefered here rather than a custom constructor, so that the Struct still classifies as an aggregate.
+    static CSSCounterStyleDescriptors create(AtomString name, const StyleProperties&);
+    bool operator==(const CSSCounterStyleDescriptors& other) const = default;
+    void setExplicitlySetDescriptors(const StyleProperties&);
+
+    Name m_name;
+    System m_system;
+    NegativeSymbols m_negativeSymbols;
+    Symbol m_prefix;
+    Symbol m_suffix;
+    Ranges m_ranges;
+    Pad m_pad;
+    Name m_fallbackName;
+    Vector<Symbol> m_symbols;
+    AdditiveSymbols m_additiveSymbols;
+    SpeakAs m_speakAs;
+    Name m_extendsName;
+    int m_fixedSystemFirstSymbolValue;
+    OptionSet<ExplicitlySetDescriptors> m_explicitlySetDescriptors;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSCounterStyleRule.h
+++ b/Source/WebCore/css/CSSCounterStyleRule.h
@@ -25,25 +25,13 @@
 
 #pragma once
 
+#include "CSSCounterStyle.h"
 #include "CSSRule.h"
 #include "StyleProperties.h"
 #include "StyleRule.h"
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
-
-// The keywords that can be used as values for the counter-style `system` descriptor.
-// https://www.w3.org/TR/css-counter-styles-3/#counter-style-system
-enum class CounterStyleSystem : uint8_t {
-    Cyclic,
-    Numeric,
-    Alphabetic,
-    Symbolic,
-    Additive,
-    Fixed,
-    Extends
-};
-
 class StyleRuleCounterStyle final : public StyleRuleBase {
 public:
     static Ref<StyleRuleCounterStyle> create(const AtomString& name, Ref<StyleProperties>&&);
@@ -52,6 +40,7 @@ public:
     Ref<StyleRuleCounterStyle> copy() const { RELEASE_ASSERT_NOT_REACHED(); }
 
     const StyleProperties& properties() const { return m_properties; }
+    RefPtr<CSSValue> getPropertyCSSValue(CSSPropertyID id) const { return m_properties->getPropertyCSSValue(id); }
     MutableStyleProperties& mutableProperties();
 
     const AtomString& name() const { return m_name; }
@@ -65,16 +54,16 @@ public:
     String symbols() const { return m_properties->getPropertyValue(CSSPropertySymbols); }
     String additiveSymbols() const { return m_properties->getPropertyValue(CSSPropertyAdditiveSymbols); }
     String speakAs() const { return m_properties->getPropertyValue(CSSPropertySpeakAs); }
-
     bool newValueInvalidOrEqual(CSSPropertyID, const RefPtr<CSSValue> newValue) const;
 
     void setName(const AtomString& name) { m_name = name; }
 
 private:
-    explicit StyleRuleCounterStyle(const AtomString&, Ref<StyleProperties>&&);
+    explicit StyleRuleCounterStyle(const AtomString&, Ref<StyleProperties>&&, CSSCounterStyleDescriptors&&);
 
     AtomString m_name;
     Ref<StyleProperties> m_properties;
+    CSSCounterStyleDescriptors m_descriptors;
 };
 
 class CSSCounterStyleRule final : public CSSRule {
@@ -117,6 +106,8 @@ private:
 
     Ref<StyleRuleCounterStyle> m_counterStyleRule;
 };
+
+CSSCounterStyleDescriptors::System toCounterStyleSystemEnum(RefPtr<CSSValue> system);
 
 } // namespace WebCore
 

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -198,6 +198,7 @@ void CSSStyleSheet::didMutateRuleFromCSSStyleDeclaration()
     didMutate();
 }
 
+// FIXME: counter-style: we might need something similar for counter-style (rdar://103018993).
 void CSSStyleSheet::didMutateRules(RuleMutationType mutationType, WhetherContentsWereClonedForMutation contentsWereClonedForMutation, StyleRuleKeyframes* insertedKeyframesRule, const String& modifiedKeyframesRuleName)
 {
     ASSERT(m_contents->isMutable());

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -484,6 +484,8 @@ simp-chinese-formal
 trad-chinese-informal
 trad-chinese-formal
 ethiopic-numeric
+// FIXME: enable representation for custom-counter-style rdar://102988393.
+custom-counter-style
 //none
 //
 // CSS_PROP_DISPLAY:

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -8224,6 +8224,8 @@ RefPtr<CSSValue> consumeCounterStyleSystem(CSSParserTokenRange& range)
     }
 
     if (auto ident = consumeIdent<CSSValueExtends>(range)) {
+        // FIXME: (rdar://103020193) "If a @counter-style uses the extends system, it must not contain a symbols or additive-symbols descriptor, or else the @counter-style rule is invalid." (https://www.w3.org/TR/css-counter-styles-3/#extends-system)
+
         // There must be a `<counter-style-name>` following the `extends` keyword. If there isn't, this value is invalid.
         auto parsedCounterStyleName = consumeCounterStyleName(range);
         if (!parsedCounterStyleName)

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -560,6 +560,7 @@ public:
     void cssAnimationsDidUpdate(PseudoId);
     void keyframesRuleDidChange(PseudoId);
     bool hasPendingKeyframesUpdate(PseudoId) const;
+    // FIXME: do we need a counter style didChange here? (rdar://103018993).
 
     bool isInTopLayer() const { return hasNodeFlag(NodeFlag::IsInTopLayer); }
     void addToTopLayer();

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -72,6 +72,8 @@ bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderS
     if (!parentStyle.fontCascade().isCurrent(fontSelector))
         return false;
 
+    // FIXME: counter-style: we might need to resolve cache like for fontSelector here (rdar://103018993).
+
     return true;
 }
 


### PR DESCRIPTION
#### ac2f8a4229ceb0edf14da7a59709f299970836b4
<pre>
Implementing CounterStyle representation from StyleRuleCounterStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=248666">https://bugs.webkit.org/show_bug.cgi?id=248666</a>
rdar://102910060

Reviewed by Antti Koivisto.
Reviewed by Antti Koivisto.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
Adding CSSCounterStyle and CSSCounterStyleDescriptors .h and .cpp files.

* Source/WebCore/css/CSSCounterStyle.cpp: Added.
(WebCore::CounterStyle::isInRange const):
Returns true if counter is in range, as defined by
<a href="https://www.w3.org/TR/css-counter-styles-3/#descdef-counter-style-range.">https://www.w3.org/TR/css-counter-styles-3/#descdef-counter-style-range.</a>

(WebCore::CounterStyle::CounterStyle):
(WebCore::CounterStyle::create):

(WebCore::CounterStyle::createCounterStyleDecimal):
Create a CounterStyle object representing a Decimal counter.

(WebCore::CounterStyle::setFallbackReference):

(WebCore::CounterStyle::extendAndResolve):
Extend another CounterStyle as defined by
<a href="https://www.w3.org/TR/css-counter-styles-3/#extends-system">https://www.w3.org/TR/css-counter-styles-3/#extends-system</a> and resolve
its Extend reference. The counter&apos;s system value is then promoted
from &apos;extend&apos; to the valye of the CounterStyle we are extending.

(WebCore::CounterStyle::text):
Dummy text representation for the counter. The real representation wil
be implemented by rdar://103648354.

* Source/WebCore/css/CSSCounterStyle.h: Added.
(WebCore::CounterStyle::operator== const):
(WebCore::CounterStyle::fallbackName const):
(WebCore::CounterStyle::extendsName const):
(WebCore::CounterStyle::isFallbackUnresolved):
(WebCore::CounterStyle::isExtendsUnresolved):
(WebCore::CounterStyle::isExtendsSystem const):
(WebCore::CounterStyle::system const):
(WebCore::CounterStyle::isPredefinedCounterStyle const):
Returns true if CounterStyle is predefined by the user agent stylesheet.
A counter style parsed from author-defined rule will return false.

(WebCore::CounterStyle::isAutoRange const):
Returns true if the range descriptor is set to &apos;auto&apos;. A &apos;auto&apos; value
is represented by a empty vector of ranges.

* Source/WebCore/css/CSSCounterStyleRule.cpp:
(WebCore::toCounterStyleSystemEnum):
* Source/WebCore/css/CSSCounterStyleRule.h:
Moving enum to CSSCounterStyle.h.
Adding getters for the properties&apos;s CSS values.

* Source/WebCore/css/CSSStyleSheet.cpp:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleSystem):
* Source/WebCore/dom/Element.h:
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::isCacheable):
Adding FIXME with matching radars.

CSSCounterStyleDescriptors defines the descriptors for the counter-style
rule in a specialized manner. It serves as a payload for CSSCounterStyle.

* Source/WebCore/css/CSSCounterStyleDescriptors.cpp: Added.
(WebCore::translateRangeFromStyleProperties):
(WebCore::symbolToString):
(WebCore::translatePadFromStyleProperties):
(WebCore::translateNegativeSymbolsFromStyleProperties):
(WebCore::translateSymbolsFromStyleProperties):
(WebCore::translateFallbackNameFromStyleProperties):
(WebCore::translatePrefixFromStyleProperties):
(WebCore::translateSuffixFromStyleProperties):
(WebCore::extractDataFromSystemDescriptor):
(WebCore::CSSCounterStyleDescriptors::setExplicitlySetDescriptors):
Translation from CSSValues of rule&apos;s properties to adequated
specialized types.
(WebCore::CSSCounterStyleDescriptors::create):
Creates an instance of CSSCounterStyleDescriptor based on
StyleProperties. A create function was preferred instead of a
constructor in order to maintain the class as a aggregate, enabling
desginated initializers.
* Source/WebCore/css/CSSCounterStyleDescriptors.h: Added.

Canonical link: <a href="https://commits.webkit.org/258434@main">https://commits.webkit.org/258434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3006368c54c55e4458f383eb89223c673d00771a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111277 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171478 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2006 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94369 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109031 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9227 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92496 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23946 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4674 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25407 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1848 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10839 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44895 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5788 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6513 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->