### PR TITLE
Regression(255052@main) Unable to log into Marcus.com on iOS

### DIFF
--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -259,7 +259,10 @@ void Navigator::initializePluginAndMimeTypeArrays()
         return;
 
     auto* frame = this->frame();
-    if (!frame || !frame->page()) {
+    bool needsEmptyNavigatorPluginsQuirk = frame && frame->document() && frame->document()->quirks().shouldNavigatorPluginsBeEmpty();
+    if (!frame || !frame->page() || needsEmptyNavigatorPluginsQuirk) {
+        if (needsEmptyNavigatorPluginsQuirk)
+            frame->document()->addConsoleMessage(MessageSource::Other, MessageLevel::Info, "QUIRK: Navigator plugins / mimeTypes empty on marcus.com. More information at https://bugs.webkit.org/show_bug.cgi?id=248798"_s);
         m_plugins = DOMPluginArray::create(*this);
         m_mimeTypes = DOMMimeTypeArray::create(*this);
         return;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1474,6 +1474,22 @@ bool Quirks::shouldExposeShowModalDialog() const
     return *m_shouldExposeShowModalDialog;
 }
 
+bool Quirks::shouldNavigatorPluginsBeEmpty() const
+{
+#if PLATFORM(IOS_FAMILY)
+    if (!needsQuirks())
+        return false;
+    if (!m_shouldNavigatorPluginsBeEmpty) {
+        auto domain = RegistrableDomain(m_document->url()).string();
+        // Marcus login issue: <rdar://103011164>.
+        m_shouldNavigatorPluginsBeEmpty = domain == "marcus.com"_s;
+    }
+    return *m_shouldNavigatorPluginsBeEmpty;
+#else
+    return false;
+#endif
+}
+
 bool Quirks::shouldDisableLazyImageLoadingQuirk() const
 {
     // Images are displaying as fully grey when loaded lazily in significant percentage of page loads.

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -83,6 +83,7 @@ public:
     bool shouldTooltipPreventFromProceedingWithClick(const Element&) const;
     bool shouldHideSearchFieldResultsButton() const;
     bool shouldExposeShowModalDialog() const;
+    bool shouldNavigatorPluginsBeEmpty() const;
 
     bool needsMillisecondResolutionForHighResTimeStamp() const;
 
@@ -218,6 +219,9 @@ private:
     mutable std::optional<bool> m_shouldEnableFontLoadingAPIQuirk;
     mutable std::optional<bool> m_needsVideoShouldMaintainAspectRatioQuirk;
     mutable std::optional<bool> m_shouldExposeShowModalDialog;
+#if PLATFORM(IOS_FAMILY)
+    mutable std::optional<bool> m_shouldNavigatorPluginsBeEmpty;
+#endif
     mutable std::optional<bool> m_shouldDisableLazyImageLoadingQuirk;
 };
 


### PR DESCRIPTION
#### 3622b4c14b28cbd60481fe9952e40e4a4f83cfa7
<pre>
Regression(255052@main) Unable to log into Marcus.com on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=248798">https://bugs.webkit.org/show_bug.cgi?id=248798</a>
rdar://102959860

Reviewed by Brent Fulgham.

Since 255052@main, login on marcus.com fails on iOS and complains about being
outside the USA. The same thing happened by we dropped `window.showModalDialog()`.
The site&apos;s login seems to rely on which properties are present on the `window`
and `navigator` object and what their values are.

In this case, the log in fails because `navigator.plugins` and
`navigator.mimeTypes` now returns the values hard-coded in the HTML
specification instead of being empty arrays.

This is a site issue so I am adding a quirk for now and contacted evangelism.

* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::initializePluginAndMimeTypeArrays):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldNavigatorPluginsBeEmpty const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/257407@main">https://commits.webkit.org/257407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d50bcfe565eb4412e3874e60c989927760f7a4d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108287 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168544 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85449 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106272 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104555 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33572 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88364 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76428 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1993 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22986 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1902 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42449 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2576 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3301 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->