### PR TITLE
WebGL drawing commands on non-default framebuffer are marked as visual in Inspector

### DIFF
--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -749,26 +749,6 @@ static bool shouldSnapshotBitmapRendererAction(const String& name)
     return name == "transferFromImageBitmap"_s;
 }
 
-#if ENABLE(WEBGL)
-static bool shouldSnapshotWebGLAction(const String& name)
-{
-    return name == "clear"_s
-        || name == "drawArrays"_s
-        || name == "drawElements"_s;
-}
-#endif
-
-#if ENABLE(WEBGL2)
-static bool shouldSnapshotWebGL2Action(const String& name)
-{
-    return name == "clear"_s
-        || name == "drawArrays"_s
-        || name == "drawArraysInstanced"_s
-        || name == "drawElements"_s
-        || name == "drawElementsInstanced"_s;
-}
-#endif
-
 void InspectorCanvas::recordAction(String&& name, InspectorCanvasCallTracer::ProcessedArguments&& arguments)
 {
     if (!m_initialState) {
@@ -803,14 +783,6 @@ void InspectorCanvas::recordAction(String&& name, InspectorCanvasCallTracer::Pro
 
     if (is<ImageBitmapRenderingContext>(context) && shouldSnapshotBitmapRendererAction(name))
         m_contentChanged = true;
-#if ENABLE(WEBGL)
-    else if (is<WebGLRenderingContext>(context) && shouldSnapshotWebGLAction(name))
-        m_contentChanged = true;
-#endif
-#if ENABLE(WEBGL2)
-    else if (is<WebGL2RenderingContext>(context) && shouldSnapshotWebGL2Action(name))
-        m_contentChanged = true;
-#endif
 
     m_lastRecordedAction = buildAction(WTFMove(name), WTFMove(arguments));
     m_bufferUsed += m_lastRecordedAction->memoryCost();

--- a/Source/WebInspectorUI/UserInterface/Models/RecordingAction.js
+++ b/Source/WebInspectorUI/UserInterface/Models/RecordingAction.js
@@ -713,18 +713,6 @@ WI.RecordingAction._visualNames = {
     [WI.Recording.Type.CanvasBitmapRenderer]: new Set([
         "transferFromImageBitmap",
     ]),
-    [WI.Recording.Type.CanvasWebGL]: new Set([
-        "clear",
-        "drawArrays",
-        "drawElements",
-    ]),
-    [WI.Recording.Type.CanvasWebGL2]: new Set([
-        "clear",
-        "drawArrays",
-        "drawArraysInstanced",
-        "drawElements",
-        "drawElementsInstanced",
-    ]),
 };
 
 WI.RecordingAction._stateModifiers = {


### PR DESCRIPTION
#### bbed1969fdc84cdd2c5fb449419317c04280a59f
<pre>
WebGL drawing commands on non-default framebuffer are marked as visual in Inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=248878">https://bugs.webkit.org/show_bug.cgi?id=248878</a>
rdar://problem/103074809

Reviewed by NOBODY (OOPS!).

Remove incomplete list of WebGL commands that are visual.
Instead, rely on the command to flip the m_contentChanged.

This reduces the amount of canvas contents being read, as the client framebuffer
operations do not cause canvas contents capture. This speeds up the frame capture
on sites that invoke such commands.

* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::recordAction):
(WebCore::shouldSnapshotWebGLAction): Deleted.
(WebCore::shouldSnapshotWebGL2Action): Deleted.
* Source/WebInspectorUI/UserInterface/Models/RecordingAction.js:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbed1969fdc84cdd2c5fb449419317c04280a59f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108559 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168803 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85709 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91672 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106491 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33760 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88573 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21657 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76631 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2259 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23175 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45585 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42650 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3604 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->