### PR TITLE
[Live Range Selection] editing/selection/programmatic-selection-on-mac-is-directionless.html fails

### DIFF
--- a/LayoutTests/editing/selection/programmatic-selection-on-mac-is-directionless.html
+++ b/LayoutTests/editing/selection/programmatic-selection-on-mac-is-directionless.html
@@ -49,8 +49,8 @@ function selectLine(node) {
     }
 }
 
-function runTestsAndVerify(name, selectionModifier, expectedDirection, expectedText) {
-    var currentTest = makeTest(name, selectionModifier, expectedDirection, expectedText);
+function runTestsAndVerify(node, selectionModifier, expectedDirection, expectedText) {
+    var currentTest = makeTest(node, selectionModifier, expectedDirection, expectedText);
 
     currentTest('no action');
     currentTest('delete');
@@ -60,9 +60,9 @@ function runTestsAndVerify(name, selectionModifier, expectedDirection, expectedT
     currentTest('insertText');
 }
 
-function makeTest(name, selectionModifier, expectedDirection, expectedText) {
+function makeTest(node, selectionModifier, expectedDirection, expectedText) {
     return function (action) {
-        selectLine(name);
+        selectLine(node);
         var actionString = '';
 
         if (action != 'no action') {
@@ -71,12 +71,16 @@ function makeTest(name, selectionModifier, expectedDirection, expectedText) {
             actionString = ', after undoing ' + action;
         }
 
-        var description = selectionModifier() + ' in ' + name.id + actionString;
+        var description = selectionModifier() + ' in ' + node.id + actionString;
         var selection = window.getSelection();
         var actualDirection = selection.baseOffset < selection.extentOffset ? 'forward' : (selection.baseOffset > selection.extentOffset ? 'backward' : 'none');
-
-        if (selection.toString() != expectedText)
-            testFailed(description + ', expected "' + expectedText + '" but got "' + selection.toString() + '"');
+        var actualText = selection.toString();
+        if (node.localName != 'div') {
+            actualDirection = node.selectionDirection;
+            actualText = node.value.substring(node.selectionStart, node.selectionEnd);
+        }
+        if (actualText != expectedText)
+            testFailed(description + ', expected "' + expectedText + '" but got "' + actualText + '"');
         else if (description.split(' ')[4] == 'div' && expectedDirection != actualDirection)
             testFailed(description + ', expected ' + expectedDirection + ' direction but got ' + actualDirection);
         else


### PR DESCRIPTION
#### c52dcd02f0e42c1392413bf9387260c6db6ad606
<pre>
[Live Range Selection] editing/selection/programmatic-selection-on-mac-is-directionless.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248797">https://bugs.webkit.org/show_bug.cgi?id=248797</a>

Reviewed by Wenson Hsieh.

Use value, selectionStart, and selectionEnd of input and textarea elements instead of relying on
getSelection().toString() to include the selected text as this will not be the case when live range
selection is enabled. Also renamed the misleadingly named &quot;name&quot; variable to &quot;node&quot; for consistency
and clarity.

* LayoutTests/editing/selection/programmatic-selection-on-mac-is-directionless.html:

Canonical link: <a href="https://commits.webkit.org/257424@main">https://commits.webkit.org/257424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/968149537aa813301b8d7f5fcd2034eac5264eb3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108261 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168518 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85424 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91379 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106249 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104529 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90079 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33544 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76409 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1968 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22953 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1877 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45423 "Found 1 new test failure: media/video-inactive-playback.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42410 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2585 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3276 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->