### PR TITLE
Disable the focus moves to an element which doesn't satisfy the spec

### DIFF
--- a/LayoutTests/fast/events/tabindex-no-focusable-all-negative-expected.txt
+++ b/LayoutTests/fast/events/tabindex-no-focusable-all-negative-expected.txt
@@ -1,0 +1,6 @@
+PASS document.activeElement.id is "focusMe"
+PASS document.activeElement.id is "focusMe"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/tabindex-no-focusable-all-negative.html
+++ b/LayoutTests/fast/events/tabindex-no-focusable-all-negative.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function test()
+{
+    if (!window.testRunner)
+        return;
+    var elem_focusme = document.getElementById('focusMe');
+    elem_focusme.focus();
+
+    eventSender.keyDown("\t"); 
+    shouldBeEqualToString('document.activeElement.id', 'focusMe');
+    elem_focusme.focus();
+    eventSender.keyDown("\t", ["shiftKey"]);
+    shouldBeEqualToString('document.activeElement.id', 'focusMe');
+}
+</script>
+<body onload="test()">
+<input tabindex="-1">
+<input id="focusMe" tabindex="-1">
+<input tabindex="-1">
+</body>

--- a/LayoutTests/fast/events/tabindex-no-focusable-expected.txt
+++ b/LayoutTests/fast/events/tabindex-no-focusable-expected.txt
@@ -1,0 +1,6 @@
+PASS document.activeElement.id is "MoveToMe"
+PASS document.activeElement.id is "MoveToMe"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/tabindex-no-focusable.html
+++ b/LayoutTests/fast/events/tabindex-no-focusable.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function test()
+{
+    if (!window.testRunner)
+        return;
+    var elem_movetome = document.getElementById('MoveToMe'); 
+    var elem_focusme = document.getElementById('focusMe');
+    elem_focusme.focus();
+
+    eventSender.keyDown("\t"); 
+    shouldBeEqualToString('document.activeElement.id', 'MoveToMe');
+    elem_focusme.focus();
+    eventSender.keyDown("\t", ["shiftKey"]);
+    shouldBeEqualToString('document.activeElement.id', 'MoveToMe');
+}
+</script>
+<body onload="test()">
+<input id="MoveToMe" tabindex="1">
+<input tabindex="-1">
+<input id="focusMe" tabindex="-1">
+<input tabindex="-1">
+</body>

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006, 2007, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc.
  * Copyright (C) 2008 Nuanti Ltd.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -711,11 +712,12 @@ Element* FocusController::nextFocusableElementOrScopeOwner(const FocusNavigation
                 if (isFocusableElementOrScopeOwner(element, event) && shadowAdjustedTabIndex(element, event) >= 0)
                     return &element;
             }
-        }
+        } else {
 
         // First try to find a node with the same tabindex as start that comes after start in the scope.
         if (Element* winner = findElementWithExactTabIndex(scope, scope.nextInScope(start), startTabIndex, event, FocusDirection::Forward))
             return winner;
+            }
 
         if (!startTabIndex)
             return nullptr; // We've reached the last node in the document with a tabindex of 0. This is the end of the tabbing order.
@@ -759,11 +761,12 @@ Element* FocusController::previousFocusableElementOrScopeOwner(const FocusNaviga
             if (isFocusableElementOrScopeOwner(element, event) && shadowAdjustedTabIndex(element, event) >= 0)
                 return &element;
         }
-    }
+    } else {
 
     if (Element* winner = findElementWithExactTabIndex(scope, startingNode, startingTabIndex, event, FocusDirection::Backward))
         return winner;
-
+    }
+    
     // There are no nodes before start with the same tabindex as start, so look for a node that:
     // 1) has the highest non-zero tabindex (that is less than start's tabindex), and
     // 2) comes last in the scope, if there's a tie.


### PR DESCRIPTION
<pre>
Disable the focus moves to an element which doesn't satisfy the spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=248903">https://bugs.webkit.org/show_bug.cgi?id=248903</a>

Reviewed by NOBODY (OOPS!).

This patch is to align Webkit behavior with Blink / Chromium, Gecko / Firefox and Web-Specification:

Web-Spec: <a href="https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation">https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation</a>

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=182040">https://src.chromium.org/viewvc/blink?view=revision&revision=182040</a>

This patch is to disallow behavior where if there are some elements that are set 
‘tabindex="negative integer" ', and then, when one of them is focused on, the next focus
moves to the others. It is not aligned with web-spec.

* Source/WebCore/page/FocusController.cpp:
(FocusController::nextFocusableElementOrScopeOwner): Add 'else if' condition around trying to find first tabindex and return it
(FocusController::previousFocusableElementOrScopeOwner): Add 'else if' condition to perform similar to above
* LayoutTests/fast/events/tabindex-no-focusable.html: Add Test Case
* LayoutTests/fast/events/tabindex-no-focusable-expected.txt: Add Test Case Expectation
* LayoutTests/fast/events/tabindex-no-focusable-all-negative.html: Add Test Case
* LayoutTests/fast/events/tabindex-no-focusable-all-negative-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ab0fb638efa4161f480a37b9a7d6e904ceafdcc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108603 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168855 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85741 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91714 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106539 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104971 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6777 "Found 1 new test failure: fast/events/tabindex-no-focusable.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90334 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33779 "Found 1 new test failure: fast/events/tabindex-no-focusable-all-negative.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88597 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21681 "Found 1 new test failure: fast/events/tabindex-no-focusable-all-negative.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76646 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2301 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23197 "Found 1 new test failure: fast/events/tabindex-no-focusable-all-negative.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2193 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45596 "Found 1 new test failure: fast/events/tabindex-no-focusable-all-negative.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7246 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42670 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3670 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->