### PR TITLE
Copied rdar:// links lose their `href` after pasting into Mail compose

### DIFF
--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -582,8 +582,8 @@ bool WebContentReader::readHTML(const String& string)
     String markup;
     if (DeprecatedGlobalSettings::customPasteboardDataEnabled() && shouldSanitize()) {
         markup = sanitizeMarkup(stringOmittingMicrosoftPrefix, msoListQuirksForMarkup(), WTF::Function<void (DocumentFragment&)> { [] (DocumentFragment& fragment) {
-            removeSubresourceURLAttributes(fragment, [] (const URL& url) {
-                return shouldReplaceSubresourceURLWithBlobDuringSanitization(url);
+            removeSubresourceURLAttributes(fragment, [](auto& url) {
+                return url.isLocalFile();
             });
         } });
     } else
@@ -601,8 +601,8 @@ bool WebContentMarkupReader::readHTML(const String& string)
     String rawHTML = stripMicrosoftPrefix(string);
     if (shouldSanitize()) {
         markup = sanitizeMarkup(rawHTML, msoListQuirksForMarkup(), WTF::Function<void (DocumentFragment&)> { [] (DocumentFragment& fragment) {
-            removeSubresourceURLAttributes(fragment, [] (const URL& url) {
-                return shouldReplaceSubresourceURLWithBlobDuringSanitization(url);
+            removeSubresourceURLAttributes(fragment, [](auto& url) {
+                return url.isLocalFile();
             });
         } });
     } else

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -175,8 +175,8 @@ void removeSubresourceURLAttributes(Ref<DocumentFragment>&& fragment, Function<b
             }
         }
     }
-    for (auto& item : attributesToRemove)
-        item.element->removeAttribute(item.attributeName);
+    for (auto& [element, attribute] : attributesToRemove)
+        element->removeAttribute(attribute);
 }
 
 std::unique_ptr<Page> createPageForSanitizingWebContent()


### PR DESCRIPTION
#### 34606a516d650d304b5ca5d3f2dd712d1aea58fb
<pre>
Copied rdar:// links lose their `href` after pasting into Mail compose
<a href="https://bugs.webkit.org/show_bug.cgi?id=248765">https://bugs.webkit.org/show_bug.cgi?id=248765</a>
rdar://101878956

Reviewed by Ryosuke Niwa.

When sanitizing pasted markup, we currently strip out all URL attributes that are not either HTTP-
family, or data URLs. Done in <a href="https://commits.webkit.org/197779@main">https://commits.webkit.org/197779@main</a>, the intent was to prevent the
user from inadvertently leaking private information — in particular, local file paths — when pasting
HTML. However, this means that in many other scenarios (e.g. when pasting app-specific URL schemes,
or even when pasting other well-known non-HTTP-family schemes such as `mailto:`), these pasted links
end up being no longer useful. To fix this, we (slightly) relax this constraint to allow non-file
URLs to remain in the sanitized markup, such that we&apos;ll allow pasted custom URL schemes (such as
`rdar://` in the original bug report), but still avoid exposing pasted file paths.

I also considered two alternatives, below:

(1) Avoid sanitizing away URL attributes on links, if the text content of the link contains the URL
    string. While this provides a nice balance between compatability and privacy (since the user-
    visible pasted text already contains the URL), it isn&apos;t sufficient to fix the bug as originally
    reported, which contains a `rdar://` link with user-visible text that does not match.

(2) Introduce SPI for Mail to adopt in compose, which would prevent us from sanitizing away non-file
    URLs (or provide a list of safe URL schemes to preserve). I decided to not go with this approach
    since this issue isn&apos;t limited to Mail compose, but rather any WebKit client, and even web apps
    in the browser. I also didn&apos;t want to introduce another behavioral difference between Mail and
    Safari (or other WebKit clients).

* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::WebContentReader::readHTML):
(WebCore::WebContentMarkupReader::readHTML):

See above for more details.

* Source/WebCore/editing/markup.cpp:
(WebCore::removeSubresourceURLAttributes):

Use destructuring syntax here to make the code a tiny bit easier to read.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm:

Augment and rename an existing API test to cover this scenario.

Canonical link: <a href="https://commits.webkit.org/257410@main">https://commits.webkit.org/257410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2f0995dcaf20f0afd5c608c613442c2a1fdf1a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108214 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168468 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102746 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85375 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91325 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106127 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33446 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88299 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21376 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76370 "Found 5 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/list-markers, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1920 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22907 "Found 30 new test failures: http/tests/navigation/subframe-pagehide-handler-starts-load2.html, http/tests/privateClickMeasurement/store-private-click-measurement-nested.html, imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-no-url-allowed.html, imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-allowed.html, imported/w3c/web-platform-tests/content-security-policy/object-src/object-src-url-embed-allowed.html, imported/w3c/web-platform-tests/css/css-flexbox/flex-column-relayout-assert.html, imported/w3c/web-platform-tests/css/css-transforms/transform-scale-hittest.html, imported/w3c/web-platform-tests/performance-timeline/po-observe.html, imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_pointermove_on_chorded_mouse_button_when_locked.html, imported/w3c/web-platform-tests/selection/deleteFromDocument.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1829 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45375 "Found 1 new test failure: media/video-inactive-playback.html (failure)") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5098 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42361 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3225 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->