### PR TITLE
Add IPC encoding and decoding support for TransformOperations and TransformOperation

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1793,8 +1793,13 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/opentype/OpenTypeVerticalData.h
 
     platform/graphics/transforms/AffineTransform.h
+    platform/graphics/transforms/IdentityTransformOperation.h
+    platform/graphics/transforms/Matrix3DTransformOperation.h
+    platform/graphics/transforms/MatrixTransformOperation.h
+    platform/graphics/transforms/PerspectiveTransformOperation.h
     platform/graphics/transforms/RotateTransformOperation.h
     platform/graphics/transforms/ScaleTransformOperation.h
+    platform/graphics/transforms/SkewTransformOperation.h
     platform/graphics/transforms/TransformOperation.h
     platform/graphics/transforms/TransformOperations.h
     platform/graphics/transforms/TransformState.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2264,6 +2264,7 @@ platform/graphics/iso/ISOTrackEncryptionBox.cpp
 platform/graphics/iso/ISOVTTCue.cpp
 platform/graphics/opentype/OpenTypeMathData.cpp
 platform/graphics/transforms/AffineTransform.cpp
+platform/graphics/transforms/IdentityTransformOperation.cpp
 platform/graphics/transforms/Matrix3DTransformOperation.cpp
 platform/graphics/transforms/MatrixTransformOperation.cpp
 platform/graphics/transforms/PerspectiveTransformOperation.cpp

--- a/Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "IdentityTransformOperation.h"
+
+namespace WebCore {
+
+Ref<IdentityTransformOperation> IdentityTransformOperation::create()
+{
+    return adoptRef(*new IdentityTransformOperation());
+}
+
+IdentityTransformOperation::IdentityTransformOperation()
+    : TransformOperation(TransformOperation::Type::Identity)
+{
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.h
@@ -33,10 +33,7 @@ struct BlendingContext;
 
 class IdentityTransformOperation final : public TransformOperation {
 public:
-    static Ref<IdentityTransformOperation> create()
-    {
-        return adoptRef(*new IdentityTransformOperation());
-    }
+    WEBCORE_EXPORT static Ref<IdentityTransformOperation> create();
 
     Ref<TransformOperation> clone() const override
     {
@@ -63,10 +60,7 @@ private:
 
     void dump(WTF::TextStream&) const final;
 
-    IdentityTransformOperation()
-        : TransformOperation(TransformOperation::Type::Identity)
-    {
-    }
+    IdentityTransformOperation();
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.cpp
@@ -32,6 +32,17 @@
 
 namespace WebCore {
 
+Ref<Matrix3DTransformOperation> Matrix3DTransformOperation::create(const TransformationMatrix& matrix)
+{
+    return adoptRef(*new Matrix3DTransformOperation(matrix));
+}
+
+Matrix3DTransformOperation::Matrix3DTransformOperation(const TransformationMatrix& mat)
+    : TransformOperation(TransformOperation::Type::Matrix3D)
+    , m_matrix(mat)
+{
+}
+
 bool Matrix3DTransformOperation::operator==(const TransformOperation& other) const
 {
     return isSameType(other) && m_matrix == downcast<Matrix3DTransformOperation>(other).m_matrix;

--- a/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.h
@@ -34,10 +34,7 @@ struct BlendingContext;
 
 class Matrix3DTransformOperation final : public TransformOperation {
 public:
-    static Ref<Matrix3DTransformOperation> create(const TransformationMatrix& matrix)
-    {
-        return adoptRef(*new Matrix3DTransformOperation(matrix));
-    }
+    WEBCORE_EXPORT static Ref<Matrix3DTransformOperation> create(const TransformationMatrix&);
 
     Ref<TransformOperation> clone() const override
     {
@@ -65,11 +62,7 @@ private:
     
     void dump(WTF::TextStream&) const final;
 
-    Matrix3DTransformOperation(const TransformationMatrix& mat)
-        : TransformOperation(TransformOperation::Type::Matrix3D)
-        , m_matrix(mat)
-    {
-    }
+    Matrix3DTransformOperation(const TransformationMatrix&);
 
     TransformationMatrix m_matrix;
 };

--- a/Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.cpp
@@ -28,6 +28,22 @@
 
 namespace WebCore {
 
+Ref<MatrixTransformOperation> MatrixTransformOperation::create(const TransformationMatrix& t)
+{
+    return adoptRef(*new MatrixTransformOperation(t));
+}
+
+MatrixTransformOperation::MatrixTransformOperation(const TransformationMatrix& t)
+    : TransformOperation(TransformOperation::Type::Matrix)
+    , m_a(t.a())
+    , m_b(t.b())
+    , m_c(t.c())
+    , m_d(t.d())
+    , m_e(t.e())
+    , m_f(t.f())
+{
+}
+
 bool MatrixTransformOperation::operator==(const TransformOperation& other) const
 {
     if (!isSameType(other))

--- a/Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.h
@@ -39,10 +39,7 @@ public:
         return adoptRef(*new MatrixTransformOperation(a, b, c, d, e, f));
     }
 
-    static Ref<MatrixTransformOperation> create(const TransformationMatrix& t)
-    {
-        return adoptRef(*new MatrixTransformOperation(t));
-    }
+    WEBCORE_EXPORT static Ref<MatrixTransformOperation> create(const TransformationMatrix&);
 
     Ref<TransformOperation> clone() const override
     {
@@ -80,17 +77,8 @@ private:
     {
     }
 
-    MatrixTransformOperation(const TransformationMatrix& t)
-        : TransformOperation(TransformOperation::Type::Matrix)
-        , m_a(t.a())
-        , m_b(t.b())
-        , m_c(t.c())
-        , m_d(t.d())
-        , m_e(t.e())
-        , m_f(t.f())
-    {
-    }
-    
+    MatrixTransformOperation(const TransformationMatrix&);
+
     double m_a;
     double m_b;
     double m_c;

--- a/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.cpp
@@ -32,6 +32,18 @@
 
 namespace WebCore {
 
+Ref<PerspectiveTransformOperation> PerspectiveTransformOperation::create(const std::optional<Length>& p)
+{
+    return adoptRef(*new PerspectiveTransformOperation(p));
+}
+
+PerspectiveTransformOperation::PerspectiveTransformOperation(const std::optional<Length>& p)
+    : TransformOperation(TransformOperation::Type::Perspective)
+    , m_p(p)
+{
+    ASSERT(!p || (*p).isFixed());
+}
+
 bool PerspectiveTransformOperation::operator==(const TransformOperation& other) const
 {
     if (!isSameType(other))

--- a/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h
@@ -37,10 +37,7 @@ struct BlendingContext;
 
 class PerspectiveTransformOperation final : public TransformOperation {
 public:
-    static Ref<PerspectiveTransformOperation> create(const std::optional<Length>& p)
-    {
-        return adoptRef(*new PerspectiveTransformOperation(p));
-    }
+    WEBCORE_EXPORT static Ref<PerspectiveTransformOperation> create(const std::optional<Length>&);
 
     Ref<TransformOperation> clone() const override
     {
@@ -80,12 +77,7 @@ private:
 
     void dump(WTF::TextStream&) const final;
 
-    PerspectiveTransformOperation(const std::optional<Length>& p)
-        : TransformOperation(TransformOperation::Type::Perspective)
-        , m_p(p)
-    {
-        ASSERT(!p || (*p).isFixed());
-    }
+    PerspectiveTransformOperation(const std::optional<Length>&);
 
     std::optional<Length> m_p;
 };

--- a/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
@@ -29,6 +29,21 @@
 
 namespace WebCore {
 
+Ref<RotateTransformOperation> RotateTransformOperation::create(double x, double y, double z, double angle, TransformOperation::Type type)
+{
+    return adoptRef(*new RotateTransformOperation(x, y, z, angle, type));
+}
+
+RotateTransformOperation::RotateTransformOperation(double x, double y, double z, double angle, TransformOperation::Type type)
+    : TransformOperation(type)
+    , m_x(x)
+    , m_y(y)
+    , m_z(z)
+    , m_angle(angle)
+{
+    ASSERT(isRotateTransformOperationType());
+}
+
 bool RotateTransformOperation::operator==(const TransformOperation& other) const
 {
     if (!isSameType(other))

--- a/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h
@@ -38,10 +38,7 @@ public:
         return adoptRef(*new RotateTransformOperation(0, 0, 1, angle, type));
     }
 
-    static Ref<RotateTransformOperation> create(double x, double y, double z, double angle, TransformOperation::Type type)
-    {
-        return adoptRef(*new RotateTransformOperation(x, y, z, angle, type));
-    }
+    WEBCORE_EXPORT static Ref<RotateTransformOperation> create(double, double, double, double, TransformOperation::Type);
 
     Ref<TransformOperation> clone() const override
     {
@@ -78,15 +75,7 @@ private:
 
     void dump(WTF::TextStream&) const final;
 
-    RotateTransformOperation(double x, double y, double z, double angle, TransformOperation::Type type)
-        : TransformOperation(type)
-        , m_x(x)
-        , m_y(y)
-        , m_z(z)
-        , m_angle(angle)
-    {
-        ASSERT(isRotateTransformOperationType());
-    }
+    RotateTransformOperation(double, double, double, double, TransformOperation::Type);
 
     double m_x;
     double m_y;

--- a/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.cpp
@@ -27,6 +27,20 @@
 
 namespace WebCore {
 
+Ref<ScaleTransformOperation> ScaleTransformOperation::create(double sx, double sy, double sz, TransformOperation::Type type)
+{
+    return adoptRef(*new ScaleTransformOperation(sx, sy, sz, type));
+}
+
+ScaleTransformOperation::ScaleTransformOperation(double sx, double sy, double sz, TransformOperation::Type type)
+    : TransformOperation(type)
+    , m_x(sx)
+    , m_y(sy)
+    , m_z(sz)
+{
+    ASSERT(isScaleTransformOperationType());
+}
+
 bool ScaleTransformOperation::operator==(const TransformOperation& other) const
 {
     if (!isSameType(other))

--- a/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h
@@ -38,10 +38,7 @@ public:
         return adoptRef(*new ScaleTransformOperation(sx, sy, 1, type));
     }
 
-    static Ref<ScaleTransformOperation> create(double sx, double sy, double sz, TransformOperation::Type type)
-    {
-        return adoptRef(*new ScaleTransformOperation(sx, sy, sz, type));
-    }
+    WEBCORE_EXPORT static Ref<ScaleTransformOperation> create(double, double, double, TransformOperation::Type);
 
     Ref<TransformOperation> clone() const override
     {
@@ -74,15 +71,8 @@ private:
 
     void dump(WTF::TextStream&) const final;
 
-    ScaleTransformOperation(double sx, double sy, double sz, TransformOperation::Type type)
-        : TransformOperation(type)
-        , m_x(sx)
-        , m_y(sy)
-        , m_z(sz)
-    {
-        ASSERT(isScaleTransformOperationType());
-    }
-        
+    ScaleTransformOperation(double, double, double, TransformOperation::Type);
+
     double m_x;
     double m_y;
     double m_z;

--- a/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.cpp
@@ -27,6 +27,19 @@
 
 namespace WebCore {
 
+Ref<SkewTransformOperation> SkewTransformOperation::create(double angleX, double angleY, TransformOperation::Type type)
+{
+    return adoptRef(*new SkewTransformOperation(angleX, angleY, type));
+}
+
+SkewTransformOperation::SkewTransformOperation(double angleX, double angleY, TransformOperation::Type type)
+    : TransformOperation(type)
+    , m_angleX(angleX)
+    , m_angleY(angleY)
+{
+    ASSERT(isSkewTransformOperationType());
+}
+
 bool SkewTransformOperation::operator==(const TransformOperation& other) const
 {
     if (!isSameType(other))

--- a/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.h
@@ -33,10 +33,7 @@ struct BlendingContext;
 
 class SkewTransformOperation final : public TransformOperation {
 public:
-    static Ref<SkewTransformOperation> create(double angleX, double angleY, TransformOperation::Type type)
-    {
-        return adoptRef(*new SkewTransformOperation(angleX, angleY, type));
-    }
+    WEBCORE_EXPORT static Ref<SkewTransformOperation> create(double, double, TransformOperation::Type);
 
     Ref<TransformOperation> clone() const override
     {
@@ -63,14 +60,8 @@ private:
 
     void dump(WTF::TextStream&) const final;
     
-    SkewTransformOperation(double angleX, double angleY, TransformOperation::Type type)
-        : TransformOperation(type)
-        , m_angleX(angleX)
-        , m_angleY(angleY)
-    {
-        ASSERT(isSkewTransformOperationType());
-    }
-    
+    SkewTransformOperation(double, double, TransformOperation::Type);
+
     double m_angleX;
     double m_angleY;
 };

--- a/Source/WebCore/platform/graphics/transforms/TransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperation.h
@@ -27,6 +27,7 @@
 #include "CompositeOperation.h"
 #include "FloatSize.h"
 #include "TransformationMatrix.h"
+#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TypeCasts.h>
@@ -136,6 +137,39 @@ WTF::TextStream& operator<<(WTF::TextStream&, TransformOperation::Type);
 WTF::TextStream& operator<<(WTF::TextStream&, const TransformOperation&);
 
 } // namespace WebCore
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::TransformOperation::Type> {
+    using values = EnumValues<
+        WebCore::TransformOperation::Type,
+        WebCore::TransformOperation::Type::ScaleX,
+        WebCore::TransformOperation::Type::ScaleY,
+        WebCore::TransformOperation::Type::Scale,
+        WebCore::TransformOperation::Type::TranslateX,
+        WebCore::TransformOperation::Type::TranslateY,
+        WebCore::TransformOperation::Type::Translate,
+        WebCore::TransformOperation::Type::RotateX,
+        WebCore::TransformOperation::Type::RotateY,
+        WebCore::TransformOperation::Type::Rotate,
+        WebCore::TransformOperation::Type::SkewX,
+        WebCore::TransformOperation::Type::SkewY,
+        WebCore::TransformOperation::Type::Skew,
+        WebCore::TransformOperation::Type::Matrix,
+        WebCore::TransformOperation::Type::ScaleZ,
+        WebCore::TransformOperation::Type::Scale3D,
+        WebCore::TransformOperation::Type::TranslateZ,
+        WebCore::TransformOperation::Type::Translate3D,
+        WebCore::TransformOperation::Type::RotateZ,
+        WebCore::TransformOperation::Type::Rotate3D,
+        WebCore::TransformOperation::Type::Matrix3D,
+        WebCore::TransformOperation::Type::Perspective,
+        WebCore::TransformOperation::Type::Identity,
+        WebCore::TransformOperation::Type::None
+    >;
+};
+
+} // namespace WTF
 
 #define SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(ToValueTypeName, predicate) \
 SPECIALIZE_TYPE_TRAITS_BEGIN(ToValueTypeName) \

--- a/Source/WebCore/platform/graphics/transforms/TransformOperations.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperations.cpp
@@ -36,6 +36,11 @@ TransformOperations::TransformOperations(bool makeIdentity)
         m_operations.append(IdentityTransformOperation::create());
 }
 
+TransformOperations::TransformOperations(Vector<RefPtr<TransformOperation>>&& operations)
+    : m_operations(WTFMove(operations))
+{
+}
+
 bool TransformOperations::operator==(const TransformOperations& o) const
 {
     if (m_operations.size() != o.m_operations.size())

--- a/Source/WebCore/platform/graphics/transforms/TransformOperations.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperations.h
@@ -36,7 +36,8 @@ struct BlendingContext;
 class TransformOperations {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit TransformOperations(bool makeIdentity = false);
+    WEBCORE_EXPORT explicit TransformOperations(bool makeIdentity = false);
+    WEBCORE_EXPORT explicit TransformOperations(Vector<RefPtr<TransformOperation>>&&);
     
     bool operator==(const TransformOperations& o) const;
     bool operator!=(const TransformOperations& o) const

--- a/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp
@@ -28,6 +28,20 @@
 
 namespace WebCore {
 
+Ref<TranslateTransformOperation> TranslateTransformOperation::create(const Length& tx, const Length& ty, const Length& tz, TransformOperation::Type type)
+{
+    return adoptRef(*new TranslateTransformOperation(tx, ty, tz, type));
+}
+
+TranslateTransformOperation::TranslateTransformOperation(const Length& tx, const Length& ty, const Length& tz, TransformOperation::Type type)
+    : TransformOperation(type)
+    , m_x(tx)
+    , m_y(ty)
+    , m_z(tz)
+{
+    ASSERT(isTranslateTransformOperationType());
+}
+
 bool TranslateTransformOperation::operator==(const TransformOperation& other) const
 {
     if (!isSameType(other))

--- a/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h
@@ -40,10 +40,7 @@ public:
         return adoptRef(*new TranslateTransformOperation(tx, ty, Length(0, LengthType::Fixed), type));
     }
 
-    static Ref<TranslateTransformOperation> create(const Length& tx, const Length& ty, const Length& tz, TransformOperation::Type type)
-    {
-        return adoptRef(*new TranslateTransformOperation(tx, ty, tz, type));
-    }
+    WEBCORE_EXPORT static Ref<TranslateTransformOperation> create(const Length&, const Length&, const Length&, TransformOperation::Type);
 
     Ref<TransformOperation> clone() const override
     {
@@ -83,14 +80,7 @@ private:
 
     void dump(WTF::TextStream&) const final;
 
-    TranslateTransformOperation(const Length& tx, const Length& ty, const Length& tz, TransformOperation::Type type)
-        : TransformOperation(type)
-        , m_x(tx)
-        , m_y(ty)
-        , m_z(tz)
-    {
-        ASSERT(isTranslateTransformOperationType());
-    }
+    TranslateTransformOperation(const Length&, const Length&, const Length&, TransformOperation::Type);
 
     Length m_x;
     Length m_y;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -66,13 +66,17 @@
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/IDBGetResult.h>
+#include <WebCore/IdentityTransformOperation.h>
 #include <WebCore/Image.h>
 #include <WebCore/JSDOMExceptionHandling.h>
 #include <WebCore/Length.h>
 #include <WebCore/LengthBox.h>
+#include <WebCore/Matrix3DTransformOperation.h>
+#include <WebCore/MatrixTransformOperation.h>
 #include <WebCore/MediaSelectionOption.h>
 #include <WebCore/NotificationResources.h>
 #include <WebCore/Pasteboard.h>
+#include <WebCore/PerspectiveTransformOperation.h>
 #include <WebCore/PluginData.h>
 #include <WebCore/PromisedAttachmentInfo.h>
 #include <WebCore/ProtectionSpace.h>
@@ -84,6 +88,8 @@
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ResourceResponse.h>
+#include <WebCore/RotateTransformOperation.h>
+#include <WebCore/ScaleTransformOperation.h>
 #include <WebCore/ScriptBuffer.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <WebCore/ScrollingConstraints.h>
@@ -97,12 +103,15 @@
 #include <WebCore/ServiceWorkerData.h>
 #include <WebCore/ShareData.h>
 #include <WebCore/SharedBuffer.h>
+#include <WebCore/SkewTransformOperation.h>
 #include <WebCore/SystemImage.h>
 #include <WebCore/TestReportBody.h>
 #include <WebCore/TextCheckerClient.h>
 #include <WebCore/TextIndicator.h>
 #include <WebCore/TimingFunction.h>
+#include <WebCore/TransformOperation.h>
 #include <WebCore/TransformationMatrix.h>
+#include <WebCore/TranslateTransformOperation.h>
 #include <WebCore/UserStyleSheet.h>
 #include <WebCore/VelocityData.h>
 #include <WebCore/ViewportArguments.h>
@@ -1747,6 +1756,144 @@ std::optional<RefPtr<WebCore::TimingFunction>> ArgumentCoder<RefPtr<WebCore::Tim
     if (!timingFunction)
         return std::nullopt;
     return WTFMove(*timingFunction);
+}
+
+void ArgumentCoder<WebCore::TransformOperation>::encode(Encoder& encoder, const WebCore::TransformOperation& transformOperation)
+{
+    if (transformOperation.type() == TransformOperation::Type::None)
+        return;
+
+    encoder << transformOperation.type();
+
+    switch (transformOperation.type()) {
+    case TransformOperation::Type::TranslateX:
+    case TransformOperation::Type::TranslateY:
+    case TransformOperation::Type::TranslateZ:
+    case TransformOperation::Type::Translate:
+    case TransformOperation::Type::Translate3D:
+        encoder << downcast<TranslateTransformOperation>(transformOperation);
+        break;
+    case TransformOperation::Type::ScaleX:
+    case TransformOperation::Type::ScaleY:
+    case TransformOperation::Type::ScaleZ:
+    case TransformOperation::Type::Scale:
+    case TransformOperation::Type::Scale3D:
+        encoder << downcast<ScaleTransformOperation>(transformOperation);
+        break;
+    case TransformOperation::Type::RotateX:
+    case TransformOperation::Type::RotateY:
+    case TransformOperation::Type::RotateZ:
+    case TransformOperation::Type::Rotate:
+    case TransformOperation::Type::Rotate3D:
+        encoder << downcast<RotateTransformOperation>(transformOperation);
+        break;
+    case TransformOperation::Type::SkewX:
+    case TransformOperation::Type::SkewY:
+    case TransformOperation::Type::Skew:
+        encoder << downcast<SkewTransformOperation>(transformOperation);
+        break;
+    case TransformOperation::Type::Matrix:
+        encoder << downcast<MatrixTransformOperation>(transformOperation);
+        break;
+    case TransformOperation::Type::Matrix3D:
+        encoder << downcast<Matrix3DTransformOperation>(transformOperation);
+        break;
+    case TransformOperation::Type::Perspective:
+        encoder << downcast<PerspectiveTransformOperation>(transformOperation);
+        break;
+    case TransformOperation::Type::Identity:
+        encoder << downcast<IdentityTransformOperation>(transformOperation);
+        break;
+    case TransformOperation::Type::None:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+}
+
+std::optional<Ref<WebCore::TransformOperation>> ArgumentCoder<WebCore::TransformOperation>::decode(Decoder& decoder)
+{
+    std::optional<TransformOperation::Type> type;
+    decoder >> type;
+    if (!type)
+        return std::nullopt;
+
+    switch (*type) {
+    case TransformOperation::Type::TranslateX:
+    case TransformOperation::Type::TranslateY:
+    case TransformOperation::Type::TranslateZ:
+    case TransformOperation::Type::Translate:
+    case TransformOperation::Type::Translate3D: {
+        std::optional<Ref<TranslateTransformOperation>> transformOperation;
+        decoder >> transformOperation;
+        if (!transformOperation)
+            return std::nullopt;
+        return WTFMove(*transformOperation);
+    }
+    case TransformOperation::Type::ScaleX:
+    case TransformOperation::Type::ScaleY:
+    case TransformOperation::Type::ScaleZ:
+    case TransformOperation::Type::Scale:
+    case TransformOperation::Type::Scale3D: {
+        std::optional<Ref<ScaleTransformOperation>> transformOperation;
+        decoder >> transformOperation;
+        if (!transformOperation)
+            return std::nullopt;
+        return WTFMove(*transformOperation);
+    }
+    case TransformOperation::Type::RotateX:
+    case TransformOperation::Type::RotateY:
+    case TransformOperation::Type::RotateZ:
+    case TransformOperation::Type::Rotate:
+    case TransformOperation::Type::Rotate3D: {
+        std::optional<Ref<RotateTransformOperation>> transformOperation;
+        decoder >> transformOperation;
+        if (!transformOperation)
+            return std::nullopt;
+        return WTFMove(*transformOperation);
+    }
+    case TransformOperation::Type::SkewX:
+    case TransformOperation::Type::SkewY:
+    case TransformOperation::Type::Skew: {
+        std::optional<Ref<SkewTransformOperation>> transformOperation;
+        decoder >> transformOperation;
+        if (!transformOperation)
+            return std::nullopt;
+        return WTFMove(*transformOperation);
+    }
+    case TransformOperation::Type::Matrix: {
+        std::optional<Ref<MatrixTransformOperation>> transformOperation;
+        decoder >> transformOperation;
+        if (!transformOperation)
+            return std::nullopt;
+        return WTFMove(*transformOperation);
+    }
+    case TransformOperation::Type::Matrix3D: {
+        std::optional<Ref<Matrix3DTransformOperation>> transformOperation;
+        decoder >> transformOperation;
+        if (!transformOperation)
+            return std::nullopt;
+        return WTFMove(*transformOperation);
+    }
+    case TransformOperation::Type::Perspective: {
+        std::optional<Ref<PerspectiveTransformOperation>> transformOperation;
+        decoder >> transformOperation;
+        if (!transformOperation)
+            return std::nullopt;
+        return WTFMove(*transformOperation);
+    }
+    case TransformOperation::Type::Identity: {
+        std::optional<Ref<IdentityTransformOperation>> transformOperation;
+        decoder >> transformOperation;
+        if (!transformOperation)
+            return std::nullopt;
+        return WTFMove(*transformOperation);
+    }
+    case TransformOperation::Type::None:
+        break;
+    }
+
+    ASSERT_NOT_REACHED();
+    return std::nullopt;
 }
 
 } // namespace IPC

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -145,6 +145,7 @@ class StickyPositionViewportConstraints;
 class SystemImage;
 class TextCheckingRequestData;
 class TimingFunction;
+class TransformOperation;
 class UserStyleSheet;
 
 struct AttributedString;
@@ -571,6 +572,11 @@ template<> struct ArgumentCoder<Ref<WebCore::TimingFunction>> {
 template<> struct ArgumentCoder<RefPtr<WebCore::TimingFunction>> {
     static void encode(Encoder&, const RefPtr<WebCore::TimingFunction>&);
     static std::optional<RefPtr<WebCore::TimingFunction>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebCore::TransformOperation> {
+    static void encode(Encoder&, const WebCore::TransformOperation&);
+    static std::optional<Ref<WebCore::TransformOperation>> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1777,3 +1777,50 @@ header: <WebCore/ScrollingConstraints.h>
 [Return=Ref] class WebCore::NotificationResources {
     RefPtr<WebCore::Image> icon();
 };
+
+[Return=Ref] class WebCore::IdentityTransformOperation {
+}
+
+[Return=Ref] class WebCore::TranslateTransformOperation {
+    WebCore::Length x();
+    WebCore::Length y();
+    WebCore::Length z();
+    WebCore::TransformOperation::Type type();
+}
+
+[Return=Ref] class WebCore::RotateTransformOperation {
+    double x();
+    double y();
+    double z();
+    double angle();
+    WebCore::TransformOperation::Type type();
+}
+
+[Return=Ref] class WebCore::ScaleTransformOperation {
+    double x();
+    double y();
+    double z();
+    WebCore::TransformOperation::Type type();
+}
+
+[Return=Ref] class WebCore::SkewTransformOperation {
+    double angleX();
+    double angleY();
+    WebCore::TransformOperation::Type type();
+}
+
+[Return=Ref] class WebCore::PerspectiveTransformOperation {
+    std::optional<WebCore::Length> perspective();
+}
+
+[Return=Ref] class WebCore::MatrixTransformOperation {
+    WebCore::TransformationMatrix matrix();
+}
+
+[Return=Ref] class WebCore::Matrix3DTransformOperation {
+    WebCore::TransformationMatrix matrix();
+}
+
+class WebCore::TransformOperations {
+    Vector<RefPtr<WebCore::TransformOperation>> operations();
+}


### PR DESCRIPTION
#### b647671abdf8dfa003663e22a64f46743294db80
<pre>
Add IPC encoding and decoding support for TransformOperations and TransformOperation
<a href="https://bugs.webkit.org/show_bug.cgi?id=248818">https://bugs.webkit.org/show_bug.cgi?id=248818</a>

Reviewed by Alex Christensen.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.cpp: Added.
(WebCore::IdentityTransformOperation::create):
(WebCore::IdentityTransformOperation::IdentityTransformOperation):
* Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.cpp:
(WebCore::Matrix3DTransformOperation::create):
(WebCore::Matrix3DTransformOperation::Matrix3DTransformOperation):
* Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.cpp:
(WebCore::MatrixTransformOperation::create):
(WebCore::MatrixTransformOperation::MatrixTransformOperation):
* Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.cpp:
(WebCore::PerspectiveTransformOperation::create):
(WebCore::PerspectiveTransformOperation::PerspectiveTransformOperation):
* Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp:
(WebCore::RotateTransformOperation::create):
(WebCore::RotateTransformOperation::RotateTransformOperation):
* Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.cpp:
(WebCore::ScaleTransformOperation::create):
(WebCore::ScaleTransformOperation::ScaleTransformOperation):
* Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/SkewTransformOperation.cpp:
(WebCore::SkewTransformOperation::create):
(WebCore::SkewTransformOperation::SkewTransformOperation):
* Source/WebCore/platform/graphics/transforms/SkewTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/TransformOperation.h:
* Source/WebCore/platform/graphics/transforms/TransformOperations.cpp:
(WebCore::TransformOperations::TransformOperations):
* Source/WebCore/platform/graphics/transforms/TransformOperations.h:
* Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp:
(WebCore::TranslateTransformOperation::create):
(WebCore::TranslateTransformOperation::TranslateTransformOperation):
* Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::TransformOperation&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::TransformOperation&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/257545@main">https://commits.webkit.org/257545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f17135beb2316686484773dd392afa86b1c1d338

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/99296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8494 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/32413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/108680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168926 "Failed to checkout and rebase branch from PR 7199") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/103293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9050 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106607 "Failed to checkout and rebase branch from PR 7199") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/105052 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/32413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/91785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/32413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2371 "Failed to checkout and rebase branch from PR 7199") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/32413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/2269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/8048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/32413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2645 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/3918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->