### PR TITLE
JSC options should check consistency after all options have been set.

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3738,7 +3738,7 @@ void CommandLine::parseArguments(int argc, char** argv)
 
         // See if the -- option is a JSC VM option.
         if (strstr(arg, "--") == arg) {
-            if (!JSC::Options::setOption(&arg[2])) {
+            if (!JSC::Options::setOption(&arg[2], /* verify = */ false)) {
                 hasBadJSCOptions = true;
                 dataLog("ERROR: invalid option: ", arg, "\n");
             }
@@ -3753,6 +3753,8 @@ void CommandLine::parseArguments(int argc, char** argv)
 
     if (hasBadJSCOptions && JSC::Options::validateOptions())
         CRASH();
+
+    JSC::Options::notifyOptionsChanged();
 
     if (m_scripts.isEmpty())
         m_interactive = true;

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -951,7 +951,7 @@ bool Options::setOptions(const char* optionsStr)
 
 // Parses a single command line option in the format "<optionName>=<value>"
 // (no spaces allowed) and set the specified option if appropriate.
-bool Options::setOptionWithoutAlias(const char* arg)
+bool Options::setOptionWithoutAlias(const char* arg, bool verify)
 {
     // arg should look like this:
     //   <jscOptionName>=<appropriate value>
@@ -973,7 +973,7 @@ bool Options::setOptionWithoutAlias(const char* arg)
         value = parse<OptionsStorage::type_>(valueStr);            \
         if (value) {                                               \
             name_() = value.value();                               \
-            notifyOptionsChanged();                                \
+            if (verify) notifyOptionsChanged();                    \
             return true;                                           \
         }                                                          \
         return false;                                              \
@@ -994,7 +994,7 @@ static const char* invertBoolOptionValue(const char* valueStr)
 }
 
 
-bool Options::setAliasedOption(const char* arg)
+bool Options::setAliasedOption(const char* arg, bool verify)
 {
     // arg should look like this:
     //   <jscOptionName>=<appropriate value>
@@ -1019,7 +1019,7 @@ bool Options::setAliasedOption(const char* arg)
                 return false;                                           \
             unaliasedOption = unaliasedOption + "=" + invertedValueStr; \
         }                                                               \
-        return setOptionWithoutAlias(unaliasedOption.utf8().data());    \
+        return setOptionWithoutAlias(unaliasedOption.utf8().data(), verify);    \
     }
 
     FOR_EACH_JSC_ALIASED_OPTION(FOR_EACH_OPTION)
@@ -1030,13 +1030,13 @@ bool Options::setAliasedOption(const char* arg)
     return false; // No option matched.
 }
 
-bool Options::setOption(const char* arg)
+bool Options::setOption(const char* arg, bool verify)
 {
     AllowUnfinalizedAccessScope scope;
-    bool success = setOptionWithoutAlias(arg);
+    bool success = setOptionWithoutAlias(arg, verify);
     if (success)
         return true;
-    return setAliasedOption(arg);
+    return setAliasedOption(arg, verify);
 }
 
 

--- a/Source/JavaScriptCore/runtime/Options.h
+++ b/Source/JavaScriptCore/runtime/Options.h
@@ -111,7 +111,7 @@ public:
 
     // Parses a single command line option in the format "<optionName>=<value>"
     // (no spaces allowed) and set the specified option if appropriate.
-    JS_EXPORT_PRIVATE static bool setOption(const char* arg);
+    JS_EXPORT_PRIVATE static bool setOption(const char* arg, bool verify = true);
 
     JS_EXPORT_PRIVATE static void dumpAllOptions(DumpLevel, const char* title = nullptr);
     JS_EXPORT_PRIVATE static void dumpAllOptionsInALine(StringBuilder&);
@@ -156,8 +156,8 @@ private:
     static void dumpOption(StringBuilder&, DumpLevel, ID,
         const char* optionHeader, const char* optionFooter, DumpDefaultsOption);
 
-    static bool setOptionWithoutAlias(const char* arg);
-    static bool setAliasedOption(const char* arg);
+    static bool setOptionWithoutAlias(const char* arg, bool verify = true);
+    static bool setAliasedOption(const char* arg, bool verify = true);
 #if !PLATFORM(COCOA)
     static bool overrideAliasedOptionWithHeuristic(const char* name);
 #endif


### PR DESCRIPTION
#### a3b7a9916a5322f641e2ad1ab1331c55bf5a9221
<pre>
JSC options should check consistency after all options have been set.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248843">https://bugs.webkit.org/show_bug.cgi?id=248843</a>

Reviewed by Yusuke Suzuki.

Debug tests are failing because we validate options too early. The JSC
shell should wait until all command line options have been set before
validating that they are valid together.

* Source/JavaScriptCore/jsc.cpp:
(CommandLine::parseArguments):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::setOptionWithoutAlias):
(JSC::Options::setAliasedOption):
(JSC::Options::setOption):
* Source/JavaScriptCore/runtime/Options.h:

Canonical link: <a href="https://commits.webkit.org/257491@main">https://commits.webkit.org/257491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ec08e130927033ff0da345fca784e5efefabba8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99052 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108447 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168696 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85616 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91564 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106401 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33692 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21594 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76547 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89770 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2151 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23110 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85592 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45511 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28836 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42585 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88451 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2616 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3466 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19801 "Passed tests") | 
<!--EWS-Status-Bubble-End-->