### PR TITLE
[content-visibility] it should trigger a layout if the value of content-visibility is changed from hidden to others

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-038-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-038-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Measure Forced Layout assert_equals: spacer when visible expected 108 but got 8
+PASS Measure Forced Layout
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006-expected.txt
@@ -1,18 +1,18 @@
 
-FAIL Basic usage assert_equals: Sizing normally - clientWidth expected 100 but got 1
+FAIL Basic usage assert_equals: Using last remembered size - clientWidth expected 100 but got 1
 FAIL Last remembered size can be 0 assert_equals: Using last remembered size - clientWidth expected 0 but got 1
-FAIL Last remembered size can be set to 0 after losing display:none assert_equals: Sizing normally - clientWidth expected 100 but got 1
-FAIL Last remembered size is logical assert_equals: Sizing normally - clientWidth expected 100 but got 1
-FAIL Last remembered size survives box destruction assert_equals: Sizing normally - clientWidth expected 100 but got 1
-FAIL Last remembered size survives display type changes assert_equals: Sizing normally - clientWidth expected 100 but got 1
-FAIL Losing cis:auto removes last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 1
-FAIL Losing cis:auto removes last remembered size even if size doesn't change assert_equals: Sizing normally - clientWidth expected 100 but got 1
-FAIL Losing cis:auto removes last remembered size immediately assert_equals: Sizing normally - clientWidth expected 100 but got 1
-FAIL Losing cis:auto during display:none doesn't remove last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 1
-FAIL Lack of cis:auto during box creation removes last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 1
-FAIL Last remembered size can be removed synchronously assert_equals: Sizing normally - clientWidth expected 100 but got 1
-FAIL Disconnected element can briefly keep last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 1
-FAIL Disconnected element ends up losing last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 1
+FAIL Last remembered size can be set to 0 after losing display:none assert_equals: Using the new last remembered size - clientWidth expected 0 but got 1
+FAIL Last remembered size is logical assert_equals: Using last remembered size - clientWidth expected 100 but got 1
+FAIL Last remembered size survives box destruction assert_equals: Using last remembered size - clientWidth expected 100 but got 1
+FAIL Last remembered size survives display type changes assert_equals: Using last remembered size - clientWidth expected 100 but got 1
+FAIL Losing cis:auto removes last remembered size assert_equals: Using last remembered size - clientWidth expected 100 but got 1
+PASS Losing cis:auto removes last remembered size even if size doesn't change
+FAIL Losing cis:auto removes last remembered size immediately assert_equals: Using last remembered size - clientWidth expected 100 but got 1
+FAIL Losing cis:auto during display:none doesn't remove last remembered size assert_equals: Using last remembered size - clientWidth expected 100 but got 1
+FAIL Lack of cis:auto during box creation removes last remembered size assert_equals: Using last remembered size - clientWidth expected 100 but got 1
+FAIL Last remembered size can be removed synchronously assert_equals: Using last remembered size - clientWidth expected 100 but got 1
+FAIL Disconnected element can briefly keep last remembered size assert_equals: Using last remembered size - clientWidth expected 100 but got 1
+FAIL Disconnected element ends up losing last remembered size assert_equals: Using last remembered size - clientWidth expected 100 but got 1
 PASS Disconnected element ends up losing last remembered size even if size was 0x0
 FAIL Last remembered size survives becoming inline assert_equals: Still using previous last remembered size - clientWidth expected 100 but got 1
 FAIL Last remembered size can be set to 0x0 after losing display:inline assert_equals: Last remembered size is now 0x0 - clientWidth expected 0 but got 1

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-008-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL requestAnimationFrame assert_equals: No last remembered size - clientWidth expected 40 but got 100
-PASS Early ResizeObserver
-PASS Late ResizeObserver
+PASS requestAnimationFrame
+FAIL Early ResizeObserver assert_equals: Using last remembered size - clientWidth expected 100 but got 40
+FAIL Late ResizeObserver assert_equals: Using last remembered size - clientWidth expected 100 but got 40
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -809,6 +809,10 @@ static bool rareNonInheritedDataChangeRequiresLayout(const StyleRareNonInherited
         || first.effectiveContainment().contains(Containment::InlineSize) != second.effectiveContainment().contains(Containment::InlineSize))
         return true;
 
+    // content-visibiliy:hidden turns on contain:size which requires relayout.
+    if ((static_cast<ContentVisibility>(first.contentVisibility) == ContentVisibility::Hidden) != (static_cast<ContentVisibility>(second.contentVisibility) == ContentVisibility::Hidden))
+        return true;
+
     if (first.scrollPadding != second.scrollPadding)
         return true;
 


### PR DESCRIPTION
#### 2e92a10ead3da46e410121584d79ca40afaf5004
<pre>
[content-visibility] it should trigger a layout if the value of content-visibility is changed from hidden to others
<a href="https://bugs.webkit.org/show_bug.cgi?id=248790">https://bugs.webkit.org/show_bug.cgi?id=248790</a>

Reviewed by Rob Buis.

Per[1], content-visibility: hidden turns on contain:size. Contain:size would change the layout size of the element.
So when an element&apos;s content-visibility value changes from hidden to other, it should trigger a layout, vice versa.

[1] <a href="https://w3c.github.io/csswg-drafts/css-contain-2/#skips-its-contents">https://w3c.github.io/csswg-drafts/css-contain-2/#skips-its-contents</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-038-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-008-expected.txt:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::rareNonInheritedDataChangeRequiresLayout):

Canonical link: <a href="https://commits.webkit.org/257484@main">https://commits.webkit.org/257484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f9d082119668111d9999b8aa2c24ac124c72e39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108495 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168737 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85653 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106437 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104828 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33709 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21615 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2198 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23131 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2090 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5151 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7051 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42609 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3506 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->