### PR TITLE
Restore Mac JSCOnly build

### DIFF
--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -683,7 +683,7 @@ set_source_files_properties(
     libpas/src/libpas/bmalloc_heap_config.c
     libpas/src/libpas/pas_heap_config_kind.c
     libpas/src/libpas/pas_segregated_page_config_kind.c
-    PROPERTIES COMPILE_OPTIONS ${COMPILE_C_AS_CXX}
+    PROPERTIES COMPILE_OPTIONS "${COMPILE_C_AS_CXX}"
 )
 
 WEBKIT_FRAMEWORK_DECLARE(bmalloc)

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
@@ -29,7 +29,6 @@
 #include "pas_platform.h"
 
 PAS_IGNORE_WARNINGS_BEGIN("missing-field-initializers")
-PAS_IGNORE_WARNINGS_BEGIN("cast-align")
 
 #include "bmalloc_heap.h"
 #include "bmalloc_heap_config.h"
@@ -577,7 +576,6 @@ PAS_END_EXTERN_C;
 
 #endif /* PAS_ENABLE_BMALLOC */
 
-PAS_IGNORE_WARNINGS_END
 PAS_IGNORE_WARNINGS_END
 
 #endif /* BMALLOC_HEAP_INLINES_H */

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
@@ -26,6 +26,8 @@
 #ifndef PAS_BITFIT_PAGE_INLINES_H
 #define PAS_BITFIT_PAGE_INLINES_H
 
+PAS_IGNORE_WARNINGS_BEGIN("cast-align")
+
 #include "pas_bitfit_allocation_result.h"
 #include "pas_bitfit_page.h"
 #include "pas_bitfit_view.h"
@@ -959,6 +961,8 @@ static PAS_ALWAYS_INLINE void pas_bitfit_page_shrink(
 }
 
 PAS_END_EXTERN_C;
+
+PAS_IGNORE_WARNINGS_END
 
 #endif /* PAS_BITFIT_PAGE_INLINES_H */
 

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -318,6 +318,8 @@ static PAS_ALWAYS_INLINE void pas_assertion_failed_noreturn_silencer6(
     pas_crash_with_info_impl6((uint64_t)line, misc1, misc2, misc3, misc4, misc5, misc6);
 }
 
+PAS_IGNORE_WARNINGS_END
+
 /* The count argument will always be computed with PAS_VA_NUM_ARGS in the client.
    Hence, it is always a constant, and the following cascade of if statements will
    reduce to a single statement for the appropriate number of __VA_ARGS__.
@@ -380,8 +382,6 @@ static PAS_ALWAYS_INLINE void pas_assertion_failed_noreturn_silencer6(
         pas_assertion_failed_noreturn_silencer6(file, line, function, exp, (uint64_t)misc1, (uint64_t)misc2, (uint64_t)misc3, (uint64_t)misc4, (uint64_t)misc5, (uint64_t)misc6)
 
 #endif /* PAS_OS(DARWIN) && PAS_VA_OPT_SUPPORTED */
-
-PAS_IGNORE_WARNINGS_END
 
 #define PAS_LIKELY(x) __PAS_LIKELY(x)
 #define PAS_UNLIKELY(x) __PAS_UNLIKELY(x)

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -446,7 +446,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 endif ()
 
 if (COMPILER_IS_GCC_OR_CLANG)
-    set(COMPILE_C_AS_CXX "-xc++")
+    set(COMPILE_C_AS_CXX "-xc++;-std=c++2a")
 endif ()
 
 # FIXME: Enable pre-compiled headers for all ports <https://webkit.org/b/139438>


### PR DESCRIPTION
#### 8c254e9f94c8fa2e9bcde83cc618004ce044cc3c
<pre>
Restore Mac JSCOnly build
<a href="https://bugs.webkit.org/show_bug.cgi?id=248805">https://bugs.webkit.org/show_bug.cgi?id=248805</a>

Reviewed by Yusuke Suzuki.

There was a recent patch titled &quot;Fix the Mac JSCOnly build&quot; (257142@main), but it&apos;s still broken, so let&apos;s fix it for real.

* Source/bmalloc/CMakeLists.txt:
* Source/cmake/WebKitCompilerFlags.cmake:
Ensure that compiling &quot;C as C++&quot; uses an appropriate standard.

* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h:
Ignore cast-align warnings when this header is included from outside bmalloc.

* Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h:
Remove unused ignore for non-bmalloc targets.

* Source/bmalloc/libpas/src/libpas/pas_utils.h:
Restrict scope of ignore.

Canonical link: <a href="https://commits.webkit.org/257401@main">https://commits.webkit.org/257401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39325d9fdf4e7cd8846e202fcbd81a2e5bc633f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108284 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168541 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85447 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106270 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104552 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33578 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76434 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89619 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1991 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85417 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1900 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28790 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5090 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6856 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42445 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88270 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3299 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19753 "Passed tests") | 
<!--EWS-Status-Bubble-End-->