### PR TITLE
Disable Experimental features in Lockdown Mode

### DIFF
--- a/Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb
+++ b/Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "Settings.h"
 
+#include "DeprecatedGlobalSettings.h"
 #include "InspectorInstrumentation.h"
 #include "Page.h"
 
@@ -146,6 +147,68 @@ Settings::Values Settings::Values::isolatedCopy() const
 
 Settings::~Settings()
 {
+}
+
+void Settings::disableUnstableFeaturesForModernWebKit()
+{
+<%- for @setting in @unstableSettings do -%>
+<%-   if @setting.condition -%>
+#if <%= @setting.condition %>
+<%-   end -%>
+<%-   if @setting.defaultValuesForModernWebKit.size() == 1 -%>
+    <%= @setting.setterFunctionName %>(false);
+<%-   else -%>
+<%-     @setting.defaultValuesForModernWebKit.each_with_index do |(key, value), index| -%>
+<%-       if index == 0 -%>
+#if <%= key %>
+<%-       elsif index != @setting.defaultValuesForModernWebKit.size() - 1 -%>
+#elif <%= key %>
+<%-       else -%>
+#else
+<%-       end -%>
+<%-       if value -%>
+    // Feature is stable on this platform. No need to disable.
+<%-       else -%>
+    <%= @setting.setterFunctionName %>(false);
+<%-       end -%>
+<%-     end -%>
+#endif
+<%-   end -%>
+<%-   if @setting.condition -%>
+#endif
+<%-   end -%>
+<%- end -%>
+}
+
+void Settings::disableGlobalUnstableFeaturesForModernWebKit()
+{
+<%- for @setting in @unstableGlobalSettings do -%>
+<%-   if @setting.condition -%>
+#if <%= @setting.condition %>
+<%-   end -%>
+<%-   if @setting.defaultValuesForModernWebKit.size() == 1 -%>
+    <%= @setting.options["webcoreBinding"] %>::<%= @setting.setterFunctionName %>(false);
+<%-   else -%>
+<%-     @setting.defaultValuesForModernWebKit.each_with_index do |(key, value), index| -%>
+<%-       if index == 0 -%>
+#if <%= key %>
+<%-       elsif index != @setting.defaultValuesForModernWebKit.size() - 1 -%>
+#elif <%= key %>
+<%-       else -%>
+#else
+<%-       end -%>
+<%-       if key != "ENABLE(EXPERIMENTAL_FEATURES)" && value -%>
+    // Feature is stable on this platform. No need to disable.
+<%-       else -%>
+    <%= @setting.options["webcoreBinding"] %>::<%= @setting.setterFunctionName %>(false);
+<%-       end -%>
+<%-     end -%>
+#endif
+<%-   end -%>
+<%-   if @setting.condition -%>
+#endif
+<%-   end -%>
+<%- end -%>
 }
 
 <%- for @condition in @allSettingsSet.conditions do -%>

--- a/Source/WebCore/Scripts/SettingsTemplates/Settings.h.erb
+++ b/Source/WebCore/Scripts/SettingsTemplates/Settings.h.erb
@@ -40,6 +40,9 @@ public:
     WEBCORE_EXPORT static Ref<Settings> create(Page*);
     WEBCORE_EXPORT virtual ~Settings();
 
+    WEBCORE_EXPORT void disableUnstableFeaturesForModernWebKit();
+    WEBCORE_EXPORT static void disableGlobalUnstableFeaturesForModernWebKit();
+
 <%- for @condition in @allSettingsSet.conditions do -%>
 <%- if @condition.condition -%>
 #if <%= @condition.condition %>

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4135,6 +4135,10 @@ bool WebPage::isParentProcessAWebBrowser() const
 
 static void adjustSettingsForLockdownMode(Settings& settings, const WebPreferencesStore& store)
 {
+    // Disable unstable Experimental settings, even if the user enabled them for local use.
+    settings.disableUnstableFeaturesForModernWebKit();
+    Settings::disableGlobalUnstableFeaturesForModernWebKit();
+
     settings.setWebGLEnabled(false);
 #if ENABLE(WEBGL2)
     settings.setWebGL2Enabled(false);


### PR DESCRIPTION
#### 01a79e657788f8f5f9c29648b0c07d428ec55379
<pre>
Disable Experimental features in Lockdown Mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=248915">https://bugs.webkit.org/show_bug.cgi?id=248915</a>
&lt;rdar://101969455&gt;

Reviewed by Chris Dumez.

Ensure that experimental features (which are generally off by default) are truly off in Lockdown Mode.
This is meant to protect users that might have an experimental feature on for development work,
who would not want that feature active for Lockdown Mode.

* Source/WebCore/Scripts/GenerateSettings.rb: Add new generators to set turn off all unstable features.
* Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb: Ditto.
* Source/WebCore/Scripts/SettingsTemplates/Settings.h.erb: Ditto.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::adjustSettingsForLockdownMode): Ensure that all unstable features are off.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm: Add tests.

Canonical link: <a href="https://commits.webkit.org/257758@main">https://commits.webkit.org/257758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0856fefa3d7836cd6322b900225b7e2aa25ee499

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109246 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169485 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86358 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92345 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107153 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7477 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34237 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22181 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2870 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23693 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46068 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5325 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43166 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->