### PR TITLE
Add serialization support for new type (baseclass/subclass relations)

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -41,6 +41,7 @@
 #include <WebCore/FloatBoxExtent.h>
 #include <WebCore/InheritanceGrandchild.h>
 #include <WebCore/InheritsFrom.h>
+#include <WebCore/TimingFunction.h>
 #include <wtf/CreateUsingClass.h>
 #include <wtf/Seconds.h>
 
@@ -509,9 +510,92 @@ std::optional<NullableSoftLinkedMember> ArgumentCoder<NullableSoftLinkedMember>:
     };
 }
 
+enum class WebCore_TimingFunction_Subclass : uint8_t {
+    LinearTimingFunction,
+    CubicBezierTimingFunction,
+    StepsTimingFunction,
+    SpringTimingFunction
+};
+
+void ArgumentCoder<WebCore::TimingFunction>::encode(Encoder& encoder, const WebCore::TimingFunction& instance)
+{
+    if (auto* subclass = dynamicDowncast<WebCore::LinearTimingFunction>(instance)) {
+        encoder << WebCore_TimingFunction_Subclass::LinearTimingFunction;
+        encoder << *subclass;
+    }
+    if (auto* subclass = dynamicDowncast<WebCore::CubicBezierTimingFunction>(instance)) {
+        encoder << WebCore_TimingFunction_Subclass::CubicBezierTimingFunction;
+        encoder << *subclass;
+    }
+    if (auto* subclass = dynamicDowncast<WebCore::StepsTimingFunction>(instance)) {
+        encoder << WebCore_TimingFunction_Subclass::StepsTimingFunction;
+        encoder << *subclass;
+    }
+    if (auto* subclass = dynamicDowncast<WebCore::SpringTimingFunction>(instance)) {
+        encoder << WebCore_TimingFunction_Subclass::SpringTimingFunction;
+        encoder << *subclass;
+    }
+}
+
+std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<WebCore::TimingFunction>::decode(Decoder& decoder)
+{
+    std::optional<WebCore_TimingFunction_Subclass> type;
+    decoder >> type;
+    if (!type)
+        return std::nullopt;
+
+    if (type == WebCore_TimingFunction_Subclass::LinearTimingFunction) {
+        std::optional<Ref<WebCore::LinearTimingFunction>> result;
+        decoder >> result;
+        if (!result)
+            return std::nullopt;
+        return WTFMove(*result);
+    }
+
+    if (type == WebCore_TimingFunction_Subclass::CubicBezierTimingFunction) {
+        std::optional<Ref<WebCore::CubicBezierTimingFunction>> result;
+        decoder >> result;
+        if (!result)
+            return std::nullopt;
+        return WTFMove(*result);
+    }
+
+    if (type == WebCore_TimingFunction_Subclass::StepsTimingFunction) {
+        std::optional<Ref<WebCore::StepsTimingFunction>> result;
+        decoder >> result;
+        if (!result)
+            return std::nullopt;
+        return WTFMove(*result);
+    }
+
+    if (type == WebCore_TimingFunction_Subclass::SpringTimingFunction) {
+        std::optional<Ref<WebCore::SpringTimingFunction>> result;
+        decoder >> result;
+        if (!result)
+            return std::nullopt;
+        return WTFMove(*result);
+    }
+
+    ASSERT_NOT_REACHED();
+    return std::nullopt;
+}
+
 } // namespace IPC
 
 namespace WTF {
+
+template<> bool isValidEnum<IPC::WebCore_TimingFunction_Subclass, void>(uint8_t value)
+{
+    switch (static_cast<IPC::WebCore_TimingFunction_Subclass>(value)) {
+    case IPC::WebCore_TimingFunction_Subclass::LinearTimingFunction:
+    case IPC::WebCore_TimingFunction_Subclass::CubicBezierTimingFunction:
+    case IPC::WebCore_TimingFunction_Subclass::StepsTimingFunction:
+    case IPC::WebCore_TimingFunction_Subclass::SpringTimingFunction:
+        return true;
+    default:
+        return false;
+    }
+}
 
 template<> bool isValidEnum<EnumWithoutNamespace, void>(uint8_t value)
 {

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -52,6 +52,7 @@ template<typename> class RectEdges;
 using FloatBoxExtent = RectEdges<float>;
 }
 struct NullableSoftLinkedMember;
+namespace WebCore { class TimingFunction; }
 
 namespace IPC {
 
@@ -121,6 +122,11 @@ template<> struct ArgumentCoder<WebCore::FloatBoxExtent> {
 template<> struct ArgumentCoder<NullableSoftLinkedMember> {
     static void encode(Encoder&, const NullableSoftLinkedMember&);
     static std::optional<NullableSoftLinkedMember> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebCore::TimingFunction> {
+    static void encode(Encoder&, const WebCore::TimingFunction&);
+    static std::optional<Ref<WebCore::TimingFunction>> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -41,6 +41,7 @@
 #include <WebCore/FloatBoxExtent.h>
 #include <WebCore/InheritanceGrandchild.h>
 #include <WebCore/InheritsFrom.h>
+#include <WebCore/TimingFunction.h>
 #include <wtf/CreateUsingClass.h>
 #include <wtf/Seconds.h>
 

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -101,3 +101,10 @@ struct NullableSoftLinkedMember {
     [Nullable, SoftLinkedClass='PAL::getDDActionContextClass()'] RetainPtr<DDActionContext> firstMember;
     [SoftLinkedClass='PAL::getDDActionContextClass()'] RetainPtr<DDActionContext> secondMember;
 }
+
+[RefCounted] class WebCore::TimingFunction subclasses {
+  WebCore::LinearTimingFunction,
+  WebCore::CubicBezierTimingFunction,
+  WebCore::StepsTimingFunction,
+  WebCore::SpringTimingFunction
+}

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -108,7 +108,6 @@
 #include <WebCore/TestReportBody.h>
 #include <WebCore/TextCheckerClient.h>
 #include <WebCore/TextIndicator.h>
-#include <WebCore/TimingFunction.h>
 #include <WebCore/TransformOperation.h>
 #include <WebCore/TransformationMatrix.h>
 #include <WebCore/TranslateTransformOperation.h>
@@ -1658,74 +1657,6 @@ std::optional<RefPtr<WebCore::ReportBody>> ArgumentCoder<RefPtr<WebCore::ReportB
     case ViolationReportType::StandardReportingAPIViolation:
         ASSERT_NOT_REACHED();
         return std::nullopt;
-    }
-
-    ASSERT_NOT_REACHED();
-    return std::nullopt;
-}
-
-void ArgumentCoder<WebCore::TimingFunction>::encode(Encoder& encoder, const WebCore::TimingFunction& timingFunction)
-{
-    encoder << timingFunction.type();
-
-    switch (timingFunction.type()) {
-    case TimingFunction::Type::LinearFunction:
-        encoder << downcast<LinearTimingFunction>(timingFunction);
-        break;
-
-    case TimingFunction::Type::CubicBezierFunction:
-        encoder << downcast<CubicBezierTimingFunction>(timingFunction);
-        break;
-
-    case TimingFunction::Type::StepsFunction:
-        encoder << downcast<StepsTimingFunction>(timingFunction);
-        break;
-
-    case TimingFunction::Type::SpringFunction:
-        encoder << downcast<SpringTimingFunction>(timingFunction);
-        break;
-    }
-}
-
-std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<WebCore::TimingFunction>::decode(Decoder& decoder)
-{
-    std::optional<TimingFunction::Type> type;
-    decoder >> type;
-    if (!type)
-        return std::nullopt;
-
-    switch (*type) {
-    case TimingFunction::Type::LinearFunction: {
-        std::optional<Ref<LinearTimingFunction>> function;
-        decoder >> function;
-        if (!function)
-            return std::nullopt;
-        return WTFMove(*function);
-    }
-
-    case TimingFunction::Type::CubicBezierFunction: {
-        std::optional<Ref<CubicBezierTimingFunction>> function;
-        decoder >> function;
-        if (!function)
-            return std::nullopt;
-        return WTFMove(*function);
-    }
-
-    case TimingFunction::Type::StepsFunction: {
-        std::optional<Ref<StepsTimingFunction>> function;
-        decoder >> function;
-        if (!function)
-            return std::nullopt;
-        return WTFMove(*function);
-    }
-
-    case TimingFunction::Type::SpringFunction: {
-        std::optional<Ref<SpringTimingFunction>> function;
-        decoder >> function;
-        if (!function)
-            return std::nullopt;
-        return WTFMove(*function);
-    }
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -144,7 +144,6 @@ class FragmentedSharedBuffer;
 class StickyPositionViewportConstraints;
 class SystemImage;
 class TextCheckingRequestData;
-class TimingFunction;
 class TransformOperation;
 class UserStyleSheet;
 
@@ -562,11 +561,6 @@ template<> struct ArgumentCoder<WebCore::PixelBuffer> {
 template<> struct ArgumentCoder<RefPtr<WebCore::ReportBody>> {
     static void encode(Encoder&, const RefPtr<WebCore::ReportBody>&);
     static std::optional<RefPtr<WebCore::ReportBody>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<WebCore::TimingFunction> {
-    static void encode(Encoder&, const WebCore::TimingFunction&);
-    static std::optional<Ref<WebCore::TimingFunction>> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<WebCore::TransformOperation> {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1933,3 +1933,10 @@ struct WebCore::GraphicsContextGLAttributes {
 #endif
 };
 #endif
+
+[RefCounted] class WebCore::TimingFunction subclasses {
+  WebCore::LinearTimingFunction,
+  WebCore::CubicBezierTimingFunction,
+  WebCore::StepsTimingFunction,
+  WebCore::SpringTimingFunction
+}

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
@@ -128,7 +128,6 @@ void PlatformCAAnimationRemote::Properties::encode(IPC::Encoder& encoder) const
     
     encoder << keyValues;
     encoder << keyTimes;
-    
     encoder << timingFunctions;
 
     encoder << animations;


### PR DESCRIPTION
#### a3c4cf83fb2630f50af6aae5a6e5e67c54e6bf69
<pre>
Add serialization support for new type (baseclass/subclass relations)
rdar://problem/103048679

Reviewed by Alex Christensen.

* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(SerializedType.subclass_enum_name):
(SerializedType):
(SerializedType.function_name_for_enum):
(MemberVariable.__init__):
(EnumMember.__init__):
(encode_type):
(decode_type.is):
(decode_type):
(generate_impl):
(generate_serialized_type_info):
(parse_serialized_types):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::Subnamespace::StructName&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::ReturnRefClass&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::InheritsFrom&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::InheritanceGrandchild&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::TimingFunction&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::TimingFunction&gt;::decode):
(WTF::void&gt;):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::TimingFunction&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::TimingFunction&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm:
(WebKit::PlatformCAAnimationRemote::Properties::encode const):

Canonical link: <a href="https://commits.webkit.org/257739@main">https://commits.webkit.org/257739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fe96628d2ed58c6cdde9cb5a33f585fa5dab061

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109244 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86356 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105657 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/103403 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2820 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/46067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8953 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2721 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->