### PR TITLE
Add a nbsp at the the end of the text when the next text has a leading space

### DIFF
--- a/LayoutTests/editing/inserting/insert-space-expected.txt
+++ b/LayoutTests/editing/inserting/insert-space-expected.txt
@@ -1,0 +1,18 @@
+
+
+Harness Error (FAIL), message = Test named "Insert a &nbsp; instead of plain space when it is inserted before the text node that has a leading plain space" passed a function to `test` that returned a value.
+
+PASS insert a plain space in the middle of text node
+PASS insert a plain space between two inserted text nodes
+PASS Insert a &nbsp; instead of plain space when it is inserted before the empty text node
+PASS Insert a &nbsp; instead of plain space when it is inserted before the text node that has a leading plain space
+FAIL Insert spaces into the editable <div> that only has <br> and space as child LayoutTests/resources/assert-selection.js:588:30
+	 expected <div contenteditable>   | </div>,
+	 but got  <div contenteditable>   |</div>,
+	 sameupto <div contenteditable>   |
+FAIL Insert spaces into the editable <div> that only has <br> and enter as child LayoutTests/resources/assert-selection.js:588:30
+	 expected <div contenteditable>   |
+</div>,
+	 but got  <div contenteditable>   |</div>,
+	 sameupto <div contenteditable>   |
+

--- a/LayoutTests/editing/inserting/insert-space.html
+++ b/LayoutTests/editing/inserting/insert-space.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/assert-selection.js"></script>
+<script>
+test(() => assert_selection(
+  '<div contenteditable><p>A|B</p></div>',
+  'insertText \ ',
+  '<div contenteditable><p>A |B</p></div>'),
+  'insert a plain space in the middle of text node');
+
+test(() => assert_selection(
+  '<div contenteditable><p id="para"></p></div>',
+  selection => {
+    var para = selection.document.getElementById('para');
+    para.appendChild(selection.document.createTextNode('A'));
+    para.appendChild(selection.document.createTextNode('B'));
+    selection.collapse(para.firstChild, 1);
+
+    selection.document.execCommand('insertText', false, ' ');
+  },
+  '<div contenteditable><p id="para">A |B</p></div>'),
+  'insert a plain space between two inserted text nodes');
+
+test(() => assert_selection(
+  '<div contenteditable><p id="para"></p></div>',
+  selection => {
+    var para = selection.document.getElementById('para');
+    para.appendChild(selection.document.createTextNode('A'));
+    para.appendChild(selection.document.createTextNode(''));
+    selection.collapse(para.firstChild, 1);
+
+    selection.document.execCommand('insertText', false, ' ');
+  },
+  '<div contenteditable><p id="para">A\u00A0|</p></div>'),
+  'Insert a &nbsp; instead of plain space when it is inserted before the empty text node');
+
+test(() => assert_selection(
+  '<div contenteditable><p id="para"></p></div>',
+  selection => {
+    var para = selection.document.getElementById('para');
+    para.appendChild(selection.document.createTextNode('A'));
+    para.appendChild(selection.document.createTextNode(' B'));
+    selection.collapse(para.firstChild, 1);
+
+    selection.document.execCommand('insertText', false, ' ');
+  },
+  '<div contenteditable><p id="para">A\u00A0| B</p></div>'),
+  'Insert a &nbsp; instead of plain space when it is inserted before the text node that has a leading plain space');
+
+test(() => assert_selection(
+  '<div contenteditable>|<br> </div>',
+  selection => {
+    selection.document.execCommand('insertText', false, ' ');
+    selection.document.execCommand('insertText', false, ' ');
+    selection.document.execCommand('insertText', false, ' ');
+  },
+  '<div contenteditable>\u00A0 \u00A0| </div>'),
+  'Insert spaces into the editable <div> that only has <br> and space as child');
+
+test(() => assert_selection(
+  '<div contenteditable>|<br>\u000A</div>',
+  selection => {
+    selection.document.execCommand('insertText', false, ' ');
+    selection.document.execCommand('insertText', false, ' ');
+    selection.document.execCommand('insertText', false, ' ');
+  },
+  '<div contenteditable>\u00A0 \u00A0|\u000A</div>'),
+  'Insert spaces into the editable <div> that only has <br> and enter as child');
+</script>

--- a/LayoutTests/resources/assert-selection.js
+++ b/LayoutTests/resources/assert-selection.js
@@ -1,0 +1,682 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+// This file provides |assert_selection(sample, tester, expectedText)| assertion
+// to W3C test harness to write editing test cases easier.
+//
+// |sample| is an HTML fragment text which is inserted as |innerHTML|. It should
+// have at least one focus boundary point marker "|" and at most one anchor
+// boundary point marker "^".
+//
+// |tester| is either name with parameter of execCommand or function taking
+// one parameter |Selection|.
+//
+// |expectedText| is an HTML fragment text containing at most one focus marker
+// and anchor marker. If resulting selection is none, you don't need to have
+// anchor and focus markers.
+//
+// Example:
+//  test(() => {
+//    assert_selection(
+//      '|foo',
+//      (selection) => selection.modify('extent', 'forward, 'character'),
+//      '<a href="http://bar">^f|oo</a>'
+//  });
+//
+//  test(() => {
+//    assert_selection(
+//      'x^y|z',
+//      'bold',  // execCommand name as a test
+//      'x<b>y</b>z',
+//      'Insert B tag');
+//  });
+//
+//  test(() => {
+//    assert_selection(
+//      'x^y|z',
+//      'createLink http://foo',  // execCommand name and parameter
+//      'x<a href="http://foo/">y</a></b>z',
+//      'Insert B tag');
+//  });
+//
+//
+// TODO(yosin): Please use "clang-format -style=Chromium -i" for formatting
+// this file.
+(function() {
+/**
+ * @param {!Node} node
+ * @return {boolean}
+ */
+function isCharacterData(node) {
+  return node.nodeType === Node.TEXT_NODE ||
+      node.nodeType === Node.COMMENT_NODE;
+}
+/**
+ * @param {!Node} node
+ * @return {boolean}
+ */
+function isElement(node) {
+  return node.nodeType === Node.ELEMENT_NODE;
+}
+/**
+ * @param {!Node} node
+ * @param {number} offset
+ */
+function checkValidNodeAndOffset(node, offset) {
+  if (!node)
+    throw new Error('Node parameter should not be a null.');
+  if (offset < 0)
+    throw new Error(`Assumes ${offset} >= 0`);
+  if (isElement(node)) {
+    if (offset > node.childNodes.length)
+      throw new Error(`Bad offset ${offset} for ${node}`);
+    return;
+  }
+  if (isCharacterData(node)) {
+    if (offset > node.nodeValue.length)
+      throw new Error(`Bad offset ${offset} for ${node}`);
+    return;
+  }
+  throw new Error(`Invalid node: ${node}`);
+}
+class SampleSelection {
+  /** @public */
+  constructor() {
+    /** @type {?Node} */
+    this.anchorNode_ = null;
+    /** @type {number} */
+    this.anchorOffset_ = 0;
+    /** @type {?Node} */
+    this.focusNode_ = null;
+    /** @type {number} */
+    this.focusOffset_ = 0;
+  }
+  /**
+   * @public
+   * @param {!Node} node
+   * @param {number} offset
+   */
+  collapse(node, offset) {
+    checkValidNodeAndOffset(node, offset);
+    this.anchorNode_ = this.focusNode_ = node;
+    this.anchorOffset_ = this.focusOffset_ = offset;
+  }
+  /**
+   * @public
+   * @param {!Node} node
+   * @param {number} offset
+   */
+  extend(node, offset) {
+    checkValidNodeAndOffset(node, offset);
+    this.focusNode_ = node;
+    this.focusOffset_ = offset;
+  }
+  /** @public @return {?Node} */
+  get anchorNode() {
+    console.assert(!this.isNone, 'Selection should not be a none.');
+    return this.anchorNode_;
+  }
+  /** @public @return {number} */
+  get anchorOffset() {
+    console.assert(!this.isNone, 'Selection should not be a none.');
+    return this.anchorOffset_;
+  }
+  /** @public @return {?Node} */
+  get focusNode() {
+    console.assert(!this.isNone, 'Selection should not be a none.');
+    return this.focusNode_;
+  }
+  /** @public @return {number} */
+  get focusOffset() {
+    console.assert(!this.isNone, 'Selection should not be a none.');
+    return this.focusOffset_;
+  }
+  /**
+   * @public
+   * @return {boolean}
+   */
+  get isCollapsed() {
+    return this.anchorNode === this.focusNode &&
+        this.anchorOffset === this.focusOffset;
+  }
+  /**
+   * @public
+   * @return {boolean}
+   */
+  get isNone() { return this.anchorNode_ === null; }
+  /**
+   * @public
+   * @param {!Selection} domSelection
+   * @return {!SampleSelection}
+   */
+  static fromDOMSelection(domSelection) {
+    /** type {!SampleSelection} */
+    const selection = new SampleSelection();
+    selection.anchorNode_ = domSelection.anchorNode;
+    selection.anchorOffset_ = domSelection.anchorOffset;
+    selection.focusNode_ = domSelection.focusNode;
+    selection.focusOffset_ = domSelection.focusOffset;
+    return selection;
+  }
+  /** @override */
+  toString() {
+    if (this.isNone)
+      return 'SampleSelection()';
+    if (this.isCollapsed)
+      return `SampleSelection(${this.focusNode_}@${this.focusOffset_})`;
+    return `SampleSelection(anchor: ${this.anchorNode_}@${this.anchorOffset_}` +
+        `focus: ${this.focusNode_}@${this.focusOffset_}`;
+  }
+}
+// Extracts selection from marker "^" as anchor and "|" as focus from
+// DOM tree and removes them.
+class Parser {
+  /** @private */
+  constructor() {
+    /** @type {?Node} */
+    this.anchorNode_ = null;
+    /** @type {number} */
+    this.anchorOffset_ = 0;
+    /** @type {?Node} */
+    this.focusNode_ = null;
+    /** @type {number} */
+    this.focusOffset_ = 0;
+  }
+  /**
+   * @public
+   * @return {!SampleSelection}
+   */
+  get selection() {
+    const selection = new SampleSelection();
+    if (!this.anchorNode_ && !this.focusNode_)
+      return selection;
+    if (this.anchorNode_ && this.focusNode_) {
+      selection.collapse(this.anchorNode_, this.anchorOffset_);
+      selection.extend(this.focusNode_, this.focusOffset_);
+      return selection;
+    }
+    if (this.focusNode_) {
+      selection.collapse(this.focusNode_, this.focusOffset_);
+      return selection;
+    }
+    throw new Error('There is no focus marker');
+  }
+  /**
+   * @private
+   * @param {!CharacterData} node
+   * @param {number} nodeIndex
+   */
+  handleCharacterData(node, nodeIndex) {
+    /** @type {string} */
+    const text = node.nodeValue;
+    /** @type {number} */
+    const anchorOffset = text.indexOf('^');
+    /** @type {number} */
+    const focusOffset = text.indexOf('|');
+    /** @type {!Node} */
+    const parentNode = node.parentNode;
+    node.nodeValue = text.replace('^', '').replace('|', '');
+    if (node.nodeValue.length == 0) {
+      if (anchorOffset >= 0)
+        this.rememberSelectionAnchor(parentNode, nodeIndex);
+      if (focusOffset >= 0)
+        this.rememberSelectionFocus(parentNode, nodeIndex);
+      node.remove();
+      return;
+    }
+    if (anchorOffset >= 0 && focusOffset >= 0) {
+      if (anchorOffset > focusOffset) {
+        this.rememberSelectionAnchor(node, anchorOffset - 1);
+        this.rememberSelectionFocus(node, focusOffset);
+        return;
+      }
+      this.rememberSelectionAnchor(node, anchorOffset);
+      this.rememberSelectionFocus(node, focusOffset - 1);
+      return;
+    }
+    if (anchorOffset >= 0) {
+      this.rememberSelectionAnchor(node, anchorOffset);
+      return;
+    }
+    if (focusOffset < 0)
+      return;
+    this.rememberSelectionFocus(node, focusOffset);
+  }
+  /**
+   * @private
+   * @param {!Element} element
+   */
+  handleElementNode(element) {
+    /** @type {number} */
+    let childIndex = 0;
+    for (const child of Array.from(element.childNodes)) {
+      this.parseInternal(child, childIndex);
+      if (!child.parentNode)
+        continue;
+      ++childIndex;
+    }
+  }
+  /**
+   * @private
+   * @param {!Node} node
+   * @return {!SampleSelection}
+   */
+  parse(node) {
+    this.parseInternal(node, 0);
+    return this.selection;
+  }
+  /**
+   * @private
+   * @param {!Node} node
+   * @param {number} nodeIndex
+   */
+  parseInternal(node, nodeIndex) {
+    if (isElement(node))
+      return this.handleElementNode(node);
+    if (isCharacterData(node))
+      return this.handleCharacterData(node, nodeIndex);
+    throw new Error(`Unexpected node ${node}`);
+  }
+  /**
+   * @private
+   * @param {!Node} node
+   * @param {number} offset
+   */
+  rememberSelectionAnchor(node, offset) {
+    checkValidNodeAndOffset(node, offset);
+    console.assert(
+        this.anchorNode_ === null, 'Anchor marker should be one.',
+        this.anchorNode_, this.anchorOffset_);
+    this.anchorNode_ = node;
+    this.anchorOffset_ = offset;
+  }
+  /**
+   * @private
+   * @param {!Node} node
+   * @param {number} offset
+   */
+  rememberSelectionFocus(node, offset) {
+    checkValidNodeAndOffset(node, offset);
+    console.assert(
+        this.focusNode_ === null, 'Focus marker should be one.',
+        this.focusNode_, this.focusOffset_);
+    this.focusNode_ = node;
+    this.focusOffset_ = offset;
+  }
+  /**
+   * @public
+   * @param {!Node} node
+   * @return {!SampleSelection}
+   */
+  static parse(node) { return (new Parser()).parse(node); }
+}
+// TODO(yosin): Once we can import JavaScript file from scripts, we should
+// import "imported/wpt/html/resources/common.js", since |HTML5_VOID_ELEMENTS|
+// is defined in there.
+/**
+ * @const @type {!Set<string>}
+ * only void (without end tag) HTML5 elements
+ */
+const HTML5_VOID_ELEMENTS = new Set([
+  'area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input',
+  'keygen', 'link', 'meta', 'param', 'source','track', 'wbr' ]);
+class Serializer {
+  /**
+   * @public
+   * @param {!SampleSelection} selection
+   */
+  constructor(selection) {
+    /** @type {!SampleSelection} */
+    this.selection_ = selection;
+    /** @type {!Array<strings>} */
+    this.strings_ = [];
+  }
+  /**
+   * @private
+   * @param {string} string
+   */
+  emit(string) { this.strings_.push(string); }
+  /**
+   * @private
+   * @param {!HTMLElement} parentNode
+   * @param {number} childIndex
+   */
+  handleSelection(parentNode, childIndex) {
+    if (this.selection_.isNone)
+      return;
+    if (parentNode === this.selection_.focusNode &&
+        childIndex === this.selection_.focusOffset) {
+      this.emit('|');
+      return;
+    }
+    if (parentNode === this.selection_.anchorNode &&
+        childIndex === this.selection_.anchorOffset) {
+      this.emit('^');
+    }
+  }
+  /**
+   * @private
+   * @param {!CharacterData} node
+   */
+  handleCharacterData(node) {
+    /** @type {string} */
+    const text = node.nodeValue;
+    if (this.selection_.isNone)
+      return this.emit(text);
+    /** @type {number} */
+    const anchorOffset = this.selection_.anchorOffset;
+    /** @type {number} */
+    const focusOffset = this.selection_.focusOffset;
+    if (node === this.selection_.focusNode &&
+        node === this.selection_.anchorNode) {
+      if (anchorOffset === focusOffset) {
+        this.emit(text.substr(0, focusOffset));
+        this.emit('|');
+        this.emit(text.substr(focusOffset));
+        return;
+      }
+      if (anchorOffset < focusOffset) {
+        this.emit(text.substr(0, anchorOffset));
+        this.emit('^');
+        this.emit(text.substr(anchorOffset, focusOffset - anchorOffset));
+        this.emit('|');
+        this.emit(text.substr(focusOffset));
+        return;
+      }
+      this.emit(text.substr(0, focusOffset));
+      this.emit('|');
+      this.emit(text.substr(focusOffset, anchorOffset - focusOffset));
+      this.emit('^');
+      this.emit(text.substr(anchorOffset));
+      return;
+    }
+    if (node === this.selection_.anchorNode) {
+      this.emit(text.substr(0, anchorOffset));
+      this.emit('^');
+      this.emit(text.substr(anchorOffset));
+      return;
+    }
+    if (node === this.selection_.focusNode) {
+      this.emit(text.substr(0, focusOffset));
+      this.emit('|');
+      this.emit(text.substr(focusOffset));
+      return;
+    }
+    this.emit(text);
+  }
+  /**
+   * @private
+   * @param {!HTMLElement} element
+   */
+  handleElementNode(element) {
+    /** @type {string} */
+    const tagName = element.tagName.toLowerCase();
+    this.emit(`<${tagName}`);
+    Array.from(element.attributes)
+        .sort((attr1, attr2) => attr1.name.localeCompare(attr2.name))
+        .forEach(attr => {
+          if (attr.value === '')
+            return this.emit(` ${attr.name}`);
+          const value = attr.value.replace(/&/g, '&amp;')
+                            .replace(/\u0022/g, '&quot;')
+                            .replace(/\u0027/g, '&apos;');
+          this.emit(` ${attr.name}="${value}"`);
+        });
+    this.emit('>');
+    if (element.childNodes.length === 0 &&
+        HTML5_VOID_ELEMENTS.has(tagName)) {
+      return;
+    }
+    this.serializeChildren(element);
+    this.emit(`</${tagName}>`);
+  }
+  /**
+   * @public
+   * @param {!HTMLDocument} document
+   */
+  serialize(document) {
+    if (document.body)
+        this.serializeChildren(document.body);
+    else
+        this.serializeInternal(document.documentElement);
+    return this.strings_.join('');
+  }
+  /**
+   * @private
+   * @param {!HTMLElement} element
+   */
+  serializeChildren(element) {
+    /** @type {!Array<!Node>} */
+    const childNodes = Array.from(element.childNodes);
+    if (childNodes.length === 0) {
+      this.handleSelection(element, 0);
+      return;
+    }
+    /** @type {number} */
+    let childIndex = 0;
+    for (const child of childNodes) {
+      this.handleSelection(element, childIndex);
+      this.serializeInternal(child, childIndex);
+      ++childIndex;
+    }
+    this.handleSelection(element, childIndex);
+  }
+  /**
+   * @private
+   * @param {!Node} node
+   */
+  serializeInternal(node) {
+    if (isElement(node))
+      return this.handleElementNode(node);
+    if (isCharacterData(node))
+      return this.handleCharacterData(node);
+    throw new Error(`Unexpected node ${node}`);
+  }
+}
+/**
+ * @this {!DOMSelection}
+ * @param {string} html
+ * @param {string=} opt_text
+ */
+function setClipboardData(html, opt_text) {
+  assert_not_equals(window.internals, undefined,
+    'This test requests clipboard access from JavaScript.');
+  function computeTextData() {
+    if (opt_text !== undefined)
+      return opt_text;
+    const element = document.createElement('div');
+    element.innerHTML = html;
+    return element.textContent;
+  }
+  function copyHandler(event) {
+    const clipboardData = event.clipboardData;
+    clipboardData.setData('text/plain', computeTextData());
+    clipboardData.setData('text/html', html);
+    event.preventDefault();
+  }
+  document.addEventListener('copy', copyHandler);
+  document.execCommand('copy');
+  document.removeEventListener('copy', copyHandler);
+}
+class Sample {
+  /**
+   * @public
+   * @param {string} sampleText
+   */
+  constructor(sampleText) {
+    /** @const @type {!HTMLIFame} */
+    this.iframe_ = document.createElement('iframe');
+    if (!document.body)
+        document.body = document.createElement("body");
+    document.body.appendChild(this.iframe_);
+    /** @const @type {!HTMLDocument} */
+    this.document_ = this.iframe_.contentDocument;
+    /** @const @type {!Selection} */
+    this.selection_ = this.iframe_.contentWindow.getSelection();
+    this.selection_.document = this.document_;
+    this.selection_.document.offsetLeft = this.iframe_.offsetLeft;
+    this.selection_.document.offsetTop = this.iframe_.offsetTop;
+    this.selection_.setClipboardData = setClipboardData;
+    // Set focus to sample IFRAME to make |eventSender| and
+    // |testRunner.execCommand()| to work on sample rather than main frame.
+    this.iframe_.focus();
+    this.load(sampleText);
+  }
+  /** @return {!HTMLDocument} */
+  get document() { return this.document_; }
+  /** @return {!Selection} */
+  get selection() { return this.selection_; }
+  /**
+   * @private
+   * @param {string} sampleText
+   */
+  load(sampleText) {
+    const anchorMarker = sampleText.indexOf('^');
+    const focusMarker = sampleText.indexOf('|');
+    if (focusMarker < 0 && anchorMarker >= 0) {
+      throw new Error(`You should specify caret position in "${sampleText}".`);
+    }
+    if (focusMarker != sampleText.lastIndexOf('|')) {
+      throw new Error(
+          `You should have at least one focus marker "|" in "${sampleText}".`);
+    }
+    if (anchorMarker != sampleText.lastIndexOf('^')) {
+      throw new Error(
+          `You should have at most one anchor marker "^" in "${sampleText}".`);
+    }
+    if (anchorMarker >= 0 && focusMarker >= 0 &&
+        (anchorMarker + 1 === focusMarker || anchorMarker - 1 === focusMarker)) {
+      throw new Error(
+          `You should have focus marker and should not have anchor marker if and only if selection is a caret in "${sampleText}".`);
+    }
+    this.document_.body.innerHTML = sampleText;
+    /** @type {!SampleSelection} */
+    const selection = Parser.parse(this.document_.body);
+    if (selection.isNone)
+      return;
+    this.selection_.collapse(selection.anchorNode, selection.anchorOffset);
+    this.selection_.extend(selection.focusNode, selection.focusOffset);
+  }
+  /**
+   * @public
+   */
+  remove() { this.iframe_.remove(); }
+  /**
+   * @public
+   * @return {string}
+   */
+  serialize() {
+    /** @type {!SampleSelection} */
+    const selection = SampleSelection.fromDOMSelection(this.selection_);
+    /** @type {!Serializer} */
+    const serializer = new Serializer(selection);
+    return serializer.serialize(this.document_);
+  }
+}
+function assembleDescription() {
+  function getStack() {
+    let stack;
+    try {
+      throw new Error('get line number');
+    } catch (error) {
+      stack = error.stack.split('\n').slice(1);
+    }
+    return stack
+  }
+  const RE_IN_ASSERT_SELECTION = new RegExp('assert_selection\\.js');
+  for (const line of getStack()) {
+    const match = RE_IN_ASSERT_SELECTION.exec(line);
+    if (!match) {
+      const RE_LAYOUTTESTS = new RegExp('LayoutTests.*');
+      return RE_LAYOUTTESTS.exec(line);
+    }
+  }
+  return '';
+}
+/**
+ * @param {string} expectedText
+ */
+function checkExpectedText(expectedText) {
+  /** @type {number} */
+  const anchorOffset = expectedText.indexOf('^');
+  /** @type {number} */
+  const focusOffset = expectedText.indexOf('|');
+  if (anchorOffset != expectedText.lastIndexOf('^')) {
+      throw new Error(
+        `You should have at most one anchor marker "^" in "${expectedText}".`);
+  }
+  if (focusOffset != expectedText.lastIndexOf('|')) {
+      throw new Error(
+        `You should have at most one focus marker "|" in "${expectedText}".`);
+  }
+  if (anchorOffset >= 0 && focusOffset < 0) {
+    throw new Error(
+        `You should have a focus marker "|" in "${expectedText}".`);
+  }
+  if (anchorOffset >= 0 && focusOffset >= 0 &&
+     (anchorOffset + 1 === focusOffset || anchorOffset - 1 === focusOffset)) {
+    throw new Error(
+        `You should have focus marker and should not have anchor marker if and only if selection is a caret in "${expectedText}".`);
+  }
+}
+/**
+ * @param {string} str1
+ * @param {string} str2
+ * @return {string}
+ */
+function commonPrefixOf(str1, str2) {
+  for (let index = 0; index < str1.length; ++index) {
+    if (str1[index] !== str2[index])
+      return str1.substr(0, index);
+  }
+  return str1;
+}
+/**
+ * @param {string} inputText
+ * @param {function(!Selection)|string}
+ * @param {string} expectedText
+ * @param {Object=} opt_options
+ * @return {!Sample}
+ */
+function assertSelection(
+    inputText, tester, expectedText, opt_options = {}) {
+  const kDescription = 'description';
+  const kRemoveSampleIfSucceeded = 'removeSampleIfSucceeded';
+  /** @type {!Object} */
+  const options = typeof(opt_options) === 'string'
+      ? {description: opt_options} : opt_options;
+  /** @type {string} */
+  const description = kDescription in options
+      ? options[kDescription] : assembleDescription();
+  /** @type {boolean} */
+  const removeSampleIfSucceeded = kRemoveSampleIfSucceeded in options
+      ? !!options[kRemoveSampleIfSucceeded] : true;
+  checkExpectedText(expectedText);
+  const sample = new Sample(inputText);
+  if (typeof(tester) === 'function') {
+    tester.call(window, sample.selection);
+  } else if (typeof(tester) === 'string') {
+    const strings = tester.split(/ (.+)/);
+    sample.document.execCommand(strings[0], false, strings[1]);
+  } else {
+    throw new Error(`Invalid tester: ${tester}`);
+  }
+  /** @type {string} */
+  const actualText = sample.serialize();
+  // We keep sample HTML when assertion is false for ease of debugging test
+  // case.
+  if (actualText === expectedText) {
+    if (removeSampleIfSucceeded)
+        sample.remove();
+    return sample;
+  }
+  throw new Error(`${description}\n` +
+    `\t expected ${expectedText},\n` +
+    `\t but got  ${actualText},\n` +
+    `\t sameupto ${commonPrefixOf(expectedText, actualText)}`);
+}
+// Export symbols
+window.Sample = Sample;
+window.assert_selection = assertSelection;
+})();

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -959,9 +959,9 @@ void CompositeEditCommand::rebalanceWhitespaceOnTextSubstring(Text& textNode, in
     String string = text.substring(upstream, length);
     // FIXME: Because of the problem mentioned at the top of this function, we must also use nbsps at the start/end of the string because
     // this function doesn't get all surrounding whitespace, just the whitespace in the current text node.
+    const bool nextSiblingIsTextNodeWithoutLeadingSpace = textNode.nextSibling() && textNode.nextSibling()->isTextNode() && downcast<Text>(textNode.nextSibling())->data().length() && !deprecatedIsEditingWhitespace(downcast<Text>(textNode.nextSibling())->data()[0]);
     String rebalancedString = stringWithRebalancedWhitespace(string, isStartOfParagraph(visibleUpstreamPos) || !upstream,
-        (isEndOfParagraph(visibleDownstreamPos) || downstream == text.length())
-        && !(textNode.nextSibling() && textNode.nextSibling()->isTextNode()));
+        (isEndOfParagraph(visibleDownstreamPos) || downstream == text.length()) && !nextSiblingIsTextNodeWithoutLeadingSpace);
 
     if (string != rebalancedString)
         replaceTextInNodePreservingMarkers(textNode, upstream, length, rebalancedString);


### PR DESCRIPTION
#### 41ea6427c93797b6c7aceb36d05329618ddd87b9
<pre>
Add a nbsp at the the end of the text when the next text has a leading space

Add a nbsp at the the end of the text when the next text has a leading space
<a href="https://bugs.webkit.org/show_bug.cgi?id=248723">https://bugs.webkit.org/show_bug.cgi?id=248723</a>

Reviewed by Ryosuke Niwa.

This patch is to fix three regressions stemming from 257136@main.

1) Breaking chat window or login forms while trying to press &apos;space&apos; key.
2) Add nbsp instead of plain space between text nodes in case next text node has a leading plain space.
3) Not accounting for all kind of whitespaces including &quot;Enter&quot;

These are merge of following Blink commits:

&gt; <a href="https://chromium.googlesource.com/chromium/src.git/+/4dab74137593abb0888e415294aeb80da27362e3">https://chromium.googlesource.com/chromium/src.git/+/4dab74137593abb0888e415294aeb80da27362e3</a>
&gt; <a href="https://chromium.googlesource.com/chromium/src.git/+/9ebff223d5d639167c3efb01a5fa912b3aee05a9">https://chromium.googlesource.com/chromium/src.git/+/9ebff223d5d639167c3efb01a5fa912b3aee05a9</a>
&gt; <a href="https://chromium.googlesource.com/chromium/src.git/+/5b9a9a6f8c9c646ac542a9e1a2f18c59140849e6">https://chromium.googlesource.com/chromium/src.git/+/5b9a9a6f8c9c646ac542a9e1a2f18c59140849e6</a>

* Source/WebCore/editing/CompositeEditingCommand.cpp:
(CompositeEditCommand::rebalanceWhitespaceOnTextSubtring):
(1) Add logic to account for leading space (including &quot;Enter&quot; key)
(2) accept &quot;Space&quot; Key
(3) Refactor code by introducing const bool &quot;nextSiblingIsTextNodeWithoutLeadingSpace&quot;
* LayoutTests/resources/assert-selection.js: Added Test Script with Chromium Copyright header
* LayoutTests/editing/inserting/insert-space.html: Added Test Case
* LayoutTests/editing/inserting/insert-space-expected.txt: Added Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/257622@main">https://commits.webkit.org/257622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d6fb9659ce1b03c2296efb5bd67cde6545be87c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108819 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169054 "Failed to checkout and rebase branch from PR 7257") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103440 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85942 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91924 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106741 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33925 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21837 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2487 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23354 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2407 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5242 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8564 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42829 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->