### PR TITLE
Add signposts to Speedometer

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer2.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer2.patch
@@ -1,0 +1,33 @@
+
+diff --git a/PerformanceTests/Speedometer/resources/benchmark-runner.js b/PerformanceTests/Speedometer/resources/benchmark-runner.js
+index 47cedfc09a4c..82a34562bfc2 100644
+--- a/resources/benchmark-runner.js
++++ b/resources/benchmark-runner.js
+@@ -125,21 +125,27 @@ BenchmarkRunner.prototype._runTest = function(suite, test, prepareReturnValue, c
+ 
+     var contentWindow = self._frame.contentWindow;
+     var contentDocument = self._frame.contentDocument;
++    let syncName = suite.name + '.' + test.name + '-sync';
++    let asyncName = suite.name + '.' + test.name + '-async';
+ 
+     self._writeMark(suite.name + '.' + test.name + '-start');
++    __signpostStart(syncName);
+     var startTime = now();
+     test.run(prepareReturnValue, contentWindow, contentDocument);
+     var endTime = now();
++    __signpostStop(syncName);
+     self._writeMark(suite.name + '.' + test.name + '-sync-end');
+ 
+     var syncTime = endTime - startTime;
+ 
++    __signpostStart(asyncName);
+     var startTime = now();
+     setTimeout(function () {
+         // Some browsers don't immediately update the layout for paint.
+         // Force the layout here to ensure we're measuring the layout time.
+         var height = self._frame.contentDocument.body.getBoundingClientRect().height;
+         var endTime = now();
++        __signpostStop(asyncName);
+         self._frame.contentWindow._unusedHeightValue = height; // Prevent dead code elimination.
+         self._writeMark(suite.name + '.' + test.name + '-async-end');
+         callback(syncTime, endTime - startTime, height);

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.0.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.0.plan
@@ -3,6 +3,7 @@
     "count": 4,
     "svn_source": "https://svn.webkit.org/repository/webkit/trunk/PerformanceTests/Speedometer/@r226694",
     "webserver_benchmark_patch": "data/patches/webserver/Speedometer2.patch",
+    "signpost_patch": "data/patches/signposts/Speedometer2.patch",
     "entry_point": "index.html",
     "output_file": "speedometer2.result"
 }

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.1.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.1.plan
@@ -3,6 +3,7 @@
     "count": 4,
     "svn_source": "https://svn.webkit.org/repository/webkit/trunk/PerformanceTests/Speedometer/@r290664",
     "webserver_benchmark_patch": "data/patches/webserver/Speedometer2.patch",
+    "signpost_patch": "data/patches/signposts/Speedometer2.patch",
     "entry_point": "index.html",
     "output_file": "speedometer2.result"
 }


### PR DESCRIPTION
#### ce23b74e03eae23c807b6dc29fcf7fa1ff5a430f
<pre>
Add signposts to Speedometer
<a href="https://bugs.webkit.org/show_bug.cgi?id=247591">https://bugs.webkit.org/show_bug.cgi?id=247591</a>
rdar://102061752

Reviewed by Dewei Zhu.

This patch adds signpost patches to Speedometer plans, which will allow us to annotate generated profiles (--profile).

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer2.patch: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.0.plan:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.1.plan:

Canonical link: <a href="https://commits.webkit.org/257454@main">https://commits.webkit.org/257454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd06895702f850088075b8b7f9006fcc60bc5137

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8257 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/32197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108449 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8802 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104778 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/32197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/91566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/102580 "webkitpy-tests running (python2)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/32197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2153 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/32197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/2051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5133 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/7016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/32197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/3468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->