### PR TITLE
REGRESSION (255664@main): Unable to toggle Lockdown Mode through privacy settings

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferencesInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferencesInternal.h
@@ -27,4 +27,5 @@
 
 constexpr auto LDMEnabledKey = "LDMGlobalEnabled";
 constexpr auto WKLockdownModeEnabledKey = "WKLockdownModeEnabled"_s;
-constexpr auto WKLockdownModeContainerConfigurationChangedNotification = @"WKLockdownModeContainerConfigurationChanged";
+// This string must remain consistent with the lockdown mode notification name in privacy settings.
+constexpr auto WKLockdownModeContainerConfigurationChangedNotification = @"WKCaptivePortalModeContainerConfigurationChanged";

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -667,7 +667,7 @@ void WebProcessPool::remoteWebInspectorEnabledCallback(CFNotificationCenterRef, 
 #endif
 
 #if PLATFORM(COCOA)
-void WebProcessPool::lockdownModeConfigUpdateCallback(CFNotificationCenterRef, void* observer, CFStringRef, const void*, CFDictionaryRef)
+void WebProcessPool::lockdownModeConfigurationUpdateCallback(CFNotificationCenterRef, void* observer, CFStringRef, const void*, CFDictionaryRef)
 {
     if (auto pool = extractWebProcessPool(observer))
         pool->lockdownModeStateChanged();
@@ -821,7 +821,7 @@ void WebProcessPool::registerNotificationObservers()
     });
 
 #if PLATFORM(COCOA)
-    addCFNotificationObserver(lockdownModeConfigUpdateCallback, (__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification);
+    addCFNotificationObserver(lockdownModeConfigurationUpdateCallback, (__bridge CFStringRef)WKLockdownModeContainerConfigurationChangedNotification);
 #endif
 
 #if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -595,7 +595,7 @@ private:
 #endif
 
 #if PLATFORM(COCOA)
-    static void lockdownModeConfigUpdateCallback(CFNotificationCenterRef, void* observer, CFStringRef name, const void* postingObject, CFDictionaryRef userInfo);
+    static void lockdownModeConfigurationUpdateCallback(CFNotificationCenterRef, void* observer, CFStringRef name, const void* postingObject, CFDictionaryRef userInfo);
 #endif
     
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### 6bfc06607bbc2da4f1a32cbeab3bdedeb070df33
<pre>
REGRESSION (255664@main): Unable to toggle Lockdown Mode through privacy settings
<a href="https://bugs.webkit.org/show_bug.cgi?id=248819">https://bugs.webkit.org/show_bug.cgi?id=248819</a>

Reviewed by Chris Dumez and Brent Fulgham.

* Source/WebKit/UIProcess/API/Cocoa/_WKSystemPreferencesInternal.h:

Change the string value back to `&quot;WKCaptivePortalModeContainerConfigurationChanged&quot;`, since it&apos;s the
name of the notification that&apos;s dispatched when toggling the preference in privacy settings;
additionally, add a brief comment clarifying this.

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::lockdownModeConfigurationUpdateCallback):

Drive-by fix: rename `lockdownModeConfigUpdateCallback` to `lockdownModeConfigurationUpdateCallback`
to align with WebKit style guidelines (full names over abbreviations).

(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::lockdownModeConfigUpdateCallback): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.h:

Canonical link: <a href="https://commits.webkit.org/257436@main">https://commits.webkit.org/257436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d5c34af739c8916b2ddf7cf2f54598e7e7be71e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108360 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8708 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106327 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104646 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33633 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21525 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2060 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23041 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1966 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5115 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42515 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2590 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3373 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->