### PR TITLE
Add IPC encoding and decoding support for TimingFunction

### DIFF
--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -101,6 +101,7 @@
 #include <WebCore/TestReportBody.h>
 #include <WebCore/TextCheckerClient.h>
 #include <WebCore/TextIndicator.h>
+#include <WebCore/TimingFunction.h>
 #include <WebCore/TransformationMatrix.h>
 #include <WebCore/UserStyleSheet.h>
 #include <WebCore/VelocityData.h>
@@ -1652,6 +1653,100 @@ std::optional<RefPtr<WebCore::ReportBody>> ArgumentCoder<RefPtr<WebCore::ReportB
 
     ASSERT_NOT_REACHED();
     return std::nullopt;
+}
+
+void ArgumentCoder<Ref<WebCore::TimingFunction>>::encode(Encoder& encoder, const Ref<WebCore::TimingFunction>& timingFunction)
+{
+    encoder << timingFunction->type();
+
+    switch (timingFunction->type()) {
+    case TimingFunction::TimingFunctionType::LinearFunction:
+        encoder << downcast<LinearTimingFunction>(timingFunction.get());
+        break;
+
+    case TimingFunction::TimingFunctionType::CubicBezierFunction:
+        encoder << downcast<CubicBezierTimingFunction>(timingFunction.get());
+        break;
+
+    case TimingFunction::TimingFunctionType::StepsFunction:
+        encoder << downcast<StepsTimingFunction>(timingFunction.get());
+        break;
+
+    case TimingFunction::TimingFunctionType::SpringFunction:
+        encoder << downcast<SpringTimingFunction>(timingFunction.get());
+        break;
+    }
+}
+
+std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<Ref<WebCore::TimingFunction>>::decode(Decoder& decoder)
+{
+    std::optional<TimingFunction::TimingFunctionType> type;
+    decoder >> type;
+    if (!type)
+        return std::nullopt;
+
+    switch (*type) {
+    case TimingFunction::TimingFunctionType::LinearFunction: {
+        std::optional<Ref<LinearTimingFunction>> function;
+        decoder >> function;
+        if (!function)
+            return std::nullopt;
+        return WTFMove(*function);
+    }
+
+    case TimingFunction::TimingFunctionType::CubicBezierFunction: {
+        std::optional<Ref<CubicBezierTimingFunction>> function;
+        decoder >> function;
+        if (!function)
+            return std::nullopt;
+        return WTFMove(*function);
+    }
+
+    case TimingFunction::TimingFunctionType::StepsFunction: {
+        std::optional<Ref<StepsTimingFunction>> function;
+        decoder >> function;
+        if (!function)
+            return std::nullopt;
+        return WTFMove(*function);
+    }
+
+    case TimingFunction::TimingFunctionType::SpringFunction: {
+        std::optional<Ref<SpringTimingFunction>> function;
+        decoder >> function;
+        if (!function)
+            return std::nullopt;
+        return WTFMove(*function);
+    }
+    }
+
+    ASSERT_NOT_REACHED();
+    return std::nullopt;
+}
+
+void ArgumentCoder<RefPtr<WebCore::TimingFunction>>::encode(Encoder& encoder, const RefPtr<WebCore::TimingFunction>& timingFunction)
+{
+    bool hasTimingFunction = !!timingFunction;
+    encoder << hasTimingFunction;
+    if (!hasTimingFunction)
+        return;
+
+    encoder << Ref { *timingFunction };
+}
+
+std::optional<RefPtr<WebCore::TimingFunction>> ArgumentCoder<RefPtr<WebCore::TimingFunction>>::decode(Decoder& decoder)
+{
+    bool hasTimingFunction;
+    if (!decoder.decode(hasTimingFunction))
+        return std::nullopt;
+
+    if (!hasTimingFunction)
+        return nullptr;
+
+    std::optional<Ref<TimingFunction>> timingFunction;
+    decoder >> timingFunction;
+    if (!timingFunction)
+        return std::nullopt;
+    return WTFMove(*timingFunction);
 }
 
 } // namespace IPC

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -144,6 +144,7 @@ class FragmentedSharedBuffer;
 class StickyPositionViewportConstraints;
 class SystemImage;
 class TextCheckingRequestData;
+class TimingFunction;
 class UserStyleSheet;
 
 struct AttributedString;
@@ -351,7 +352,7 @@ template<> struct ArgumentCoder<WebCore::FilterOperations> {
     static void encode(Encoder&, const WebCore::FilterOperations&);
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::FilterOperations&);
 };
-    
+
 template<> struct ArgumentCoder<WebCore::FilterOperation> {
     static void encode(Encoder&, const WebCore::FilterOperation&);
 };
@@ -560,6 +561,16 @@ template<> struct ArgumentCoder<WebCore::PixelBuffer> {
 template<> struct ArgumentCoder<RefPtr<WebCore::ReportBody>> {
     static void encode(Encoder&, const RefPtr<WebCore::ReportBody>&);
     static std::optional<RefPtr<WebCore::ReportBody>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<Ref<WebCore::TimingFunction>> {
+    static void encode(Encoder&, const Ref<WebCore::TimingFunction>&);
+    static std::optional<Ref<WebCore::TimingFunction>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<RefPtr<WebCore::TimingFunction>> {
+    static void encode(Encoder&, const RefPtr<WebCore::TimingFunction>&);
+    static std::optional<RefPtr<WebCore::TimingFunction>> decode(Decoder&);
 };
 
 } // namespace IPC


### PR DESCRIPTION
#### 46a94976a5d034e23b745c8410251a5f27833510
<pre>
Add IPC encoding and decoding support for TimingFunction
<a href="https://bugs.webkit.org/show_bug.cgi?id=248814">https://bugs.webkit.org/show_bug.cgi?id=248814</a>

Reviewed by Alex Christensen.

Generalize the encoding and decoding static functions found in PlatformCAAnimationRemote.mm.

* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;Ref&lt;WebCore::TimingFunction&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;Ref&lt;WebCore::TimingFunction&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::TimingFunction&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::TimingFunction&gt;&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm:
(WebKit::PlatformCAAnimationRemote::Properties::encode const):
(WebKit::PlatformCAAnimationRemote::Properties::decode):
(WebKit::encodeTimingFunction): Deleted.
(WebKit::decodeTimingFunction): Deleted.

Canonical link: <a href="https://commits.webkit.org/257544@main">https://commits.webkit.org/257544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7edf2c4328068fd5c69c8cd3fe59958f130fb6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108675 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85807 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91780 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106602 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105047 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2366 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2264 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/8020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/42723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2644 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3904 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->