### PR TITLE
Add iframe depth limit

### DIFF
--- a/LayoutTests/fast/frames/frame-depth-limit-expected.txt
+++ b/LayoutTests/fast/frames/frame-depth-limit-expected.txt
@@ -1,0 +1,5 @@
+There should be no crash and no timeout.
+
+The test stopped at depth 31.
+
+

--- a/LayoutTests/fast/frames/frame-depth-limit.html
+++ b/LayoutTests/fast/frames/frame-depth-limit.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test iframe depth limit</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <style>
+        body, html {
+            height: 100%;
+        }
+        iframe {
+            width: 100%;
+            height: 100%;
+            display: block;
+        }
+    </style>
+</head>
+<body>
+    <p>There should be no crash and no timeout.</p>
+    <p id="result"></p>
+    <iframe id="iframe" scrolling=no></iframe>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        iframe.src = "resources/self-referential-iframe.html?depth=1";
+
+        let finishTest = (depth) => {
+            result.textContent = `The test stopped at depth ${depth}.`;
+            if (window.testRunner)
+                testRunner.notifyDone();
+        };
+
+        addEventListener("load", () => {
+            let delay = setTimeout(() => finishTest(0), 1000);
+            addEventListener("message", ({ data }) => {
+                clearTimeout(delay);
+                delay = setTimeout(() => finishTest(data), 1000);
+            });
+        });
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/frames/resources/self-referential-iframe.html
+++ b/LayoutTests/fast/frames/resources/self-referential-iframe.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body, html {
+            height: 100%;
+            margin: 0;
+        }
+        .container {
+            height: 100%;
+        }
+        iframe {
+            display: block;
+            border: 0.5px solid gray;
+            width: 99.99%;
+            height: 99.99%;
+        }
+    </style>
+    <script>
+        addEventListener("load", () => {
+            let iframe = document.getElementsByTagName("iframe")[0];
+            let params = new URL(location.href).searchParams;
+            let currentDepth = params.has("depth") ? parseInt(params.get("depth")) : 0;
+            iframe.src = `self-referential-iframe.html?depth=${currentDepth + 1}`;
+            top.postMessage(currentDepth, "*");
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="container">
+    <div class="container">
+    <div class="container">
+        <iframe scrolling="no"></iframe>
+    </div>
+    </div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -268,6 +268,9 @@ RefPtr<Frame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerElement& o
     if (!m_frame.page() || m_frame.page()->subframeCount() >= Page::maxNumberOfFrames)
         return nullptr;
 
+    if (m_frame.tree().depth() >= Page::maxFrameDepth)
+        return nullptr;
+
     // Prevent initial empty document load from triggering load events.
     document->incrementLoadEventDelayCount();
 

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -491,6 +491,14 @@ AbstractFrame& FrameTree::top() const
     return *frame;
 }
 
+unsigned FrameTree::depth() const
+{
+    unsigned depth = 0;
+    for (auto* parent = &m_thisFrame; parent; parent = parent->tree().parent())
+        depth++;
+    return depth;
+}
+
 ASCIILiteral blankTargetFrameName()
 {
     return "_blank"_s;

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -75,6 +75,7 @@ public:
     WEBCORE_EXPORT unsigned childCount() const;
     unsigned descendantCount() const;
     WEBCORE_EXPORT AbstractFrame& top() const;
+    unsigned depth() const;
 
     WEBCORE_EXPORT AbstractFrame* scopedChild(unsigned index) const;
     WEBCORE_EXPORT AbstractFrame* scopedChild(const AtomString& name) const;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -694,7 +694,10 @@ public:
     // This seems like a reasonable upper bound, and otherwise mutually
     // recursive frameset pages can quickly bring the program to its knees
     // with exponential growth in the number of frames.
-    static const int maxNumberOfFrames = 1000;
+    static constexpr int maxNumberOfFrames = 1000;
+
+    // Don't allow more than a certain frame depth to avoid stack exhaustion.
+    static constexpr int maxFrameDepth = 32;
 
     void setEditable(bool isEditable) { m_isEditable = isEditable; }
     bool isEditable() const { return m_isEditable; }


### PR DESCRIPTION
#### 65071a674a05a195850647ffccfb78b36fc22000
<pre>
Add iframe depth limit
<a href="https://bugs.webkit.org/show_bug.cgi?id=67940">https://bugs.webkit.org/show_bug.cgi?id=67940</a>
rdar://101560112

Reviewed by Darin Adler and Alex Christensen.

* LayoutTests/fast/frames/frame-depth-limit-expected.txt: Added.
* LayoutTests/fast/frames/frame-depth-limit.html: Added.
* LayoutTests/fast/frames/resources/self-referential-iframe.html: Added.
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::loadSubframe):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::depth const):
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/page/Page.h:

Canonical link: <a href="https://commits.webkit.org/257550@main">https://commits.webkit.org/257550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd2d9d308c59c04f90ce137f566dcdf9b7cdfc27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108632 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168880 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85766 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91741 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106564 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33796 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88614 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegateReload (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21698 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2326 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23214 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2221 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5192 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42688 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->