### PR TITLE
Add a macOS WK1 baseline for imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-nested-shadow-dom

### DIFF
--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-nested-shadow-dom-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-nested-shadow-dom-expected.txt
@@ -1,0 +1,17 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: expected Element node <div id="outer">
+      <slot></slot>
+    </div> but got null
+fullscreen
+
+Harness Error (FAIL), message = Unhandled rejection: assert_equals: expected Element node <div id="outer">
+      <slot></slot>
+    </div> but got null
+
+TIMEOUT Exiting fullscreen from a nested shadow root works correctly. Test timed out
+
+Harness Error (FAIL), message = Unhandled rejection: assert_equals: expected Element node <div id="outer">
+      <slot></slot>
+    </div> but got null
+
+TIMEOUT Exiting fullscreen from a nested shadow root works correctly. Test timed out
+


### PR DESCRIPTION
#### 1f9e72a2795b6147894e6a5f50bd38bc779060a7
<pre>
Add a macOS WK1 baseline for imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-nested-shadow-dom
<a href="https://bugs.webkit.org/show_bug.cgi?id=248900">https://bugs.webkit.org/show_bug.cgi?id=248900</a>

Unreviewed test gardening.

webkit.org/b/248879 tracks resolving the underlying issue.

* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-nested-shadow-dom-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/257506@main">https://commits.webkit.org/257506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35ffb4d57ee87edfca57cc56572f4e9bd689bb45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/99202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/8410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/32335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108595 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/8966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/104955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/8966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/32335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/91704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/8966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/32335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/32335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/2185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/7238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/32335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2625 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/3663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->