### PR TITLE
iOS Mail app issues with copying attachments from an email and pasting into new email or note or Files

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -10390,7 +10390,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
     [item registerDataRepresentationForTypeIdentifier:utiType visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[attachment](void (^completionHandler)(NSData *, NSError *)) -> NSProgress * {
         attachment->doWithFileWrapper([&](NSFileWrapper *fileWrapper) {
-            if (auto nsData = RetainPtr { fileWrapper.serializedRepresentation })
+            if (auto nsData = RetainPtr { fileWrapper.regularFileContents })
                 completionHandler(nsData.get(), nil);
             else
                 completionHandler(nil, [NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:nil]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
@@ -2722,7 +2722,7 @@ TEST(WKAttachmentTestsIOS, CopyAttachmentUsingElementAction)
 
     __block bool done = false;
     [itemProvider loadDataRepresentationForTypeIdentifier:(__bridge NSString *)kUTTypePDF completionHandler:^(NSData *data, NSError *) {
-        EXPECT_TRUE([[document serializedRepresentation] isEqualToData:data]);
+        EXPECT_TRUE([[document regularFileContents] isEqualToData:data]);
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);


### PR DESCRIPTION
#### 4690d8d04a27a89412a880798fb2ac374a0770a3
<pre>
iOS Mail app issues with copying attachments from an email and pasting into new email or note or Files
<a href="https://bugs.webkit.org/show_bug.cgi?id=248746">https://bugs.webkit.org/show_bug.cgi?id=248746</a>
rdar://70201914

Reviewed by Wenson Hsieh.

When copying an attachment in Mail, and pasting it in Mail or another app, the
file becomes corrupted. This is because when copying the file to the clipboard,
we use `-[NSFileWrapper serializedRepresentation]` to serialize the file and
then send that data.

However, when pasting the file, clients such as Mail do not expect the data
to be serialized, and so they use `-[NSFileWrapper initRegularFileWithContents:]`
to try to read it, which causes the file to be corrupted.

There are two solutions to this:
1. Get all clients to use the correct initializer, `-[NSFileWrapper initWithSerializedRepresentation:]`
2. Do not serialize the data when copying it to the clipboard

This PR does the latter, as it is the safer option.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(createItemProvider):

Canonical link: <a href="https://commits.webkit.org/257371@main">https://commits.webkit.org/257371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ea8f2abd21c7fdcdef7c77ecb245d7d34e61289

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108149 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168402 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102681 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85309 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91261 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106067 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89973 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33401 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21316 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76327 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1862 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22845 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1770 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45326 "Found 2 new test failures: fast/events/blur-remove-parent-crash.html, media/video-inactive-playback.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5067 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6716 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42300 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->