### PR TITLE
[content-visibility] c-v:hidden only turns on contain: size, not contain: inline-size

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-033-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-033-expected.txt
@@ -17,41 +17,21 @@ PASS .test 15
 PASS .test 16
 PASS .test 17
 PASS .test 18
-FAIL .test 19 assert_equals:
-<img src="resources/dice.png" class="test ci-width" data-expected-client-width="10" data-expected-client-height="0">
-clientWidth expected 10 but got 0
+PASS .test 19
 PASS .test 20
-FAIL .test 21 assert_equals:
-<img src="resources/dice.png" class="test ci-both" data-expected-client-width="10" data-expected-client-height="20">
-clientWidth expected 10 but got 0
-FAIL .test 22 assert_equals:
-<svg class="test ci-width" data-expected-client-width="10" data-expected-client-height="0"></svg>
-clientWidth expected 10 but got 0
+PASS .test 21
+PASS .test 22
 PASS .test 23
-FAIL .test 24 assert_equals:
-<svg class="test ci-both" data-expected-client-width="10" data-expected-client-height="20"></svg>
-clientWidth expected 10 but got 0
-FAIL .test 25 assert_equals:
-<canvas class="test ci-width" data-expected-client-width="10" data-expected-client-height="0"></canvas>
-clientWidth expected 10 but got 0
+PASS .test 24
+PASS .test 25
 PASS .test 26
-FAIL .test 27 assert_equals:
-<canvas class="test ci-both" data-expected-client-width="10" data-expected-client-height="20"></canvas>
-clientWidth expected 10 but got 0
-FAIL .test 28 assert_equals:
-<iframe class="test ci-width" data-expected-client-width="10" data-expected-client-height="0"></iframe>
-clientWidth expected 10 but got 0
+PASS .test 27
+PASS .test 28
 PASS .test 29
-FAIL .test 30 assert_equals:
-<iframe class="test ci-both" data-expected-client-width="10" data-expected-client-height="20"></iframe>
-clientWidth expected 10 but got 0
-FAIL .test 31 assert_equals:
-<video class="test ci-width" data-expected-client-width="10" data-expected-client-height="0"></video>
-clientWidth expected 10 but got 0
+PASS .test 30
+PASS .test 31
 PASS .test 32
-FAIL .test 33 assert_equals:
-<video class="test ci-both" data-expected-client-width="10" data-expected-client-height="20"></video>
-clientWidth expected 10 but got 0
+PASS .test 33
 PASS .test 34
 PASS .test 35
 PASS .test 36

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -545,7 +545,7 @@ inline bool RenderElement::shouldApplySizeContainment() const
 
 inline bool RenderElement::shouldApplyInlineSizeContainment() const
 {
-    return shouldApplySizeOrStyleContainment(style().containsInlineSize() || style().contentVisibility() == ContentVisibility::Hidden);
+    return shouldApplySizeOrStyleContainment(style().containsInlineSize());
 }
 
 inline bool RenderElement::shouldApplySizeOrInlineSizeContainment() const


### PR DESCRIPTION
#### eaa26fbd160ee4fac5713f73783a6f582323e0ae
<pre>
[content-visibility] c-v:hidden only turns on contain: size, not contain: inline-size
<a href="https://bugs.webkit.org/show_bug.cgi?id=248280">https://bugs.webkit.org/show_bug.cgi?id=248280</a>

Reviewed by Rob Buis.

Content-visibility:hidden makes that element skips its contents. Per [1], when an element skips its contents,
it turns on contain:size, not contain:inline-size.

[1] <a href="https://w3c.github.io/csswg-drafts/css-contain-2/#skips-its-contents">https://w3c.github.io/csswg-drafts/css-contain-2/#skips-its-contents</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-033-expected.txt:
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::shouldApplyInlineSizeContainment const):

Canonical link: <a href="https://commits.webkit.org/257431@main">https://commits.webkit.org/257431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/137cafea54e85d6b17bfb6a3dc06b87602a9cf28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108272 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168529 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85435 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91390 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106259 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33563 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76420 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1979 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22964 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1888 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45429 "Found 1 new test failure: media/video-inactive-playback.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5118 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42422 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3287 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->