### PR TITLE
[CMake] Add targets for Apple Frameworks

### DIFF
--- a/Source/JavaScriptCore/PlatformWin.cmake
+++ b/Source/JavaScriptCore/PlatformWin.cmake
@@ -21,7 +21,7 @@ if (USE_CF)
     )
 
     list(APPEND JavaScriptCore_LIBRARIES
-        ${COREFOUNDATION_LIBRARY}
+        Apple::CoreFoundation
     )
 endif ()
 

--- a/Source/WTF/wtf/PlatformWin.cmake
+++ b/Source/WTF/wtf/PlatformWin.cmake
@@ -54,7 +54,7 @@ if (USE_CF)
         text/cf/StringViewCF.cpp
     )
 
-    list(APPEND WTF_LIBRARIES ${COREFOUNDATION_LIBRARY})
+    list(APPEND WTF_LIBRARIES Apple::CoreFoundation)
 endif ()
 
 set(WTF_OUTPUT_NAME WTF${DEBUG_SUFFIX})

--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -205,8 +205,8 @@ if (USE_CF)
         loader/archive/cf/LegacyWebArchive.h
     )
 
-    list(APPEND WebCore_LIBRARIES ${COREFOUNDATION_LIBRARY})
-    list(APPEND WebCoreTestSupport_LIBRARIES ${COREFOUNDATION_LIBRARY})
+    list(APPEND WebCore_LIBRARIES Apple::CoreFoundation)
+    list(APPEND WebCoreTestSupport_LIBRARIES Apple::CoreFoundation)
 else ()
     list(APPEND WebCore_SOURCES
         platform/text/Hyphenation.cpp

--- a/Source/WebKitLegacy/PlatformWin.cmake
+++ b/Source/WebKitLegacy/PlatformWin.cmake
@@ -16,11 +16,11 @@ else ()
         win/WebURLAuthenticationChallengeSenderCFNet.cpp
     )
     list(APPEND WebKitLegacy_PRIVATE_LIBRARIES
-        CFNetwork${DEBUG_SUFFIX}
-        CoreGraphics${DEBUG_SUFFIX}
-        CoreText${DEBUG_SUFFIX}
-        QuartzCore${DEBUG_SUFFIX}
-        libdispatch${DEBUG_SUFFIX}
+        Apple::CFNetwork
+        Apple::CoreGraphics
+        Apple::CoreText
+        Apple::QuartzCore
+        Apple::libdispatch
         libxml2${DEBUG_SUFFIX}
         libxslt${DEBUG_SUFFIX}
         zdll${DEBUG_SUFFIX}
@@ -225,7 +225,7 @@ if (USE_CF)
     )
 
     list(APPEND WebKitLegacy_LIBRARIES
-        ${COREFOUNDATION_LIBRARY}
+        Apple::CoreFoundation
     )
 endif ()
 

--- a/Source/WebKitLegacy/win/WebKitQuartzCoreAdditions/CMakeLists.txt
+++ b/Source/WebKitLegacy/win/WebKitQuartzCoreAdditions/CMakeLists.txt
@@ -51,11 +51,11 @@ include_directories(
 add_library(WebKitQuartzCoreAdditions SHARED ${WebKitQuartzCoreAdditions_SOURCES})
 set_target_properties(WebKitQuartzCoreAdditions PROPERTIES OUTPUT_NAME WebKitQuartzCoreAdditions${DEBUG_SUFFIX})
 target_link_libraries(WebKitQuartzCoreAdditions
+    Apple::CoreFoundation
+    Apple::CoreGraphics
+    Apple::QuartzCore
     D3d9
     WebKit::WTF
-    CoreFoundation${DEBUG_SUFFIX}
-    CoreGraphics${DEBUG_SUFFIX}
-    QuartzCore${DEBUG_SUFFIX}
 )
 
 target_precompile_headers(WebKitQuartzCoreAdditions PRIVATE WebKitQuartzCoreAdditionsPrefix.h)

--- a/Source/cmake/FindApple.cmake
+++ b/Source/cmake/FindApple.cmake
@@ -1,0 +1,208 @@
+# Copyright (C) 2022 Sony Interactive Entertainment Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindApple
+--------------
+
+Find Apple frameworks.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+  Apple::<C>
+
+Where ``<C>`` is the name of an Apple framework, for example
+``Apple::CoreFoundation``.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+Apple component libraries are reported in::
+
+  <C>_FOUND - ON if framework was found
+  <C>_LIBRARIES - libraries for component
+
+#]=======================================================================]
+
+set(_Apple_REQUIRED_LIBS_FOUND YES)
+
+function(_FIND_APPLE_FRAMEWORK framework)
+    set(OPTIONS "")
+    set(oneValueArgs HEADER)
+    set(multiValueArgs LIBRARY_NAMES)
+    cmake_parse_arguments(opt "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Find include directory and library
+    find_path(${framework}_INCLUDE_DIR NAMES ${opt_HEADER})
+    find_library(${framework}_LIBRARY NAMES ${opt_LIBRARY_NAMES})
+
+    if (${framework}_INCLUDE_DIR AND ${framework}_LIBRARY)
+        add_library(Apple::${framework} UNKNOWN IMPORTED)
+        set_target_properties(Apple::${framework} PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${${framework}_INCLUDE_DIR}"
+            IMPORTED_LOCATION "${${framework}_LIBRARY}"
+        )
+        set(${framework}_FOUND ON PARENT_SCOPE)
+        if (Apple_FIND_REQUIRED_${framework})
+            set(Apple_LIBS_FOUND ${Apple_LIBS_FOUND} "${framework} (required): ${${framework}_LIBRARY}" PARENT_SCOPE)
+        else ()
+            set(Apple_LIBS_FOUND ${Apple_LIBS_FOUND} "${framework} (optional): ${${framework}_LIBRARY}}" PARENT_SCOPE)
+        endif ()
+    else ()
+        if (Apple_FIND_REQUIRED_${framework})
+            set(_Apple_REQUIRED_LIBS_FOUND NO PARENT_SCOPE)
+            set(Apple_LIBS_NOT_FOUND ${Apple_LIBS_NOT_FOUND} "${framework} (required)" PARENT_SCOPE)
+        else ()
+            set(Apple_LIBS_NOT_FOUND ${Apple_LIBS_NOT_FOUND} "${framework} (optional)" PARENT_SCOPE)
+        endif ()
+    endif ()
+
+    mark_as_advanced(${framework}_INCLUDE_DIR ${framework}_LIBRARY)
+endfunction()
+
+if ("ApplicationServices" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(ApplicationServices
+        HEADER ApplicationServices/ApplicationServices.h
+        LIBRARY_NAMES ASL${DEBUG_SUFFIX}
+    )
+endif ()
+
+if ("AVFoundationCF" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(AVFoundationCF
+        HEADER AVFoundationCF/AVFoundationCF.h
+        LIBRARY_NAMES AVFoundationCF${DEBUG_SUFFIX}
+    )
+endif ()
+
+if ("CFNetwork" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(CFNetwork
+        HEADER CFNetwork/CFNetwork.h
+        LIBRARY_NAMES CFNetwork${DEBUG_SUFFIX}
+    )
+endif ()
+
+if ("CoreAudio" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(CoreAudio
+        HEADER CoreAudio/CoreAudioTypes.h
+        LIBRARY_NAMES CoreAudioToolbox${DEBUG_SUFFIX}
+    )
+endif ()
+
+if ("CoreFoundation" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(CoreFoundation
+        HEADER CoreFoundation/CoreFoundation.h
+        LIBRARY_NAMES CoreFoundation${DEBUG_SUFFIX} CFlite
+    )
+endif ()
+
+if ("CoreGraphics" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(CoreGraphics
+        HEADER CoreGraphics/CoreGraphics.h
+        LIBRARY_NAMES CoreGraphics${DEBUG_SUFFIX}
+    )
+endif ()
+
+if ("CoreMedia" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(CoreMedia
+        HEADER CoreMedia/CoreMedia.h
+        LIBRARY_NAMES CoreMedia${DEBUG_SUFFIX}
+    )
+endif ()
+
+if ("CoreText" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(CoreText
+        HEADER CoreText/CoreText.h
+        LIBRARY_NAMES CoreText${DEBUG_SUFFIX}
+    )
+endif ()
+
+if ("CoreVideo" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(CoreVideo
+        HEADER CoreVideo/CVBase.h
+        LIBRARY_NAMES CoreVideo${DEBUG_SUFFIX}
+    )
+endif ()
+
+if ("MediaAccessibility" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(MediaAccessibility
+        HEADER MediaAccessibility/MediaAccessibility.h
+        LIBRARY_NAMES MediaAccessibility${DEBUG_SUFFIX}
+    )
+endif ()
+
+if ("MediaToolbox" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(MediaToolbox
+        HEADER MediaToolbox/MTAudioProcessingTap.h
+        LIBRARY_NAMES MediaToolbox${DEBUG_SUFFIX}
+    )
+endif ()
+
+if ("QuartzCore" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(QuartzCore
+        HEADER QuartzCore/QuartzCore.h
+        LIBRARY_NAMES QuartzCore${DEBUG_SUFFIX}
+    )
+endif ()
+
+if ("SarfariTheme" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(SarfariTheme
+        HEADER dispatch/dispatch.h
+        LIBRARY_NAMES SarfariTheme${DEBUG_SUFFIX}
+    )
+endif ()
+
+if ("WebKitQuartzCoreAdditions" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(WebKitQuartzCoreAdditions
+        HEADER WebKitQuartzCoreAdditions/WebKitQuartzCoreAdditionsBase.h
+        LIBRARY_NAMES WebKitQuartzCoreAdditions${DEBUG_SUFFIX}
+    )
+endif ()
+
+if ("libdispatch" IN_LIST Apple_FIND_COMPONENTS)
+    _FIND_APPLE_FRAMEWORK(libdispatch
+        HEADER dispatch/dispatch.h
+        LIBRARY_NAMES libdispatch${DEBUG_SUFFIX}
+    )
+endif ()
+
+if (NOT Apple_FIND_QUIETLY)
+    if (Apple_LIBS_FOUND)
+        message(STATUS "Found the following Apple libraries:")
+        foreach (found ${Apple_LIBS_FOUND})
+            message(STATUS " ${found}")
+        endforeach ()
+    endif ()
+    if (Apple_LIBS_NOT_FOUND)
+        message(STATUS "The following Apple libraries were not found:")
+        foreach (found ${Apple_LIBS_NOT_FOUND})
+            message(STATUS " ${found}")
+        endforeach ()
+    endif ()
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Apple
+    REQUIRED_VARS _Apple_REQUIRED_LIBS_FOUND
+    FAIL_MESSAGE "Failed to find all Apple components"
+)

--- a/Source/cmake/OptionsAppleWin.cmake
+++ b/Source/cmake/OptionsAppleWin.cmake
@@ -36,14 +36,22 @@ SET_AND_EXPOSE_TO_BUILD(USE_CFURLCONNECTION ON)
 
 set(SQLite3_NAMES SQLite3${DEBUG_SUFFIX})
 
+find_package(Apple REQUIRED COMPONENTS
+    AVFoundationCF
+    ApplicationServices
+    CFNetwork
+    CoreFoundation
+    CoreGraphics
+    CoreText
+    QuartzCore
+    libdispatch
+)
+
 find_package(ICU 61.2 REQUIRED COMPONENTS data i18n uc)
 find_package(LibXml2 REQUIRED)
 find_package(LibXslt REQUIRED)
 find_package(SQLite3 REQUIRED)
 find_package(ZLIB REQUIRED)
-
-# Libraries where find_package does not work
-set(COREFOUNDATION_LIBRARY CoreFoundation${DEBUG_SUFFIX})
 
 SET_AND_EXPOSE_TO_BUILD(USE_CA ON)
 SET_AND_EXPOSE_TO_BUILD(USE_CG ON)

--- a/Source/cmake/OptionsWinCairo.cmake
+++ b/Source/cmake/OptionsWinCairo.cmake
@@ -79,7 +79,7 @@ cmake_pop_check_state()
 # CoreFoundation is required when building WebKitLegacy
 if (ENABLE_WEBKIT_LEGACY)
     SET_AND_EXPOSE_TO_BUILD(USE_CF ON)
-    set(COREFOUNDATION_LIBRARY CFlite)
+    find_package(Apple REQUIRED COMPONENTS CoreFoundation)
 endif ()
 
 add_definitions(-DWTF_PLATFORM_WIN_CAIRO=1)

--- a/Source/cmake/target/TargetJavaScriptCore.cmake
+++ b/Source/cmake/target/TargetJavaScriptCore.cmake
@@ -9,8 +9,7 @@ if (NOT TARGET WebKit::JavaScriptCore)
     set_target_properties(WebKit::JavaScriptCore PROPERTIES
         IMPORTED_LOCATION ${WEBKIT_LIBRARIES_RUNTIME_DIR}/JavaScriptCore${DEBUG_SUFFIX}.dll
         IMPORTED_IMPLIB ${WEBKIT_LIBRARIES_LINK_DIR}/JavaScriptCore${DEBUG_SUFFIX}.lib
-        # Should add Apple::CoreFoundation here when https://bugs.webkit.org/show_bug.cgi?id=205085 lands
-        INTERFACE_LINK_LIBRARIES "WebKit::WTF;ICU::data;ICU::i18n;ICU::uc"
+        INTERFACE_LINK_LIBRARIES "WebKit::WTF;ICU::data;ICU::i18n;ICU::uc;Apple::CoreFoundation"
     )
     set(JavaScriptCore_FRAMEWORK_HEADERS_DIR "${CMAKE_BINARY_DIR}/../include/private/JavaScriptCore")
     set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS_DIR ${JavaScriptCore_FRAMEWORK_HEADERS_DIR})

--- a/Source/cmake/target/TargetWTF.cmake
+++ b/Source/cmake/target/TargetWTF.cmake
@@ -9,8 +9,7 @@ if (NOT TARGET WebKit::WTF)
     set_target_properties(WebKit::WTF PROPERTIES
         IMPORTED_LOCATION ${WEBKIT_LIBRARIES_RUNTIME_DIR}/WTF${DEBUG_SUFFIX}.dll
         IMPORTED_IMPLIB ${WEBKIT_LIBRARIES_LINK_DIR}/WTF${DEBUG_SUFFIX}.lib
-        # Should add Apple::CoreFoundation here when https://bugs.webkit.org/show_bug.cgi?id=205085 lands
-        INTERFACE_LINK_LIBRARIES "ICU::data;ICU::i18n;ICU::uc"
+        INTERFACE_LINK_LIBRARIES "ICU::data;ICU::i18n;ICU::uc;Apple::CoreFoundation"
     )
     set(WTF_FRAMEWORK_HEADERS_DIR "${CMAKE_BINARY_DIR}/../include/private/WTF")
     target_include_directories(WebKit::WTF INTERFACE

--- a/Tools/MiniBrowser/win/CMakeLists.txt
+++ b/Tools/MiniBrowser/win/CMakeLists.txt
@@ -22,7 +22,7 @@ set(MiniBrowser_PRIVATE_LIBRARIES
 
 if (USE_CF)
     list(APPEND MiniBrowser_PRIVATE_LIBRARIES
-        ${COREFOUNDATION_LIBRARY}
+        Apple::CoreFoundation
     )
 endif ()
 

--- a/Tools/TestWebKitAPI/PlatformWin.cmake
+++ b/Tools/TestWebKitAPI/PlatformWin.cmake
@@ -56,20 +56,20 @@ if (${WTF_PLATFORM_WIN_CAIRO})
     )
 else ()
     list(APPEND TestWebCore_LIBRARIES
-        ASL${DEBUG_SUFFIX}
-        CFNetwork${DEBUG_SUFFIX}
-        CoreGraphics${DEBUG_SUFFIX}
-        CoreText${DEBUG_SUFFIX}
+        Apple::ApplicationServices
+        Apple::CFNetwork
+        Apple::CoreGraphics
+        Apple::CoreText
+        Apple::QuartzCore
+        Apple::libdispatch
         LibXslt::LibExslt
-        QuartzCore${DEBUG_SUFFIX}
         WebKitQuartzCoreAdditions${DEBUG_SUFFIX}
-        libdispatch${DEBUG_SUFFIX}
     )
 endif ()
 
 if (USE_CF)
     list(APPEND TestWebCore_LIBRARIES
-        ${COREFOUNDATION_LIBRARY}
+        Apple::CoreFoundation
     )
 endif ()
 


### PR DESCRIPTION
#### d9aab5144958ec79974320ac150b7e53ba54b45c
<pre>
[CMake] Add targets for Apple Frameworks
<a href="https://bugs.webkit.org/show_bug.cgi?id=205085">https://bugs.webkit.org/show_bug.cgi?id=205085</a>

Reviewed by Tim Horton and Per Arne Vollan.

Create a FindApple module which will find Apple frameworks. The module
creates a CMake target for each component in the form Apple::&lt;C&gt;. All
frameworks within the Apple Windows builds are represented.

Currently just the Windows ports are migrated to using the module.

* Source/JavaScriptCore/PlatformWin.cmake:
* Source/WTF/wtf/PlatformWin.cmake:
* Source/WebCore/PlatformWin.cmake:
* Source/WebKitLegacy/PlatformWin.cmake:
* Source/WebKitLegacy/win/WebKitQuartzCoreAdditions/CMakeLists.txt:
* Source/cmake/FindApple.cmake: Added.
* Source/cmake/OptionsAppleWin.cmake:
* Source/cmake/OptionsWinCairo.cmake:
* Source/cmake/target/TargetJavaScriptCore.cmake:
* Source/cmake/target/TargetWTF.cmake:
* Tools/MiniBrowser/win/CMakeLists.txt:
* Tools/TestWebKitAPI/PlatformWin.cmake:

Canonical link: <a href="https://commits.webkit.org/257428@main">https://commits.webkit.org/257428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e4e96a84cebf6c5cf48dd2989870f104fbf6ccb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108267 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168524 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85430 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91385 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106255 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90132 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33549 "Archived test results (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88348 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76414 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89602 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1974 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23002 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85400 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1883 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45424 "Found 1 new test failure: media/video-inactive-playback.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28784 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5114 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6839 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42466 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88253 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3282 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19749 "Passed tests") | 
<!--EWS-Status-Bubble-End-->