### PR TITLE
[GStreamer] Handle latency messages

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -178,6 +178,9 @@ bool AudioDestinationGStreamer::handleMessage(GstMessage* message)
     case GST_MESSAGE_ERROR:
         notifyIsPlaying(false);
         break;
+    case GST_MESSAGE_LATENCY:
+        gst_bin_recalculate_latency(GST_BIN_CAST(m_pipeline.get()));
+        break;
     default:
         break;
     }

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -481,6 +481,9 @@ void connectSimpleBusMessageCallback(GstElement* pipeline, Function<void(GstMess
             GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(pipeline), GST_DEBUG_GRAPH_SHOW_ALL, dotFileName.utf8().data());
             break;
         }
+        case GST_MESSAGE_LATENCY:
+            gst_bin_recalculate_latency(GST_BIN_CAST(pipeline));
+            break;
         default:
             break;
         }

--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
@@ -23,7 +23,6 @@
 #if USE(GSTREAMER) && ENABLE(VIDEO)
 
 #include "FloatSize.h"
-#include "GStreamerCommon.h"
 #include "GStreamerRegistryScanner.h"
 #include "ImageGStreamer.h"
 #include "MediaSampleGStreamer.h"
@@ -367,6 +366,8 @@ void ImageDecoderGStreamer::InnerDecoder::preparePipeline()
 {
     static Atomic<uint32_t> pipelineId;
     m_pipeline = gst_pipeline_new(makeString("image-decoder-", pipelineId.exchangeAdd(1)).utf8().data());
+
+    connectSimpleBusMessageCallback(m_pipeline.get());
 
     GRefPtr<GstBus> bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
     ASSERT(bus);

--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.h
@@ -21,7 +21,7 @@
 
 #if USE(GSTREAMER) && ENABLE(VIDEO)
 
-#include "GRefPtrGStreamer.h"
+#include "GStreamerCommon.h"
 #include "ImageDecoder.h"
 #include "MIMETypeRegistry.h"
 #include "SampleMap.h"
@@ -98,6 +98,7 @@ private:
 
         ~InnerDecoder()
         {
+            disconnectSimpleBusMessageCallback(m_pipeline.get());
             gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
         }
 


### PR DESCRIPTION
#### 57191c0bb3eefcf88bbc54b10e4903420c862cbb
<pre>
[GStreamer] Handle latency messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=248813">https://bugs.webkit.org/show_bug.cgi?id=248813</a>

Reviewed by Xabier Rodriguez-Calvar.

When a latency message is received on the bus the application should recalculate and distribute a
new latency. Also included in this patch is a drive-by improvement in state-change message handling
in the audio file reader, where we process only the notification from the top-level pipeline.

* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::AudioDestinationGStreamer::handleMessage):
* Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp:
(WebCore::AudioFileReader::handleMessage):
* Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp:
(WebCore::AudioSourceProviderGStreamer::AudioSourceProviderGStreamer):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::connectSimpleBusMessageCallback):
* Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp:
(WebCore::ImageDecoderGStreamer::InnerDecoder::handleMessage):

Canonical link: <a href="https://commits.webkit.org/257788@main">https://commits.webkit.org/257788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b696958f28e270ecea0049bd02ef2d6666004adb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109369 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169610 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104021 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86547 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92469 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107268 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105790 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34329 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22288 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2985 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23803 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2944 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/46175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43284 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5346 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4794 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->