### PR TITLE
REGRESSION (256665@main): [ Ventura ] fast/images/avif-as-image.html is a consistent image failure

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2252,8 +2252,9 @@ fast/images/animated-webp.html [ Skip ]
 # These tests don't have to be platform-specific, but they are only implemented on Mac now.
 fast/images/eps-as-image.html [ Skip ]
 
-# libavif does not render resources/green-400x400.avif correctly.
+# libavif does not render resources/green-313x313.avif and resources/green-400x400.avif correctly.
 # See https://github.com/AOMediaCodec/av1-avif/issues/195
+fast/images/avif-as-image.html [ ImageOnlyFailure ]
 fast/images/avif-heif-container-as-image.html [ ImageOnlyFailure ]
 
 # Only applicable on platforms with JPEG XL support

--- a/LayoutTests/fast/images/avif-as-image-expected.html
+++ b/LayoutTests/fast/images/avif-as-image-expected.html
@@ -3,7 +3,7 @@
 div {
   width: 313px;
   height: 313px;
-  background-color: green;
+  background-color: lime;
 }
 </style>
 <body>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3787,7 +3787,6 @@ imported/w3c/web-platform-tests/css/selectors/selection-image-002.html [ ImageOn
 
 # AVIF tests
 webkit.org/b/247831 fast/images/avif-image-decoding.html [ Failure ]
-webkit.org/b/247831 fast/images/avif-as-image.html [ ImageOnlyFailure ]
 webkit.org/b/247831 fast/images/animated-avif.html [ Timeout ]
 
 # Screen Orientation API doesn't support nested frames yet

--- a/LayoutTests/platform/mac-ventura/TestExpectations
+++ b/LayoutTests/platform/mac-ventura/TestExpectations
@@ -1,3 +1,1 @@
 webkit.org/b/245686 [ Ventura+ ] fast/text/system-font-fallback.html [ ImageOnlyFailure ]
-
-webkit.org/b/248544 [ Ventura+ ] fast/images/avif-as-image.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -108,6 +108,7 @@ fast/images/heic-as-background-image.html [ Pass ]
 fast/images/mac/play-all-pause-all-animations-context-menu-items.html [ Skip ]
 
 # AVIF tests
+[ Ventura+ ] fast/images/avif-as-image.html [ Pass ]
 [ Ventura+ ] fast/images/avif-heif-container-as-image.html [ Pass ]
 
 # <rdar://problem/5647952> fast/events/mouseout-on-window.html needs mac DRT to issue mouse out events
@@ -2400,7 +2401,6 @@ svg/transforms/translation-tiny-element.svg [ ImageOnlyFailure ]
 [ Ventura+ x86_64 ] http/tests/media/now-playing-info.html [ Pass Failure ]
 [ BigSur+ x86_64 ] animations/stop-animation-on-suspend.html [ Pass Failure ]
 [ Ventura+ ] imported/w3c/web-platform-tests/mathml/relations/css-styling/display-2.html [ Failure ]
-[ Ventura+ ] fast/images/avif-as-image.html [ ImageOnlyFailure Crash ]
 [ BigSur+ ] fast/images/animated-avif.html [ Pass ImageOnlyFailure Timeout Crash ]
 [ Ventura+ ] animations/animation-events-not-cancelable.html [ Pass Failure ]
 [ Bigsur+ ] animations/remove-syncing-animation.html [ Pass Failure ]


### PR DESCRIPTION
#### c7d2aef57843b53db1ea43bda7654f22414f6ad6
<pre>
REGRESSION (256665@main): [ Ventura ] fast/images/avif-as-image.html is a consistent image failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=248544">https://bugs.webkit.org/show_bug.cgi?id=248544</a>
rdar://102823196

Reviewed by Simon Fraser.

libavif does not render fast/images/resources/green-313x313.avif and
fast/images/resources/green-400x400.avif correctly.

See <a href="https://github.com/AOMediaCodec/av1-avif/issues/195.">https://github.com/AOMediaCodec/av1-avif/issues/195.</a>

We need to fix the expectation file fast/images/avif-as-image-expected.html
with the correct rendering; i.e. the image should be lime not green. This will
require marking this test [ ImageOnlyFailure ] for non Apple ports and macOS
down-level ports.

* LayoutTests/TestExpectations:
* LayoutTests/fast/images/avif-as-image-expected.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-ventura/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/257738@main">https://commits.webkit.org/257738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a151bde3752da5d805d2fb0f455d99552efcc0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108735 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168986 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85869 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91841 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106663 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33867 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88710 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21775 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76741 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2421 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23292 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45694 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5318 "Failed to push commit to Webkit repository") | [💥 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8485 "An unexpected error occured. Recent messages:Failed to print configuration") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42767 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4191 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->