### PR TITLE
Add support for the Web Extension's Event API in the UIProcess.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h
@@ -29,6 +29,8 @@
 
 namespace WebKit {
 
+// If you are adding a new event, you will also need to increase 'currentBackgroundPageListenerStateVersion'
+// so that your new event gets fired to non-persistent background pages.
 enum class WebExtensionEventListenerType : uint8_t {
     Unknown = 0,
     ActionOnClicked,

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm
@@ -129,7 +129,7 @@ static constexpr NSString *identifierCodingKey = @"identifier";
 
 - (BOOL)isPersistent
 {
-    return _webExtensionControllerConfiguration->isPersistent();
+    return _webExtensionControllerConfiguration->storageIsPersistent();
 }
 
 #pragma mark WKObject protocol implementation

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
@@ -32,6 +32,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "WKWebViewInternal.h"
 #import "WebExtensionController.h"
 #import "_WKWebExtensionControllerDelegatePrivate.h"
 #import "_WKWebExtensionControllerInternal.h"
@@ -40,12 +41,14 @@ namespace WebKit {
 
 void WebExtensionContext::addListener(WebPageProxyIdentifier identifier, WebExtensionEventListenerType type)
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=248684.
+    if (!extension().backgroundContentIsPersistent() && m_backgroundWebView.get()._page->identifier() == identifier)
+        m_backgroundPageListeners.add(type);
 }
 
 void WebExtensionContext::removeListener(WebPageProxyIdentifier identifier, WebExtensionEventListenerType type)
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=248684
+    if (!extension().backgroundContentIsPersistent() && m_backgroundWebView.get()._page->identifier() == identifier)
+        m_backgroundPageListeners.remove(type);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -49,7 +49,7 @@ namespace WebKit {
 
 String WebExtensionController::storageDirectory(WebExtensionContext& extensionContext) const
 {
-    if (m_configuration->isPersistent() && extensionContext.isPersistent())
+    if (m_configuration->storageIsPersistent() && extensionContext.storageIsPersistent())
         return FileSystem::pathByAppendingComponent(m_configuration->storageDirectory(), extensionContext.uniqueIdentifier());
     return nullString();
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -129,7 +129,7 @@ public:
 
     NSError *createError(Error, NSString *customLocalizedDescription = nil, NSError *underlyingError = nil);
 
-    bool isPersistent() const { return hasCustomUniqueIdentifier(); }
+    bool storageIsPersistent() const { return hasCustomUniqueIdentifier(); }
 
     bool load(WebExtensionController&, String storageDirectory, NSError ** = nullptr);
     bool unload(NSError ** = nullptr);
@@ -243,6 +243,10 @@ private:
     void loadBackgroundWebView();
     void unloadBackgroundWebView();
 
+    uint64_t loadBackgroundPageListenersVersionNumberFromStorage();
+    void loadBackgroundPageListenersFromStorage();
+    void saveBackgroundPageListenersToStorage();
+
     void performTasksAfterBackgroundContentLoads();
 
     void addInjectedContent() { addInjectedContent(injectedContents()); }
@@ -304,6 +308,7 @@ private:
 #endif
 
     EventListenterTypeCountedSet m_backgroundPageListeners;
+    bool m_shouldFireStartupEvent { false };
 
     RetainPtr<WKWebView> m_backgroundWebView;
     RetainPtr<_WKWebExtensionContextDelegate> m_delegate;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -79,7 +79,7 @@ public:
     bool operator==(const WebExtensionController& other) const { return (this == &other); }
     bool operator!=(const WebExtensionController& other) const { return !(this == &other); }
 
-    bool isPersistent() const { return m_configuration->isPersistent(); }
+    bool storageIsPersistent() const { return m_configuration->storageIsPersistent(); }
     String storageDirectory(WebExtensionContext&) const;
 
     bool hasLoadedContexts() const { return !m_extensionContexts.isEmpty(); }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
@@ -45,7 +45,7 @@ Ref<WebExtensionControllerConfiguration> WebExtensionControllerConfiguration::co
 {
     if (m_identifier)
         return create(m_identifier.value());
-    if (isPersistent())
+    if (storageIsPersistent())
         return createDefault();
     return createNonPersistent();
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
@@ -52,7 +52,7 @@ public:
 
     std::optional<UUID> identifier() const { return m_identifier; }
 
-    bool isPersistent() const { return !m_storageDirectory.isEmpty(); }
+    bool storageIsPersistent() const { return !m_storageDirectory.isEmpty(); }
     String storageDirectory() const { return m_storageDirectory; }
 
     bool operator==(const WebExtensionControllerConfiguration&) const;


### PR DESCRIPTION
#### afed0b22500b9d8e73f1bc3bc28c381d2c95c956
<pre>
Add support for the Web Extension&apos;s Event API in the UIProcess.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248684.">https://bugs.webkit.org/show_bug.cgi?id=248684.</a>

Reviewed by Timothy Hatcher.

This patch adds support for the Event API in the UIProcess. This includes loading the background
page listeners from storage when the extension loads, and saving these listeners to storage
(for non-persistent background pages).

* Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h:

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm:
(-[_WKWebExtensionControllerConfiguration storageIsPersistent]):
Rename isPersistent() to storageIsPersistent() to make it clear that this function is for checking
to see if information relating to the extension is saved to storage and not for the extension
background page being persistent.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
(WebKit::WebExtensionContext::addListener):
(WebKit::WebExtensionContext::removeListener):

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load):
Add FIXME to check to see if extension is being loaded as part of startup.

(WebKit::WebExtensionContext::stateFilePath const):
(WebKit::WebExtensionContext::readStateFromStorage):
(WebKit::WebExtensionContext::writeStateToStorage const):
Use newly renamed storageIsPersistent().

(WebKit::WebExtensionContext::loadBackgroundWebViewDuringLoad):
Load background page listeners from storage.
Add FIXME to check to see if the extension is being loaded as part of startup.

(WebKit::WebExtensionContext::loadBackgroundPageListenersFromStorage):
Retrieve background page listeners data from storage. Populate m_backgroundPageListeners.

(WebKit::WebExtensionContext::saveBackgroundPageListenersToStorage):
Save background page listeners to storage for non persistent background pages.

(WebKit::WebExtensionContext::loadBackgroundPageListenersVersionNumberFromStorage):
(WebKit::WebExtensionContext::performTasksAfterBackgroundContentLoads):
Save background page listeners to storage.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::storageDirectory const):

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::storageIsPersistent const):
(WebKit::WebExtensionContext::isPersistent const): Deleted.

* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::storageIsPersistent const):
(WebKit::WebExtensionController::isPersistent const): Deleted.

* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp:
(WebKit::WebExtensionControllerConfiguration::copy const):
Use newly renamed storageIsPersistent().

* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h:
(WebKit::WebExtensionControllerConfiguration::storageIsPersistent const):
(WebKit::WebExtensionControllerConfiguration::isPersistent const): Deleted.

Canonical link: <a href="https://commits.webkit.org/257589@main">https://commits.webkit.org/257589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9890c2821a5d4e208ea523b36ed1936e8ca4a84

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99355 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108740 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85875 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106668 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105113 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33870 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2426 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23303 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2329 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [💥 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8490 "An unexpected error occured. Recent messages:Failed to print configuration") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42778 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2666 "Built successfully and passed tests") | [💥 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4197 "An unexpected error occured. Recent messages:Failed to print configuration") | | | 
<!--EWS-Status-Bubble-End-->