### PR TITLE
PDF print preview shows blank preview with UI-side compositing

### DIFF
--- a/Source/WebCore/platform/graphics/RenderingMode.h
+++ b/Source/WebCore/platform/graphics/RenderingMode.h
@@ -34,7 +34,8 @@ enum class RenderingPurpose : uint8_t {
     LayerBacking,
     Snapshot,
     ShareableSnapshot,
-    MediaPainting
+    ShareableLocalSnapshot,
+    MediaPainting,
 };
 
 enum class RenderingMode : bool { Unaccelerated, Accelerated };

--- a/Source/WebKit/Shared/ImageOptions.h
+++ b/Source/WebKit/Shared/ImageOptions.h
@@ -30,6 +30,8 @@ namespace WebKit {
 
 enum ImageOptions {
     ImageOptionsShareable = 1 << 0,
+    // Makes local in process buffer
+    ImageOptionsLocal = 1 << 1,
 };
 
 enum {

--- a/Source/WebKit/Shared/WebImage.cpp
+++ b/Source/WebKit/Shared/WebImage.cpp
@@ -37,6 +37,8 @@ RefPtr<WebImage> WebImage::create(const IntSize& size, ImageOptions options, con
 {
     if (client) {
         auto purpose = (options & ImageOptionsShareable) ? RenderingPurpose::ShareableSnapshot : RenderingPurpose::Snapshot;
+        purpose = (options & ImageOptionsLocal) ? RenderingPurpose::ShareableLocalSnapshot : purpose;
+        
         auto buffer = client->createImageBuffer(size, RenderingMode::Unaccelerated, purpose, 1, colorSpace, PixelFormat::BGRA8);
         if (buffer)
             return WebImage::create(buffer.releaseNonNull());

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1966,7 +1966,6 @@ RefPtr<ShareableBitmap> PDFPlugin::snapshot()
 
     context->scale(FloatSize(contentsScaleFactor, -contentsScaleFactor));
     context->translate(-m_scrollOffset.width(), -m_pdfDocumentSize.height() + m_scrollOffset.height());
-
     [m_pdfLayerController snapshotInContext:context->platformContext()];
 
     return bitmap;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -903,10 +903,10 @@ WebCore::DisplayRefreshMonitorFactory* WebChromeClient::displayRefreshMonitorFac
 RefPtr<ImageBuffer> WebChromeClient::createImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, bool avoidBackendSizeCheck) const
 {
     if (!WebProcess::singleton().shouldUseRemoteRenderingFor(purpose)) {
-        if (purpose != RenderingPurpose::ShareableSnapshot)
+        if (purpose != RenderingPurpose::ShareableSnapshot && purpose != RenderingPurpose::ShareableLocalSnapshot)
             return nullptr;
 
-        return ImageBuffer::create<ImageBufferShareableBitmapBackend>(size, resolutionScale, colorSpace, PixelFormat::BGRA8, RenderingPurpose::ShareableSnapshot, { });
+        return ImageBuffer::create<ImageBufferShareableBitmapBackend>(size, resolutionScale, colorSpace, PixelFormat::BGRA8, purpose, { });
     }
 
     return m_page.ensureRemoteRenderingBackendProxy().createImageBuffer(size, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat, avoidBackendSizeCheck);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5802,8 +5802,8 @@ void WebPage::drawRectToImage(FrameIdentifier frameID, const PrintInfo& printInf
 #else
         ASSERT(coreFrame->document()->printing());
 #endif
-
-        image = WebImage::create(imageSize, ImageOptionsShareable, DestinationColorSpace::SRGB(), &m_page->chrome().client());
+        
+        image = WebImage::create(imageSize, ImageOptionsLocal, DestinationColorSpace::SRGB(), &m_page->chrome().client());
         if (!image) {
             ASSERT_NOT_REACHED();
             return completionHandler({ });


### PR DESCRIPTION
#### 94dbfb8994c360197362ec90dac20b5e85082ed6
<pre>
PDF print preview shows blank preview with UI-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=248785">https://bugs.webkit.org/show_bug.cgi?id=248785</a>
&lt;rdar://102826227&gt;

Reviewed by Simon Fraser.

Create local buffer in the WebProcess so that the PDF print preview
generation code can use the CGContext to draw the PDF.

* Source/WebCore/platform/graphics/RenderingMode.h:
* Source/WebKit/Shared/ImageOptions.h:
* Source/WebKit/Shared/WebImage.cpp:
(WebKit::WebImage::create):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createImageBuffer const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::drawRectToImage):

Canonical link: <a href="https://commits.webkit.org/257667@main">https://commits.webkit.org/257667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4a20f507a65b3cc82942b2f83d2978d60d8f23c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108949 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169186 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86068 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92060 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106866 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105362 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34033 "An unexpected error occured. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21945 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2601 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23459 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2535 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42932 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4395 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2700 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->