### PR TITLE
Workaround occasional black snapshots on macOS

### DIFF
--- a/LayoutTests/fast/harness/all-black-expected.html
+++ b/LayoutTests/fast/harness/all-black-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+    :root {
+        background-color: black;
+    }
+</style>

--- a/LayoutTests/fast/harness/all-black.html
+++ b/LayoutTests/fast/harness/all-black.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+    :root {
+        background-color: black;
+    }
+</style>

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -292,10 +292,10 @@ void TestInvocation::dumpAudio(WKDataRef audioData)
     fprintf(stderr, "#EOF\n");
 }
 
-bool TestInvocation::compareActualHashToExpectedAndDumpResults(const char actualHash[33])
+bool TestInvocation::compareActualHashToExpectedAndDumpResults(const std::string& actualHash)
 {
     // Compute the hash of the bitmap context pixels
-    fprintf(stdout, "\nActualHash: %s\n", actualHash);
+    fprintf(stdout, "\nActualHash: %s\n", actualHash.c_str());
 
     if (!m_expectedPixelHash.length())
         return false;

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -127,7 +127,7 @@ private:
     enum class SnapshotResultType { WebView, WebContents };
     void dumpPixelsAndCompareWithExpected(SnapshotResultType, WKArrayRef repaintRects, WKImageRef = nullptr);
     void dumpAudio(WKDataRef);
-    bool compareActualHashToExpectedAndDumpResults(const char[33]);
+    bool compareActualHashToExpectedAndDumpResults(const std::string&);
 
     static void forceRepaintDoneCallback(WKErrorRef, void* context);
     

--- a/Tools/WebKitTestRunner/cg/TestInvocationCG.cpp
+++ b/Tools/WebKitTestRunner/cg/TestInvocationCG.cpp
@@ -31,6 +31,7 @@
 #include "TestController.h"
 #include <ImageIO/ImageIO.h>
 #include <WebKit/WKImageCG.h>
+#include <wtf/ASCIICType.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/SHA1.h>
 
@@ -67,11 +68,11 @@ static RetainPtr<CGContextRef> createCGContextFromImage(WKImageRef wkImage)
     return createCGContextFromCGImage(image.get());
 }
 
-void computeSHA1HashStringForContext(CGContextRef bitmapContext, char hashString[33])
+static std::optional<std::string> computeSHA1HashStringForContext(CGContextRef bitmapContext)
 {
     if (!bitmapContext) {
         WTFLogAlways("computeSHA1HashStringForContext: context is null\n");
-        return;
+        return { };
     }
     ASSERT(CGBitmapContextGetBitsPerPixel(bitmapContext) == 32); // ImageDiff assumes 32 bit RGBA, we must as well.
     size_t pixelsHigh = CGBitmapContextGetHeight(bitmapContext);
@@ -99,15 +100,48 @@ void computeSHA1HashStringForContext(CGContextRef bitmapContext, char hashString
         }
     }
 
-    SHA1::Digest hash;
-    sha1.computeHash(hash);
-
-    hashString[0] = '\0';
-    for (size_t i = 0; i < 16; i++)
-        snprintf(hashString, 33, "%s%02x", hashString, hash[i]);
+    auto hexString = sha1.computeHexDigest();
+    
+    auto result = hexString.toStdString();
+    std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c) { return toASCIILower(c); });
+    return result;
 }
 
-static void dumpBitmap(CGContextRef bitmapContext, const char* checksum, WKSize imageSize, WKSize windowSize)
+#if PLATFORM(MAC)
+static bool operator==(const WKSize& a, const WKSize& b)
+{
+    return a.width == b.width && a.height == b.height;
+}
+
+static std::optional<std::string> hashForBlackImageOfSize(WKSize size)
+{
+    // Hardcode some well-known sizes for performance.
+    if (size == WKSize { 800, 600 })
+        return "6c0b5c4dc61390fd6a45eebdebf7301828ef0e56";
+    if (size == WKSize { 1600, 1200 })
+        return "11d642624de9935a659bcd042d6ff83f5a917504";
+    if (size == WKSize { 480, 360 })
+        return "feed54e9caa58b83b0c644fc037f0137828b2c76";
+
+    size_t pixelsWide = size.width;
+    size_t pixelsHigh = size.height;
+    size_t rowBytes = (4 * pixelsWide + 63) & ~63;
+
+    auto colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
+    auto context = adoptCF(CGBitmapContextCreate(nullptr, pixelsWide, pixelsHigh, 8, rowBytes, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedFirst) | static_cast<uint32_t>(kCGBitmapByteOrder32Host)));
+    if (!context)
+        return { };
+
+    CGContextSetRGBFillColor(context.get(), 0, 0, 0, 1);
+
+    CGRect bounds = CGRectMake(0, 0, pixelsWide, pixelsHigh);
+    CGContextFillRect(context.get(), bounds);
+
+    return computeSHA1HashStringForContext(context.get());
+}
+#endif // PLATFORM(MAC)
+
+static void dumpBitmap(CGContextRef bitmapContext, const std::string& checksum, WKSize imageSize, WKSize windowSize)
 {
     auto image = adoptCF(CGBitmapContextCreateImage(bitmapContext));
     auto imageData = adoptCF(CFDataCreateMutable(0, 0));
@@ -127,7 +161,7 @@ static void dumpBitmap(CGContextRef bitmapContext, const char* checksum, WKSize 
     const unsigned char* data = CFDataGetBytePtr(imageData.get());
     const size_t dataLength = CFDataGetLength(imageData.get());
 
-    printPNG(data, dataLength, checksum);
+    printPNG(data, dataLength, checksum.c_str());
 }
 
 static void paintRepaintRectOverlay(CGContextRef context, WKSize imageSize, WKArrayRef repaintRects)
@@ -160,42 +194,73 @@ void TestInvocation::dumpPixelsAndCompareWithExpected(SnapshotResultType snapsho
 {
     RetainPtr<CGContextRef> context;
     WKSize imageSize;
-
-    switch (snapshotType) {
-    case SnapshotResultType::WebContents:
-        if (!wkImage) {
-            WTFLogAlways("dumpPixelsAndCompareWithExpected: image is null\n");
-            return;
-        }
-        context = createCGContextFromImage(wkImage);
-        imageSize = WKImageGetSize(wkImage);
-        break;
-    case SnapshotResultType::WebView:
-        auto image = TestController::singleton().mainWebView()->windowSnapshotImage();
-        if (!image) {
-            WTFLogAlways("dumpPixelsAndCompareWithExpected: image is null\n");
-            return;
-        }
-        context = createCGContextFromCGImage(image.get());
-        imageSize = WKSizeMake(CGImageGetWidth(image.get()), CGImageGetHeight(image.get()));
-        break;
-    }
-
-    if (!context) {
-        WTFLogAlways("dumpPixelsAndCompareWithExpected: context is null\n");
-        return;
-    }
-
-    // A non-null repaintRects array means we're doing a repaint test.
-    if (repaintRects)
-        paintRepaintRectOverlay(context.get(), imageSize, repaintRects);
+    std::string snapshotHash;
 
     auto windowSize = TestController::singleton().mainWebView()->windowFrame().size;
 
-    char actualHash[33];
-    computeSHA1HashStringForContext(context.get(), actualHash);
-    if (!compareActualHashToExpectedAndDumpResults(actualHash))
-        dumpBitmap(context.get(), actualHash, imageSize, windowSize);
+    auto generateSnapshot = [&]() -> bool {
+
+        switch (snapshotType) {
+        case SnapshotResultType::WebContents:
+            if (!wkImage) {
+                WTFLogAlways("dumpPixelsAndCompareWithExpected: image is null\n");
+                return false;
+            }
+            context = createCGContextFromImage(wkImage);
+            imageSize = WKImageGetSize(wkImage);
+            break;
+        case SnapshotResultType::WebView:
+            auto image = TestController::singleton().mainWebView()->windowSnapshotImage();
+            if (!image) {
+                WTFLogAlways("dumpPixelsAndCompareWithExpected: image is null\n");
+                return false;
+            }
+            context = createCGContextFromCGImage(image.get());
+            imageSize = WKSizeMake(CGImageGetWidth(image.get()), CGImageGetHeight(image.get()));
+            break;
+        }
+
+        if (!context) {
+            WTFLogAlways("dumpPixelsAndCompareWithExpected: context is null\n");
+            return false;
+        }
+
+        // A non-null repaintRects array means we're doing a repaint test.
+        if (repaintRects)
+            paintRepaintRectOverlay(context.get(), imageSize, repaintRects);
+
+        auto computedHash = computeSHA1HashStringForContext(context.get());
+        if (!computedHash)
+            return false;
+
+        snapshotHash = *computedHash;
+        return true;
+    };
+
+    bool gotBlackSnapshot = false;
+    constexpr unsigned maxNumTries = 3;
+    unsigned numTries = 1;
+    do {
+        bool snapshotSucceeded = generateSnapshot();
+        if (!snapshotSucceeded)
+            return;
+
+#if PLATFORM(MAC)
+        // Detect rdar://89840327 and retry.
+        auto blackSnapshotHash = hashForBlackImageOfSize(imageSize);
+        if (!blackSnapshotHash) {
+            WTFLogAlways("Failed to compute hash for black snapshot of size %.0f x %.0f", imageSize.width, imageSize.height);
+            return;
+        }
+
+        gotBlackSnapshot = snapshotHash == *blackSnapshotHash;
+        if (gotBlackSnapshot)
+            WTFLogAlways("dumpPixelsAndCompareWithExpected: got all black snapshot (try %u of %u)", numTries, maxNumTries);
+#endif
+    } while (gotBlackSnapshot && numTries++ < maxNumTries);
+
+    if (!compareActualHashToExpectedAndDumpResults(snapshotHash))
+        dumpBitmap(context.get(), snapshotHash, imageSize, windowSize);
 }
 
 } // namespace WTR


### PR DESCRIPTION
#### c2f8b499772412dbf100797162778234cd634a67
<pre>
Workaround occasional black snapshots on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=248718">https://bugs.webkit.org/show_bug.cgi?id=248718</a>
rdar://89840327

Reviewed by Jonathan Bedard.

An OS issue (rdar://89840327) causes test snapshots to be black sometimes,
on Intel machines.

Try to work around this by detecting black snapshots, and re-taking the snapshot
up to three times. We detect black snapshots via their hash, hardcoding
the hashes of some commonly sized black snapshots for performance. The code
logs when black snapshots are detected, but this does not trigger test failure.

Add an all-black ref test in fast/harness to test that all black ref tests
still succeed.

* LayoutTests/fast/harness/all-black-expected.html: Added.
* LayoutTests/fast/harness/all-black.html: Added.
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::compareActualHashToExpectedAndDumpResults):
* Tools/WebKitTestRunner/TestInvocation.h:
* Tools/WebKitTestRunner/cg/TestInvocationCG.cpp:
(WTR::computeSHA1HashStringForContext):
(WTR::operator==):
(WTR::hashForBlackImageOfSize):
(WTR::dumpBitmap):
(WTR::TestInvocation::dumpPixelsAndCompareWithExpected):

Canonical link: <a href="https://commits.webkit.org/257420@main">https://commits.webkit.org/257420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b1a1dc66f9b7e689191a7f16615ec0ba5b828be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108218 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168473 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85380 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91331 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106132 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33452 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88303 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76375 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1925 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22911 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1834 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45380 "Found 1 new test failure: media/video-inactive-playback.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5108 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42366 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3230 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->