### PR TITLE
[JSC] Clean up Structure transition watchpoint firing to pave a way to faster / cheap adaptive watchpoint

### DIFF
--- a/Source/JavaScriptCore/bytecode/Watchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.cpp
@@ -213,11 +213,6 @@ void InlineWatchpointSet::freeFat()
     fat()->deref();
 }
 
-void DeferredWatchpointFire::fireAllSlow()
-{
-    m_watchpointsToFire.fireAll(m_vm, *this);
-}
-
 void DeferredWatchpointFire::takeWatchpointsToFire(WatchpointSet* watchpointsToFire)
 {
     ASSERT(m_watchpointsToFire.state() == ClearWatchpoint);

--- a/Source/JavaScriptCore/bytecode/Watchpoint.h
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.h
@@ -495,26 +495,22 @@ private:
     uintptr_t m_data;
 };
 
-class DeferredWatchpointFire : public FireDetail {
+class DeferredWatchpointFire {
     WTF_MAKE_NONCOPYABLE(DeferredWatchpointFire);
 public:
-    DeferredWatchpointFire(VM& vm)
-        : m_vm(vm)
-        , m_watchpointsToFire(ClearWatchpoint)
+    DeferredWatchpointFire()
+        : m_watchpointsToFire(ClearWatchpoint)
     {
     }
 
     JS_EXPORT_PRIVATE void takeWatchpointsToFire(WatchpointSet*);
-    void fireAll()
-    {
-        if (m_watchpointsToFire.state() == IsWatched)
-            fireAllSlow();
-    }
+
+protected:
+    WatchpointSet& watchpointsToFire() { return m_watchpointsToFire; }
 
 private:
     JS_EXPORT_PRIVATE void fireAllSlow();
 
-    VM& m_vm;
     WatchpointSet m_watchpointsToFire;
 };
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -788,7 +788,7 @@ void JSGlobalObject::init(VM& vm)
     ASSERT(vm.currentThreadIsHoldingAPILock());
     auto catchScope = DECLARE_CATCH_SCOPE(vm);
 
-    Base::setStructure(vm, Structure::toCacheableDictionaryTransition(vm, structure()));
+    convertToDictionary(vm);
 
     m_debugger = nullptr;
 

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -1137,7 +1137,11 @@ void JSObject::notifyPresenceOfIndexedAccessors(VM& vm)
     if (mayInterceptIndexedAccesses())
         return;
     
-    setStructure(vm, Structure::nonPropertyTransition(vm, structure(), TransitionKind::AddIndexedAccessors));
+    {
+        Structure* oldStructure = structure();
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        setStructure(vm, Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AddIndexedAccessors, &deferred));
+    }
     
     if (!mayBePrototype())
         return;
@@ -1169,9 +1173,12 @@ Butterfly* JSObject::createInitialUndecided(VM& vm, unsigned length)
     Butterfly* newButterfly = createInitialIndexedStorage(vm, length);
     StructureID oldStructureID = this->structureID();
     Structure* oldStructure = oldStructureID.decode();
-    Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateUndecided);
-    nukeStructureAndSetButterfly(vm, oldStructureID, newButterfly);
-    setStructure(vm, newStructure);
+    {
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateUndecided, &deferred);
+        nukeStructureAndSetButterfly(vm, oldStructureID, newButterfly);
+        setStructure(vm, newStructure);
+    }
     return newButterfly;
 }
 
@@ -1183,9 +1190,12 @@ ContiguousJSValues JSObject::createInitialInt32(VM& vm, unsigned length)
         newButterfly->contiguous().at(this, i).setWithoutWriteBarrier(JSValue());
     StructureID oldStructureID = this->structureID();
     Structure* oldStructure = oldStructureID.decode();
-    Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateInt32);
-    nukeStructureAndSetButterfly(vm, oldStructureID, newButterfly);
-    setStructure(vm, newStructure);
+    {
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateInt32, &deferred);
+        nukeStructureAndSetButterfly(vm, oldStructureID, newButterfly);
+        setStructure(vm, newStructure);
+    }
     return newButterfly->contiguousInt32();
 }
 
@@ -1197,9 +1207,12 @@ ContiguousDoubles JSObject::createInitialDouble(VM& vm, unsigned length)
         newButterfly->contiguousDouble().at(this, i) = PNaN;
     StructureID oldStructureID = this->structureID();
     Structure* oldStructure = oldStructureID.decode();
-    Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateDouble);
-    nukeStructureAndSetButterfly(vm, oldStructureID, newButterfly);
-    setStructure(vm, newStructure);
+    {
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateDouble, &deferred);
+        nukeStructureAndSetButterfly(vm, oldStructureID, newButterfly);
+        setStructure(vm, newStructure);
+    }
     return newButterfly->contiguousDouble();
 }
 
@@ -1211,9 +1224,12 @@ ContiguousJSValues JSObject::createInitialContiguous(VM& vm, unsigned length)
         newButterfly->contiguous().at(this, i).setWithoutWriteBarrier(JSValue());
     StructureID oldStructureID = this->structureID();
     Structure* oldStructure = oldStructureID.decode();
-    Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateContiguous);
-    nukeStructureAndSetButterfly(vm, oldStructureID, newButterfly);
-    setStructure(vm, newStructure);
+    {
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateContiguous, &deferred);
+        nukeStructureAndSetButterfly(vm, oldStructureID, newButterfly);
+        setStructure(vm, newStructure);
+    }
     return newButterfly->contiguous();
 }
 
@@ -1246,9 +1262,12 @@ ArrayStorage* JSObject::createArrayStorage(VM& vm, unsigned length, unsigned vec
 
     Butterfly* newButterfly = createArrayStorageButterfly(vm, this, oldStructure, length, vectorLength, butterfly());
     ArrayStorage* result = newButterfly->arrayStorage();
-    Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, suggestedArrayStorageTransition());
-    nukeStructureAndSetButterfly(vm, oldStructureID, newButterfly);
-    setStructure(vm, newStructure);
+    {
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, suggestedArrayStorageTransition(), &deferred);
+        nukeStructureAndSetButterfly(vm, oldStructureID, newButterfly);
+        setStructure(vm, newStructure);
+    }
     return result;
 }
 
@@ -1266,7 +1285,11 @@ ContiguousJSValues JSObject::convertUndecidedToInt32(VM& vm)
     for (unsigned i = butterfly->vectorLength(); i--;)
         butterfly->contiguous().at(this, i).setWithoutWriteBarrier(JSValue());
 
-    setStructure(vm, Structure::nonPropertyTransition(vm, structure(), TransitionKind::AllocateInt32));
+    {
+        Structure* oldStructure = structure();
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        setStructure(vm, Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateInt32, &deferred));
+    }
     return m_butterfly->contiguousInt32();
 }
 
@@ -1279,7 +1302,11 @@ ContiguousDoubles JSObject::convertUndecidedToDouble(VM& vm)
     for (unsigned i = butterfly->vectorLength(); i--;)
         butterfly->contiguousDouble().at(this, i) = PNaN;
     
-    setStructure(vm, Structure::nonPropertyTransition(vm, structure(), TransitionKind::AllocateDouble));
+    {
+        Structure* oldStructure = structure();
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        setStructure(vm, Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateDouble, &deferred));
+    }
     return m_butterfly->contiguousDouble();
 }
 
@@ -1292,7 +1319,11 @@ ContiguousJSValues JSObject::convertUndecidedToContiguous(VM& vm)
         butterfly->contiguous().at(this, i).setWithoutWriteBarrier(JSValue());
 
     WTF::storeStoreFence();
-    setStructure(vm, Structure::nonPropertyTransition(vm, structure(), TransitionKind::AllocateContiguous));
+    {
+        Structure* oldStructure = structure();
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        setStructure(vm, Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateContiguous, &deferred));
+    }
     return m_butterfly->contiguous();
 }
 
@@ -1332,9 +1363,12 @@ ArrayStorage* JSObject::convertUndecidedToArrayStorage(VM& vm, TransitionKind tr
     
     StructureID oldStructureID = this->structureID();
     Structure* oldStructure = oldStructureID.decode();
-    Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, transition);
-    nukeStructureAndSetButterfly(vm, oldStructureID, storage->butterfly());
-    setStructure(vm, newStructure);
+    {
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, transition, &deferred);
+        nukeStructureAndSetButterfly(vm, oldStructureID, storage->butterfly());
+        setStructure(vm, newStructure);
+    }
     return storage;
 }
 
@@ -1362,7 +1396,11 @@ ContiguousDoubles JSObject::convertInt32ToDouble(VM& vm)
         *currentAsDouble = v.asInt32();
     }
     
-    setStructure(vm, Structure::nonPropertyTransition(vm, structure(), TransitionKind::AllocateDouble));
+    {
+        Structure* oldStructure = structure();
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        setStructure(vm, Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateDouble, &deferred));
+    }
     return m_butterfly->contiguousDouble();
 }
 
@@ -1370,7 +1408,11 @@ ContiguousJSValues JSObject::convertInt32ToContiguous(VM& vm)
 {
     ASSERT(hasInt32(indexingType()));
     
-    setStructure(vm, Structure::nonPropertyTransition(vm, structure(), TransitionKind::AllocateContiguous));
+    {
+        Structure* oldStructure = structure();
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        setStructure(vm, Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateContiguous, &deferred));
+    }
     return m_butterfly->contiguous();
 }
 
@@ -1391,9 +1433,12 @@ ArrayStorage* JSObject::convertInt32ToArrayStorage(VM& vm, TransitionKind transi
     
     StructureID oldStructureID = this->structureID();
     Structure* oldStructure = oldStructureID.decode();
-    Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, transition);
-    nukeStructureAndSetButterfly(vm, oldStructureID, newStorage->butterfly());
-    setStructure(vm, newStructure);
+    {
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, transition, &deferred);
+        nukeStructureAndSetButterfly(vm, oldStructureID, newStorage->butterfly());
+        setStructure(vm, newStructure);
+    }
     return newStorage;
 }
 
@@ -1421,7 +1466,11 @@ ContiguousJSValues JSObject::convertDoubleToContiguous(VM& vm)
     }
     
     WTF::storeStoreFence();
-    setStructure(vm, Structure::nonPropertyTransition(vm, structure(), TransitionKind::AllocateContiguous));
+    {
+        Structure* oldStructure = structure();
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        setStructure(vm, Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::AllocateContiguous, &deferred));
+    }
     return m_butterfly->contiguous();
 }
 
@@ -1445,9 +1494,12 @@ ArrayStorage* JSObject::convertDoubleToArrayStorage(VM& vm, TransitionKind trans
     
     StructureID oldStructureID = this->structureID();
     Structure* oldStructure = oldStructureID.decode();
-    Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, transition);
-    nukeStructureAndSetButterfly(vm, oldStructureID, newStorage->butterfly());
-    setStructure(vm, newStructure);
+    {
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, transition, &deferred);
+        nukeStructureAndSetButterfly(vm, oldStructureID, newStorage->butterfly());
+        setStructure(vm, newStructure);
+    }
     return newStorage;
 }
 
@@ -1523,13 +1575,16 @@ ArrayStorage* JSObject::convertContiguousToArrayStorage(VM& vm, TransitionKind t
     ASSERT(newStorage->butterfly() != butterfly);
     StructureID oldStructureID = this->structureID();
     Structure* oldStructure = oldStructureID.decode();
-    Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, transition);
+    {
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, transition, &deferred);
 
-    // Ensure new Butterfly initialization is correctly done before exposing it to the concurrent threads.
-    if (isX86() || vm.heap.mutatorShouldBeFenced())
-        WTF::storeStoreFence();
-    nukeStructureAndSetButterfly(vm, oldStructureID, newStorage->butterfly());
-    setStructure(vm, newStructure);
+        // Ensure new Butterfly initialization is correctly done before exposing it to the concurrent threads.
+        if (isX86() || vm.heap.mutatorShouldBeFenced())
+            WTF::storeStoreFence();
+        nukeStructureAndSetButterfly(vm, oldStructureID, newStorage->butterfly());
+        setStructure(vm, newStructure);
+    }
     
     return newStorage;
 }
@@ -1615,9 +1670,13 @@ void JSObject::convertFromCopyOnWrite(VM& vm)
         }
     })();
     StructureID oldStructureID = structureID();
-    Structure* newStructure = Structure::nonPropertyTransition(vm, structure(), transition);
-    nukeStructureAndSetButterfly(vm, oldStructureID, newButterfly);
-    setStructure(vm, newStructure);
+    Structure* oldStructure = oldStructureID.decode();
+    {
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, transition, &deferred);
+        nukeStructureAndSetButterfly(vm, oldStructureID, newButterfly);
+        setStructure(vm, newStructure);
+    }
 }
 
 void JSObject::setIndexQuicklyToUndecided(VM& vm, unsigned index, JSValue value)
@@ -1864,7 +1923,9 @@ void JSObject::switchToSlowPutArrayStorage(VM& vm)
         
     case NonArrayWithArrayStorage:
     case ArrayWithArrayStorage: {
-        Structure* newStructure = Structure::nonPropertyTransition(vm, structure(), TransitionKind::SwitchToSlowPutArrayStorage);
+        Structure* oldStructure = structure();
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        Structure* newStructure = Structure::nonPropertyTransition(vm, oldStructure, TransitionKind::SwitchToSlowPutArrayStorage, &deferred);
         setStructure(vm, newStructure);
         break;
     }
@@ -2613,7 +2674,11 @@ void JSObject::seal(VM& vm)
     if (isSealed(vm))
         return;
     enterDictionaryIndexingMode(vm);
-    setStructure(vm, Structure::sealTransition(vm, structure()));
+    {
+        Structure* oldStructure = structure();
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        setStructure(vm, Structure::sealTransition(vm, oldStructure, &deferred));
+    }
 }
 
 void JSObject::freeze(VM& vm)
@@ -2621,7 +2686,11 @@ void JSObject::freeze(VM& vm)
     if (isFrozen(vm))
         return;
     enterDictionaryIndexingMode(vm);
-    setStructure(vm, Structure::freezeTransition(vm, structure()));
+    {
+        Structure* oldStructure = structure();
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        setStructure(vm, Structure::freezeTransition(vm, oldStructure, &deferred));
+    }
 }
 
 bool JSObject::preventExtensions(JSObject* object, JSGlobalObject* globalObject)
@@ -2635,7 +2704,11 @@ bool JSObject::preventExtensions(JSObject* object, JSGlobalObject* globalObject)
     }
 
     object->enterDictionaryIndexingMode(vm);
-    object->setStructure(vm, Structure::preventExtensionsTransition(vm, object->structure()));
+    {
+        Structure* oldStructure = object->structure();
+        DeferredStructureTransitionWatchpointFire deferred(vm, oldStructure);
+        object->setStructure(vm, Structure::preventExtensionsTransition(vm, oldStructure, &deferred));
+    }
     return true;
 }
 
@@ -2662,7 +2735,7 @@ void JSObject::reifyAllStaticProperties(JSGlobalObject* globalObject)
     }
 
     if (!structure()->isDictionary())
-        setStructure(vm, Structure::toCacheableDictionaryTransition(vm, structure()));
+        convertToDictionary(vm);
 
     for (const ClassInfo* info = classInfo(); info; info = info->parentClass) {
         const HashTable* hashTable = info->staticPropHashTable;
@@ -3844,18 +3917,18 @@ bool JSObject::defineOwnProperty(JSObject* object, JSGlobalObject* globalObject,
 
 void JSObject::convertToDictionary(VM& vm)
 {
-    DeferredStructureTransitionWatchpointFire deferredWatchpointFire(vm, structure());
-    setStructure(
-        vm, Structure::toCacheableDictionaryTransition(vm, structure(), &deferredWatchpointFire));
+    Structure* oldStructure = structure();
+    DeferredStructureTransitionWatchpointFire deferredWatchpointFire(vm, oldStructure);
+    setStructure(vm, Structure::toCacheableDictionaryTransition(vm, oldStructure, &deferredWatchpointFire));
 }
 
 void JSObject::convertToUncacheableDictionary(VM& vm)
 {
-    if (structure()->isUncacheableDictionary())
+    Structure* oldStructure = structure();
+    if (oldStructure->isUncacheableDictionary())
         return;
-    DeferredStructureTransitionWatchpointFire deferredWatchpointFire(vm, structure());
-    setStructure(
-        vm, Structure::toUncacheableDictionaryTransition(vm, structure(), &deferredWatchpointFire));
+    DeferredStructureTransitionWatchpointFire deferredWatchpointFire(vm, oldStructure);
+    setStructure(vm, Structure::toUncacheableDictionaryTransition(vm, oldStructure, &deferredWatchpointFire));
 }
 
 

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -365,9 +365,10 @@ ALWAYS_INLINE ASCIILiteral JSObject::putDirectInternal(VM& vm, PropertyName prop
 
             // FIXME: Check attributes against PropertyAttribute::CustomAccessorOrValue. Changing GetterSetter should work w/o transition.
             // https://bugs.webkit.org/show_bug.cgi?id=214342
-            if (mode == PutModeDefineOwnProperty && (attributes != currentAttributes || (attributes & PropertyAttribute::AccessorOrCustomAccessorOrValue)))
-                setStructure(vm, Structure::attributeChangeTransition(vm, structure, propertyName, attributes));
-            else {
+            if (mode == PutModeDefineOwnProperty && (attributes != currentAttributes || (attributes & PropertyAttribute::AccessorOrCustomAccessorOrValue))) {
+                DeferredStructureTransitionWatchpointFire deferred(vm, structure);
+                setStructure(vm, Structure::attributeChangeTransition(vm, structure, propertyName, attributes, &deferred));
+            } else {
                 ASSERT(!(currentAttributes & PropertyAttribute::AccessorOrCustomAccessorOrValue));
                 slot.setExistingProperty(this, offset);
             }

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -256,11 +256,10 @@ public:
     JS_EXPORT_PRIVATE static Structure* attributeChangeTransitionToExistingStructure(Structure*, PropertyName, unsigned attributes, PropertyOffset&);
     JS_EXPORT_PRIVATE static Structure* toCacheableDictionaryTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
     static Structure* toUncacheableDictionaryTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
-    JS_EXPORT_PRIVATE static Structure* sealTransition(VM&, Structure*);
-    JS_EXPORT_PRIVATE static Structure* freezeTransition(VM&, Structure*);
-    static Structure* preventExtensionsTransition(VM&, Structure*);
-    static Structure* nonPropertyTransition(VM&, Structure*, TransitionKind);
-    JS_EXPORT_PRIVATE static Structure* nonPropertyTransitionSlow(VM&, Structure*, TransitionKind);
+    JS_EXPORT_PRIVATE static Structure* sealTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
+    JS_EXPORT_PRIVATE static Structure* freezeTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
+    static Structure* preventExtensionsTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
+    static Structure* nonPropertyTransition(VM&, Structure*, TransitionKind, DeferredStructureTransitionWatchpointFire*);
     static Structure* setBrandTransitionFromExistingStructureConcurrently(Structure*, UniquedStringImpl*);
     static Structure* setBrandTransition(VM&, Structure*, Symbol* brand, DeferredStructureTransitionWatchpointFire* = nullptr);
 
@@ -744,9 +743,6 @@ public:
     void didTransitionFromThisStructureWithoutFiringWatchpoint() const;
     void fireStructureTransitionWatchpoint(DeferredStructureTransitionWatchpointFire*) const;
 
-    // This function does the both didTransitionFromThisStructureWithoutFiringWatchpoint and fireStructureTransitionWatchpoint.
-    void didTransitionFromThisStructure(DeferredStructureTransitionWatchpointFire* = nullptr) const;
-    
     InlineWatchpointSet& transitionWatchpointSet() const
     {
         return m_transitionWatchpointSet;
@@ -843,11 +839,16 @@ private:
     JS_EXPORT_PRIVATE Structure(VM&, JSGlobalObject*, JSValue prototype, const TypeInfo&, const ClassInfo*, IndexingType, unsigned inlineCapacity);
     Structure(VM&, CreatingEarlyCellTag);
 
-    static Structure* create(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
+    static Structure* create(VM&, Structure*, DeferredStructureTransitionWatchpointFire*);
     
     static Structure* addPropertyTransitionToExistingStructureImpl(Structure*, UniquedStringImpl* uid, unsigned attributes, PropertyOffset&);
     static Structure* removePropertyTransitionFromExistingStructureImpl(Structure*, PropertyName, unsigned attributes, PropertyOffset&);
     static Structure* setBrandTransitionFromExistingStructureImpl(Structure*, UniquedStringImpl*);
+
+    JS_EXPORT_PRIVATE static Structure* nonPropertyTransitionSlow(VM&, Structure*, TransitionKind, DeferredStructureTransitionWatchpointFire*);
+
+    // This function does the both didTransitionFromThisStructureWithoutFiringWatchpoint and fireStructureTransitionWatchpoint.
+    void didTransitionFromThisStructure(DeferredStructureTransitionWatchpointFire*) const;
 
     // This will return the structure that has a usable property table, that property table,
     // and the list of structures that we visited before we got to it. If it returns a


### PR DESCRIPTION
#### 1f69d0944e676846b9daa722f4830db27390b14f
<pre>
[JSC] Clean up Structure transition watchpoint firing to pave a way to faster / cheap adaptive watchpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=248853">https://bugs.webkit.org/show_bug.cgi?id=248853</a>

Reviewed by Ross Kirsling and Alexey Shvayka.

This patch paves the way to adding more complex / faster / cheaper adaptive watchpoint for some of important objects.
Right now, we adaptively re-install watchpoint by using ObjectPropertyCondition&apos;s validation, which works great, but
a bit too generic &amp; focusing on super common pattern. We would like to have more complex condition for this check,
and we would like to examine the reason of transition in that case.

So, we clean up our transition code to appropriately pass StructureFireDetail. We also clean up JSObject&apos;s transitions
so that we always use DeferredStructureTransitionWatchpointFire when structure is held by an object.

* Source/JavaScriptCore/bytecode/Watchpoint.cpp:
(JSC::DeferredWatchpointFire::fireAllSlow): Deleted.
* Source/JavaScriptCore/bytecode/Watchpoint.h:
(JSC::DeferredWatchpointFire::DeferredWatchpointFire):
(JSC::DeferredWatchpointFire::watchpointsToFire):
(JSC::DeferredWatchpointFire::fireAll): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::notifyPresenceOfIndexedAccessors):
(JSC::JSObject::createInitialUndecided):
(JSC::JSObject::createInitialInt32):
(JSC::JSObject::createInitialDouble):
(JSC::JSObject::createInitialContiguous):
(JSC::JSObject::createArrayStorage):
(JSC::JSObject::convertUndecidedToInt32):
(JSC::JSObject::convertUndecidedToDouble):
(JSC::JSObject::convertUndecidedToContiguous):
(JSC::JSObject::convertUndecidedToArrayStorage):
(JSC::JSObject::convertInt32ToDouble):
(JSC::JSObject::convertInt32ToContiguous):
(JSC::JSObject::convertInt32ToArrayStorage):
(JSC::JSObject::convertDoubleToContiguous):
(JSC::JSObject::convertDoubleToArrayStorage):
(JSC::JSObject::convertContiguousToArrayStorage):
(JSC::JSObject::convertFromCopyOnWrite):
(JSC::JSObject::switchToSlowPutArrayStorage):
(JSC::JSObject::seal):
(JSC::JSObject::freeze):
(JSC::JSObject::preventExtensions):
(JSC::JSObject::reifyAllStaticProperties):
(JSC::JSObject::convertToDictionary):
(JSC::JSObject::convertToUncacheableDictionary):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::putDirectInternal):
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::create):
(JSC::Structure::addPropertyTransition):
(JSC::Structure::addNewPropertyTransition):
(JSC::Structure::removeNewPropertyTransition):
(JSC::Structure::changePrototypeTransition):
(JSC::Structure::attributeChangeTransition):
(JSC::Structure::toDictionaryTransition):
(JSC::Structure::sealTransition):
(JSC::Structure::freezeTransition):
(JSC::Structure::preventExtensionsTransition):
(JSC::Structure::nonPropertyTransitionSlow):
(JSC::DeferredStructureTransitionWatchpointFire::DeferredStructureTransitionWatchpointFire):
(JSC::DeferredStructureTransitionWatchpointFire::~DeferredStructureTransitionWatchpointFire):
* Source/JavaScriptCore/runtime/Structure.h:
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::nonPropertyTransition):

Canonical link: <a href="https://commits.webkit.org/257515@main">https://commits.webkit.org/257515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/015b31d052f3df5d2e54e7aee63c0861b7679a82

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/99232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/8436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/32357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/108622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/8988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/104989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/8988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/32357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/91729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/8988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/32357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/89935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/32357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85768 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/2210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/28866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/7301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/32357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88634 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2633 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/3685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/19833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->