### PR TITLE
[Live Range Selection] editing/pasteboard/drag-selected-image-to-contenteditable.html fails

### DIFF
--- a/LayoutTests/editing/pasteboard/drag-selected-image-to-contenteditable.html
+++ b/LayoutTests/editing/pasteboard/drag-selected-image-to-contenteditable.html
@@ -20,7 +20,7 @@ function runTest() {
     if (window.testRunner)
         testRunner.waitUntilDone();
     e = document.getElementById("dragme");
-    setSelectionCommand(e, 0, e, 1);
+    setSelectionCommand(e.parentNode, e.nodeIndex, e.parentNode, e.nodeIndex + 1);
 
     if (!window.testRunner) {
         log("This test uses the eventSender.  To run it manually, drag the selected image into the editable div and drop it.  It should appear inside the editable div.");


### PR DESCRIPTION
#### 6b01beb368c2b9d90dfc5d3fbb44ccafdea1c5dd
<pre>
[Live Range Selection] editing/pasteboard/drag-selected-image-to-contenteditable.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248786">https://bugs.webkit.org/show_bug.cgi?id=248786</a>

Reviewed by Wenson Hsieh.

Select img element using its parent node instead of setting a legacy editing offset,
which would throw an exception when live range selection is enabled.

* LayoutTests/editing/pasteboard/drag-selected-image-to-contenteditable.html:

Canonical link: <a href="https://commits.webkit.org/257402@main">https://commits.webkit.org/257402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a8f34a9ce7857a03c84cf563e330c28c73d2a93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108245 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168503 "Hash 0a8f34a9 for PR 7168 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85408 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91361 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106217 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90099 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33530 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76395 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1953 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1862 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5092 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6818 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42431 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3258 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->