### PR TITLE
[Curl] Add missing error domain check to ResourceErrorCurl.

### DIFF
--- a/Source/WebCore/platform/network/curl/ResourceError.h
+++ b/Source/WebCore/platform/network/curl/ResourceError.h
@@ -31,8 +31,6 @@
 namespace WebCore {
 
 class ResourceError : public ResourceErrorBase {
-    friend class ResourceErrorBase;
-
 public:
     ResourceError(Type type = Type::Null)
         : ResourceErrorBase(type)
@@ -46,15 +44,14 @@ public:
 
     WEBCORE_EXPORT static ResourceError httpError(int errorCode, const URL& failingURL, Type = Type::General);
 
-    bool isSSLConnectError() const;
     WEBCORE_EXPORT bool isSSLCertVerificationError() const;
 
     static bool platformCompare(const ResourceError& a, const ResourceError& b);
 
 private:
-    void doPlatformIsolatedCopy(const ResourceError&);
+    friend class ResourceErrorBase;
 
-    static ASCIILiteral curlErrorDomain;
+    void doPlatformIsolatedCopy(const ResourceError&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/curl/ResourceErrorCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceErrorCurl.cpp
@@ -32,21 +32,20 @@
 
 namespace WebCore {
 
-ASCIILiteral ResourceError::curlErrorDomain = "CurlErrorDomain"_s;
+static const String& curlErrorDomain()
+{
+    static NeverDestroyed<const String> errorDomain(MAKE_STATIC_STRING_IMPL("CurlErrorDomain"));
+    return errorDomain;
+}
 
 ResourceError ResourceError::httpError(int errorCode, const URL& failingURL, Type type)
 {
-    return ResourceError(curlErrorDomain, errorCode, failingURL, CurlHandle::errorDescription(static_cast<CURLcode>(errorCode)), type);
-}
-
-bool ResourceError::isSSLConnectError() const
-{
-    return errorCode() == CURLE_SSL_CONNECT_ERROR;
+    return ResourceError(curlErrorDomain(), errorCode, failingURL, CurlHandle::errorDescription(static_cast<CURLcode>(errorCode)), type);
 }
 
 bool ResourceError::isSSLCertVerificationError() const
 {
-    return errorCode() == CURLE_PEER_FAILED_VERIFICATION;
+    return domain() == curlErrorDomain() && errorCode() == CURLE_PEER_FAILED_VERIFICATION;
 }
 
 void ResourceError::doPlatformIsolatedCopy(const ResourceError&)


### PR DESCRIPTION
#### 9c89d71e14887e19ecccb5b7a3c38566e21c14cd
<pre>
[Curl] Add missing error domain check to ResourceErrorCurl.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248920">https://bugs.webkit.org/show_bug.cgi?id=248920</a>

Reviewed by Fujii Hironori.

Add missing error domain check to ResourceError::isSSLCertVerificationError.
Also, we delete ResourceError::isSSLConnectError as it is not used.

* Source/WebCore/platform/network/curl/ResourceError.h:
* Source/WebCore/platform/network/curl/ResourceErrorCurl.cpp:
(WebCore::curlErrorDomain):
(WebCore::ResourceError::httpError):
(WebCore::ResourceError::isSSLCertVerificationError const):
(WebCore::ResourceError::isSSLConnectError const): Deleted.

Canonical link: <a href="https://commits.webkit.org/257546@main">https://commits.webkit.org/257546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/822a0d0c3fa00afca7820b0b590dd48d8233d0f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108638 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168886 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103250 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85772 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91747 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106570 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33802 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21704 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2332 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23220 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2228 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5188 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7557 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42694 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->