### PR TITLE
Add deprecation guards for various AVFoundation calls

### DIFF
--- a/Source/WebCore/PAL/pal/avfoundation/OutputDevice.mm
+++ b/Source/WebCore/PAL/pal/avfoundation/OutputDevice.mm
@@ -46,7 +46,9 @@ OutputDevice::OutputDevice(RetainPtr<AVOutputDevice>&& device)
 
 String OutputDevice::name() const
 {
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     return [m_device name];
+ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 uint8_t OutputDevice::deviceFeatures() const

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
@@ -92,7 +92,9 @@ RefPtr<Uint8Array> CDMSessionAVFoundationObjC::generateKeyRequest(const String& 
     NSString* assetStr = keyID;
     RetainPtr<NSData> assetID = [NSData dataWithBytes: [assetStr cStringUsingEncoding:NSUTF8StringEncoding] length:[assetStr lengthOfBytesUsingEncoding:NSUTF8StringEncoding]];
     NSError* nsError = 0;
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     RetainPtr<NSData> keyRequest = [m_request streamingContentKeyRequestDataForApp:certificateData.get() contentIdentifier:assetID.get() options:nil error:&nsError];
+ALLOW_DEPRECATED_DECLARATIONS_END
 
     if (!keyRequest) {
         ERROR_LOG(LOGIDENTIFIER, "failed to generate key request with error: ", String(nsError.localizedDescription));

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
@@ -359,7 +359,9 @@ bool ImageDecoderAVFObjC::canDecodeType(const String& mimeType)
 
 AVAssetTrack *ImageDecoderAVFObjC::firstEnabledTrack()
 {
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     NSArray<AVAssetTrack *> *videoTracks = [m_asset tracksWithMediaCharacteristic:AVMediaCharacteristicVisual];
+ALLOW_DEPRECATED_DECLARATIONS_END
     NSUInteger firstEnabledIndex = [videoTracks indexOfObjectPassingTest:^(AVAssetTrack *track, NSUInteger, BOOL*) {
         return track.enabled;
     }];


### PR DESCRIPTION
#### ce361abc6ad80a0353e8af5115af58af333c1dd4
<pre>
Add deprecation guards for various AVFoundation calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=248794">https://bugs.webkit.org/show_bug.cgi?id=248794</a>
&lt;rdar://problem/103000288&gt;

Reviewed by Antoine Quint.

* Source/WebCore/PAL/pal/avfoundation/OutputDevice.mm:
(PAL::OutputDevice::name const):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm:
(WebCore::CDMSessionAVFoundationObjC::generateKeyRequest):
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm:
(WebCore::ImageDecoderAVFObjC::firstEnabledTrack):

Canonical link: <a href="https://commits.webkit.org/257395@main">https://commits.webkit.org/257395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d768e22c51da79527222b194a9b247f0ed5b732

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8051 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/32041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108256 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168513 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85418 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91373 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106244 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33539 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76404 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1963 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22948 "Unable to confirm if test failures are introduced by change, retrying build") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1872 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42405 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2575 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->