### PR TITLE
[GTK][WPE] Merge functions of registering and unregistering script message handler in WebKitUserContentManager API

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in
@@ -64,26 +64,178 @@ webkit_user_content_manager_remove_style_sheet                         (WebKitUs
 WEBKIT_API void
 webkit_user_content_manager_remove_all_style_sheets                    (WebKitUserContentManager *manager);
 
+#if !ENABLE(2022_GLIB_API)
+/**
+ * webkit_user_content_manager_register_script_message_handler:
+ * @manager: A #WebKitUserContentManager
+ * @name: Name of the script message channel
+ *
+ * Registers a new user script message handler.
+ *
+ * After it is registered,
+ * scripts can use `window.webkit.messageHandlers.<name>.postMessage(value)`
+ * to send messages. Those messages are received by connecting handlers
+ * to the #WebKitUserContentManager::script-message-received signal. The
+ * handler name is used as the detail of the signal. To avoid race
+ * conditions between registering the handler name, and starting to
+ * receive the signals, it is recommended to connect to the signal
+ * *before* registering the handler name:
+ *
+ * ```c
+ * WebKitWebView *view = webkit_web_view_new ();
+ * WebKitUserContentManager *manager = webkit_web_view_get_user_content_manager ();
+ * g_signal_connect (manager, "script-message-received::foobar",
+ *                   G_CALLBACK (handle_script_message), NULL);
+ * webkit_user_content_manager_register_script_message_handler (manager, "foobar");
+ * ```
+ *
+ * Registering a script message handler will fail if the requested
+ * name has been already registered before.
+ *
+ * Returns: %TRUE if message handler was registered successfully, or %FALSE otherwise.
+ *
+ * Since: 2.8
+ */
 WEBKIT_API gboolean
 webkit_user_content_manager_register_script_message_handler            (WebKitUserContentManager *manager,
                                                                         const gchar              *name);
+/**
+ * webkit_user_content_manager_unregister_script_message_handler:
+ * @manager: A #WebKitUserContentManager
+ * @name: Name of the script message channel
+ *
+ * Unregisters a previously registered message handler.
+ *
+ * Note that this does *not* disconnect handlers for the
+ * #WebKitUserContentManager::script-message-received signal;
+ * they will be kept connected, but the signal will not be emitted
+ * unless the handler name is registered again.
+ *
+ * See also webkit_user_content_manager_register_script_message_handler().
+ *
+ * Since: 2.8
+ */
 WEBKIT_API void
 webkit_user_content_manager_unregister_script_message_handler          (WebKitUserContentManager *manager,
                                                                         const gchar              *name);
+#else
+/**
+ * webkit_user_content_manager_register_script_message_handler:
+ * @manager: A #WebKitUserContentManager
+ * @name: Name of the script message channel
+ * @world_name (nullable): the name of a #WebKitScriptWorld
+ *
+ * Registers a new user script message handler in script world.
+ *
+ * After it is registered,
+ * scripts can use `window.webkit.messageHandlers.<name>.postMessage(value)`
+ * to send messages. Those messages are received by connecting handlers
+ * to the #WebKitUserContentManager::script-message-received signal. The
+ * handler name is used as the detail of the signal. To avoid race
+ * conditions between registering the handler name, and starting to
+ * receive the signals, it is recommended to connect to the signal
+ * *before* registering the handler name:
+ *
+ * ```c
+ * WebKitWebView *view = webkit_web_view_new ();
+ * WebKitUserContentManager *manager = webkit_web_view_get_user_content_manager ();
+ * g_signal_connect (manager, "script-message-received::foobar",
+ *                   G_CALLBACK (handle_script_message), NULL);
+ * webkit_user_content_manager_register_script_message_handler (manager, "foobar");
+ * ```
+ *
+ * Registering a script message handler will fail if the requested
+ * name has been already registered before.
+ *
+ * If %NULL is passed as the @world_name, the default world will be used.
+ *
+ * The registered handler can be unregistered by using
+ * webkit_user_content_manager_unregister_script_message_handler().
+ *
+ * Returns: %TRUE if message handler was registered successfully, or %FALSE otherwise.
+ *
+ * Since: 2.40
+ */
+WEBKIT_API gboolean
+webkit_user_content_manager_register_script_message_handler            (WebKitUserContentManager *manager,
+                                                                        const char               *name,
+                                                                        const char               *world_name);
+
+
+/**
+ * webkit_user_content_manager_unregister_script_message_handler:
+ * @manager: A #WebKitUserContentManager
+ * @name: Name of the script message channel
+ * @world_name: (nullable): the name of a #WebKitScriptWorld
+ *
+ * Unregisters a previously registered message handler in script world with name @world_name.
+ * If %NULL is passed as the @world_name, the default world will be used.
+ *
+ * Note that this does *not* disconnect handlers for the
+ * #WebKitUserContentManager::script-message-received signal;
+ * they will be kept connected, but the signal will not be emitted
+ * unless the handler name is registered again.
+ *
+ * See also webkit_user_content_manager_register_script_message_handler().
+ *
+ * Since: 2.40
+ */
+WEBKIT_API void
+webkit_user_content_manager_unregister_script_message_handler          (WebKitUserContentManager *manager,
+                                                                        const gchar              *name,
+                                                                        const gchar              *world_name);
+#endif
 
 WEBKIT_API gboolean
 webkit_user_content_manager_register_script_message_handler_with_reply (WebKitUserContentManager *manager,
                                                                         const char               *name,
                                                                         const char               *world_name);
 
+#if !ENABLE(2022_GLIB_API)
+/**
+ * webkit_user_content_manager_register_script_message_handler_in_world:
+ * @manager: A #WebKitUserContentManager
+ * @name: Name of the script message channel
+ * @world_name: the name of a #WebKitScriptWorld
+ *
+ * Registers a new user script message handler in script world.
+ *
+ * Registers a new user script message handler in script world with name @world_name.
+ * See webkit_user_content_manager_register_script_message_handler() for full description.
+ *
+ * Registering a script message handler will fail if the requested
+ * name has been already registered before.
+ *
+ * Returns: %TRUE if message handler was registered successfully, or %FALSE otherwise.
+ *
+ * Since: 2.22
+ */
 WEBKIT_API gboolean
 webkit_user_content_manager_register_script_message_handler_in_world   (WebKitUserContentManager *manager,
                                                                         const gchar              *name,
                                                                         const gchar              *world_name);
+/**
+ * webkit_user_content_manager_unregister_script_message_handler_in_world:
+ * @manager: A #WebKitUserContentManager
+ * @name: Name of the script message channel
+ * @world_name: the name of a #WebKitScriptWorld
+ *
+ * Unregisters a previously registered message handler in script world with name @world_name.
+ *
+ * Note that this does *not* disconnect handlers for the
+ * #WebKitUserContentManager::script-message-received signal;
+ * they will be kept connected, but the signal will not be emitted
+ * unless the handler name is registered again.
+ *
+ * See also webkit_user_content_manager_register_script_message_handler_in_world().
+ *
+ * Since: 2.22
+ */
 WEBKIT_API void
 webkit_user_content_manager_unregister_script_message_handler_in_world (WebKitUserContentManager *manager,
                                                                         const gchar              *name,
                                                                         const gchar              *world_name);
+#endif
 
 WEBKIT_API void
 webkit_user_content_manager_add_script                                 (WebKitUserContentManager *manager,

--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -781,7 +781,11 @@ static void activate(GApplication *application, WebKitSettings *webkitSettings)
     webkit_web_context_register_uri_scheme(webContext, BROWSER_ABOUT_SCHEME, (WebKitURISchemeRequestCallback)aboutURISchemeRequestCallback, NULL, NULL);
 
     WebKitUserContentManager *userContentManager = webkit_user_content_manager_new();
+#if GTK_CHECK_VERSION(3, 98, 0)
+    webkit_user_content_manager_register_script_message_handler(userContentManager, "aboutData", NULL);
+#else
     webkit_user_content_manager_register_script_message_handler(userContentManager, "aboutData");
+#endif
     WebKitWebsiteDataManager *dataManager;
 #if GTK_CHECK_VERSION(3, 98, 0)
     dataManager = webkit_network_session_get_website_data_manager(networkSession);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp
@@ -63,7 +63,11 @@ public:
 
     ConsoleMessageTest()
     {
+#if !ENABLE(2022_GLIB_API)
         webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "console");
+#else
+        webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "console", nullptr);
+#endif
         g_signal_connect(m_userContentManager.get(), "script-message-received::console", G_CALLBACK(consoleMessageReceivedCallback), this);
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp
@@ -275,13 +275,21 @@ public:
         webkit_web_view_set_input_method_context(m_webView, WEBKIT_INPUT_METHOD_CONTEXT(m_context.get()));
         g_assert_true(webkit_web_view_get_input_method_context(m_webView) == WEBKIT_INPUT_METHOD_CONTEXT(m_context.get()));
 
+#if !ENABLE(2022_GLIB_API)
         webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "imEvent");
+#else
+        webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "imEvent", nullptr);
+#endif
         g_signal_connect(m_userContentManager.get(), "script-message-received::imEvent", G_CALLBACK(imEventCallback), this);
     }
 
     ~InputMethodTest()
     {
+#if !ENABLE(2022_GLIB_API)
         webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), "imEvent");
+#else
+        webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), "imEvent", nullptr);
+#endif
         g_signal_handlers_disconnect_by_data(m_userContentManager.get(), this);
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestSSL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestSSL.cpp
@@ -446,13 +446,21 @@ public:
 
     WebSocketTest()
     {
+#if !ENABLE(2022_GLIB_API)
         webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "event");
+#else
+        webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "event", nullptr);
+#endif
         g_signal_connect(m_userContentManager.get(), "script-message-received::event", G_CALLBACK(webSocketTestResultCallback), this);
     }
 
     virtual ~WebSocketTest()
     {
+#if !ENABLE(2022_GLIB_API)
         webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), "event");
+#else
+        webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), "event", nullptr);
+#endif
         g_signal_handlers_disconnect_by_data(m_userContentManager.get(), this);
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp
@@ -350,8 +350,13 @@ public:
         g_signal_connect(m_webView, "mouse-target-changed", G_CALLBACK(mouseTargetChanged), this);
         g_signal_connect(m_webView, "permission-request", G_CALLBACK(permissionRequested), this);
         g_signal_connect(m_webView, "query-permission-state", G_CALLBACK(queryPermissionStateCallback), this);
+#if !ENABLE(2022_GLIB_API)
         webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "permission");
         webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "queryPermission");
+#else
+        webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "permission", nullptr);
+        webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "queryPermission", nullptr);
+#endif
         g_signal_connect(m_userContentManager.get(), "script-message-received::permission", G_CALLBACK(permissionResultMessageReceivedCallback), this);
         g_signal_connect(m_userContentManager.get(), "script-message-received::queryPermission", G_CALLBACK(queryPermissionResultMessageReceivedCallback), this);
     }
@@ -360,8 +365,14 @@ public:
     {
         g_signal_handlers_disconnect_matched(m_webView, G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
         g_signal_handlers_disconnect_matched(m_userContentManager.get(), G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
+
+#if !ENABLE(2022_GLIB_API)
         webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), "permission");
         webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), "queryPermission");
+#else
+        webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), "permission", nullptr);
+        webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), "queryPermission", nullptr);
+#endif
     }
 
     static void tryWebViewCloseCallback(UIClientTest* test)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp
@@ -110,7 +110,11 @@ public:
         : LoadTrackingTest()
     {
         g_signal_connect(m_webView, "decide-policy", G_CALLBACK(decidePolicyCallback), this);
+#if !ENABLE(2022_GLIB_API)
         webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "testHandler");
+#else
+        webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "testHandler", nullptr);
+#endif
         g_signal_connect(m_userContentManager.get(), "script-message-received::testHandler", G_CALLBACK(testHandlerMessageReceivedCallback), this);
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp
@@ -281,14 +281,22 @@ public:
     {
         if (async)
             return webkit_user_content_manager_register_script_message_handler_with_reply(m_userContentManager.get(), handlerName, worldName);
+#if ENABLE(2022_GLIB_API)
+        return webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), handlerName, worldName);
+#else
         return worldName ? webkit_user_content_manager_register_script_message_handler_in_world(m_userContentManager.get(), handlerName, worldName)
             : webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), handlerName);
+#endif
     }
 
     void unregisterHandler(const char* handlerName, const char* worldName = nullptr)
     {
+#if !ENABLE(2022_GLIB_API)
         return worldName ? webkit_user_content_manager_unregister_script_message_handler_in_world(m_userContentManager.get(), handlerName, worldName)
             : webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), handlerName);
+#else
+        return webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), handlerName, worldName);
+#endif
     }
 
     static void scriptMessageReceived(WebKitUserContentManager* userContentManager, WebKitJavascriptResult* jsResult, UserScriptMessageTest* test)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp
@@ -644,7 +644,11 @@ static void testWebContextSecurityFileXHR(WebViewTest* test, gconstpointer)
     GUniquePtr<char> xhr(g_strdup_printf("var xhr = new XMLHttpRequest; xhr.open(\"GET\", \"%s\"); xhr.onreadystatechange = ()=> { if (xhr.readyState == 4) { setTimeout(() => { window.webkit.messageHandlers.xhr.postMessage('DONE'); }, 0)} }; xhr.onerror = () => { window.webkit.messageHandlers.xhr.postMessage('ERROR'); }; xhr.send();", jsonURL.get()));
 
     WebKitJavascriptResult* xhrMessage = nullptr;
+#if !ENABLE(2022_GLIB_API)
     webkit_user_content_manager_register_script_message_handler(test->m_userContentManager.get(), "xhr");
+#else
+    webkit_user_content_manager_register_script_message_handler(test->m_userContentManager.get(), "xhr", nullptr);
+#endif
     g_signal_connect(test->m_userContentManager.get(), "script-message-received::xhr", G_CALLBACK(xhrMessageReceivedCallback), &xhrMessage);
 
     auto waitUntilXHRDone = [&]() -> bool {
@@ -690,7 +694,11 @@ static void testWebContextSecurityFileXHR(WebViewTest* test, gconstpointer)
     g_assert_false(waitUntilXHRDone());
 
     g_signal_handlers_disconnect_matched(test->m_userContentManager.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, &xhrMessage);
+#if !ENABLE(2022_GLIB_API)
     webkit_user_content_manager_unregister_script_message_handler(test->m_userContentManager.get(), "xhr");
+#else
+    webkit_user_content_manager_unregister_script_message_handler(test->m_userContentManager.get(), "xhr", nullptr);
+#endif
 
     webkit_settings_set_allow_file_access_from_file_urls(webkit_web_view_get_settings(test->m_webView), FALSE);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
@@ -1328,7 +1328,11 @@ public:
         initializeWebView();
         g_signal_connect(m_webView, "permission-request", G_CALLBACK(permissionRequestCallback), this);
         g_signal_connect(m_webView, "show-notification", G_CALLBACK(showNotificationCallback), this);
+#if !ENABLE(2022_GLIB_API)
         webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "notifications");
+#else
+        webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "notifications", nullptr);
+#endif
         g_signal_connect(m_userContentManager.get(), "script-message-received::notifications", G_CALLBACK(notificationsMessageReceivedCallback), this);
     }
 
@@ -1336,7 +1340,12 @@ public:
     {
         g_signal_handlers_disconnect_matched(m_webView, G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
         g_signal_handlers_disconnect_matched(m_userContentManager.get(), G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
+
+#if !ENABLE(2022_GLIB_API)
         webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), "notifications");
+#else
+        webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), "notifications", nullptr);
+#endif
     }
 
     bool hasPermission()


### PR DESCRIPTION
#### 0e04927f8eba1d5140e63a9b88970e0b321c701b
<pre>
[GTK][WPE] Merge functions of registering and unregistering script message handler in WebKitUserContentManager API
<a href="https://bugs.webkit.org/show_bug.cgi?id=248748">https://bugs.webkit.org/show_bug.cgi?id=248748</a>

Reviewed by Carlos Garcia Campos.

For the new upcoming API (guarded with ENABLE_2022_GLIB_API),
replace webkit_user_content_manager_register_script_message_handler_in_world and
webkit_user_content_manager_register_script_message_handler
into a single function that always receives a script world
and NULL can be passed to use the default one, along with
their counterpart functions for unregistering the message handler.

* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp:
(webkit_user_content_manager_unregister_script_message_handler):
* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestSSL.cpp:
(WebSocketTest::~WebSocketTest):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp:
(UserScriptMessageTest::unregisterHandler):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp:
(testWebContextSecurityFileXHR):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp:

Canonical link: <a href="https://commits.webkit.org/260442@main">https://commits.webkit.org/260442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c851e2adca358a93d06a08533778635d1c72a791

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117429 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/116811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112198 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/18929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8683 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100530 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/114081 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/18929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97356 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/42082 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/96097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/29000 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/83765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10242 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30344 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7253 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49941 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12568 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3923 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->