### PR TITLE
Improve some CSS WPT tests so their output is easier to read and fix some mistaken expectations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoxQuads-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoxQuads-001-expected.txt
@@ -1,3 +1,8 @@
 
-FAIL CSSOM View - getBoxQuads() returns proper border and margin boxes for block and flex bb.getBoxQuads is not a function. (In 'bb.getBoxQuads({box: "border"})', 'bb.getBoxQuads' is undefined)
+FAIL Block layout border box is expected width. bb.getBoxQuads is not a function. (In 'bb.getBoxQuads({box: "border"})', 'bb.getBoxQuads' is undefined)
+FAIL Block layout margin box is expected width. bb.getBoxQuads is not a function. (In 'bb.getBoxQuads({box: "margin"})', 'bb.getBoxQuads' is undefined)
+FAIL Flex layout border box is expected width. fb.getBoxQuads is not a function. (In 'fb.getBoxQuads({box: "border"})', 'fb.getBoxQuads' is undefined)
+FAIL Flex layout margin box is expected width. fb.getBoxQuads is not a function. (In 'fb.getBoxQuads({box: "margin"})', 'fb.getBoxQuads' is undefined)
+FAIL Flex layout border box is expected height. fb.getBoxQuads is not a function. (In 'fb.getBoxQuads({box: "border"})', 'fb.getBoxQuads' is undefined)
+FAIL Flex layout margin box is expected height. fb.getBoxQuads is not a function. (In 'fb.getBoxQuads({box: "margin"})', 'fb.getBoxQuads' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoxQuads-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoxQuads-001.html
@@ -33,19 +33,29 @@
   </div>
 
   <script>
+    let bb = document.getElementById("block-block")
+    let fb = document.getElementById("flex-block")
     test(function() {
-      let bb = document.getElementById("block-block");
-      assert_equals(bb.getBoxQuads({box: "border"})[0].getBounds().width,  20, "Block layout border box is expected width.");
-      assert_equals(bb.getBoxQuads({box: "margin"})[0].getBounds().width, 100, "Block layout margin box is expected width.");
+      assert_equals(bb.getBoxQuads({box: "border"})[0].getBounds().width, 20)
+    }, "Block layout border box is expected width.")
+    test(function() {
+      assert_equals(bb.getBoxQuads({box: "margin"})[0].getBounds().width, 100)
+    }, "Block layout margin box is expected width.")
 
-      // For containers that expand items to fill block-axis space, measure the box heights also.
-      let fb = document.getElementById("flex-block");
-      assert_equals(fb.getBoxQuads({box: "border"})[0].getBounds().width,  20, "Flex layout border box is expected width.");
-      assert_equals(fb.getBoxQuads({box: "margin"})[0].getBounds().width, 100, "Flex layout margin box is expected width.");
+    // For containers that expand items to fill block-axis space, measure the box heights also.
+    test(function() {
+      assert_equals(fb.getBoxQuads({box: "border"})[0].getBounds().width, 20)
+    }, "Flex layout border box is expected width.")
+    test(function() {
+      assert_equals(fb.getBoxQuads({box: "margin"})[0].getBounds().width, 100)
+    }, "Flex layout margin box is expected width.")
 
-      assert_equals(fb.getBoxQuads({box: "border"})[0].getBounds().height, 10, "Flex layout border box is expected height.");
-      assert_equals(fb.getBoxQuads({box: "margin"})[0].getBounds().height, 50, "Flex layout margin box is expected height.");
-    });
+    test(function() {
+      assert_equals(fb.getBoxQuads({box: "border"})[0].getBounds().height, 10)
+    }, "Flex layout border box is expected height.")
+    test(function() {
+      assert_equals(fb.getBoxQuads({box: "margin"})[0].getBounds().height, 50)
+    }, "Flex layout margin box is expected height.")
   </script>
  </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/flex-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/flex-serialization-expected.txt
@@ -1,3 +1,7 @@
 
-FAIL CSSOM - Flex serialization assert_in_array: Single value flex with non-CSS-wide keyword should serialize correctly. value "flex: 0 1 0%;" not in array ["flex: 0px;", "flex: 0 1 0px;"]
+PASS Single value flex with CSS-wide keyword should serialize correctly.
+FAIL Single value flex with non-CSS-wide value should serialize correctly. assert_in_array: value "flex: 0 1 0%;" not in array ["flex: 0px;", "flex: 0 1 0px;"]
+PASS Multiple values flex with CSS-wide keyword should serialize correctly.
+PASS Multiple values flex with CSS-wide keywords and non-CSS-wide value should serialize correctly.
+PASS Multiple values flex with CSS-wide and two non-CSS-wide-keyword values should serialize correctly.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/flex-serialization.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/flex-serialization.html
@@ -15,15 +15,22 @@
     </style>
 
     <script>
+    var styleSheet = document.styleSheets[0]
     test(function () {
-        var styleSheet = document.styleSheets[0];
-
-        assert_equals(styleSheet.cssRules[0].style.cssText, "flex: initial;", "Single value flex with CSS-wide keyword should serialize correctly.");
-        assert_in_array(styleSheet.cssRules[1].style.cssText, ["flex: 0px;", "flex: 0 1 0px;"], "Single value flex with non-CSS-wide keyword should serialize correctly.");
-        assert_equals(styleSheet.cssRules[2].style.cssText, "flex: initial;", "Multiple values flex with CSS-wide keyword should serialize correctly.");
-        assert_equals(styleSheet.cssRules[3].style.cssText, "flex-grow: initial; flex-basis: initial; flex-shrink: 0;", "Multiple values flex with CSS-wide and non-CSS-wide keyword should serialize correctly.");
-        assert_equals(styleSheet.cssRules[4].style.cssText, "flex-grow: initial; flex-basis: 0px; flex-shrink: 2;", "Multiple values flex with CSS-wide and non-CSS-wide keyword should serialize correctly.");
-    });
+        assert_equals(styleSheet.cssRules[0].style.cssText, "flex: initial;")
+    }, "Single value flex with CSS-wide keyword should serialize correctly.")
+    test(function () {
+        assert_in_array(styleSheet.cssRules[1].style.cssText, ["flex: 0px;", "flex: 0 1 0px;"])
+    }, "Single value flex with non-CSS-wide value should serialize correctly.")
+    test(function () {
+        assert_equals(styleSheet.cssRules[2].style.cssText, "flex: initial;")
+    }, "Multiple values flex with CSS-wide keyword should serialize correctly.")
+    test(function () {
+        assert_equals(styleSheet.cssRules[3].style.cssText, "flex-grow: initial; flex-basis: initial; flex-shrink: 0;")
+    }, "Multiple values flex with CSS-wide keywords and non-CSS-wide value should serialize correctly.")
+    test(function () {
+        assert_equals(styleSheet.cssRules[4].style.cssText, "flex-grow: initial; flex-basis: 0px; flex-shrink: 2;")
+    }, "Multiple values flex with CSS-wide and two non-CSS-wide-keyword values should serialize correctly.")
     </script>
 </head>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/overflow-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/overflow-serialization-expected.txt
@@ -1,3 +1,12 @@
 
-PASS CSSOM - Overflow shorthand serialization
+PASS Single value overflow with CSS-wide keyword should serialize correctly.
+PASS Single value overflow with non-CSS-wide keyword should serialize correctly.
+PASS Overflow-x/y longhands with same CSS-wide keyword should serialize correctly.
+PASS Overflow-x/y longhands with same non-CSS-wide keyword should serialize correctly.
+PASS Overflow-x/y longhands with different keywords should serialize correctly.
+PASS Single value overflow on element with CSS-wide keyword should serialize correctly.
+PASS Single value overflow on element with non-CSS-wide keyword should serialize correctly.
+PASS Overflow-x/y longhands on element with same CSS-wide keyword should serialize correctly.
+PASS Overflow-x/y longhands on element with same non-CSS-wide keyword should serialize correctly.
+PASS Overflow-x/y longhands on element with different keywords should serialize correctly.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/overflow-serialization.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/overflow-serialization.html
@@ -15,35 +15,47 @@
     </style>
 
     <script>
+    var styleSheet = document.styleSheets[0]
+    var div = document.createElement('div')
     test(function () {
-        var styleSheet = document.styleSheets[0];
-
-        assert_equals(styleSheet.cssRules[0].style.cssText, "overflow: inherit;", "Single value overflow with CSS-wide keyword should serialize correctly.");
-        assert_equals(styleSheet.cssRules[1].style.cssText, "overflow: hidden;", "Single value overflow with non-CSS-wide keyword should serialize correctly.");
-        assert_equals(styleSheet.cssRules[2].style.cssText, "overflow: initial;", "Overflow-x/y longhands with same CSS-wide keyword should serialize correctly.");
-        assert_equals(styleSheet.cssRules[3].style.cssText, "overflow: scroll;", "Overflow-x/y longhands with same non-CSS-wide keyword should serialize correctly.");
-        assert_equals(styleSheet.cssRules[4].style.cssText, "overflow: scroll hidden;", "Overflow-x/y longhands with different keywords should serialize correctly.");
-
-        var div = document.createElement('div');
-        div.style.overflow = "inherit";
-        assert_equals(div.style.overflow, "inherit", "Single value overflow with CSS-wide keyword should serialize correctly.");
-
-        div.style.overflow = "hidden";
-        assert_equals(div.style.overflow, "hidden", "Single value overflow with non-CSS-wide keyword should serialize correctly.");
-
-        div.style.overflow = "";
-        div.style.overflowX = "initial";
-        div.style.overflowY = "initial";
-        assert_equals(div.style.overflow, "initial", "Overflow-x/y longhands with same CSS-wide keyword should serialize correctly.");
-
-        div.style.overflowX = "scroll";
-        div.style.overflowY = "scroll";
-        assert_equals(div.style.overflow, "scroll", "Overflow-x/y longhands with same non-CSS-wide keyword should serialize correctly.");
-
-        div.style.overflowX = "scroll";
-        div.style.overflowY = "hidden";
-        assert_equals(div.style.overflow, "scroll hidden", "Overflow-x/y longhands with different keywords should serialize correctly.");
-    });
+        assert_equals(styleSheet.cssRules[0].style.cssText, "overflow: inherit;")
+    }, "Single value overflow with CSS-wide keyword should serialize correctly.")
+    test(function () {
+        assert_equals(styleSheet.cssRules[1].style.cssText, "overflow: hidden;")
+    }, "Single value overflow with non-CSS-wide keyword should serialize correctly.")
+    test(function () {
+        assert_equals(styleSheet.cssRules[2].style.cssText, "overflow: initial;")
+    }, "Overflow-x/y longhands with same CSS-wide keyword should serialize correctly.")
+    test(function () {
+        assert_equals(styleSheet.cssRules[3].style.cssText, "overflow: scroll;")
+    }, "Overflow-x/y longhands with same non-CSS-wide keyword should serialize correctly.")
+    test(function () {
+        assert_equals(styleSheet.cssRules[4].style.cssText, "overflow: scroll hidden;")
+    }, "Overflow-x/y longhands with different keywords should serialize correctly.")
+    test(function () {
+        div.style.overflow = "inherit"
+        assert_equals(div.style.overflow, "inherit")
+    }, "Single value overflow on element with CSS-wide keyword should serialize correctly.")
+    test(function () {
+        div.style.overflow = "hidden"
+        assert_equals(div.style.overflow, "hidden")
+    }, "Single value overflow on element with non-CSS-wide keyword should serialize correctly.")
+    test(function () {
+        div.style.overflow = ""
+        div.style.overflowX = "initial"
+        div.style.overflowY = "initial"
+        assert_equals(div.style.overflow, "initial")
+    }, "Overflow-x/y longhands on element with same CSS-wide keyword should serialize correctly.")
+    test(function () {
+        div.style.overflowX = "scroll"
+        div.style.overflowY = "scroll"
+        assert_equals(div.style.overflow, "scroll")
+    }, "Overflow-x/y longhands on element with same non-CSS-wide keyword should serialize correctly.")
+    test(function () {
+        div.style.overflowX = "scroll"
+        div.style.overflowY = "hidden"
+        assert_equals(div.style.overflow, "scroll hidden")
+    }, "Overflow-x/y longhands on element with different keywords should serialize correctly.")
     </script>
 </head>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values-expected.txt
@@ -14,7 +14,7 @@ PASS The serialization of overflow-x: scroll; overflow-y: hidden; should be cano
 PASS The serialization of overflow-x: scroll; overflow-y: scroll; should be canonical.
 PASS The serialization of outline-width: 2px; outline-style: dotted; outline-color: blue; should be canonical.
 PASS The serialization of margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px; should be canonical.
-FAIL The serialization of list-style-type: circle; list-style-position: inside; list-style-image: initial; should be canonical. assert_equals: expected "list-style: inside circle;" but got "list-style-type: circle; list-style-position: inside; list-style-image: initial;"
+FAIL The serialization of list-style-type: circle; list-style-position: inside; list-style-image: none; should be canonical. assert_equals: expected "list-style: inside circle;" but got "list-style: inside none circle;"
 PASS The serialization of list-style-type: lower-alpha; should be canonical.
 PASS The serialization of font-family: sans-serif; line-height: 2em; font-size: 3em; font-style: italic; font-weight: bold; should be canonical.
 PASS The serialization of padding-top: 1px; padding-right: 2px; padding-bottom: 3px; padding-left: 4px; should be canonical.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values.html
@@ -36,7 +36,7 @@
         'overflow-x: scroll; overflow-y: scroll;': 'overflow: scroll;',
         'outline-width: 2px; outline-style: dotted; outline-color: blue;': 'outline: blue dotted 2px;',
         'margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px;': 'margin: 1px 2px 3px 4px;',
-        'list-style-type: circle; list-style-position: inside; list-style-image: initial;': 'list-style: inside circle;',
+        'list-style-type: circle; list-style-position: inside; list-style-image: none;': 'list-style: inside circle;',
         'list-style-type: lower-alpha;': 'list-style-type: lower-alpha;',
         'font-family: sans-serif; line-height: 2em; font-size: 3em; font-style: italic; font-weight: bold;': 'font-family: sans-serif; line-height: 2em; font-size: 3em; font-style: italic; font-weight: bold;',
         'padding-top: 1px; padding-right: 2px; padding-bottom: 3px; padding-left: 4px;': 'padding: 1px 2px 3px 4px;'


### PR DESCRIPTION
#### e18f26fb8c87bba56e15e584dbc6a0fe7538cd48
<pre>
Improve some CSS WPT tests so their output is easier to read and fix some mistaken expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=248817">https://bugs.webkit.org/show_bug.cgi?id=248817</a>
rdar://problem/103026393

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoxQuads-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoxQuads-001.html:
Update to be a set of separate tests instead of a single test with a lot of assertions.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/flex-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/flex-serialization.html:
Ditto.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/overflow-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/overflow-serialization.html:
Ditto.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values.html:
Fixed the test to cover a case that should work where the longhand has the initial value rather
than a case that should not where the longhand has the initial keyword as its value. WebKit is now
failing this test case.

Canonical link: <a href="https://commits.webkit.org/257438@main">https://commits.webkit.org/257438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/717d68457ca04cab7f5b219f97bf9fb3800d67fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108415 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168667 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8768 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91532 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104730 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2116 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2020 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5120 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6983 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/42562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3434 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->