### PR TITLE
Interaction regions don't update when event listeners change without rendering updates

### DIFF
--- a/LayoutTests/interaction-region/click-handler-dynamically-added-expected.txt
+++ b/LayoutTests/interaction-region/click-handler-dynamically-added-expected.txt
@@ -1,0 +1,22 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (region
+            (rect (0,0) width=100 height=100)
+)
+        (borderRadius 10.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/click-handler-dynamically-added.html
+++ b/LayoutTests/interaction-region/click-handler-dynamically-added.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+
+    #button {
+        display: inline-block;
+        width: 100px;
+        height: 100px;
+        background-color: green;
+        cursor: pointer;
+        border-radius: 10px;
+    }
+</style>
+<body>
+<div id="button"></div>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    document.getElementById("button").addEventListener("click", function () { });
+
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/click-handler-dynamically-removed-expected.txt
+++ b/LayoutTests/interaction-region/click-handler-dynamically-removed-expected.txt
@@ -1,0 +1,16 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/click-handler-dynamically-removed.html
+++ b/LayoutTests/interaction-region/click-handler-dynamically-removed.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+
+    #button {
+        display: inline-block;
+        width: 100px;
+        height: 100px;
+        background-color: green;
+        cursor: pointer;
+        border-radius: 10px;
+    }
+</style>
+<body>
+<div id="button" onclick="2+2"></div>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    document.getElementById("button").onclick = null;
+
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1289,6 +1289,8 @@ public:
     void didAddWheelEventHandler(Node&);
     void didRemoveWheelEventHandler(Node&, EventHandlerRemoval = EventHandlerRemoval::One);
 
+    void didAddOrRemoveMouseEventHandler(Node&);
+
     MonotonicTime lastHandledUserGestureTimestamp() const { return m_lastHandledUserGestureTimestamp; }
     bool hasHadUserInteraction() const { return static_cast<bool>(m_lastHandledUserGestureTimestamp); }
     void updateLastHandledUserGestureTimestamp(MonotonicTime);

--- a/Source/WebCore/dom/EventNames.h
+++ b/Source/WebCore/dom/EventNames.h
@@ -369,6 +369,8 @@ public:
     bool isGestureEventType(const AtomString& eventType) const;
     bool isTouchRelatedEventType(const AtomString& eventType, const EventTarget&) const;
     bool isTouchScrollBlockingEventType(const AtomString& eventType) const;
+    bool isMouseClickRelatedEventType(const AtomString& eventType) const;
+    bool isMouseMoveRelatedEventType(const AtomString& eventType) const;
 #if ENABLE(GAMEPAD)
     bool isGamepadEventType(const AtomString& eventType) const;
 #endif
@@ -430,6 +432,21 @@ inline bool EventNames::isWheelEventType(const AtomString& eventType) const
 {
     return eventType == wheelEvent
         || eventType == mousewheelEvent;
+}
+
+inline bool EventNames::isMouseClickRelatedEventType(const AtomString& eventType) const
+{
+    return eventType == mouseupEvent
+        || eventType == mousedownEvent
+        || eventType == clickEvent
+        || eventType == DOMActivateEvent;
+}
+
+inline bool EventNames::isMouseMoveRelatedEventType(const AtomString& eventType) const
+{
+    return eventType == mousemoveEvent
+        || eventType == mouseoverEvent
+        || eventType == mouseoutEvent;
 }
 
 inline std::array<std::reference_wrapper<const AtomString>, 13> EventNames::touchRelatedEventNames() const

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -481,7 +481,6 @@ public:
     bool willRespondToMouseClickEvents() const;
     Editability computeEditabilityForMouseClickEvents(const RenderStyle* = nullptr) const;
     virtual bool willRespondToMouseClickEventsWithEditability(Editability) const;
-    virtual bool willRespondToMouseWheelEvents() const;
     virtual bool willRespondToTouchEvents() const;
 
     WEBCORE_EXPORT unsigned short compareDocumentPosition(Node&);

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1088,11 +1088,6 @@ bool HTMLElement::willRespondToMouseMoveEvents() const
     return !isDisabledFormControl() && Element::willRespondToMouseMoveEvents();
 }
 
-bool HTMLElement::willRespondToMouseWheelEvents() const
-{
-    return !isDisabledFormControl() && Element::willRespondToMouseWheelEvents();
-}
-
 bool HTMLElement::willRespondToMouseClickEventsWithEditability(Editability editability) const
 {
     return !isDisabledFormControl() && Element::willRespondToMouseClickEventsWithEditability(editability);

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -96,7 +96,6 @@ public:
     virtual bool isSearchFieldResultsButtonElement() const { return false; }
 
     bool willRespondToMouseMoveEvents() const override;
-    bool willRespondToMouseWheelEvents() const override;
     bool willRespondToMouseClickEventsWithEditability(Editability) const override;
 
     virtual bool isLabelable() const { return false; }


### PR DESCRIPTION
#### 82f024ac0b5757189369a944edc20f08c4b7a1ef
<pre>
Interaction regions don&apos;t update when event listeners change without rendering updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=248804">https://bugs.webkit.org/show_bug.cgi?id=248804</a>

Reviewed by Aditya Keerthi.

* LayoutTests/interaction-region/click-handler-dynamically-added-expected.txt: Added.
* LayoutTests/interaction-region/click-handler-dynamically-added.html: Added.
* LayoutTests/interaction-region/click-handler-dynamically-removed-expected.txt: Added.
* LayoutTests/interaction-region/click-handler-dynamically-removed.html: Added.
Add some tests for both dynamic addition and removal of event listeners.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::httpEquivPolicy const):
Move this so it&apos;s not in the middle of event-related code.

(WebCore::Document::didAddOrRemoveMouseEventHandler):
Add a method that invalidates style when mouse event handlers change.

* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EventNames.h:
(WebCore::EventNames::isMouseClickRelatedEventType const):
(WebCore::EventNames::isMouseMoveRelatedEventType const):
Add methods for click and move related events.

* Source/WebCore/dom/Node.cpp:
(WebCore::tryAddEventListener):
(WebCore::tryRemoveEventListener):
(WebCore::Node::willRespondToMouseMoveEvents const):
(WebCore::Node::willRespondToMouseClickEventsWithEditability const):
(WebCore::Node::willRespondToMouseWheelEvents const): Deleted.
Adopt EventNames methods instead of hardcoded name checks.
Call didAddOrRemoveMouseEventHandler when relevant.

* Source/WebCore/dom/Node.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::willRespondToMouseWheelEvents const): Deleted.
* Source/WebCore/html/HTMLElement.h:
Remove the unused willRespondToMouseWheelEvents.

Canonical link: <a href="https://commits.webkit.org/257453@main">https://commits.webkit.org/257453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1374155e1cb8b5a25fe0aab077a22e187ec385b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108410 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168662 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85549 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91527 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106369 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104723 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90217 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33659 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21562 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2111 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45469 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5129 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6978 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42553 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3429 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->