### PR TITLE
Stop aliasing the view size in RemoteLayerTreeDrawingArea

### DIFF
--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-class TiledCoreAnimationDrawingAreaProxy : public DrawingAreaProxy {
+class TiledCoreAnimationDrawingAreaProxy final : public DrawingAreaProxy {
 public:
     TiledCoreAnimationDrawingAreaProxy(WebPageProxy&, WebProcessProxy&);
     virtual ~TiledCoreAnimationDrawingAreaProxy();

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -138,7 +138,6 @@ public:
     virtual bool addMilestonesToDispatch(OptionSet<WebCore::LayoutMilestone>) { return false; }
 
 #if PLATFORM(COCOA)
-    // Used by TiledCoreAnimationDrawingArea.
     virtual void updateGeometry(const WebCore::IntSize& viewSize, bool flushSynchronously, const WTF::MachSendRight& fencePort) { }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -143,8 +143,6 @@ private:
     std::unique_ptr<RemoteLayerTreeContext> m_remoteLayerTreeContext;
     Ref<WebCore::GraphicsLayer> m_rootLayer;
 
-    WebCore::IntSize m_viewSize;
-
     std::optional<WebCore::FloatRect> m_viewExposedRect;
 
     WebCore::Timer m_updateRenderingTimer;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -150,7 +150,6 @@ void RemoteLayerTreeDrawingArea::setRootCompositingLayer(GraphicsLayer* rootLaye
 
 void RemoteLayerTreeDrawingArea::updateGeometry(const IntSize& viewSize, bool flushSynchronously, const WTF::MachSendRight&)
 {
-    m_viewSize = viewSize;
     m_webPage.setSize(viewSize);
 
     triggerRenderingUpdate();
@@ -323,7 +322,8 @@ void RemoteLayerTreeDrawingArea::updateRendering()
     SetForScope change(m_inUpdateRendering, true);
     m_webPage.updateRendering();
 
-    FloatRect visibleRect(FloatPoint(), m_viewSize);
+    auto size = m_webPage.size();
+    FloatRect visibleRect(FloatPoint(), size);
     if (auto exposedRect = m_webPage.mainFrameView()->viewExposedRect())
         visibleRect.intersect(*exposedRect);
 


### PR DESCRIPTION
#### 582ab7ce73b775c0d90b7541f4ec7125805bb46e
<pre>
Stop aliasing the view size in RemoteLayerTreeDrawingArea
<a href="https://bugs.webkit.org/show_bug.cgi?id=248857">https://bugs.webkit.org/show_bug.cgi?id=248857</a>

Reviewed by Tim Horton.

With UI-side compositing on macOS, web inspector highlights don&apos;t show up until a window
resize. This happened because RemoteLayerTreeDrawingArea::m_viewSize was empty; it doesn&apos;t
become non-empty until an `updateGeometry()`. This member just aliases WebPage::size(),
so remove it.

Also TiledCoreAnimationDrawingAreaProxy can be `final` and remove an obsolete
comment in DrawingArea.h.

* Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateGeometry):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):

Canonical link: <a href="https://commits.webkit.org/257488@main">https://commits.webkit.org/257488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb78b50e7fcf2359d0c499fb56a5e26239ebc2f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108484 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85643 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91594 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106428 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90263 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33699 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76556 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2187 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23124 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2079 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5153 "'git push ...'") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42600 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->