### PR TITLE
BroadcastChannel is not always computing correctly its origin

### DIFF
--- a/LayoutTests/http/wpt/shared-workers/resources/third-party-shared-worker-broadcast-channel-iframe.html
+++ b/LayoutTests/http/wpt/shared-workers/resources/third-party-shared-worker-broadcast-channel-iframe.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+const channel = new BroadcastChannel('test');
+
+channel.onmessage = function (e) {
+    parent.postMessage(e.data, "*");
+}
+
+const worker = new SharedWorker("third-party-shared-worker-broadcast-channel-sharedworker.js");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/shared-workers/resources/third-party-shared-worker-broadcast-channel-sharedworker.js
+++ b/LayoutTests/http/wpt/shared-workers/resources/third-party-shared-worker-broadcast-channel-sharedworker.js
@@ -1,0 +1,2 @@
+const channel = new BroadcastChannel('test');
+channel.postMessage('hello');

--- a/LayoutTests/http/wpt/shared-workers/third-party-shared-worker-broadcast-channel-expected.txt
+++ b/LayoutTests/http/wpt/shared-workers/third-party-shared-worker-broadcast-channel-expected.txt
@@ -1,0 +1,3 @@
+
+PASS BroadcastChannel between third-party iframe and shared worker should work properly
+

--- a/LayoutTests/http/wpt/shared-workers/third-party-shared-worker-broadcast-channel.html
+++ b/LayoutTests/http/wpt/shared-workers/third-party-shared-worker-broadcast-channel.html
@@ -1,0 +1,27 @@
+<html><!-- webkit-test-runner [ BroadcastChannelOriginPartitioningEnabled=true ] -->
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+ <script src="/common/get-host-info.sub.js"></script>
+</head>
+<body>
+<script>
+function with_iframe(url) {
+    return new Promise(function(resolve) {
+        var frame = document.createElement('iframe');
+        frame.className = 'test-iframe';
+        frame.src = url;
+        frame.onload = function() { resolve(frame); };
+        document.body.appendChild(frame);
+    });
+}
+
+promise_test(async (t) => {
+    const frame = await with_iframe(get_host_info().HTTP_REMOTE_ORIGIN +  "/WebKit/shared-workers/resources/third-party-shared-worker-broadcast-channel-iframe.html");
+    const data = await new Promise(resolve => window.onmessage = (e) => resolve(e.data));
+    assert_equals(data, "hello");
+    frame.remove();
+}, "BroadcastChannel between third-party iframe and shared worker should work properly");
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -68,7 +68,6 @@ private:
     BroadcastChannel(ScriptExecutionContext&, const String& name);
 
     void dispatchMessage(Ref<SerializedScriptValue>&&);
-    void ensureOnMainThread(Function<void(Document&)>&&);
 
     bool isEligibleForMessaging() const;
 

--- a/Source/WebCore/page/PartitionedSecurityOrigin.h
+++ b/Source/WebCore/page/PartitionedSecurityOrigin.h
@@ -51,6 +51,8 @@ struct PartitionedSecurityOrigin {
     bool isHashTableDeletedValue() const { return topOrigin.isHashTableDeletedValue(); }
     bool isHashTableEmptyValue() const { return topOrigin.isHashTableEmptyValue(); }
 
+    PartitionedSecurityOrigin isolatedCopy() const { return { topOrigin->isolatedCopy(), clientOrigin->isolatedCopy() }; }
+
     Ref<SecurityOrigin> topOrigin;
     Ref<SecurityOrigin> clientOrigin;
 };


### PR DESCRIPTION
#### b5f2a68531f7fe3718d62f999d770dc9594e82fc
<pre>
BroadcastChannel is not always computing correctly its origin
<a href="https://bugs.webkit.org/show_bug.cgi?id=248869">https://bugs.webkit.org/show_bug.cgi?id=248869</a>
rdar://102519898

Reviewed by Chris Dumez.

Shared Workers document is also its own top document.
This makes Document::topOrigin() computation wrong in case of third-party Shared Workers.
Update BroadcastChannel to directly use ScriptExecutionContext::topOrigin instead.
As a follow-up, we should probably update third-party SharedWorker/ServiceWorker document creation to ensure this mistake does not pop up again.

* LayoutTests/http/wpt/shared-workers/resources/third-party-shared-worker-broadcast-channel-iframe.html: Added.
* LayoutTests/http/wpt/shared-workers/resources/third-party-shared-worker-broadcast-channel-sharedworker.js: Added.
* LayoutTests/http/wpt/shared-workers/third-party-shared-worker-broadcast-channel-expected.txt: Added.
* LayoutTests/http/wpt/shared-workers/third-party-shared-worker-broadcast-channel.html: Added.
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::shouldPartitionOrigin):
(WebCore::BroadcastChannel::MainThreadBridge::ensureOnMainThread):
(WebCore::BroadcastChannel::MainThreadBridge::registerChannel):
(WebCore::BroadcastChannel::MainThreadBridge::unregisterChannel):
(WebCore::BroadcastChannel::MainThreadBridge::postMessage):
* Source/WebCore/dom/BroadcastChannel.h:
* Source/WebCore/page/PartitionedSecurityOrigin.h:
(WebCore::PartitionedSecurityOrigin::isolatedCopy const):
* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp:
(WebKit::NetworkBroadcastChannelRegistry::registerChannel):
(WebKit::NetworkBroadcastChannelRegistry::unregisterChannel):
(WebKit::NetworkBroadcastChannelRegistry::postMessage):
* Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp:
(WebKit::WebBroadcastChannelRegistry::registerChannel):
(WebKit::WebBroadcastChannelRegistry::unregisterChannel):
(WebKit::WebBroadcastChannelRegistry::postMessage):
(WebKit::WebBroadcastChannelRegistry::postMessageLocally):
(WebKit::WebBroadcastChannelRegistry::postMessageToRemote):

Canonical link: <a href="https://commits.webkit.org/257551@main">https://commits.webkit.org/257551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e2fab74c5fd03f58c5e1757ddaa64b86ba96af2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108674 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168928 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85806 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91779 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106601 "Hash 6e2fab74 for PR 7258 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105046 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90381 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33820 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21727 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2365 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23244 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2263 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5193 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42722 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->