### PR TITLE
Implement ShadowRoot.fullscreenElement

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-nested-shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-nested-shadow-dom-expected.txt
@@ -1,17 +1,11 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: expected Element node <div id="outer">
-      <slot></slot>
-    </div> but got null
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Type error
 fullscreen
 
-Harness Error (FAIL), message = Unhandled rejection: assert_equals: expected Element node <div id="outer">
-      <slot></slot>
-    </div> but got null
+Harness Error (FAIL), message = Unhandled rejection: Type error
 
 TIMEOUT Exiting fullscreen from a nested shadow root works correctly. Test timed out
 
-Harness Error (FAIL), message = Unhandled rejection: assert_equals: expected Element node <div id="outer">
-      <slot></slot>
-    </div> but got null
+Harness Error (FAIL), message = Unhandled rejection: Type error
 
 TIMEOUT Exiting fullscreen from a nested shadow root works correctly. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/shadowroot-fullscreen-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/shadowroot-fullscreen-element-expected.txt
@@ -1,0 +1,5 @@
+Exit fullscreen
+Go fullscreen
+
+PASS shadowRoot.fullscreenElement works correctly
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/shadowroot-fullscreen-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/shadowroot-fullscreen-element.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+<head>
+    <title>shadowRoot.fullscreenElement works correctly</title>
+    <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+    <link rel="help" href="https://fullscreen.spec.whatwg.org/#dom-document-fullscreenelement">
+</head>
+<div id="host">
+    <button onclick="document.exitFullscreen()" id="exitButton">Exit fullscreen</button>
+</div>
+<button id="requestButton">Go fullscreen</button>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+promise_test(async function() {
+    let host = document.getElementById("host");
+    host.attachShadow({ mode: "open" }).innerHTML = `
+        <style>
+        #outer { width: 200px; height: 200px; background: blue }
+        </style>
+        <div id="outer">
+        <slot></slot>
+        </div>
+    `;
+    let outer = host.shadowRoot.querySelector("#outer");
+    await new Promise((resolve) => {
+        addEventListener("fullscreenchange", resolve, { once: true });
+        requestButton.addEventListener("click", () => outer.requestFullscreen());
+        test_driver.click(requestButton);
+    });
+
+    assert_equals(outer.getRootNode().fullscreenElement, outer, "Correct shadowRoot.fullscreenElement after entering");
+    assert_equals(document.fullscreenElement, host, "Correct document.fullscreenElement after entering");
+
+    await new Promise((resolve) => {
+        addEventListener("fullscreenchange", resolve, { once: true });
+        test_driver.click(exitButton);
+    });
+
+    assert_equals(outer.getRootNode().fullscreenElement, null, "Correct shadowRoot.fullscreenElement after exiting");
+    assert_equals(document.fullscreenElement, null, "Correct document.fullscreenElement after exiting");
+}, "shadowRoot.fullscreenElement works correctly");
+</script>
+</html>

--- a/Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp
@@ -38,10 +38,8 @@ namespace WebCore {
 // https://fullscreen.spec.whatwg.org/#dom-document-fullscreenelement
 Element* DocumentOrShadowRootFullscreen::fullscreenElement(TreeScope& treeScope)
 {
-    if (auto* document = dynamicDowncast<Document>(treeScope.rootNode()))
-        return document->fullscreenManager().fullscreenElement();
-    // FIXME: Add a proper implementation for ShadowRoot.
-    return nullptr;
+    auto& document = treeScope.documentScope();
+    return treeScope.ancestorElementInThisScope(document.fullscreenManager().fullscreenElement());
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 9d1bb9c5d5663e614e6c67465a99363255eafa01
<pre>
Implement ShadowRoot.fullscreenElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=248712">https://bugs.webkit.org/show_bug.cgi?id=248712</a>
rdar://102937497

Reviewed by Chris Dumez.

Use ancestorElementInThisScope() similarly to webkitFullscreenElement.

* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-nested-shadow-dom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/shadowroot-fullscreen-element-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/shadowroot-fullscreen-element.html: Added.
* Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp:
(WebCore::DocumentOrShadowRootFullscreen::fullscreenElement):

Canonical link: <a href="https://commits.webkit.org/257457@main">https://commits.webkit.org/257457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f60a8d85163acc95652f3b24ca8ec11f51f3daf8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108486 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168728 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85645 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91596 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104817 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90264 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2189 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2081 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/7044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42601 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2598 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3497 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->