### PR TITLE
[JSC] Make Object.values faster

### DIFF
--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -520,7 +520,7 @@ bool Stringifier::Holder::appendNextProperty(Stringifier& stringifier, StringBui
             if (stringifier.m_usingArrayReplacer) {
                 m_propertyNames = stringifier.m_arrayReplacerPropertyNames.data();
                 m_size = m_propertyNames->propertyNameVector().size();
-            } else if (m_structure && m_object->structureID() == m_structure->id() && canPerformFastPropertyEnumerationForJSONStringify(m_structure)) {
+            } else if (m_structure && m_object->structureID() == m_structure->id() && m_structure->canPerformFastPropertyEnumeration()) {
                 m_structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
                     if (entry.attributes() & PropertyAttribute::DontEnum)
                         return true;
@@ -1046,7 +1046,7 @@ void FastStringifier::append(JSValue value)
             return;
         }
         m_buffer[m_length++] = '{';
-        if (UNLIKELY(!canPerformFastPropertyEnumerationForJSONStringify(&structure))) {
+        if (UNLIKELY(!structure.canPerformFastPropertyEnumeration())) {
             recordFastPropertyEnumerationFailure(object);
             return;
         }

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -995,6 +995,9 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    template<typename Functor>
+    bool fastForEachPropertyWithSideEffectFreeFunctor(VM&, const Functor&);
+
 protected:
     void finishCreation(VM& vm)
     {

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -807,4 +807,19 @@ inline void JSObject::setPrivateBrand(JSGlobalObject* globalObject, JSValue bran
     this->setStructure(vm, newStructure);
 }
 
+template<typename Functor>
+bool JSObject::fastForEachPropertyWithSideEffectFreeFunctor(VM& vm, const Functor& functor)
+{
+    if (!staticPropertiesReified())
+        return false;
+
+    Structure* structure = this->structure();
+
+    if (!structure->canPerformFastPropertyEnumeration())
+        return false;
+
+    structure->forEachProperty(vm, functor);
+    return true;
+}
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -341,10 +341,8 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorAssign, (JSGlobalObject* globalObject,
                 RETURN_IF_EXCEPTION(scope, { });
             }
 
-            if (canPerformFastPropertyEnumerationForObjectAssign(source->structure())) {
-                objectAssignFast(vm, target, source, properties, values);
+            if (objectAssignFast(vm, target, source, properties, values))
                 continue;
-            }
         }
 
         targetCanPerformFastPut = false;
@@ -370,10 +368,10 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorEntries, (JSGlobalObject* globalObject
         RETURN_IF_EXCEPTION(scope, { });
     }
 
-    if (canPerformFastPropertyEnumerationForObjectEntries(target->structure())) {
+    {
         Vector<RefPtr<UniquedStringImpl>, 8> properties;
         MarkedArgumentBuffer values;
-        target->structure()->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
+        bool canUseFastPath = target->fastForEachPropertyWithSideEffectFreeFunctor(vm, [&](const PropertyTableEntry& entry) -> bool {
             if (entry.attributes() & PropertyAttribute::DontEnum)
                 return true;
 
@@ -386,68 +384,70 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorEntries, (JSGlobalObject* globalObject
             return true;
         });
 
-        Structure* arrayStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous);
-        JSArray* entries = JSArray::tryCreate(vm, arrayStructure, properties.size());
-        if (UNLIKELY(!entries)) {
-            throwOutOfMemoryError(globalObject, scope);
-            return { };
-        }
-
-        Structure* targetStructure = target->structure();
-        JSImmutableButterfly* cachedButterfly = nullptr;
-        if (LIKELY(!globalObject->isHavingABadTime())) {
-            auto* butterfly = targetStructure->cachedPropertyNames(CachedPropertyNamesKind::Keys);
-            if (butterfly) {
-                ASSERT(butterfly->length() == properties.size());
-                if (butterfly->length() == properties.size())
-                    cachedButterfly = butterfly;
-            }
-        }
-
-        if (!cachedButterfly && properties.size() < MIN_SPARSE_ARRAY_INDEX && !globalObject->isHavingABadTime() && targetStructure->canCacheOwnPropertyNames()) {
-            auto* canSentinel = targetStructure->cachedPropertyNamesIgnoringSentinel(CachedPropertyNamesKind::Keys);
-            if (canSentinel == StructureRareData::cachedPropertyNamesSentinel()) {
-                size_t numProperties = properties.size();
-                auto* newButterfly = JSImmutableButterfly::create(vm, CopyOnWriteArrayWithContiguous, numProperties);
-                for (size_t i = 0; i < numProperties; i++) {
-                    const auto& identifier = properties[i];
-                    newButterfly->setIndex(vm, i, jsOwnedString(vm, identifier.get()));
-                }
-
-                targetStructure->setCachedPropertyNames(vm, CachedPropertyNamesKind::Keys, newButterfly);
-                cachedButterfly = newButterfly;
-            } else
-                targetStructure->setCachedPropertyNames(vm, CachedPropertyNamesKind::Keys, StructureRareData::cachedPropertyNamesSentinel());
-        }
-
-        for (size_t i = 0; i < properties.size(); ++i) {
-            JSString* key = nullptr;
-            if (cachedButterfly) {
-                auto* cachedKey = asString(cachedButterfly->get(i));
-                if (cachedKey->tryGetValueImpl() == properties[i].get())
-                    key = cachedKey;
-            }
-
-            if (!key)
-                key = jsOwnedString(vm, properties[i].get());
-
-            JSArray* entry = nullptr;
-            {
-                ObjectInitializationScope initializationScope(vm);
-                if (LIKELY(entry = JSArray::tryCreateUninitializedRestricted(initializationScope, nullptr, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 2))) {
-                    entry->initializeIndex(initializationScope, 0, key);
-                    entry->initializeIndex(initializationScope, 1, values.at(i));
-                }
-            }
-            if (UNLIKELY(!entry)) {
+        if (canUseFastPath) {
+            Structure* arrayStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous);
+            JSArray* entries = JSArray::tryCreate(vm, arrayStructure, properties.size());
+            if (UNLIKELY(!entries)) {
                 throwOutOfMemoryError(globalObject, scope);
                 return { };
             }
-            entries->putDirectIndex(globalObject, i, entry);
-            RETURN_IF_EXCEPTION(scope, { });
-        }
 
-        return JSValue::encode(entries);
+            Structure* targetStructure = target->structure();
+            JSImmutableButterfly* cachedButterfly = nullptr;
+            if (LIKELY(!globalObject->isHavingABadTime())) {
+                auto* butterfly = targetStructure->cachedPropertyNames(CachedPropertyNamesKind::Keys);
+                if (butterfly) {
+                    ASSERT(butterfly->length() == properties.size());
+                    if (butterfly->length() == properties.size())
+                        cachedButterfly = butterfly;
+                }
+            }
+
+            if (!cachedButterfly && properties.size() < MIN_SPARSE_ARRAY_INDEX && !globalObject->isHavingABadTime() && targetStructure->canCacheOwnPropertyNames()) {
+                auto* canSentinel = targetStructure->cachedPropertyNamesIgnoringSentinel(CachedPropertyNamesKind::Keys);
+                if (canSentinel == StructureRareData::cachedPropertyNamesSentinel()) {
+                    size_t numProperties = properties.size();
+                    auto* newButterfly = JSImmutableButterfly::create(vm, CopyOnWriteArrayWithContiguous, numProperties);
+                    for (size_t i = 0; i < numProperties; i++) {
+                        const auto& identifier = properties[i];
+                        newButterfly->setIndex(vm, i, jsOwnedString(vm, identifier.get()));
+                    }
+
+                    targetStructure->setCachedPropertyNames(vm, CachedPropertyNamesKind::Keys, newButterfly);
+                    cachedButterfly = newButterfly;
+                } else
+                    targetStructure->setCachedPropertyNames(vm, CachedPropertyNamesKind::Keys, StructureRareData::cachedPropertyNamesSentinel());
+            }
+
+            for (size_t i = 0; i < properties.size(); ++i) {
+                JSString* key = nullptr;
+                if (cachedButterfly) {
+                    auto* cachedKey = asString(cachedButterfly->get(i));
+                    if (cachedKey->tryGetValueImpl() == properties[i].get())
+                        key = cachedKey;
+                }
+
+                if (!key)
+                    key = jsOwnedString(vm, properties[i].get());
+
+                JSArray* entry = nullptr;
+                {
+                    ObjectInitializationScope initializationScope(vm);
+                    if (LIKELY(entry = JSArray::tryCreateUninitializedRestricted(initializationScope, nullptr, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 2))) {
+                        entry->initializeIndex(initializationScope, 0, key);
+                        entry->initializeIndex(initializationScope, 1, values.at(i));
+                    }
+                }
+                if (UNLIKELY(!entry)) {
+                    throwOutOfMemoryError(globalObject, scope);
+                    return { };
+                }
+                entries->putDirectIndex(globalObject, i, entry);
+                RETURN_IF_EXCEPTION(scope, { });
+            }
+
+            return JSValue::encode(entries);
+        }
     }
 
     JSArray* entries = constructEmptyArray(globalObject, nullptr);
@@ -508,6 +508,40 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorValues, (JSGlobalObject* globalObject,
         return throwVMTypeError(globalObject, scope, "Object.values requires that input parameter not be null or undefined"_s);
     JSObject* target = targetValue.toObject(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
+
+    if (!target->staticPropertiesReified()) {
+        target->reifyAllStaticProperties(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    {
+        MarkedArgumentBuffer values;
+        bool canUseFastPath = target->fastForEachPropertyWithSideEffectFreeFunctor(vm, [&](const PropertyTableEntry& entry) -> bool {
+            if (entry.attributes() & PropertyAttribute::DontEnum)
+                return true;
+
+            if (entry.key()->isSymbol())
+                return true;
+
+            values.appendWithCrashOnOverflow(target->getDirect(entry.offset()));
+            return true;
+        });
+
+        if (canUseFastPath) {
+            Structure* arrayStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous);
+            {
+                ObjectInitializationScope initializationScope(vm);
+                JSArray* result = nullptr;
+                if (LIKELY(result = JSArray::tryCreateUninitializedRestricted(initializationScope, nullptr, arrayStructure, values.size()))) {
+                    for (unsigned i = 0; i < values.size(); ++i)
+                        result->initializeIndex(initializationScope, i, values.at(i));
+                    return JSValue::encode(result);
+                }
+            }
+            throwOutOfMemoryError(globalObject, scope);
+            return { };
+        }
+    }
 
     JSArray* values = constructEmptyArray(globalObject, nullptr);
     RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
@@ -29,41 +29,7 @@
 
 namespace JSC {
 
-ALWAYS_INLINE bool canPerformFastPropertyEnumerationForObjectAssign(Structure* structure)
-{
-    if (structure->typeInfo().overridesGetOwnPropertySlot())
-        return false;
-    if (structure->typeInfo().overridesAnyFormOfGetOwnPropertyNames())
-        return false;
-    // FIXME: Indexed properties can be handled.
-    // https://bugs.webkit.org/show_bug.cgi?id=185358
-    if (hasIndexedProperties(structure->indexingType()))
-        return false;
-    if (structure->hasGetterSetterProperties())
-        return false;
-    if (structure->hasReadOnlyOrGetterSetterPropertiesExcludingProto())
-        return false;
-    if (structure->hasCustomGetterSetterProperties())
-        return false;
-    if (structure->isUncacheableDictionary())
-        return false;
-    // Cannot perform fast [[Put]] to |target| if the property names of the |source| contain "__proto__".
-    if (structure->hasUnderscoreProtoPropertyExcludingOriginalProto())
-        return false;
-    return true;
-}
-
-ALWAYS_INLINE bool canPerformFastPropertyEnumerationForJSONStringify(Structure* structure)
-{
-    return canPerformFastPropertyEnumerationForObjectAssign(structure);
-}
-
-ALWAYS_INLINE bool canPerformFastPropertyEnumerationForObjectEntries(Structure* structure)
-{
-    return canPerformFastPropertyEnumerationForObjectAssign(structure);
-}
-
-ALWAYS_INLINE void objectAssignFast(VM& vm, JSObject* target, JSObject* source, Vector<RefPtr<UniquedStringImpl>, 8>& properties, MarkedArgumentBuffer& values)
+ALWAYS_INLINE bool objectAssignFast(VM& vm, JSObject* target, JSObject* source, Vector<RefPtr<UniquedStringImpl>, 8>& properties, MarkedArgumentBuffer& values)
 {
     // |source| Structure does not have any getters. And target can perform fast put.
     // So enumerating properties and putting properties are non observable.
@@ -81,7 +47,7 @@ ALWAYS_INLINE void objectAssignFast(VM& vm, JSObject* target, JSObject* source, 
     // Do not clear since Vector::clear shrinks the backing store.
     properties.resize(0);
     values.clear();
-    source->structure()->forEachProperty(vm, [&] (const PropertyTableEntry& entry) -> bool {
+    bool canUseFastPath = source->fastForEachPropertyWithSideEffectFreeFunctor(vm, [&](const PropertyTableEntry& entry) -> bool {
         if (entry.attributes() & PropertyAttribute::DontEnum)
             return true;
 
@@ -94,6 +60,8 @@ ALWAYS_INLINE void objectAssignFast(VM& vm, JSObject* target, JSObject* source, 
 
         return true;
     });
+    if (!canUseFastPath)
+        return false;
 
     for (size_t i = 0; i < properties.size(); ++i) {
         // FIXME: We could put properties in a batching manner to accelerate Object.assign more.
@@ -101,6 +69,7 @@ ALWAYS_INLINE void objectAssignFast(VM& vm, JSObject* target, JSObject* source, 
         PutPropertySlot putPropertySlot(target, true);
         target->putOwnDataProperty(vm, properties[i].get(), values.at(i), putPropertySlot);
     }
+    return true;
 }
 
 

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -572,6 +572,8 @@ public:
     PropertyOffset get(VM&, PropertyName);
     PropertyOffset get(VM&, PropertyName, unsigned& attributes);
 
+    bool canPerformFastPropertyEnumeration() const;
+
     // This is a somewhat internalish method. It will call your functor while possibly holding the
     // Structure's lock. There is no guarantee whether the lock is held or not in any particular
     // call. So, you have to assume the worst. Also, the functor returns true if it wishes for you

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -745,4 +745,28 @@ inline void Structure::clearCachedPrototypeChain()
     rareData()->clearCachedPropertyNameEnumerator();
 }
 
+ALWAYS_INLINE bool Structure::canPerformFastPropertyEnumeration() const
+{
+    if (typeInfo().overridesGetOwnPropertySlot())
+        return false;
+    if (typeInfo().overridesAnyFormOfGetOwnPropertyNames())
+        return false;
+    // FIXME: Indexed properties can be handled.
+    // https://bugs.webkit.org/show_bug.cgi?id=185358
+    if (hasIndexedProperties(indexingType()))
+        return false;
+    if (hasGetterSetterProperties())
+        return false;
+    if (hasReadOnlyOrGetterSetterPropertiesExcludingProto())
+        return false;
+    if (hasCustomGetterSetterProperties())
+        return false;
+    if (isUncacheableDictionary())
+        return false;
+    // Cannot perform fast [[Put]] to |target| if the property names of the |source| contain "__proto__".
+    if (hasUnderscoreProtoPropertyExcludingOriginalProto())
+        return false;
+    return true;
+}
+
 } // namespace JSC


### PR DESCRIPTION
#### 0fdf9960015a8210d00f65256142db6bd125adf1
<pre>
[JSC] Make Object.values faster
<a href="https://bugs.webkit.org/show_bug.cgi?id=248749">https://bugs.webkit.org/show_bug.cgi?id=248749</a>
rdar://102966742

Reviewed by Justin Michaud.

This patch adds JSObject::fastForEachPropertyWithSideEffectFreeFunctor, and apply this to Object.values
to accelerate performance. It makes Object.values 3x faster.

                               ToT                     Patched

    object-values        17.2415+-0.0379     ^      5.6210+-0.0133        ^ definitely 3.0673x faster

* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::Stringifier::Holder::appendNextProperty):
(JSC::FastStringifier::append):
* Source/JavaScriptCore/runtime/JSObject.h:
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::fastForEachPropertyWithSideEffectFreeFunctor):
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ObjectConstructorInlines.h:
(JSC::objectAssignFast):
(JSC::canPerformFastPropertyEnumerationForObjectAssign): Deleted.
(JSC::canPerformFastPropertyEnumerationForJSONStringify): Deleted.
(JSC::canPerformFastPropertyEnumerationForObjectEntries): Deleted.
* Source/JavaScriptCore/runtime/Structure.h:
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::canPerformFastPropertyEnumeration const):

Canonical link: <a href="https://commits.webkit.org/257382@main">https://commits.webkit.org/257382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5b8ab7bfd26fbabf8114d2c736e7e80a6649f6e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108155 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168410 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85315 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91268 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106073 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33408 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88244 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76334 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89501 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1867 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22854 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85284 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1775 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45333 "Found 1 new test failure: media/video-inactive-playback.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28757 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5077 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42309 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88137 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3168 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19733 "Passed tests") | 
<!--EWS-Status-Bubble-End-->