### PR TITLE
[ews-build.webkit.org] Commit URL assigned to wrong step

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -717,11 +717,15 @@ class CheckOutSpecificRevision(shell.ShellCommand):
     flunkOnFailure = False
     haltOnFailure = False
 
+    @staticmethod
+    def doCheckOutSpecificRevision(obj):
+        return obj.getProperty('ews_revision', False)
+
     def __init__(self, **kwargs):
         super(CheckOutSpecificRevision, self).__init__(logEnviron=False, **kwargs)
 
     def doStepIf(self, step):
-        return self.getProperty('ews_revision', False)
+        return self.doCheckOutSpecificRevision(self)
 
     def hideStepIf(self, results, step):
         return not self.doStepIf(step)
@@ -802,8 +806,7 @@ class ShowIdentifier(shell.ShellCommand):
             if identifier:
                 identifier = identifier.replace('master', DEFAULT_BRANCH)
             self.setProperty('identifier', identifier)
-            if self.getProperty('ews_revision', False) and not self.getProperty('github.number', False):
-                # Note that this if condition matches with CheckOutSpecificRevision.doStepIf
+            if CheckOutSpecificRevision.doCheckOutSpecificRevision(self):
                 step = self.getLastBuildStepByName(CheckOutSpecificRevision.name)
             else:
                 step = self.getLastBuildStepByName(CheckOutSource.name)


### PR DESCRIPTION
#### 124a3086a938b67c297d48c323f5fcee0cb97971
<pre>
[ews-build.webkit.org] Commit URL assigned to wrong step
<a href="https://bugs.webkit.org/show_bug.cgi?id=248801">https://bugs.webkit.org/show_bug.cgi?id=248801</a>
rdar://103003905

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(CheckOutSpecificRevision.doCheckOutSpecificRevision): Create static method usable by other steps.
(CheckOutSpecificRevision.doStepIf): Invoke static method.
(ShowIdentifier.evaluateCommand): Invoke CheckOutSpecificRevision&apos;s conditional specifically.
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/257450@main">https://commits.webkit.org/257450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75316f87fd145c20115ae62e65ea99025465334f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108268 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168525 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85431 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91386 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106256 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33551 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88349 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76416 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1975 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22962 "Found 30 new test failures: http/tests/appcache/fail-on-update-2.html, http/wpt/fetch/fetch-in-pagehide.html, http/wpt/fetch/response-opaque-clone.html, imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-disabled-regular-sheet-insertion.html, imported/w3c/web-platform-tests/fetch/api/abort/cache.https.any.html, imported/w3c/web-platform-tests/fetch/range/general.any.serviceworker.html, imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.roundrect.3.radii.3.double.html, imported/w3c/web-platform-tests/html/semantics/document-metadata/interactions-of-styling-and-scripting/script-created-style-element-does-not-block-script.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.octal.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/img-picture-ancestor.html ... (failure)") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/97784 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1884 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45426 "Found 1 new test failure: media/video-inactive-playback.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42420 "Passed tests") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2596 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3283 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->