### PR TITLE
gdesktopappinfo.h not excluded on macOS

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1382,3 +1382,9 @@
     || PLATFORM(APPLETV)
 #define HAVE_MEDIAPLAYBACKD 1
 #endif
+
+#if (PLATFORM(GTK) || PLATFORM(WPE)) && defined(__has_include)
+#if __has_include(<gio/gdesktopappinfo.h>)
+#define HAVE_GDESKTOPAPPINFO 1
+#endif
+#endif

--- a/Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp
+++ b/Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp
@@ -31,7 +31,6 @@
 #include <WebCore/NotificationResources.h>
 #include <WebCore/RefPtrCairo.h>
 #include <cairo.h>
-#include <gio/gdesktopappinfo.h>
 #include <gio/gio.h>
 #include <glib/gi18n-lib.h>
 #include <mutex>
@@ -49,6 +48,10 @@
 
 #if PLATFORM(GTK)
 #include <WebCore/GtkVersioning.h>
+#endif
+
+#if HAVE(GDESKTOPAPPINFO)
+#include <gio/gdesktopappinfo.h>
 #endif
 
 namespace WebKit {
@@ -294,6 +297,7 @@ void NotificationService::processCapabilities(GVariant* variant)
 static const char* applicationIcon(const char* applicationID)
 {
     static std::optional<CString> appIcon;
+#if HAVE(GDESKTOPAPPINFO)
     if (!appIcon) {
         appIcon = [applicationID]() -> CString {
             if (!applicationID)
@@ -328,6 +332,7 @@ static const char* applicationIcon(const char* applicationID)
             return { };
         }();
     }
+#endif // HAVE(GDESKTOPAPPINFO)
 
     return appIcon->data();
 }


### PR DESCRIPTION
#### 1446ba237462e1c5fcbe2cedd92c4ea8ac6bb4a6
<pre>
gdesktopappinfo.h not excluded on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=248727">https://bugs.webkit.org/show_bug.cgi?id=248727</a>

Reviewed by Carlos Garcia Campos.

Although macOS has most of the gio-unix-2.0 functionality, this
particular header is an exception and just needs to be handled
specially.

MacPorts has a patch to sometimes build with GDesktopAppInfo enabled, so
it&apos;s best to just detect the presence of the header instead of trying to
enable this code on OS(UNIX_BUT_NOT_MACOS_EXCEPT_SOMETIMES).

* Source/WTF/wtf/PlatformHave.h:
* Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp:
(WebKit::applicationIcon):

Canonical link: <a href="https://commits.webkit.org/258260@main">https://commits.webkit.org/258260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/193439be36fd7944f7491c0501e00bc65ce989c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110651 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1390 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93775 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108479 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107160 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91816 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87950 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1724 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4205 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29308 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44384 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90849 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5685 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5967 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20297 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->