### PR TITLE
Remove deprecated uppercase URL attribute alias on WebSocket interface

### DIFF
--- a/LayoutTests/http/tests/websocket/tests/hybi/network-process-crash-error.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/network-process-crash-error.html
@@ -11,7 +11,7 @@ if (window.testRunner) {
 }
 
 var ws = new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/slow-reply");
-alert("Created a socket to '" + ws.URL + "'; readyState " + ws.readyState + ".");
+alert("Created a socket to '" + ws.url + "'; readyState " + ws.readyState + ".");
 
 ws.onopen = function()
 {

--- a/LayoutTests/http/tests/websocket/tests/hybi/simple-wss.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/simple-wss.html
@@ -21,7 +21,7 @@ function endTest()
 }
 
 var ws = new WebSocket("wss://127.0.0.1:9323/websocket/tests/hybi/simple");
-debug("Created a socket to '" + ws.URL + "'; readyState " + ws.readyState + ".");
+debug("Created a socket to '" + ws.url + "'; readyState " + ws.readyState + ".");
 
 ws.onopen = function()
 {

--- a/LayoutTests/http/tests/websocket/tests/hybi/simple.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/simple.html
@@ -18,7 +18,7 @@ function endTest()
 }
 
 var ws = new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/simple");
-debug("Created a socket to '" + ws.URL + "'; readyState " + ws.readyState + ".");
+debug("Created a socket to '" + ws.url + "'; readyState " + ws.readyState + ".");
 
 ws.onopen = function()
 {

--- a/LayoutTests/http/tests/websocket/tests/hybi/url-attribute-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/url-attribute-expected.txt
@@ -1,10 +1,9 @@
-Both .URL and .url attributes should work (for compatibility reasons).
+.url attribute should work, previously supported .URL should not.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 PASS ws.url is "ws://127.0.0.1:8880/"
-PASS ws.URL is "ws://127.0.0.1:8880/"
-PASS ws.URL === ws.url is true
+PASS ws.URL is undefined.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/websocket/tests/hybi/url-attribute.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/url-attribute.html
@@ -8,14 +8,13 @@
 <div id="console"></div>
 <script type="text/javascript">
 
-description("Both .URL and .url attributes should work (for compatibility reasons).");
+description(".url attribute should work, previously supported .URL should not.");
 
 var url = "ws://127.0.0.1:8880/";
 var ws = new WebSocket(url);
 
 shouldBeEqualToString("ws.url", url);
-shouldBeEqualToString("ws.URL", url);
-shouldBeTrue("ws.URL === ws.url");
+shouldBeUndefined("ws.URL");
 
 </script>
 <script src="../../../../js-test-resources/js-test-post.js"></script>

--- a/LayoutTests/http/tests/websocket/tests/hybi/url-parsing-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/url-parsing-expected.txt
@@ -13,9 +13,9 @@ PASS new WebSocket(null) threw exception SyntaxError: The string did not match t
 PASS new WebSocket("ws://javascript:a") threw exception SyntaxError: The string did not match the expected pattern..
 PASS new WebSocket("/applet") threw exception SyntaxError: The string did not match the expected pattern..
 PASS new WebSocket("javascript:a") threw exception SyntaxError: The string did not match the expected pattern..
-PASS (new WebSocket("ws://127.0.0.1:8880/a/../websocket/tests/hybi/simple")).URL is "ws://127.0.0.1:8880/websocket/tests/hybi/simple"
-PASS (new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/simple?")).URL is "ws://127.0.0.1:8880/websocket/tests/hybi/simple?"
-PASS (new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/simple?k=v")).URL is "ws://127.0.0.1:8880/websocket/tests/hybi/simple?k=v"
+PASS (new WebSocket("ws://127.0.0.1:8880/a/../websocket/tests/hybi/simple")).url is "ws://127.0.0.1:8880/websocket/tests/hybi/simple"
+PASS (new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/simple?")).url is "ws://127.0.0.1:8880/websocket/tests/hybi/simple?"
+PASS (new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/simple?k=v")).url is "ws://127.0.0.1:8880/websocket/tests/hybi/simple?k=v"
 PASS new WebSocket("ws://127.0.0.1/path#") threw exception SyntaxError: The string did not match the expected pattern..
 PASS new WebSocket("ws://127.0.0.1/path#fragment") threw exception SyntaxError: The string did not match the expected pattern..
 PASS successfullyParsed is true

--- a/LayoutTests/http/tests/websocket/tests/hybi/url-parsing.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/url-parsing.html
@@ -26,9 +26,9 @@ shouldThrow('new WebSocket("javascript:a")');
 
 // Resolve the url string using the resolve a Web address algorithm.
 // Use 127.0.0.1:8880 and existing ws handler to make sure we don't receive unexpected response (so no console message appears)
-shouldBe('(new WebSocket("ws://127.0.0.1:8880/a/../websocket/tests/hybi/simple")).URL', '"ws://127.0.0.1:8880/websocket/tests/hybi/simple"');
-shouldBe('(new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/simple?")).URL', '"ws://127.0.0.1:8880/websocket/tests/hybi/simple?"');
-shouldBe('(new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/simple?k=v")).URL', '"ws://127.0.0.1:8880/websocket/tests/hybi/simple?k=v"');
+shouldBe('(new WebSocket("ws://127.0.0.1:8880/a/../websocket/tests/hybi/simple")).url', '"ws://127.0.0.1:8880/websocket/tests/hybi/simple"');
+shouldBe('(new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/simple?")).url', '"ws://127.0.0.1:8880/websocket/tests/hybi/simple?"');
+shouldBe('(new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/simple?k=v")).url', '"ws://127.0.0.1:8880/websocket/tests/hybi/simple?k=v"');
 
 // draft-hixie-thewebsocketprotocol-60 says If /url/ has a <fragment>
 // component, then fail the parsing Web Socket URLs, so throw a SYNTAX_ERR

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/url/004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/url/004-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL WebSockets: 'URL' assert_equals: expected (undefined) undefined but got (string) "ws://localhost:49001/"
+PASS WebSockets: 'URL'
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/url/004-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/url/004-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL WebSockets: 'URL' assert_equals: expected (undefined) undefined but got (string) "ws://web-platform.test:49001/"
+PASS WebSockets: 'URL'
 

--- a/Source/WebCore/Modules/websockets/WebSocket.idl
+++ b/Source/WebCore/Modules/websockets/WebSocket.idl
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009 Google Inc.  All rights reserved.
- * Copyright (C) 2010, 2011 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,6 +29,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://html.spec.whatwg.org/multipage/comms.html#the-websocket-interface
+
 [
     ActiveDOMObject,
     Exposed=(Window,Worker),
@@ -37,7 +39,6 @@
     [CallWith=CurrentScriptExecutionContext] constructor(USVString url, optional sequence<DOMString> protocols = []);
     [CallWith=CurrentScriptExecutionContext] constructor(USVString url, DOMString protocol);
 
-    readonly attribute USVString URL; // Lowercased .url is the one in the spec, but leaving .URL for compatibility reasons.
     readonly attribute USVString url;
 
     const unsigned short CONNECTING = 0;


### PR DESCRIPTION
#### a05af340527ab26ff2e81de10b6630b25b83e922
<pre>
Remove deprecated uppercase URL attribute alias on WebSocket interface

Remove deprecated uppercase URL attribute alias on WebSocket interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=248781">https://bugs.webkit.org/show_bug.cgi?id=248781</a>

Reviewed by Chris Dumez.

This patch is to align Webkit with Blink / Chromium, Gecko / Firefox and Web-Specification:

<a href="https://html.spec.whatwg.org/multipage/comms.html#the-websocket-interface">https://html.spec.whatwg.org/multipage/comms.html#the-websocket-interface</a>

Partial Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/825c9732ce83f380fadfc062331cc12495e5eb12">https://chromium.googlesource.com/chromium/blink/+/825c9732ce83f380fadfc062331cc12495e5eb12</a>

The `URL` attribute is from early iterations of the spec and was
maintained for compatibility even after `url` was standardized but now it is not in the latest web-specification and was removed from Blink in 2015 as well.

* Source/WebCore/Modules/websockets/WebSocket.idl: Remove &apos;URL&apos; attribute and also add link to web-spec
* LayoutTests/http/tests/websocket/tests/hybi/network-process-crash-error.html: Rebaselined
* LayoutTests/http/tests/websocket/tests/hybi/simple.html: Rebaselined
* LayoutTests/http/tests/websocket/tests/hybi/url-attribute.html: Rebaselined
* LayoutTests/http/tests/websocket/tests/hybi/url-attribute-expected.txt: Rebaselined
* LayoutTests/http/tests/websocket/tests/hybi/url-parsing.html: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/url/004-expected.txt: Rebaselined
* LayoutTests/http/tests/websockets/tests/hybi/url-parsing-expected.txt: Rebaselined
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/url/004-expected.txt: Rebaselined
* LayoutTests/http/tests/websocket/tests/hybi/simple-wss.html: Rebaselined

Canonical link: <a href="https://commits.webkit.org/257467@main">https://commits.webkit.org/257467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edb1b6735651bb1c69f619a7184cb580db280e96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108413 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168665 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85551 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91530 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106371 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90219 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33661 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76515 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2114 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23080 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45470 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5143 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42555 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3432 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->