### PR TITLE
[JSC] Update Intl.Locale info's getter to method

### DIFF
--- a/JSTests/stress/intl-date-pattern-includes-literal-text.js
+++ b/JSTests/stress/intl-date-pattern-includes-literal-text.js
@@ -9,6 +9,6 @@ shouldBe(new Intl.DateTimeFormat("fr", {hour: "numeric", hour12: false}).format(
 shouldBe(new Intl.DateTimeFormat("fr", {hour: "numeric", hourCycle: 'h24'}).format(new Date(2021, 2, 3, 23)), '23 h');
 shouldBe(new Intl.DateTimeFormat("fr", {hour: "numeric", hourCycle: 'h23'}).format(new Date(2021, 2, 3, 23)), '23 h');
 
-shouldBe(JSON.stringify(new Intl.Locale("fr", {hourCycle: 'h24'}).hourCycles), `["h24"]`);
-shouldBe(JSON.stringify(new Intl.Locale("fr", {hourCycle: 'h23'}).hourCycles), `["h23"]`);
-shouldBe(JSON.stringify(new Intl.Locale("fr").hourCycles), `["h23"]`);
+shouldBe(JSON.stringify(new Intl.Locale("fr", {hourCycle: 'h24'}).hourCycles()), `["h24"]`);
+shouldBe(JSON.stringify(new Intl.Locale("fr", {hourCycle: 'h23'}).hourCycles()), `["h23"]`);
+shouldBe(JSON.stringify(new Intl.Locale("fr").hourCycles()), `["h23"]`);

--- a/JSTests/stress/intl-locale-info.js
+++ b/JSTests/stress/intl-locale-info.js
@@ -10,117 +10,117 @@ function shouldBeOneOf(actual, expectedArray) {
 
 {
     let he = new Intl.Locale("he")
-    shouldBe(JSON.stringify(he.weekInfo), `{"firstDay":7,"weekend":[5,6],"minimalDays":1}`);
+    shouldBe(JSON.stringify(he.weekInfo()), `{"firstDay":7,"weekend":[5,6],"minimalDays":1}`);
     let af = new Intl.Locale("af")
-    shouldBe(JSON.stringify(af.weekInfo), `{"firstDay":7,"weekend":[6,7],"minimalDays":1}`);
+    shouldBe(JSON.stringify(af.weekInfo()), `{"firstDay":7,"weekend":[6,7],"minimalDays":1}`);
     let enGB = new Intl.Locale("en-GB")
-    shouldBe(JSON.stringify(enGB.weekInfo), `{"firstDay":1,"weekend":[6,7],"minimalDays":4}`);
+    shouldBe(JSON.stringify(enGB.weekInfo()), `{"firstDay":1,"weekend":[6,7],"minimalDays":4}`);
     let msBN = new Intl.Locale("ms-BN");
     // "weekend" should be [5,7]. But currently ICU/CLDR does not support representing non-contiguous weekend.
-    shouldBe(JSON.stringify(msBN.weekInfo), `{"firstDay":1,"weekend":[6,7],"minimalDays":1}`);
+    shouldBe(JSON.stringify(msBN.weekInfo()), `{"firstDay":1,"weekend":[6,7],"minimalDays":1}`);
 }
 {
     let l = new Intl.Locale("ar")
-    shouldBe(JSON.stringify(l.textInfo), `{"direction":"rtl"}`);
+    shouldBe(JSON.stringify(l.textInfo()), `{"direction":"rtl"}`);
 }
 {
     let locale = new Intl.Locale("ar")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory","coptic","islamic","islamic-civil","islamic-tbla"]`);
-    shouldBe(JSON.stringify(locale.collations), `["compat","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.calendars()), `["gregory","coptic","islamic","islamic-civil","islamic-tbla"]`);
+    shouldBe(JSON.stringify(locale.collations()), `["compat","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h12"]`);
-    let ns = JSON.stringify(locale.numberingSystems);
+    shouldBe(JSON.stringify(locale.hourCycles()), `["h12"]`);
+    let ns = JSON.stringify(locale.numberingSystems());
     shouldBe(ns === `["arab"]` || ns === `["latn"]`, true);
-    shouldBe(locale.timeZones, undefined);
+    shouldBe(locale.timeZones(), undefined);
 }
 {
     let locale = new Intl.Locale("ar-EG")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory","coptic","islamic","islamic-civil","islamic-tbla"]`);
-    shouldBe(JSON.stringify(locale.collations), `["compat","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.calendars()), `["gregory","coptic","islamic","islamic-civil","islamic-tbla"]`);
+    shouldBe(JSON.stringify(locale.collations()), `["compat","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h12"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["arab"]`);
-    shouldBe(JSON.stringify(locale.timeZones), `["Africa/Cairo"]`);
+    shouldBe(JSON.stringify(locale.hourCycles()), `["h12"]`);
+    shouldBe(JSON.stringify(locale.numberingSystems()), `["arab"]`);
+    shouldBe(JSON.stringify(locale.timeZones()), `["Africa/Cairo"]`);
 }
 {
     let locale = new Intl.Locale("ar-SA")
-    let calendars = JSON.stringify(locale.calendars);
+    let calendars = JSON.stringify(locale.calendars());
     shouldBe(calendars === `["islamic-umalqura","islamic-rgsa","islamic","gregory"]` || calendars === `["islamic-umalqura","gregory","islamic","islamic-rgsa"]`, true);
-    shouldBe(JSON.stringify(locale.collations), `["compat","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.collations()), `["compat","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h12"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["arab"]`);
-    shouldBe(JSON.stringify(locale.timeZones), `["Asia/Riyadh"]`);
+    shouldBe(JSON.stringify(locale.hourCycles()), `["h12"]`);
+    shouldBe(JSON.stringify(locale.numberingSystems()), `["arab"]`);
+    shouldBe(JSON.stringify(locale.timeZones()), `["Asia/Riyadh"]`);
 }
 {
     let locale = new Intl.Locale("ja")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory","japanese"]`);
-    shouldBe(JSON.stringify(locale.collations), `["unihan","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.calendars()), `["gregory","japanese"]`);
+    shouldBe(JSON.stringify(locale.collations()), `["unihan","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h23"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["latn"]`);
-    shouldBe(locale.timeZones, undefined);
+    shouldBe(JSON.stringify(locale.hourCycles()), `["h23"]`);
+    shouldBe(JSON.stringify(locale.numberingSystems()), `["latn"]`);
+    shouldBe(locale.timeZones(), undefined);
 }
 {
     let locale = new Intl.Locale("ja-JP")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory","japanese"]`);
-    shouldBe(JSON.stringify(locale.collations), `["unihan","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.calendars()), `["gregory","japanese"]`);
+    shouldBe(JSON.stringify(locale.collations()), `["unihan","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h23"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["latn"]`);
-    shouldBe(JSON.stringify(locale.timeZones), `["Asia/Tokyo"]`);
+    shouldBe(JSON.stringify(locale.hourCycles()), `["h23"]`);
+    shouldBe(JSON.stringify(locale.numberingSystems()), `["latn"]`);
+    shouldBe(JSON.stringify(locale.timeZones()), `["Asia/Tokyo"]`);
 }
 {
     let locale = new Intl.Locale("en-US")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory"]`);
-    shouldBe(JSON.stringify(locale.collations), `["emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.calendars()), `["gregory"]`);
+    shouldBe(JSON.stringify(locale.collations()), `["emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h12"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["latn"]`);
-    shouldBe(JSON.stringify(locale.timeZones), `["America/Adak","America/Anchorage","America/Boise","America/Chicago","America/Denver","America/Detroit","America/Indiana/Knox","America/Indiana/Marengo","America/Indiana/Petersburg","America/Indiana/Tell_City","America/Indiana/Vevay","America/Indiana/Vincennes","America/Indiana/Winamac","America/Indianapolis","America/Juneau","America/Kentucky/Monticello","America/Los_Angeles","America/Louisville","America/Menominee","America/Metlakatla","America/New_York","America/Nome","America/North_Dakota/Beulah","America/North_Dakota/Center","America/North_Dakota/New_Salem","America/Phoenix","America/Sitka","America/Yakutat","Pacific/Honolulu"]`);
+    shouldBe(JSON.stringify(locale.hourCycles()), `["h12"]`);
+    shouldBe(JSON.stringify(locale.numberingSystems()), `["latn"]`);
+    shouldBe(JSON.stringify(locale.timeZones()), `["America/Adak","America/Anchorage","America/Boise","America/Chicago","America/Denver","America/Detroit","America/Indiana/Knox","America/Indiana/Marengo","America/Indiana/Petersburg","America/Indiana/Tell_City","America/Indiana/Vevay","America/Indiana/Vincennes","America/Indiana/Winamac","America/Indianapolis","America/Juneau","America/Kentucky/Monticello","America/Los_Angeles","America/Louisville","America/Menominee","America/Metlakatla","America/New_York","America/Nome","America/North_Dakota/Beulah","America/North_Dakota/Center","America/North_Dakota/New_Salem","America/Phoenix","America/Sitka","America/Yakutat","Pacific/Honolulu"]`);
 }
 {
     let locale = new Intl.Locale("en-NZ")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory"]`);
-    shouldBe(JSON.stringify(locale.collations), `["emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.calendars()), `["gregory"]`);
+    shouldBe(JSON.stringify(locale.collations()), `["emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h12"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["latn"]`);
-    shouldBe(JSON.stringify(locale.timeZones), `["Pacific/Auckland","Pacific/Chatham"]`);
+    shouldBe(JSON.stringify(locale.hourCycles()), `["h12"]`);
+    shouldBe(JSON.stringify(locale.numberingSystems()), `["latn"]`);
+    shouldBe(JSON.stringify(locale.timeZones()), `["Pacific/Auckland","Pacific/Chatham"]`);
 }
 {
     let locale = new Intl.Locale("zh")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory","chinese"]`);
-    shouldBe(JSON.stringify(locale.collations), `["pinyin","big5han","gb2312","stroke","unihan","zhuyin","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.calendars()), `["gregory","chinese"]`);
+    shouldBe(JSON.stringify(locale.collations()), `["pinyin","big5han","gb2312","stroke","unihan","zhuyin","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBeOneOf(JSON.stringify(locale.hourCycles), [ `["h23"]`, `["h12"]` ]);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["latn"]`);
-    shouldBe(locale.timeZones, undefined);
+    shouldBeOneOf(JSON.stringify(locale.hourCycles()), [ `["h23"]`, `["h12"]` ]);
+    shouldBe(JSON.stringify(locale.numberingSystems()), `["latn"]`);
+    shouldBe(locale.timeZones(), undefined);
 }
 {
     let locale = new Intl.Locale("zh-TW")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory","roc","chinese"]`);
-    shouldBe(JSON.stringify(locale.collations), `["stroke","big5han","gb2312","pinyin","unihan","zhuyin","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.calendars()), `["gregory","roc","chinese"]`);
+    shouldBe(JSON.stringify(locale.collations()), `["stroke","big5han","gb2312","pinyin","unihan","zhuyin","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h12"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["latn"]`);
-    shouldBe(JSON.stringify(locale.timeZones), `["Asia/Taipei"]`);
+    shouldBe(JSON.stringify(locale.hourCycles()), `["h12"]`);
+    shouldBe(JSON.stringify(locale.numberingSystems()), `["latn"]`);
+    shouldBe(JSON.stringify(locale.timeZones()), `["Asia/Taipei"]`);
 }
 {
     let locale = new Intl.Locale("zh-HK")
-    shouldBe(JSON.stringify(locale.calendars), `["gregory","chinese"]`);
-    shouldBe(JSON.stringify(locale.collations), `["stroke","big5han","gb2312","pinyin","unihan","zhuyin","emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.calendars()), `["gregory","chinese"]`);
+    shouldBe(JSON.stringify(locale.collations()), `["stroke","big5han","gb2312","pinyin","unihan","zhuyin","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h12"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["latn"]`);
-    shouldBe(JSON.stringify(locale.timeZones), `["Asia/Hong_Kong"]`);
+    shouldBe(JSON.stringify(locale.hourCycles()), `["h12"]`);
+    shouldBe(JSON.stringify(locale.numberingSystems()), `["latn"]`);
+    shouldBe(JSON.stringify(locale.timeZones()), `["Asia/Hong_Kong"]`);
 }
 {
     let locale = new Intl.Locale("fa")
-    shouldBe(JSON.stringify(locale.calendars), `["persian","gregory","islamic","islamic-civil","islamic-tbla"]`);
-    shouldBe(JSON.stringify(locale.collations), `["emoji","eor"]`);
+    shouldBe(JSON.stringify(locale.calendars()), `["persian","gregory","islamic","islamic-civil","islamic-tbla"]`);
+    shouldBe(JSON.stringify(locale.collations()), `["emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
-    shouldBe(JSON.stringify(locale.hourCycles), `["h23"]`);
-    shouldBe(JSON.stringify(locale.numberingSystems), `["arabext"]`);
-    shouldBe(locale.timeZones, undefined);
+    shouldBe(JSON.stringify(locale.hourCycles()), `["h23"]`);
+    shouldBe(JSON.stringify(locale.numberingSystems()), `["arabext"]`);
+    shouldBe(locale.timeZones(), undefined);
 }

--- a/JSTests/stress/intl-locale-invalid-hourCycles.js
+++ b/JSTests/stress/intl-locale-invalid-hourCycles.js
@@ -1,7 +1,12 @@
+function touch(arg) {
+    return arg + "Hello"; // Touching.
+}
+noInline(touch);
+
 function main() {
     const v24 = new Intl.Locale("trimEnd", { 'numberingSystem': "foobar" });
-    let empty = v24.hourCycles;
-    print(empty);
+    let empty = v24.hourCycles();
+    touch(empty);
 }
 
 try {

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1338,9 +1338,111 @@ test/intl402/Locale/getters-grandfathered.js:
 test/intl402/Locale/likely-subtags-grandfathered.js:
   default: 'Test262Error: Expected SameValue(«cel-gaulish», «xtg») to be true'
   strict mode: 'Test262Error: Expected SameValue(«cel-gaulish», «xtg») to be true'
+test/intl402/Locale/prototype/calendars/branding.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/intl402/Locale/prototype/calendars/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/intl402/Locale/prototype/calendars/output-array.js:
+  default: 'Test262Error: Expected true but got false'
+  strict mode: 'Test262Error: Expected true but got false'
+test/intl402/Locale/prototype/calendars/prop-desc.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/intl402/Locale/prototype/collations/branding.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/intl402/Locale/prototype/collations/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/intl402/Locale/prototype/collations/output-array-values.js:
+  default: 'Test262Error: array has at least one element'
+  strict mode: 'Test262Error: array has at least one element'
+test/intl402/Locale/prototype/collations/output-array.js:
+  default: 'Test262Error: Expected true but got false'
+  strict mode: 'Test262Error: Expected true but got false'
+test/intl402/Locale/prototype/collations/prop-desc.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/intl402/Locale/prototype/hourCycles/branding.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/intl402/Locale/prototype/hourCycles/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/intl402/Locale/prototype/hourCycles/output-array-values.js:
+  default: 'Test262Error: array has at least one element'
+  strict mode: 'Test262Error: array has at least one element'
+test/intl402/Locale/prototype/hourCycles/output-array.js:
+  default: 'Test262Error: Expected true but got false'
+  strict mode: 'Test262Error: Expected true but got false'
+test/intl402/Locale/prototype/hourCycles/prop-desc.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
 test/intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js:
   default: 'Test262Error: "und".minimize() should be "en" Expected SameValue(«en-u-va-posix», «en») to be true'
   strict mode: 'Test262Error: "und".minimize() should be "en" Expected SameValue(«en-u-va-posix», «en») to be true'
+test/intl402/Locale/prototype/numberingSystems/branding.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/intl402/Locale/prototype/numberingSystems/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/intl402/Locale/prototype/numberingSystems/output-array.js:
+  default: 'Test262Error: Expected true but got false'
+  strict mode: 'Test262Error: Expected true but got false'
+test/intl402/Locale/prototype/numberingSystems/prop-desc.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/intl402/Locale/prototype/textInfo/branding.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/intl402/Locale/prototype/textInfo/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/intl402/Locale/prototype/textInfo/output-object-keys.js:
+  default: 'Test262Error: Expected [length, name] and [direction] to have the same contents. '
+  strict mode: 'Test262Error: Expected [length, name] and [direction] to have the same contents. '
+test/intl402/Locale/prototype/textInfo/output-object.js:
+  default: 'Test262Error: Expected SameValue(«function () {'
+  strict mode: 'Test262Error: Expected SameValue(«function () {'
+test/intl402/Locale/prototype/textInfo/prop-desc.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/intl402/Locale/prototype/timeZones/branding.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/intl402/Locale/prototype/timeZones/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/intl402/Locale/prototype/timeZones/output-array-sorted.js:
+  default: 'TypeError: Spread syntax requires ...iterable[Symbol.iterator] to be a function'
+  strict mode: 'TypeError: Spread syntax requires ...iterable[Symbol.iterator] to be a function'
+test/intl402/Locale/prototype/timeZones/output-array.js:
+  default: 'Test262Error: Expected true but got false'
+  strict mode: 'Test262Error: Expected true but got false'
+test/intl402/Locale/prototype/timeZones/output-undefined.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/intl402/Locale/prototype/timeZones/prop-desc.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/intl402/Locale/prototype/weekInfo/branding.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/intl402/Locale/prototype/weekInfo/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/intl402/Locale/prototype/weekInfo/output-object-keys.js:
+  default: 'Test262Error: Expected [length, name] and [firstDay, weekend, minimalDays] to have the same contents. '
+  strict mode: 'Test262Error: Expected [length, name] and [firstDay, weekend, minimalDays] to have the same contents. '
+test/intl402/Locale/prototype/weekInfo/output-object.js:
+  default: 'Test262Error: Expected SameValue(«function () {'
+  strict mode: 'Test262Error: Expected SameValue(«function () {'
+test/intl402/Locale/prototype/weekInfo/prop-desc.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
 test/intl402/NumberFormat/constructor-roundingIncrement-invalid.js:
   default: 'Test262Error: "maximumFractionDigits" is not equal to "minimumFractionDigits" Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: "maximumFractionDigits" is not equal to "minimumFractionDigits" Expected a RangeError to be thrown but no exception was thrown at all'

--- a/Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp
@@ -35,23 +35,24 @@ namespace JSC {
 static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncMaximize);
 static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncMinimize);
 static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncToString);
+static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncCalendars);
+static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncCollations);
+static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncHourCycles);
+static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncNumberingSystems);
+static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncTimeZones);
+static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncTextInfo);
+static JSC_DECLARE_HOST_FUNCTION(intlLocalePrototypeFuncWeekInfo);
+
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterBaseName);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterCalendar);
-static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterCalendars);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterCaseFirst);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterCollation);
-static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterCollations);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterHourCycle);
-static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterHourCycles);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterNumeric);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterNumberingSystem);
-static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterNumberingSystems);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterLanguage);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterScript);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterRegion);
-static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterTimeZones);
-static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterTextInfo);
-static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterWeekInfo);
 
 }
 
@@ -68,21 +69,21 @@ const ClassInfo IntlLocalePrototype::s_info = { "Intl.Locale"_s, &Base::s_info, 
   toString         intlLocalePrototypeFuncToString           DontEnum|Function 0
   baseName         intlLocalePrototypeGetterBaseName         DontEnum|ReadOnly|CustomAccessor
   calendar         intlLocalePrototypeGetterCalendar         DontEnum|ReadOnly|CustomAccessor
-  calendars        intlLocalePrototypeGetterCalendars        DontEnum|ReadOnly|CustomAccessor
+  calendars        intlLocalePrototypeFuncCalendars          DontEnum|Function 0
   caseFirst        intlLocalePrototypeGetterCaseFirst        DontEnum|ReadOnly|CustomAccessor
   collation        intlLocalePrototypeGetterCollation        DontEnum|ReadOnly|CustomAccessor
-  collations       intlLocalePrototypeGetterCollations       DontEnum|ReadOnly|CustomAccessor
+  collations       intlLocalePrototypeFuncCollations         DontEnum|Function 0
   hourCycle        intlLocalePrototypeGetterHourCycle        DontEnum|ReadOnly|CustomAccessor
-  hourCycles       intlLocalePrototypeGetterHourCycles       DontEnum|ReadOnly|CustomAccessor
+  hourCycles       intlLocalePrototypeFuncHourCycles         DontEnum|Function 0
   numeric          intlLocalePrototypeGetterNumeric          DontEnum|ReadOnly|CustomAccessor
   numberingSystem  intlLocalePrototypeGetterNumberingSystem  DontEnum|ReadOnly|CustomAccessor
-  numberingSystems intlLocalePrototypeGetterNumberingSystems DontEnum|ReadOnly|CustomAccessor
+  numberingSystems intlLocalePrototypeFuncNumberingSystems   DontEnum|Function 0
   language         intlLocalePrototypeGetterLanguage         DontEnum|ReadOnly|CustomAccessor
   script           intlLocalePrototypeGetterScript           DontEnum|ReadOnly|CustomAccessor
   region           intlLocalePrototypeGetterRegion           DontEnum|ReadOnly|CustomAccessor
-  timeZones        intlLocalePrototypeGetterTimeZones        DontEnum|ReadOnly|CustomAccessor
-  textInfo         intlLocalePrototypeGetterTextInfo         DontEnum|ReadOnly|CustomAccessor
-  weekInfo         intlLocalePrototypeGetterWeekInfo         DontEnum|ReadOnly|CustomAccessor
+  timeZones        intlLocalePrototypeFuncTimeZones          DontEnum|Function 0
+  textInfo         intlLocalePrototypeFuncTextInfo           DontEnum|Function 0
+  weekInfo         intlLocalePrototypeFuncWeekInfo           DontEnum|Function 0
 @end
 */
 
@@ -185,12 +186,12 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCalendar, (JSGlobalObject* glo
 }
 
 // https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.calendars
-JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCalendars, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncCalendars, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
     if (!locale)
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.calendars called on value that's not a Locale"_s);
 
@@ -226,12 +227,12 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCollation, (JSGlobalObject* gl
 }
 
 // https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.collations
-JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCollations, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncCollations, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
     if (!locale)
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.collations called on value that's not a Locale"_s);
 
@@ -253,12 +254,12 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterHourCycle, (JSGlobalObject* gl
 }
 
 // https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.hourcycles
-JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterHourCycles, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncHourCycles, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
     if (!locale)
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.hourCycles called on value that's not a Locale"_s);
 
@@ -293,12 +294,12 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterNumberingSystem, (JSGlobalObje
 }
 
 // https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.numberingSystems
-JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterNumberingSystems, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncNumberingSystems, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
     if (!locale)
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.numberingSystems called on value that's not a Locale"_s);
 
@@ -348,12 +349,12 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterRegion, (JSGlobalObject* globa
 }
 
 // https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.timezones
-JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterTimeZones, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncTimeZones, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
     if (!locale)
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.timeZones called on value that's not a Locale"_s);
 
@@ -361,12 +362,12 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterTimeZones, (JSGlobalObject* gl
 }
 
 // https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.textInfo
-JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterTextInfo, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncTextInfo, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
     if (!locale)
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.textInfo called on value that's not a Locale"_s);
 
@@ -374,12 +375,12 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterTextInfo, (JSGlobalObject* glo
 }
 
 // https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.weekInfo
-JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterWeekInfo, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncWeekInfo, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
     if (!locale)
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.weekInfo called on value that's not a Locale"_s);
 


### PR DESCRIPTION
#### 10c3a1f127858ec867d53da153362e1222c7ddda
<pre>
[JSC] Update Intl.Locale info&apos;s getter to method
<a href="https://bugs.webkit.org/show_bug.cgi?id=248836">https://bugs.webkit.org/show_bug.cgi?id=248836</a>
rdar://problem/103041601

Reviewed by Justin Michaud.

Nov 30 TC39 meeting decided to change Intl.Locale info getters to methods[1] because of object identity issue[2].
This patch aligns our implementation to this change.

[1]: <a href="https://github.com/tc39/proposal-intl-locale-info/pull/65">https://github.com/tc39/proposal-intl-locale-info/pull/65</a>
[2]: <a href="https://github.com/tc39/proposal-intl-locale-info/issues/62">https://github.com/tc39/proposal-intl-locale-info/issues/62</a>

* JSTests/stress/intl-locale-info.js:
(throw.new.Error):
(shouldBe):
(let.l.new.Intl.Locale.shouldBe):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/257449@main">https://commits.webkit.org/257449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82c3afb4b0389d897fa57fd616231af7b9ee1f2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108422 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168673 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85559 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91538 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106379 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104737 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90221 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89747 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2123 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85560 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2026 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28823 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/6993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42557 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88415 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2597 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3441 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19787 "Passed tests") | 
<!--EWS-Status-Bubble-End-->