### PR TITLE
Add support for <model src> and honor <source type> attributes

### DIFF
--- a/LayoutTests/model-element/model-element-source-expected.txt
+++ b/LayoutTests/model-element/model-element-source-expected.txt
@@ -9,4 +9,16 @@ PASS Removing the <source> changes the currentSrc property.
 PASS currentSrc returns the src value for the first <source> element.
 PASS Removing a <source> element updates currentSrc.
 PASS Adding a <source> before the current <source> updates currentSrc.
+PASS The HTMLModelElement interface has a src property.
+PASS HTMLModelElement src property reflects src attribute value as a resolved URL.
+PASS <model> src attribute reflects HTMLModelElement src property.
+PASS Changing the src attribute of a <model> changes the currentSrc property.
+PASS A non-empty src attribute takes precedence over a <source> child.
+PASS An empty src attribute does not take precedence over a <source> child.
+PASS Removing a src attribute selects the first matching <source> child.
+PASS The first <source> with a supported type is selected.
+PASS Changing a <source type> to a supported type causes it to be selected.
+PASS Changing a <source type> to an unsupported type causes it not to be selected.
+PASS An inserted <source> with an unsupported type is not selected.
+PASS An inserted <source> with a supported type is selected.
 

--- a/LayoutTests/model-element/model-element-source.html
+++ b/LayoutTests/model-element/model-element-source.html
@@ -2,9 +2,11 @@
 <script src="../resources/testharnessreport.js"></script>
 <script>
 
-const makeSource = src => {
+const makeSource = (src, type) => {
     const source = document.createElement("source");
     source.src = src;
+    if (type)
+        source.type = type;
     return source;
 }
 
@@ -76,6 +78,88 @@ test(() => {
     assert_equals(model.currentSrc, secondSource.src);
 }, "Adding a <source> before the current <source> updates currentSrc.");
 
+test(() => {
+    assert_idl_attribute(document.createElement("model"), "src");
+}, "The HTMLModelElement interface has a src property.");
+
+test(() => {
+    const model = document.createElement("model");
+    model.setAttribute("src", "some-model.usdz");
+    assert_true(model.src.endsWith("/some-model.usdz"));
+}, "HTMLModelElement src property reflects src attribute value as a resolved URL.");
+
+test(() => {
+    const model = document.createElement("model");
+    model.src = "some-model.usdz";
+    assert_equals(model.getAttribute("src"), "some-model.usdz");
+}, "<model> src attribute reflects HTMLModelElement src property.");
+
+test(() => {
+    const model = document.createElement("model");
+    model.src = "model.usdz";
+    assert_equals(model.currentSrc, model.src);
+}, "Changing the src attribute of a <model> changes the currentSrc property.");
+
+test(() => {
+    const model = document.createElement("model");
+    model.appendChild(makeSource("model-child.usdz"));
+    model.src = "model-attr.usdz";
+    assert_equals(model.currentSrc, model.src);
+}, "A non-empty src attribute takes precedence over a <source> child.");
+
+test(() => {
+    const model = document.createElement("model");
+    const source = model.appendChild(makeSource("model-child.usdz"));
+    model.src = "";
+    assert_true(model.hasAttribute("src"));
+    assert_equals(model.currentSrc, source.src);
+}, "An empty src attribute does not take precedence over a <source> child.");
+
+test(() => {
+    const model = document.createElement("model");
+    const source = model.appendChild(makeSource("model-child.usdz"));
+    model.src = "model-attr.usdz";
+    assert_equals(model.currentSrc, model.src);
+    model.src = "";
+    assert_equals(model.currentSrc, source.src);
+}, "Removing a src attribute selects the first matching <source> child.");
+
+test(() => {
+    const model = document.createElement("model");
+    const firstSource = model.appendChild(makeSource("model-child-1.unknown", "model/unknown"));
+    const secondSource = model.appendChild(makeSource("model-child-2.usdz", "model/vnd.usdz+zip"));
+    assert_equals(model.currentSrc, secondSource.src);
+}, "The first <source> with a supported type is selected.");
+
+test(() => {
+    const model = document.createElement("model");
+    const firstSource = model.appendChild(makeSource("model-child-1.usdz", "model/unknown"));
+    const secondSource = model.appendChild(makeSource("model-child-2.usdz", "model/vnd.usdz+zip"));
+    firstSource.type = "model/vnd.usdz+zip";
+    assert_equals(model.currentSrc, firstSource.src);
+}, "Changing a <source type> to a supported type causes it to be selected.");
+
+test(() => {
+    const model = document.createElement("model");
+    const firstSource = model.appendChild(makeSource("model-child-1.usdz", "model/vnd.usdz+zip"));
+    const secondSource = model.appendChild(makeSource("model-child-2.usdz", "model/vnd.usdz+zip"));
+    firstSource.type = "model/unknown";
+    assert_equals(model.currentSrc, secondSource.src);
+}, "Changing a <source type> to an unsupported type causes it not to be selected.");
+
+test(() => {
+    const model = document.createElement("model");
+    const initialSource = model.appendChild(makeSource("model-child-1.usdz", "model/vnd.usdz+zip"));
+    const newSource = model.insertBefore(makeSource("model-child-2.usdz", "model/unsupported"), model.firstChild);
+    assert_equals(model.currentSrc, initialSource.src);
+}, "An inserted <source> with an unsupported type is not selected.");
+
+test(() => {
+    const model = document.createElement("model");
+    const initialSource = model.appendChild(makeSource("model-child-1.usdz", "model/vnd.usdz+zip"));
+    const newSource = model.insertBefore(makeSource("model-child-2.usdz", "model/vnd.usdz+zip"), model.firstChild);
+    assert_equals(model.currentSrc, newSource.src);
+}, "An inserted <source> with a supported type is selected.");
 </script>
 </body>
 </html>

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -120,6 +120,7 @@ public:
 private:
     HTMLModelElement(const QualifiedName&, Document&);
 
+    URL selectModelSource() const;
     void setSourceURL(const URL&);
     void modelDidChange();
     void createModelPlayer();
@@ -132,7 +133,8 @@ private:
 
     // DOM overrides.
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
-    void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
+    bool isURLAttribute(const Attribute&) const final;
+    void parseAttribute(const QualifiedName&, const AtomString&) final;
 
     // StyledElement
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.idl
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.idl
@@ -32,6 +32,7 @@
 ] interface HTMLModelElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute unsigned long width;
     [CEReactions=NotNeeded, Reflect] attribute unsigned long height;
+    [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
     [URL] readonly attribute USVString currentSrc;
 
     readonly attribute boolean complete;


### PR DESCRIPTION
#### 7d493da919b53d9c012a73806fc91305776276eb
<pre>
Add support for &lt;model src&gt; and honor &lt;source type&gt; attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=248855">https://bugs.webkit.org/show_bug.cgi?id=248855</a>
rdar://problem/103056552

Reviewed by Antoine Quint.

* LayoutTests/model-element/model-element-source-expected.txt:
* LayoutTests/model-element/model-element-source.html:
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::isSupportedModelType):
(WebCore::HTMLModelElement::selectModelSource const):
(WebCore::HTMLModelElement::sourcesChanged):
(WebCore::HTMLModelElement::parseAttribute):
(WebCore::HTMLModelElement::isURLAttribute const):
(WebCore::HTMLModelElement::attributeChanged): Deleted.
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/HTMLModelElement.idl:

Canonical link: <a href="https://commits.webkit.org/257518@main">https://commits.webkit.org/257518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ccf06474490f9fabeabd9b1aa3afbafb0f8a4e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108490 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168732 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85648 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91600 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106433 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6689 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33704 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88511 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76562 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2193 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45541 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5166 "Built successfully and passed tests") | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7063 "Hash 9ccf0647 for PR 7245 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42603 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3501 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->