### PR TITLE
[SIMD] Intel support for saturating integer arithmetic operations

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -3972,6 +3972,13 @@ public:
         return X86Assembler::patchableJumpSize();
     }
 
+    static bool supportsSSE4_1()
+    {
+        if (s_sse4_1CheckState == CPUIDCheckState::NotChecked)
+            collectCPUFeatures();
+        return s_sse4_1CheckState == CPUIDCheckState::Set;
+    }
+
     static bool supportsFloatingPointRounding()
     {
         if (s_sse4_1CheckState == CPUIDCheckState::NotChecked)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -2353,29 +2353,131 @@ public:
 
     void vectorMax(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
-        UNUSED_PARAM(right); UNUSED_PARAM(dest);
-        if (scalarTypeIsFloatingPoint(simdInfo.lane))
-            UNUSED_PARAM(left);
-        else {
-            ASSERT(simdInfo.signMode != SIMDSignMode::None);
-            if (simdInfo.signMode == SIMDSignMode::Signed)
-                UNUSED_PARAM(left);
-            else
-                UNUSED_PARAM(left);
+        ASSERT(simdInfo.signMode != SIMDSignMode::None);
+
+        switch (simdInfo.lane) {
+        case SIMDLane::i8x16:
+            if (supportsAVX()) {
+                if (simdInfo.signMode == SIMDSignMode::Signed)                
+                    m_assembler.vpmaxsb_rr(right, left, dest);
+                else
+                    m_assembler.vpmaxub_rr(right, left, dest);
+            } else {
+                if (left != dest)
+                    m_assembler.movapd_rr(left, dest);
+                if (simdInfo.signMode == SIMDSignMode::Signed) {
+                    if (supportsSSE4_1())
+                        m_assembler.pmaxsb_rr(right, dest);
+                    else
+                        RELEASE_ASSERT_NOT_REACHED();
+                } else
+                    m_assembler.pmaxub_rr(right, dest);
+            }
+            return;
+        case SIMDLane::i16x8:
+            if (supportsAVX()) {
+                if (simdInfo.signMode == SIMDSignMode::Signed)                
+                    m_assembler.vpmaxsw_rr(right, left, dest);
+                else
+                    m_assembler.vpmaxuw_rr(right, left, dest);
+            } else {
+                if (left != dest)
+                    m_assembler.movapd_rr(left, dest);
+                if (simdInfo.signMode == SIMDSignMode::Signed)
+                    m_assembler.pmaxsw_rr(right, dest);
+                else {
+                    if (supportsSSE4_1())
+                        m_assembler.pmaxuw_rr(right, dest);
+                    else
+                        RELEASE_ASSERT_NOT_REACHED();
+                }
+            }
+            return;
+        case SIMDLane::i32x4:
+            if (supportsAVX()) {
+                if (simdInfo.signMode == SIMDSignMode::Signed)                
+                    m_assembler.vpmaxsd_rr(right, left, dest);
+                else
+                    m_assembler.vpmaxud_rr(right, left, dest);
+            } else {
+                if (left != dest)
+                    m_assembler.movapd_rr(left, dest);
+                if (simdInfo.signMode == SIMDSignMode::Signed) {
+                    if (supportsSSE4_1())
+                        m_assembler.pmaxsd_rr(right, dest);
+                    else
+                        RELEASE_ASSERT_NOT_REACHED();
+                } else
+                    m_assembler.pmaxud_rr(right, dest);
+            }
+            return;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
         }
     }
 
     void vectorMin(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
-        UNUSED_PARAM(right); UNUSED_PARAM(dest);
-        if (scalarTypeIsFloatingPoint(simdInfo.lane))
-            UNUSED_PARAM(left);
-        else {
-            ASSERT(simdInfo.signMode != SIMDSignMode::None);
-            if (simdInfo.signMode == SIMDSignMode::Signed)
-                UNUSED_PARAM(left);
-            else
-                UNUSED_PARAM(left);
+        ASSERT(simdInfo.signMode != SIMDSignMode::None);
+
+        switch (simdInfo.lane) {
+        case SIMDLane::i8x16:
+            if (supportsAVX()) {
+                if (simdInfo.signMode == SIMDSignMode::Signed)                
+                    m_assembler.vpminsb_rr(right, left, dest);
+                else
+                    m_assembler.vpminub_rr(right, left, dest);
+            } else {
+                if (left != dest)
+                    m_assembler.movapd_rr(left, dest);
+                if (simdInfo.signMode == SIMDSignMode::Signed) {
+                    if (supportsSSE4_1())
+                        m_assembler.pminsb_rr(right, dest);
+                    else
+                        RELEASE_ASSERT_NOT_REACHED();
+                } else
+                    m_assembler.pminub_rr(right, dest);
+            }
+            return;
+        case SIMDLane::i16x8:
+            if (supportsAVX()) {
+                if (simdInfo.signMode == SIMDSignMode::Signed)                
+                    m_assembler.vpminsw_rr(right, left, dest);
+                else
+                    m_assembler.vpminuw_rr(right, left, dest);
+            } else {
+                if (left != dest)
+                    m_assembler.movapd_rr(left, dest);
+                if (simdInfo.signMode == SIMDSignMode::Signed)
+                    m_assembler.pminsw_rr(right, dest);
+                else {
+                    if (supportsSSE4_1())
+                        m_assembler.pminuw_rr(right, dest);
+                    else
+                        RELEASE_ASSERT_NOT_REACHED();
+                }
+            }
+            return;
+        case SIMDLane::i32x4:
+            if (supportsAVX()) {
+                if (simdInfo.signMode == SIMDSignMode::Signed)                
+                    m_assembler.vpminsd_rr(right, left, dest);
+                else
+                    m_assembler.vpminud_rr(right, left, dest);
+            } else {
+                if (left != dest)
+                    m_assembler.movapd_rr(left, dest);
+                if (simdInfo.signMode == SIMDSignMode::Signed) {
+                    if (supportsSSE4_1())
+                        m_assembler.pminsd_rr(right, dest);
+                    else
+                        RELEASE_ASSERT_NOT_REACHED();
+                } else
+                    m_assembler.pminud_rr(right, dest);
+            }
+            return;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
         }
     }
 
@@ -2430,11 +2532,48 @@ public:
 
     void vectorAbs(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
     {
-        if (scalarTypeIsFloatingPoint(simdInfo.lane))
-            UNUSED_PARAM(dest);
-        else
-            UNUSED_PARAM(dest);
-        UNUSED_PARAM(input);
+        switch (simdInfo.lane) {
+        case SIMDLane::i8x16:
+            if (supportsAVX())
+                m_assembler.vpabsb_rr(input, dest);
+            else if (supportsSupplementalSSE3())
+                m_assembler.pabsb_rr(input, dest);
+            else
+                RELEASE_ASSERT_NOT_REACHED();
+            return;
+        case SIMDLane::i16x8:
+            if (supportsAVX())
+                m_assembler.vpabsw_rr(input, dest);
+            else if (supportsSupplementalSSE3())
+                m_assembler.pabsw_rr(input, dest);
+            else
+                RELEASE_ASSERT_NOT_REACHED();
+            return;
+        case SIMDLane::i32x4:
+            if (supportsAVX())
+                m_assembler.vpabsd_rr(input, dest);
+            else if (supportsSupplementalSSE3())
+                m_assembler.pabsd_rr(input, dest);
+            else
+                RELEASE_ASSERT_NOT_REACHED();
+            return;
+        case SIMDLane::i64x2:
+            // https://github.com/WebAssembly/simd/pull/413
+            if (supportsAVX()) {
+                m_assembler.vpxor_rr(dest, dest, dest);
+                m_assembler.vpsubq_rr(input, dest, dest);
+                m_assembler.vblendvpd_rr(input, dest, input, dest);
+            } else if (supportsSSE4_1()) {
+                // FIXME: SSE4_1
+                RELEASE_ASSERT_NOT_REACHED();
+            } else {
+                // FIXME: SSE2
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+            return;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
     }
 
     void vectorNeg(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
@@ -2605,22 +2744,82 @@ public:
 
     void vectorAddSat(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
-        ASSERT(scalarTypeIsIntegral(simdInfo.lane));
         ASSERT(simdInfo.signMode != SIMDSignMode::None);
-        UNUSED_PARAM(simdInfo);
-        UNUSED_PARAM(left);
-        UNUSED_PARAM(right);
-        UNUSED_PARAM(dest);
+
+        switch (simdInfo.lane) {
+        case SIMDLane::i8x16:
+            if (supportsAVX()) {
+                if (simdInfo.signMode == SIMDSignMode::Signed)                
+                    m_assembler.vpaddsb_rr(right, left, dest);
+                else
+                    m_assembler.vpaddusb_rr(right, left, dest);
+            } else {
+                if (left != dest)
+                    m_assembler.movapd_rr(left, dest);
+                if (simdInfo.signMode == SIMDSignMode::Signed)
+                    m_assembler.paddsb_rr(right, dest);
+                else
+                    m_assembler.paddusb_rr(right, dest);
+            }
+            return;
+        case SIMDLane::i16x8:
+            if (supportsAVX()) {
+                if (simdInfo.signMode == SIMDSignMode::Signed)                
+                    m_assembler.vpaddsw_rr(right, left, dest);
+                else
+                    m_assembler.vpaddusw_rr(right, left, dest);
+            } else {
+                if (left != dest)
+                    m_assembler.movapd_rr(left, dest);
+                if (simdInfo.signMode == SIMDSignMode::Signed)
+                    m_assembler.paddsw_rr(right, dest);
+                else
+                    m_assembler.paddusw_rr(right, dest);
+            }
+            return;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
     }
 
     void vectorSubSat(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         ASSERT(scalarTypeIsIntegral(simdInfo.lane));
-        ASSERT(simdInfo.signMode != SIMDSignMode::None);
-        UNUSED_PARAM(simdInfo);
-        UNUSED_PARAM(left);
-        UNUSED_PARAM(right);
-        UNUSED_PARAM(dest);
+
+        switch (simdInfo.lane) {
+        case SIMDLane::i8x16:
+            if (supportsAVX()) {
+                if (simdInfo.signMode == SIMDSignMode::Signed)                
+                    m_assembler.vpsubsb_rr(right, left, dest);
+                else
+                    m_assembler.vpsubusb_rr(right, left, dest);
+            } else {
+                if (left != dest)
+                    m_assembler.movapd_rr(left, dest);
+                if (simdInfo.signMode == SIMDSignMode::Signed)
+                    m_assembler.psubsb_rr(right, dest);
+                else
+                    m_assembler.psubusb_rr(right, dest);
+            }
+            return;
+        case SIMDLane::i16x8:
+            if (supportsAVX()) {
+                if (simdInfo.signMode == SIMDSignMode::Signed)                
+                    m_assembler.vpsubsw_rr(right, left, dest);
+                else
+                    m_assembler.vpsubusw_rr(right, left, dest);
+            } else {
+                if (left != dest)
+                    m_assembler.movapd_rr(left, dest);
+                if (simdInfo.signMode == SIMDSignMode::Signed)
+                    m_assembler.psubsw_rr(right, dest);
+                else
+                    m_assembler.psubusw_rr(right, dest);
+            }
+            return;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
     }
 
     void vectorLoad8Splat(Address address, FPRegisterID dest) { UNUSED_PARAM(address); UNUSED_PARAM(dest); }
@@ -2637,8 +2836,51 @@ public:
     void vectorAllTrue(SIMDInfo simdInfo, FPRegisterID vec, RegisterID dest) { UNUSED_PARAM(simdInfo); UNUSED_PARAM(vec); UNUSED_PARAM(dest); }
     void vectorBitmask(SIMDInfo simdInfo, FPRegisterID vec, RegisterID dest) { UNUSED_PARAM(simdInfo); UNUSED_PARAM(vec); UNUSED_PARAM(dest); }
     void vectorExtaddPairwise(SIMDInfo simdInfo, FPRegisterID vec, FPRegisterID dest) { UNUSED_PARAM(simdInfo); UNUSED_PARAM(vec); UNUSED_PARAM(dest); }
-    void vectorAvgRound(SIMDInfo simdInfo, FPRegisterID a, FPRegisterID b, FPRegisterID dest) { UNUSED_PARAM(simdInfo); UNUSED_PARAM(a); UNUSED_PARAM(b); UNUSED_PARAM(dest); }
-    void vectorMulSat(FPRegisterID a, FPRegisterID b, FPRegisterID dest) { UNUSED_PARAM(a); UNUSED_PARAM(b); UNUSED_PARAM(dest); }
+
+    void vectorAvgRound(SIMDInfo simdInfo, FPRegisterID a, FPRegisterID b, FPRegisterID dest)
+    {
+        switch (simdInfo.lane) {
+        case SIMDLane::i8x16:
+            if (supportsAVX())
+                m_assembler.vpavgb_rr(b, a, dest);
+            else {
+                if (a != dest)
+                    m_assembler.movapd_rr(a, dest);
+                m_assembler.pavgb_rr(b, dest);
+            }
+            return;
+        case SIMDLane::i16x8:
+            if (supportsAVX())
+                m_assembler.vpavgw_rr(b, a, dest);
+            else {
+                if (a != dest)
+                    m_assembler.movapd_rr(a, dest);
+                m_assembler.pavgw_rr(b, dest);
+            }
+            return;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+    }
+
+    void vectorMulSat(FPRegisterID a, FPRegisterID b, FPRegisterID dest, RegisterID scratchGPR, FPRegisterID scratchFPR)
+    {
+        // https://github.com/WebAssembly/simd/pull/365
+        if (supportsAVX()) {
+            m_assembler.vpmulhrsw_rr(b, a, dest);
+            m_assembler.movq_i64r(0x8000, scratchGPR);
+            vectorSplat(SIMDLane::i16x8, scratchGPR, scratchFPR);
+            m_assembler.vpcmpeqw_rr(scratchFPR, dest, scratchFPR);
+            m_assembler.vpxor_rr(scratchFPR, dest, dest);
+        } else if (supportsSupplementalSSE3()) {
+            // FIXME: SSSE3
+            RELEASE_ASSERT_NOT_REACHED();
+        } else {
+            // FIXME: SSE2
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+
+    }
     void vectorDotProductInt32(FPRegisterID a, FPRegisterID b, FPRegisterID dest, FPRegisterID) { UNUSED_PARAM(a); UNUSED_PARAM(b); UNUSED_PARAM(dest); }
 
     void vectorSwizzle(FPRegisterID a, FPRegisterID b, FPRegisterID dest)

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -297,6 +297,7 @@ private:
         OP2_PSHUFHW_VdqWdqIb            = 0x70,
         OP2_PSLLQ_UdqIb                 = 0x73,
         OP2_PSRLQ_UdqIb                 = 0x73,
+        OP2_PCMPEQW_VdqWdq              = 0x75,
         OP2_MOVD_EdVd                   = 0x7E,
         OP2_JCC_rel32                   = 0x80,
         OP_SETCC                        = 0x90,
@@ -324,23 +325,51 @@ private:
         OP2_SHUFPD_VpdWpdIb             = 0xC6,
         OP2_SHUFPS_VpdWpdIb             = 0xC6,
         OP2_BSWAP                       = 0xC8,
+        OP2_PSUBUSB_VdqWdq              = 0xD8,
+        OP2_PSUBUSW_VdqWdq              = 0xD9,
+        OP2_PMINUB_VdqWdq               = 0xDA,
+        OP2_PADDUSB_VdqWdq              = 0xDC,
+        OP2_PADDUSW_VdqWdq              = 0xDD,
+        OP2_PMAXUB_VdqWdq               = 0xDE,
+        OP2_PAVGB_VdqWdq                = 0xE0,
+        OP2_PAVGW_VdqWdq                = 0xE3,
+        OP2_PSUBSB_VdqWdq               = 0xE8,
+        OP2_PSUBSW_VdqWdq               = 0xE9,
+        OP2_PMINSW_VdqWdq               = 0xEA,
         OP2_POR_VdqWdq                  = 0XEB,
+        OP2_PADDSB_VdqWdq               = 0xEC,
+        OP2_PADDSW_VdqWdq               = 0xED,
+        OP2_PMAXSW_VdqWdq               = 0xEE,
+        OP2_PXOR_VdqWdq                 = 0xEF,
+        OP2_PSUBQ_VdqWdq                = 0xFB,
     } TwoByteOpcodeID;
     
     typedef enum {
         OP3_PSHUFB_VdqWdq       = 0x00,
         OP3_ROUNDSS_VssWssIb    = 0x0A,
         OP3_ROUNDSD_VsdWsdIb    = 0x0B,
-        OP3_LFENCE              = 0xE8,
-        OP3_MFENCE              = 0xF0,
-        OP3_SFENCE              = 0xF8,
         OP3_PEXTRB_MbVdqIb      = 0x14,
         OP3_PEXTRW_MwVdqIb      = 0x15,
         OP3_PEXTRD_EdVdqIb      = 0x16,
         OP3_EXTRACTPS           = 0x17,
+        OP3_PABSB_VdqWdq        = 0x1C,
+        OP3_PABSW_VdqWdq        = 0x1D,
+        OP3_PABSD_VdqWdq        = 0x1E,
         OP3_PINSRB              = 0x20,
         OP3_INSERTPS_VpsUpsIb   = 0x21,
         OP3_PINSRD              = 0x22,
+        OP3_PMINSB_VdqWdq       = 0x38,
+        OP3_PMINSD_VdqWdq       = 0x39,
+        OP3_PMINUW_VdqWdq       = 0x3A,
+        OP3_PMINUD_VdqWdq       = 0x3B,
+        OP3_PMAXSB_VdqWdq       = 0x3C,
+        OP3_PMAXSD_VdqWdq       = 0x3D,
+        OP3_PMAXUW_VdqWdq       = 0x3E,
+        OP3_PMAXUD_VdqWdq       = 0x3F,
+        OP3_BLENDVPD_VpdWpdXMM0 = 0x4B,
+        OP3_LFENCE              = 0xE8,
+        OP3_MFENCE              = 0xF0,
+        OP3_SFENCE              = 0xF8,
     } ThreeByteOpcodeID;
 
     struct VexPrefix {
@@ -2590,6 +2619,473 @@ public:
         m_formatter.immediate8((uint8_t)controlBits);
     }
 
+    void paddsb_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/paddsb:paddsw
+        // 66 0F EC /r PADDSB xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PADDSB_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpaddsb_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/paddsb:paddsw
+        // VEX.128.66.0F.WIG EC /r VPADDSB xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PADDSB_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void paddusb_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/paddusb:paddusw
+        // 66 0F DC /r PADDUSB xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PADDUSB_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpaddusb_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/paddusb:paddusw
+        // VEX.128.66.0F.WIG DC /r VPADDUSB xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PADDUSB_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void paddsw_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/paddsb:paddsw
+        // 66 0F ED /r PADDSW xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PADDSW_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpaddsw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/paddsb:paddsw
+        // VEX.128.66.0F.WIG ED /r VPADDSW xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PADDSW_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void paddusw_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/paddusb:paddusw
+        // 66 0F DD /r PADDUSW xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PADDUSW_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpaddusw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/paddusb:paddusw
+        // VEX.128.66.0F.WIG DD /r VPADDUSW xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PADDUSW_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void psubsb_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/psubsb:psubsw
+        // 66 0F E8 /r PSUBSB xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PSUBSB_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpsubsb_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/psubsb:psubsw
+        // VEX.128.66.0F.WIG E8 /r VPSUBSB xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PSUBSB_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void psubusb_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/psubusb:psubusw
+        // 66 0F D8 /r PSUBUSB xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PSUBUSB_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpsubusb_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/psubusb:psubusw
+        // VEX.128.66.0F.WIG D8 /r VPSUBUSB xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PSUBUSB_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void psubsw_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/psubsb:psubsw
+        // 66 0F E9 /r PSUBSW xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PSUBSW_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpsubsw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/psubsb:psubsw
+        // VEX.128.66.0F.WIG E9 /r VPSUBSW xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PSUBSW_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void psubusw_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/psubusb:psubusw
+        // 66 0F D9 /r PSUBUSW xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PSUBUSW_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpsubusw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/psubusb:psubusw
+        // VEX.128.66.0F.WIG D9 /r VPSUBUSW xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PSUBUSW_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pmaxsb_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pmaxsb:pmaxsw:pmaxsd:pmaxsq
+        // 66 0F 38 3C /r PMAXSB xmm1, xmm2/m128 | SSE4_1
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMAXSB_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpmaxsb_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pmaxsb:pmaxsw:pmaxsd:pmaxsq
+        // VEX.128.66.0F38.WIG 3C /r VPMAXSB xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, isW1, OP3_PMAXSB_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pmaxsw_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pmaxsb:pmaxsw:pmaxsd:pmaxsq
+        // 66 0F EE /r PMAXSW xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PMAXSW_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpmaxsw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pmaxsb:pmaxsw:pmaxsd:pmaxsq
+        // VEX.128.66.0F.WIG EE /r VPMAXSW xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PMAXSW_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pmaxsd_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pmaxsb:pmaxsw:pmaxsd:pmaxsq
+        // 66 0F 38 3D /r PMAXSD xmm1, xmm2/m128 | SSE4_1
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMAXSD_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpmaxsd_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pmaxsb:pmaxsw:pmaxsd:pmaxsq
+        // VEX.128.66.0F38.WIG 3D /r VPMAXSD xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, isW1, OP3_PMAXSD_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pmaxub_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pmaxub:pmaxuw
+        // 66 0F DE /r PMAXUB xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PMAXUB_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpmaxub_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pmaxub:pmaxuw
+        // VEX.128.66.0F DE /r VPMAXUB xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        m_formatter.vexTwoByteOp(isVEX256, PRE_SSE_66, OP2_PMAXUB_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pmaxuw_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pmaxub:pmaxuw
+        // 66 0F 38 3E /r PMAXUW xmm1, xmm2/m128 | SSE4_1
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMAXUW_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpmaxuw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pmaxub:pmaxuw
+        // VEX.128.66.0F38 3E /r VPMAXUW xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, isW1, OP3_PMAXUW_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pmaxud_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pmaxud:pmaxuq
+        // 66 0F 38 3F /r PMAXUD xmm1, xmm2/m128 | SSE4_1
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMAXUD_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpmaxud_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pmaxud:pmaxuq
+        // VEX.128.66.0F38.WIG 3F /r VPMAXUD xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, isW1, OP3_PMAXUD_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pminsb_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pminsb:pminsw
+        // 66 0F 38 38 /r PMINSB xmm1, xmm2/m128 | SSE4_1
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMINSB_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpminsb_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pminsb:pminsw
+        // VEX.128.66.0F38 38 /r VPMINSB xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, isW1, OP3_PMINSB_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pminsw_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pminsb:pminsw
+        // 66 0F EA /r PMINSW xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PMINSW_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpminsw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pminsb:pminsw
+        // VEX.128.66.0F EA /r VPMINSW xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        m_formatter.vexTwoByteOp(isVEX256, PRE_SSE_66, OP2_PMINSW_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pminsd_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pminsd:pminsq
+        // 66 0F 38 39 /r PMINSD xmm1, xmm2/m128 | SSE4_1
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMINSD_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpminsd_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pminsd:pminsq
+        // VEX.128.66.0F38.WIG 39 /r VPMINSD xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, isW1, OP3_PMINSD_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pminub_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pminub:pminuw
+        // 66 0F DA /r PMINUB xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PMINUB_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpminub_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pminub:pminuw
+        // VEX.128.66.0F DA /r VPMINUB xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        m_formatter.vexTwoByteOp(isVEX256, PRE_SSE_66, OP2_PMINUB_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pminuw_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pminub:pminuw
+        // 66 0F 38 3A /r PMINUW xmm1, xmm2/m128 | SSE4_1
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMINUW_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpminuw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pminub:pminuw
+        // VEX.128.66.0F38 3A /r VPMINUW xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, isW1, OP3_PMINUW_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pminud_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pminud:pminuq
+        // 66 0F 38 3B /r PMINUD xmm1, xmm2/m128 | SSE4_1
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMINUD_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpminud_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pminud:pminuq
+        // VEX.128.66.0F38.WIG 3B /r VPMINUD xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, isW1, OP3_PMINUD_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pavgb_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pavgb:pavgw
+        // 66 0F E0, /r PAVGB xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PAVGB_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpavgb_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pavgb:pavgw
+        // VEX.128.66.0F.WIG E0 /r VPAVGB xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PAVGB_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pavgw_rr(XMMRegisterID right, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pavgb:pavgw
+        // 66 0F E3 /r PAVGW xmm1, xmm2/m128
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_PAVGW_VdqWdq, (RegisterID)vd, (RegisterID)right);
+    }
+
+    void vpavgw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pavgb:pavgw
+        // VEX.128.66.0F.WIG E3 /r VPAVGW xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PAVGW_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void pabsb_rr(XMMRegisterID vn, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pabsb:pabsw:pabsd:pabsq
+        // 66 0F 38 1C /r PABSB xmm1, xmm2/m128 | SSSE3
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PABSB_VdqWdq, (RegisterID)vd, (RegisterID)vn);
+    }
+
+    void vpabsb_rr(XMMRegisterID vn, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pabsb:pabsw:pabsd:pabsq
+        // VEX.128.66.0F38.WIG 1C /r VPABSB xmm1, xmm2/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, isW1, OP3_PABSB_VdqWdq, (RegisterID)vd, (RegisterID)vn, (RegisterID)0);
+    }
+
+    void pabsw_rr(XMMRegisterID vn, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pabsb:pabsw:pabsd:pabsq
+        // 66 0F 38 1D /r PABSW xmm1, xmm2/m128 | SSSE3
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PABSW_VdqWdq, (RegisterID)vd, (RegisterID)vn);
+    }
+
+    void vpabsw_rr(XMMRegisterID vn, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pabsb:pabsw:pabsd:pabsq
+        // VEX.128.66.0F38.WIG 1D /r VPABSW xmm1, xmm2/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, isW1, OP3_PABSW_VdqWdq, (RegisterID)vd, (RegisterID)vn, (RegisterID)0);
+    }
+
+    void pabsd_rr(XMMRegisterID vn, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pabsb:pabsw:pabsd:pabsq
+        // 66 0F 38 1E /r PABSD xmm1, xmm2/m128 | SSSE3
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PABSD_VdqWdq, (RegisterID)vd, (RegisterID)vn);
+    }
+
+    void vpabsd_rr(XMMRegisterID vn, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pabsb:pabsw:pabsd:pabsq
+        // VEX.128.66.0F38.WIG 1E /r VPABSD xmm1, xmm2/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, isW1, OP3_PABSD_VdqWdq, (RegisterID)vd, (RegisterID)vn, (RegisterID)0);
+    }
+
+    void vpxor_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/pxor
+        // VEX.128.66.0F.WIG EF /r VPXOR xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PXOR_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void vpsubq_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    {
+        // https://www.felixcloutier.com/x86/psubq
+        // VEX.128.66.0F.WIG FB /r VPSUBQ xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PSUBQ_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+    }
+
+    void vblendvpd_rr(XMMRegisterID xmm4, XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        // https://www.felixcloutier.com/x86/blendvpd
+        // VEX.128.66.0F3A.W0 4B /r /is4 VBLENDVPD xmm1, xmm2, xmm3/m128, xmm4
+        bool isVEX256 = false;
+        bool isW1 = false;    
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, isW1, OP3_BLENDVPD_VpdWpdXMM0, xmm4, (RegisterID)xmm1, (RegisterID)xmm3, (RegisterID)xmm2);
+    }
+
+    void vpmulhrsw_rr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        // https://www.felixcloutier.com/x86/pmulhrsw
+        // VEX.128.66.0F38.WIG 0B /r VPMULHRSW xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;    
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, isW1, OP3_ROUNDSD_VsdWsdIb, (RegisterID)xmm1, (RegisterID)xmm3, (RegisterID)xmm2);
+    }
+
+    void vpcmpeqw_rr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        // https://www.felixcloutier.com/x86/pcmpeqb:pcmpeqw:pcmpeqd
+        // VEX.128.66.0F.WIG 75 /r VPCMPEQW xmm1, xmm2, xmm3/m128
+        bool isVEX256 = false;
+        bool isW1 = false;    
+        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PCMPEQW_VdqWdq, (RegisterID)xmm1, (RegisterID)xmm3, (RegisterID)xmm2);
+    }
+
     void movl_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.oneByteOp(OP_MOV_EvGv, src, dst);
@@ -4590,9 +5086,26 @@ private:
                 putByteUnchecked(thirdByte);
             }
 
+            ALWAYS_INLINE void twoBytesVex(bool isVEX256, OneByteOpcodeID simdPrefix, RegisterID r, RegisterID vvvv)
+            {
+                // https://en.wikipedia.org/wiki/VEX_prefix
+                // https://wiki.osdev.org/X86-64_Instruction_Encoding#REX_prefix
+                uint8_t firstByte = VexPrefix::TwoBytes;       // 0xC5
+
+                uint8_t secondByte = 0;
+                secondByte |= !regRequiresRex(r) << 7;         // R
+                secondByte |= (~vvvv & 0xf) << 3;              // vvvv
+                secondByte |= isVEX256 << 2;                   // L
+                secondByte |= vexEncodeSIMDPrefix(simdPrefix); // pp
+
+                putByteUnchecked(firstByte);
+                putByteUnchecked(secondByte);
+            }
+
             ALWAYS_INLINE void threeBytesVex(bool isVEX256, OneByteOpcodeID simdPrefix, VexImpliedBytes impliedBytes, bool isW1, RegisterID r, RegisterID x, RegisterID b, RegisterID vvvv)
             {
                 // https://en.wikipedia.org/wiki/VEX_prefix
+                // https://wiki.osdev.org/X86-64_Instruction_Encoding#REX_prefix
                 uint8_t firstByte = VexPrefix::ThreeBytes;        // 0xC4
 
                 uint8_t secondByte = 0;
@@ -4603,7 +5116,7 @@ private:
 
                 uint8_t thirdByte = 0;
                 thirdByte |= isW1 << 7;                           // W
-                thirdByte = (~vvvv & 0xf) << 3;                   // vvvv
+                thirdByte |= (~vvvv & 0xf) << 3;                  // vvvv
                 thirdByte |= isVEX256 << 2;                       // L
                 thirdByte |= vexEncodeSIMDPrefix(simdPrefix);     // pp
 
@@ -4809,6 +5322,14 @@ private:
             writer.memoryModRM(dest, base, index, scale, offset);
         }
 
+        void vexTwoByteOp(bool isVEX256, OneByteOpcodeID simdPrefix, TwoByteOpcodeID opcode, RegisterID reg, RegisterID rm, RegisterID vvvv)
+        {
+            SingleInstructionBufferWriter writer(m_buffer);
+            writer.twoBytesVex(isVEX256, simdPrefix, reg, vvvv);
+            writer.putByteUnchecked(opcode);
+            writer.registerModRM(reg, rm);
+        }
+
         void vexThreeByteOp(bool isVEX256, OneByteOpcodeID simdPrefix, VexImpliedBytes impliedBytes, bool isW1, ThreeByteOpcodeID opcode, uint8_t laneIndex, RegisterID reg, RegisterID rm)
         {
             SingleInstructionBufferWriter writer(m_buffer);
@@ -4816,6 +5337,15 @@ private:
             writer.putByteUnchecked(opcode);
             writer.registerModRM(reg, rm);
             writer.putByteUnchecked((uint8_t)laneIndex);
+        }
+
+        void vexThreeByteOp(bool isVEX256, OneByteOpcodeID simdPrefix, VexImpliedBytes impliedBytes, bool isW1, ThreeByteOpcodeID opcode, uint8_t imm8, RegisterID reg, RegisterID rm, RegisterID vvvv)
+        {
+            SingleInstructionBufferWriter writer(m_buffer);
+            writer.threeBytesVex(isVEX256, simdPrefix, impliedBytes, isW1, reg, (RegisterID)0, rm, vvvv);
+            writer.putByteUnchecked(opcode);
+            writer.registerModRM(reg, rm);
+            writer.putByteUnchecked((uint8_t)imm8 << 4);
         }
 
         void vexThreeByteOp(bool isVEX256, OneByteOpcodeID simdPrefix, VexImpliedBytes impliedBytes, bool isW1, ThreeByteOpcodeID opcode, RegisterID reg, RegisterID rm, RegisterID vvvv)

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1851,8 +1851,11 @@ arm64: VectorAddPairwise U:G:8, U:F:128, U:F:128, D:F:128
 VectorAvgRound U:G:8, U:F:128, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp, Tmp
 
-VectorMulSat U:F:128, U:F:128, D:F:128
+arm64: VectorMulSat U:F:128, U:F:128, D:F:128
     Tmp, Tmp, Tmp
+
+x86_64: VectorMulSat U:F:128, U:F:128, D:F:128, S:G:64, S:F:128
+    Tmp, Tmp, Tmp, Tmp, Tmp
 
 VectorDotProductInt32 U:F:128, U:F:128, D:F:128, S:F:128
     Tmp, Tmp, Tmp, Tmp

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
@@ -595,6 +595,7 @@ public:
         // Let each byte mask be 112 (0x70) then after VectorAddSat
         // each index > 15 would set the saturated index's bit 7 to 1, 
         // whose corresponding byte will be zero cleared in VectorSwizzle.
+        // https://github.com/WebAssembly/simd/issues/93
         v128_t mask;
         mask.u64x2[0] = 0x7070707070707070;
         mask.u64x2[1] = 0x7070707070707070;
@@ -626,6 +627,11 @@ public:
         AIR_OP_CASE(Max)
         AIR_OP_CASE(Min)
         result = tmpForType(Types::V128);
+
+        if (isX86() && airOp == B3::Air::VectorMulSat) {
+            append(airOp, a, b, result, tmpForType(Types::I64), tmpForType(Types::V128));
+            return { };
+        }
 
         if (isX86() && airOp == B3::Air::VectorSwizzle) {
             addSIMDSwizzle(a, b, result);


### PR DESCRIPTION
#### 5a0f6d496df12411613df873460a8b0717a65459
<pre>
[SIMD] Intel support for saturating integer arithmetic operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=248862">https://bugs.webkit.org/show_bug.cgi?id=248862</a>
rdar://103061350

Reviewed by Yusuke Suzuki.

Add WASM SIMD saturating integer arithmetic operations.
<a href="https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md#saturating-integer-arithmetic">https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md#saturating-integer-arithmetic</a>

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::vectorMax):
(JSC::MacroAssemblerX86_64::vectorMin):
(JSC::MacroAssemblerX86_64::vectorAbs):
(JSC::MacroAssemblerX86_64::vectorAddSat):
(JSC::MacroAssemblerX86_64::vectorSubSat):
(JSC::MacroAssemblerX86_64::vectorAvgRound):
(JSC::MacroAssemblerX86_64::vectorMulSat):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::paddsb_rr):
(JSC::X86Assembler::vpaddsb_rr):
(JSC::X86Assembler::paddusb_rr):
(JSC::X86Assembler::vpaddusb_rr):
(JSC::X86Assembler::paddsw_rr):
(JSC::X86Assembler::vpaddsw_rr):
(JSC::X86Assembler::paddusw_rr):
(JSC::X86Assembler::vpaddusw_rr):
(JSC::X86Assembler::psubsb_rr):
(JSC::X86Assembler::vpsubsb_rr):
(JSC::X86Assembler::psubusb_rr):
(JSC::X86Assembler::vpsubusb_rr):
(JSC::X86Assembler::psubsw_rr):
(JSC::X86Assembler::vpsubsw_rr):
(JSC::X86Assembler::psubusw_rr):
(JSC::X86Assembler::vpsubusw_rr):
(JSC::X86Assembler::pmaxsb_rr):
(JSC::X86Assembler::vpmaxsb_rr):
(JSC::X86Assembler::pmaxsw_rr):
(JSC::X86Assembler::vpmaxsw_rr):
(JSC::X86Assembler::pmaxsd_rr):
(JSC::X86Assembler::vpmaxsd_rr):
(JSC::X86Assembler::pmaxub_rr):
(JSC::X86Assembler::vpmaxub_rr):
(JSC::X86Assembler::pmaxuw_rr):
(JSC::X86Assembler::vpmaxuw_rr):
(JSC::X86Assembler::pmaxud_rr):
(JSC::X86Assembler::vpmaxud_rr):
(JSC::X86Assembler::pminsb_rr):
(JSC::X86Assembler::vpminsb_rr):
(JSC::X86Assembler::pminsw_rr):
(JSC::X86Assembler::vpminsw_rr):
(JSC::X86Assembler::pminsd_rr):
(JSC::X86Assembler::vpminsd_rr):
(JSC::X86Assembler::pminub_rr):
(JSC::X86Assembler::vpminub_rr):
(JSC::X86Assembler::pminuw_rr):
(JSC::X86Assembler::vpminuw_rr):
(JSC::X86Assembler::pminud_rr):
(JSC::X86Assembler::vpminud_rr):
(JSC::X86Assembler::pavgb_rr):
(JSC::X86Assembler::vpavgb_rr):
(JSC::X86Assembler::pavgw_rr):
(JSC::X86Assembler::vpavgw_rr):
(JSC::X86Assembler::pabsb_rr):
(JSC::X86Assembler::vpabsb_rr):
(JSC::X86Assembler::pabsw_rr):
(JSC::X86Assembler::vpabsw_rr):
(JSC::X86Assembler::pabsd_rr):
(JSC::X86Assembler::vpabsd_rr):
(JSC::X86Assembler::vpxor_rr):
(JSC::X86Assembler::vpsubq_rr):
(JSC::X86Assembler::vblendvpd_rr):
(JSC::X86Assembler::vpmulhrsw_rr):
(JSC::X86Assembler::vpcmpeqw_rr):
(JSC::X86Assembler::X86InstructionFormatter::SingleInstructionBufferWriter::memoryModRM):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::addSIMDSwizzle):
(JSC::Wasm::AirIRGenerator::addSIMDV_VV):

Canonical link: <a href="https://commits.webkit.org/257468@main">https://commits.webkit.org/257468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77a1d613064da633bbb56d3b4412b676d881de7f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99121 "check-webkit-style running") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108515 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168757 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8880 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91628 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104858 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/89832 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2217 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85661 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2109 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28851 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5144 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/7071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/42628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88523 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3526 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19815 "Passed tests") | 
<!--EWS-Status-Bubble-End-->