### PR TITLE
[SIMD] Refactor X86Assembler.h: All destinations should be on the right side.

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -2137,21 +2137,21 @@ public:
 
     void vectorReplaceLane(SIMDLane simdLane, TrustedImm32 lane, RegisterID src, FPRegisterID dest)
     {
-        m_assembler.pinsr(dest, src, simdLane, lane.m_value);
+        m_assembler.pinsr(simdLane, lane.m_value, src, dest);
     }
 
     void vectorReplaceLane(SIMDLane simdLane, TrustedImm32 lane, FPRegisterID src, FPRegisterID dest, RegisterID scratch)
     {
         // FIXME: Maybe we can use INSERTPS instead to get rid of the scratch register.
         moveDoubleTo64(src, scratch);
-        m_assembler.pinsr(dest, scratch, simdLane, lane.m_value);
+        m_assembler.pinsr(simdLane, lane.m_value, scratch, dest);
     }
 
     DEFINE_SIMD_FUNCS(vectorReplaceLane);
     
     void vectorExtractLane(SIMDLane simdLane, SIMDSignMode signMode, TrustedImm32 lane, FPRegisterID src, RegisterID dest)
     {
-        m_assembler.pextr(dest, src, simdLane, lane.m_value);
+        m_assembler.pextr(simdLane, lane.m_value, src, dest);
         if (signMode == SIMDSignMode::Signed)
             signExtendForSIMDLane(dest, simdLane);
     }
@@ -2163,13 +2163,13 @@ public:
             ASSERT(lane.m_value < 4);
             if (src != dest)
                 m_assembler.movaps_rr(src, dest);
-            m_assembler.shufps(dest, dest, lane.m_value);
+            m_assembler.shufps(lane.m_value, dest, dest);
             return;
         case SIMDLane::f64x2:
             ASSERT(lane.m_value < 2);
             if (src != dest)
                 m_assembler.movapd_rr(src, dest);
-            m_assembler.shufpd(dest, dest, lane.m_value);
+            m_assembler.shufpd(lane.m_value, dest, dest);
             return;
         default:
             RELEASE_ASSERT_NOT_REACHED();
@@ -2478,15 +2478,15 @@ public:
             m_assembler.movddup(dest, dest);
             return;
         case SIMDLane::i32x4:
-            m_assembler.shufps(dest, dest, 0);
+            m_assembler.shufps(0, dest, dest);
             return;
         case SIMDLane::i16x8:
-            m_assembler.pshuflw(dest, dest, 0);
+            m_assembler.pshuflw(0, dest, dest);
             m_assembler.punpcklqdq(dest, dest);
             return;
         case SIMDLane::i8x16:
             vectorReplaceLane(SIMDLane::i8x16, TrustedImm32(1), src, dest);
-            m_assembler.pshuflw(dest, dest, 0);
+            m_assembler.pshuflw(0, dest, dest);
             m_assembler.punpcklqdq(dest, dest);
             return;
         default:
@@ -2499,9 +2499,9 @@ public:
         switch (lane) {
         case SIMDLane::f32x4:
             if (src != dest)
-                m_assembler.pshufd(dest, src, 0);
+                m_assembler.pshufd(0, src, dest);
             else
-                m_assembler.shufps(dest, dest, 0);
+                m_assembler.shufps(0, dest, dest);
             return;
         case SIMDLane::f64x2:
             m_assembler.movddup(src, dest);

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -2375,19 +2375,17 @@ public:
     }
 #endif
     
-    // FIXME: All destinations should be on the right side.
-    // https://bugs.webkit.org/show_bug.cgi?id=248703
-    void pinsr(XMMRegisterID vd, RegisterID rn, SIMDLane lane, uint8_t laneIndex)
+    void pinsr(SIMDLane lane, uint8_t laneIndex, RegisterID rn, XMMRegisterID vd)
     {
-        m_formatter.pinsr((RegisterID) vd, rn, lane, laneIndex);
+        m_formatter.pinsr(lane, laneIndex, rn, (RegisterID) vd);
     }
 
-    void pextr(RegisterID rd, XMMRegisterID vn, SIMDLane lane, uint8_t laneIndex)
+    void pextr(SIMDLane lane, uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
     {
-        m_formatter.pextr(rd, (RegisterID) vn, lane, laneIndex);
+        m_formatter.pextr(lane, laneIndex, (RegisterID) vn, rd);
     }
 
-    void vextractps(FPRegisterID rd, XMMRegisterID vn, SIMDLane lane, uint8_t laneIndex)
+    void vextractps(SIMDLane lane, uint8_t laneIndex, XMMRegisterID vn, FPRegisterID rd)
     {
         m_formatter.prefix(PRE_OPERAND_SIZE);
 
@@ -2400,7 +2398,7 @@ public:
         m_formatter.immediate8((uint8_t) laneIndex);
     }
 
-    void pshufd(XMMRegisterID vd, XMMRegisterID vn, uint8_t controlBits)
+    void pshufd(uint8_t controlBits, XMMRegisterID vn, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pshufd
         // 66 0F 70 /r ib PSHUFD xmm1, xmm2/m128, imm8
@@ -2409,7 +2407,7 @@ public:
         m_formatter.immediate8((uint8_t) controlBits);
     }
 
-    void pshufb(XMMRegisterID vd, XMMRegisterID vn)
+    void pshufb(XMMRegisterID vn, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pshufb
         // 66 0F 38 00 /r PSHUFB xmm1, xmm2/m128
@@ -2417,7 +2415,7 @@ public:
         m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PSHUFB, (RegisterID) vd, (RegisterID) vn);
     }
 
-    void pshuflw(XMMRegisterID vd, XMMRegisterID vn, uint8_t controlBits)
+    void pshuflw(uint8_t controlBits, XMMRegisterID vn, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pshuflw
         // F2 0F 70 /r ib PSHUFLW xmm1, xmm2/m128, imm8
@@ -2426,7 +2424,7 @@ public:
         m_formatter.immediate8((uint8_t) controlBits);
     }
 
-    void pshufhw(XMMRegisterID vd, XMMRegisterID vn, uint8_t controlBits)
+    void pshufhw(uint8_t controlBits, XMMRegisterID vn, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pshufhw
         // F3 0F 70 /r ib PSHUFHW xmm1, xmm2/m128, imm8
@@ -2435,7 +2433,7 @@ public:
         m_formatter.immediate8((uint8_t) controlBits);
     }   
 
-    void punpcklqdq(XMMRegisterID vd, XMMRegisterID vn)
+    void punpcklqdq(XMMRegisterID vn, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/punpcklbw:punpcklwd:punpckldq:punpcklqdq
         // 66 0F 6C /r PUNPCKLQDQ xmm1, xmm2/m128
@@ -2443,7 +2441,7 @@ public:
         m_formatter.twoByteOp(OP2_PUNPCKLQDQ, (RegisterID) vd, (RegisterID) vn);
     }
 
-    void shufps(XMMRegisterID vd, XMMRegisterID vn, uint8_t controlBits)
+    void shufps(uint8_t controlBits, XMMRegisterID vn, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/shufps
         // NP 0F C6 /r ib SHUFPS xmm1, xmm3/m128, imm8
@@ -2451,7 +2449,7 @@ public:
         m_formatter.immediate8((uint8_t) controlBits);
     }
 
-    void shufpd(XMMRegisterID vd, XMMRegisterID vn, uint8_t controlBits)
+    void shufpd(uint8_t controlBits, XMMRegisterID vn, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/shufpd
         // 66 0F C6 /r ib SHUFPD xmm1, xmm2/m128, imm8
@@ -4662,7 +4660,7 @@ private:
             writer.memoryModRM(dest, base, index, scale, offset);
         }
 
-        void pinsr(RegisterID reg, RegisterID rm, SIMDLane lane, uint8_t laneIndex)
+        void pinsr(SIMDLane lane, uint8_t laneIndex, RegisterID rm, RegisterID reg)
         {
             SingleInstructionBufferWriter writer(m_buffer);
 
@@ -4702,7 +4700,7 @@ private:
             writer.putByteUnchecked((uint8_t) laneIndex);
         }
 
-        void pextr(RegisterID rm, RegisterID reg, SIMDLane lane, uint8_t laneIndex)
+        void pextr(SIMDLane lane, uint8_t laneIndex, RegisterID reg, RegisterID rm)
         {
             SingleInstructionBufferWriter writer(m_buffer);
 


### PR DESCRIPTION
#### 97a80fa6aa7871c1aa1ef75c7e2598b5aa72cc44
<pre>
[SIMD] Refactor X86Assembler.h: All destinations should be on the right side.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248703">https://bugs.webkit.org/show_bug.cgi?id=248703</a>
rdar://102938073

Reviewed by Yusuke Suzuki.

Follow X86Assembler&apos;s convention and use AT&amp;T syntax.

* JSTests/wasm/stress/simd-kitchen-sink.js:
(v128.const.f32x4.0x0p.0.0x0p.0.0x0p.0.0x0p.0.async test):
(1.4.3.4.3.16.6144_q15.i16x8.extract_lane_s.0.return.func.export.string_appeared_here.result.i32.v128.not.v128.const.i32x4.0.0.0.0.i32x4.eq.v128.const.i32x4.1.1.1.1.i32x4.extract_lane.0.return.func.export.string_appeared_here.param.i32.result.i32.i8x16.extract_lane_s.15.i8x16.splat.local.0.func.export.string_appeared_here.param.i32.i32.i32.i32.result.i32.local.0.i32.const.257.local.1.i32.const.128.local.2.i32.const.16.local.3.i32.const.16.i16x8.mul.v128.const.i16x8.16.16.16.16.16.16.16.16.v128.const.i16x8.16.16.16.16.16.16.16.16.i32x4.extract_lane.0.func.export.string_appeared_here.param.i.i32.result.i32.global.g.i32x4.splat.local.i.i32x4.extract_lane.0.global.g.return.func.export.string_appeared_here.param.address.i32.result.i64.local.ret.i64.v128.store8_lane.align.1.4.local.address.v128.const.i8x16.0.0.0.0.4.0.0.0.0.0.0.0.0.0.0.0.local.ret.i64.load.local.address.v128.store.offset.4.i32.const.0.global.zero.local.ret.func.export.string_appeared_here.result.i32.v128.const.f64x2.2147483647.0.2147483647.0.i32x4.trunc_sat_f64x2_s_zero.i32x4.extract_lane.0.func.export.string_appeared_here.result.i32.i8x16.bitmask.v128.const.i8x16.0xFF.0xFF.0xFF.0xFF.0xFF.0xFF.0xFF.0xFF.0xFF.0xFF.0xFF.0xFF.0xFF.0xFF.0xFF.0xFF.func.export.string_appeared_here.result.i32.i8x16.bitmask.v128.const.i8x16.1.0.1.2.3.4.5.6.7.8.9.0xA.0xB.0xC.0xD.0xF.func.export.string_appeared_here.result.f64.f64x2.extract_lane.0.f64x2.convert_low_i32x4_s.v128.const.i32x4.2147483647.2147483647.0.0.func.export.string_appeared_here.result.f32.f32x4.extract_lane.0.f32x4.pmin.v128.const.f32x4.0x0p.0.0x0p.0.0x0p.0.0x0p.0.v128.const.f32x4.0x0p.0.0x0p.0.0x0p.0.0x0p.0.async test): Deleted.
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::vectorReplaceLane):
(JSC::MacroAssemblerX86_64::vectorExtractLane):
(JSC::MacroAssemblerX86_64::vectorSplat):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::pinsr):
(JSC::X86Assembler::pextr):
(JSC::X86Assembler::vextractps):
(JSC::X86Assembler::pshufd):
(JSC::X86Assembler::pshufb):
(JSC::X86Assembler::pshuflw):
(JSC::X86Assembler::pshufhw):
(JSC::X86Assembler::punpcklqdq):
(JSC::X86Assembler::shufps):
(JSC::X86Assembler::shufpd):
(JSC::X86Assembler::X86InstructionFormatter::SingleInstructionBufferWriter::memoryModRM):

Canonical link: <a href="https://commits.webkit.org/257342@main">https://commits.webkit.org/257342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67efa7815fdaedd250c7ff52a806dc196d51841b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108048 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168311 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85215 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91164 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33333 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88143 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21236 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76258 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89413 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1769 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85185 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1680 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28743 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5046 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42205 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88037 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3069 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19721 "Passed tests") | 
<!--EWS-Status-Bubble-End-->