### PR TITLE
Shorthands are still using "initial" for longhands that are set implicitly (next batch)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/parsing/list-style-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/parsing/list-style-valid-expected.txt
@@ -1,6 +1,6 @@
 
 PASS e.style['list-style'] = "none" should set the property value
-FAIL e.style['list-style'] = "disc outside none" should set the property value assert_equals: serialization should be canonical expected "outside" but got "outside none disc"
+FAIL e.style['list-style'] = "disc outside none" should set the property value assert_equals: serialization should be canonical expected "outside" but got "outside disc"
 PASS e.style['list-style'] = "inside" should set the property value
 FAIL e.style['list-style'] = "inside disc" should set the property value assert_equals: serialization should be canonical expected "inside" but got "inside disc"
 PASS e.style['list-style'] = "inside none" should set the property value


### PR DESCRIPTION
#### 760a6e52c542bf62ac5da5beeef3d33db43b84d8
<pre>
Shorthands are still using &quot;initial&quot; for longhands that are set implicitly (next batch)
<a href="https://bugs.webkit.org/show_bug.cgi?id=248839">https://bugs.webkit.org/show_bug.cgi?id=248839</a>
rdar://problem/103044698

Reviewed by Tim Nguyen.

Use implicit initial values instead of the implicit initial keyword. Later we will also eliminate
the concept of &quot;implicit&quot; and not serialize these because of their value, rather than leaving them
out of the serialization because of an implicit flag. This doesn&apos;t fix all of them. There are still
a few remaining in places that are slightly harder to remove.

* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/parsing/list-style-valid-expected.txt:
A small progression; this still does not omit enough of the properties that it should.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeBorderImage): Removed unused code for parsing
-webkit-mask-box-image as a shorthand. We can restore this later if it&apos;s needed.
(WebCore::CSSPropertyParser::consumeContainerShorthand): Use initial value rather than the
initial keyword for container-type when parsing the container shorthand.
(WebCore::CSSPropertyParser::consumeListStyleShorthand): Use initial values rather than the
initial keyword for list-style-position, list-style-image, and list-style-type when parsing the
list-style shorthand.

Canonical link: <a href="https://commits.webkit.org/257556@main">https://commits.webkit.org/257556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/741470e9baba1a79ba746d22c20167f118d6c037

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108696 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168943 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85828 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91801 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105069 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2387 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2285 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/8298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/42740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2648 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/3957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->