### PR TITLE
[SIMD] Intel support for swizzle and shuffle and fix extract_lane and replace_lane

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1639,13 +1639,9 @@ VectorReplaceLaneInt16 U:G:8, U:G:16, UD:F:128
     Imm, Tmp, Tmp
 VectorReplaceLaneInt8 U:G:8, U:G:8, UD:F:128
     Imm, Tmp, Tmp
-x86_64: VectorReplaceLaneFloat64 U:G:8, U:F:64, UD:F:128, S:G:64
-    Imm, Tmp, Tmp, Tmp
-arm64: VectorReplaceLaneFloat64 U:G:8, U:F:64, UD:F:128
+VectorReplaceLaneFloat64 U:G:8, U:F:64, UD:F:128
     Imm, Tmp, Tmp
-x86_64: VectorReplaceLaneFloat32 U:G:8, U:F:32, UD:F:128, S:G:32
-    Imm, Tmp, Tmp, Tmp
-arm64: VectorReplaceLaneFloat32 U:G:8, U:F:32, UD:F:128
+VectorReplaceLaneFloat32 U:G:8, U:F:32, UD:F:128
     Imm, Tmp, Tmp
 
 VectorExtractLaneInt64 U:G:8, U:F:128, D:G:64


### PR DESCRIPTION
#### cef394ff577b74bcaebdd6d3494aaef7bf78760b
<pre>
[SIMD] Intel support for swizzle and shuffle and fix extract_lane and replace_lane
<a href="https://bugs.webkit.org/show_bug.cgi?id=248728">https://bugs.webkit.org/show_bug.cgi?id=248728</a>
rdar://102942396

Reviewed by Yusuke Suzuki.

This patch aims for three tasks:

    1. Add WASM SIMD operations `swizzle` and `shuffle`.
    <a href="https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md#shuffling-using-immediate-indices">https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md#shuffling-using-immediate-indices</a>

    2. Refactor MacroAssemblerX86_64.h and X86Assembler.h for `pinsr` and `pextr`,
    where X86Assembler should do simple instruction emission only. And MacroAssemblerX86
    should select the instruction.

    3. Fix WASM SIMD operation `replace_lane`. Previously, the operation is
    implemented with instruction `pinsr` in AVX format but only passing three parameters
    which is wrong.
        <a href="https://www.felixcloutier.com/x86/pinsrb">https://www.felixcloutier.com/x86/pinsrb</a>:pinsrd:pinsrq
        <a href="https://www.felixcloutier.com/x86/pinsrw">https://www.felixcloutier.com/x86/pinsrw</a>
        <a href="https://www.officedaytime.com/simd512e/simdimg/si.php?f=pinsrb">https://www.officedaytime.com/simd512e/simdimg/si.php?f=pinsrb</a>
        <a href="https://www.officedaytime.com/simd512e/simdimg/si.php?f=pinsrw">https://www.officedaytime.com/simd512e/simdimg/si.php?f=pinsrw</a>
        <a href="https://www.officedaytime.com/simd512e/simdimg/si.php?f=pinsrd">https://www.officedaytime.com/simd512e/simdimg/si.php?f=pinsrd</a>
        <a href="https://www.officedaytime.com/simd512e/simdimg/si.php?f=pinsrq">https://www.officedaytime.com/simd512e/simdimg/si.php?f=pinsrq</a>

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::vectorReplaceLane):
(JSC::MacroAssemblerX86_64::vectorExtractLane):
(JSC::MacroAssemblerX86_64::vectorSwizzle):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::pinsrb):
(JSC::X86Assembler::pinsrw):
(JSC::X86Assembler::pinsrd):
(JSC::X86Assembler::pinsrq):
(JSC::X86Assembler::insertps):
(JSC::X86Assembler::unpcklpd):
(JSC::X86Assembler::vpextrb):
(JSC::X86Assembler::vpextrw):
(JSC::X86Assembler::vpextrd):
(JSC::X86Assembler::vpextrq):
(JSC::X86Assembler::X86InstructionFormatter::SingleInstructionBufferWriter::memoryModRM):
(JSC::X86Assembler::pinsr): Deleted.
(JSC::X86Assembler::pextr): Deleted.
(JSC::X86Assembler::vextractps): Deleted.
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::addReplaceLane):

Canonical link: <a href="https://commits.webkit.org/257400@main">https://commits.webkit.org/257400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dea943f81b3958fa1b65efea2b92e5a8aa6c04d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98890 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108303 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168559 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85463 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91421 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106283 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104581 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90128 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89635 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2009 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85435 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1918 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/28799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5089 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42462 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88289 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3318 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19761 "Passed tests") | 
<!--EWS-Status-Bubble-End-->