### PR TITLE
[GStreamer][MSE] Logging improvements

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -354,7 +354,7 @@ void MediaPlayerPrivateGStreamerMSE::sourceSetup(GstElement* sourceElement)
 void MediaPlayerPrivateGStreamerMSE::updateStates()
 {
     bool shouldBePlaying = !m_isPaused && readyState() >= MediaPlayer::ReadyState::HaveFutureData;
-    GST_DEBUG_OBJECT(pipeline(), "shouldBePlaying = %d, m_isPipelinePlaying = %d", static_cast<int>(shouldBePlaying), static_cast<int>(m_isPipelinePlaying));
+    GST_DEBUG_OBJECT(pipeline(), "shouldBePlaying = %s, m_isPipelinePlaying = %s", boolForPrinting(shouldBePlaying), boolForPrinting(m_isPipelinePlaying));
     if (shouldBePlaying && !m_isPipelinePlaying) {
         if (!changePipelineState(GST_STATE_PLAYING))
             GST_ERROR_OBJECT(pipeline(), "Setting the pipeline to PLAYING failed");

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -97,6 +97,10 @@ private:
     static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
 
+    friend class AppendPipeline;
+    friend class SourceBufferPrivateGStreamer;
+    friend class MediaSourcePrivateGStreamer;
+
     void updateStates() override;
 
     // FIXME: Implement videoPlaybackQualityMetrics.

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -49,6 +49,9 @@
 #include <wtf/RefPtr.h>
 #include <wtf/glib/GRefPtr.h>
 
+GST_DEBUG_CATEGORY_EXTERN(webkit_mse_debug);
+#define GST_CAT_DEFAULT webkit_mse_debug
+
 namespace WebCore {
 
 Ref<MediaSourcePrivateGStreamer> MediaSourcePrivateGStreamer::open(MediaSourcePrivateClient& mediaSource, MediaPlayerPrivateGStreamerMSE& playerPrivate)
@@ -108,7 +111,7 @@ void MediaSourcePrivateGStreamer::durationChanged(const MediaTime&)
     ASSERT(isMainThread());
 
     MediaTime duration = m_mediaSource ? m_mediaSource->duration() : MediaTime::invalidTime();
-    GST_TRACE("duration: %f", duration.toFloat());
+    GST_TRACE_OBJECT(m_playerPrivate.pipeline(), "Duration: %" GST_TIME_FORMAT, GST_TIME_ARGS(toGstClockTime(duration)));
     if (!duration.isValid() || duration.isNegativeInfinite())
         return;
 
@@ -118,6 +121,21 @@ void MediaSourcePrivateGStreamer::durationChanged(const MediaTime&)
 void MediaSourcePrivateGStreamer::markEndOfStream(EndOfStreamStatus endOfStreamStatus)
 {
     ASSERT(isMainThread());
+#ifndef GST_DISABLE_GST_DEBUG
+    const char* statusString = nullptr;
+    switch (endOfStreamStatus) {
+    case EndOfStreamStatus::EosNoError:
+        statusString = "no-error";
+        break;
+    case EndOfStreamStatus::EosDecodeError:
+        statusString = "decode-error";
+        break;
+    case EndOfStreamStatus::EosNetworkError:
+        statusString = "network-error";
+        break;
+    }
+    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Marking EOS, status is %s", statusString);
+#endif
     if (endOfStreamStatus == EosNoError)
         m_playerPrivate.setNetworkState(MediaPlayer::NetworkState::Loaded);
     m_isEnded = true;
@@ -126,6 +144,7 @@ void MediaSourcePrivateGStreamer::markEndOfStream(EndOfStreamStatus endOfStreamS
 void MediaSourcePrivateGStreamer::unmarkEndOfStream()
 {
     ASSERT(isMainThread());
+    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Un-marking EOS");
     m_isEnded = false;
 }
 
@@ -174,12 +193,12 @@ void MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks()
 
     for (auto& sourceBuffer : m_sourceBuffers) {
         if (!sourceBuffer->hasReceivedInitializationSegment()) {
-            GST_DEBUG("MediaSourcePrivateGStreamer(%p) - There are still SourceBuffers without an initialization segment, not starting source yet.", this);
+            GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "There are still SourceBuffers without an initialization segment, not starting source yet.");
             return;
         }
     }
 
-    GST_DEBUG("MediaSourcePrivateGStreamer(%p) - All SourceBuffers have an initialization segment, starting source.", this);
+    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "All SourceBuffers have an initialization segment, starting source.");
     m_hasAllTracks = true;
 
     Vector<RefPtr<MediaSourceTrackGStreamer>> tracks;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -90,7 +90,7 @@ void SourceBufferPrivateGStreamer::append(Vector<unsigned char>&& data)
     ASSERT(m_mediaSource);
     ASSERT(m_client);
 
-    GST_DEBUG("Appending %zu bytes", data.size());
+    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Appending %zu bytes", data.size());
     // Wrap the whole Vector object in case the data is stored in the inlined buffer.
     auto* bufferData = data.data();
     auto bufferLength = data.size();
@@ -106,14 +106,14 @@ void SourceBufferPrivateGStreamer::append(Vector<unsigned char>&& data)
 void SourceBufferPrivateGStreamer::abort()
 {
     ASSERT(isMainThread());
-    GST_DEBUG("aborting");
+    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "aborting");
     m_appendPipeline->resetParserState();
 }
 
 void SourceBufferPrivateGStreamer::resetParserState()
 {
     ASSERT(isMainThread());
-    GST_DEBUG("resetting parser state");
+    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "resetting parser state");
     m_appendPipeline->resetParserState();
 }
 
@@ -147,13 +147,13 @@ void SourceBufferPrivateGStreamer::flush(const AtomString& trackId)
     // This is only for on-the-fly reenqueues after appends. When seeking, the seek will do its own flush.
 
     if (!m_playerPrivate.hasAllTracks()) {
-        GST_DEBUG("Source element has not emitted tracks yet, so we only need to clear the queue. trackId = '%s'", trackId.string().utf8().data());
+        GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Source element has not emitted tracks yet, so we only need to clear the queue. trackId = '%s'", trackId.string().utf8().data());
         MediaSourceTrackGStreamer* track = m_tracks.get(trackId);
         track->clearQueue();
         return;
     }
 
-    GST_DEBUG("Source element has emitted tracks, let it handle the flush, which may cause a pipeline flush as well. trackId = '%s'", trackId.string().utf8().data());
+    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Source element has emitted tracks, let it handle the flush, which may cause a pipeline flush as well. trackId = '%s'", trackId.string().utf8().data());
     webKitMediaSrcFlush(m_playerPrivate.webKitMediaSrc(), trackId);
 }
 
@@ -161,15 +161,14 @@ void SourceBufferPrivateGStreamer::enqueueSample(Ref<MediaSample>&& sample, cons
 {
     ASSERT(isMainThread());
 
-    GST_TRACE("enqueing sample trackId=%s PTS=%s presentationSize=%.0fx%.0f at %" GST_TIME_FORMAT " duration: %" GST_TIME_FORMAT,
-        trackId.string().utf8().data(), sample->presentationTime().toString().utf8().data(),
-        sample->presentationSize().width(), sample->presentationSize().height(),
-        GST_TIME_ARGS(WebCore::toGstClockTime(sample->presentationTime())),
-        GST_TIME_ARGS(WebCore::toGstClockTime(sample->duration())));
-
     GRefPtr<GstSample> gstSample = sample->platformSample().sample.gstSample;
     ASSERT(gstSample);
     ASSERT(gst_sample_get_buffer(gstSample.get()));
+
+    GST_TRACE_OBJECT(m_playerPrivate.pipeline(), "enqueing sample trackId=%s presentationSize=%.0fx%.0f at PTS %" GST_TIME_FORMAT " duration: %" GST_TIME_FORMAT,
+        trackId.string().utf8().data(), sample->presentationSize().width(), sample->presentationSize().height(),
+        GST_TIME_ARGS(WebCore::toGstClockTime(sample->presentationTime())),
+        GST_TIME_ARGS(WebCore::toGstClockTime(sample->duration())));
 
     MediaSourceTrackGStreamer* track = m_tracks.get(trackId);
     track->enqueueObject(adoptGRef(GST_MINI_OBJECT(gstSample.leakRef())));
@@ -180,7 +179,7 @@ bool SourceBufferPrivateGStreamer::isReadyForMoreSamples(const AtomString& track
     ASSERT(isMainThread());
     MediaSourceTrackGStreamer* track = m_tracks.get(trackId);
     bool ret = track->isReadyForMoreSamples();
-    GST_TRACE("SourceBufferPrivate(%p) - isReadyForMoreSamples: %s", this, boolForPrinting(ret));
+    GST_TRACE_OBJECT(m_playerPrivate.pipeline(), "isReadyForMoreSamples: %s", boolForPrinting(ret));
     return ret;
 }
 
@@ -199,7 +198,7 @@ void SourceBufferPrivateGStreamer::notifyClientWhenReadyForMoreSamples(const Ato
 void SourceBufferPrivateGStreamer::allSamplesInTrackEnqueued(const AtomString& trackId)
 {
     ASSERT(isMainThread());
-    GST_DEBUG("Enqueueing EOS for track '%s'", trackId.string().utf8().data());
+    GST_DEBUG_OBJECT(m_playerPrivate.pipeline(), "Enqueueing EOS for track '%s'", trackId.string().utf8().data());
     MediaSourceTrackGStreamer* track = m_tracks.get(trackId);
     track->enqueueObject(adoptGRef(GST_MINI_OBJECT(gst_event_new_eos())));
 }


### PR DESCRIPTION
#### 1e5066813c753343545f6148144885cd576b6499
<pre>
[GStreamer][MSE] Logging improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=248740">https://bugs.webkit.org/show_bug.cgi?id=248740</a>

Reviewed by Alicia Boya Garcia.

Use _OBJECT gst logging macros more often, helping with debugging on pages where there are multiple
media elements.

* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::assertedElementSetState):
(WebCore::AppendPipeline::AppendPipeline):
(WebCore::AppendPipeline::~AppendPipeline):
(WebCore::AppendPipeline::handleErrorSyncMessage):
(WebCore::AppendPipeline::appsrcEndOfAppendCheckerProbe):
(WebCore::AppendPipeline::appsinkCapsChanged):
(WebCore::AppendPipeline::handleEndOfAppend):
(WebCore::AppendPipeline::appsinkNewSample):
(WebCore::AppendPipeline::didReceiveInitializationSegment):
(WebCore::AppendPipeline::consumeAppsinksAvailableSamples):
(WebCore::AppendPipeline::resetParserState):
(WebCore::AppendPipeline::stopParser):
(WebCore::AppendPipeline::pushNewBuffer):
(WebCore::AppendPipeline::handleAppsinkNewSampleFromStreamingThread):
(WebCore::createOptionalParserForFormat):
(WebCore::AppendPipeline::Track::emplaceOptionalParserForFormat):
(WebCore::appendPipelinePadProbeDebugInformation):
(WebCore::appendPipelineAppsinkPadEventProbe):
(WebCore::appendPipelineDemuxerBlackHolePadProbe):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::updateStates):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::durationChanged):
(WebCore::MediaSourcePrivateGStreamer::markEndOfStream):
(WebCore::MediaSourcePrivateGStreamer::unmarkEndOfStream):
(WebCore::MediaSourcePrivateGStreamer::startPlaybackIfHasAllTracks):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::append):
(WebCore::SourceBufferPrivateGStreamer::abort):
(WebCore::SourceBufferPrivateGStreamer::resetParserState):
(WebCore::SourceBufferPrivateGStreamer::flush):
(WebCore::SourceBufferPrivateGStreamer::enqueueSample):
(WebCore::SourceBufferPrivateGStreamer::isReadyForMoreSamples):
(WebCore::SourceBufferPrivateGStreamer::allSamplesInTrackEnqueued):

Canonical link: <a href="https://commits.webkit.org/257422@main">https://commits.webkit.org/257422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccb53de12ae36881ba41dc61a5605498b4db975f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108368 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168621 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8717 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91486 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106336 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104661 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33629 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21529 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2068 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1974 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5105 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42519 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->