### PR TITLE
Remove uses of Options::useWebAssemblySIMD.

### DIFF
--- a/JSTests/wasm/stress/simd-const-spill.js
+++ b/JSTests/wasm/stress/simd-const-spill.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64" && $architecture != "x86_64"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const.js
+++ b/JSTests/wasm/stress/simd-const.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64" && $architecture != "x86_64"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-kitchen-sink.js
+++ b/JSTests/wasm/stress/simd-kitchen-sink.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-load.js
+++ b/JSTests/wasm/stress/simd-load.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64" && $architecture != "x86_64"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-register-allocation.js
+++ b/JSTests/wasm/stress/simd-register-allocation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64" && $architecture != "x86_64"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-return-value-alignment.js
+++ b/JSTests/wasm/stress/simd-return-value-alignment.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64" && $architecture != "x86_64"
 
 /*

--- a/JSTests/wasm/v8/exceptions-simd.js
+++ b/JSTests/wasm/v8/exceptions-simd.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/liftoff-simd-params.js
+++ b/JSTests/wasm/v8/liftoff-simd-params.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/multi-value-simd.js
+++ b/JSTests/wasm/v8/multi-value-simd.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-10309.js
+++ b/JSTests/wasm/v8/regress/regress-10309.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1054466.js
+++ b/JSTests/wasm/v8/regress/regress-1054466.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1065599.js
+++ b/JSTests/wasm/v8/regress/regress-1065599.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1070078.js
+++ b/JSTests/wasm/v8/regress/regress-1070078.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1081030.js
+++ b/JSTests/wasm/v8/regress/regress-1081030.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-10831.js
+++ b/JSTests/wasm/v8/regress/regress-10831.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1111522.js
+++ b/JSTests/wasm/v8/regress/regress-1111522.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1112124.js
+++ b/JSTests/wasm/v8/regress/regress-1112124.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1116019.js
+++ b/JSTests/wasm/v8/regress/regress-1116019.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1124885.js
+++ b/JSTests/wasm/v8/regress/regress-1124885.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1132461.js
+++ b/JSTests/wasm/v8/regress/regress-1132461.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1161555.js
+++ b/JSTests/wasm/v8/regress/regress-1161555.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1161654.js
+++ b/JSTests/wasm/v8/regress/regress-1161654.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1161954.js
+++ b/JSTests/wasm/v8/regress/regress-1161954.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1165966.js
+++ b/JSTests/wasm/v8/regress/regress-1165966.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1179182.js
+++ b/JSTests/wasm/v8/regress/regress-1179182.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1187831.js
+++ b/JSTests/wasm/v8/regress/regress-1187831.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1188975.js
+++ b/JSTests/wasm/v8/regress/regress-1188975.js
@@ -1,6 +1,6 @@
 //@ skip
 //@ skip if $architecture != "arm64"
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1199662.js
+++ b/JSTests/wasm/v8/regress/regress-1199662.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1231950.js
+++ b/JSTests/wasm/v8/regress/regress-1231950.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1242300.js
+++ b/JSTests/wasm/v8/regress/regress-1242300.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1242689.js
+++ b/JSTests/wasm/v8/regress/regress-1242689.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1264462.js
+++ b/JSTests/wasm/v8/regress/regress-1264462.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1271244.js
+++ b/JSTests/wasm/v8/regress/regress-1271244.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1271456.js
+++ b/JSTests/wasm/v8/regress/regress-1271456.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1271538.js
+++ b/JSTests/wasm/v8/regress/regress-1271538.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1282224.js
+++ b/JSTests/wasm/v8/regress/regress-1282224.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1283042.js
+++ b/JSTests/wasm/v8/regress/regress-1283042.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1283395.js
+++ b/JSTests/wasm/v8/regress/regress-1283395.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1284980.js
+++ b/JSTests/wasm/v8/regress/regress-1284980.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1286253.js
+++ b/JSTests/wasm/v8/regress/regress-1286253.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1289678.js
+++ b/JSTests/wasm/v8/regress/regress-1289678.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1290079.js
+++ b/JSTests/wasm/v8/regress/regress-1290079.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-9447.js
+++ b/JSTests/wasm/v8/regress/regress-9447.js
@@ -1,5 +1,5 @@
 //@ skip if $architecture != "arm64"
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-crbug-1338980.js
+++ b/JSTests/wasm/v8/regress/regress-crbug-1338980.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-crbug-1355070.js
+++ b/JSTests/wasm/v8/regress/regress-crbug-1355070.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-crbug-1356718.js
+++ b/JSTests/wasm/v8/regress/regress-crbug-1356718.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/simd-call.js
+++ b/JSTests/wasm/v8/simd-call.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/simd-errors.js
+++ b/JSTests/wasm/v8/simd-errors.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/simd-globals.js
+++ b/JSTests/wasm/v8/simd-globals.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/simd-i64x2-mul.js
+++ b/JSTests/wasm/v8/simd-i64x2-mul.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp
@@ -73,7 +73,7 @@ void PatchpointSpecial::forEachArg(Inst& inst, const ScopedLambda<Inst::EachArgC
     for (unsigned i = patchpoint->numGPScratchRegisters; i--;)
         callback(inst.args[argIndex++], Arg::Scratch, GP, conservativeWidth(GP));
     for (unsigned i = patchpoint->numFPScratchRegisters; i--;)
-        callback(inst.args[argIndex++], Arg::Scratch, FP, Options::useWebAssemblySIMD() ? conservativeWidth(FP) : conservativeWidthWithoutVectors(FP));
+        callback(inst.args[argIndex++], Arg::Scratch, FP, procedure.usesSIMD() ? conservativeWidth(FP) : conservativeWidthWithoutVectors(FP));
 }
 
 bool PatchpointSpecial::isValid(Inst& inst)

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -282,6 +282,13 @@ public:
     bool shouldDumpIR() const { return m_shouldDumpIR; }
     void setShouldDumpIR();
 
+    void setUsessSIMD()
+    { 
+        RELEASE_ASSERT(Options::useWebAssemblySIMD());
+        m_usesSIMD = true;
+    }
+    bool usesSIMD() const { return m_usesSIMD; }
+
 private:
     friend class BlockInsertionSet;
 
@@ -310,6 +317,7 @@ private:
     bool m_hasQuirks { false };
     bool m_needsPCToOriginMap { false };
     bool m_shouldDumpIR { false };
+    bool m_usesSIMD { false };
 };
     
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3ValueRep.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueRep.cpp
@@ -33,7 +33,7 @@
 
 namespace JSC { namespace B3 {
 
-void ValueRep::addUsedRegistersTo(RegisterSetBuilder& set) const
+void ValueRep::addUsedRegistersTo(bool isSIMDContext, RegisterSetBuilder& set) const
 {
     switch (m_kind) {
     case WarmAny:
@@ -47,7 +47,7 @@ void ValueRep::addUsedRegistersTo(RegisterSetBuilder& set) const
         return;
     case LateRegister:
     case Register:
-        set.add(reg(), Options::useWebAssemblySIMD() ? conservativeWidth(reg()) : conservativeWidthWithoutVectors(reg()));
+        set.add(reg(), isSIMDContext ? conservativeWidth(reg()) : conservativeWidthWithoutVectors(reg()));
         return;
     case Stack:
     case StackArgument:
@@ -58,10 +58,10 @@ void ValueRep::addUsedRegistersTo(RegisterSetBuilder& set) const
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-RegisterSetBuilder ValueRep::usedRegisters() const
+RegisterSetBuilder ValueRep::usedRegisters(bool isSIMDContext) const
 {
     RegisterSetBuilder result;
-    addUsedRegistersTo(result);
+    addUsedRegistersTo(isSIMDContext, result);
     return result;
 }
 

--- a/Source/JavaScriptCore/b3/B3ValueRep.h
+++ b/Source/JavaScriptCore/b3/B3ValueRep.h
@@ -284,17 +284,17 @@ public:
         }
     }
 
-    void addUsedRegistersTo(RegisterSetBuilder&) const;
+    void addUsedRegistersTo(bool isSIMDContext, RegisterSetBuilder&) const;
     
-    RegisterSetBuilder usedRegisters() const;
+    RegisterSetBuilder usedRegisters(bool isSIMDContext) const;
 
     // Get the used registers for a vector of ValueReps.
     template<typename VectorType>
-    static RegisterSetBuilder usedRegisters(const VectorType& vector)
+    static RegisterSetBuilder usedRegisters(bool isSIMDContext, const VectorType& vector)
     {
         RegisterSetBuilder result;
         for (const ValueRep& value : vector)
-            value.addUsedRegistersTo(result);
+            value.addUsedRegistersTo(isSIMDContext, result);
         return result;
     }
 

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
@@ -177,7 +177,7 @@ ALWAYS_INLINE void GenerateAndAllocateRegisters::flush(Tmp tmp, Reg reg)
     JIT_COMMENT(*m_jit, "Flush(", tmp, ", ", reg, ", offset=", offset, ")");
     if (tmp.isGP())
         m_jit->store64(reg.gpr(), callFrameAddr(*m_jit, offset));
-    else if (B3::conservativeRegisterBytes(B3::FP) == sizeof(double) || !Options::useWebAssemblySIMD()) {
+    else if (B3::conservativeRegisterBytes(B3::FP) == sizeof(double) || !m_code.usesSIMD()) {
         ASSERT(m_map[tmp].spillSlot->byteSize() == bytesForWidth(Width64));
         m_jit->storeDouble(reg.fpr(), callFrameAddr(*m_jit, offset));
     } else {
@@ -213,7 +213,7 @@ ALWAYS_INLINE void GenerateAndAllocateRegisters::alloc(Tmp tmp, Reg reg, Arg::Ro
         intptr_t offset = m_map[tmp].spillSlot->offsetFromFP();
         if (tmp.bank() == GP)
             m_jit->load64(callFrameAddr(*m_jit, offset), reg.gpr());
-        else if (B3::conservativeRegisterBytes(B3::FP) == sizeof(double) || !Options::useWebAssemblySIMD()) {
+        else if (B3::conservativeRegisterBytes(B3::FP) == sizeof(double) || !m_code.usesSIMD()) {
             ASSERT(m_map[tmp].spillSlot->byteSize() == bytesForWidth(Width64));
             m_jit->loadDouble(callFrameAddr(*m_jit, offset), reg.fpr());
         } else {
@@ -375,7 +375,7 @@ void GenerateAndAllocateRegisters::prepareForGeneration()
                 }
 
                 unsigned slotSize = conservativeRegisterBytes(tmp.bank());
-                if (!Options::useWebAssemblySIMD())
+                if (!m_code.usesSIMD())
                     slotSize = conservativeRegisterBytesWithoutVectors(tmp.bank());
 
                 if (freeSlots.size() && freeSlots.last()->byteSize() >= slotSize)
@@ -429,7 +429,7 @@ void GenerateAndAllocateRegisters::prepareForGeneration()
             m_allowedRegisters.add(reg, IgnoreVectors);
             TmpData& data = m_map[Tmp(reg)];
             unsigned slotSize = conservativeRegisterBytes(bank);
-            if (!Options::useWebAssemblySIMD())
+            if (!m_code.usesSIMD())
                 slotSize = conservativeRegisterBytesWithoutVectors(bank);
             data.spillSlot = m_code.addStackSlot(slotSize, StackSlotKind::Spill);
             dataLogLnIf(GenerateAndAllocateRegistersInternal::verbose, "allowedRegisters: reg: ", reg, " -> slot ", data.spillSlot);
@@ -716,7 +716,7 @@ void GenerateAndAllocateRegisters::generate(CCallHelpers& jit)
                 auto& entry = m_map[tmp];
                 if (!entry.reg) {
                     // We're a cold use, and our current location is already on the stack. Just use that.
-                    ASSERT(entry.spillSlot->byteSize() <= bytesForWidth(Width64) || Options::useWebAssemblySIMD());
+                    ASSERT(entry.spillSlot->byteSize() <= bytesForWidth(Width64) || m_code.usesSIMD());
                     arg = Arg::addr(Tmp(GPRInfo::callFrameRegister), entry.spillSlot->offsetFromFP());
                 }
             });
@@ -828,7 +828,7 @@ void GenerateAndAllocateRegisters::generate(CCallHelpers& jit)
                 RegisterSetBuilder registerSetBuilder;
                 for (size_t i = 0; i < currentAllocation.size(); ++i) {
                     if (currentAllocation[i])
-                        registerSetBuilder.add(Reg::fromIndex(i), Options::useWebAssemblySIMD() ? conservativeWidth(Reg::fromIndex(i)) : conservativeWidthWithoutVectors(Reg::fromIndex(i)));
+                        registerSetBuilder.add(Reg::fromIndex(i), m_code.usesSIMD() ? conservativeWidth(Reg::fromIndex(i)) : conservativeWidthWithoutVectors(Reg::fromIndex(i)));
                 }
                 inst.reportUsedRegisters(registerSetBuilder);
             }

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp
@@ -542,7 +542,7 @@ private:
     {
         TmpData& entry = m_map[tmp];
         RELEASE_ASSERT(!entry.isUnspillable);
-        entry.spilled = m_code.addStackSlot(Options::useWebAssemblySIMD() ? conservativeRegisterBytes(tmp.bank()) : conservativeRegisterBytesWithoutVectors(tmp.bank()), StackSlotKind::Spill);
+        entry.spilled = m_code.addStackSlot(m_code.usesSIMD() ? conservativeRegisterBytes(tmp.bank()) : conservativeRegisterBytesWithoutVectors(tmp.bank()), StackSlotKind::Spill);
         entry.assigned = Reg();
         m_didSpill = true;
     }
@@ -578,7 +578,7 @@ private:
                         StackSlot* spilled = m_map[tmp].spilled;
                         if (!spilled)
                             return;
-                        Opcode move = bank == GP ? Move : (Options::useWebAssemblySIMD() ? MoveVector : MoveDouble);
+                        Opcode move = bank == GP ? Move : (m_code.usesSIMD() ? MoveVector : MoveDouble);
                         tmp = addSpillTmpWithInterval(bank, intervalForSpill(indexOfEarly, role));
                         if (role == Arg::Scratch)
                             return;
@@ -621,7 +621,7 @@ private:
             }
             
             entry.spillIndex = m_usedSpillSlots.findBit(0, false);
-            size_t slotSize = Options::useWebAssemblySIMD() ? conservativeRegisterBytes(FP) : conservativeRegisterBytesWithoutVectors(FP);
+            size_t slotSize = m_code.usesSIMD() ? conservativeRegisterBytes(FP) : conservativeRegisterBytesWithoutVectors(FP);
             ASSERT(entry.spilled->byteSize() <= slotSize);
             ptrdiff_t offset = -static_cast<ptrdiff_t>(m_code.frameSize()) - static_cast<ptrdiff_t>(entry.spillIndex) * slotSize - slotSize;
             if (verbose())

--- a/Source/JavaScriptCore/b3/air/AirCCallSpecial.h
+++ b/Source/JavaScriptCore/b3/air/AirCCallSpecial.h
@@ -44,7 +44,7 @@ namespace JSC { namespace B3 { namespace Air {
 
 class CCallSpecial final : public Special {
 public:
-    CCallSpecial();
+    CCallSpecial(bool isSIMDContext);
     ~CCallSpecial() final;
 
     // You cannot use this register to pass arguments. It just so happens that this register is not
@@ -77,6 +77,7 @@ private:
         numSpecialArgs + numCalleeArgs + numReturnGPArgs + numReturnFPArgs;
     
     RegisterSetBuilder m_clobberedRegs;
+    bool m_isSIMDContext { false };
 };
 
 } } } // namespace JSC::B3::Air

--- a/Source/JavaScriptCore/b3/air/AirCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCode.cpp
@@ -180,7 +180,7 @@ CCallSpecial* Code::cCallSpecial()
 {
     if (!m_cCallSpecial) {
         m_cCallSpecial = static_cast<CCallSpecial*>(
-            addSpecial(makeUnique<CCallSpecial>()));
+            addSpecial(makeUnique<CCallSpecial>(usesSIMD())));
     }
 
     return m_cCallSpecial;
@@ -325,6 +325,11 @@ unsigned Code::jsHash() const
 void Code::setNumEntrypoints(unsigned numEntryPoints)
 {
     m_prologueGenerators = { numEntryPoints, m_defaultPrologueGenerator.copyRef() };
+}
+
+bool Code::usesSIMD() const
+{
+    return m_proc.usesSIMD();
 }
 
 } } } // namespace JSC::B3::Air

--- a/Source/JavaScriptCore/b3/air/AirCode.h
+++ b/Source/JavaScriptCore/b3/air/AirCode.h
@@ -344,6 +344,8 @@ public:
     bool shouldPreserveB3Origins() const { return m_preserveB3Origins; }
     void forcePreservationOfB3Origins() { m_preserveB3Origins = true; }
 
+    bool usesSIMD() const;
+
     void setDisassembler(std::unique_ptr<Disassembler>&& disassembler)
     {
         m_disassembler = WTFMove(disassembler);

--- a/Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp
+++ b/Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp
@@ -309,7 +309,7 @@ Vector<Inst> emitShuffle(
         return moveFor(bank, width);
     };
 
-    Opcode conservativeMove = moveForWidth(Options::useWebAssemblySIMD() ? conservativeWidth(bank) : conservativeWidthWithoutVectors(bank));
+    Opcode conservativeMove = moveForWidth(code.usesSIMD() ? conservativeWidth(bank) : conservativeWidthWithoutVectors(bank));
 
     // We will emit things in reverse. We maintain a list of packs of instructions, and then we emit
     // append them together in reverse (for example the thing at the end of resultPacks is placed

--- a/Source/JavaScriptCore/b3/air/AirLowerAfterRegAlloc.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerAfterRegAlloc.cpp
@@ -135,7 +135,7 @@ void lowerAfterRegAlloc(Code& code)
             if (!found) {
                 StackSlot*& slot = slots[bank][i];
                 if (!slot)
-                    slot = code.addStackSlot(Options::useWebAssemblySIMD() ? conservativeRegisterBytes(bank) : conservativeRegisterBytesWithoutVectors(bank), StackSlotKind::Spill);
+                    slot = code.addStackSlot(code.usesSIMD() ? conservativeRegisterBytes(bank) : conservativeRegisterBytesWithoutVectors(bank), StackSlotKind::Spill);
                 result[i] = Arg::stack(slots[bank][i]);
             }
         }

--- a/Source/JavaScriptCore/b3/air/AirRegLiveness.cpp
+++ b/Source/JavaScriptCore/b3/air/AirRegLiveness.cpp
@@ -167,7 +167,7 @@ RegLiveness::LocalCalcForUnifiedTmpLiveness::LocalCalcForUnifiedTmpLiveness(Unif
 {
     for (Tmp tmp : liveness.liveAtTail(block)) {
         if (tmp.isReg())
-            m_workset.add(tmp.reg(), Options::useWebAssemblySIMD() ? conservativeWidth(tmp.reg()) : conservativeWidthWithoutVectors(tmp.reg()));
+            m_workset.add(tmp.reg(), m_code.usesSIMD() ? conservativeWidth(tmp.reg()) : conservativeWidthWithoutVectors(tmp.reg()));
     }
 }
 
@@ -181,7 +181,7 @@ void RegLiveness::LocalCalcForUnifiedTmpLiveness::execute(unsigned instIndex)
     for (unsigned index : m_actions[instIndex].use) {
         Tmp tmp = Tmp::tmpForLinearIndex(m_code, index);
         if (tmp.isReg())
-            m_workset.add(tmp.reg(), Options::useWebAssemblySIMD() ? conservativeWidth(tmp.reg()) : conservativeWidthWithoutVectors(tmp.reg()));
+            m_workset.add(tmp.reg(), m_code.usesSIMD() ? conservativeWidth(tmp.reg()) : conservativeWidthWithoutVectors(tmp.reg()));
     }
 }
 

--- a/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
+++ b/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
@@ -68,7 +68,7 @@ void TmpWidth::recompute(Code& code)
     
     auto assumeTheWorst = [&] (Tmp tmp) {
         if (bank == Arg(tmp).bank()) {
-            Width conservative = Options::useWebAssemblySIMD() ? conservativeWidth(bank) : conservativeWidthWithoutVectors(bank);
+            Width conservative = code.usesSIMD() ? conservativeWidth(bank) : conservativeWidthWithoutVectors(bank);
             addWidths(tmp, { conservative, conservative });
         }
     };
@@ -129,7 +129,7 @@ void TmpWidth::recompute(Code& code)
                     if (Arg::isZDef(role))
                         tmpWidths.def = std::max(tmpWidths.def, width);
                     else if (Arg::isAnyDef(role))
-                        tmpWidths.def = Options::useWebAssemblySIMD() ? conservativeWidth(tmpBank) : conservativeWidthWithoutVectors(tmpBank);
+                        tmpWidths.def = code.usesSIMD() ? conservativeWidth(tmpBank) : conservativeWidthWithoutVectors(tmpBank);
                 });
         }
     }

--- a/Source/JavaScriptCore/ftl/FTLJITCode.cpp
+++ b/Source/JavaScriptCore/ftl/FTLJITCode.cpp
@@ -158,7 +158,7 @@ RegisterSetBuilder JITCode::liveRegistersToPreserveAtExceptionHandlingCallSite(C
         if (exit.m_exceptionHandlerCallSiteIndex.bits() == callSiteIndex.bits()) {
             RELEASE_ASSERT(exit.isExceptionHandler());
             RELEASE_ASSERT(exit.isGenericUnwindHandler());
-            return ValueRep::usedRegisters(exit.m_valueReps);
+            return ValueRep::usedRegisters(/* isSIMDContext = */ false, exit.m_valueReps);
         }
     }
     return { };

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -661,12 +661,14 @@ void Options::notifyOptionsChanged()
 
         // FIXME: This should be removed when we add LLint/OMG support for WASM SIMD
         if (Options::useWebAssemblySIMD()) {
-            Options::useBBQJIT() = true;
-            Options::useOMGJIT() = false;
-            Options::webAssemblyBBQAirModeThreshold() = 0;
-            Options::wasmBBQUsesAir() = true;
-            Options::useWasmLLInt() = true;
-            Options::wasmLLIntTiersUpToBBQ() = true;
+            bool isValid = true;
+            isValid &= Options::useBBQJIT();
+            isValid &= !Options::webAssemblyBBQAirModeThreshold();
+            isValid &= Options::wasmBBQUsesAir();
+            isValid &= Options::useWasmLLInt();
+            isValid &= Options::wasmLLIntTiersUpToBBQ();
+            if (!isValid)
+                Options::useWebAssemblySIMD() = false;
         }
     }
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -558,7 +558,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useWebAssemblyThreading, true, Normal, "Allow instructions from the wasm threading spec.") \
     v(Bool, useWebAssemblyTypedFunctionReferences, false, Normal, "Allow function types from the wasm typed function references spec.") \
     v(Bool, useWebAssemblyGC, false, Normal, "Allow gc types from the wasm gc proposal.") \
-    v(Bool, useWebAssemblySIMD, false, Normal, "Allow the new simd instructions and types from the wasm simd spec.") \
+    v(Bool, useWebAssemblySIMD, isARM64(), Normal, "Allow the new simd instructions and types from the wasm simd spec.") \
 
 
 enum OptionEquivalence {

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -2695,8 +2695,9 @@ void B3IRGenerator::emitEntryTierUpCheck()
             ScratchRegisterAllocator::restoreRegistersFromStackForCall(jit, registersToSpill, { }, numberOfStackBytesUsedForRegisterPreservation, extraPaddingBytes);
             jit.jump(tierUpResume);
 
+            bool isSIMD = m_proc.usesSIMD();
             jit.addLinkTask([=] (LinkBuffer& linkBuffer) {
-                MacroAssembler::repatchNearCall(linkBuffer.locationOfNearCall<NoPtrTag>(call), CodeLocationLabel<JITThunkPtrTag>(Thunks::singleton().stub(triggerOMGEntryTierUpThunkGenerator).code()));
+                MacroAssembler::repatchNearCall(linkBuffer.locationOfNearCall<NoPtrTag>(call), CodeLocationLabel<JITThunkPtrTag>(Thunks::singleton().stub(triggerOMGEntryTierUpThunkGenerator(isSIMD)).code()));
             });
         });
     });
@@ -3574,6 +3575,10 @@ Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileB3(Compilatio
     Procedure& procedure = *compilationContext.procedure;
     if (shouldDumpIRFor(functionIndex + info.importFunctionCount()))
         procedure.setShouldDumpIR();
+
+    bool usesSIMD = info.isSIMDFunction(functionIndex);
+    if (usesSIMD)
+        procedure.setUsessSIMD();
 
 
     if (Options::useSamplingProfiler()) {

--- a/Source/JavaScriptCore/wasm/WasmThunks.h
+++ b/Source/JavaScriptCore/wasm/WasmThunks.h
@@ -32,13 +32,21 @@
 
 namespace JSC { namespace Wasm {
 
+typedef MacroAssemblerCodeRef<JITThunkPtrTag> (*ThunkGenerator)(const AbstractLocker&);
+
 MacroAssemblerCodeRef<JITThunkPtrTag> throwExceptionFromWasmThunkGenerator(const AbstractLocker&);
 MacroAssemblerCodeRef<JITThunkPtrTag> throwStackOverflowFromWasmThunkGenerator(const AbstractLocker&);
 #if ENABLE(WEBASSEMBLY_B3JIT)
-MacroAssemblerCodeRef<JITThunkPtrTag> triggerOMGEntryTierUpThunkGenerator(const AbstractLocker&);
+MacroAssemblerCodeRef<JITThunkPtrTag> triggerOMGEntryTierUpThunkGeneratorImpl(const AbstractLocker&, bool isSIMDContext);
+MacroAssemblerCodeRef<JITThunkPtrTag> triggerOMGEntryTierUpThunkGeneratorSIMD(const AbstractLocker&);
+MacroAssemblerCodeRef<JITThunkPtrTag> triggerOMGEntryTierUpThunkGeneratorNoSIMD(const AbstractLocker&);
+constexpr ThunkGenerator triggerOMGEntryTierUpThunkGenerator(bool isSIMDContext)
+{
+    if (isSIMDContext)
+        return triggerOMGEntryTierUpThunkGeneratorSIMD;
+    return triggerOMGEntryTierUpThunkGeneratorNoSIMD;
+}
 #endif
-
-typedef MacroAssemblerCodeRef<JITThunkPtrTag> (*ThunkGenerator)(const AbstractLocker&);
 
 class Thunks {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -1946,7 +1946,7 @@ end
 
 def runWebAssemblySIMDSpecTest(mode)
     return if !$isSIMDPlatform
-    runWebAssemblySpecTestBase(mode, "simd-spec-harness", "--useWebAssemblySIMD=true")
+    runWebAssemblySpecTestBase(mode, "simd-spec-harness", "--useWebAssemblySIMD=true", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 end
 
 def runWebAssemblyLowExecutableMemory(*optionalTestSpecificOptions)


### PR DESCRIPTION
#### 4ce45cf323661a55744011f98077db15d65380fb
<pre>
Remove uses of Options::useWebAssemblySIMD.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248917">https://bugs.webkit.org/show_bug.cgi?id=248917</a>

Reviewed by Yusuke Suzuki.

This patch removes useWebAssemblySIMD everywhere except for when we are
parsing WASM functions.

Using vectors throughout our code causes a 7% JS2 regression, so we need
to gate conservative vector behaviour behind a flag. Previously, this was
the global feature flag. Now, we check per-function if SIMD instructions
are used.

We also enable the B3 JIT, since SIMD functions already should not be
tiering up.

A subsequent patch should hopefully turn on this option by default without
regressing non-simd code. In preparation for that, we also ensure that we
are not reducing test coverage by enabling SIMD.

* JSTests/wasm/stress/simd-const-spill.js:
* JSTests/wasm/stress/simd-const.js:
* JSTests/wasm/stress/simd-kitchen-sink.js:
* JSTests/wasm/stress/simd-load.js:
* JSTests/wasm/stress/simd-register-allocation.js:
* JSTests/wasm/stress/simd-return-value-alignment.js:
* JSTests/wasm/v8/exceptions-simd.js:
* JSTests/wasm/v8/liftoff-simd-params.js:
* JSTests/wasm/v8/multi-value-simd.js:
* JSTests/wasm/v8/regress/regress-10309.js:
* JSTests/wasm/v8/regress/regress-1054466.js:
* JSTests/wasm/v8/regress/regress-1065599.js:
* JSTests/wasm/v8/regress/regress-1070078.js:
* JSTests/wasm/v8/regress/regress-1081030.js:
* JSTests/wasm/v8/regress/regress-10831.js:
* JSTests/wasm/v8/regress/regress-1111522.js:
* JSTests/wasm/v8/regress/regress-1112124.js:
* JSTests/wasm/v8/regress/regress-1116019.js:
* JSTests/wasm/v8/regress/regress-1124885.js:
* JSTests/wasm/v8/regress/regress-1132461.js:
* JSTests/wasm/v8/regress/regress-1161555.js:
* JSTests/wasm/v8/regress/regress-1161654.js:
* JSTests/wasm/v8/regress/regress-1161954.js:
* JSTests/wasm/v8/regress/regress-1165966.js:
* JSTests/wasm/v8/regress/regress-1179182.js:
* JSTests/wasm/v8/regress/regress-1187831.js:
* JSTests/wasm/v8/regress/regress-1188975.js:
* JSTests/wasm/v8/regress/regress-1199662.js:
* JSTests/wasm/v8/regress/regress-1231950.js:
* JSTests/wasm/v8/regress/regress-1242300.js:
* JSTests/wasm/v8/regress/regress-1242689.js:
* JSTests/wasm/v8/regress/regress-1264462.js:
* JSTests/wasm/v8/regress/regress-1271244.js:
* JSTests/wasm/v8/regress/regress-1271456.js:
* JSTests/wasm/v8/regress/regress-1271538.js:
* JSTests/wasm/v8/regress/regress-1282224.js:
* JSTests/wasm/v8/regress/regress-1283042.js:
* JSTests/wasm/v8/regress/regress-1283395.js:
* JSTests/wasm/v8/regress/regress-1284980.js:
* JSTests/wasm/v8/regress/regress-1286253.js:
* JSTests/wasm/v8/regress/regress-1289678.js:
* JSTests/wasm/v8/regress/regress-1290079.js:
* JSTests/wasm/v8/regress/regress-9447.js:
* JSTests/wasm/v8/regress/regress-crbug-1338980.js:
* JSTests/wasm/v8/regress/regress-crbug-1355070.js:
* JSTests/wasm/v8/regress/regress-crbug-1356718.js:
* JSTests/wasm/v8/simd-call.js:
* JSTests/wasm/v8/simd-errors.js:
* JSTests/wasm/v8/simd-globals.js:
* JSTests/wasm/v8/simd-i64x2-mul.js:
* Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp:
(JSC::B3::PatchpointSpecial::forEachArg):
* Source/JavaScriptCore/b3/B3Procedure.h:
(JSC::B3::Procedure::setIsSIMD):
(JSC::B3::Procedure::isSIMD const):
* Source/JavaScriptCore/b3/B3ValueRep.cpp:
(JSC::B3::ValueRep::addUsedRegistersTo const):
(JSC::B3::ValueRep::usedRegisters const):
* Source/JavaScriptCore/b3/B3ValueRep.h:
(JSC::B3::ValueRep::usedRegisters):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
(JSC::B3::Air::GenerateAndAllocateRegisters::flush):
(JSC::B3::Air::GenerateAndAllocateRegisters::alloc):
(JSC::B3::Air::GenerateAndAllocateRegisters::prepareForGeneration):
(JSC::B3::Air::GenerateAndAllocateRegisters::generate):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp:
* Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp:
(JSC::B3::Air::CCallSpecial::CCallSpecial):
(JSC::B3::Air::CCallSpecial::forEachArg):
* Source/JavaScriptCore/b3/air/AirCCallSpecial.h:
* Source/JavaScriptCore/b3/air/AirCode.cpp:
(JSC::B3::Air::Code::cCallSpecial):
(JSC::B3::Air::Code::isSIMD const):
* Source/JavaScriptCore/b3/air/AirCode.h:
* Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp:
(JSC::B3::Air::emitShuffle):
* Source/JavaScriptCore/b3/air/AirLowerAfterRegAlloc.cpp:
(JSC::B3::Air::lowerAfterRegAlloc):
* Source/JavaScriptCore/b3/air/AirRegLiveness.cpp:
(JSC::B3::Air::RegLiveness::LocalCalcForUnifiedTmpLiveness::LocalCalcForUnifiedTmpLiveness):
(JSC::B3::Air::RegLiveness::LocalCalcForUnifiedTmpLiveness::execute):
* Source/JavaScriptCore/b3/air/AirTmpWidth.cpp:
(JSC::B3::Air::TmpWidth::recompute):
* Source/JavaScriptCore/ftl/FTLJITCode.cpp:
(JSC::FTL::JITCode::liveRegistersToPreserveAtExceptionHandlingCallSite):
* Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp:
(JSC::ScratchRegisterAllocator::allocateScratch):
(JSC::ScratchRegisterAllocator::preserveReusedRegistersByPushing):
(JSC::ScratchRegisterAllocator::restoreReusedRegistersByPopping):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::emitEntryTierUpCheck):
(JSC::Wasm::AirIRGenerator::emitCatchImpl):
(JSC::Wasm::AirIRGenerator::addThrow):
(JSC::Wasm::AirIRGenerator::addRethrow):
(JSC::Wasm::AirIRGenerator::emitCallPatchpoint):
(JSC::Wasm::parseAndCompileAir):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::emitEntryTierUpCheck):
(JSC::Wasm::parseAndCompileB3):
* Source/JavaScriptCore/wasm/WasmThunks.cpp:
(JSC::Wasm::triggerOMGEntryTierUpThunkGeneratorImpl):
(JSC::Wasm::triggerOMGEntryTierUpThunkGeneratorSIMD):
(JSC::Wasm::triggerOMGEntryTierUpThunkGeneratorNoSIMD):
(JSC::Wasm::triggerOMGEntryTierUpThunkGenerator): Deleted.
* Source/JavaScriptCore/wasm/WasmThunks.h:
(JSC::Wasm::triggerOMGEntryTierUpThunkGenerator):
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/257632@main">https://commits.webkit.org/257632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be687a6ba7d1df705822b3fbaf0a87b662292ca2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108713 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85846 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91818 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106640 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105086 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6875 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/metadata/generated/css-font-face.https.sub.tentative.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33852 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88694 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21760 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76724 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90036 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2403 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23282 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85865 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45680 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28876 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5250 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42756 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88732 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4037 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19844 "Passed tests") | 
<!--EWS-Status-Bubble-End-->