### PR TITLE
TransformOperation::OperationType enum should be an `enum class`

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -214,11 +214,11 @@ static RefPtr<ScaleTransformOperation> blendFunc(ScaleTransformOperation* from, 
         RefPtr<ScaleTransformOperation> normalizedFrom;
         RefPtr<ScaleTransformOperation> normalizedTo;
         if (from->is3DOperation() || to->is3DOperation()) {
-            normalizedFrom = ScaleTransformOperation::create(from->x(), from->y(), from->z(), TransformOperation::SCALE_3D);
-            normalizedTo = ScaleTransformOperation::create(to->x(), to->y(), to->z(), TransformOperation::SCALE_3D);
+            normalizedFrom = ScaleTransformOperation::create(from->x(), from->y(), from->z(), TransformOperation::Type::Scale3D);
+            normalizedTo = ScaleTransformOperation::create(to->x(), to->y(), to->z(), TransformOperation::Type::Scale3D);
         } else {
-            normalizedFrom = ScaleTransformOperation::create(from->x(), from->y(), TransformOperation::SCALE);
-            normalizedTo = ScaleTransformOperation::create(to->x(), to->y(), TransformOperation::SCALE);
+            normalizedFrom = ScaleTransformOperation::create(from->x(), from->y(), TransformOperation::Type::Scale);
+            normalizedTo = ScaleTransformOperation::create(to->x(), to->y(), TransformOperation::Type::Scale);
         }
         return blendFunc(normalizedFrom.get(), normalizedTo.get(), context);
     }
@@ -250,11 +250,11 @@ static RefPtr<RotateTransformOperation> blendFunc(RotateTransformOperation* from
         RefPtr<RotateTransformOperation> normalizedFrom;
         RefPtr<RotateTransformOperation> normalizedTo;
         if (from->is3DOperation() || to->is3DOperation()) {
-            normalizedFrom = RotateTransformOperation::create(from->x(), from->y(), from->z(), from->angle(), TransformOperation::ROTATE_3D);
-            normalizedTo = RotateTransformOperation::create(to->x(), to->y(), to->z(), to->angle(), TransformOperation::ROTATE_3D);
+            normalizedFrom = RotateTransformOperation::create(from->x(), from->y(), from->z(), from->angle(), TransformOperation::Type::Rotate3D);
+            normalizedTo = RotateTransformOperation::create(to->x(), to->y(), to->z(), to->angle(), TransformOperation::Type::Rotate3D);
         } else {
-            normalizedFrom = RotateTransformOperation::create(from->angle(), TransformOperation::ROTATE);
-            normalizedTo = RotateTransformOperation::create(to->angle(), TransformOperation::ROTATE);
+            normalizedFrom = RotateTransformOperation::create(from->angle(), TransformOperation::Type::Rotate);
+            normalizedTo = RotateTransformOperation::create(to->angle(), TransformOperation::Type::Rotate);
         }
         return blendFunc(normalizedFrom.get(), normalizedTo.get(), context);
     }
@@ -286,11 +286,11 @@ static RefPtr<TranslateTransformOperation> blendFunc(TranslateTransformOperation
         RefPtr<TranslateTransformOperation> normalizedFrom;
         RefPtr<TranslateTransformOperation> normalizedTo;
         if (from->is3DOperation() || to->is3DOperation()) {
-            normalizedFrom = TranslateTransformOperation::create(from->x(), from->y(), from->z(), TransformOperation::TRANSLATE_3D);
-            normalizedTo = TranslateTransformOperation::create(to->x(), to->y(), to->z(), TransformOperation::TRANSLATE_3D);
+            normalizedFrom = TranslateTransformOperation::create(from->x(), from->y(), from->z(), TransformOperation::Type::Translate3D);
+            normalizedTo = TranslateTransformOperation::create(to->x(), to->y(), to->z(), TransformOperation::Type::Translate3D);
         } else {
-            normalizedFrom = TranslateTransformOperation::create(from->x(), from->y(), TransformOperation::TRANSLATE);
-            normalizedTo = TranslateTransformOperation::create(to->x(), to->y(), TransformOperation::TRANSLATE);
+            normalizedFrom = TranslateTransformOperation::create(from->x(), from->y(), TransformOperation::Type::Translate);
+            normalizedTo = TranslateTransformOperation::create(to->x(), to->y(), TransformOperation::Type::Translate);
         }
         return blendFunc(normalizedFrom.get(), normalizedTo.get(), context);
     }

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2042,7 +2042,7 @@ bool KeyframeEffect::computeExtentOfTransformAnimation(LayoutRect& bounds) const
 static bool containsRotation(const Vector<RefPtr<TransformOperation>>& operations)
 {
     for (const auto& operation : operations) {
-        if (operation->type() == TransformOperation::ROTATE)
+        if (operation->type() == TransformOperation::Type::Rotate)
             return true;
     }
     return false;
@@ -2061,7 +2061,7 @@ bool KeyframeEffect::computeTransformedExtentViaTransformList(const FloatRect& r
     }
 
     for (const auto& operation : style.transform().operations()) {
-        if (operation->type() == TransformOperation::ROTATE) {
+        if (operation->type() == TransformOperation::Type::Rotate) {
             // For now, just treat this as a full rotation. This could take angle into account to reduce inflation.
             floatBounds = boundsOfRotatingRect(floatBounds);
         } else {
@@ -2070,7 +2070,7 @@ bool KeyframeEffect::computeTransformedExtentViaTransformList(const FloatRect& r
             if (!transform.isAffine())
                 return false;
 
-            if (operation->type() == TransformOperation::MATRIX || operation->type() == TransformOperation::MATRIX_3D) {
+            if (operation->type() == TransformOperation::Type::Matrix || operation->type() == TransformOperation::Type::Matrix3D) {
                 TransformationMatrix::Decomposed2Type toDecomp;
                 transform.decompose2(toDecomp);
                 // Any rotation prevents us from using a simple start/end rect union.

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -771,20 +771,20 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
 
         switch (type) {
         // translate
-        case TransformOperation::TRANSLATE_X:
+        case TransformOperation::Type::TranslateX:
             functionValue = CSSFunctionValue::create(CSSValueTranslateX);
             functionValue->append(translateLengthAsCSSValue(downcast<TranslateTransformOperation>(*operation).x()));
             break;
-        case TransformOperation::TRANSLATE_Y:
+        case TransformOperation::Type::TranslateY:
             functionValue = CSSFunctionValue::create(CSSValueTranslateY);
             functionValue->append(translateLengthAsCSSValue(downcast<TranslateTransformOperation>(*operation).y()));
             break;
-        case TransformOperation::TRANSLATE_Z:
+        case TransformOperation::Type::TranslateZ:
             functionValue = CSSFunctionValue::create(CSSValueTranslateZ);
             functionValue->append(translateLengthAsCSSValue(downcast<TranslateTransformOperation>(*operation).z()));
             break;
-        case TransformOperation::TRANSLATE:
-        case TransformOperation::TRANSLATE_3D: {
+        case TransformOperation::Type::Translate:
+        case TransformOperation::Type::Translate3D: {
             auto& translate = downcast<TranslateTransformOperation>(*operation);
             auto is3D = translate.is3DOperation();
             functionValue = CSSFunctionValue::create(is3D ? CSSValueTranslate3d : CSSValueTranslate);
@@ -796,20 +796,20 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
             break;
         }
         // scale
-        case TransformOperation::SCALE_X:
+        case TransformOperation::Type::ScaleX:
             functionValue = CSSFunctionValue::create(CSSValueScaleX);
             functionValue->append(cssValuePool.createValue(downcast<ScaleTransformOperation>(*operation).x(), CSSUnitType::CSS_NUMBER));
             break;
-        case TransformOperation::SCALE_Y:
+        case TransformOperation::Type::ScaleY:
             functionValue = CSSFunctionValue::create(CSSValueScaleY);
             functionValue->append(cssValuePool.createValue(downcast<ScaleTransformOperation>(*operation).y(), CSSUnitType::CSS_NUMBER));
             break;
-        case TransformOperation::SCALE_Z:
+        case TransformOperation::Type::ScaleZ:
             functionValue = CSSFunctionValue::create(CSSValueScaleZ);
             functionValue->append(cssValuePool.createValue(downcast<ScaleTransformOperation>(*operation).z(), CSSUnitType::CSS_NUMBER));
             break;
-        case TransformOperation::SCALE:
-        case TransformOperation::SCALE_3D: {
+        case TransformOperation::Type::Scale:
+        case TransformOperation::Type::Scale3D: {
             auto& scale = downcast<ScaleTransformOperation>(*operation);
             auto is3D = scale.is3DOperation();
             functionValue = CSSFunctionValue::create(is3D ? CSSValueScale3d : CSSValueScale);
@@ -821,25 +821,25 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
             break;
         }
         // rotate
-        case TransformOperation::ROTATE_X:
+        case TransformOperation::Type::RotateX:
             functionValue = CSSFunctionValue::create(CSSValueRotateX);
             functionValue->append(cssValuePool.createValue(downcast<RotateTransformOperation>(*operation).angle(), CSSUnitType::CSS_DEG));
             break;
-        case TransformOperation::ROTATE_Y:
+        case TransformOperation::Type::RotateY:
             functionValue = CSSFunctionValue::create(CSSValueRotateX);
             functionValue->append(cssValuePool.createValue(downcast<RotateTransformOperation>(*operation).angle(), CSSUnitType::CSS_DEG));
             break;
-        case TransformOperation::ROTATE_Z:
+        case TransformOperation::Type::RotateZ:
             functionValue = CSSFunctionValue::create(CSSValueRotateZ);
             functionValue->append(cssValuePool.createValue(downcast<RotateTransformOperation>(*operation).angle(), CSSUnitType::CSS_DEG));
             break;
-        case TransformOperation::ROTATE: {
+        case TransformOperation::Type::Rotate: {
             auto& rotate = downcast<RotateTransformOperation>(*operation);
             functionValue = CSSFunctionValue::create(CSSValueRotate);
             functionValue->append(cssValuePool.createValue(rotate.angle(), CSSUnitType::CSS_DEG));
             break;
         }
-        case TransformOperation::ROTATE_3D: {
+        case TransformOperation::Type::Rotate3D: {
             auto& rotate = downcast<RotateTransformOperation>(*operation);
             functionValue = CSSFunctionValue::create(CSSValueRotate3d);
             functionValue->append(cssValuePool.createValue(rotate.x(), CSSUnitType::CSS_NUMBER));
@@ -849,15 +849,15 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
             break;
         }
         // skew
-        case TransformOperation::SKEW_X:
+        case TransformOperation::Type::SkewX:
             functionValue = CSSFunctionValue::create(CSSValueSkewX);
             functionValue->append(cssValuePool.createValue(downcast<SkewTransformOperation>(*operation).angleX(), CSSUnitType::CSS_DEG));
             break;
-        case TransformOperation::SKEW_Y:
+        case TransformOperation::Type::SkewY:
             functionValue = CSSFunctionValue::create(CSSValueSkewX);
             functionValue->append(cssValuePool.createValue(downcast<SkewTransformOperation>(*operation).angleY(), CSSUnitType::CSS_DEG));
             break;
-        case TransformOperation::SKEW: {
+        case TransformOperation::Type::Skew: {
             auto& skew = downcast<SkewTransformOperation>(*operation);
             functionValue = CSSFunctionValue::create(CSSValueSkew);
             functionValue->append(cssValuePool.createValue(skew.angleX(), CSSUnitType::CSS_DEG));
@@ -866,7 +866,7 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
             break;
         }
         // perspective
-        case TransformOperation::PERSPECTIVE:
+        case TransformOperation::Type::Perspective:
             functionValue = CSSFunctionValue::create(CSSValuePerspective);
             if (auto perspective = downcast<PerspectiveTransformOperation>(*operation).perspective())
                 functionValue->append(zoomAdjustedPixelValueForLength(*perspective, style));
@@ -874,15 +874,15 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
                 functionValue->append(cssValuePool.createIdentifierValue(CSSValueNone));
             break;
         // matrix
-        case TransformOperation::MATRIX:
-        case TransformOperation::MATRIX_3D: {
+        case TransformOperation::Type::Matrix:
+        case TransformOperation::Type::Matrix3D: {
             TransformationMatrix transform;
             operation->apply(transform, { });
             functionValue = matrixTransformValue(transform, style);
             break;
         }
-        case TransformOperation::IDENTITY:
-        case TransformOperation::NONE:
+        case TransformOperation::Type::Identity:
+        case TransformOperation::Type::None:
             continue;
         }
 

--- a/Source/WebCore/css/TransformFunctions.cpp
+++ b/Source/WebCore/css/TransformFunctions.cpp
@@ -46,55 +46,55 @@
 
 namespace WebCore {
 
-static TransformOperation::OperationType transformOperationType(CSSValueID type)
+static TransformOperation::Type transformOperationType(CSSValueID type)
 {
     switch (type) {
     case CSSValueScale:
-        return TransformOperation::SCALE;
+        return TransformOperation::Type::Scale;
     case CSSValueScaleX:
-        return TransformOperation::SCALE_X;
+        return TransformOperation::Type::ScaleX;
     case CSSValueScaleY:
-        return TransformOperation::SCALE_Y;
+        return TransformOperation::Type::ScaleY;
     case CSSValueScaleZ:
-        return TransformOperation::SCALE_Z;
+        return TransformOperation::Type::ScaleZ;
     case CSSValueScale3d:
-        return TransformOperation::SCALE_3D;
+        return TransformOperation::Type::Scale3D;
     case CSSValueTranslate:
-        return TransformOperation::TRANSLATE;
+        return TransformOperation::Type::Translate;
     case CSSValueTranslateX:
-        return TransformOperation::TRANSLATE_X;
+        return TransformOperation::Type::TranslateX;
     case CSSValueTranslateY:
-        return TransformOperation::TRANSLATE_Y;
+        return TransformOperation::Type::TranslateY;
     case CSSValueTranslateZ:
-        return TransformOperation::TRANSLATE_Z;
+        return TransformOperation::Type::TranslateZ;
     case CSSValueTranslate3d:
-        return TransformOperation::TRANSLATE_3D;
+        return TransformOperation::Type::Translate3D;
     case CSSValueRotate:
-        return TransformOperation::ROTATE;
+        return TransformOperation::Type::Rotate;
     case CSSValueRotateX:
-        return TransformOperation::ROTATE_X;
+        return TransformOperation::Type::RotateX;
     case CSSValueRotateY:
-        return TransformOperation::ROTATE_Y;
+        return TransformOperation::Type::RotateY;
     case CSSValueRotateZ:
-        return TransformOperation::ROTATE_Z;
+        return TransformOperation::Type::RotateZ;
     case CSSValueRotate3d:
-        return TransformOperation::ROTATE_3D;
+        return TransformOperation::Type::Rotate3D;
     case CSSValueSkew:
-        return TransformOperation::SKEW;
+        return TransformOperation::Type::Skew;
     case CSSValueSkewX:
-        return TransformOperation::SKEW_X;
+        return TransformOperation::Type::SkewX;
     case CSSValueSkewY:
-        return TransformOperation::SKEW_Y;
+        return TransformOperation::Type::SkewY;
     case CSSValueMatrix:
-        return TransformOperation::MATRIX;
+        return TransformOperation::Type::Matrix;
     case CSSValueMatrix3d:
-        return TransformOperation::MATRIX_3D;
+        return TransformOperation::Type::Matrix3D;
     case CSSValuePerspective:
-        return TransformOperation::PERSPECTIVE;
+        return TransformOperation::Type::Perspective;
     default:
         break;
     }
-    return TransformOperation::NONE;
+    return TransformOperation::Type::None;
 }
 
 Length convertToFloatLength(const CSSPrimitiveValue* primitiveValue, const CSSToLengthConversionData& conversionData)
@@ -363,7 +363,7 @@ RefPtr<TranslateTransformOperation> translateForValue(const CSSValue& value, con
     if (!valueList.length())
         return nullptr;
 
-    auto type = TransformOperation::TRANSLATE;
+    auto type = TransformOperation::Type::Translate;
     Length tx = Length(0, LengthType::Fixed);
     Length ty = Length(0, LengthType::Fixed);
     Length tz = Length(0, LengthType::Fixed);
@@ -376,7 +376,7 @@ RefPtr<TranslateTransformOperation> translateForValue(const CSSValue& value, con
         else if (i == 1)
             ty = convertToFloatLength(downcast<CSSPrimitiveValue>(valueItem), conversionData);
         else if (i == 2) {
-            type = TransformOperation::TRANSLATE_3D;
+            type = TransformOperation::Type::Translate3D;
             tz = convertToFloatLength(downcast<CSSPrimitiveValue>(valueItem), conversionData);
         }
     }
@@ -393,7 +393,7 @@ RefPtr<ScaleTransformOperation> scaleForValue(const CSSValue& value)
     if (!valueList.length())
         return nullptr;
 
-    auto type = TransformOperation::SCALE;
+    auto type = TransformOperation::Type::Scale;
     double sx = 1.0;
     double sy = 1.0;
     double sz = 1.0;
@@ -407,7 +407,7 @@ RefPtr<ScaleTransformOperation> scaleForValue(const CSSValue& value)
         } else if (i == 1)
             sy = downcast<CSSPrimitiveValue>(*valueItem).doubleValueDividingBy100IfPercentage();
         else if (i == 2) {
-            type = TransformOperation::SCALE_3D;
+            type = TransformOperation::Type::Scale3D;
             sz = downcast<CSSPrimitiveValue>(*valueItem).doubleValueDividingBy100IfPercentage();
         }
     }
@@ -437,12 +437,12 @@ RefPtr<RotateTransformOperation> rotateForValue(const CSSValue& value)
     auto angle = downcast<CSSPrimitiveValue>(*lastValue).computeDegrees();
 
     if (numberOfItems == 1)
-        return RotateTransformOperation::create(angle, TransformOperation::ROTATE);
+        return RotateTransformOperation::create(angle, TransformOperation::Type::Rotate);
 
     double x = 0.0;
     double y = 0.0;
     double z = 0.0;
-    auto type = TransformOperation::ROTATE;
+    auto type = TransformOperation::Type::Rotate;
 
     if (numberOfItems == 2) {
         // An axis identifier was specified.
@@ -451,19 +451,19 @@ RefPtr<RotateTransformOperation> rotateForValue(const CSSValue& value)
             return nullptr;
         auto axisIdentifier = downcast<CSSPrimitiveValue>(*axisIdentifierItem).valueID();
         if (axisIdentifier == CSSValueX) {
-            type = TransformOperation::ROTATE_X;
+            type = TransformOperation::Type::RotateX;
             x = 1.0;
         } else if (axisIdentifier == CSSValueY) {
-            type = TransformOperation::ROTATE_Y;
+            type = TransformOperation::Type::RotateY;
             y = 1.0;
         } else if (axisIdentifier == CSSValueZ) {
-            type = TransformOperation::ROTATE_3D;
+            type = TransformOperation::Type::Rotate3D;
             z = 1.0;
         } else
             return nullptr;
     } else if (numberOfItems == 4) {
         // The axis was specified using a vector.
-        type = TransformOperation::ROTATE;
+        type = TransformOperation::Type::Rotate;
         for (unsigned i = 0; i < 3; ++i) {
             auto* valueItem = valueList.itemWithoutBoundsCheck(i);
             if (!is<CSSPrimitiveValue>(valueItem))
@@ -473,7 +473,7 @@ RefPtr<RotateTransformOperation> rotateForValue(const CSSValue& value)
             else if (i == 1)
                 y = downcast<CSSPrimitiveValue>(*valueItem).doubleValue();
             else if (i == 2) {
-                type = TransformOperation::ROTATE_3D;
+                type = TransformOperation::Type::Rotate3D;
                 z = downcast<CSSPrimitiveValue>(*valueItem).doubleValue();
             }
         }

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -108,66 +108,66 @@ static const unsigned cMaxScaledTiledLayerMemorySize = 1024 * 1024 * 156;
 // of 250ms. So send a very small value instead.
 static const float cAnimationAlmostZeroDuration = 1e-3f;
 
-static bool isTransformTypeTransformationMatrix(TransformOperation::OperationType transformType)
+static bool isTransformTypeTransformationMatrix(TransformOperation::Type transformType)
 {
     switch (transformType) {
-    case TransformOperation::SKEW_X:
-    case TransformOperation::SKEW_Y:
-    case TransformOperation::SKEW:
-    case TransformOperation::MATRIX:
-    case TransformOperation::ROTATE_3D:
-    case TransformOperation::MATRIX_3D:
-    case TransformOperation::PERSPECTIVE:
-    case TransformOperation::IDENTITY:
-    case TransformOperation::NONE:
+    case TransformOperation::Type::SkewX:
+    case TransformOperation::Type::SkewY:
+    case TransformOperation::Type::Skew:
+    case TransformOperation::Type::Matrix:
+    case TransformOperation::Type::Rotate3D:
+    case TransformOperation::Type::Matrix3D:
+    case TransformOperation::Type::Perspective:
+    case TransformOperation::Type::Identity:
+    case TransformOperation::Type::None:
         return true;
     default:
         return false;
     }
 }
 
-static bool isTransformTypeFloatPoint3D(TransformOperation::OperationType transformType)
+static bool isTransformTypeFloatPoint3D(TransformOperation::Type transformType)
 {
     switch (transformType) {
-    case TransformOperation::SCALE:
-    case TransformOperation::SCALE_3D:
-    case TransformOperation::TRANSLATE:
-    case TransformOperation::TRANSLATE_3D:
+    case TransformOperation::Type::Scale:
+    case TransformOperation::Type::Scale3D:
+    case TransformOperation::Type::Translate:
+    case TransformOperation::Type::Translate3D:
         return true;
     default:
         return false;
     }
 }
 
-static bool isTransformTypeNumber(TransformOperation::OperationType transformType)
+static bool isTransformTypeNumber(TransformOperation::Type transformType)
 {
     return !isTransformTypeTransformationMatrix(transformType) && !isTransformTypeFloatPoint3D(transformType);
 }
 
-static void getTransformFunctionValue(const TransformOperation* transformOp, TransformOperation::OperationType transformType, const FloatSize& size, float& value)
+static void getTransformFunctionValue(const TransformOperation* transformOp, TransformOperation::Type transformType, const FloatSize& size, float& value)
 {
     switch (transformType) {
-    case TransformOperation::ROTATE:
-    case TransformOperation::ROTATE_X:
-    case TransformOperation::ROTATE_Y:
+    case TransformOperation::Type::Rotate:
+    case TransformOperation::Type::RotateX:
+    case TransformOperation::Type::RotateY:
         value = transformOp ? narrowPrecisionToFloat(deg2rad(downcast<RotateTransformOperation>(*transformOp).angle())) : 0;
         break;
-    case TransformOperation::SCALE_X:
+    case TransformOperation::Type::ScaleX:
         value = transformOp ? narrowPrecisionToFloat(downcast<ScaleTransformOperation>(*transformOp).x()) : 1;
         break;
-    case TransformOperation::SCALE_Y:
+    case TransformOperation::Type::ScaleY:
         value = transformOp ? narrowPrecisionToFloat(downcast<ScaleTransformOperation>(*transformOp).y()) : 1;
         break;
-    case TransformOperation::SCALE_Z:
+    case TransformOperation::Type::ScaleZ:
         value = transformOp ? narrowPrecisionToFloat(downcast<ScaleTransformOperation>(*transformOp).z()) : 1;
         break;
-    case TransformOperation::TRANSLATE_X:
+    case TransformOperation::Type::TranslateX:
         value = transformOp ? downcast<TranslateTransformOperation>(*transformOp).xAsFloat(size) : 0;
         break;
-    case TransformOperation::TRANSLATE_Y:
+    case TransformOperation::Type::TranslateY:
         value = transformOp ? downcast<TranslateTransformOperation>(*transformOp).yAsFloat(size) : 0;
         break;
-    case TransformOperation::TRANSLATE_Z:
+    case TransformOperation::Type::TranslateZ:
         value = transformOp ? downcast<TranslateTransformOperation>(*transformOp).zAsFloat() : 0;
         break;
     default:
@@ -175,19 +175,19 @@ static void getTransformFunctionValue(const TransformOperation* transformOp, Tra
     }
 }
 
-static void getTransformFunctionValue(const TransformOperation* transformOp, TransformOperation::OperationType transformType, const FloatSize& size, FloatPoint3D& value)
+static void getTransformFunctionValue(const TransformOperation* transformOp, TransformOperation::Type transformType, const FloatSize& size, FloatPoint3D& value)
 {
     switch (transformType) {
-    case TransformOperation::SCALE:
-    case TransformOperation::SCALE_3D: {
+    case TransformOperation::Type::Scale:
+    case TransformOperation::Type::Scale3D: {
         const auto* scaleTransformOp = downcast<ScaleTransformOperation>(transformOp);
         value.setX(scaleTransformOp ? narrowPrecisionToFloat(scaleTransformOp->x()) : 1);
         value.setY(scaleTransformOp ? narrowPrecisionToFloat(scaleTransformOp->y()) : 1);
         value.setZ(scaleTransformOp ? narrowPrecisionToFloat(scaleTransformOp->z()) : 1);
         break;
     }
-    case TransformOperation::TRANSLATE:
-    case TransformOperation::TRANSLATE_3D: {
+    case TransformOperation::Type::Translate:
+    case TransformOperation::Type::Translate3D: {
         const auto* translateTransformOp = downcast<TranslateTransformOperation>(transformOp);
         value.setX(translateTransformOp ? translateTransformOp->xAsFloat(size) : 0);
         value.setY(translateTransformOp ? translateTransformOp->yAsFloat(size) : 0);
@@ -199,18 +199,18 @@ static void getTransformFunctionValue(const TransformOperation* transformOp, Tra
     }
 }
 
-static void getTransformFunctionValue(const TransformOperation* transformOp, TransformOperation::OperationType transformType, const FloatSize& size, TransformationMatrix& value)
+static void getTransformFunctionValue(const TransformOperation* transformOp, TransformOperation::Type transformType, const FloatSize& size, TransformationMatrix& value)
 {
     switch (transformType) {
-    case TransformOperation::SKEW_X:
-    case TransformOperation::SKEW_Y:
-    case TransformOperation::SKEW:
-    case TransformOperation::MATRIX:
-    case TransformOperation::ROTATE_3D:
-    case TransformOperation::MATRIX_3D:
-    case TransformOperation::PERSPECTIVE:
-    case TransformOperation::IDENTITY:
-    case TransformOperation::NONE:
+    case TransformOperation::Type::SkewX:
+    case TransformOperation::Type::SkewY:
+    case TransformOperation::Type::Skew:
+    case TransformOperation::Type::Matrix:
+    case TransformOperation::Type::Rotate3D:
+    case TransformOperation::Type::Matrix3D:
+    case TransformOperation::Type::Perspective:
+    case TransformOperation::Type::Identity:
+    case TransformOperation::Type::None:
         if (transformOp)
             transformOp->apply(value, size);
         else
@@ -221,33 +221,33 @@ static void getTransformFunctionValue(const TransformOperation* transformOp, Tra
     }
 }
 
-static PlatformCAAnimation::ValueFunctionType getValueFunctionNameForTransformOperation(TransformOperation::OperationType transformType)
+static PlatformCAAnimation::ValueFunctionType getValueFunctionNameForTransformOperation(TransformOperation::Type transformType)
 {
     // Use literal strings to avoid link-time dependency on those symbols.
     switch (transformType) {
-    case TransformOperation::ROTATE_X:
+    case TransformOperation::Type::RotateX:
         return PlatformCAAnimation::RotateX;
-    case TransformOperation::ROTATE_Y:
+    case TransformOperation::Type::RotateY:
         return PlatformCAAnimation::RotateY;
-    case TransformOperation::ROTATE:
+    case TransformOperation::Type::Rotate:
         return PlatformCAAnimation::RotateZ;
-    case TransformOperation::SCALE_X:
+    case TransformOperation::Type::ScaleX:
         return PlatformCAAnimation::ScaleX;
-    case TransformOperation::SCALE_Y:
+    case TransformOperation::Type::ScaleY:
         return PlatformCAAnimation::ScaleY;
-    case TransformOperation::SCALE_Z:
+    case TransformOperation::Type::ScaleZ:
         return PlatformCAAnimation::ScaleZ;
-    case TransformOperation::TRANSLATE_X:
+    case TransformOperation::Type::TranslateX:
         return PlatformCAAnimation::TranslateX;
-    case TransformOperation::TRANSLATE_Y:
+    case TransformOperation::Type::TranslateY:
         return PlatformCAAnimation::TranslateY;
-    case TransformOperation::TRANSLATE_Z:
+    case TransformOperation::Type::TranslateZ:
         return PlatformCAAnimation::TranslateZ;
-    case TransformOperation::SCALE:
-    case TransformOperation::SCALE_3D:
+    case TransformOperation::Type::Scale:
+    case TransformOperation::Type::Scale3D:
         return PlatformCAAnimation::Scale;
-    case TransformOperation::TRANSLATE:
-    case TransformOperation::TRANSLATE_3D:
+    case TransformOperation::Type::Translate:
+    case TransformOperation::Type::Translate3D:
         return PlatformCAAnimation::Translate;
     default:
         return PlatformCAAnimation::NoValueFunction;
@@ -3436,7 +3436,7 @@ bool GraphicsLayerCA::createAnimationFromKeyframes(const KeyframeValueList& valu
     return true;
 }
 
-bool GraphicsLayerCA::appendToUncommittedAnimations(const KeyframeValueList& valueList, TransformOperation::OperationType operationType, const Animation* animation, const String& animationName, const FloatSize& boxSize, unsigned animationIndex, Seconds timeOffset, bool isMatrixAnimation, bool keyframesShouldUseAnimationWideTimingFunction)
+bool GraphicsLayerCA::appendToUncommittedAnimations(const KeyframeValueList& valueList, TransformOperation::Type operationType, const Animation* animation, const String& animationName, const FloatSize& boxSize, unsigned animationIndex, Seconds timeOffset, bool isMatrixAnimation, bool keyframesShouldUseAnimationWideTimingFunction)
 {
     RefPtr<PlatformCAAnimation> caAnimation;
     bool validMatrices = true;
@@ -3473,7 +3473,7 @@ static bool hasBig3DRotation(const KeyframeValueList& valueList, const SharedPri
     const auto& primitives = prefix.primitives();
     for (unsigned animationIndex = 0; animationIndex < primitives.size(); ++animationIndex) {
         auto type = primitives[animationIndex];
-        if (type != TransformOperation::ROTATE_3D)
+        if (type != TransformOperation::Type::Rotate3D)
             continue;
         for (size_t i = 1; i < valueList.size(); ++i) {
             // Since the shared primitive at this index is a rotation, both of these transform
@@ -3496,7 +3496,7 @@ bool GraphicsLayerCA::createTransformAnimationsFromKeyframes(const KeyframeValue
     // https://www.w3.org/TR/css-transforms-1/#interpolation-of-transforms
     // In the CSS Transform Level 1 and 2 Specification some transform functions can share a compatible transform
     // function primitive. For instance, the shared primitive of a translateX and translate3D operation is
-    // TransformOperation::TRANSLATE_3D. When the transform function list of every keyframe in an animation
+    // TransformOperation::Type::Translate3D. When the transform function list of every keyframe in an animation
     // shares the same transform function primitive, we should interpolate between them without resorting
     // to matrix decomposition. The remaining parts of the transform function list should be interpolated
     // using matrix decomposition. The code below finds the shared primitives in this prefix.
@@ -3525,7 +3525,7 @@ bool GraphicsLayerCA::createTransformAnimationsFromKeyframes(const KeyframeValue
 
     // If there were any incompatible transform functions, they will be appended to the animation list
     // as a single combined transformation matrix animation.
-    return appendToUncommittedAnimations(valueList, TransformOperation::MATRIX_3D, animation, animationName, boxSize, primitives.size(), timeOffset, true /* isMatrixAnimation */, keyframesShouldUseAnimationWideTimingFunction);
+    return appendToUncommittedAnimations(valueList, TransformOperation::Type::Matrix3D, animation, animationName, boxSize, primitives.size(), timeOffset, true /* isMatrixAnimation */, keyframesShouldUseAnimationWideTimingFunction);
 }
 
 bool GraphicsLayerCA::appendToUncommittedAnimations(const KeyframeValueList& valueList, const FilterOperation* operation, const Animation* animation, const String& animationName, int animationIndex, Seconds timeOffset, bool keyframesShouldUseAnimationWideTimingFunction)
@@ -3731,7 +3731,7 @@ bool GraphicsLayerCA::setAnimationKeyframes(const KeyframeValueList& valueList, 
     return true;
 }
 
-bool GraphicsLayerCA::setTransformAnimationEndpoints(const KeyframeValueList& valueList, const Animation* animation, PlatformCAAnimation* basicAnim, int functionIndex, TransformOperation::OperationType transformOpType, bool isMatrixAnimation, const FloatSize& boxSize)
+bool GraphicsLayerCA::setTransformAnimationEndpoints(const KeyframeValueList& valueList, const Animation* animation, PlatformCAAnimation* basicAnim, int functionIndex, TransformOperation::Type transformOpType, bool isMatrixAnimation, const FloatSize& boxSize)
 {
     ASSERT(valueList.size() == 2);
 
@@ -3789,7 +3789,7 @@ bool GraphicsLayerCA::setTransformAnimationEndpoints(const KeyframeValueList& va
     return true;
 }
 
-bool GraphicsLayerCA::setTransformAnimationKeyframes(const KeyframeValueList& valueList, const Animation* animation, PlatformCAAnimation* keyframeAnim, int functionIndex, TransformOperation::OperationType transformOpType, bool isMatrixAnimation, const FloatSize& boxSize, bool keyframesShouldUseAnimationWideTimingFunction)
+bool GraphicsLayerCA::setTransformAnimationKeyframes(const KeyframeValueList& valueList, const Animation* animation, PlatformCAAnimation* keyframeAnim, int functionIndex, TransformOperation::Type transformOpType, bool isMatrixAnimation, const FloatSize& boxSize, bool keyframesShouldUseAnimationWideTimingFunction)
 {
     Vector<float> keyTimes;
     Vector<float> floatValues;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -285,8 +285,8 @@ private:
     bool setAnimationEndpoints(const KeyframeValueList&, const Animation*, PlatformCAAnimation*);
     bool setAnimationKeyframes(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, bool keyframesShouldUseAnimationWideTimingFunction);
 
-    bool setTransformAnimationEndpoints(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex, TransformOperation::OperationType, bool isMatrixAnimation, const FloatSize& boxSize);
-    bool setTransformAnimationKeyframes(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex, TransformOperation::OperationType, bool isMatrixAnimation, const FloatSize& boxSize, bool keyframesShouldUseAnimationWideTimingFunction);
+    bool setTransformAnimationEndpoints(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex, TransformOperation::Type, bool isMatrixAnimation, const FloatSize& boxSize);
+    bool setTransformAnimationKeyframes(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex, TransformOperation::Type, bool isMatrixAnimation, const FloatSize& boxSize, bool keyframesShouldUseAnimationWideTimingFunction);
     
     bool setFilterAnimationEndpoints(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex, int internalFilterPropertyIndex);
     bool setFilterAnimationKeyframes(const KeyframeValueList&, const Animation*, PlatformCAAnimation*, int functionIndex, int internalFilterPropertyIndex, FilterOperation::OperationType, bool keyframesShouldUseAnimationWideTimingFunction);
@@ -534,7 +534,7 @@ private:
         moveOrCopyAnimations(Copy, fromLayer, toLayer);
     }
 
-    bool appendToUncommittedAnimations(const KeyframeValueList&, const TransformOperation::OperationType, const Animation*, const String& animationName, const FloatSize& boxSize, unsigned animationIndex, Seconds timeOffset, bool isMatrixAnimation, bool keyframesShouldUseAnimationWideTimingFunction);
+    bool appendToUncommittedAnimations(const KeyframeValueList&, const TransformOperation::Type, const Animation*, const String& animationName, const FloatSize& boxSize, unsigned animationIndex, Seconds timeOffset, bool isMatrixAnimation, bool keyframesShouldUseAnimationWideTimingFunction);
     bool appendToUncommittedAnimations(const KeyframeValueList&, const FilterOperation*, const Animation*, const String& animationName, int animationIndex, Seconds timeOffset, bool keyframesShouldUseAnimationWideTimingFunction);
 
     enum LayerChange : uint64_t {

--- a/Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.h
@@ -64,11 +64,11 @@ private:
     void dump(WTF::TextStream&) const final;
 
     IdentityTransformOperation()
-        : TransformOperation(IDENTITY)
+        : TransformOperation(TransformOperation::Type::Identity)
     {
     }
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::IdentityTransformOperation, type() == WebCore::TransformOperation::IDENTITY)
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::IdentityTransformOperation, type() == WebCore::TransformOperation::Type::Identity)

--- a/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.h
@@ -66,7 +66,7 @@ private:
     void dump(WTF::TextStream&) const final;
 
     Matrix3DTransformOperation(const TransformationMatrix& mat)
-        : TransformOperation(MATRIX_3D)
+        : TransformOperation(TransformOperation::Type::Matrix3D)
         , m_matrix(mat)
     {
     }
@@ -76,4 +76,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::Matrix3DTransformOperation, type() == WebCore::TransformOperation::MATRIX_3D)
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::Matrix3DTransformOperation, type() == WebCore::TransformOperation::Type::Matrix3D)

--- a/Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.h
@@ -70,7 +70,7 @@ private:
     void dump(WTF::TextStream&) const final;
 
     MatrixTransformOperation(double a, double b, double c, double d, double e, double f)
-        : TransformOperation(MATRIX)
+        : TransformOperation(TransformOperation::Type::Matrix)
         , m_a(a)
         , m_b(b)
         , m_c(c)
@@ -81,7 +81,7 @@ private:
     }
 
     MatrixTransformOperation(const TransformationMatrix& t)
-        : TransformOperation(MATRIX)
+        : TransformOperation(TransformOperation::Type::Matrix)
         , m_a(t.a())
         , m_b(t.b())
         , m_c(t.c())
@@ -101,4 +101,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::MatrixTransformOperation, type() == WebCore::TransformOperation::MATRIX)
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::MatrixTransformOperation, type() == WebCore::TransformOperation::Type::Matrix)

--- a/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h
@@ -81,7 +81,7 @@ private:
     void dump(WTF::TextStream&) const final;
 
     PerspectiveTransformOperation(const std::optional<Length>& p)
-        : TransformOperation(PERSPECTIVE)
+        : TransformOperation(TransformOperation::Type::Perspective)
         , m_p(p)
     {
         ASSERT(!p || (*p).isFixed());
@@ -92,4 +92,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::PerspectiveTransformOperation, type() == WebCore::TransformOperation::PERSPECTIVE)
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::PerspectiveTransformOperation, type() == WebCore::TransformOperation::Type::Perspective)

--- a/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
@@ -112,7 +112,7 @@ Ref<TransformOperation> RotateTransformOperation::blend(const TransformOperation
         y = 0;
         z = 1;
     }
-    return RotateTransformOperation::create(x, y, z, angle, ROTATE_3D);
+    return RotateTransformOperation::create(x, y, z, angle, Type::Rotate3D);
 }
 
 void RotateTransformOperation::dump(TextStream& ts) const

--- a/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h
@@ -33,12 +33,12 @@ struct BlendingContext;
 
 class RotateTransformOperation final : public TransformOperation {
 public:
-    static Ref<RotateTransformOperation> create(double angle, OperationType type)
+    static Ref<RotateTransformOperation> create(double angle, TransformOperation::Type type)
     {
         return adoptRef(*new RotateTransformOperation(0, 0, 1, angle, type));
     }
 
-    static Ref<RotateTransformOperation> create(double x, double y, double z, double angle, OperationType type)
+    static Ref<RotateTransformOperation> create(double x, double y, double z, double angle, TransformOperation::Type type)
     {
         return adoptRef(*new RotateTransformOperation(x, y, z, angle, type));
     }
@@ -53,7 +53,7 @@ public:
     double z() const { return m_z; }
     double angle() const { return m_angle; }
 
-    OperationType primitiveType() const final { return type() == ROTATE ? ROTATE : ROTATE_3D; }
+    TransformOperation::Type primitiveType() const final { return type() == Type::Rotate ? Type::Rotate : Type::Rotate3D; }
 
     bool operator==(const RotateTransformOperation& other) const { return operator==(static_cast<const TransformOperation&>(other)); }
     bool operator==(const TransformOperation&) const override;
@@ -69,7 +69,7 @@ private:
 
     bool apply(TransformationMatrix& transform, const FloatSize& /*borderBoxSize*/) const override
     {
-        if (type() == TransformOperation::ROTATE)
+        if (type() == TransformOperation::Type::Rotate)
             transform.rotate(m_angle);
         else
             transform.rotate3d(m_x, m_y, m_z, m_angle);
@@ -78,7 +78,7 @@ private:
 
     void dump(WTF::TextStream&) const final;
 
-    RotateTransformOperation(double x, double y, double z, double angle, OperationType type)
+    RotateTransformOperation(double x, double y, double z, double angle, TransformOperation::Type type)
         : TransformOperation(type)
         , m_x(x)
         , m_y(y)

--- a/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h
@@ -33,12 +33,12 @@ struct BlendingContext;
 
 class ScaleTransformOperation final : public TransformOperation {
 public:
-    static Ref<ScaleTransformOperation> create(double sx, double sy, OperationType type)
+    static Ref<ScaleTransformOperation> create(double sx, double sy, TransformOperation::Type type)
     {
         return adoptRef(*new ScaleTransformOperation(sx, sy, 1, type));
     }
 
-    static Ref<ScaleTransformOperation> create(double sx, double sy, double sz, OperationType type)
+    static Ref<ScaleTransformOperation> create(double sx, double sy, double sz, TransformOperation::Type type)
     {
         return adoptRef(*new ScaleTransformOperation(sx, sy, sz, type));
     }
@@ -52,7 +52,7 @@ public:
     double y() const { return m_y; }
     double z() const { return m_z; }
 
-    OperationType primitiveType() const final { return (type() == SCALE_Z || type() == SCALE_3D) ? SCALE_3D : SCALE; }
+    TransformOperation::Type primitiveType() const final { return (type() == Type::ScaleZ || type() == Type::Scale3D) ? Type::Scale3D : Type::Scale; }
 
     bool operator==(const ScaleTransformOperation& other) const { return operator==(static_cast<const TransformOperation&>(other)); }
     bool operator==(const TransformOperation&) const final;
@@ -74,7 +74,7 @@ private:
 
     void dump(WTF::TextStream&) const final;
 
-    ScaleTransformOperation(double sx, double sy, double sz, OperationType type)
+    ScaleTransformOperation(double sx, double sy, double sz, TransformOperation::Type type)
         : TransformOperation(type)
         , m_x(sx)
         , m_y(sy)

--- a/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.h
@@ -33,7 +33,7 @@ struct BlendingContext;
 
 class SkewTransformOperation final : public TransformOperation {
 public:
-    static Ref<SkewTransformOperation> create(double angleX, double angleY, OperationType type)
+    static Ref<SkewTransformOperation> create(double angleX, double angleY, TransformOperation::Type type)
     {
         return adoptRef(*new SkewTransformOperation(angleX, angleY, type));
     }
@@ -63,7 +63,7 @@ private:
 
     void dump(WTF::TextStream&) const final;
     
-    SkewTransformOperation(double angleX, double angleY, OperationType type)
+    SkewTransformOperation(double angleX, double angleY, TransformOperation::Type type)
         : TransformOperation(type)
         , m_angleX(angleX)
         , m_angleY(angleY)

--- a/Source/WebCore/platform/graphics/transforms/TransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperation.cpp
@@ -36,32 +36,32 @@ void IdentityTransformOperation::dump(TextStream& ts) const
     ts << type();
 }
 
-TextStream& operator<<(TextStream& ts, TransformOperation::OperationType type)
+TextStream& operator<<(TextStream& ts, TransformOperation::Type type)
 {
     switch (type) {
-    case TransformOperation::SCALE_X: ts << "scaleX"; break;
-    case TransformOperation::SCALE_Y: ts << "scaleY"; break;
-    case TransformOperation::SCALE: ts << "scale"; break;
-    case TransformOperation::TRANSLATE_X: ts << "translateX"; break;
-    case TransformOperation::TRANSLATE_Y: ts << "translateY"; break;
-    case TransformOperation::TRANSLATE: ts << "translate"; break;
-    case TransformOperation::ROTATE: ts << "rotate"; break;
-    case TransformOperation::SKEW_X: ts << "skewX"; break;
-    case TransformOperation::SKEW_Y: ts << "skewY"; break;
-    case TransformOperation::SKEW: ts << "skew"; break;
-    case TransformOperation::MATRIX: ts << "matrix"; break;
-    case TransformOperation::SCALE_Z: ts << "scaleX"; break;
-    case TransformOperation::SCALE_3D: ts << "scale3d"; break;
-    case TransformOperation::TRANSLATE_Z: ts << "translateZ"; break;
-    case TransformOperation::TRANSLATE_3D: ts << "translate3d"; break;
-    case TransformOperation::ROTATE_X: ts << "rotateX"; break;
-    case TransformOperation::ROTATE_Y: ts << "rotateY"; break;
-    case TransformOperation::ROTATE_Z: ts << "rotateZ"; break;
-    case TransformOperation::ROTATE_3D: ts << "rotate3d"; break;
-    case TransformOperation::MATRIX_3D: ts << "matrix3d"; break;
-    case TransformOperation::PERSPECTIVE: ts << "perspective"; break;
-    case TransformOperation::IDENTITY: ts << "identity"; break;
-    case TransformOperation::NONE: ts << "none"; break;
+    case TransformOperation::Type::ScaleX: ts << "scaleX"; break;
+    case TransformOperation::Type::ScaleY: ts << "scaleY"; break;
+    case TransformOperation::Type::Scale: ts << "scale"; break;
+    case TransformOperation::Type::TranslateX: ts << "translateX"; break;
+    case TransformOperation::Type::TranslateY: ts << "translateY"; break;
+    case TransformOperation::Type::Translate: ts << "translate"; break;
+    case TransformOperation::Type::Rotate: ts << "rotate"; break;
+    case TransformOperation::Type::SkewX: ts << "skewX"; break;
+    case TransformOperation::Type::SkewY: ts << "skewY"; break;
+    case TransformOperation::Type::Skew: ts << "skew"; break;
+    case TransformOperation::Type::Matrix: ts << "matrix"; break;
+    case TransformOperation::Type::ScaleZ: ts << "scaleX"; break;
+    case TransformOperation::Type::Scale3D: ts << "scale3d"; break;
+    case TransformOperation::Type::TranslateZ: ts << "translateZ"; break;
+    case TransformOperation::Type::Translate3D: ts << "translate3d"; break;
+    case TransformOperation::Type::RotateX: ts << "rotateX"; break;
+    case TransformOperation::Type::RotateY: ts << "rotateY"; break;
+    case TransformOperation::Type::RotateZ: ts << "rotateZ"; break;
+    case TransformOperation::Type::Rotate3D: ts << "rotate3d"; break;
+    case TransformOperation::Type::Matrix3D: ts << "matrix3d"; break;
+    case TransformOperation::Type::Perspective: ts << "perspective"; break;
+    case TransformOperation::Type::Identity: ts << "identity"; break;
+    case TransformOperation::Type::None: ts << "none"; break;
     }
     
     return ts;
@@ -73,7 +73,7 @@ TextStream& operator<<(TextStream& ts, const TransformOperation& operation)
     return ts;
 }
 
-std::optional<TransformOperation::OperationType> TransformOperation::sharedPrimitiveType(OperationType other) const
+std::optional<TransformOperation::Type> TransformOperation::sharedPrimitiveType(Type other) const
 {
     // https://drafts.csswg.org/css-transforms-2/#interpolation-of-transform-functions
     // "If both transform functions share a primitive in the two-dimensional space, both transform
@@ -82,10 +82,10 @@ std::optional<TransformOperation::OperationType> TransformOperation::sharedPrimi
     auto type = primitiveType();
     if (type == other)
         return type;
-    static constexpr OperationType sharedPrimitives[][2] = {
-        { ROTATE, ROTATE_3D },
-        { SCALE, SCALE_3D },
-        { TRANSLATE, TRANSLATE_3D }
+    static constexpr Type sharedPrimitives[][2] = {
+        { Type::Rotate, Type::Rotate3D },
+        { Type::Scale, Type::Scale3D },
+        { Type::Translate, Type::Translate3D }
     };
     for (auto typePair : sharedPrimitives) {
         if ((type == typePair[0] || type == typePair[1]) && (other == typePair[0] || other == typePair[1]))
@@ -94,7 +94,7 @@ std::optional<TransformOperation::OperationType> TransformOperation::sharedPrimi
     return std::nullopt;
 }
 
-std::optional<TransformOperation::OperationType> TransformOperation::sharedPrimitiveType(const TransformOperation* other) const
+std::optional<TransformOperation::Type> TransformOperation::sharedPrimitiveType(const TransformOperation* other) const
 {
     // Blending with a null operation is always supported via blending with identity.
     if (!other)

--- a/Source/WebCore/platform/graphics/transforms/TransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperation.h
@@ -37,21 +37,33 @@ struct BlendingContext;
 
 class TransformOperation : public RefCounted<TransformOperation> {
 public:
-    enum OperationType {
-        SCALE_X, SCALE_Y, SCALE, 
-        TRANSLATE_X, TRANSLATE_Y, TRANSLATE, 
-        ROTATE_X, ROTATE_Y, ROTATE,
-        SKEW_X, SKEW_Y, SKEW,
-        MATRIX,
-        SCALE_Z, SCALE_3D,
-        TRANSLATE_Z, TRANSLATE_3D,
-        ROTATE_Z, ROTATE_3D,
-        MATRIX_3D,
-        PERSPECTIVE,
-        IDENTITY, NONE
+    enum class Type : uint8_t {
+        ScaleX,
+        ScaleY,
+        Scale,
+        TranslateX,
+        TranslateY,
+        Translate,
+        RotateX,
+        RotateY,
+        Rotate,
+        SkewX,
+        SkewY,
+        Skew,
+        Matrix,
+        ScaleZ,
+        Scale3D,
+        TranslateZ,
+        Translate3D,
+        RotateZ,
+        Rotate3D,
+        Matrix3D,
+        Perspective,
+        Identity,
+        None
     };
 
-    TransformOperation(OperationType type)
+    TransformOperation(Type type)
         : m_type(type)
     {
     }
@@ -69,58 +81,58 @@ public:
 
     virtual Ref<TransformOperation> blend(const TransformOperation* from, const BlendingContext&, bool blendToIdentity = false) = 0;
 
-    OperationType type() const { return m_type; }
+    Type type() const { return m_type; }
     bool isSameType(const TransformOperation& other) const { return type() == other.type(); }
 
-    virtual OperationType primitiveType() const { return m_type; }
-    std::optional<OperationType> sharedPrimitiveType(OperationType other) const;
-    std::optional<OperationType> sharedPrimitiveType(const TransformOperation* other) const;
+    virtual Type primitiveType() const { return m_type; }
+    std::optional<Type> sharedPrimitiveType(Type other) const;
+    std::optional<Type> sharedPrimitiveType(const TransformOperation* other) const;
 
     virtual bool isAffectedByTransformOrigin() const { return false; }
     
     bool is3DOperation() const
     {
-        OperationType opType = type();
-        return opType == SCALE_Z ||
-               opType == SCALE_3D ||
-               opType == TRANSLATE_Z ||
-               opType == TRANSLATE_3D ||
-               opType == ROTATE_X ||
-               opType == ROTATE_Y ||
-               opType == ROTATE_3D ||
-               opType == MATRIX_3D ||
-               opType == PERSPECTIVE;
+        Type opType = type();
+        return opType == Type::ScaleZ
+            || opType == Type::Scale3D
+            || opType == Type::TranslateZ
+            || opType == Type::Translate3D
+            || opType == Type::RotateX
+            || opType == Type::RotateY
+            || opType == Type::Rotate3D
+            || opType == Type::Matrix3D
+            || opType == Type::Perspective;
     }
     
     virtual bool isRepresentableIn2D() const { return true; }
 
     bool isRotateTransformOperationType() const
     {
-        return type() == ROTATE_X || type() == ROTATE_Y || type() == ROTATE_Z || type() == ROTATE || type() == ROTATE_3D;
+        return type() == Type::RotateX || type() == Type::RotateY || type() == Type::RotateZ || type() == Type::Rotate || type() == Type::Rotate3D;
     }
 
     bool isScaleTransformOperationType() const
     {
-        return type() == SCALE_X || type() == SCALE_Y || type() == SCALE_Z || type() == SCALE || type() == SCALE_3D;
+        return type() == Type::ScaleX || type() == Type::ScaleY || type() == Type::ScaleZ || type() == Type::Scale || type() == Type::Scale3D;
     }
 
     bool isSkewTransformOperationType() const
     {
-        return type() == SKEW_X || type() == SKEW_Y || type() == SKEW;
+        return type() == Type::SkewX || type() == Type::SkewY || type() == Type::Skew;
     }
 
     bool isTranslateTransformOperationType() const
     {
-        return type() == TRANSLATE_X || type() == TRANSLATE_Y || type() == TRANSLATE_Z || type() == TRANSLATE || type() == TRANSLATE_3D;
+        return type() == Type::TranslateX || type() == Type::TranslateY || type() == Type::TranslateZ || type() == Type::Translate || type() == Type::Translate3D;
     }
     
     virtual void dump(WTF::TextStream&) const = 0;
 
 private:
-    OperationType m_type;
+    Type m_type;
 };
 
-WTF::TextStream& operator<<(WTF::TextStream&, TransformOperation::OperationType);
+WTF::TextStream& operator<<(WTF::TextStream&, TransformOperation::Type);
 WTF::TextStream& operator<<(WTF::TextStream&, const TransformOperation&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/transforms/TransformOperations.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperations.h
@@ -66,7 +66,7 @@ public:
     bool hasMatrixOperation() const
     {
         return std::any_of(m_operations.begin(), m_operations.end(), [](auto operation) {
-            return operation->type() == WebCore::TransformOperation::MATRIX;
+            return operation->type() == WebCore::TransformOperation::Type::Matrix;
         });
     }
 
@@ -118,11 +118,11 @@ public:
     virtual ~SharedPrimitivesPrefix() = default;
     void update(const TransformOperations&);
     bool hadIncompatibleTransformFunctions() { return m_indexOfFirstMismatch.has_value(); }
-    const Vector<TransformOperation::OperationType>& primitives() const { return m_primitives; }
+    const Vector<TransformOperation::Type>& primitives() const { return m_primitives; }
 
 private:
     std::optional<size_t> m_indexOfFirstMismatch;
-    Vector<TransformOperation::OperationType> m_primitives;
+    Vector<TransformOperation::Type> m_primitives;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const TransformOperations&);

--- a/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h
@@ -35,12 +35,12 @@ struct BlendingContext;
 
 class TranslateTransformOperation final : public TransformOperation {
 public:
-    static Ref<TranslateTransformOperation> create(const Length& tx, const Length& ty, OperationType type)
+    static Ref<TranslateTransformOperation> create(const Length& tx, const Length& ty, TransformOperation::Type type)
     {
         return adoptRef(*new TranslateTransformOperation(tx, ty, Length(0, LengthType::Fixed), type));
     }
 
-    static Ref<TranslateTransformOperation> create(const Length& tx, const Length& ty, const Length& tz, OperationType type)
+    static Ref<TranslateTransformOperation> create(const Length& tx, const Length& ty, const Length& tz, TransformOperation::Type type)
     {
         return adoptRef(*new TranslateTransformOperation(tx, ty, tz, type));
     }
@@ -62,7 +62,7 @@ public:
     void setY(Length newY) { m_y = newY; }
     void setZ(Length newZ) { m_z = newZ; }
 
-    OperationType primitiveType() const final { return isRepresentableIn2D() ? TRANSLATE : TRANSLATE_3D; }
+    TransformOperation::Type primitiveType() const final { return isRepresentableIn2D() ? Type::Translate : Type::Translate3D; }
 
     bool apply(TransformationMatrix& transform, const FloatSize& borderBoxSize) const final
     {
@@ -83,7 +83,7 @@ private:
 
     void dump(WTF::TextStream&) const final;
 
-    TranslateTransformOperation(const Length& tx, const Length& ty, const Length& tz, OperationType type)
+    TranslateTransformOperation(const Length& tx, const Length& ty, const Length& tz, TransformOperation::Type type)
         : TransformOperation(type)
         , m_x(tx)
         , m_y(ty)

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5411,24 +5411,24 @@ RenderStyle RenderLayer::createReflectionStyle()
     TransformOperations transform;
     switch (renderer().style().boxReflect()->direction()) {
     case ReflectionDirection::Below:
-        transform.operations().append(TranslateTransformOperation::create(Length(0, LengthType::Fixed), Length(100., LengthType::Percent), TransformOperation::TRANSLATE));
-        transform.operations().append(TranslateTransformOperation::create(Length(0, LengthType::Fixed), renderer().style().boxReflect()->offset(), TransformOperation::TRANSLATE));
-        transform.operations().append(ScaleTransformOperation::create(1.0, -1.0, ScaleTransformOperation::SCALE));
+        transform.operations().append(TranslateTransformOperation::create(Length(0, LengthType::Fixed), Length(100., LengthType::Percent), TransformOperation::Type::Translate));
+        transform.operations().append(TranslateTransformOperation::create(Length(0, LengthType::Fixed), renderer().style().boxReflect()->offset(), TransformOperation::Type::Translate));
+        transform.operations().append(ScaleTransformOperation::create(1.0, -1.0, ScaleTransformOperation::Type::Scale));
         break;
     case ReflectionDirection::Above:
-        transform.operations().append(ScaleTransformOperation::create(1.0, -1.0, ScaleTransformOperation::SCALE));
-        transform.operations().append(TranslateTransformOperation::create(Length(0, LengthType::Fixed), Length(100., LengthType::Percent), TransformOperation::TRANSLATE));
-        transform.operations().append(TranslateTransformOperation::create(Length(0, LengthType::Fixed), renderer().style().boxReflect()->offset(), TransformOperation::TRANSLATE));
+        transform.operations().append(ScaleTransformOperation::create(1.0, -1.0, ScaleTransformOperation::Type::Scale));
+        transform.operations().append(TranslateTransformOperation::create(Length(0, LengthType::Fixed), Length(100., LengthType::Percent), TransformOperation::Type::Translate));
+        transform.operations().append(TranslateTransformOperation::create(Length(0, LengthType::Fixed), renderer().style().boxReflect()->offset(), TransformOperation::Type::Translate));
         break;
     case ReflectionDirection::Right:
-        transform.operations().append(TranslateTransformOperation::create(Length(100., LengthType::Percent), Length(0, LengthType::Fixed), TransformOperation::TRANSLATE));
-        transform.operations().append(TranslateTransformOperation::create(renderer().style().boxReflect()->offset(), Length(0, LengthType::Fixed), TransformOperation::TRANSLATE));
-        transform.operations().append(ScaleTransformOperation::create(-1.0, 1.0, ScaleTransformOperation::SCALE));
+        transform.operations().append(TranslateTransformOperation::create(Length(100., LengthType::Percent), Length(0, LengthType::Fixed), TransformOperation::Type::Translate));
+        transform.operations().append(TranslateTransformOperation::create(renderer().style().boxReflect()->offset(), Length(0, LengthType::Fixed), TransformOperation::Type::Translate));
+        transform.operations().append(ScaleTransformOperation::create(-1.0, 1.0, ScaleTransformOperation::Type::Scale));
         break;
     case ReflectionDirection::Left:
-        transform.operations().append(ScaleTransformOperation::create(-1.0, 1.0, ScaleTransformOperation::SCALE));
-        transform.operations().append(TranslateTransformOperation::create(Length(100., LengthType::Percent), Length(0, LengthType::Fixed), TransformOperation::TRANSLATE));
-        transform.operations().append(TranslateTransformOperation::create(renderer().style().boxReflect()->offset(), Length(0, LengthType::Fixed), TransformOperation::TRANSLATE));
+        transform.operations().append(ScaleTransformOperation::create(-1.0, 1.0, ScaleTransformOperation::Type::Scale));
+        transform.operations().append(TranslateTransformOperation::create(Length(100., LengthType::Percent), Length(0, LengthType::Fixed), TransformOperation::Type::Translate));
+        transform.operations().append(TranslateTransformOperation::create(renderer().style().boxReflect()->offset(), Length(0, LengthType::Fixed), TransformOperation::Type::Translate));
         break;
     }
     newStyle.setTransform(transform);

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1643,7 +1643,7 @@ void RenderStyle::setPageScaleTransform(float scale)
     if (scale == 1)
         return;
     TransformOperations transform;
-    transform.operations().append(ScaleTransformOperation::create(scale, scale, ScaleTransformOperation::SCALE));
+    transform.operations().append(ScaleTransformOperation::create(scale, scale, TransformOperation::Type::Scale));
     setTransform(transform);
     setTransformOriginX(Length(0, LengthType::Fixed));
     setTransformOriginY(Length(0, LengthType::Fixed));


### PR DESCRIPTION
#### ca028cc950803580b8107440b6ed4b490dccb013
<pre>
TransformOperation::OperationType enum should be an `enum class`
<a href="https://bugs.webkit.org/show_bug.cgi?id=248762">https://bugs.webkit.org/show_bug.cgi?id=248762</a>

Reviewed by Simon Fraser.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::containsRotation):
(WebCore::KeyframeEffect::computeTransformedExtentViaTransformList const):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::computedTransform):
* Source/WebCore/css/TransformFunctions.cpp:
(WebCore::transformOperationType):
(WebCore::translateForValue):
(WebCore::scaleForValue):
(WebCore::rotateForValue):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::isTransformTypeTransformationMatrix):
(WebCore::isTransformTypeFloatPoint3D):
(WebCore::isTransformTypeNumber):
(WebCore::getTransformFunctionValue):
(WebCore::getValueFunctionNameForTransformOperation):
(WebCore::GraphicsLayerCA::appendToUncommittedAnimations):
(WebCore::hasBig3DRotation):
(WebCore::GraphicsLayerCA::createTransformAnimationsFromKeyframes):
(WebCore::GraphicsLayerCA::setTransformAnimationEndpoints):
(WebCore::GraphicsLayerCA::setTransformAnimationKeyframes):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp:
(WebCore::RotateTransformOperation::blend):
* Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/SkewTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/TransformOperation.cpp:
(WebCore::operator&lt;&lt;):
(WebCore::TransformOperation::sharedPrimitiveType const):
* Source/WebCore/platform/graphics/transforms/TransformOperation.h:
(WebCore::TransformOperation::TransformOperation):
(WebCore::TransformOperation::type const):
(WebCore::TransformOperation::primitiveType const):
(WebCore::TransformOperation::is3DOperation const):
(WebCore::TransformOperation::isRotateTransformOperationType const):
(WebCore::TransformOperation::isScaleTransformOperationType const):
(WebCore::TransformOperation::isSkewTransformOperationType const):
(WebCore::TransformOperation::isTranslateTransformOperationType const):
(): Deleted.
* Source/WebCore/platform/graphics/transforms/TransformOperations.h:
(WebCore::TransformOperations::hasMatrixOperation const):
(WebCore::SharedPrimitivesPrefix::primitives const):
* Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::setPageScaleTransform):

Canonical link: <a href="https://commits.webkit.org/257380@main">https://commits.webkit.org/257380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e19413ebe2891274ca48cf5aa517b82a0197ebf9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31965 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/108235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102769 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85397 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104498 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/91348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1942 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/1851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6807 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/42384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2560 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->