### PR TITLE
[WK2] Add test cases testing move occurrences during IPC decoding

### DIFF
--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -211,4 +211,205 @@ INSTANTIATE_TEST_SUITE_P(ArgumentCoderTest,
     testing::Values(EncodingCounterTestType::LValue, EncodingCounterTestType::RValue, EncodingCounterTestType::MovedRValue),
     TestParametersToStringFormatter());
 
+// DecodingMoveCounter is a move-only class whose move constructor and
+// move assignment operator increase the moved-in object's move counter.
+
+struct DecodingMoveCounter {
+    DecodingMoveCounter() = default;
+
+    DecodingMoveCounter(const DecodingMoveCounter&) = delete;
+    DecodingMoveCounter& operator=(const DecodingMoveCounter&) = delete;
+
+    DecodingMoveCounter(DecodingMoveCounter&& o)
+    {
+        moveCounter = o.moveCounter + 1;
+    }
+
+    DecodingMoveCounter& operator=(DecodingMoveCounter&& o)
+    {
+        moveCounter = o.moveCounter + 1;
+        return *this;
+    }
+
+    void encode(IPC::Encoder& encoder)
+    {
+        encoder << uint64_t(42);
+    }
+
+    static std::optional<DecodingMoveCounter> decode(IPC::Decoder& decoder)
+    {
+        auto value = decoder.decode<uint64_t>();
+        if (!value || *value != 42)
+            return std::nullopt;
+        return std::make_optional<DecodingMoveCounter>();
+    }
+
+    unsigned moveCounter { 0 };
+};
+
+struct DecodingMoveCounterTest {
+    static constexpr IPC::MessageName name()  { return static_cast<IPC::MessageName>(123); }
+};
+
+// ArgumentCoderDecodingMoveCounterTest internally constructs an Encoder object
+// into which each test can encode the desired objects. It then uses that Encoder's
+// internal buffer to create a Decoder object, intended for the test to decode those
+// objects and check the amount of exhibited moves.
+
+class ArgumentCoderDecodingMoveCounterTest : public ::testing::Test {
+public:
+    void SetUp() override
+    {
+        m_encoder = makeUnique<IPC::Encoder>(DecodingMoveCounterTest::name(), 0);
+    }
+
+    IPC::Encoder& encoder() const { return *m_encoder; }
+
+    std::unique_ptr<IPC::Decoder> createDecoder() const
+    {
+        return IPC::Decoder::create(m_encoder->buffer(), m_encoder->bufferSize(), { });
+    }
+
+private:
+    std::unique_ptr<IPC::Encoder> m_encoder;
+};
+
+TEST_F(ArgumentCoderDecodingMoveCounterTest, DecodeDirectly)
+{
+    encoder() << DecodingMoveCounter { };
+
+    auto decoder = createDecoder();
+    auto counter = DecodingMoveCounter::decode(*decoder);
+    ASSERT_TRUE(!!counter);
+    ASSERT_EQ(counter->moveCounter, 0u);
+}
+
+TEST_F(ArgumentCoderDecodingMoveCounterTest, DecodeValue)
+{
+    encoder() << DecodingMoveCounter { } << DecodingMoveCounter { };
+
+    auto decoder = createDecoder();
+    {
+        std::optional<DecodingMoveCounter> counter;
+        *decoder >> counter;
+        ASSERT_TRUE(!!counter);
+        ASSERT_EQ(counter->moveCounter, 1u);
+    }
+    {
+        auto counter = decoder->decode<DecodingMoveCounter>();
+        ASSERT_TRUE(!!counter);
+        ASSERT_EQ(counter->moveCounter, 0u);
+    }
+}
+
+TEST_F(ArgumentCoderDecodingMoveCounterTest, DecodeOptional)
+{
+    encoder() << std::make_optional<DecodingMoveCounter>();
+    encoder() << std::make_optional<DecodingMoveCounter>();
+
+    auto decoder = createDecoder();
+    {
+        std::optional<std::optional<DecodingMoveCounter>> optional;
+        *decoder >> optional;
+        ASSERT_TRUE(!!optional);
+
+        auto& counter = *optional;
+        ASSERT_TRUE(!!counter);
+        ASSERT_EQ(counter->moveCounter, 3u);
+    }
+    {
+        auto optional = decoder->decode<std::optional<DecodingMoveCounter>>();
+        ASSERT_TRUE(!!optional);
+
+        auto& counter = *optional;
+        ASSERT_TRUE(!!counter);
+        ASSERT_EQ(counter->moveCounter, 2u);
+    }
+}
+
+TEST_F(ArgumentCoderDecodingMoveCounterTest, DecodePair)
+{
+    encoder() << std::pair { uint64_t(0), DecodingMoveCounter { } };
+    encoder() << std::pair { uint64_t(0), DecodingMoveCounter { } };
+
+    auto decoder = createDecoder();
+    {
+        std::optional<std::pair<uint64_t, DecodingMoveCounter>> pair;
+        *decoder >> pair;
+        ASSERT_TRUE(!!pair);
+        ASSERT_EQ(pair->second.moveCounter, 4u);
+    }
+    {
+        auto pair = decoder->decode<std::pair<uint64_t, DecodingMoveCounter>>();
+        ASSERT_TRUE(!!pair);
+        ASSERT_EQ(pair->second.moveCounter, 3u);
+    }
+}
+
+TEST_F(ArgumentCoderDecodingMoveCounterTest, DecodeTuple)
+{
+    using TupleType = std::tuple<DecodingMoveCounter, uint64_t, DecodingMoveCounter>;
+    encoder() << TupleType { DecodingMoveCounter { }, 42, DecodingMoveCounter { } };
+    encoder() << TupleType { DecodingMoveCounter { }, 42, DecodingMoveCounter { } };
+
+    auto decoder = createDecoder();
+    {
+        std::optional<TupleType> tuple;
+        *decoder >> tuple;
+        ASSERT_TRUE(!!tuple);
+        ASSERT_EQ(std::get<0>(*tuple).moveCounter, 3u);
+        ASSERT_EQ(std::get<2>(*tuple).moveCounter, 3u);
+    }
+    {
+        auto tuple = decoder->decode<TupleType>();
+        ASSERT_TRUE(!!tuple);
+        ASSERT_EQ(std::get<0>(*tuple).moveCounter, 2u);
+        ASSERT_EQ(std::get<2>(*tuple).moveCounter, 2u);
+    }
+}
+
+TEST_F(ArgumentCoderDecodingMoveCounterTest, DecodeArray)
+{
+    encoder() << std::array<DecodingMoveCounter, 2> { DecodingMoveCounter { }, DecodingMoveCounter { } };
+    encoder() << std::array<DecodingMoveCounter, 2> { DecodingMoveCounter { }, DecodingMoveCounter { } };
+
+    auto decoder = createDecoder();
+    {
+        std::optional<std::array<DecodingMoveCounter, 2>> array;
+        *decoder >> array;
+        ASSERT_TRUE(!!array);
+        for (auto&& entry : *array)
+            ASSERT_EQ(entry.moveCounter, 3u);
+    }
+    {
+        auto array = decoder->decode<std::array<DecodingMoveCounter, 2>>();
+        ASSERT_TRUE(!!array);
+        for (auto&& entry : *array)
+            ASSERT_EQ(entry.moveCounter, 2u);
+    }
+}
+
+TEST_F(ArgumentCoderDecodingMoveCounterTest, DecodeVector)
+{
+    encoder() << Vector<DecodingMoveCounter>::from(DecodingMoveCounter { }, DecodingMoveCounter { });
+    encoder() << Vector<DecodingMoveCounter>::from(DecodingMoveCounter { }, DecodingMoveCounter { });
+
+    auto decoder = createDecoder();
+    {
+        std::optional<Vector<DecodingMoveCounter>> vector;
+        *decoder >> vector;
+        ASSERT_TRUE(!!vector);
+        ASSERT_EQ(vector->size(), 2u);
+        for (auto&& entry : *vector)
+            ASSERT_EQ(entry.moveCounter, 3u);
+    }
+    {
+        auto vector = decoder->decode<Vector<DecodingMoveCounter>>();
+        ASSERT_TRUE(!!vector);
+        ASSERT_EQ(vector->size(), 2u);
+        for (auto&& entry : *vector)
+            ASSERT_EQ(entry.moveCounter, 3u);
+    }
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 66ffe5bc6f05344ffb99942f90de5c275049c8cf
<pre>
[WK2] Add test cases testing move occurrences during IPC decoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=248887">https://bugs.webkit.org/show_bug.cgi?id=248887</a>

Reviewed by Kimmo Kinnunen.

Add test cases that check the amount of moves an object of a given type
goes through during IPC decoding.

The test cases use a move-only DecodingMoveCounter struct that increases
the move counter whenever constructed through a move operation. This is
used to assess the amount of moves a given object went through during
the IPC decoding process.

A fixture class is provided, internally establishing an IPC::Encoder
object into which the test case can encode the desired object. The
encoder&apos;s buffer is then used for the IPC::Decoder from which decoding
is then done. In each test, a certain amount of moves is expected and
appropriately validated.

The actual amount of moves depends on the way the decoding is done and
on any container or wrapping object used.

The test cases show that one move can be immediately avoided if the
IPC::Decoder::decode&lt;T&gt;() method is used instead of constructing an
empty std::optional&lt;T&gt; and using the stream extraction operator with
that optional object as the destination. Avoiding and replacing the use
of the stream extraction operator should be considered.

Testing the decoding of containers and wrapper objects also shows an
abundance of moves occurring for the wrapped object. I think probably
in all cases this could be reduced down to a single move of a
DecodingMoveCounter object.

* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::DecodingMoveCounter::DecodingMoveCounter):
(TestWebKitAPI::DecodingMoveCounter::operator=):
(TestWebKitAPI::DecodingMoveCounter::encode):
(TestWebKitAPI::DecodingMoveCounter::decode):
(TestWebKitAPI::DecodingMoveCounterTest::name):
(TestWebKitAPI::ArgumentCoderDecodingMoveCounterTest::encoder const):
(TestWebKitAPI::ArgumentCoderDecodingMoveCounterTest::createDecoder const):
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/257562@main">https://commits.webkit.org/257562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33e5bdc43f07ffef2f5ac8ac9511176a0f85f9e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108566 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168814 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85713 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91676 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106495 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33756 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88565 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76626 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2263 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23182 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45587 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5204 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42654 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3629 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->