### PR TITLE
Remove deprecated uppercase URL attribute alias from EventSource interface

### DIFF
--- a/LayoutTests/http/tests/eventsource/eventsource-url-attribute-expected.txt
+++ b/LayoutTests/http/tests/eventsource/eventsource-url-attribute-expected.txt
@@ -1,11 +1,10 @@
-Both .URL and .url should work (for compatibility reasons).
+Only .url should work, previously supported .URL should not.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS source.URL is "http://127.0.0.1:8000/eventsource/resources/event-stream.py"
 PASS source.url is "http://127.0.0.1:8000/eventsource/resources/event-stream.py"
-PASS source.URL === source.url is true
+PASS source.URL is undefined.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/eventsource/eventsource-url-attribute.html
+++ b/LayoutTests/http/tests/eventsource/eventsource-url-attribute.html
@@ -7,14 +7,13 @@
 <body>
 <script>
 
-description("Both .URL and .url should work (for compatibility reasons).");
+description("Only .url should work, previously supported .URL should not.");
 
 var url = "http://127.0.0.1:8000/eventsource/resources/event-stream.py";
 var source = new EventSource(url);
 
-shouldBeEqualToString("source.URL", url);
 shouldBeEqualToString("source.url", url);
-shouldBeTrue("source.URL === source.url");
+shouldBeUndefined("source.URL");
 
 </script>
 <script src="../../js-test-resources/js-test-post.js"></script>

--- a/Source/WebCore/page/EventSource.idl
+++ b/Source/WebCore/page/EventSource.idl
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009 Ericsson AB. All rights reserved.
- * Copyright (C) 2010, 2011 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,13 +29,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface
+
 [
     Exposed=(Window,Worker),
     ActiveDOMObject,
 ] interface EventSource : EventTarget {
     [CallWith=CurrentScriptExecutionContext] constructor(USVString url, optional EventSourceInit eventSourceInitDict);
 
-    readonly attribute USVString URL; // Lowercased .url is the one in the spec, but leaving .URL for compatibility reasons.
     readonly attribute USVString url;
     readonly attribute boolean withCredentials;
 


### PR DESCRIPTION
#### 710c43c6b66e8eeb73f6eed984155b43c2936390
<pre>
Remove deprecated uppercase URL attribute alias from EventSource interface

Remove deprecated uppercase URL attribute alias from EventSource interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=248787">https://bugs.webkit.org/show_bug.cgi?id=248787</a>

Reviewed by Ryosuke Niwa.

This is to align Webkit with Blink / Chromium, Gecko / Firefox and Web-Specifications:

<a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface</a>

Partial Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/f0e6045bfaa96d3a3211e8074feb83d37913f9d3">https://chromium.googlesource.com/chromium/blink/+/f0e6045bfaa96d3a3211e8074feb83d37913f9d3</a>

The upper case &quot;URL&quot; attribute was only in draft specifications from 2009 but later dropped in 2011 specs, which were implemented by non-Webkit browsers. It was later dropped by Blink in 2015 as well.

* Source/WebCore/page/EventSource.idl: Remove &apos;URL&apos; attribute and also add link to web-spec
* LayoutTests/http/tests/eventsource/eventsource-url-attribute.html: Rebaselined
* LayoutTests/http/tests/eventsource/eventsource-url-attribute-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/257553@main">https://commits.webkit.org/257553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82f0b9f1aa2ac1319444f62e4f8a7dcbf24d66bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108541 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168783 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103144 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85692 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91652 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106469 "Hash 82f0b9f1 for PR 7194 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33746 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76610 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2241 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23172 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2133 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45579 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5194 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42647 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->