### PR TITLE
[JSC] Fix async wasm tests

### DIFF
--- a/JSTests/wasm/assert.js
+++ b/JSTests/wasm/assert.js
@@ -178,6 +178,7 @@ const asyncTestImpl = (promise, thenFunc, catchFunc) => {
 const printExn = (e) => {
     print("Failed: ", e);
     print(e.stack);
+    $vm.abort();
 };
 
 export const asyncTest = (promise) => asyncTestImpl(promise, harnessCall(() => asyncTestPassed()), printExn);
@@ -186,7 +187,7 @@ export const asyncTestEq = (promise, expected) => {
         if (value === expected)
             return harnessCall(() => asyncTestPassed());
         print("Failed: got ", value, " but expected ", expected);
-
+        $vm.abort();
     }
     asyncTestImpl(promise, thenCheck, printExn);
 };

--- a/JSTests/wasm/function-references/ref_types.js
+++ b/JSTests/wasm/function-references/ref_types.js
@@ -208,7 +208,7 @@ async function testRefGlobalCheck() {
       )
     },
     WebAssembly.CompileError,
-    "WebAssembly.Module doesn't validate: set_global 0 with type Externref with a variable of type Externref, in function at index 0 (evaluating 'new WebAssembly.Module(buffer)')"
+    `WebAssembly.Module doesn't validate: set_global 0 with type Ref with a variable of type RefNull, in function at index 0 (evaluating 'new WebAssembly.Module(buffer)')`
   );
 }
 

--- a/JSTests/wasm/references/memory_copy_shared.js
+++ b/JSTests/wasm/references/memory_copy_shared.js
@@ -1,3 +1,4 @@
+//@ skip if $architecture == "arm"
 import * as assert from '../assert.js';
 import { instantiate } from "../wabt-wrapper.js";
 

--- a/JSTests/wasm/references/memory_fill_shared.js
+++ b/JSTests/wasm/references/memory_fill_shared.js
@@ -1,3 +1,4 @@
+//@ skip if $architecture == "arm"
 import * as assert from '../assert.js';
 import { instantiate } from "../wabt-wrapper.js";
 


### PR DESCRIPTION
#### c3cabf531d738de5d543050e84fc0584b58fc449
<pre>
[JSC] Fix async wasm tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=248858">https://bugs.webkit.org/show_bug.cgi?id=248858</a>

Reviewed by Ross Kirsling.

Test failure should crash.

* JSTests/wasm/assert.js:
* JSTests/wasm/function-references/ref_types.js:
(async testRefGlobalCheck):

Canonical link: <a href="https://commits.webkit.org/257462@main">https://commits.webkit.org/257462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37bb55d7d56512cc9c6809597ef45d4eef6b043a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108502 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85660 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91614 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104839 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90277 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33716 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21623 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89821 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2205 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85648 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2097 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28847 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/7060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42617 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88510 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2601 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3513 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19811 "Passed tests") | 
<!--EWS-Status-Bubble-End-->