### PR TITLE
[Lockdown mode] Add syscall telemetry

### DIFF
--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -168,10 +168,12 @@ function webcontent_sandbox_entitlements()
     plistbuddy Add :com.apple.private.security.mutable-state-flags:1 string EnableExperimentalSandbox
     plistbuddy Add :com.apple.private.security.mutable-state-flags:2 string EnableExperimentalSandboxWithProbability
     plistbuddy Add :com.apple.private.security.mutable-state-flags:3 string BlockIOKitInWebContentSandbox
+    plistbuddy Add :com.apple.private.security.mutable-state-flags:4 string LockdownModeEnabled
     plistbuddy Add :com.apple.private.security.enable-state-flags array
     plistbuddy Add :com.apple.private.security.enable-state-flags:0 string EnableExperimentalSandbox
     plistbuddy Add :com.apple.private.security.enable-state-flags:1 string EnableExperimentalSandboxWithProbability
     plistbuddy Add :com.apple.private.security.enable-state-flags:2 string BlockIOKitInWebContentSandbox
+    plistbuddy Add :com.apple.private.security.enable-state-flags:3 string LockdownModeEnabled
 }
 
 function mac_process_webcontent_shared_entitlements()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -969,6 +969,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         sandbox_enable_state_flag("EnableExperimentalSandboxWithProbability", *auditToken);
     }
 #endif // USE(APPLE_INTERNAL_SDK)
+
+    if (WebProcess::singleton().isLockdownModeEnabled())
+        sandbox_enable_state_flag("LockdownModeEnabled", *auditToken);
 #endif // HAVE(SANDBOX_STATE_FLAGS)
 
     updateThrottleState();

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1855,8 +1855,6 @@
     (syscall-number
         SYS___disable_threadsignal
         SYS___mac_syscall
-        SYS___pthread_sigmask
-        SYS___semwait_signal
         SYS_access
         SYS_bsdthread_create
         SYS_bsdthread_ctl
@@ -1866,28 +1864,21 @@
         SYS_csops
         SYS_csops_audittoken
         SYS_csrctl
+        SYS_dup ;; Remove when <rdar://88210738> is fixed
         SYS_exit
-        SYS_faccessat ;; <rdar://problem/56690456>
         SYS_fcntl
-        SYS_fcntl_nocancel
-        SYS_fgetxattr
-        SYS_fileport_makefd
         SYS_flock
         SYS_fsetxattr ;; <rdar://problem/56332491>
         SYS_fsgetpath
         SYS_fstat64
-        SYS_fstatat64
         SYS_fstatfs64
         SYS_ftruncate
         SYS_getattrlist
-        SYS_getattrlistbulk
         SYS_getaudit_addr
         SYS_getdirentries64
         SYS_getentropy
         SYS_geteuid
         SYS_getfsstat64
-        SYS_getgid
-        SYS_gethostuuid
         SYS_getrlimit
         SYS_getrusage
         SYS_gettimeofday
@@ -1900,16 +1891,12 @@
         SYS_kdebug_trace_string ;; Needed for performance sampling, see <rdar://problem/48829655>.
         SYS_kevent_id
         SYS_kevent_qos
-        SYS_kqueue ;; See <rdar://problem/88241768>. Remove after <rdar://56634240> is resolved.
-        SYS_kqueue_workloop_ctl ;; <rdar://problem/50999499>
-        SYS_listxattr
         SYS_lseek
         SYS_lstat64
         SYS_madvise
 #if !PLATFORM(MAC)
         SYS_memorystatus_control
 #endif
-        SYS_mincore
         SYS_mkdir
         SYS_mmap
         SYS_mprotect
@@ -1922,31 +1909,23 @@
         SYS_pread
         SYS_proc_info
         SYS_psynch_cvbroad
-        SYS_psynch_cvclrprepost
         SYS_psynch_cvsignal
         SYS_psynch_cvwait
         SYS_psynch_mutexdrop
         SYS_psynch_mutexwait
-        SYS_psynch_rw_unlock
-        SYS_psynch_rw_wrlock
         SYS_read
         SYS_read_nocancel
         SYS_readlink
         SYS_rename
-        SYS_sendto
-        SYS_sigaltstack
-        SYS_sigprocmask
         SYS_stat64
         SYS_statfs64
-        SYS_sysctlbyname
+        SYS_sysctl
         SYS_thread_selfid
 #if !PLATFORM(MAC)
         SYS_thread_selfusage
 #endif
         SYS_ulock_wait
         SYS_ulock_wake
-        SYS_umask
-        SYS_work_interval_ctl
         SYS_workq_kernreturn
         SYS_write_nocancel
         SYS_writev))
@@ -1962,7 +1941,6 @@
         SYS___semwait_signal_nocancel
         SYS_change_fdguard_np
         SYS_chmod
-        SYS_dup ;; Remove when <rdar://88210738> is fixed
         SYS_fchmod
         SYS_fsync
         SYS_getegid
@@ -1988,7 +1966,6 @@
         SYS_setsockopt ;; <rdar://90249455>
         SYS_shm_open
         SYS_sigaction
-        SYS_sysctl
         SYS_unlink
         SYS_write
 #if !PLATFORM(MAC)
@@ -2004,35 +1981,61 @@
 #endif
 ))
 
-(when (defined? 'syscall-unix)
-    (deny syscall-unix)
-    (allow syscall-unix
-        (syscall-unix-common))
+(define (syscall-unix-blocked-in-lockdown-mode) (syscall-number
+    SYS___pthread_sigmask
+    SYS___semwait_signal
+    SYS_faccessat
+    SYS_fcntl_nocancel
+    SYS_fgetxattr
+    SYS_fileport_makefd
+    SYS_fstatat64
+    SYS_getattrlistbulk
+    SYS_getgid
+    SYS_gethostuuid
+    SYS_kqueue ;; See <rdar://problem/88241768>. Remove after <rdar://56634240> is resolved.
+    SYS_kqueue_workloop_ctl ;; <rdar://problem/50999499>
+    SYS_listxattr
+    SYS_mincore
+    SYS_psynch_cvclrprepost
+    SYS_psynch_rw_unlock
+    SYS_psynch_rw_wrlock
+    SYS_sendto
+    SYS_sigaltstack
+    SYS_sigprocmask
+    SYS_sysctlbyname
+    SYS_umask
+    SYS_work_interval_ctl))
 
-    (if (equal? (param "CPU") "arm64")
-        (begin
-            (allow syscall-unix
-                (syscall-unix-apple-silicon))))
+(deny syscall-unix)
 
-    (allow syscall-unix
-        (syscalls-rarely-used))
+(allow syscall-unix (syscall-unix-common))
 
-#if __MAC_OS_X_VERSION_MIN_REQUIRED > 101500
-    (if (defined? 'SYS_objc_bp_assist_cfg_np)
-        (allow syscall-unix (syscall-number SYS_objc_bp_assist_cfg_np)))
-#endif
-    (when (defined? 'SYS_map_with_linking_np)
-        (allow syscall-unix (syscall-number SYS_map_with_linking_np)))
-)
+(with-filter (require-entitlement "com.apple.security.cs.allow-jit")
+    (allow syscall-unix (syscall-unix-blocked-in-lockdown-mode))
+
+    (when (equal? (param "CPU") "arm64")
+        (allow syscall-unix (syscall-unix-apple-silicon)))
+
+    (allow syscall-unix (syscalls-rarely-used)))
+
+(when (defined? 'SYS_objc_bp_assist_cfg_np)
+    (allow syscall-unix (syscall-number SYS_objc_bp_assist_cfg_np)))
+(when (defined? 'SYS_map_with_linking_np)
+    (allow syscall-unix (syscall-number SYS_map_with_linking_np)))
 
 (with-filter (uid 0)
     (allow syscall-unix (syscall-number SYS_gettid))) ;; Needed for base system, see <rdar://problem/48651255>
 
 #if HAVE(SANDBOX_STATE_FLAGS)
 (with-filter (require-not (state-flag "WebContentProcessLaunched"))
-    (allow syscall-unix
-        (syscall-number SYS_quotactl)))
+    (allow syscall-unix (syscall-number SYS_quotactl)))
 #endif
+
+(with-filter (require-not (require-entitlement "com.apple.security.cs.allow-jit"))
+    (allow syscall-unix (with report) (with telemetry) (syscall-unix-blocked-in-lockdown-mode))
+    (allow syscall-unix (with report) (with telemetry) (syscalls-rarely-used))
+    (when (equal? (param "CPU") "arm64")
+        (allow syscall-unix (with report) (with telemetry) (syscall-unix-apple-silicon))))
 
 #if HAVE(ADDITIONAL_APPLE_CAMERA_SERVICE)
 (if (equal? (param "CPU") "arm64")
@@ -2066,7 +2069,7 @@
             (allow mach-bootstrap
                 (apply-message-filter
                     (deny mach-message-send)
-                    (allow mach-message-send 
+                    (allow mach-message-send
                         (mach-bootstrap-message-numbers-post-launch))))
         ;; else
             (allow-mach-bootstrap-with-filter))


### PR DESCRIPTION
#### 83206fb964d8815de27a053a122a07f73e6b6318
<pre>
[Lockdown mode] Add syscall telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=248808">https://bugs.webkit.org/show_bug.cgi?id=248808</a>
&lt;rdar://problem/103014299&gt;

Reviewed by Brent Fulgham.

Add syscall telemetry in Lockdown mode on macOS. Ideally, we would use a sandbox state variable
to conditionalize the rules, but since there are some issues with combining sandbox state
variables and syscalls, we use an entitlement that is unique in Lockdown mode.

* Source/WebKit/Scripts/process-entitlements.sh:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/257461@main">https://commits.webkit.org/257461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e12145021d5aea21f7110751e0f6ca3b55e56d22

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8322 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/32256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108511 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8870 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/104853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/32256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/91623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/102644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/32256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2214 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/32256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/2105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/7068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/32256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2600 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3522 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->