### PR TITLE
Represent ImageOnlyFailures with a separate icon when looking at results on the databases

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js
@@ -29,6 +29,7 @@ class Expectations
             success: computedStyle.getPropertyValue('--greenLight').trim(),
             warning: computedStyle.getPropertyValue('--orangeDark').trim(),
             failed: computedStyle.getPropertyValue('--redLight').trim(),
+            image: computedStyle.getPropertyValue('--blueLight').trim(),
             timedout: computedStyle.getPropertyValue('--orangeLight').trim(),
             crashed: computedStyle.getPropertyValue('--purpleLight').trim(),
         };
@@ -88,10 +89,11 @@ Expectations.stateToIdMap = {
     WARNING: 0x38,
     PASS: 0x40,
 };
-Expectations.failureTypes = ['warning', 'failed', 'timedout', 'crashed'];
+Expectations.failureTypes = ['warning', 'failed', 'image', 'timedout', 'crashed'];
 Expectations.failureTypeMap = {
     warning: 'WARNING',
     failed: 'ERROR',
+    image: 'ERROR',
     timedout: 'TIMEOUT',
     crashed: 'CRASH',
 }
@@ -104,6 +106,7 @@ Expectations.symbolMap = {
     success: '✓',
     warning: '?',
     failed: '𝖷',
+    image: 'I',
     timedout: timeoutImage,
     crashed: '!',
 }

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
@@ -1061,6 +1061,10 @@ function Legend(callback=null, plural=false, defaultWillFilterExpected=false, fl
             expected: plural ? 'Some tests unexpectedly failed' : 'Unexpectedly failed',
             unexpected: plural ? 'Some tests failed' : 'Test failed',
         },
+        image: {
+            expected: plural ? 'Some tests unexpectedly image failed' : 'Unexpectedly image failed',
+            unexpected: plural ? 'Some tests image failed' : 'Test image failed',
+        },
         timedout: {
             expected: plural ? 'Some tests unexpectedly timed out' : 'Unexpectedly timed out',
             unexpected: plural ? 'Some tests timed out' : 'Test timed out',

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/css/webkit.css
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/css/webkit.css
@@ -28,7 +28,7 @@ Copyright (C) 2019 Apple Inc. All rights reserved.
   --blueDarker: #0262ca;
   --blueDark: #066ee0;
   --blue: #0070c9;
-  --blueLight: #3b99fc;
+  --blueLight: #36C5F0;
   --blueLighter: #9dccfe;
   --blueLightest: #f5f9fe;
   --greenDarker: #43c359;


### PR DESCRIPTION
#### c46ef76f2def121dc6357786c87bd57fbef8dceb
<pre>
Represent ImageOnlyFailures with a separate icon when looking at results on the databases
<a href="https://bugs.webkit.org/show_bug.cgi?id=248911">https://bugs.webkit.org/show_bug.cgi?id=248911</a>
rdar://102920285

Reviewed by NOBODY (OOPS!).

It would be easier if ImageOnlyFailures were marked with a different
icon from text failures. The changes in this commit are to effectivly
mark ImageOnlyFailures with a blue I instead of a red X. And the colour
blue has been specifically chosen as one that is colour blind friendly.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js:
(Expectations.colorMap):
(Expectations.unexpectedResults):
(Expectations):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/css/webkit.css:
(:root):
</pre>