### PR TITLE
A server-reflexive candidate is discarded when the host IPv4 address is public and obfuscated

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/AUTHORS
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/AUTHORS
@@ -67,6 +67,7 @@ Jose Antonio Olivera Ortega <josea.olivera@gmail.com>
 Keiichi Enomoto <enm10k@gmail.com>
 Kiran Thind <kiran.thind@gmail.com>
 Korniltsev Anatoly <korniltsev.anatoly@gmail.com>
+Kyutae Lee <gorisanson@gmail.com>
 Lennart Grahl <lennart.grahl@gmail.com>
 Luke Weber <luke.weber@gmail.com>
 Maksim Khobat <maksimkhobat@gmail.com>

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/stun_port.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/stun_port.h
@@ -234,7 +234,7 @@ class UDPPort : public Port {
   // changed to SignalPortReady.
   void MaybeSetPortCompleteOrError();
 
-  bool HasCandidateWithAddress(const rtc::SocketAddress& addr) const;
+  bool HasStunCandidateWithAddress(const rtc::SocketAddress& addr) const;
 
   // If this is a low-cost network, it will keep on sending STUN binding
   // requests indefinitely to keep the NAT binding alive. Otherwise, stop


### PR DESCRIPTION
#### 8d4875ea01141ecc3d7136b202a4369a58655490
<pre>
A server-reflexive candidate is discarded when the host IPv4 address is public and obfuscated
<a href="https://bugs.webkit.org/show_bug.cgi?id=233414">https://bugs.webkit.org/show_bug.cgi?id=233414</a>
rdar://problem/85661079

Reviewed by Alex Christensen.

Cherry-picking of <a href="https://webrtc.googlesource.com/src/+/7eea6672285f765599fd883a5737f5cae8d20917.">https://webrtc.googlesource.com/src/+/7eea6672285f765599fd883a5737f5cae8d20917.</a>

* Source/ThirdParty/libwebrtc/Source/webrtc/AUTHORS:
* Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/stun_port.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/stun_port.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/stun_port_unittest.cc:

Canonical link: <a href="https://commits.webkit.org/257481@main">https://commits.webkit.org/257481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01b4e7fa0bdc2312b57b13979206351355390591

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108367 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168620 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85587 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91485 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106335 "Hash 01b4e7fa for PR 7203 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33626 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88420 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21530 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76476 "Found 6 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/security-error, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/console-api, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/js-exception, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2067 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23046 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45494 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5148 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42520 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->