### PR TITLE
Add helper methods to compare `WebCore::IPAddress`es

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/IPAddressTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IPAddressTests.cpp
@@ -61,6 +61,22 @@ TEST(IPAddressTests, InvalidAddresses)
     EXPECT_EQ(WebCore::IPAddress::fromString("192.168.255.256"_s), std::nullopt);
 }
 
+TEST(IPAddressTests, CompareIPAddresses)
+{
+    auto address1 = *WebCore::IPAddress::fromString("17.100.100.255"_s);
+    auto address2 = *WebCore::IPAddress::fromString("18.101.100.0"_s);
+    auto address3 = *WebCore::IPAddress::fromString("2001:db8::1234:1000"_s);
+    auto address4 = *WebCore::IPAddress::fromString("2001:db9::1234:0000"_s);
+
+    EXPECT_TRUE(address1 < address2);
+    EXPECT_TRUE(address2 > address1);
+    EXPECT_TRUE(address3 < address4);
+    EXPECT_TRUE(address4 > address3);
+    EXPECT_TRUE(address1 == WebCore::IPAddress::fromString("17.100.100.255"_s));
+    EXPECT_EQ(address1.compare(address3), WebCore::IPAddress::ComparisonResult::CannotCompare);
+    EXPECT_EQ(address4.compare(address2), WebCore::IPAddress::ComparisonResult::CannotCompare);
+}
+
 #endif // OS(UNIX)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 26acda475c8a24f288048011d53aa52f74a84e32
<pre>
Add helper methods to compare `WebCore::IPAddress`es
<a href="https://bugs.webkit.org/show_bug.cgi?id=248726">https://bugs.webkit.org/show_bug.cgi?id=248726</a>
rdar://99360259

Reviewed by Tim Horton.

Add a helper method to compare two `WebCore::IPAddress`-es, and use it to implement some comparison
operators. Also, add an additions hook that allows us to adjust newly created `NSURLSession`s.

Test: IPAddressTests.CompareIPAddresses

* Source/WebCore/platform/network/DNS.h:
(WebCore::IPAddress::compare const):
(WebCore::IPAddress::operator&lt; const):
(WebCore::IPAddress::operator&gt; const):
(WebCore::IPAddress::operator== const):
(WebCore::IPAddress::operator!= const):

Add the `compare()` method, and use it to implement several binary comparison operators.

* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::applyAdditionalSettings):
(WebKit::createURLSession):

Factor out logic to create a new `NSURLSession` into a separate helper method, and call the
additions hook (`applyAdditionalSettings`) from within this new helper.

(WebKit::SessionWrapper::initialize):
(WebKit::NetworkSessionCocoa::clearCredentials):
* Tools/TestWebKitAPI/Tests/WebCore/IPAddressTests.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/257443@main">https://commits.webkit.org/257443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dc577b062ab79c0c52c9b7ef6676787f766a67c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108394 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168646 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102949 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85540 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91511 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106360 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104704 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90206 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33648 "Found 1 new test failure: media/video-as-img-output-pts.html (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21551 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2095 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1999 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5126 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6962 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42541 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->