### PR TITLE
[SIMD] Intel temporary fix for splat on ARM64

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
@@ -3826,33 +3826,65 @@ auto AirIRGenerator::addSIMDStore(ExpressionType value, ExpressionType pointer, 
 
 auto AirIRGenerator::addSIMDSplat(SIMDLane lane, ExpressionType scalar, ExpressionType& result) -> PartialResult
 {
-    B3::Air::Opcode op;
+    // FIXME: We should optimize this code.
+    if (isX86()) {
+        B3::Air::Opcode op;
 
-    switch (lane) {
-    case SIMDLane::i8x16:
+        switch (lane) {
+        case SIMDLane::i8x16:
+            op = VectorSplat8;
+            break;
+        case SIMDLane::i16x8:
+            op = VectorSplat16;
+            break;
+        case SIMDLane::i32x4:
+            op = VectorSplat32;
+            break;
+        case SIMDLane::i64x2:
+            op = VectorSplat64;
+            break;
+        case SIMDLane::f32x4:
+            op = VectorSplatFloat32;
+            break;
+        case SIMDLane::f64x2:
+            op = VectorSplatFloat64;
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+
+        result = v128();
+        append(op, scalar, result.tmp());
+        return { };
+    }
+
+    Tmp toSplat = scalar.tmp();
+    if (scalarTypeIsFloatingPoint(lane)) {
+        Tmp gpCast = newTmp(B3::GP);
+        append(elementByteSize(lane) == 4 ? MoveFloatTo32 : MoveDoubleTo64, toSplat, gpCast);
+        toSplat = gpCast;
+    }
+
+    B3::Air::Opcode op;
+    switch (elementByteSize(lane)) {
+    case 1:
         op = VectorSplat8;
         break;
-    case SIMDLane::i16x8:
+    case 2:
         op = VectorSplat16;
         break;
-    case SIMDLane::i32x4:
+    case 4:
         op = VectorSplat32;
         break;
-    case SIMDLane::i64x2:
+    case 8:
         op = VectorSplat64;
-        break;
-    case SIMDLane::f32x4:
-        op = VectorSplatFloat32;
-        break;
-    case SIMDLane::f64x2:
-        op = VectorSplatFloat64;
         break;
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }
 
     result = v128();
-    append(op, scalar, result.tmp());
+    append(op, toSplat, result.tmp());
     return { };
 }
 


### PR DESCRIPTION
#### 55efffeb0d0ca97b9d5d86792a41e0dbcde8a2f3
<pre>
[SIMD] Intel temporary fix for splat on ARM64
<a href="https://bugs.webkit.org/show_bug.cgi?id=248837">https://bugs.webkit.org/show_bug.cgi?id=248837</a>
rdar://103043311

Reviewed by Yusuke Suzuki.

This is a temporary fix for operation splat on ARM64. Will optimize
the WasmAirIRGenerator.cpp code in the future.

* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::addSIMDSplat):

Canonical link: <a href="https://commits.webkit.org/257440@main">https://commits.webkit.org/257440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eab54a8f6bd3669add0608f03ef08006ee5c1866

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8231 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/32176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108428 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8782 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104747 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/32176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/91547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/32176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/89753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2131 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/32176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85569 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2032 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28829 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5125 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/6999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/32176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88425 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/3450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19794 "Passed tests") | 
<!--EWS-Status-Bubble-End-->