### PR TITLE
Support GPUAutoLayoutMode

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1571,6 +1571,7 @@ list(APPEND WebCore_NON_SVG_IDL_FILES
     Modules/WebGPU/GPU.idl
     Modules/WebGPU/GPUAdapter.idl
     Modules/WebGPU/GPUAddressMode.idl
+    Modules/WebGPU/GPUAutoLayoutMode.idl
     Modules/WebGPU/GPUBindGroup.idl
     Modules/WebGPU/GPUBindGroupDescriptor.idl
     Modules/WebGPU/GPUBindGroupEntry.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -37,6 +37,7 @@ $(PROJECT_DIR)/DerivedSources.make
 $(PROJECT_DIR)/Modules/WebGPU/GPU.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUAdapter.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUAddressMode.idl
+$(PROJECT_DIR)/Modules/WebGPU/GPUAutoLayoutMode.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUBindGroup.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUBindGroupDescriptor.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUBindGroupEntry.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -973,6 +973,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUAdapter.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUAdapter.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUAddressMode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUAddressMode.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUAutoLayoutMode.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUAutoLayoutMode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUBindGroup.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUBindGroup.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUBindGroupDescriptor.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -60,6 +60,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/WebGPU/GPU.idl \
     $(WebCore)/Modules/WebGPU/GPUAdapter.idl \
     $(WebCore)/Modules/WebGPU/GPUAddressMode.idl \
+    $(WebCore)/Modules/WebGPU/GPUAutoLayoutMode.idl \
     $(WebCore)/Modules/WebGPU/GPUBindGroup.idl \
     $(WebCore)/Modules/WebGPU/GPUBindGroupDescriptor.idl \
     $(WebCore)/Modules/WebGPU/GPUBindGroupEntry.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2,6 +2,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/WebGPU/GPU.h
     Modules/WebGPU/GPUAdapter.h
     Modules/WebGPU/GPUAddressMode.h
+    Modules/WebGPU/GPUAutoLayoutMode.h
     Modules/WebGPU/GPUBindGroup.h
     Modules/WebGPU/GPUBindGroupDescriptor.h
     Modules/WebGPU/GPUBindGroupEntry.h

--- a/Source/WebCore/Modules/WebGPU/GPUAutoLayoutMode.h
+++ b/Source/WebCore/Modules/WebGPU/GPUAutoLayoutMode.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class GPUAutoLayoutMode : uint8_t {
+    Auto
+};
+
+}

--- a/Source/WebCore/Modules/WebGPU/GPUAutoLayoutMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAutoLayoutMode.idl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://gpuweb.github.io/gpuweb/#enumdef-gpuautolayoutmode
+
+[
+    EnabledBySetting=WebGPU
+]
+enum GPUAutoLayoutMode {
+    "auto"
+};

--- a/Source/WebCore/Modules/WebGPU/GPUComputePipelineDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePipelineDescriptor.h
@@ -32,12 +32,12 @@
 namespace WebCore {
 
 struct GPUComputePipelineDescriptor : public GPUPipelineDescriptorBase {
-    PAL::WebGPU::ComputePipelineDescriptor convertToBacking() const
+    PAL::WebGPU::ComputePipelineDescriptor convertToBacking(const Ref<GPUPipelineLayout>& autoLayout) const
     {
         return {
             {
                 { label },
-                layout ? &layout->backing() : nullptr,
+                &convertPipelineLayoutToBacking(layout, autoLayout),
             },
             compute.convertToBacking()
         };

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -138,12 +138,7 @@ public:
     using RefCounted::deref;
 
 private:
-    GPUDevice(ScriptExecutionContext* scriptExecutionContext, Ref<PAL::WebGPU::Device>&& backing)
-        : ActiveDOMObject { scriptExecutionContext }
-        , m_backing(WTFMove(backing))
-        , m_queue(GPUQueue::create(Ref { m_backing->queue() }))
-    {
-    }
+    GPUDevice(ScriptExecutionContext*, Ref<PAL::WebGPU::Device>&&);
 
     // ActiveDOMObject.
     // FIXME: We probably need to override more methods to make this work properly.
@@ -158,6 +153,7 @@ private:
     LostPromise m_lostPromise;
     Ref<PAL::WebGPU::Device> m_backing;
     Ref<GPUQueue> m_queue;
+    Ref<GPUPipelineLayout> m_autoPipelineLayout;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.idl
@@ -29,5 +29,5 @@
     EnabledBySetting=WebGPU
 ]
 dictionary GPUPipelineDescriptorBase : GPUObjectDescriptorBase {
-    GPUPipelineLayout layout;
+    (GPUPipelineLayout or GPUAutoLayoutMode) layout;
 };

--- a/Source/WebCore/Modules/WebGPU/GPURenderPipelineDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPipelineDescriptor.h
@@ -37,12 +37,12 @@
 namespace WebCore {
 
 struct GPURenderPipelineDescriptor : public GPUPipelineDescriptorBase {
-    PAL::WebGPU::RenderPipelineDescriptor convertToBacking() const
+    PAL::WebGPU::RenderPipelineDescriptor convertToBacking(const Ref<GPUPipelineLayout>& autoLayout) const
     {
         return {
             {
                 { label },
-                layout ? &layout->backing() : nullptr,
+                &convertPipelineLayoutToBacking(layout, autoLayout),
             },
             vertex.convertToBacking(),
             primitive ? std::optional { primitive->convertToBacking() } : std::nullopt,

--- a/Source/WebCore/Modules/WebGPU/GPUShaderModuleCompilationHint.h
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderModuleCompilationHint.h
@@ -25,21 +25,21 @@
 
 #pragma once
 
+#include "GPUPipelineDescriptorBase.h"
 #include "GPUPipelineLayout.h"
 #include <pal/graphics/WebGPU/WebGPUShaderModuleCompilationHint.h>
 
 namespace WebCore {
 
 struct GPUShaderModuleCompilationHint {
-    PAL::WebGPU::ShaderModuleCompilationHint convertToBacking() const
+    PAL::WebGPU::ShaderModuleCompilationHint convertToBacking(const Ref<GPUPipelineLayout>& autoLayout) const
     {
-        ASSERT(layout);
         return {
-            layout->backing(),
+            convertPipelineLayoutToBacking(layout, autoLayout)
         };
     }
 
-    GPUPipelineLayout* layout { nullptr };
+    GPULayoutMode layout { nullptr };
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUShaderModuleCompilationHint.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderModuleCompilationHint.idl
@@ -29,5 +29,5 @@
     EnabledBySetting=WebGPU
 ]
 dictionary GPUShaderModuleCompilationHint {
-    required GPUPipelineLayout layout;
+    required (GPUPipelineLayout or GPUAutoLayoutMode) layout;
 };

--- a/Source/WebCore/Modules/WebGPU/GPUShaderModuleDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderModuleDescriptor.h
@@ -35,14 +35,14 @@
 namespace WebCore {
 
 struct GPUShaderModuleDescriptor : public GPUObjectDescriptorBase {
-    PAL::WebGPU::ShaderModuleDescriptor convertToBacking() const
+    PAL::WebGPU::ShaderModuleDescriptor convertToBacking(const Ref<GPUPipelineLayout>& autoLayout) const
     {
         return {
             { label },
             code,
             // FIXME: Handle the sourceMap.
-            hints.map([] (auto& hint) {
-                return KeyValuePair<String, PAL::WebGPU::ShaderModuleCompilationHint>(hint.key, hint.value.convertToBacking());
+            hints.map([&autoLayout] (auto& hint) {
+                return KeyValuePair<String, PAL::WebGPU::ShaderModuleCompilationHint>(hint.key, hint.value.convertToBacking(autoLayout));
             }),
         };
     }

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3298,6 +3298,7 @@ JSFormDataEvent.cpp
 JSGPU.cpp
 JSGPUAdapter.cpp
 JSGPUAddressMode.cpp
+JSGPUAutoLayoutMode.cpp
 JSGPUBindGroup.cpp
 JSGPUBindGroupDescriptor.cpp
 JSGPUBindGroupEntry.cpp

--- a/Websites/webkit.org/demos/webgpu/hello-cube-auto-layout.html
+++ b/Websites/webkit.org/demos/webgpu/hello-cube-auto-layout.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=600">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+<title>WebGPU Hello Cube (Auto Layout)</title>
+<link rel="stylesheet" href="css/style.css">
+<style>
+body {
+    font-family: system-ui;
+    color: #f7f7ff;
+    background-color: rgb(38, 38, 127);
+    text-align: center;
+}
+canvas {
+    margin: 0 auto;
+}
+</style>
+</head>
+<body>
+<div id="contents">
+    <h1>Rotating Cube (Auto Layout)</h1>
+    <canvas></canvas>
+</div>
+<div id="error">
+    <h2>WebGPU not available</h2>
+    <p>
+        Make sure you are on a system with WebGPU enabled. In
+        Safari, first make sure the Developer Menu is visible (Preferences >
+        Advanced), then Develop > Experimental Features > WebGPU.
+    </p>
+    <p>
+        In addition, you must be using Safari Technology Preview 92 or above.
+        You can get the latest STP <a href="https://developer.apple.com/safari/download/">here</a>.
+    </p>
+</div>
+<script src="scripts/hello-cube-auto-layout.js"></script>
+</body>
+</html>

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-cube-auto-layout.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-cube-auto-layout.js
@@ -1,0 +1,245 @@
+async function helloCube() {
+    if (!navigator.gpu || GPUBufferUsage.COPY_SRC === undefined) {
+        document.body.className = 'error';
+        return;
+    }
+
+    const adapter = await navigator.gpu.requestAdapter();
+    const device = await adapter.requestDevice();
+    
+    /*** Vertex Buffer Setup ***/
+    
+    /* Vertex Data */
+    const vertexStride = 8 * 4;
+    const vertexDataSize = vertexStride * 36;
+    
+    /* GPUBufferDescriptor */
+    const vertexDataBufferDescriptor = {
+        size: vertexDataSize,
+        usage: GPUBufferUsage.VERTEX,
+        mappedAtCreation: true
+    };
+
+    /* GPUBuffer */
+    const vertexBuffer = device.createBuffer(vertexDataBufferDescriptor);
+    const vertexWriteArray = new Float32Array(vertexBuffer.getMappedRange());
+    vertexWriteArray.set([
+        // float4 position, float4 color
+        .5, -.5, .5, 1,   1, 0, 1, 1,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,
+        .5, -.5, .5, 1,   1, 0, 1, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,
+
+        .5, .5, .5, 1,    1, 1, 1, 1,
+        .5, -.5, .5, 1,   1, 0, 1, 1,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,
+        .5, .5, -.5, 1,   1, 1, 0, 1,
+        .5, .5, .5, 1,    1, 1, 1, 1,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,
+
+        -.5, .5, .5, 1,   0, 1, 1, 1,
+        .5, .5, .5, 1,    1, 1, 1, 1,
+        .5, .5, -.5, 1,   1, 1, 0, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,
+        -.5, .5, .5, 1,   0, 1, 1, 1,
+        .5, .5, -.5, 1,   1, 1, 0, 1,
+
+        -.5, -.5, .5, 1,  0, 0, 1, 1,
+        -.5, .5, .5, 1,   0, 1, 1, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,
+
+        .5, .5, .5, 1,    1, 1, 1, 1,
+        -.5, .5, .5, 1,   0, 1, 1, 1,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,
+        .5, -.5, .5, 1,   1, 0, 1, 1,
+        .5, .5, .5, 1,    1, 1, 1, 1,
+
+        .5, -.5, -.5, 1,  1, 0, 0, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,
+        .5, .5, -.5, 1,   1, 1, 0, 1,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,
+    ]);
+    vertexBuffer.unmap();
+    
+    const uniformBufferSize = 12;
+    const uniformBuffer = device.createBuffer({
+        size: uniformBufferSize,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+
+    /*** Shader Setup ***/
+    
+    const uniformBindGroupLayout = device.createBindGroupLayout({ entries: [{binding: 0, visibility: GPUShaderStage.VERTEX, buffer: {}}] });
+    const uniformBindGroup = device.createBindGroup({
+        layout: uniformBindGroupLayout,
+        entries: [
+          {
+            binding: 0,
+            resource: {
+              buffer: uniformBuffer,
+              offset: 0
+            },
+          },
+        ],
+      });
+/*
+    FIXME: Use WGSL once compiler is brought up
+    const wgslSource = `
+                     @vertex fn main(@builtin(vertex_index) VertexIndex: u32) -> @builtin(position) vec4<f32>
+                     {
+                         var pos = array<vec2<f32>, 3>(
+                             vec2<f32>( 0.0,  0.5),
+                             vec2<f32>(-0.5, -0.5),
+                             vec2<f32>( 0.5, -0.5)
+                         );
+                         return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+                     }
+
+                     @fragment fn main() -> @location(0) vec4<f32>
+                     {
+                         return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+                     }
+    `;
+ */
+    const wgslSource = `
+                #include <metal_stdlib>
+                using namespace metal;
+                struct Vertex {
+                   float4 position [[position]];
+                   float4 color;
+                };
+    
+                struct VertexShaderArguments {
+                    device float *time [[id(0)]];
+                };
+    
+                vertex Vertex vsmain(device Vertex *vertices [[buffer(0)]], device VertexShaderArguments &values [[buffer(1)]], unsigned VertexIndex [[vertex_id]])
+                {
+                    Vertex vout;
+                    float alpha = values.time[0];
+                    float beta = values.time[1];
+                    float gamma = values.time[2];
+                    float cA = cos(alpha);
+                    float sA = sin(alpha);
+                    float cB = cos(beta);
+                    float sB = sin(beta);
+                    float cG = cos(gamma);
+                    float sG = sin(gamma);
+    
+                    float4x4 m = float4x4(cA * cB,  sA * cB,   -sB, 0,
+                                          cA*sB*sG - sA*cG,  sA*sB*sG + cA*cG,   cB * sG, 0,
+                                             cA*sB*cG + sA*sG, sA*sB*cG - cA*sG, cB * cG, 0,
+                                              0,     0,     0, 1);
+                    vout.position = vertices[VertexIndex].position * m;
+                    vout.position.z = (vout.position.z + 0.5) * 0.5;
+                    vout.color = vertices[VertexIndex].color;
+                    return vout;
+                }
+
+                fragment float4 fsmain(Vertex in [[stage_in]])
+                {
+                    return in.color;
+                }
+    `;
+
+    const shaderModule = device.createShaderModule({ code: wgslSource, isWHLSL: false, hints: [ {layout: "auto" }, ] });
+    
+    /* GPUPipelineStageDescriptors */
+    const vertexStageDescriptor = { module: shaderModule, entryPoint: "vsmain" };
+
+    const fragmentStageDescriptor = { module: shaderModule, entryPoint: "fsmain", targets: [ {format: "bgra8unorm" }, ],  };
+    
+    /* GPURenderPipelineDescriptor */
+
+    const renderPipelineDescriptor = {
+        layout: "auto",
+        vertex: vertexStageDescriptor,
+        fragment: fragmentStageDescriptor,
+        primitive: {
+            topology: "triangle-list",
+            cullMode: "back"
+        },
+    };
+    /* GPURenderPipeline */
+    const renderPipeline = device.createRenderPipeline(renderPipelineDescriptor);
+    
+    /*** Swap Chain Setup ***/
+    function frameUpdate() {
+        const secondsBuffer = new Float32Array(3);
+        const d = new Date();
+        const seconds = d.getMilliseconds() / 1000.0 + d.getSeconds();
+        secondsBuffer.set([seconds*10 * (6.28318530718 / 60.0),
+                          seconds*5 * (6.28318530718 / 60.0),
+                          seconds*1 * (6.28318530718 / 60.0)]);
+        // document.writeln(d.getSeconds());
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, 12);
+
+        const canvas = document.querySelector("canvas");
+        canvas.width = 600;
+        canvas.height = 600;
+        
+        const gpuContext = canvas.getContext("webgpu");
+        
+        /* GPUCanvasConfiguration */
+        const canvasConfiguration = { device: device, format: "bgra8unorm" };
+        gpuContext.configure(canvasConfiguration);
+        /* GPUTexture */
+        const currentTexture = gpuContext.getCurrentTexture();
+        
+        /*** Render Pass Setup ***/
+        
+        /* Acquire Texture To Render To */
+        
+        /* GPUTextureView */
+        const renderAttachment = currentTexture.createView();
+        
+        /* GPUColor */
+        const darkBlue = { r: 0.15, g: 0.15, b: 0.5, a: 1 };
+        
+        /* GPURenderPassColorATtachmentDescriptor */
+        const colorAttachmentDescriptor = {
+        view: renderAttachment,
+        loadOp: "clear",
+        storeOp: "store",
+        clearColor: darkBlue
+        };
+        
+        /* GPURenderPassDescriptor */
+        const renderPassDescriptor = { colorAttachments: [colorAttachmentDescriptor] };
+        
+        /*** Rendering ***/
+        
+        /* GPUCommandEncoder */
+        const commandEncoder = device.createCommandEncoder();
+        /* GPURenderPassEncoder */
+        const renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+        
+        renderPassEncoder.setPipeline(renderPipeline);
+        const vertexBufferSlot = 0;
+        renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
+        renderPassEncoder.setBindGroup(1, uniformBindGroup);
+        renderPassEncoder.draw(36, 1, 0, 0); // 36 vertices, 1 instance, 0th vertex, 0th instance.
+        renderPassEncoder.end();
+        
+        /* GPUComamndBuffer */
+        const commandBuffer = commandEncoder.finish();
+        
+        /* GPUQueue */
+        const queue = device.queue;
+        queue.submit([commandBuffer]);
+
+        requestAnimationFrame(frameUpdate);
+    }
+
+    requestAnimationFrame(frameUpdate);
+}
+
+window.addEventListener("DOMContentLoaded", helloCube);


### PR DESCRIPTION
#### 60342c994bcb6d900091f653662773eb1db91fe7
<pre>
Support GPUAutoLayoutMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=248706">https://bugs.webkit.org/show_bug.cgi?id=248706</a>
&lt;rdar://101404965&gt;

Reviewed by Dean Jackson.

Allow layout: &quot;auto&quot; to be specified in place of creating a pipeline layout.

This is needed to support running some WebGPU existing samples, e.g., the ones
located at <a href="https://austin-eng.com/webgpu-samples/">https://austin-eng.com/webgpu-samples/</a>

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/WebGPU/GPUAutoLayoutMode.h: Copied from Source/WebCore/Modules/WebGPU/GPUShaderModuleCompilationHint.idl.
* Source/WebCore/Modules/WebGPU/GPUAutoLayoutMode.idl: Copied from Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.idl.
Add files.
* Source/WebCore/Modules/WebGPU/GPUComputePipelineDescriptor.h:
(WebCore::GPUComputePipelineDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::GPUDevice):
(WebCore::m_queue):
(WebCore::m_autoPipelineLayout):
(WebCore::GPUDevice::createShaderModule):
(WebCore::GPUDevice::createComputePipeline):
(WebCore::GPUDevice::createRenderPipeline):
(WebCore::GPUDevice::createComputePipelineAsync):
(WebCore::GPUDevice::createRenderPipelineAsync):
Support auto pipeline layouts by passing an empty pipeline layout.

* Source/WebCore/Modules/WebGPU/GPUDevice.h:
(WebCore::GPUDevice::GPUDevice): Deleted.
(WebCore::GPUDevice::m_queue): Deleted.
Moved to cpp file.

* Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.h:
(WebCore::convertPipelineLayoutToBacking):
(WebCore::GPUPipelineDescriptorBase::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPipelineDescriptor.h:
(WebCore::GPURenderPipelineDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUShaderModuleCompilationHint.h:
(WebCore::GPUShaderModuleCompilationHint::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUShaderModuleCompilationHint.idl:
* Source/WebCore/Modules/WebGPU/GPUShaderModuleDescriptor.h:
(WebCore::GPUShaderModuleDescriptor::convertToBacking const):
Pass the auto layout to convertToBacking(), so we can fall back to that
one if needed.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Websites/webkit.org/demos/webgpu/hello-cube-auto-layout.html: Added.
* Websites/webkit.org/demos/webgpu/scripts/hello-cube-auto-layout.js: Added.
(async helloCube.frameUpdate):
(async helloCube):
Example using layout: &quot;auto&quot; in the call to createRenderPipeline and the shader
hint, which are both supported in the specification.

Canonical link: <a href="https://commits.webkit.org/257537@main">https://commits.webkit.org/257537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/402bc8ebc69a3ba2a2f7549ed87a633a6323088b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99196 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32330 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108589 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168836 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85729 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91698 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106523 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33771 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88586 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21674 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2289 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23190 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2179 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5179 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7233 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42663 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3656 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->