### PR TITLE
[Live Range Selection] editing/selection/doubleclick-whitespace-live-range.html fails

### DIFF
--- a/LayoutTests/editing/selection/doubleclick-whitespace-live-range-expected.txt
+++ b/LayoutTests/editing/selection/doubleclick-whitespace-live-range-expected.txt
@@ -1,0 +1,17 @@
+This tests that double-clicking a word on the Windows platform selects the whitespace after the word.
+
+Doubleclickme     |END|
+Doubleclickme|END|
+Doubleclickme    |END|
+Doubleclickme
+   |(Should not have been extended into this line)|
+Doubleclickme      
+Doubleclickme   			 |END|
+
+Passed test1
+Passed test2
+Passed test3
+Passed test4
+Passed test5
+Passed test6
+

--- a/LayoutTests/editing/selection/doubleclick-whitespace-live-range.html
+++ b/LayoutTests/editing/selection/doubleclick-whitespace-live-range.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<head>
+<script>
+if (window.testRunner) {
+     testRunner.dumpAsText();
+     internals.settings.setSmartInsertDeleteEnabled(false);
+     internals.settings.setSelectTrailingWhitespaceEnabled(true);
+}
+
+function getPositionOfNode(id)
+{
+    var n = document.getElementById(id);
+    var pos = {x: 0, y: 0};
+
+    while (n) {
+        pos.x += n.offsetLeft + n.clientLeft;
+        pos.y += n.offsetTop + n.clientTop;
+        n = n.offsetParent;
+    }
+    return pos;
+}
+
+function doubleClickNode(id)
+{
+    var pos = getPositionOfNode(id);
+    eventSender.mouseMoveTo(pos.x + 2, pos.y + 2);
+    eventSender.mouseDown();
+    eventSender.leapForward(1);
+    eventSender.mouseUp();
+    eventSender.leapForward(100);
+    eventSender.mouseDown();
+    eventSender.leapForward(1);
+    eventSender.mouseUp();
+}
+
+function doTest(testId, expectedText)
+{
+    // Simulate a double click.
+    doubleClickNode(testId);
+
+    // Get the text of the current selection.
+    var sel = window.getSelection();
+    var actualText = sel.getRangeAt(0).toString();
+
+    if (expectedText == actualText) {
+        log("Passed " + testId);
+    } else {
+        log("Failed " + testId);
+        log("  Expected: " + expectedText);
+        log("  Actual: " + actualText);
+    }
+
+}
+
+function runTests()
+{
+    if (window.testRunner) {
+        doTest("test1", "Doubleclickme \u00a0\u00a0\u00a0 ");
+        doTest("test2", "Doubleclickme");
+        doTest("test3", "Doubleclickme \u00a0\u00a0 ");
+        doTest("test4", "Doubleclickme");
+        doTest("test5", "Doubleclickme  \u00a0\u00a0");
+        doTest("test6", "Doubleclickme  \u00a0\t\t\t\u00a0");
+    }
+}
+
+function log(msg)
+{
+    var l = document.getElementById('log');
+    l.appendChild(document.createTextNode(msg));
+    l.appendChild(document.createElement('br'));
+}
+
+</script>
+</head>
+<body onload="runTests()">
+<p>
+This tests that double-clicking a word on the Windows platform selects the whitespace after the word.
+</p>
+
+<div>
+<span id=test1>Doubleclickme &nbsp;&nbsp;&nbsp; |END|</span>
+</div>
+
+<div>
+<span id=test2>Doubleclickme|END|</span>
+</div>
+
+<div>
+<span id=test3>Doubleclickme</span> &nbsp;&nbsp; 
+|END|</span>
+</div>
+
+<div>
+<div>
+<span id="test4">Doubleclickme</span>
+</div>
+&nbsp;&nbsp;&nbsp;|(Should not have been extended into this line)|
+</div>
+
+<div>
+<span id="test5">Doubleclickme </span> &nbsp;&nbsp;<img src="does-not-exist.png" />&nbsp; &nbsp;
+</div>
+
+<pre>
+<span id="test6">Doubleclickme </span> &nbsp;			&nbsp;|END|
+</pre>
+
+<br/>
+<pre id=log>
+</pre>
+
+</body>
+</html>

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -239,6 +239,10 @@ void VisibleSelection::appendTrailingWhitespace()
         if ((!isSpaceOrNewline(c) && c != noBreakSpace) || c == '\n')
             break;
         m_end = makeDeprecatedLegacyPosition(charIt.range().end);
+        if (m_anchorIsFirst)
+            m_focus = m_end;
+        else
+            m_anchor = m_end;
     }
 }
 


### PR DESCRIPTION
#### cb70973c26fd7f76b003507e19391055385d6b41
<pre>
[Live Range Selection] editing/selection/doubleclick-whitespace-live-range.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248778">https://bugs.webkit.org/show_bug.cgi?id=248778</a>

Reviewed by Darin Adler.

Update m_focus/m_anchor when expanding selection to include trailing whitespace.

* LayoutTests/editing/selection/doubleclick-whitespace-live-range-expected.txt: Added.
* LayoutTests/editing/selection/doubleclick-whitespace-live-range.html: Added.
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::appendTrailingWhitespace):

Canonical link: <a href="https://commits.webkit.org/257390@main">https://commits.webkit.org/257390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0c02bf74098d750b7828c03ad069a81f78e36f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108239 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168495 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85400 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91352 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106202 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104501 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90094 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33526 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76392 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1945 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1854 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42426 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2569 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3250 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->