### PR TITLE
Interaction regions are missing for some links

### DIFF
--- a/LayoutTests/interaction-region/event-region-overflow-expected.txt
+++ b/LayoutTests/interaction-region/event-region-overflow-expected.txt
@@ -1,46 +1,23 @@
+Hi
 (GraphicsLayer
-  (children 2
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
     (GraphicsLayer
-      (position 0.00 59.00)
-      (anchor 0.00 0.00)
-      (bounds 956.00 604.00)
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
       (backgroundColor #FFFFFF)
-    )
-    (GraphicsLayer
-      (position 0.00 59.00)
-      (anchor 0.00 0.00)
-      (bounds 956.00 663.00)
       (event region
-        (rect (0,0) width=956 height=663)
-      )
-      (children 1
-        (GraphicsLayer
-          (anchor 0.00 0.00)
-          (children 1
-            (GraphicsLayer
-              (anchor 0.00 0.00)
-              (bounds 956.00 604.00)
-              (children 1
-                (GraphicsLayer
-                  (bounds 956.00 604.00)
-                  (contentsOpaque 1)
-                  (drawsContent 1)
-                  (backgroundColor #FFFFFF)
-                  (event region
-                    (rect (0,0) width=956 height=604)
+        (rect (0,0) width=800 height=600)
 
-                  (interaction regions [
-                    (region 
-                        (rect (31,21) width=46 height=50)
+      (interaction regions [
+        (region
+            (rect (30,22) width=48 height=49)
 )
-                    (borderRadius 0.00)])
-                  )
-                )
-              )
-            )
-          )
-        )
+        (borderRadius 8.75)])
       )
     )
   )
 )
+

--- a/LayoutTests/interaction-region/inline-link-dark-background-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-dark-background-expected.txt
@@ -13,7 +13,7 @@ This is a link.
 
       (interaction regions [
         (region
-            (rect (-3,-3) width=35 height=24)
+            (rect (-3,-3) width=35 height=25)
 )
         (borderRadius 0.00)])
       )

--- a/LayoutTests/interaction-region/inline-link-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-expected.txt
@@ -13,7 +13,7 @@ This is a link.
 
       (interaction regions [
         (region
-            (rect (-3,-3) width=35 height=24)
+            (rect (-3,-3) width=35 height=25)
 )
         (borderRadius 0.00)])
       )

--- a/LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt
@@ -14,13 +14,13 @@ This is a link, outside the frame.
 
       (interaction regions [
         (region
-            (rect (-3,-3) width=35 height=24)
+            (rect (-3,-3) width=35 height=25)
 )
         (borderRadius 0.00)])
       )
       (children 1
         (GraphicsLayer
-          (position 0.00 18.00)
+          (position 0.00 20.00)
           (bounds 204.00 204.00)
           (drawsContent 1)
           (event region
@@ -28,7 +28,7 @@ This is a link, outside the frame.
 
           (interaction regions [
             (region
-                (rect (7,7) width=35 height=24)
+                (rect (7,7) width=35 height=25)
 )
             (borderRadius 0.00)])
           )

--- a/LayoutTests/interaction-region/inline-link-in-layer-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-layer-expected.txt
@@ -14,13 +14,13 @@ This is a link, inside the layer.
 
       (interaction regions [
         (region
-            (rect (-3,-3) width=35 height=24)
+            (rect (-3,-3) width=35 height=25)
 )
         (borderRadius 0.00)])
       )
       (children 1
         (GraphicsLayer
-          (position 0.00 18.00)
+          (position 0.00 20.00)
           (bounds 200.00 200.00)
           (drawsContent 1)
           (event region
@@ -28,7 +28,7 @@ This is a link, inside the layer.
 
           (interaction regions [
             (region
-                (rect (-3,-3) width=35 height=24)
+                (rect (-3,-3) width=35 height=25)
 )
             (borderRadius 0.00)])
           )

--- a/LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt
@@ -14,11 +14,11 @@ This is a link, outside the frame.
 
       (interaction regions [
         (region
-            (rect (7,25) width=35 height=24)
+            (rect (-3,-3) width=35 height=25)
 )
         (borderRadius 0.00),
         (region
-            (rect (-3,-3) width=35 height=24)
+            (rect (7,27) width=35 height=25)
 )
         (borderRadius 0.00)])
       )

--- a/LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt
@@ -1,6 +1,4 @@
-
-inner
-button
+Link Child Disabled Link
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -15,9 +13,9 @@ button
 
       (interaction regions [
         (region
-            (rect (1,4) width=57 height=28)
+            (rect (-3,-3) width=76 height=25)
 )
-        (borderRadius 14.00)])
+        (borderRadius 0.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/inline-link-with-pointer-events-none-content.html
+++ b/LayoutTests/interaction-region/inline-link-with-pointer-events-none-content.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+    a.disabled, a > * { pointer-events: none; }
+</style>
+<body>
+<a href="#"><span>Link Child</span></a>
+<a class="disabled" href="#"><span>Disabled Link</span></a>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/paused-video-regions-expected.txt
+++ b/LayoutTests/interaction-region/paused-video-regions-expected.txt
@@ -25,42 +25,44 @@
               )
               (children 1
                 (GraphicsLayer
-                  (position 176.00 144.00)
-                  (bounds 60.00 60.00)
-                  (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [-30.00 -30.00 0.00 1.00])
+                  (offsetFromRenderer width=-33 height=-33)
+                  (position 143.00 111.00)
+                  (bounds 136.00 136.00)
+                  (drawsContent 1)
+                  (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [-35.00 -35.00 0.00 1.00])
                   (event region
-                    (rect (15,0) width=30 height=5)
-                    (rect (5,5) width=50 height=10)
-                    (rect (5,15) width=55 height=1)
-                    (rect (0,16) width=60 height=28)
-                    (rect (0,44) width=55 height=1)
-                    (rect (5,45) width=50 height=10)
-                    (rect (16,55) width=29 height=5)
+                    (rect (51,33) width=34 height=5)
+                    (rect (38,38) width=60 height=13)
+                    (rect (33,51) width=70 height=34)
+                    (rect (38,85) width=60 height=13)
+                    (rect (51,98) width=34 height=5)
 
                   (interaction regions [
                     (region
-                        (rect (0,0) width=60 height=60)
+                        (rect (33,33) width=70 height=70)
 )
-                    (borderRadius 30.00)])
+                    (borderRadius 35.00)])
                   )
                   (children 3
                     (GraphicsLayer
-                      (bounds 60.00 60.00)
+                      (position 33.00 33.00)
+                      (bounds 70.00 70.00)
                       (drawsContent 1)
                     )
                     (GraphicsLayer
-                      (bounds 60.00 60.00)
+                      (position 33.00 33.00)
+                      (bounds 70.00 70.00)
                       (blendMode lighten)
                       (drawsContent 1)
                     )
                     (GraphicsLayer
-                      (position 3.00 0.00)
-                      (bounds 60.00 60.00)
-                      (blendMode plus-lighter)
+                      (position 36.00 33.00)
+                      (bounds 70.00 70.00)
+                      (contentsOpaque 1)
                       (transform [0.40 0.00 0.00 0.00] [0.00 0.40 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
                       (mask layer)
                         (GraphicsLayer
-                          (bounds 60.00 60.00)
+                          (bounds 70.00 70.00)
                           (drawsContent 1)
                         )
                     )

--- a/LayoutTests/interaction-region/region-area-overflow-does-not-crash-expected.txt
+++ b/LayoutTests/interaction-region/region-area-overflow-does-not-crash-expected.txt
@@ -1,14 +1,14 @@
  (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 135800.00 35017.00)
+  (bounds 135800.00 35018.00)
   (children 1
     (GraphicsLayer
-      (bounds 135800.00 35017.00)
+      (bounds 135800.00 35018.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=135800 height=35017)
+        (rect (0,0) width=135800 height=35018)
       )
     )
   )

--- a/LayoutTests/interaction-region/split-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/split-inline-link-expected.txt
@@ -14,10 +14,10 @@ short second line.
 
       (interaction regions [
         (region
-            (rect (197,-3) width=31 height=18)
-            (rect (-3,15) width=115 height=6)
-            (rect (197,15) width=31 height=6)
-            (rect (-3,21) width=115 height=18)
+            (rect (198,-3) width=31 height=20)
+            (rect (-3,17) width=115 height=5)
+            (rect (198,17) width=31 height=5)
+            (rect (-3,22) width=115 height=20)
 )
         (borderRadius 0.00)])
       )

--- a/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
@@ -16,7 +16,7 @@ Line
 
       (interaction regions [
         (region
-            (rect (-3,-3) width=36 height=78)
+            (rect (-3,-3) width=36 height=85)
 )
         (borderRadius 0.00)])
       )

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -130,6 +130,9 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
 
     auto& renderer = *element->renderer();
 
+    if (renderer.style().effectivePointerEvents() == PointerEvents::None)
+        return std::nullopt;
+
     // FIXME: Consider also allowing elements that only receive touch events.
     if (!renderer.style().eventListenerRegionTypes().contains(EventListenerRegionType::MouseClick))
         return std::nullopt;

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -159,6 +159,9 @@ bool EventRegion::operator==(const EventRegion& other) const
 
 void EventRegion::unite(const Region& region, const RenderStyle& style, bool overrideUserModifyIsEditable)
 {
+    if (style.effectivePointerEvents() == PointerEvents::None)
+        return;
+
     m_region.unite(region);
 
 #if ENABLE(TOUCH_ACTION_REGIONS)

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -101,7 +101,8 @@ void TextBoxPainter<TextBoxPath>::paint()
         return;
 
     if (m_paintInfo.phase == PaintPhase::EventRegion) {
-        if (m_renderer.parent()->visibleToHitTesting())
+        constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::IgnoreCSSPointerEventsProperty };
+        if (m_renderer.parent()->visibleToHitTesting(hitType))
             m_paintInfo.eventRegionContext->unite(enclosingIntRect(m_paintRect), const_cast<RenderText&>(m_renderer), m_style);
         return;
     }


### PR DESCRIPTION
#### f45d2e181f08e97b6132a19f81a3b1593c19bae0
<pre>
Interaction regions are missing for some links
<a href="https://bugs.webkit.org/show_bug.cgi?id=248761">https://bugs.webkit.org/show_bug.cgi?id=248761</a>
&lt;rdar://100575815&gt;

Reviewed by Tim Horton.

Properly detect inline links with `pointer-events: none` children when
building interaction regions.

* LayoutTests/interaction-region/event-region-overflow-expected.txt:
* LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt:
* LayoutTests/interaction-region/inline-link-dark-background-expected.txt:
* LayoutTests/interaction-region/inline-link-expected.txt:
* LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt:
* LayoutTests/interaction-region/inline-link-in-layer-expected.txt:
* LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt:
* LayoutTests/interaction-region/paused-video-regions-expected.txt:
* LayoutTests/interaction-region/region-area-overflow-does-not-crash-expected.txt:
* LayoutTests/interaction-region/split-inline-link-expected.txt:
* LayoutTests/interaction-region/wrapped-inline-link-expected.txt:
Update existing test expectations.

* LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt: Added.
* LayoutTests/interaction-region/inline-link-with-pointer-events-none-content.html: Added.
Add a test case.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Make sure the element we select can receive user interactions.

* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegion::unite):
Continue taking pointer-events into account for event regions.

* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paint):
Ignore the CSS pointer-events property to get a chance to find enclosing
links.

Canonical link: <a href="https://commits.webkit.org/257499@main">https://commits.webkit.org/257499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88d19497042fa482e6cac8bf85ee4812758819b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108523 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168765 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85684 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91637 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106460 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104866 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33739 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21638 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2225 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23155 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2117 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5157 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42632 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3534 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->