### PR TITLE
Remove HTMLElement::form() and de-virtualize the method

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/compile-event-handler-lexical-scopes-form-owner-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/compile-event-handler-lexical-scopes-form-owner-expected.txt
@@ -1,0 +1,9 @@
+
+div
+x-foo
+
+PASS <input> has a form owner
+PASS <img> has a form owner
+PASS <div> doesn't have a form owner
+FAIL form-associated <x-foo> has a form owner assert_equals: expected (object) object "[object HTMLFormControlsCollection]" but got (string) "global_elements"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/compile-event-handler-lexical-scopes-form-owner.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/compile-event-handler-lexical-scopes-form-owner.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Form's lexical scope is established only for form-associated elements</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/forms.html#form-associated-element">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<form id="form">
+  <input onclick="window.inputOnClickElements = elements;">
+  <img onclick="window.imgOnClickElements = elements;" alt="img">
+  <div onclick="window.divOnClickElements = elements;">div</div>
+  <x-foo onclick="window.xFooOnClickElements = elements;">x-foo</x-foo>
+</form>
+
+<script>
+"use strict";
+
+window.elements = "global_elements";
+
+test(() => {
+  const input = form.querySelector("input");
+  input.click();
+  assert_equals(window.inputOnClickElements, form.elements);
+}, "<input> has a form owner");
+
+test(() => {
+  const img = form.querySelector("img");
+  img.click();
+  assert_equals(window.imgOnClickElements, form.elements);
+}, "<img> has a form owner");
+
+test(() => {
+  const div = form.querySelector("div");
+  div.click();
+  assert_equals(window.divOnClickElements, window.elements);
+}, "<div> doesn't have a form owner");
+
+test(() => {
+  customElements.define("x-foo", class extends HTMLElement {
+    static formAssociated = true;
+  });
+
+  const xFoo = form.querySelector("x-foo");
+  xFoo.click();
+  assert_equals(window.xFooOnClickElements, form.elements);
+}, "form-associated <x-foo> has a form owner");
+</script>

--- a/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
@@ -127,8 +127,10 @@ JSScope* JSHTMLElement::pushEventHandlerScope(JSGlobalObject* lexicalGlobalObjec
     scope = JSWithScope::create(vm, lexicalGlobalObject, scope, asObject(toJS(lexicalGlobalObject, globalObject(), element.document())));
 
     // The form is next, searched before the document, but after the element itself.
-    if (HTMLFormElement* form = element.form())
-        scope = JSWithScope::create(vm, lexicalGlobalObject, scope, asObject(toJS(lexicalGlobalObject, globalObject(), *form)));
+    if (auto* formAssociated = element.asFormAssociatedElement()) {
+        if (RefPtr form = formAssociated->form())
+            scope = JSWithScope::create(vm, lexicalGlobalObject, scope, asObject(toJS(lexicalGlobalObject, globalObject(), *form)));
+    }
 
     // The element is on top, searched first.
     return JSWithScope::create(vm, lexicalGlobalObject, scope, asObject(toJS(lexicalGlobalObject, globalObject(), element)));

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -757,11 +757,6 @@ bool HTMLElement::rendererIsEverNeeded()
     return StyledElement::rendererIsEverNeeded();
 }
 
-HTMLFormElement* HTMLElement::form() const
-{
-    return HTMLFormElement::findClosestFormAncestor(*this);
-}
-
 FormAssociatedElement* HTMLElement::asFormAssociatedElement()
 {
     return nullptr;

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -83,8 +83,6 @@ public:
 
     bool rendererIsEverNeeded() final;
 
-    WEBCORE_EXPORT virtual HTMLFormElement* form() const;
-
     WEBCORE_EXPORT const AtomString& dir() const;
     WEBCORE_EXPORT void setDir(const AtomString&);
 

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -623,8 +623,6 @@ void HTMLFormControlElement::dispatchBlurEvent(RefPtr<Element>&& newFocusedEleme
 
 #if ENABLE(AUTOCORRECT)
 
-// FIXME: We should look to share this code with class HTMLFormElement instead of duplicating the logic.
-
 bool HTMLFormControlElement::shouldAutocorrect() const
 {
     const AtomString& autocorrectValue = attributeWithoutSynchronization(autocorrectAttr);

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -48,8 +48,6 @@ class HTMLFormControlElement : public LabelableElement, public FormListedElement
 public:
     virtual ~HTMLFormControlElement();
 
-    HTMLFormElement* form() const final { return FormListedElement::form(); }
-
     WEBCORE_EXPORT String formEnctype() const;
     WEBCORE_EXPORT void setFormEnctype(const AtomString&);
     WEBCORE_EXPORT String formMethod() const;

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -518,22 +518,6 @@ void HTMLFormElement::resetListedFormControlElements()
         listedElement->reset();
 }
 
-#if ENABLE(AUTOCORRECT)
-
-// FIXME: We should look to share this code with class HTMLFormControlElement instead of duplicating the logic.
-
-bool HTMLFormElement::shouldAutocorrect() const
-{
-    const AtomString& autocorrectValue = attributeWithoutSynchronization(autocorrectAttr);
-    if (!autocorrectValue.isEmpty())
-        return !equalLettersIgnoringASCIICase(autocorrectValue, "off"_s);
-    if (RefPtr<HTMLFormElement> form = this->form())
-        return form->shouldAutocorrect();
-    return true;
-}
-
-#endif
-
 void HTMLFormElement::parseAttribute(const QualifiedName& name, const AtomString& value)
 {
     if (name == actionAttr) {
@@ -636,7 +620,7 @@ unsigned HTMLFormElement::formElementIndex(FormListedElement& listedElement)
             return i;
         if (!is<HTMLFormControlElement>(element) && !is<HTMLObjectElement>(element))
             continue;
-        if (element.form() != this)
+        if (element.asFormListedElement()->form() != this)
             continue;
         ++i;
     }
@@ -885,8 +869,8 @@ bool HTMLFormElement::reportValidity()
 #if ASSERT_ENABLED
 void HTMLFormElement::assertItemCanBeInPastNamesMap(FormAssociatedElement& item) const
 {
+    ASSERT(item.form() == this);
     HTMLElement& element = item.asHTMLElement();
-    ASSERT(element.form() == this);
 
     if (item.isFormListedElement()) {
         ASSERT(m_listedElements.find(&element) != notFound);

--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -64,10 +64,6 @@ public:
     WEBCORE_EXPORT void setAutocomplete(const AtomString&);
     WEBCORE_EXPORT const AtomString& autocomplete() const;
 
-#if ENABLE(AUTOCORRECT)
-    WEBCORE_EXPORT bool shouldAutocorrect() const final;
-#endif
-
     void registerFormListedElement(FormListedElement&);
     void unregisterFormListedElement(FormListedElement&);
 

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -173,7 +173,6 @@ protected:
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) override;
 
 private:
-    HTMLFormElement* form() const final { return FormAssociatedElement::form(); }
     void resetFormOwner() final;
     void refFormAssociatedElement() final { HTMLElement::ref(); }
     void derefFormAssociatedElement() final { HTMLElement::deref(); }

--- a/Source/WebCore/html/HTMLLabelElement.h
+++ b/Source/WebCore/html/HTMLLabelElement.h
@@ -34,7 +34,7 @@ public:
     static Ref<HTMLLabelElement> create(const QualifiedName&, Document&);
 
     WEBCORE_EXPORT RefPtr<LabelableElement> control() const;
-    WEBCORE_EXPORT HTMLFormElement* form() const final;
+    WEBCORE_EXPORT HTMLFormElement* form() const;
 
     bool willRespondToMouseClickEventsWithEditability(Editability) const final;
 

--- a/Source/WebCore/html/HTMLLegendElement.h
+++ b/Source/WebCore/html/HTMLLegendElement.h
@@ -33,7 +33,7 @@ class HTMLLegendElement final : public HTMLElement {
 public:
     static Ref<HTMLLegendElement> create(const QualifiedName&, Document&);
 
-    WEBCORE_EXPORT HTMLFormElement* form() const final;
+    WEBCORE_EXPORT HTMLFormElement* form() const;
 
 private:
     HTMLLegendElement(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -54,8 +54,6 @@ public:
     using HTMLPlugInImageElement::ref;
     using HTMLPlugInImageElement::deref;
 
-    HTMLFormElement* form() const final { return FormListedElement::form(); }
-
 private:
     HTMLObjectElement(const QualifiedName&, Document&, HTMLFormElement*);
     ~HTMLObjectElement();

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -42,7 +42,7 @@ public:
     WEBCORE_EXPORT String text() const;
     void setText(String&&);
 
-    WEBCORE_EXPORT HTMLFormElement* form() const final;
+    WEBCORE_EXPORT HTMLFormElement* form() const;
 
     WEBCORE_EXPORT int index() const;
 


### PR DESCRIPTION
#### 8bc1b9f068aa6256966efb5c40963ebd8009a87c
<pre>
Remove HTMLElement::form() and de-virtualize the method
<a href="https://bugs.webkit.org/show_bug.cgi?id=248880">https://bugs.webkit.org/show_bug.cgi?id=248880</a>

Reviewed by Ryosuke Niwa.

De-virtualization of form() speeds up HTMLFormControlElement,
removes method forwarding from form-associated elements, and
exposes 2 issues:

  1. HTMLFormElement::shouldAutocorrect() attempted to access
     form() on a &lt;form&gt; element, which doesn&apos;t make sense as
     nested forms are not allowed by HTML [1].

     Removed in favor of now identical HTMLElement::shouldAutocorrect(),
     resolving a few FIXMEs.

  2. Per spec [2], JSHTMLElement::pushEventHandlerScope() should
     set up HTMLFormElement&apos;s lexical scope only for form-associated
     elements rather than all &lt;form&gt; descendants.

     This speeds up inline event handler compilation / execution and
     aligns WebKit with Blink and partly Gecko.

[1] <a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">https://html.spec.whatwg.org/multipage/forms.html#the-form-element</a> (content model)
[2] <a href="https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler">https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler</a> (step 3.5)

* Source/WebCore/bindings/js/JSHTMLElementCustom.cpp:
(WebCore::JSHTMLElement::pushEventHandlerScope const):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::form const): Deleted.
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLFormControlElement.cpp:
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::formElementIndex):
(WebCore::HTMLFormElement::shouldAutocorrect const): Deleted.
* Source/WebCore/html/HTMLFormElement.h:
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLLabelElement.h:
* Source/WebCore/html/HTMLLegendElement.h:
* Source/WebCore/html/HTMLObjectElement.h:
* Source/WebCore/html/HTMLOptionElement.h:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/compile-event-handler-lexical-scopes-form-owner-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/compile-event-handler-lexical-scopes-form-owner.html

Canonical link: <a href="https://commits.webkit.org/258430@main">https://commits.webkit.org/258430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3aa49e1f8fcbdbea00c9efaa363024042e3e98b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111237 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171442 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1966 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94309 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108991 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/36994 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91079 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23895 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78753 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4635 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25374 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1812 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10800 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44862 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6474 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3040 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->