### PR TITLE
Get VP9 extension support flag in WebProcess

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
@@ -52,6 +52,7 @@ std::optional<MediaCapabilitiesInfo> computeVPParameters(const VideoConfiguratio
 bool isVPSoftwareDecoderSmooth(const VideoConfiguration&);
 
 Ref<VideoInfo> createVideoInfoFromVP9HeaderParser(const vp9_parser::Vp9HeaderParser&, const webm::Element<webm::Colour>&);
+WEBCORE_EXPORT bool hasVP9ExtensionSupport();
 
 struct VP8FrameHeader {
     bool keyframe { false };

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -733,6 +733,15 @@ Ref<VideoInfo> createVideoInfoFromVP8Header(const VP8FrameHeader& header, const 
     return createVideoInfoFromVPCodecConfigurationRecord(record, header.width, header.height);
 }
 
+bool hasVP9ExtensionSupport()
+{
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/VP9UtilitiesCocoaAdditions.mm>
+#endif
+
+    return false;
+}
+
 }
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -288,6 +288,13 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
         hasVP9HardwareDecoder = WebCore::vp9HardwareDecoderAvailable();
         gpuProcess.send(Messages::GPUProcessProxy::SetHasVP9HardwareDecoder(hasVP9HardwareDecoder));
     }
+    bool hasVP9ExtensionSupport;
+    if (parameters.hasVP9ExtensionSupport)
+        hasVP9ExtensionSupport = *parameters.hasVP9ExtensionSupport;
+    else {
+        hasVP9ExtensionSupport = WebCore::hasVP9ExtensionSupport();
+        gpuProcess.send(Messages::GPUProcessProxy::SetHasVP9ExtensionSupport(hasVP9ExtensionSupport));
+    }
 #endif
 
     WebKit::GPUProcessConnectionInfo info {
@@ -295,7 +302,8 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
         gpuProcess.parentProcessConnection()->getAuditToken(),
 #endif
 #if ENABLE(VP9)
-        hasVP9HardwareDecoder
+        hasVP9HardwareDecoder,
+        hasVP9ExtensionSupport
 #endif
     };
     m_connection->send(Messages::GPUProcessConnection::DidInitialize(info), 0);

--- a/Source/WebKit/Shared/GPUProcessConnectionParameters.h
+++ b/Source/WebKit/Shared/GPUProcessConnectionParameters.h
@@ -45,6 +45,7 @@ struct GPUProcessConnectionParameters {
 #endif
 #if ENABLE(VP9)
     std::optional<bool> hasVP9HardwareDecoder;
+    std::optional<bool> hasVP9ExtensionSupport;
 #endif
 
     void encode(IPC::Encoder& encoder) const
@@ -60,6 +61,7 @@ struct GPUProcessConnectionParameters {
 #endif
 #if ENABLE(VP9)
         encoder << hasVP9HardwareDecoder;
+        encoder << hasVP9ExtensionSupport;
 #endif
     }
 
@@ -76,6 +78,7 @@ struct GPUProcessConnectionParameters {
 #endif
 #if ENABLE(VP9)
         auto hasVP9HardwareDecoder = decoder.decode<std::optional<bool>>();
+        auto hasVP9ExtensionSupport = decoder.decode<std::optional<bool>>();
 #endif
         if (!decoder.isValid())
             return std::nullopt;
@@ -92,6 +95,7 @@ struct GPUProcessConnectionParameters {
 #endif
 #if ENABLE(VP9)
             WTFMove(*hasVP9HardwareDecoder),
+            WTFMove(*hasVP9ExtensionSupport),
 #endif
         };
     }

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -393,12 +393,14 @@ void GPUProcessProxy::processWillShutDown(IPC::Connection& connection)
 
 #if ENABLE(VP9)
 std::optional<bool> GPUProcessProxy::s_hasVP9HardwareDecoder;
+std::optional<bool> GPUProcessProxy::s_hasVP9ExtensionSupport;
 #endif
 
 void GPUProcessProxy::createGPUProcessConnection(WebProcessProxy& webProcessProxy, IPC::Connection::Handle&& connectionIdentifier, GPUProcessConnectionParameters&& parameters)
 {
 #if ENABLE(VP9)
     parameters.hasVP9HardwareDecoder = s_hasVP9HardwareDecoder;
+    parameters.hasVP9ExtensionSupport = s_hasVP9ExtensionSupport;
 #endif
 
     if (auto* store = webProcessProxy.websiteDataStore())

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -154,7 +154,9 @@ private:
 
 #if ENABLE(VP9)
     void setHasVP9HardwareDecoder(bool hasVP9HardwareDecoder) { s_hasVP9HardwareDecoder = hasVP9HardwareDecoder; }
+    void setHasVP9ExtensionSupport(bool hasVP9ExtensionSupport) { s_hasVP9ExtensionSupport = hasVP9ExtensionSupport; }
 #endif
+
 #if ENABLE(MEDIA_STREAM) && PLATFORM(IOS_FAMILY)
     void statusBarWasTapped(CompletionHandler<void()>&&);
 #endif
@@ -180,6 +182,7 @@ private:
 #endif
 #if ENABLE(VP9)
     static std::optional<bool> s_hasVP9HardwareDecoder;
+    static std::optional<bool> s_hasVP9ExtensionSupport;
 #endif
 
     HashSet<PAL::SessionID> m_sessionIDs;

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
@@ -30,6 +30,7 @@ messages -> GPUProcessProxy {
 
 #if ENABLE(VP9)
     SetHasVP9HardwareDecoder(bool hasVP9HardwareDecoder)
+    SetHasVP9ExtensionSupport(bool hasVP9ExtensionSupport)
 #endif
 #if ENABLE(MEDIA_STREAM) && PLATFORM(IOS_FAMILY)
     StatusBarWasTapped() -> () Async

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -305,6 +305,7 @@ void GPUProcessConnection::didInitialize(std::optional<GPUProcessConnectionInfo>
     m_hasInitialized = true;
 #if ENABLE(VP9)
     m_hasVP9HardwareDecoder = info->hasVP9HardwareDecoder;
+    m_hasVP9ExtensionSupport = info->hasVP9ExtensionSupport;
 #endif
 }
 
@@ -384,6 +385,12 @@ bool GPUProcessConnection::hasVP9HardwareDecoder()
     return m_hasVP9HardwareDecoder;
 }
 
+bool GPUProcessConnection::hasVP9ExtensionSupport()
+{
+    if (!waitForDidInitialize())
+        return false;
+    return m_hasVP9ExtensionSupport;
+}
 #endif
 
 void GPUProcessConnection::updateMediaConfiguration()

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -95,6 +95,7 @@ public:
     bool isVP9DecoderEnabled() const { return m_enableVP9Decoder; }
     bool isVPSWDecoderEnabled() const { return m_enableVP9SWDecoder; }
     bool hasVP9HardwareDecoder();
+    bool hasVP9ExtensionSupport();
 #endif
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
@@ -158,6 +159,7 @@ private:
     bool m_enableVP9Decoder { false };
     bool m_enableVP9SWDecoder { false };
     bool m_hasVP9HardwareDecoder { false };
+    bool m_hasVP9ExtensionSupport { false };
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.h
@@ -38,6 +38,7 @@ struct GPUProcessConnectionInfo {
 #endif
 #if ENABLE(VP9)
     bool hasVP9HardwareDecoder { false };
+    bool hasVP9ExtensionSupport { false };
 #endif
 
     void encode(IPC::Encoder& encoder) const
@@ -47,6 +48,7 @@ struct GPUProcessConnectionInfo {
 #endif
 #if ENABLE(VP9)
         encoder << hasVP9HardwareDecoder;
+        encoder << hasVP9ExtensionSupport;
 #endif
     }
 
@@ -57,6 +59,7 @@ struct GPUProcessConnectionInfo {
 #endif
 #if ENABLE(VP9)
         auto hasVP9HardwareDecoder = decoder.decode<bool>();
+        auto hasVP9ExtensionSupport = decoder.decode<bool>();
 #endif
         if (!decoder.isValid())
             return std::nullopt;
@@ -66,6 +69,7 @@ struct GPUProcessConnectionInfo {
 #endif
 #if ENABLE(VP9)
             *hasVP9HardwareDecoder,
+            *hasVP9ExtensionSupport
 #endif
         };
     }

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -248,6 +248,7 @@ void LibWebRTCCodecs::setCallbacks(bool useGPUProcess, bool useRemoteFrames)
 
 #if ENABLE(VP9)
     WebProcess::singleton().libWebRTCCodecs().setVP9VTBSupport(WebProcess::singleton().ensureGPUProcessConnection().hasVP9HardwareDecoder());
+    WebProcess::singleton().libWebRTCCodecs().setHasVP9ExtensionSupport(WebProcess::singleton().ensureGPUProcessConnection().hasVP9ExtensionSupport());
 #endif
 
     webrtc::setVideoDecoderCallbacks(createVideoDecoder, releaseVideoDecoder, decodeVideoFrame, registerDecodeCompleteCallback);

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -146,6 +146,9 @@ public:
     bool supportVP9VTB() const { return m_supportVP9VTB; }
     void setLoggingLevel(WTFLogLevel);
 
+    void setHasVP9ExtensionSupport(bool hasVP9ExtensionSupport) { m_hasVP9ExtensionSupport = hasVP9ExtensionSupport; }
+    bool hasVP9ExtensionSupport() const { return m_hasVP9ExtensionSupport; }
+
 private:
     LibWebRTCCodecs();
     void ensureGPUProcessConnectionAndDispatchToThread(Function<void()>&&);
@@ -197,6 +200,7 @@ private:
     bool m_supportVP9VTB { false };
     std::optional<WTFLogLevel> m_loggingLevel;
     bool m_useRemoteFrames { false };
+    bool m_hasVP9ExtensionSupport { false };
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 3f3450975d6ad1a61091b64ac0facf8a18900865
<pre>
Get VP9 extension support flag in WebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=248757">https://bugs.webkit.org/show_bug.cgi?id=248757</a>
rdar://problem/102976372

Reviewed by Eric Carlson.

Pipe VP9 extension support flag from GPUProcess to WebProcess via UIProcess.

* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm:
(WebCore::hasVP9ExtensionSupport):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::m_routingArbitrator):
* Source/WebKit/Shared/GPUProcessConnectionParameters.h:
(WebKit::GPUProcessConnectionParameters::encode const):
(WebKit::GPUProcessConnectionParameters::decode):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::createGPUProcessConnection):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::didInitialize):
(WebKit::GPUProcessConnection::hasVP9ExtensionSupport):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
* Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.h:
(WebKit::GPUProcessConnectionInfo::encode const):
(WebKit::GPUProcessConnectionInfo::decode):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::setCallbacks):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
(WebKit::LibWebRTCCodecs::setHasVP9ExtensionSupport):
(WebKit::LibWebRTCCodecs::hasVP9ExtensionSupport const):

Canonical link: <a href="https://commits.webkit.org/257398@main">https://commits.webkit.org/257398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2fa7e4dfffbc16bed51ed61217acac30dc0a540

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108175 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168429 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85338 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91288 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106092 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33421 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76346 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1887 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22875 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1794 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45358 "Found 1 new test failure: media/video-inactive-playback.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5087 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42330 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->