### PR TITLE
Return vertical writing mode aware intrinsic information for SVG

### DIFF
--- a/LayoutTests/svg/in-html/sizing/svg-inline-vertical-expected.txt
+++ b/LayoutTests/svg/in-html/sizing/svg-inline-vertical-expected.txt
@@ -1,0 +1,8 @@
+This is a testharness.js-based test.
+PASS Test size calculation in vertical writing mode 
+FAIL Test size calculation in vertical writing mode assert_equals: Height expected 200 but got 100
+PASS Test size calculation in vertical writing mode 
+FAIL Test size calculation in vertical writing mode assert_equals: Height expected 200 but got 100
+FAIL Test size calculation in vertical writing mode assert_equals: Width expected 100 but got 200
+Harness: the test ran to completion.
+

--- a/LayoutTests/svg/in-html/sizing/svg-inline-vertical.html
+++ b/LayoutTests/svg/in-html/sizing/svg-inline-vertical.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<title>Test SVG sizing in vertical writing mode</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+  div {
+      -webkit-writing-mode: vertical-rl;
+      writing-mode: vertical-rl;
+      height: 200px;
+  }
+</style>
+<div>
+  <!-- All SVGs expected size is 100x200 -->
+  <svg width="100" height="200">
+    <rect x="0" y="0" width="100" height="200" fill="lime" stroke="black" stroke-width="10"/>
+  </svg>
+  <svg style="width: auto !important; height: auto !important" width="100" height="200">
+    <rect x="0" y="0" width="100" height="200" fill="lime" stroke="black" stroke-width="10"/>
+  </svg>
+  <svg viewBox="0 0 100 200">
+    <rect x="0" y="0" width="100" height="200" fill="lime" stroke="black" stroke-width="10"/>
+  </svg>
+  <svg width="100" viewBox="0 0 100 200">
+    <rect x="0" y="0" width="100" height="200" fill="lime" stroke="black" stroke-width="10"/>
+  </svg>
+  <svg height="200" viewBox="0 0 100 200">
+    <rect x="0" y="0" width="100" height="200" fill="lime" stroke="black" stroke-width="10"/>
+  </svg>
+</div>
+<script>
+  var svgs = document.querySelectorAll('svg');
+  [].forEach.call(svgs, function (svg, index) {
+      test(function() {
+          var bounds = svg.getBoundingClientRect();
+          assert_equals(bounds.height, 200, "Height");
+          assert_equals(bounds.width, 100, "Width");
+
+      }, "Test size calculation in vertical writing mode (" + (index + 1) + ")");
+  });
+</script>

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2007, 2008, 2009 Rob Buis <buis@kde.org>
  * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
- * Copyright (C) 2009 Google, Inc.
+ * Copyright (C) 2009-2015 Google, Inc.
  * Copyright (C) Research In Motion Limited 2011. All rights reserved.
  * Copyright (C) 2020, 2021, 2022 Igalia S.L.
  *
@@ -105,6 +105,10 @@ void RenderSVGRoot::computeIntrinsicRatioInformation(FloatSize& intrinsicSize, d
     }
 
     std::optional<double> intrinsicRatioValue;
+
+    if (!isHorizontalWritingMode())
+        intrinsicSize = intrinsicSize.transposedSize();
+
     if (!intrinsicSize.isEmpty())
         intrinsicRatioValue = intrinsicSize.width() / static_cast<double>(intrinsicSize.height());
     else {
@@ -116,6 +120,8 @@ void RenderSVGRoot::computeIntrinsicRatioInformation(FloatSize& intrinsicSize, d
         if (!viewBoxSize.isEmpty()) {
             // The viewBox can only yield an intrinsic ratio, not an intrinsic size.
             intrinsicRatioValue = viewBoxSize.width() / static_cast<double>(viewBoxSize.height());
+            if (!isHorizontalWritingMode())
+                intrinsicRatio = 1 / intrinsicRatio;
         }
     }
 


### PR DESCRIPTION
<pre>
Return vertical writing mode aware intrinsic information for SVG
<a href="https://bugs.webkit.org/show_bug.cgi?id=248769">https://bugs.webkit.org/show_bug.cgi?id=248769</a>

Reviewed by NOBODY (OOPS!).

This patch is to align Webkit with Gecko / Firefox and Blink / Chromium.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/60af46f13e39be1daacbcdab27c4e7212ae27886">https://chromium.googlesource.com/chromium/blink/+/60af46f13e39be1daacbcdab27c4e7212ae27886</a>

This patch is to make computeIntrinsicRatioInformation function aware of 
writing mode by taking the logical values returned into consideration.

* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(RenderSVGRoot::computeIntrinsicRatioInformation): Add logic to consider "HorizontalWritingMode"
* LayoutTests/svg/in-html/sizing/svg-inline-vertical.html: Add Test Case
* LayoutTests/svg/in-html/sizing/svg-inline-vertical-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9a27893f3d9dac4d8d01ae6b7f0c4bd3bf34663

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108228 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168485 "Found 1 new test failure: svg/in-html/sizing/svg-inline-vertical.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85390 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91341 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106142 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104491 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6492 "Found 1 new test failure: svg/in-html/sizing/svg-inline-vertical.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90091 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33461 "Found 1 new test failure: svg/in-html/sizing/svg-inline-vertical.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88314 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21434 "Found 1 new test failure: svg/in-html/sizing/svg-inline-vertical.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76383 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1935 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22965 "Found 1 new test failure: svg/in-html/sizing/svg-inline-vertical.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1844 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45386 "Found 2 new test failures: media/video-inactive-playback.html, svg/in-html/sizing/svg-inline-vertical.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6800 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42423 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->