### PR TITLE
Unreviewed, do not use (void)

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -2181,7 +2181,7 @@ public:
     void compareFloatingPointVector(DoubleCondition cond, SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         RELEASE_ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));
-        (void) left; (void) right; (void) dest;
+        UNUSED_PARAM(left); UNUSED_PARAM(right); UNUSED_PARAM(dest);
 
         switch (cond) {
         case DoubleEqualAndOrdered:
@@ -2206,7 +2206,7 @@ public:
     void compareIntegerVector(RelationalCondition cond, SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         RELEASE_ASSERT(scalarTypeIsIntegral(simdInfo.lane));
-        (void) left; (void) right; (void) dest;
+        UNUSED_PARAM(left); UNUSED_PARAM(right); UNUSED_PARAM(dest);
 
         switch (cond) {
         case Equal:
@@ -2241,67 +2241,67 @@ public:
     void compareIntegerVectorWithZero(RelationalCondition cond, SIMDInfo simdInfo, FPRegisterID vector, FPRegisterID dest) 
     {
         RELEASE_ASSERT(scalarTypeIsIntegral(simdInfo.lane));
-        (void) cond; (void) vector; (void) dest;
+        UNUSED_PARAM(cond); UNUSED_PARAM(vector); UNUSED_PARAM(dest);
     }
 
     void vectorAdd(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         if (scalarTypeIsFloatingPoint(simdInfo.lane))
-            (void) left;
+            UNUSED_PARAM(left);
         else
-            (void) left;
-        (void) left; (void) right; (void) dest;
+            UNUSED_PARAM(left);
+        UNUSED_PARAM(left); UNUSED_PARAM(right); UNUSED_PARAM(dest);
     }
 
     void vectorSub(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         if (scalarTypeIsFloatingPoint(simdInfo.lane))
-            (void) left;
+            UNUSED_PARAM(left);
         else
-            (void) left;
-        (void) left; (void) right; (void) dest;
+            UNUSED_PARAM(left);
+        UNUSED_PARAM(left); UNUSED_PARAM(right); UNUSED_PARAM(dest);
     }
 
     void vectorMul(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         if (scalarTypeIsFloatingPoint(simdInfo.lane))
-            (void) left;
+            UNUSED_PARAM(left);
         else
-            (void) left;
-        (void) left; (void) right; (void) dest;
+            UNUSED_PARAM(left);
+        UNUSED_PARAM(left); UNUSED_PARAM(right); UNUSED_PARAM(dest);
     }
 
     void vectorDiv(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));
-        (void) left; (void) right; (void) dest; (void) simdInfo;
+        UNUSED_PARAM(left); UNUSED_PARAM(right); UNUSED_PARAM(dest); UNUSED_PARAM(simdInfo);
     }
 
     void vectorMax(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
-        (void) right; (void) dest;
+        UNUSED_PARAM(right); UNUSED_PARAM(dest);
         if (scalarTypeIsFloatingPoint(simdInfo.lane))
-            (void) left;
+            UNUSED_PARAM(left);
         else {
             ASSERT(simdInfo.signMode != SIMDSignMode::None);
             if (simdInfo.signMode == SIMDSignMode::Signed)
-                (void) left;
+                UNUSED_PARAM(left);
             else
-                (void) left;
+                UNUSED_PARAM(left);
         }
     }
 
     void vectorMin(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
-        (void) right; (void) dest;
+        UNUSED_PARAM(right); UNUSED_PARAM(dest);
         if (scalarTypeIsFloatingPoint(simdInfo.lane))
-            (void) left;
+            UNUSED_PARAM(left);
         else {
             ASSERT(simdInfo.signMode != SIMDSignMode::None);
             if (simdInfo.signMode == SIMDSignMode::Signed)
-                (void) left;
+                UNUSED_PARAM(left);
             else
-                (void) left;
+                UNUSED_PARAM(left);
         }
     }
 
@@ -2309,91 +2309,91 @@ public:
     {
         ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));
         // right > left, dest = left
-        (void) left; (void) right; (void) dest; (void) simdInfo;
+        UNUSED_PARAM(left); UNUSED_PARAM(right); UNUSED_PARAM(dest); UNUSED_PARAM(simdInfo);
     }
 
     void vectorPmax(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));
         // left > right, dest = left
-        (void) left; (void) right; (void) dest; (void) simdInfo;
+        UNUSED_PARAM(left); UNUSED_PARAM(right); UNUSED_PARAM(dest); UNUSED_PARAM(simdInfo);
     }
 
     void vectorBitwiseSelect(FPRegisterID left, FPRegisterID right, FPRegisterID inputBitsAndDest)
     {
-        (void) left; (void) right; (void) inputBitsAndDest;
+        UNUSED_PARAM(left); UNUSED_PARAM(right); UNUSED_PARAM(inputBitsAndDest);
     }
 
     void vectorNot(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
     {
         ASSERT_UNUSED(simdInfo, simdInfo.lane == SIMDLane::v128);
-        (void) input; (void) dest;
+        UNUSED_PARAM(input); UNUSED_PARAM(dest);
     }
 
     void vectorAnd(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         ASSERT_UNUSED(simdInfo, simdInfo.lane == SIMDLane::v128);
-        (void) left; (void) right; (void) dest;
+        UNUSED_PARAM(left); UNUSED_PARAM(right); UNUSED_PARAM(dest);
     }
 
     void vectorAndnot(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         ASSERT_UNUSED(simdInfo, simdInfo.lane == SIMDLane::v128);
-        (void) left; (void) right; (void) dest;
+        UNUSED_PARAM(left); UNUSED_PARAM(right); UNUSED_PARAM(dest);
     }
 
     void vectorOr(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         ASSERT_UNUSED(simdInfo, simdInfo.lane == SIMDLane::v128);
-        (void) left; (void) right; (void) dest;
+        UNUSED_PARAM(left); UNUSED_PARAM(right); UNUSED_PARAM(dest);
     }
 
     void vectorXor(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         ASSERT_UNUSED(simdInfo, simdInfo.lane == SIMDLane::v128);
-        (void) left; (void) right; (void) dest;
+        UNUSED_PARAM(left); UNUSED_PARAM(right); UNUSED_PARAM(dest);
     }
 
     void vectorAbs(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
     {
         if (scalarTypeIsFloatingPoint(simdInfo.lane))
-            (void) dest;
+            UNUSED_PARAM(dest);
         else
-            (void) dest;
-        (void) input;
+            UNUSED_PARAM(dest);
+        UNUSED_PARAM(input);
     }
 
     void vectorNeg(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
     {
         if (scalarTypeIsFloatingPoint(simdInfo.lane))
-            (void) dest;
+            UNUSED_PARAM(dest);
         else
-            (void) dest;
-        (void) input;
+            UNUSED_PARAM(dest);
+        UNUSED_PARAM(input);
     }
 
     void vectorPopcnt(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
     {
         ASSERT(simdInfo.lane == SIMDLane::i8x16);
-        (void) input; (void) dest; (void) simdInfo;
+        UNUSED_PARAM(input); UNUSED_PARAM(dest); UNUSED_PARAM(simdInfo);
     }
 
     void vectorCeil(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
     {
         ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));
-        (void) input; (void) dest; (void) simdInfo;
+        UNUSED_PARAM(input); UNUSED_PARAM(dest); UNUSED_PARAM(simdInfo);
     }
 
     void vectorFloor(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
     {
         ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));
-        (void) input; (void) dest; (void) simdInfo;
+        UNUSED_PARAM(input); UNUSED_PARAM(dest); UNUSED_PARAM(simdInfo);
     }
 
     void vectorTrunc(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
     {
         ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));
-        (void) input; (void) dest; (void) simdInfo;
+        UNUSED_PARAM(input); UNUSED_PARAM(dest); UNUSED_PARAM(simdInfo);
     }
 
     void vectorTruncSat(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
@@ -2408,13 +2408,13 @@ public:
     void vectorNearest(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
     {
         ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));
-        (void) input; (void) dest; (void) simdInfo;
+        UNUSED_PARAM(input); UNUSED_PARAM(dest); UNUSED_PARAM(simdInfo);
     }
 
     void vectorSqrt(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
     {
         ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));
-        (void) input; (void) dest; (void) simdInfo;
+        UNUSED_PARAM(input); UNUSED_PARAM(dest); UNUSED_PARAM(simdInfo);
     }
 
     void vectorExtendLow(SIMDInfo, FPRegisterID, FPRegisterID)
@@ -2548,15 +2548,15 @@ public:
     void vectorLoad32Lane(Address address, TrustedImm32 imm, FPRegisterID dest) { UNUSED_PARAM(address); UNUSED_PARAM(imm); UNUSED_PARAM(dest); }
     void vectorLoad64Lane(Address address, TrustedImm32 imm, FPRegisterID dest) { UNUSED_PARAM(address); UNUSED_PARAM(imm); UNUSED_PARAM(dest); }
 
-    void vectorAnyTrue(FPRegisterID vec, RegisterID dest) { (void) vec; (void) dest; }
-    void vectorAllTrue(SIMDInfo simdInfo, FPRegisterID vec, RegisterID dest) { (void) simdInfo, (void) vec; (void) dest; }
-    void vectorBitmask(SIMDInfo simdInfo, FPRegisterID vec, RegisterID dest) { (void) simdInfo, (void) vec; (void) dest; }
-    void vectorExtaddPairwise(SIMDInfo simdInfo, FPRegisterID vec, FPRegisterID dest) { (void) simdInfo, (void) vec; (void) dest; }
-    void vectorAvgRound(SIMDInfo simdInfo, FPRegisterID a, FPRegisterID b, FPRegisterID dest) { (void) simdInfo, (void) a; (void) b; (void) dest; }
-    void vectorMulSat(FPRegisterID a, FPRegisterID b, FPRegisterID dest) { (void) a; (void) b; (void) dest; }
-    void vectorDotProductInt32(FPRegisterID a, FPRegisterID b, FPRegisterID dest, FPRegisterID) { (void) a; (void) b; (void) dest; }
-    void vectorSwizzle(FPRegisterID a, FPRegisterID b, FPRegisterID dest) { (void) a; (void) b; (void) dest; }
-    void vectorShuffle(TrustedImm64 immLow, TrustedImm64 immHigh, FPRegisterID a, FPRegisterID b, FPRegisterID dest) { (void) immLow; (void) immHigh; (void) a; (void) b; (void) dest; }
+    void vectorAnyTrue(FPRegisterID vec, RegisterID dest) { UNUSED_PARAM(vec); UNUSED_PARAM(dest); }
+    void vectorAllTrue(SIMDInfo simdInfo, FPRegisterID vec, RegisterID dest) { UNUSED_PARAM(simdInfo); UNUSED_PARAM(vec); UNUSED_PARAM(dest); }
+    void vectorBitmask(SIMDInfo simdInfo, FPRegisterID vec, RegisterID dest) { UNUSED_PARAM(simdInfo); UNUSED_PARAM(vec); UNUSED_PARAM(dest); }
+    void vectorExtaddPairwise(SIMDInfo simdInfo, FPRegisterID vec, FPRegisterID dest) { UNUSED_PARAM(simdInfo); UNUSED_PARAM(vec); UNUSED_PARAM(dest); }
+    void vectorAvgRound(SIMDInfo simdInfo, FPRegisterID a, FPRegisterID b, FPRegisterID dest) { UNUSED_PARAM(simdInfo); UNUSED_PARAM(a); UNUSED_PARAM(b); UNUSED_PARAM(dest); }
+    void vectorMulSat(FPRegisterID a, FPRegisterID b, FPRegisterID dest) { UNUSED_PARAM(a); UNUSED_PARAM(b); UNUSED_PARAM(dest); }
+    void vectorDotProductInt32(FPRegisterID a, FPRegisterID b, FPRegisterID dest, FPRegisterID) { UNUSED_PARAM(a); UNUSED_PARAM(b); UNUSED_PARAM(dest); }
+    void vectorSwizzle(FPRegisterID a, FPRegisterID b, FPRegisterID dest) { UNUSED_PARAM(a); UNUSED_PARAM(b); UNUSED_PARAM(dest); }
+    void vectorShuffle(TrustedImm64 immLow, TrustedImm64 immHigh, FPRegisterID a, FPRegisterID b, FPRegisterID dest) { UNUSED_PARAM(immLow); UNUSED_PARAM(immHigh); UNUSED_PARAM(a); UNUSED_PARAM(b); UNUSED_PARAM(dest); }
 
     // Misc helper functions.
 


### PR DESCRIPTION
#### 98a9fd6268625ec6e46d648bb4e0c7d6a72f5d64
<pre>
Unreviewed, do not use (void)
<a href="https://bugs.webkit.org/show_bug.cgi?id=248722">https://bugs.webkit.org/show_bug.cgi?id=248722</a>
rdar://102941133

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::compareFloatingPointVector):
(JSC::MacroAssemblerX86_64::compareIntegerVector):
(JSC::MacroAssemblerX86_64::compareIntegerVectorWithZero):
(JSC::MacroAssemblerX86_64::vectorAdd):
(JSC::MacroAssemblerX86_64::vectorSub):
(JSC::MacroAssemblerX86_64::vectorMul):
(JSC::MacroAssemblerX86_64::vectorDiv):
(JSC::MacroAssemblerX86_64::vectorMax):
(JSC::MacroAssemblerX86_64::vectorMin):
(JSC::MacroAssemblerX86_64::vectorPmin):
(JSC::MacroAssemblerX86_64::vectorPmax):
(JSC::MacroAssemblerX86_64::vectorBitwiseSelect):
(JSC::MacroAssemblerX86_64::vectorNot):
(JSC::MacroAssemblerX86_64::vectorAnd):
(JSC::MacroAssemblerX86_64::vectorAndnot):
(JSC::MacroAssemblerX86_64::vectorOr):
(JSC::MacroAssemblerX86_64::vectorXor):
(JSC::MacroAssemblerX86_64::vectorAbs):
(JSC::MacroAssemblerX86_64::vectorNeg):
(JSC::MacroAssemblerX86_64::vectorPopcnt):
(JSC::MacroAssemblerX86_64::vectorCeil):
(JSC::MacroAssemblerX86_64::vectorFloor):
(JSC::MacroAssemblerX86_64::vectorTrunc):
(JSC::MacroAssemblerX86_64::vectorNearest):
(JSC::MacroAssemblerX86_64::vectorSqrt):
(JSC::MacroAssemblerX86_64::vectorAnyTrue):
(JSC::MacroAssemblerX86_64::vectorAllTrue):
(JSC::MacroAssemblerX86_64::vectorBitmask):
(JSC::MacroAssemblerX86_64::vectorExtaddPairwise):
(JSC::MacroAssemblerX86_64::vectorAvgRound):
(JSC::MacroAssemblerX86_64::vectorMulSat):
(JSC::MacroAssemblerX86_64::vectorDotProductInt32):
(JSC::MacroAssemblerX86_64::vectorSwizzle):
(JSC::MacroAssemblerX86_64::vectorShuffle):

Canonical link: <a href="https://commits.webkit.org/257340@main">https://commits.webkit.org/257340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bbea7cddca9fedbc9db81188770c7d0d93f0773

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98679 "23 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108100 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168352 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85259 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91213 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104360 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76293 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89448 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1812 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85232 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1721 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28748 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6666 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42251 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88084 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2535 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3113 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19724 "Passed tests") | 
<!--EWS-Status-Bubble-End-->