### PR TITLE
Align Document::fullscreenEnabled and Document::webkitFullscreenEnabled

### DIFF
--- a/Source/WebCore/dom/Document+Fullscreen.idl
+++ b/Source/WebCore/dom/Document+Fullscreen.idl
@@ -30,14 +30,14 @@
     DisabledByQuirk=shouldDisableElementFullscreen,
     ImplementedBy=DocumentFullscreen
 ] partial interface Document {
-    [LegacyLenientSetter, EnabledBySetting=UnprefixedFullscreenAPIEnabled, ImplementedAs=fullscreenEnabled] readonly attribute boolean fullscreenEnabled;
+    [LegacyLenientSetter, EnabledBySetting=UnprefixedFullscreenAPIEnabled] readonly attribute boolean fullscreenEnabled;
     [LegacyLenientSetter, Unscopable, EnabledBySetting=UnprefixedFullscreenAPIEnabled, ImplementedAs=webkitIsFullScreen] readonly attribute boolean fullscreen; // historical
     [EnabledBySetting=UnprefixedFullscreenAPIEnabled] Promise<undefined> exitFullscreen();
     [EnabledBySetting=UnprefixedFullscreenAPIEnabled] attribute EventHandler onfullscreenchange;
     [EnabledBySetting=UnprefixedFullscreenAPIEnabled] attribute EventHandler onfullscreenerror;
 
     // Legacy WebKit-specific versions.
-    readonly attribute boolean webkitFullscreenEnabled;
+    [ImplementedAs=fullscreenEnabled] readonly attribute boolean webkitFullscreenEnabled;
     readonly attribute Element? webkitFullscreenElement;
     undefined webkitExitFullscreen();
     [NotEnumerable] attribute EventHandler onwebkitfullscreenchange;

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -48,14 +48,6 @@ void DocumentFullscreen::exitFullscreen(Document& document, Ref<DeferredPromise>
     });
 }
 
-// https://fullscreen.spec.whatwg.org/#dom-document-fullscreenenabled
-bool DocumentFullscreen::fullscreenEnabled(Document& document)
-{
-    if (!document.isFullyActive())
-        return false;
-    return document.fullscreenManager().isFullscreenEnabled();
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(FULLSCREEN_API)

--- a/Source/WebCore/dom/DocumentFullscreen.h
+++ b/Source/WebCore/dom/DocumentFullscreen.h
@@ -40,9 +40,8 @@ class Element;
 class DocumentFullscreen {
 public:
     static void exitFullscreen(Document&, Ref<DeferredPromise>&&);
-    static bool fullscreenEnabled(Document&);
+    static bool fullscreenEnabled(Document& document) { return document.fullscreenManager().isFullscreenEnabled(); }
 
-    static bool webkitFullscreenEnabled(Document& document) { return document.fullscreenManager().isFullscreenEnabled(); }
     static Element* webkitFullscreenElement(Document& document) { return document.ancestorElementInThisScope(document.fullscreenManager().fullscreenElement()); }
     static void webkitExitFullscreen(Document& document) { document.fullscreenManager().exitFullscreen(); }
     static bool webkitIsFullScreen(Document& document) { return document.fullscreenManager().isFullscreen(); }

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -416,10 +416,13 @@ void FullscreenManager::exitFullscreen()
     });
 }
 
+// https://fullscreen.spec.whatwg.org/#dom-document-fullscreenenabled
 bool FullscreenManager::isFullscreenEnabled() const
 {
-    // 4. The fullscreenEnabled attribute must return true if the context object and all ancestor
-    // browsing context's documents have their fullscreen enabled flag set, or false otherwise.
+    // FIXME: This check should move in isFeaturePolicyAllowedByDocumentAndAllOwners according to the spec.
+    // See https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use.
+    if (!document().isFullyActive())
+        return false;
 
     // Top-level browsing contexts are implied to have their allowFullscreen attribute set.
     return isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Fullscreen, document());

--- a/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
@@ -372,7 +372,7 @@
 - (BOOL)webkitFullscreenEnabled
 {
     WebCore::JSMainThreadNullState state;
-    return WebCore::DocumentFullscreen::webkitFullscreenEnabled(*IMPL);
+    return WebCore::DocumentFullscreen::fullscreenEnabled(*IMPL);
 }
 
 - (DOMElement *)webkitFullscreenElement


### PR DESCRIPTION
#### a16fbf94bb478001e1306b366d5f8d166d1a7cf3
<pre>
Align Document::fullscreenEnabled and Document::webkitFullscreenEnabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=248714">https://bugs.webkit.org/show_bug.cgi?id=248714</a>
rdar://102937855

Reviewed by NOBODY (OOPS!).

The original implementation of the unprefixed API tried to make as little change as possible to the prefixed API.

The only difference between the two methods is the `isFullyActive()` check.
Since we successfully unified that check for `Element::requestFullscreen` in <a href="https://commits.webkit.org/255551@main">https://commits.webkit.org/255551@main</a>, we should also do it for `Document::fullscreenEnabled`.

* Source/WebCore/dom/Document+Fullscreen.idl:
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::fullscreenEnabled): Deleted.
* Source/WebCore/dom/DocumentFullscreen.h:
(WebCore::DocumentFullscreen::fullscreenEnabled):
(WebCore::DocumentFullscreen::webkitFullscreenEnabled): Deleted.
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::isFullscreenEnabled const):
* Source/WebKitLegacy/mac/DOM/DOMDocument.mm:
(-[DOMDocument webkitFullscreenEnabled]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a16fbf94bb478001e1306b366d5f8d166d1a7cf3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108055 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168318 "Failed to checkout and rebase branch from PR 7117") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85222 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91171 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106005 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104315 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6321 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/metadata/generated/css-font-face.https.sub.tentative.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33329 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88146 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21240 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76255 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1776 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22769 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1687 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45259 "Found 1 new test failure: media/video-inactive-playback.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6627 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42211 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3076 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->