### PR TITLE
REGRESSION (253865@main): Crashes under RenderLayerCompositor::updateScrollingNodeForViewportConstrainedRole

### DIFF
--- a/LayoutTests/scrollingcoordinator/scrolling-tree/sticky-gain-composited-scrolling-ancestor-expected.txt
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/sticky-gain-composited-scrolling-ancestor-expected.txt
@@ -1,0 +1,3 @@
+Test passes if it doesn't crash.
+
+

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/sticky-gain-composited-scrolling-ancestor.html
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/sticky-gain-composited-scrolling-ancestor.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 300vh;
+        }
+        .container {
+            position: relative;
+            z-index: 0;
+            overflow: auto;
+            width: 400px;
+            height: 400px;
+            border: 1px solid black;
+        }
+        
+        .sticky {
+            position: sticky;
+            top: 10px;
+            width: 300px;
+            padding: 20px;
+            margin: 20px;
+            height: 20px;
+            background-color: silver;
+        }
+        
+        .composited {
+            will-change: transform
+        }
+
+        .spacer {
+            height: 100px;
+            width: 10px;
+            background-color: silver;
+        }
+
+        body.changed .spacer {
+            height: 400px;
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+        window.addEventListener('load', async () => {
+            await UIHelper.delayFor(0);
+            document.body.classList.add('changed');
+            await UIHelper.renderingUpdate();
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+    <p>Test passes if it doesn't crash.</p>
+    <div class="container">
+        <div class="composited sticky"></div>
+        <div class="spacer"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1023,7 +1023,7 @@ void RenderLayer::recursiveUpdateLayerPositions(RenderGeometryMap* geometryMap, 
     m_hasFixedContainingBlockAncestor = flags.contains(SeenFixedContainingBlockLayer);
     m_hasTransformedAncestor = flags.contains(SeenTransformedLayer);
     m_has3DTransformedAncestor = flags.contains(Seen3DTransformedLayer);
-    m_behavesAsFixed = flags.contains(SeenFixedLayer);
+    setBehavesAsFixed(flags.contains(SeenFixedLayer));
     setHasCompositedScrollingAncestor(flags.contains(SeenCompositedScrollingLayer));
 
     // Update the reflection's position and size.
@@ -1047,7 +1047,7 @@ void RenderLayer::recursiveUpdateLayerPositions(RenderGeometryMap* geometryMap, 
 
     // Fixed inside transform behaves like absolute (per spec).
     if (renderer().isFixedPositioned() && !m_hasFixedContainingBlockAncestor) {
-        m_behavesAsFixed = true;
+        setBehavesAsFixed(true);
         flags.add(SeenFixedLayer);
     }
 
@@ -1499,6 +1499,14 @@ void RenderLayer::updatePagination()
             return;
         }
     }
+}
+
+void RenderLayer::setBehavesAsFixed(bool behavesAsFixed)
+{
+    if (m_behavesAsFixed != behavesAsFixed && renderer().isFixedPositioned())
+        setNeedsCompositingConfigurationUpdate();
+
+    m_behavesAsFixed = behavesAsFixed;
 }
 
 void RenderLayer::setHasVisibleContent()

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -538,6 +538,7 @@ public:
     bool hasVisibleBoxDecorationsOrBackground() const;
     bool hasVisibleBoxDecorations() const;
     
+    void setBehavesAsFixed(bool);
     bool behavesAsFixed() const { return m_behavesAsFixed; }
 
     struct PaintedContentRequest {

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4522,8 +4522,11 @@ FixedPositionViewportConstraints RenderLayerCompositor::computeFixedViewportCons
 {
     ASSERT(layer.isComposited());
 
-    ASSERT(layer.backing()->viewportAnchorLayer());
     auto* anchorLayer = layer.backing()->viewportAnchorLayer();
+    if (!anchorLayer) {
+        ASSERT_NOT_REACHED();
+        return { };
+    }
 
     FixedPositionViewportConstraints constraints;
     constraints.setLayerPositionAtLastLayout(anchorLayer->position());
@@ -4560,8 +4563,11 @@ StickyPositionViewportConstraints RenderLayerCompositor::computeStickyViewportCo
 
     auto& renderer = downcast<RenderBoxModelObject>(layer.renderer());
 
-    ASSERT(layer.backing()->viewportAnchorLayer());
     auto* anchorLayer = layer.backing()->viewportAnchorLayer();
+    if (!anchorLayer) {
+        ASSERT_NOT_REACHED();
+        return { };
+    }
 
     StickyPositionViewportConstraints constraints;
     renderer.computeStickyPositionConstraints(constraints, renderer.constrainingRectForStickyPosition());


### PR DESCRIPTION
#### df0e5116081b07f064024f844c7a7111850e3298
<pre>
REGRESSION (253865@main): Crashes under RenderLayerCompositor::updateScrollingNodeForViewportConstrainedRole
<a href="https://bugs.webkit.org/show_bug.cgi?id=248827">https://bugs.webkit.org/show_bug.cgi?id=248827</a>
rdar://102619100

Reviewed by Alan Baradlay.

In 253865@main I introduced `m_viewportAnchorLayer`, which is used by the scrolling tree
to move fixed and sticky position layers. However, this revealed bugs in the compositing
dirty state management in the RenderLayer tree, where some types of tree mutations would
fail to trigger the &quot;configuration&quot; compositing update on a composited layer which is
responsible for the addition/removal of the `m_viewportAnchorLayer`.

From the collection of crash reports, I diagnosed two scenarios:

On google.com, when selecting results in the map view (rdar://102713246), a fixed layer
gained/lost a transformed ancestor. Transforms act as containing block for fixed, so
this changes whether the fixed layer is viewport-constrained. Fixed by having
`RenderLayer::setBehavesAsFixed()` call `setNeedsCompositingConfigurationUpdate()` on
fixed layers. Normally repaints trigger `setNeedsCompositingConfigurationUpdate()`; I
was not able to creation a reduction for this (the google page has nested fixed and
`visibility:hidden`, which may contribute).

The second scenario involved a sticky position layer which gains/loses an
async-scrollable ancestor. Fixed by having
`RenderLayerScrollableArea::computeHasCompositedScrollableOverflow()` call
`setDescendantsNeedUpdateBackingAndHierarchyTraversal()` on the stacking context
ancestor. Tested by sticky-gain-composited-scrolling-ancestor.html.

Also defensively early return in `computeFixedViewportConstraints()` and
`computeStickyViewportConstraints()` if the anchor layer is null.

* LayoutTests/scrollingcoordinator/scrolling-tree/sticky-gain-composited-scrolling-ancestor-expected.txt: Added.
* LayoutTests/scrollingcoordinator/scrolling-tree/sticky-gain-composited-scrolling-ancestor.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::recursiveUpdateLayerPositions):
(WebCore::RenderLayer::setBehavesAsFixed):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::computeFixedViewportConstraints const):
(WebCore::RenderLayerCompositor::computeStickyViewportConstraints const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::computeHasCompositedScrollableOverflow):

Canonical link: <a href="https://commits.webkit.org/257455@main">https://commits.webkit.org/257455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64ab1b51a67666d4137b084d10f50cf75b4ac804

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108388 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168641 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8739 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91506 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106356 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33645 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76498 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2089 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23064 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1994 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5134 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42538 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->