### PR TITLE
JetStream3: add class fields tests

### DIFF
--- a/PerformanceTests/JetStream3/JetStreamDriver.js
+++ b/PerformanceTests/JetStream3/JetStreamDriver.js
@@ -1207,6 +1207,7 @@ const SunSpiderGroup = Symbol.for("SunSpider");
 const BigIntNobleGroup = Symbol.for("BigIntNoble");
 const BigIntMiscGroup = Symbol.for("BigIntMisc");
 const ProxyGroup = Symbol.for("ProxyGroup");
+const ClassFieldsGroup = Symbol.for("ClassFieldsGroup");
 const WasmGroup = Symbol.for("Wasm");
 const WorkerTestsGroup = Symbol.for("WorkerTests");
 const WSLGroup = Symbol.for("WSL");
@@ -1403,7 +1404,6 @@ let testPlans = [
         files: [
             "./Octane/raytrace.js"
         ],
-        deterministicRandom: true,
         testGroup: OctaneGroup
     },
     {
@@ -1654,6 +1654,21 @@ let testPlans = [
         iterations: 20,
         worstCaseCount: 2,
         testGroup: ProxyGroup,
+    },
+    // Class fields
+    {
+        name: "raytrace-public-class-fields",
+        files: [
+            "./class-fields/raytrace-public-class-fields.js",
+        ],
+        testGroup: ClassFieldsGroup,
+    },
+    {
+        name: "raytrace-private-class-fields",
+        files: [
+            "./class-fields/raytrace-private-class-fields.js",
+        ],
+        testGroup: ClassFieldsGroup,
     },
     // Wasm
     {
@@ -1915,6 +1930,7 @@ let runSunSpider = true;
 let runBigIntNoble = true;
 let runBigIntMisc = true;
 let runProxy = true;
+let runClassFields = true;
 let runSimple = true;
 let runCDJS = true;
 let runWorkerTests = !!isInBrowser;
@@ -1934,6 +1950,7 @@ if (false) {
     runBigIntNoble = false;
     runBigIntMisc = false;
     runProxy = false;
+    runClassFields = false;
     runSimple = false;
     runCDJS = false;
     runWorkerTests = false;
@@ -1979,6 +1996,9 @@ if (typeof testList !== "undefined") {
 
     if (runProxy)
         addTestsByGroup(ProxyGroup);
+
+    if (runClassFields)
+        addTestsByGroup(ClassFieldsGroup);
 
     if (runWasm)
         addTestsByGroup(WasmGroup);

--- a/PerformanceTests/JetStream3/class-fields/raytrace-private-class-fields.js
+++ b/PerformanceTests/JetStream3/class-fields/raytrace-private-class-fields.js
@@ -6,31 +6,35 @@
 // It has been modified slightly by Google to work as a standalone benchmark,
 // but all the computational code remains untouched.
 
-// For JetStream3, this code was rewritten using ES6 classes,
+// For JetStream3, this code was rewritten using ES6 classes and private fields,
 // dropping namespaces and Prototype.js class system, as well as slightly refactored.
 // All the computational code still remains untouched.
 
 class Color {
+    #red = 0;
+    #green = 0;
+    #blue = 0;
+
     constructor(red, green, blue) {
-        this.red = red;
-        this.green = green;
-        this.blue = blue;
+        this.#red = red;
+        this.#green = green;
+        this.#blue = blue;
     }
 
     static add(c1, c2) {
-        return new Color(c1.red + c2.red, c1.green + c2.green, c1.blue + c2.blue);
+        return new Color(c1.#red + c2.#red, c1.#green + c2.#green, c1.#blue + c2.#blue);
     }
 
     static addScalar(c1, s) {
-        return new Color(c1.red + s, c1.green + s, c1.blue + s).limit();
+        return new Color(c1.#red + s, c1.#green + s, c1.#blue + s).limit();
     }
 
     static multiply(c1, c2) {
-        return new Color(c1.red * c2.red, c1.green * c2.green, c1.blue * c2.blue);
+        return new Color(c1.#red * c2.#red, c1.#green * c2.#green, c1.#blue * c2.#blue);
     }
 
     static multiplyScalar(c1, f) {
-        return new Color(c1.red * f, c1.green * f, c1.blue * f);
+        return new Color(c1.#red * f, c1.#green * f, c1.#blue * f);
     }
 
     static blend(c1, c2, w) {
@@ -41,35 +45,43 @@ class Color {
     }
 
     limit() {
-        this.red = this.red > 0 ? (this.red > 1 ? 1 : this.red) : 0;
-        this.green = this.green > 0 ? (this.green > 1 ? 1 : this.green) : 0;
-        this.blue = this.blue > 0 ? (this.blue > 1 ? 1 : this.blue) : 0;
+        this.#red = this.#red > 0 ? (this.#red > 1 ? 1 : this.#red) : 0;
+        this.#green = this.#green > 0 ? (this.#green > 1 ? 1 : this.#green) : 0;
+        this.#blue = this.#blue > 0 ? (this.#blue > 1 ? 1 : this.#blue) : 0;
 
         return this;
     }
 
     brightness() {
-        const r = Math.floor(this.red * 255);
-        const g = Math.floor(this.green * 255);
-        const b = Math.floor(this.blue * 255);
+        const r = Math.floor(this.#red * 255);
+        const g = Math.floor(this.#green * 255);
+        const b = Math.floor(this.#blue * 255);
 
         return (r * 77 + g * 150 + b * 29) >> 8;
     }
 
     toString() {
-        const r = Math.floor(this.red * 255);
-        const g = Math.floor(this.green * 255);
-        const b = Math.floor(this.blue * 255);
+        const r = Math.floor(this.#red * 255);
+        const g = Math.floor(this.#green * 255);
+        const b = Math.floor(this.#blue * 255);
 
         return `rgb(${r},${g},${b})`;
     }
 }
 
 class Light {
+    static #defaultColor = new Color(0, 0, 0);
+
+    #position = null;
+    #color = Light.#defaultColor;
+
     constructor(position, color) {
-        this.position = position;
-        this.color = color;
+        this.#position = position;
+        this.#color = color;
     }
+
+    get position() { return this.#position; }
+    get color() { return this.#color; }
 
     toString() {
         return `Light [${this.position}]`;
@@ -77,60 +89,74 @@ class Light {
 }
 
 class Vector {
+    #x = 0;
+    #y = 0;
+    #z = 0;
+
     static add(v, w) {
-        return new Vector(w.x + v.x, w.y + v.y, w.z + v.z);
+        return new Vector(w.#x + v.#x, w.#y + v.#y, w.#z + v.#z);
     }
 
     static subtract(v, w) {
-        return new Vector(v.x - w.x, v.y - w.y, v.z - w.z);
+        return new Vector(v.#x - w.#x, v.#y - w.#y, v.#z - w.#z);
     }
 
     static multiplyScalar(v, w) {
-        return new Vector(v.x * w, v.y * w, v.z * w);
+        return new Vector(v.#x * w, v.#y * w, v.#z * w);
     }
 
     constructor(x, y, z) {
-        this.x = x;
-        this.y = y;
-        this.z = z;
+        this.#x = x;
+        this.#y = y;
+        this.#z = z;
     }
 
-    normalize() {
-        const m = this.magnitude();
+    get x() { return this.#x; }
+    get y() { return this.#y; }
+    get z() { return this.#z; }
 
-        return new Vector(this.x / m, this.y / m, this.z / m);
+    normalize() {
+        const m = this.#magnitude();
+
+        return new Vector(this.#x / m, this.#y / m, this.#z / m);
     }
 
     negateY() {
-        this.y *= -1;
+        this.#y *= -1;
     }
 
-    magnitude() {
-        return Math.sqrt((this.x * this.x) + (this.y * this.y) + (this.z * this.z));
+    #magnitude() {
+        return Math.sqrt((this.#x * this.#x) + (this.#y * this.#y) + (this.#z * this.#z));
     }
 
     cross(w) {
         return new Vector(
-            -this.z * w.y + this.y * w.z,
-            this.z * w.x - this.x * w.z,
-            -this.y * w.x + this.x * w.y,
+            -this.#z * w.#y + this.#y * w.#z,
+            this.#z * w.#x - this.#x * w.#z,
+            -this.#y * w.#x + this.#x * w.#y,
         );
     }
 
     dot(w) {
-        return this.x * w.x + this.y * w.y + this.z * w.z;
+        return this.#x * w.#x + this.#y * w.#y + this.#z * w.#z;
     }
 
     toString() {
-        return `Vector [${this.x},${this.y},${this.z}]`;
+        return `Vector [${this.#x},${this.#y},${this.#z}]`;
     }
 }
 
 class Ray {
+    #position = null;
+    #direction = null;
+
     constructor(position, direction) {
-        this.position = position;
-        this.direction = direction;
+        this.#position = position;
+        this.#direction = direction;
     }
+
+    get position() { return this.#position; }
+    get direction() { return this.#direction; }
 
     toString() {
         return `Ray [${this.position},${this.direction}]`;
@@ -138,21 +164,41 @@ class Ray {
 }
 
 class Scene {
+    #camera = null;
+    #background = null;
+    #shapes = [];
+    #lights = [];
+
     constructor(camera, background, shapes, lights) {
-        this.camera = camera;
-        this.background = background;
-        this.shapes = shapes;
-        this.lights = lights;
+        this.#camera = camera;
+        this.#background = background;
+        this.#shapes = shapes;
+        this.#lights = lights;
     }
+
+    get camera() { return this.#camera; }
+    get background() { return this.#background; }
+    get shapes() { return this.#shapes; }
+    get lights() { return this.#lights; }
 }
 
 class Material {
+    #reflection = 0;
+    #transparency = 0;
+    #gloss = 0;
+    #hasTexture = false;
+
     constructor(reflection, transparency, gloss, hasTexture) {
-        this.reflection = reflection;
-        this.transparency = transparency;
-        this.gloss = gloss;
-        this.hasTexture = hasTexture;
+        this.#reflection = reflection;
+        this.#transparency = transparency;
+        this.#gloss = gloss;
+        this.#hasTexture = hasTexture;
     }
+
+    get reflection() { return this.#reflection; }
+    get transparency() { return this.#transparency; }
+    get gloss() { return this.#gloss; }
+    get hasTexture() { return this.#hasTexture; }
 
     getColor() {
         throw new Error("getColor() isn't implemented");
@@ -164,17 +210,17 @@ class Material {
 }
 
 class SolidMaterial extends Material {
-    static defaultColor = new Color(0, 0, 0);
+    static #defaultColor = new Color(0, 0, 0);
 
-    color = SolidMaterial.defaultColor;
+    #color = SolidMaterial.#defaultColor;
 
     constructor(color, reflection, transparency, gloss) {
         super(reflection, transparency, gloss, true);
-        this.color = color;
+        this.#color = color;
     }
 
     getColor() {
-        return this.color;
+        return this.#color;
     }
 
     toString() {
@@ -183,14 +229,21 @@ class SolidMaterial extends Material {
 }
 
 class ChessboardMaterial extends Material {
+    static #defaultColorEven = new Color(0, 0, 0);
+    static #defaultColorOdd = new Color(0, 0, 0);
+
+    #colorEven = ChessboardMaterial.#defaultColorEven;
+    #colorOdd = ChessboardMaterial.#defaultColorOdd;
+    #density = 1;
+
     constructor(colorEven, colorOdd, reflection, transparency, gloss, density) {
         super(reflection, transparency, gloss, true);
-        this.colorEven = colorEven;
-        this.colorOdd = colorOdd;
-        this.density = density;
+        this.#colorEven = colorEven;
+        this.#colorOdd = colorOdd;
+        this.#density = density;
     }
 
-    wrapUp(t) {
+    #wrapUp(t) {
         t %= 2;
         if (t < -1) t += 2;
         if (t >= 1) t -= 2;
@@ -198,8 +251,8 @@ class ChessboardMaterial extends Material {
     }
 
     getColor(u, v) {
-        const t = this.wrapUp(u * this.density) * this.wrapUp(v * this.density);
-        return t < 0 ? this.colorEven : this.colorOdd;
+        const t = this.#wrapUp(u * this.#density) * this.#wrapUp(v * this.#density);
+        return t < 0 ? this.#colorEven : this.#colorOdd;
     }
 
     toString() {
@@ -208,10 +261,16 @@ class ChessboardMaterial extends Material {
 }
 
 class Shape {
+    #position = null;
+    #material = null;
+
     constructor(position, material) {
-        this.position = position;
-        this.material = material;
+        this.#position = position;
+        this.#material = material;
     }
+
+    get position() { return this.#position; }
+    get material() { return this.#material; }
 
     intersect(ray) {
         throw new Error("intersect() isn't implemented");
@@ -219,9 +278,11 @@ class Shape {
 }
 
 class Sphere extends Shape {
+    #radius = 0;
+
     constructor(position, material, radius) {
         super(position, material);
-        this.radius = radius;
+        this.#radius = radius;
     }
 
     intersect(ray) {
@@ -231,7 +292,7 @@ class Sphere extends Shape {
         const dst = Vector.subtract(ray.position, this.position);
 
         const B = dst.dot(ray.direction);
-        const C = dst.dot(dst) - (this.radius * this.radius);
+        const C = dst.dot(dst) - (this.#radius * this.#radius);
         const D = (B * B) - C;
 
         if (D > 0) { // intersection!
@@ -248,14 +309,16 @@ class Sphere extends Shape {
     }
 
     toString() {
-        return `Sphere [position=${this.position}, radius=${this.radius}]`;
+        return `Sphere [position=${this.position}, radius=${this.#radius}]`;
     }
 }
 
 class Plane extends Shape {
+    #d = 0;
+
     constructor(position, material, d) {
         super(position, material);
-        this.d = d;
+        this.#d = d;
     }
 
     intersect(ray) {
@@ -265,7 +328,7 @@ class Plane extends Shape {
         const Vd = this.position.dot(ray.direction);
         if (Vd === 0) return info; // no intersection
 
-        const t = -(this.position.dot(ray.position) + this.d) / Vd;
+        const t = -(this.position.dot(ray.position) + this.#d) / Vd;
         if (t <= 0) return info;
 
         info.isHit = true;
@@ -287,49 +350,55 @@ class Plane extends Shape {
     }
 
     toString() {
-        return `Plane [${this.position}, d=${this.d}]`;
+        return `Plane [${this.position}, d=${this.#d}]`;
     }
 }
 
 class IntersectionInfo {
-    constructor() {
-        this.isHit = false;
-        this.hitCount = 0;
-        this.shape = null;
-        this.position = null;
-        this.normal = null;
-        this.color = IntersectionInfo.defaultColor;
-        this.distance = null;
-    }
+    static #defaultColor = new Color(0, 0, 0);
+
+    isHit = false;
+    hitCount = 0;
+    shape = null;
+    position = null;
+    normal = null;
+    color = IntersectionInfo.#defaultColor;
+    distance = null;
 
     toString() {
         return `Intersection [${this.position}]`;
     }
 }
 
-IntersectionInfo.defaultColor = new Color(0, 0, 0);
-
 class Camera {
+    #position = null;
+    #lookAt = null;
+    #up = null;
+    #equator = null;
+    #screen = null;
+
     constructor(position, lookAt, up) {
-        this.position = position;
-        this.lookAt = lookAt;
-        this.up = up;
-        this.equator = this.lookAt.normalize().cross(this.up);
-        this.screen = Vector.add(this.position, this.lookAt);
+        this.#position = position;
+        this.#lookAt = lookAt;
+        this.#up = up;
+        this.#equator = this.#lookAt.normalize().cross(this.#up);
+        this.#screen = Vector.add(this.#position, this.#lookAt);
     }
+
+    get position() { return this.#position; }
 
     getRay(vx, vy) {
         const pos = Vector.subtract(
-            this.screen,
+            this.#screen,
             Vector.subtract(
-                Vector.multiplyScalar(this.equator, vx),
-                Vector.multiplyScalar(this.up, vy),
+                Vector.multiplyScalar(this.#equator, vx),
+                Vector.multiplyScalar(this.#up, vy),
             ),
         );
 
         pos.negateY();
 
-        const dir = Vector.subtract(pos, this.position);
+        const dir = Vector.subtract(pos, this.#position);
         return new Ray(pos, dir.normalize());
     }
 
@@ -339,10 +408,18 @@ class Camera {
 }
 
 class Background {
+    static #defaultColor = new Color(0, 0, 0);
+
+    #color = Background.#defaultColor;
+    #ambience = 0;
+
     constructor(color, ambience) {
-        this.color = color;
-        this.ambience = ambience;
+        this.#color = color;
+        this.#ambience = ambience;
     }
+
+    get color() { return this.#color; }
+    get ambience() { return this.#ambience; }
 
     toString() {
         return `Background [${this.color}]`;
@@ -350,12 +427,13 @@ class Background {
 }
 
 class Engine {
-    constructor(options) {
-        // Variable used to hold a number that can be used to verify that
-        // the scene was ray traced correctly.
-        this.checkNumber = 0;
+    // Variable used to hold a number that can be used to verify that
+    // the scene was ray traced correctly.
+    #checkNumber = 0;
+    #options = {};
 
-        this.options = {
+    constructor(options) {
+        this.#options = {
             canvasHeight: 100,
             canvasWidth: 100,
             pixelWidth: 2,
@@ -368,40 +446,40 @@ class Engine {
             ...options,
         };
 
-        this.options.canvasHeight /= this.options.pixelHeight;
-        this.options.canvasWidth /= this.options.pixelWidth;
+        this.#options.canvasHeight /= this.#options.pixelHeight;
+        this.#options.canvasWidth /= this.#options.pixelWidth;
     }
 
     renderScene(scene) {
-        for (let x = 0; x < this.options.canvasWidth; x++) {
-            for (let y = 0; y < this.options.canvasHeight; y++) {
-                const xp = x * 1 / this.options.canvasWidth * 2 - 1;
-                const yp = y * 1 / this.options.canvasHeight * 2 - 1;
+        for (let x = 0; x < this.#options.canvasWidth; x++) {
+            for (let y = 0; y < this.#options.canvasHeight; y++) {
+                const xp = x * 1 / this.#options.canvasWidth * 2 - 1;
+                const yp = y * 1 / this.#options.canvasHeight * 2 - 1;
 
                 const ray = scene.camera.getRay(xp, yp);
-                const color = this.getPixelColor(ray, scene);
+                const color = this.#getPixelColor(ray, scene);
 
-                this.setPixel(x, y, color);
+                this.#setPixel(x, y, color);
             }
         }
 
-        if (this.checkNumber !== 2321)
+        if (this.#checkNumber !== 2321)
             throw new Error("Scene rendered incorrectly");
     }
 
-    getPixelColor(ray, scene) {
-        const info = this.testIntersection(ray, scene, null);
+    #getPixelColor(ray, scene) {
+        const info = this.#testIntersection(ray, scene, null);
         if (info.isHit)
-            return this.rayTrace(info, ray, scene, 0);
+            return this.#rayTrace(info, ray, scene, 0);
         return scene.background.color;
     }
 
-    setPixel(x, y, color) {
+    #setPixel(x, y, color) {
         if (x === y)
-            this.checkNumber += color.brightness();
+            this.#checkNumber += color.brightness();
     }
 
-    testIntersection(ray, scene, exclude) {
+    #testIntersection(ray, scene, exclude) {
         let hitCount = 0;
         let best = new IntersectionInfo();
         best.distance = 2000;
@@ -421,13 +499,13 @@ class Engine {
         return best;
     }
 
-    getReflectionRay(P, N, V) {
+    #getReflectionRay(P, N, V) {
         const c1 = -N.dot(V);
         const R1 = Vector.add(Vector.multiplyScalar(N, 2 * c1), V);
         return new Ray(P, R1);
     }
 
-    rayTrace(info, ray, scene, depth) {
+    #rayTrace(info, ray, scene, depth) {
         // Calc ambient
         let color = Color.multiplyScalar(info.color, scene.background.ambience);
         const shininess = 10 ** (info.shape.material.gloss + 1);
@@ -438,7 +516,7 @@ class Engine {
             // Calc diffuse lighting
             const v = Vector.subtract(light.position, info.position).normalize();
 
-            if (this.options.renderDiffuse) {
+            if (this.#options.renderDiffuse) {
                 const L = v.dot(info.normal);
                 if (L > 0) {
                     color = Color.add(
@@ -453,14 +531,14 @@ class Engine {
 
             // The greater the depth the more accurate the colours, but
             // this is exponentially (!) expensive
-            if (depth <= this.options.rayDepth) {
+            if (depth <= this.#options.rayDepth) {
                 // calculate reflection ray
-                if (this.options.renderReflections && info.shape.material.reflection > 0) {
-                    const reflectionRay = this.getReflectionRay(info.position, info.normal, ray.direction);
-                    const refl = this.testIntersection(reflectionRay, scene, info.shape);
+                if (this.#options.renderReflections && info.shape.material.reflection > 0) {
+                    const reflectionRay = this.#getReflectionRay(info.position, info.normal, ray.direction);
+                    const refl = this.#testIntersection(reflectionRay, scene, info.shape);
 
                     if (refl.isHit && refl.distance > 0) {
-                        refl.color = this.rayTrace(refl, reflectionRay, scene, depth + 1);
+                        refl.color = this.#rayTrace(refl, reflectionRay, scene, depth + 1);
                     } else {
                         refl.color = scene.background.color;
                     }
@@ -476,10 +554,10 @@ class Engine {
             // Render shadows and highlights
             let shadowInfo = new IntersectionInfo();
 
-            if (this.options.renderShadows) {
+            if (this.#options.renderShadows) {
                 const shadowRay = new Ray(info.position, v);
 
-                shadowInfo = this.testIntersection(shadowRay, scene, info.shape);
+                shadowInfo = this.#testIntersection(shadowRay, scene, info.shape);
                 if (shadowInfo.isHit && shadowInfo.shape !== info.shape) {
                     const vA = Color.multiplyScalar(color, 0.5);
                     const dB = 0.5 * (shadowInfo.shape.material.transparency ** 0.5);
@@ -488,7 +566,7 @@ class Engine {
             }
 
             // Phong specular highlights
-            if (this.options.renderHighlights && !shadowInfo.isHit && info.shape.material.gloss > 0) {
+            if (this.#options.renderHighlights && !shadowInfo.isHit && info.shape.material.gloss > 0) {
                 const Lv = Vector.subtract(info.shape.position, light.position).normalize();
                 const E = Vector.subtract(scene.camera.position, info.shape.position).normalize();
                 const H = Vector.subtract(E, Lv).normalize();

--- a/PerformanceTests/JetStream3/class-fields/raytrace-public-class-fields.js
+++ b/PerformanceTests/JetStream3/class-fields/raytrace-public-class-fields.js
@@ -6,11 +6,15 @@
 // It has been modified slightly by Google to work as a standalone benchmark,
 // but all the computational code remains untouched.
 
-// For JetStream3, this code was rewritten using ES6 classes,
+// For JetStream3, this code was rewritten using ES6 classes and public fields,
 // dropping namespaces and Prototype.js class system, as well as slightly refactored.
 // All the computational code still remains untouched.
 
 class Color {
+    red = 0;
+    green = 0;
+    blue = 0;
+
     constructor(red, green, blue) {
         this.red = red;
         this.green = green;
@@ -66,6 +70,11 @@ class Color {
 }
 
 class Light {
+    static defaultColor = new Color(0, 0, 0);
+
+    position = null;
+    color = Light.defaultColor;
+
     constructor(position, color) {
         this.position = position;
         this.color = color;
@@ -77,6 +86,10 @@ class Light {
 }
 
 class Vector {
+    x = 0;
+    y = 0;
+    z = 0;
+
     static add(v, w) {
         return new Vector(w.x + v.x, w.y + v.y, w.z + v.z);
     }
@@ -127,6 +140,9 @@ class Vector {
 }
 
 class Ray {
+    position = null;
+    direction = null;
+
     constructor(position, direction) {
         this.position = position;
         this.direction = direction;
@@ -138,6 +154,11 @@ class Ray {
 }
 
 class Scene {
+    camera = null;
+    background = null;
+    shapes = [];
+    lights = [];
+
     constructor(camera, background, shapes, lights) {
         this.camera = camera;
         this.background = background;
@@ -147,6 +168,11 @@ class Scene {
 }
 
 class Material {
+    reflection = 0;
+    transparency = 0;
+    gloss = 0;
+    hasTexture = false;
+
     constructor(reflection, transparency, gloss, hasTexture) {
         this.reflection = reflection;
         this.transparency = transparency;
@@ -183,6 +209,13 @@ class SolidMaterial extends Material {
 }
 
 class ChessboardMaterial extends Material {
+    static defaultColorEven = new Color(0, 0, 0);
+    static defaultColorOdd = new Color(0, 0, 0);
+
+    colorEven = ChessboardMaterial.defaultColorEven;
+    colorOdd = ChessboardMaterial.defaultColorOdd;
+    density = 1;
+
     constructor(colorEven, colorOdd, reflection, transparency, gloss, density) {
         super(reflection, transparency, gloss, true);
         this.colorEven = colorEven;
@@ -208,6 +241,9 @@ class ChessboardMaterial extends Material {
 }
 
 class Shape {
+    position = null;
+    material = null;
+
     constructor(position, material) {
         this.position = position;
         this.material = material;
@@ -219,6 +255,8 @@ class Shape {
 }
 
 class Sphere extends Shape {
+    radius = 0;
+
     constructor(position, material, radius) {
         super(position, material);
         this.radius = radius;
@@ -253,6 +291,8 @@ class Sphere extends Shape {
 }
 
 class Plane extends Shape {
+    d = 0;
+
     constructor(position, material, d) {
         super(position, material);
         this.d = d;
@@ -292,24 +332,28 @@ class Plane extends Shape {
 }
 
 class IntersectionInfo {
-    constructor() {
-        this.isHit = false;
-        this.hitCount = 0;
-        this.shape = null;
-        this.position = null;
-        this.normal = null;
-        this.color = IntersectionInfo.defaultColor;
-        this.distance = null;
-    }
+    static defaultColor = new Color(0, 0, 0);
+
+    isHit = false;
+    hitCount = 0;
+    shape = null;
+    position = null;
+    normal = null;
+    color = IntersectionInfo.defaultColor;
+    distance = null;
 
     toString() {
         return `Intersection [${this.position}]`;
     }
 }
 
-IntersectionInfo.defaultColor = new Color(0, 0, 0);
-
 class Camera {
+    position = null;
+    lookAt = null;
+    up = null;
+    equator = null;
+    screen = null;
+
     constructor(position, lookAt, up) {
         this.position = position;
         this.lookAt = lookAt;
@@ -339,6 +383,11 @@ class Camera {
 }
 
 class Background {
+    static defaultColor = new Color(0, 0, 0);
+
+    color = Background.defaultColor;
+    ambience = 0;
+
     constructor(color, ambience) {
         this.color = color;
         this.ambience = ambience;
@@ -350,11 +399,12 @@ class Background {
 }
 
 class Engine {
-    constructor(options) {
-        // Variable used to hold a number that can be used to verify that
-        // the scene was ray traced correctly.
-        this.checkNumber = 0;
+    // Variable used to hold a number that can be used to verify that
+    // the scene was ray traced correctly.
+    checkNumber = 0;
+    options = {};
 
+    constructor(options) {
         this.options = {
             canvasHeight: 100,
             canvasWidth: 100,

--- a/PerformanceTests/JetStream3/in-depth.html
+++ b/PerformanceTests/JetStream3/in-depth.html
@@ -259,10 +259,26 @@
 
         <dt id="raytrace">raytrace</dt>
         <dd>
-        <a href="https://en.wikipedia.org/wiki/Ray_tracing_(graphics)">Ray tracer</a> written in JavaScript using prototype.js. Tests object construction performance
-         and floating point math.
+         <a href="https://en.wikipedia.org/wiki/Ray_tracing_(graphics)">Ray tracer</a> written in JavaScript using ES6 classes.
+         Tests object construction performance and floating point math.
          A similar version of this benchmark was previously published in Octane version 2.
          Source code: <a href="Octane/raytrace.js">raytrace.js</a>
+        </dd>
+
+        <dt id="raytrace-private-class-fields">raytrace-private-class-fields</dt>
+        <dd>
+         <a href="https://en.wikipedia.org/wiki/Ray_tracing_(graphics)">Ray tracer</a> written in JavaScript using ES6 classes and private fields.
+         Tests object construction performance, along with setting default values of private fields, their access speed, and floating point math.
+         A similar version of this benchmark was previously published in Octane version 2.
+         Source code: <a href="class-fields/raytrace-private-class-fields.js">raytrace-private-class-fields.js</a>
+        </dd>
+
+        <dt id="raytrace-public-class-fields">raytrace-public-class-fields</dt>
+        <dd>
+         <a href="https://en.wikipedia.org/wiki/Ray_tracing_(graphics)">Ray tracer</a> written in JavaScript using ES6 classes and public fields.
+         Tests object construction performance, along with setting default values of public fields, and floating point math.
+         A similar version of this benchmark was previously published in Octane version 2.
+         Source code: <a href="class-fields/raytrace-public-class-fields.js">raytrace-public-class-fields.js</a>
         </dd>
 
         <dt id="quicksort-wasm">quicksort-wasm</dt>


### PR DESCRIPTION
#### 174dc21a4f6279231e6b565b42d1edce0b0fd58e
<pre>
JetStream3: add class fields tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=248499">https://bugs.webkit.org/show_bug.cgi?id=248499</a>

Reviewed by Yusuke Suzuki.

Rewrites Octane&apos;s raytrace.js to use ES6 classes, and duplicates it twice
to also include public and private class fields, including default values
and static fields.

raytrace.js is the only existing test that captures object construction
performance, which is currently heavily impacted in JSC by class fields:
private class fields test is 25% slower than public class counterpart,
which in turn is 25% slower than pure ES6 class one.

* PerformanceTests/JetStream3/JetStreamDriver.js:
(Driver.prototype.async fetchResources):
* PerformanceTests/JetStream3/Octane/raytrace.js: Updated.
* PerformanceTests/JetStream3/class-fields/raytrace-private-class-fields.js: Added.
* PerformanceTests/JetStream3/class-fields/raytrace-public-class-fields.js: Added.
* PerformanceTests/JetStream3/in-depth.html:

Canonical link: <a href="https://commits.webkit.org/257473@main">https://commits.webkit.org/257473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cca75be970b7c23c3fb718ed46585e8cd7d82200

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108455 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85624 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91572 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106409 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90245 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33683 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21590 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76539 "Found 4 new API test failures: /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/console-api, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/js-exception, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/security-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2159 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23106 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45513 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42581 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2606 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3474 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->