### PR TITLE
[JSC][armv7] Unskip most of newly-added v8/regress tests

### DIFF
--- a/JSTests/wasm.yaml
+++ b/JSTests/wasm.yaml
@@ -50,7 +50,7 @@
 - path: wasm/v8/
   cmd: runV8WebAssemblySuite(:no_module, "mjsunit.js") unless parseRunCommands
 - path: wasm/v8/regress/
-  cmd: if 'arm' == $architecture; skip; else runV8WebAssemblySuite(:no_module, "mjsunit.js") unless parseRunCommands; end
+  cmd: runV8WebAssemblySuite(:no_module, "mjsunit.js") unless parseRunCommands
 - path: wasm/branch-hints
   cmd: runWebAssemblySuite unless parseRunCommands
 

--- a/JSTests/wasm/v8/regress/regress-1045225.js
+++ b/JSTests/wasm/v8/regress/regress-1045225.js
@@ -1,3 +1,4 @@
+//@ skip if 'arm' == $architecture
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1045737.js
+++ b/JSTests/wasm/v8/regress/regress-1045737.js
@@ -1,3 +1,4 @@
+//@ skip if 'arm' == $architecture
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1048241.js
+++ b/JSTests/wasm/v8/regress/regress-1048241.js
@@ -1,3 +1,4 @@
+//@ skip if 'arm' == $architecture
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1074586.js
+++ b/JSTests/wasm/v8/regress/regress-1074586.js
@@ -1,3 +1,4 @@
+//@ skip if 'arm' == $architecture
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1080902.js
+++ b/JSTests/wasm/v8/regress/regress-1080902.js
@@ -1,3 +1,4 @@
+//@ skip if 'arm' == $architecture
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-10898.js
+++ b/JSTests/wasm/v8/regress/regress-10898.js
@@ -1,3 +1,4 @@
+//@ skip if 'arm' == $architecture
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1140549.js
+++ b/JSTests/wasm/v8/regress/regress-1140549.js
@@ -1,3 +1,4 @@
+//@ skip if 'arm' == $architecture
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1153442.js
+++ b/JSTests/wasm/v8/regress/regress-1153442.js
@@ -1,3 +1,4 @@
+//@ skip if 'arm' == $architecture
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1179025.js
+++ b/JSTests/wasm/v8/regress/regress-1179025.js
@@ -1,3 +1,4 @@
+//@ skip if 'arm' == $architecture
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1220855.js
+++ b/JSTests/wasm/v8/regress/regress-1220855.js
@@ -1,3 +1,4 @@
+//@ skip if 'arm' == $architecture
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-873600.js
+++ b/JSTests/wasm/v8/regress/regress-873600.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-9425.js
+++ b/JSTests/wasm/v8/regress/regress-9425.js
@@ -1,3 +1,4 @@
+//@ skip if 'arm' == $architecture
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.


### PR DESCRIPTION
#### a424a3666e9ffa84ccb087b7bfc677299aa0f236
<pre>
[JSC][armv7] Unskip most of newly-added v8/regress tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=248905">https://bugs.webkit.org/show_bug.cgi?id=248905</a>

Reviewed by Yusuke Suzuki.

Many of these tests do pass on 32-bit arm; we just need to skip a few that
require wasm shared memory or &gt;2GB allocations; so, do that and run the rest of
the suite as normal for now.

Of the unconditionally skipped tests in this directory, I suspect only
`JSTests/wasm/v8/regress/regress-crbug-816961.js` has the potential to be
problematic for the 32-bit port.

* JSTests/wasm.yaml:
* JSTests/wasm/v8/regress/regress-1045225.js:
* JSTests/wasm/v8/regress/regress-1045737.js:
* JSTests/wasm/v8/regress/regress-1048241.js:
* JSTests/wasm/v8/regress/regress-1074586.js:
* JSTests/wasm/v8/regress/regress-1080902.js:
* JSTests/wasm/v8/regress/regress-10898.js:
* JSTests/wasm/v8/regress/regress-1140549.js:
* JSTests/wasm/v8/regress/regress-1153442.js:
* JSTests/wasm/v8/regress/regress-1179025.js:
* JSTests/wasm/v8/regress/regress-1220855.js:
* JSTests/wasm/v8/regress/regress-873600.js:
* JSTests/wasm/v8/regress/regress-9425.js:

Canonical link: <a href="https://commits.webkit.org/257516@main">https://commits.webkit.org/257516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a63e7032c524151da76de98c8d5503cd33f4dd53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 🧪 win ](https://ews-build.webkit.org/#/builders/Windows-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-9-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2634 "Built successfully and passed tests") | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-9-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->