### PR TITLE
REGRESSION: File attachment icons appear upside down

### DIFF
--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -2369,8 +2369,14 @@ RetainPtr<NSImage> RenderThemeMac::iconForAttachment(const String& fileName, con
     if (fileName.isNull() && attachmentType.isNull() && title.isNull())
         return nil;
 
-    if (auto icon = WebCore::iconForAttachment(fileName, attachmentType, title))
-        return adoptNS([[NSImage alloc] initWithCGImage:icon->image()->platformImage().get() size:NSZeroSize]);
+    if (auto icon = WebCore::iconForAttachment(fileName, attachmentType, title)) {
+        auto imageForIcon = adoptNS([[NSImage alloc] initWithCGImage:icon->image()->platformImage().get() size:NSZeroSize]);
+        // Need this because WebCore uses AppKit's flipped coordinate system exclusively.
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        [imageForIcon setFlipped:YES];
+        ALLOW_DEPRECATED_DECLARATIONS_END
+        return imageForIcon;
+    }
 
     return nil;
 }


### PR DESCRIPTION
#### 5f18c2a38b4330fc150979b68b1f94a6f72d1110
<pre>
REGRESSION: File attachment icons appear upside down
<a href="https://bugs.webkit.org/show_bug.cgi?id=248910">https://bugs.webkit.org/show_bug.cgi?id=248910</a>
rdar://103089779

Reviewed by Simon Fraser.

Prior to <a href="https://github.com/WebKit/WebKit/pull/4954">https://github.com/WebKit/WebKit/pull/4954</a>, attachment icons on macOS
were flipped in `IconMac` to preserve the correct orientation, however this
change removed that behavior in its refactoring.

This PR fixes this by adding back the flipping behavior where its needed
for attachemnts, which is in `RenderThemeMac::iconForAttachment`.

* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::iconForAttachment):

Canonical link: <a href="https://commits.webkit.org/257524@main">https://commits.webkit.org/257524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ddb3ca882521abef347ab3b046afe6c4dec4232

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108614 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85750 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106548 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104981 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/91723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2310 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2203 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5171 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/7260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/42676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3679 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->