### PR TITLE
Remove special handling of xlink Namespace

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString-expected.txt
@@ -22,6 +22,6 @@ PASS Check if start tag serialization applied the original prefix even if it is 
 FAIL Check if start tag serialization does NOT apply the default namespace if its namespace is declared in an ancestor. assert_equals: expected "<root xmlns:x=\"uri1\"><x:table xmlns=\"uri1\"/></root>" but got "<root xmlns:x=\"uri1\"><table xmlns=\"uri1\"/></root>"
 FAIL Check if generated prefixes match to "ns${index}". assert_equals: expected "<root><child1 xmlns:ns1=\"uri1\" ns1:attr1=\"value1\" xmlns:ns2=\"uri2\" ns2:attr2=\"value2\"/><child2 xmlns:ns3=\"uri3\" ns3:attr3=\"value3\"/></root>" but got "<root><child1 NS1:attr1=\"value1\" xmlns:NS1=\"uri1\" NS2:attr2=\"value2\" xmlns:NS2=\"uri2\"/><child2 NS3:attr3=\"value3\" xmlns:NS3=\"uri3\"/></root>"
 FAIL Check if "ns1" is generated even if the element already has xmlns:ns1. assert_equals: expected "<root xmlns:ns2=\"uri2\"><child xmlns:ns1=\"uri1\" xmlns:ns1=\"uri3\" ns1:attr1=\"value1\"/></root>" but got "<root xmlns:ns2=\"uri2\"><child xmlns:ns1=\"uri1\" NS1:attr1=\"value1\" xmlns:NS1=\"uri3\"/></root>"
-FAIL Check if no special handling for XLink namespace unlike HTML serializer. assert_equals: expected "<root xmlns:ns1=\"http://www.w3.org/1999/xlink\" ns1:href=\"v\"/>" but got "<root NS1:href=\"v\" xmlns:NS1=\"http://www.w3.org/1999/xlink\"/>"
+PASS Check if no special handling for XLink namespace unlike HTML serializer.
 PASS Check if document fragment serializes.
 

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -40,7 +40,6 @@
 #include "HTMLTemplateElement.h"
 #include "ProcessingInstruction.h"
 #include "TemplateContentDocumentFragment.h"
-#include "XLinkNames.h"
 #include "XMLNSNames.h"
 #include "XMLNames.h"
 #include <memory>
@@ -509,8 +508,7 @@ static String htmlAttributeSerialization(const Attribute& attribute)
         if (prefixedName.localName() == xmlnsAtom())
             return xmlnsAtom();
         prefixedName.setPrefix(xmlnsAtom());
-    } else if (attribute.namespaceURI() == XLinkNames::xlinkNamespaceURI)
-        prefixedName.setPrefix(AtomString("xlink"_s));
+    }
     return prefixedName.toString();
 }
 


### PR DESCRIPTION
<pre>
Remove special handling of xlink Namespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=248747">https://bugs.webkit.org/show_bug.cgi?id=248747</a>

Reviewed by NOBODY (OOPS!).

This patch is to align Webkit behavior with Blink / Chromium.

Partial Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/7cdca37b049e399257d0c9e8fe657cb3724a9809">https://chromium.googlesource.com/chromium/src.git/+/7cdca37b049e399257d0c9e8fe657cb3724a9809</a>

This patch is to remove special handling for xlink namespace and handle them similar
to HTML serializer.

* Source/WebCore/editing/MarkAccumulator.cpp:
(htmlAttributeSerialization): Remove special handling for xlink and associated header
* LayoutTests/imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString-expected.txt: Update Test Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0be28fd6328c101a6289f0d1830bde3970b29ef7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108468 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168714 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85632 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91580 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106417 "Hash 0be28fd6 for PR 7239 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104799 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6678 "Found 1 new test failure: imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90252 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33693 "Found 1 new test failure: imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88500 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21597 "Found 1 new test failure: imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76548 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2172 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23113 "Found 1 new test failure: imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2067 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45534 "Found 1 new test failure: imported/w3c/web-platform-tests/domparsing/XMLSerializer-serializeToString.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42588 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3483 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->