### PR TITLE
Avoid trailing whitespace when generating import-expectations.json

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_downloader.py
+++ b/Tools/Scripts/webkitpy/w3c/test_downloader.py
@@ -108,7 +108,7 @@ class TestDownloader(object):
         import_lines = json.loads(self._filesystem.read_text_file(self.import_expectations_path))
         for path in test_paths:
             import_lines[path] = 'import'
-        self._filesystem.write_text_file(self.import_expectations_path, json.dumps(import_lines, sort_keys=True, indent=4))
+        self._filesystem.write_text_file(self.import_expectations_path, json.dumps(import_lines, sort_keys=True, indent=4, separators=(',', ': ')))
 
     def _add_test_suite_paths(self, test_paths, directory, webkit_path):
         for name in self._filesystem.listdir(directory):


### PR DESCRIPTION
#### 06d28085c8e71bd372b8119765048ce6cdac6aed
<pre>
Avoid trailing whitespace when generating import-expectations.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=248721">https://bugs.webkit.org/show_bug.cgi?id=248721</a>
rdar://102940524

Reviewed by Alexey Shvayka.

Generating import-expectations.json can cause trailing whitespaces, in older versions of Python, this causes noise in WPT import diffs.
This is because older versions of python have `separators=(&apos;, &apos;, &apos;: &apos;)` as default separators instead of `separators=(&apos;,&apos;, &apos;: &apos;)`.

* Tools/Scripts/webkitpy/w3c/test_downloader.py:
(TestDownloader.update_import_expectations):

Canonical link: <a href="https://commits.webkit.org/257335@main">https://commits.webkit.org/257335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44b5f301e660fd630a38e43e34ed4445a4b269cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108084 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85245 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91198 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104344 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/102197 "Found 1 webkitpy python2 test failure: webkitpy.port.server_process_unittest.TestServerProcess.test_broken_pipe") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1798 "Failed to checkout and rebase branch from PR 7121") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/1708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6651 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/42233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2533 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->