### PR TITLE
[Live Range Selection] editing/pasteboard/drag-drop-dead-frame.html fails

### DIFF
--- a/LayoutTests/editing/pasteboard/drag-drop-dead-frame.html
+++ b/LayoutTests/editing/pasteboard/drag-drop-dead-frame.html
@@ -24,7 +24,7 @@ function editingTest() {
 
 function dragDropIt1() {
     var e = document.getElementById("dragme");
-    window.getSelection().setBaseAndExtent(e, 0, e, 4); 
+    window.getSelection().setBaseAndExtent(e, 0, e, 1);
     x = e.offsetLeft + 10;
     y = e.offsetTop + e.offsetHeight / 2;
     eventSender.mouseMoveTo(x, y);


### PR DESCRIPTION
#### d4016528ecca75120cc843a4663fd9dc9526a2fe
<pre>
[Live Range Selection] editing/pasteboard/drag-drop-dead-frame.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248783">https://bugs.webkit.org/show_bug.cgi?id=248783</a>

Reviewed by Wenson Hsieh.

Use a valid offset to select the dragged content.

* LayoutTests/editing/pasteboard/drag-drop-dead-frame.html:

Canonical link: <a href="https://commits.webkit.org/257396@main">https://commits.webkit.org/257396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ff1638122681e13e75163c20038ac1c8940836c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108243 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168500 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85405 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91359 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106219 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90060 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33531 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88328 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76396 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1950 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22934 "Found 30 new test failures: http/tests/appcache/fail-on-update-2.html, http/wpt/fetch/response-opaque-clone.html, http/wpt/fetch/response-status-text.html, imported/w3c/web-platform-tests/css/css-contain/contain-size-042.html, imported/w3c/web-platform-tests/css/css-grid/placement/grid-container-change-named-grid-recompute-child-positions-001.html, imported/w3c/web-platform-tests/css/css-position/position-absolute-chrome-bug-001.html, imported/w3c/web-platform-tests/css/css-writing-modes/padding-percent-orthogonal-dynamic.html, imported/w3c/web-platform-tests/fetch/api/basic/header-value-null-byte.any.worker.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-opener.https.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-popup.https.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1859 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5084 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42391 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->