### PR TITLE
[iOS] No media controls after restoring fullscreen from PiP

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
@@ -294,7 +294,7 @@ View::View(struct wpe_view_backend* backend, const API::PageConfiguration& baseC
         [](void* data)
         {
             auto& view = *reinterpret_cast<View*>(data);
-            view.page().fullScreenManager()->requestEnterFullScreen();
+            view.page().fullScreenManager()->requestRestoreFullScreen();
         },
         // request_exit_fullscreen
         [](void* data)

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -112,9 +112,9 @@ void WebFullScreenManagerProxy::setAnimatingFullScreen(bool animating)
     m_page.send(Messages::WebFullScreenManager::SetAnimatingFullScreen(animating));
 }
 
-void WebFullScreenManagerProxy::requestEnterFullScreen()
+void WebFullScreenManagerProxy::requestRestoreFullScreen()
 {
-    m_page.send(Messages::WebFullScreenManager::RequestEnterFullScreen());
+    m_page.send(Messages::WebFullScreenManager::RequestRestoreFullScreen());
 }
 
 void WebFullScreenManagerProxy::requestExitFullScreen()

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -93,7 +93,7 @@ public:
     void willExitFullScreen();
     void didExitFullScreen();
     void setAnimatingFullScreen(bool);
-    void requestEnterFullScreen();
+    void requestRestoreFullScreen();
     void requestExitFullScreen();
     void saveScrollPosition();
     void restoreScrollPosition();

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
@@ -36,7 +36,7 @@
 - (id)initWithWebView:(WKWebView *)webView;
 - (void)enterFullScreen:(CGSize)videoDimensions;
 - (void)beganEnterFullScreenWithInitialFrame:(CGRect)initialFrame finalFrame:(CGRect)finalFrame;
-- (void)requestEnterFullScreen;
+- (void)requestRestoreFullScreen;
 - (void)requestExitFullScreen;
 - (void)exitFullScreen;
 - (void)beganExitFullScreenWithInitialFrame:(CGRect)initialFrame finalFrame:(CGRect)finalFrame;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -774,7 +774,7 @@ static constexpr CGFloat kTargetWindowAspectRatio = 1.7778;
     }];
 }
 
-- (void)requestEnterFullScreen
+- (void)requestRestoreFullScreen
 {
     if (_fullScreenState != WebKit::NotInFullScreen)
         return;
@@ -784,7 +784,7 @@ static constexpr CGFloat kTargetWindowAspectRatio = 1.7778;
         page->fullscreenMayReturnToInline();
 
     if (auto* manager = self._manager) {
-        manager->requestEnterFullScreen();
+        manager->requestRestoreFullScreen();
         return;
     }
 
@@ -936,7 +936,7 @@ static constexpr CGFloat kTargetWindowAspectRatio = 1.7778;
         _exitingFullScreen = NO;
         if (_enterRequested) {
             _enterRequested = NO;
-            [self requestEnterFullScreen];
+            [self requestRestoreFullScreen];
         }
     });
 
@@ -997,7 +997,7 @@ static constexpr CGFloat kTargetWindowAspectRatio = 1.7778;
                 if (_fullScreenState == WebKit::InFullScreen)
                     videoFullscreenInterface->preparedToReturnToStandby();
                 else
-                    [self requestEnterFullScreen];
+                    [self requestRestoreFullScreen];
             } else
                 _enterRequested = YES;
 

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -159,6 +159,7 @@ void WebFullScreenManager::setElement(WebCore::Element& element)
     clearElement();
 
     m_element = &element;
+    m_elementToRestore = element;
 
     for (auto& eventName : eventsToObserve())
         m_element->addEventListener(eventName, *this, { true });
@@ -328,14 +329,18 @@ void WebFullScreenManager::setAnimatingFullScreen(bool animating)
     m_element->document().fullscreenManager().setAnimatingFullscreen(animating);
 }
 
-void WebFullScreenManager::requestEnterFullScreen()
+void WebFullScreenManager::requestRestoreFullScreen()
 {
-    ASSERT(m_element);
-    if (!m_element)
+    ASSERT(!m_element);
+    if (m_element)
         return;
 
-    WebCore::UserGestureIndicator gestureIndicator(WebCore::ProcessingUserGesture);
-    m_element->document().fullscreenManager().requestFullscreenForElement(*m_element, nullptr, WebCore::FullscreenManager::ExemptIFrameAllowFullscreenRequirement);
+    auto element = RefPtr { m_elementToRestore.get() };
+    if (!element)
+        return;
+
+    WebCore::UserGestureIndicator gestureIndicator(WebCore::ProcessingUserGesture, &element->document());
+    element->document().fullscreenManager().requestFullscreenForElement(*element, nullptr, WebCore::FullscreenManager::ExemptIFrameAllowFullscreenRequirement);
 }
 
 void WebFullScreenManager::requestExitFullScreen()

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -81,7 +81,7 @@ protected:
     void setPIPStandbyElement(WebCore::HTMLVideoElement*);
 
     void setAnimatingFullScreen(bool);
-    void requestEnterFullScreen();
+    void requestRestoreFullScreen();
     void requestExitFullScreen();
     void saveScrollPosition();
     void restoreScrollPosition();
@@ -97,6 +97,7 @@ protected:
     float m_topContentInset { 0 };
     RefPtr<WebPage> m_page;
     RefPtr<WebCore::Element> m_element;
+    WeakPtr<WebCore::Element, WebCore::WeakPtrImplWithEventTargetData> m_elementToRestore;
 #if ENABLE(VIDEO)
     RefPtr<WebCore::HTMLVideoElement> m_pipStandbyElement;
 #endif

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(FULLSCREEN_API)
 messages -> WebFullScreenManager LegacyReceiver {
-    RequestEnterFullScreen()
+    RequestRestoreFullScreen()
     RequestExitFullScreen()
     WillEnterFullScreen()
     DidEnterFullScreen()

--- a/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj
@@ -21,8 +21,6 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		3F0B439B1D908D0C00D186B5 /* looping2s.html in Resources */ = {isa = PBXBuildFile; fileRef = 3F0B439A1D908D0C00D186B5 /* looping2s.html */; };
-		3F0B439D1D908DE700D186B5 /* test2s.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 3F0B439C1D908DE700D186B5 /* test2s.mp4 */; };
 		457D0F7A29088D9000AE5914 /* SettingsViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 457D0F7729088C9500AE5914 /* SettingsViewController.h */; };
 		45BE567C2908C74600FD7A95 /* SettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 457D0F7829088D4000AE5914 /* SettingsViewController.m */; };
 		CD1DAF971D709E3600017CF0 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = CD1DAF961D709E3600017CF0 /* main.m */; };
@@ -39,9 +37,11 @@
 		CD498B501D763D7600681FA7 /* AppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1DAF981D709E3600017CF0 /* AppDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CD498B511D763D7F00681FA7 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD1DAF9E1D709E3600017CF0 /* Main.storyboard */; };
 		CD498B521D763D8800681FA7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CD1DAFA11D709E3600017CF0 /* Assets.xcassets */; };
-		CDA985191D76483400EBC399 /* test.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = CDA985151D76477900EBC399 /* test.mp4 */; };
-		CDA9851A1D76483400EBC399 /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = CDA985131D76474100EBC399 /* index.html */; };
-		CDA9851B1D76483400EBC399 /* looping.html in Resources */ = {isa = PBXBuildFile; fileRef = CDA985171D7647CD00EBC399 /* looping.html */; };
+		CDC2792A2935418400151088 /* looping.html in Resources */ = {isa = PBXBuildFile; fileRef = CDC279272935417100151088 /* looping.html */; };
+		CDC2792B2935418400151088 /* test2s.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = CDC279252935417100151088 /* test2s.mp4 */; };
+		CDC2792C2935418400151088 /* test.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = CDC279282935417100151088 /* test.mp4 */; };
+		CDC2792D2935418400151088 /* looping2s.html in Resources */ = {isa = PBXBuildFile; fileRef = CDC279292935417100151088 /* looping2s.html */; };
+		CDC2792E2935418400151088 /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = CDC279262935417100151088 /* index.html */; };
 		DD403C5828500FE300D899FC /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD1DAFC11D70E12D00017CF0 /* WebKit.framework */; };
 /* End PBXBuildFile section */
 
@@ -84,8 +84,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		3F0B439A1D908D0C00D186B5 /* looping2s.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = looping2s.html; path = Resources/looping2s.html; sourceTree = "<group>"; };
-		3F0B439C1D908DE700D186B5 /* test2s.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; name = test2s.mp4; path = Resources/test2s.mp4; sourceTree = "<group>"; };
 		457D0F7729088C9500AE5914 /* SettingsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsViewController.h; sourceTree = "<group>"; };
 		457D0F7829088D4000AE5914 /* SettingsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsViewController.m; sourceTree = "<group>"; };
 		CD1DAF921D709E3600017CF0 /* MobileMiniBrowser.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MobileMiniBrowser.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -110,9 +108,11 @@
 		CD4DEEE21D78C6FF00625986 /* Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Base.xcconfig; path = Configurations/Base.xcconfig; sourceTree = "<group>"; };
 		CD4DEEE31D78C6FF00625986 /* DebugRelease.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = DebugRelease.xcconfig; path = Configurations/DebugRelease.xcconfig; sourceTree = "<group>"; };
 		CD4DEEE41D78C6FF00625986 /* MobileMiniBrowser.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = MobileMiniBrowser.xcconfig; path = Configurations/MobileMiniBrowser.xcconfig; sourceTree = "<group>"; };
-		CDA985131D76474100EBC399 /* index.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = index.html; path = Resources/index.html; sourceTree = "<group>"; };
-		CDA985151D76477900EBC399 /* test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; name = test.mp4; path = Resources/test.mp4; sourceTree = "<group>"; };
-		CDA985171D7647CD00EBC399 /* looping.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = looping.html; path = Resources/looping.html; sourceTree = "<group>"; };
+		CDC279252935417100151088 /* test2s.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = test2s.mp4; sourceTree = "<group>"; };
+		CDC279262935417100151088 /* index.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = index.html; sourceTree = "<group>"; };
+		CDC279272935417100151088 /* looping.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = looping.html; sourceTree = "<group>"; };
+		CDC279282935417100151088 /* test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = test.mp4; sourceTree = "<group>"; };
+		CDC279292935417100151088 /* looping2s.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = looping2s.html; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -178,6 +178,7 @@
 		CD1DAFAE1D709E3600017CF0 /* MobileMiniBrowserUITests */ = {
 			isa = PBXGroup;
 			children = (
+				CDC279242935417100151088 /* Resources */,
 				CD1DAFB11D709E3600017CF0 /* Info.plist */,
 				CD1DAFAF1D709E3600017CF0 /* MobileMiniBrowserUITests.m */,
 			);
@@ -195,7 +196,6 @@
 		CD498B3C1D76348000681FA7 /* MobileMiniBrowser Framework */ = {
 			isa = PBXGroup;
 			children = (
-				CDA985121D76471700EBC399 /* Resources */,
 				CD1DAF981D709E3600017CF0 /* AppDelegate.h */,
 				CD1DAF991D709E3600017CF0 /* AppDelegate.m */,
 				CD1DAFA11D709E3600017CF0 /* Assets.xcassets */,
@@ -223,16 +223,16 @@
 			name = Configurations;
 			sourceTree = "<group>";
 		};
-		CDA985121D76471700EBC399 /* Resources */ = {
+		CDC279242935417100151088 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				CDA985131D76474100EBC399 /* index.html */,
-				CDA985171D7647CD00EBC399 /* looping.html */,
-				3F0B439A1D908D0C00D186B5 /* looping2s.html */,
-				CDA985151D76477900EBC399 /* test.mp4 */,
-				3F0B439C1D908DE700D186B5 /* test2s.mp4 */,
+				CDC279262935417100151088 /* index.html */,
+				CDC279272935417100151088 /* looping.html */,
+				CDC279292935417100151088 /* looping2s.html */,
+				CDC279282935417100151088 /* test.mp4 */,
+				CDC279252935417100151088 /* test2s.mp4 */,
 			);
-			name = Resources;
+			path = Resources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -367,6 +367,11 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CDC2792E2935418400151088 /* index.html in Resources */,
+				CDC2792A2935418400151088 /* looping.html in Resources */,
+				CDC2792D2935418400151088 /* looping2s.html in Resources */,
+				CDC2792C2935418400151088 /* test.mp4 in Resources */,
+				CDC2792B2935418400151088 /* test2s.mp4 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -375,12 +380,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CD498B521D763D8800681FA7 /* Assets.xcassets in Resources */,
-				CDA9851A1D76483400EBC399 /* index.html in Resources */,
-				CDA9851B1D76483400EBC399 /* looping.html in Resources */,
-				3F0B439B1D908D0C00D186B5 /* looping2s.html in Resources */,
 				CD498B511D763D7F00681FA7 /* Main.storyboard in Resources */,
-				CDA985191D76483400EBC399 /* test.mp4 in Resources */,
-				3F0B439D1D908DE700D186B5 /* test2s.mp4 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/xcshareddata/xcschemes/MobileMiniBrowser.xcscheme
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/xcshareddata/xcschemes/MobileMiniBrowser.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CD1DAFAA1D709E3600017CF0"
+               BuildableName = "MobileMiniBrowserUITests.xctest"
+               BlueprintName = "MobileMiniBrowserUITests"
+               ReferencedContainer = "container:MobileMiniBrowser.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,92 +2,97 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "20x20",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "20x20",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "60x60"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "60x60"
     },
     {
       "idiom" : "ipad",
-      "size" : "20x20",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "20x20",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "76x76"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "76x76"
     },
     {
       "idiom" : "ipad",
-      "size" : "83.5x83.5",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m
@@ -197,6 +197,7 @@ void* URLContext = &URLContext;
     WKWebViewConfiguration *configuration = [[WKWebViewConfiguration alloc] init];
 
     configuration.preferences._mockCaptureDevicesEnabled = YES;
+    configuration.preferences.elementFullscreenEnabled = YES;
 
     WKWebView *webView = [[WKWebView alloc] initWithFrame:self.webViewContainer.bounds configuration:configuration];
     webView.inspectable = YES;
@@ -251,6 +252,9 @@ void* URLContext = &URLContext;
         if (url)
             return url;
     }
+
+    if (NSProcessInfo.processInfo.arguments.count >= 2)
+        return [NSURL URLWithString:NSProcessInfo.processInfo.arguments[1]];
 
     return [NSURL URLWithString:[self.settingsViewController defaultURL]];
 }

--- a/Tools/MobileMiniBrowser/MobileMiniBrowserUITests/MobileMiniBrowserUITests.m
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserUITests/MobileMiniBrowserUITests.m
@@ -44,11 +44,12 @@
 {
     [super setUp];
 
+    XCUIDevice.sharedDevice.orientation = UIDeviceOrientationPortrait;
+
     self.continueAfterFailure = NO;
 
     exists = [NSPredicate predicateWithFormat:@"exists == 1"];
     app = [[XCUIApplication alloc] init];
-    [app launch];
 }
 
 - (void)tearDown
@@ -61,6 +62,34 @@
     [self expectationForPredicate:exists evaluatedWithObject:button handler:nil];
     [self waitForExpectationsWithTimeout:5.0 handler:nil];
     [button tap];
+}
+
+- (void)waitForWindowNamed:(NSString *)name forApp:(XCUIApplication *)targetApp {
+    XCUIElement *window = targetApp.windows[name];
+    [self expectationForPredicate:exists evaluatedWithObject:window handler:nil];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
+- (void)waitForOtherElementNamed:(NSString *)name forApp:(XCUIApplication *)targetApp {
+    XCUIElement *window = targetApp.otherElements[name];
+    [self expectationForPredicate:exists evaluatedWithObject:window handler:nil];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
+- (void)tapMiddleTopOfApp:(XCUIApplication *)targetApp {
+    XCUICoordinate* middleTop = [targetApp coordinateWithNormalizedOffset:CGVectorMake(0.5, 0.25)];
+    [middleTop tap];
+}
+
+- (void)launchURL:(NSString *)url {
+
+    app.launchArguments = @[ url ];
+    [app launch];
+}
+
+- (void)launchPageNamed:(NSString *)name {
+    NSString* url = [NSBundle.mainBundle URLForResource:name withExtension:@"html" subdirectory:@"PlugIns/MobileMiniBrowserUITests.xctest"].absoluteString;
+    [self launchURL:url];
 }
 
 - (void)loadURL:(NSString *)url {
@@ -105,57 +134,69 @@
 
 - (void)testBasicVideoPlayback
 {
-    [self loadURL:@"bundle:/looping.html"];
-    [self waitToTapButtonNamed:@"Start Playback" forApp:app];
-
-    UIUserInterfaceIdiom idiom = [[UIDevice currentDevice] userInterfaceIdiom];
-    if (idiom == UIUserInterfaceIdiomPhone) {
-        [self waitToTapButtonNamed:@"PauseButton" forApp:app];
-        [self waitToTapButtonNamed:@"Done" forApp:app];
-    } else if (idiom == UIUserInterfaceIdiomPad)
-        [self waitToTapButtonNamed:@"Pause" forApp:app];
+    [self launchPageNamed:@"looping"];
+    [self waitToTapButtonNamed:@"Play" forApp:app];
+    [self waitToTapButtonNamed:@"Pause" forApp:app];
 }
 
 - (void)testBasicVideoFullscreen
 {
-    [self loadURL:@"bundle:/looping.html"];
-    [self waitToTapButtonNamed:@"Start Playback" forApp:app];
-    
-    UIUserInterfaceIdiom idiom = [[UIDevice currentDevice] userInterfaceIdiom];
-    if (idiom == UIUserInterfaceIdiomPad)
-        [self waitToTapButtonNamed:@"Display Full Screen" forApp:app];
-    
-    [self waitToTapButtonNamed:@"PauseButton" forApp:app];
-    [self waitToTapButtonNamed:@"Done" forApp:app];
+    [self launchPageNamed:@"looping"];
+    [self waitToTapButtonNamed:@"Display Full Screen" forApp:app];
+
+    [app tap];
+
+    [self waitToTapButtonNamed:@"Play/Pause" forApp:app];
+    [self waitToTapButtonNamed:@"Close" forApp:app];
+}
+
+- (void)testRepeatedFullScreenToPiPAndBack
+{
+    [self launchPageNamed:@"looping"];
+    [self waitToTapButtonNamed:@"Display Full Screen" forApp:app];
+
+    [app tap];
+
+    [self waitToTapButtonNamed:@"Play/Pause" forApp:app];
+    [self waitToTapButtonNamed:@"minimize video" forApp:app];
+
+    XCUIApplication* springboard = [[XCUIApplication alloc] initPrivateWithPath:nil bundleID:@"com.apple.springboard"];
+    [self waitForWindowNamed:@"Picture in Picture" forApp:springboard];
+    [self waitToTapButtonNamed:@"Restore fullscreen" forApp:springboard];
+
+    [self waitForOtherElementNamed:@"Media" forApp:app];
+    [self tapMiddleTopOfApp:app];
+
+    [self waitToTapButtonNamed:@"minimize video" forApp:app];
+    [self waitForWindowNamed:@"Picture in Picture" forApp:springboard];
+    [self waitToTapButtonNamed:@"Restore fullscreen" forApp:springboard];
+
+    [self waitForOtherElementNamed:@"Media" forApp:app];
+    [self tapMiddleTopOfApp:app];
+
+    [self waitToTapButtonNamed:@"Close" forApp:app];
 }
 
 - (void)testVideoFullscreenAndRotationAnimation
 {
-    XCUIDevice *device = [XCUIDevice sharedDevice];
-    device.orientation = UIDeviceOrientationPortrait;
+    [self launchPageNamed:@"looping"];
+    [self waitToTapButtonNamed:@"Play" forApp:app];
     
-    [self loadURL:@"bundle:/looping.html"];
-    [self waitToTapButtonNamed:@"Start Playback" forApp:app];
-    
-    UIUserInterfaceIdiom idiom = [[UIDevice currentDevice] userInterfaceIdiom];
-    if (idiom == UIUserInterfaceIdiomPad)
-        [self waitToTapButtonNamed:@"Display Full Screen" forApp:app];
+    [self waitToTapButtonNamed:@"Display Full Screen" forApp:app];
     
     [self requireMinFPS:30 sampleDurationSeconds:1 message:@"Framerate during enter fullscreen animation."];
-    device.orientation = UIDeviceOrientationLandscapeLeft;
+    XCUIDevice.sharedDevice.orientation = UIDeviceOrientationLandscapeLeft;
     [self requireMinFPS:30 sampleDurationSeconds:1 message:@"Framerate during rotation animation."];
-    [self waitToTapButtonNamed:@"Done" forApp:app];
+    [app tap];
+    [self waitToTapButtonNamed:@"Close" forApp:app];
     [self requireMinFPS:30 sampleDurationSeconds:1 message:@"Framerate during exit fullscreen  animation."];
 }
 
 - (void)testVideoFullscreenControlCenter
 {
-    [self loadURL:@"bundle:/looping.html"];
-    [self waitToTapButtonNamed:@"Start Playback" forApp:app];
-    
-    UIUserInterfaceIdiom idiom = [[UIDevice currentDevice] userInterfaceIdiom];
-    if (idiom == UIUserInterfaceIdiomPad)
-        [self waitToTapButtonNamed:@"Display Full Screen" forApp:app];
+    [self launchPageNamed:@"looping"];
+    [self waitToTapButtonNamed:@"Play" forApp:app];
+    [self waitToTapButtonNamed:@"Display Full Screen" forApp:app];
     
     XCUIElement* window = [app.windows allElementsBoundByIndex][0];
     XCUICoordinate* top = [window coordinateWithNormalizedOffset:CGVectorMake(0.5, 0.5)];
@@ -190,13 +231,13 @@
 // rdar://problem/27685077
 - (void)testLoopingFullscreenLockup
 {
-    [self loadURL:@"bundle:/looping2s.html"];
-    
+    [self launchPageNamed:@"looping2s"];
+
     XCUIElement* window = [app.windows allElementsBoundByIndex][0];
     XCUICoordinate* gifLoc = [window coordinateWithNormalizedOffset:CGVectorMake(0.5, 0.75)];
     [gifLoc pressForDuration:0];
     
-    [self waitToTapButtonNamed:@"Start Playback" forApp:app];
+    [self waitToTapButtonNamed:@"Play" forApp:app];
     
     [self waitToTapButtonNamed:@"ExitFullScreenButton" forApp:app];
     [self waitToTapButtonNamed:@"ExitFullScreenButton" forApp:app];


### PR DESCRIPTION
#### 61358f64bf9d37c84a3cfdc931aa2dd616b23675
<pre>
[iOS] No media controls after restoring fullscreen from PiP
<a href="https://bugs.webkit.org/show_bug.cgi?id=248834">https://bugs.webkit.org/show_bug.cgi?id=248834</a>
rdar://102880747

Reviewed by Eric Carlson and Jean-Yves Avenard.

When attempting to &quot;restore&quot; fullscreen mode from PiP, WebFullScreenManager uses
the m_element ivar to decide which element to request element fullscreen. However
in 256812@main, m_element is cleared upon exit.

Restore the functionality by introducing a new ivar, m_elementToRestore. This WeakPtr
will be queried when requesting fullscreen and, if valid, will be used instead of
m_element.

To make it more clear that we are requesting fullscreen mode be restored, rename
all instances of requestEnterFullScreen to requestRestoreFullScreen.

Add a XCUITest that exercises entering video fullscreen, entering PiP, and restoring
to fullscreen twice.

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::requestRestoreFullScreen):
(WebKit::WebFullScreenManagerProxy::requestEnterFullScreen): Deleted.
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController requestRestoreFullScreen]):
(-[WKFullScreenWindowController _completedExitFullScreen]):
(-[WKFullScreenWindowController didExitPictureInPicture]):
(-[WKFullScreenWindowController requestEnterFullScreen]): Deleted.
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::setElement):
(WebKit::WebFullScreenManager::requestRestoreFullScreen):
(WebKit::WebFullScreenManager::requestEnterFullScreen): Deleted.
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in:
* Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj:
* Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/xcshareddata/xcschemes/MobileMiniBrowser.xcscheme:
* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/Assets.xcassets/AppIcon.appiconset/Contents.json:
* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m:
(-[WebViewController createWebView]):
(-[WebViewController targetURLorDefaultURL]):
* Tools/MobileMiniBrowser/MobileMiniBrowserUITests/MobileMiniBrowserUITests.m:
(-[MobileMiniBrowserUITests setUp]):
(-[MobileMiniBrowserUITests waitForWindowNamed:forApp:]):
(-[MobileMiniBrowserUITests waitForOtherElementNamed:forApp:]):
(-[MobileMiniBrowserUITests tapMiddleTopOfApp:]):
(-[MobileMiniBrowserUITests launchURL:]):
(-[MobileMiniBrowserUITests launchPageNamed:]):
(-[MobileMiniBrowserUITests testBasicVideoPlayback]):
(-[MobileMiniBrowserUITests testBasicVideoFullscreen]):
(-[MobileMiniBrowserUITests testRepeatedFullScreenToPiPAndBack]):
(-[MobileMiniBrowserUITests testVideoFullscreenAndRotationAnimation]):
(-[MobileMiniBrowserUITests testVideoFullscreenControlCenter]):
(-[MobileMiniBrowserUITests testLoopingFullscreenLockup]):

Canonical link: <a href="https://commits.webkit.org/257486@main">https://commits.webkit.org/257486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/530403f3b4ae953f56d9418b42573a2dfa94cd59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108426 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168677 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85563 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91546 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106383 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33671 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88470 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21575 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76526 "Found 5 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/console-api, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/js-exception, /WebKitGTK/TestConsoleMessage:afterAll (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2128 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23091 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45479 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5152 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42566 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3447 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->