### PR TITLE
Migrate SerializedScriptValue and SameSiteInfo to generated serialization

### DIFF
--- a/Source/WebCore/platform/network/SameSiteInfo.h
+++ b/Source/WebCore/platform/network/SameSiteInfo.h
@@ -37,29 +37,6 @@ struct SameSiteInfo {
     bool isSameSite { false };
     bool isTopSite { false };
     bool isSafeHTTPMethod { false };
-
-    template <class Encoder> void encode(Encoder&) const;
-    template <class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, SameSiteInfo&);
 };
-
-template <class Encoder>
-void SameSiteInfo::encode(Encoder& encoder) const
-{
-    encoder << isSameSite;
-    encoder << isTopSite;
-    encoder << isSafeHTTPMethod;
-}
-
-template <class Decoder>
-bool SameSiteInfo::decode(Decoder& decoder, SameSiteInfo& info)
-{
-    if (!decoder.decode(info.isSameSite))
-        return false;
-    if (!decoder.decode(info.isTopSite))
-        return false;
-    if (!decoder.decode(info.isSafeHTTPMethod))
-        return false;
-    return true;
-}
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -392,31 +392,6 @@ bool ArgumentCoder<WebCore::ApplePaySessionPaymentRequest::MerchantCapabilities>
     return true;
 }
 
-void ArgumentCoder<RefPtr<WebCore::ApplePayError>>::encode(Encoder& encoder, const RefPtr<WebCore::ApplePayError>& error)
-{
-    encoder << !!error;
-    if (error)
-        encoder << *error;
-}
-
-std::optional<RefPtr<WebCore::ApplePayError>> ArgumentCoder<RefPtr<WebCore::ApplePayError>>::decode(Decoder& decoder)
-{
-    std::optional<bool> isValid;
-    decoder >> isValid;
-    if (!isValid)
-        return std::nullopt;
-
-    if (!*isValid)
-        return { nullptr };
-
-    std::optional<Ref<WebCore::ApplePayError>> error;
-    decoder >> error;
-    if (!error)
-        return std::nullopt;
-
-    return error;
-}
-
 void ArgumentCoder<WebCore::PaymentSessionError>::encode(Encoder& encoder, const WebCore::PaymentSessionError& error)
 {
     encoder << error.platformError();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -1042,31 +1042,6 @@ bool ArgumentCoder<MediaPlaybackTargetContext>::decode(Decoder& decoder, MediaPl
 }
 #endif
 
-void ArgumentCoder<RefPtr<WebCore::SerializedScriptValue>>::encode(Encoder& encoder, const RefPtr<WebCore::SerializedScriptValue>& instance)
-{
-    encoder << !!instance;
-    if (instance)
-        encoder << instance->wireBytes();
-}
-
-std::optional<RefPtr<WebCore::SerializedScriptValue>> ArgumentCoder<RefPtr<WebCore::SerializedScriptValue>>::decode(Decoder& decoder)
-{
-    std::optional<bool> nonEmpty;
-    decoder >> nonEmpty;
-    if (!nonEmpty)
-        return std::nullopt;
-
-    if (!*nonEmpty)
-        return nullptr;
-
-    std::optional<Vector<uint8_t>> wireBytes;
-    decoder >> wireBytes;
-    if (!wireBytes)
-        return std::nullopt;
-
-    return SerializedScriptValue::createFromWireBytes(WTFMove(*wireBytes));
-}
-
 #if ENABLE(SERVICE_WORKER)
 void ArgumentCoder<ServiceWorkerOrClientData>::encode(Encoder& encoder, const ServiceWorkerOrClientData& data)
 {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -275,11 +275,6 @@ template<> struct ArgumentCoder<RefPtr<WebCore::Image>> {
     static WARN_UNUSED_RETURN bool decode(Decoder&, RefPtr<WebCore::Image>&);
 };
 
-template<> struct ArgumentCoder<RefPtr<WebCore::SerializedScriptValue>> {
-    static void encode(Encoder&, const RefPtr<WebCore::SerializedScriptValue>&);
-    static std::optional<RefPtr<WebCore::SerializedScriptValue>> decode(Decoder&);
-};
-
 template<> struct ArgumentCoder<WebCore::Font> {
     static void encode(Encoder&, const WebCore::Font&);
     static std::optional<Ref<WebCore::Font>> decode(Decoder&);
@@ -418,11 +413,6 @@ template<> struct ArgumentCoder<WebCore::ApplePaySessionPaymentRequest::ContactF
 template<> struct ArgumentCoder<WebCore::ApplePaySessionPaymentRequest::MerchantCapabilities> {
     static void encode(Encoder&, const WebCore::ApplePaySessionPaymentRequest::MerchantCapabilities&);
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ApplePaySessionPaymentRequest::MerchantCapabilities&);
-};
-
-template<> struct ArgumentCoder<RefPtr<WebCore::ApplePayError>> {
-    static void encode(Encoder&, const RefPtr<WebCore::ApplePayError>&);
-    static std::optional<RefPtr<WebCore::ApplePayError>> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<WebCore::PaymentSessionError> {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1777,3 +1777,13 @@ header: <WebCore/ScrollingConstraints.h>
 [Return=Ref] class WebCore::NotificationResources {
     RefPtr<WebCore::Image> icon();
 };
+
+[Return=Ref, CreateUsing=createFromWireBytes] class WebCore::SerializedScriptValue {
+    Vector<uint8_t> wireBytes()
+}
+
+struct WebCore::SameSiteInfo {
+    bool isSameSite
+    bool isTopSite
+    bool isSafeHTTPMethod
+};


### PR DESCRIPTION
#### 34ad0e7fb782e88e7afaaf5a5e6d72496f0b0c30
<pre>
Migrate SerializedScriptValue and SameSiteInfo to generated serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=248850">https://bugs.webkit.org/show_bug.cgi?id=248850</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/network/SameSiteInfo.h:
(WebCore::SameSiteInfo::encode const): Deleted.
(WebCore::SameSiteInfo::decode): Deleted.
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::ApplePayError&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::ApplePayError&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::SerializedScriptValue&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::SerializedScriptValue&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/218a77835fa88f9f9d6fa2fc34798657bc7c65bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108473 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168718 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85636 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91634 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106421 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104803 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6750 "Found 60 new test failures: editing/selection/doubleclick-whitespace-live-range.html, editing/selection/ios/change-selection-by-tapping.html, fast/canvas/image-pattern-rotate.html, fast/events/message-port-close.html, fast/forms/ios/focus-button.html, fast/html/broadcast-channel-between-different-sessions.html, fast/text/preserved-white-space-with-word-spacing.html, http/tests/app-privacy-report/app-attribution-beacon-isnotappinitiated.html, http/tests/app-privacy-report/user-attribution-cors-preflight-redirect.html, http/tests/blink/sendbeacon/beacon-cookie.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90258 "Found 30 new API test failures: TestWebKitAPI.ServiceWorkers.SuspendServiceWorkerProcessBasedOnClientProcessesWithoutSeparateServiceWorkerProcess, TestWebKitAPI.ServiceWorkers.ThrottleCrash, TestWebKitAPI.ServiceWorker.ServiceWorkerWindowClientFocusRequiresUserGesture, TestWebKitAPI.ServiceWorkers.LoadData, TestWebKitAPI.ServiceWorkers.NonDefaultSessionID, TestWebKitAPI.ServiceWorker.OpenWindowCOOP, TestWebKitAPI.ServiceWorkers.LoadAboutBlankBeforeNavigatingThroughOutOfProcessServiceWorker, TestWebKitAPI.ServiceWorkers.ServiceWorkerCacheAccessEphemeralSession, TestWebKitAPI.ServiceWorkers.SuspendNetworkProcess, TestWebKitAPI.ServiceWorker.WindowClientNavigateCrossOrigin ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33733 "Found unexpected failure with change (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88572 "Found 30 new API test failures: TestWebKitAPI.UIPasteboardTests.InvalidPreferredPresentationSizeForImage, TestWebKitAPI.ServiceWorkers.BasicWithMainThreadSW, TestWebKitAPI.InAppBrowserPrivacy.AppBoundDomainAllowsServiceWorkers, TestWebKitAPI.ServiceWorker.ServiceWorkerWindowClientFocusRequiresUserGesture, TestWebKitAPI.UIPasteboardTests.MissingPreferredPresentationSizeForImage, TestWebKitAPI.WebKit2.RTCDataChannelPostMessage, TestWebKitAPI.ServiceWorkers.UserAgentOverride, TestWebKitAPI.ServiceWorker.ServiceWorkerWindowClientFocus, TestWebKitAPI.WebKit.CookieCachePruning, TestWebKitAPI.ServiceWorkers.SuspendServiceWorkerProcessBasedOnClientProcessesWithoutSeparateServiceWorkerProcess ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21603 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76596 "Found 4 new API test failures: /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/console-api, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/js-exception, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/security-error, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2176 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23119 "Found 30 new test failures: accessibility/mac/value-change/value-change-user-info-textarea.html, fast/events/message-port-close.html, fast/events/message-port-deleted-document.html, fast/events/message-port-deleted-frame.html, fast/events/message-port-inactive-document.html, fast/html/broadcast-channel-between-different-sessions.html, http/tests/cache/disk-cache/disk-cache-vary-cookie.html, http/tests/dom/window-open-about-webkit-org-and-access-document-async-delegates.html, http/tests/messaging/broadcastchannel-partitioning.html, http/tests/navigation/page-cache-shared-worker.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2071 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45535 "Found 60 new test failures: fast/events/message-port-close.html, fast/events/message-port-deleted-document.html, fast/events/message-port-deleted-frame.html, fast/events/message-port-inactive-document.html, fast/html/broadcast-channel-between-different-sessions.html, http/tests/cache/post-with-cached-subresources.py, http/tests/messaging/broadcastchannel-partitioning.html, http/tests/navigation/page-cache-shared-worker.html, http/tests/notifications/permission/service-worker-permissions-query.html, http/tests/notifications/permission/shared-worker-permissions-query.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42594 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->