### PR TITLE
[UI-side compositing] Keyboard scrolling Amazon.com crashes Safari

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -140,8 +140,13 @@ enum class KeyboardScrollAction : uint8_t {
 };
 
 struct RequestedKeyboardScrollData {
-    KeyboardScrollAction action;
+    KeyboardScrollAction action { KeyboardScrollAction::StartAnimation };
     std::optional<KeyboardScroll> keyboardScroll;
+
+    bool operator==(const RequestedKeyboardScrollData& other) const
+    {
+        return action == other.action && keyboardScroll == other.keyboardScroll;
+    }
 };
 
 enum class ScrollUpdateType : uint8_t {
@@ -191,6 +196,15 @@ template<> struct EnumTraits<WebCore::ScrollingNodeType> {
         WebCore::ScrollingNodeType::Fixed,
         WebCore::ScrollingNodeType::Sticky,
         WebCore::ScrollingNodeType::Positioned
+    >;
+};
+
+template<> struct EnumTraits<WebCore::KeyboardScrollAction> {
+    using values = EnumValues<
+        WebCore::KeyboardScrollAction,
+        WebCore::KeyboardScrollAction::StartAnimation,
+        WebCore::KeyboardScrollAction::StopWithAnimation,
+        WebCore::KeyboardScrollAction::StopImmediately
     >;
 };
 

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
@@ -201,9 +201,9 @@ void ScrollingStateScrollingNode::setSynchronousScrollingReasons(OptionSet<Synch
 #endif
 
 
-void ScrollingStateScrollingNode::setKeyboardScrollData(RequestedKeyboardScrollData&& scrollData)
+void ScrollingStateScrollingNode::setKeyboardScrollData(const RequestedKeyboardScrollData& scrollData)
 {
-    m_keyboardScrollData = WTFMove(scrollData);
+    m_keyboardScrollData = scrollData;
     setPropertyChanged(Property::KeyboardScrollData);
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
@@ -76,7 +76,7 @@ public:
 #endif
 
     const RequestedKeyboardScrollData& keyboardScrollData() const { return m_keyboardScrollData; }
-    WEBCORE_EXPORT void setKeyboardScrollData(RequestedKeyboardScrollData&&);
+    WEBCORE_EXPORT void setKeyboardScrollData(const RequestedKeyboardScrollData&);
 
     const RequestedScrollData& requestedScrollData() const { return m_requestedScrollData; }
     WEBCORE_EXPORT void setRequestedScrollData(const RequestedScrollData&);

--- a/Source/WebCore/platform/KeyboardScroll.h
+++ b/Source/WebCore/platform/KeyboardScroll.h
@@ -37,8 +37,17 @@ struct KeyboardScroll {
     FloatSize maximumVelocity; // Points per second.
     FloatSize force;
 
-    ScrollGranularity granularity;
-    ScrollDirection direction;
+    ScrollGranularity granularity { ScrollGranularity::Line };
+    ScrollDirection direction { ScrollDirection::ScrollUp };
+
+    bool operator==(const KeyboardScroll& other) const
+    {
+        return offset == other.offset
+            && maximumVelocity == other.maximumVelocity
+            && force == other.force
+            && granularity == other.granularity
+            && direction == other.direction;
+    }
 };
 
 struct KeyboardScrollParameters {

--- a/Source/WebCore/platform/ScrollTypes.cpp
+++ b/Source/WebCore/platform/ScrollTypes.cpp
@@ -107,4 +107,42 @@ TextStream& operator<<(TextStream& ts, OverflowAnchor behavior)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, ScrollDirection direction)
+{
+    switch (direction) {
+    case ScrollDirection::ScrollUp:
+        ts << "up";
+        break;
+    case ScrollDirection::ScrollDown:
+        ts << "down";
+        break;
+    case ScrollDirection::ScrollLeft:
+        ts << "left";
+        break;
+    case ScrollDirection::ScrollRight:
+        ts << "right";
+        break;
+    }
+    return ts;
+}
+
+TextStream& operator<<(TextStream& ts, ScrollGranularity granularity)
+{
+    switch (granularity) {
+    case ScrollGranularity::Line:
+        ts << "line";
+        break;
+    case ScrollGranularity::Page:
+        ts << "page";
+        break;
+    case ScrollGranularity::Document:
+        ts << "document";
+        break;
+    case ScrollGranularity::Pixel:
+        ts << "pixel";
+        break;
+    }
+    return ts;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -347,6 +347,8 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollBehaviorForFi
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollElasticity);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollbarMode);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, OverflowAnchor);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollDirection);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollGranularity);
 
 struct ScrollPositionChangeOptions {
     ScrollType type;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -107,7 +107,6 @@ template<> struct ArgumentCoder<SnapOffset<float>> {
     static WARN_UNUSED_RETURN bool decode(Decoder&, SnapOffset<float>&);
 };
 
-
 } // namespace IPC
 
 namespace WTF {
@@ -219,6 +218,7 @@ void ArgumentCoder<ScrollingStateScrollingNode>::encode(Encoder& encoder, const 
     SCROLLING_NODE_ENCODE(ScrollingStateNode::Property::ScrollableAreaParams, scrollableAreaParameters)
     // UI-side compositing can't do synchronous scrolling so don't encode synchronousScrollingReasons.
     SCROLLING_NODE_ENCODE(ScrollingStateNode::Property::RequestedScrollPosition, requestedScrollData)
+    SCROLLING_NODE_ENCODE(ScrollingStateNode::Property::KeyboardScrollData, keyboardScrollData)
 
     if (node.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
         encoder << static_cast<GraphicsLayer::PlatformLayerID>(node.scrollContainerLayer());
@@ -313,6 +313,7 @@ bool ArgumentCoder<ScrollingStateScrollingNode>::decode(Decoder& decoder, Scroll
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::CurrentVerticalSnapOffsetIndex, std::optional<unsigned>, setCurrentVerticalSnapPointIndex);
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::ScrollableAreaParams, ScrollableAreaParameters, setScrollableAreaParameters);
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::RequestedScrollPosition, RequestedScrollData, setRequestedScrollData);
+    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::KeyboardScrollData, RequestedKeyboardScrollData, setKeyboardScrollData);
 
     if (node.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
         GraphicsLayer::PlatformLayerID layerID;
@@ -556,7 +557,6 @@ bool ArgumentCoder<SnapOffset<float>>::decode(Decoder& decoder, SnapOffset<float
     return true;
 }
 
-
 void ArgumentCoder<FloatScrollSnapOffsetsInfo>::encode(Encoder& encoder, const FloatScrollSnapOffsetsInfo& info)
 {
     encoder << info.horizontalSnapOffsets;
@@ -757,6 +757,22 @@ static void dump(TextStream& ts, const ScrollingStateScrollingNode& node, bool c
         ts.dumpProperty("vertical snap offsets", node.snapOffsetsInfo().verticalSnapOffsets);
         ts.dumpProperty("current horizontal snap point index", node.currentHorizontalSnapPointIndex());
         ts.dumpProperty("current vertical snap point index", node.currentVerticalSnapPointIndex());
+    }
+
+    if (!changedPropertiesOnly || node.hasChangedProperty(ScrollingStateNode::Property::KeyboardScrollData)) {
+        const auto& keyboardScrollData = node.keyboardScrollData();
+        if (keyboardScrollData.action == KeyboardScrollAction::StartAnimation && keyboardScrollData.keyboardScroll) {
+            ts.dumpProperty("keyboard-scroll-data-action", "start animation");
+
+            ts.dumpProperty("keyboard-scroll-data-scroll-offset", keyboardScrollData.keyboardScroll->offset);
+            ts.dumpProperty("keyboard-scroll-data-scroll-maximum-velocity", keyboardScrollData.keyboardScroll->maximumVelocity);
+            ts.dumpProperty("keyboard-scroll-data-scroll-force", keyboardScrollData.keyboardScroll->force);
+            ts.dumpProperty("keyboard-scroll-data-scroll-granularity", keyboardScrollData.keyboardScroll->granularity);
+            ts.dumpProperty("keyboard-scroll-data-scroll-direction", keyboardScrollData.keyboardScroll->direction);
+        } else if (keyboardScrollData.action == KeyboardScrollAction::StopWithAnimation)
+            ts.dumpProperty("keyboard-scroll-data-action", "stop with animation");
+        else if (keyboardScrollData.action == KeyboardScrollAction::StopImmediately)
+            ts.dumpProperty("keyboard-scroll-data-action", "stop immediately");
     }
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1768,10 +1768,25 @@ header: <WebCore/ScrollingCoordinatorTypes.h>
     bool useDarkAppearanceForScrollbars;
 };
 
+header: <WebCore/ScrollingCoordinatorTypes.h>
+[CustomHeader] struct WebCore::RequestedKeyboardScrollData {
+    WebCore::KeyboardScrollAction action;
+    std::optional<WebCore::KeyboardScroll> keyboardScroll;
+};
+
 header: <WebCore/ScrollingConstraints.h>
 [CustomHeader] class WebCore::AbsolutePositionConstraints {
     WebCore::FloatSize alignmentOffset();
     WebCore::FloatPoint layerPositionAtLastLayout();
+};
+
+header: <WebCore/KeyboardScroll.h>
+[CustomHeader] struct WebCore::KeyboardScroll {
+    WebCore::FloatSize offset;
+    WebCore::FloatSize maximumVelocity;
+    WebCore::FloatSize force;
+    WebCore::ScrollGranularity granularity;
+    WebCore::ScrollDirection direction;
 };
 
 [Return=Ref] class WebCore::NotificationResources {


### PR DESCRIPTION
#### 40453f0edcf34cb76ca4095f3a779a69a09c8393
<pre>
[UI-side compositing] Keyboard scrolling Amazon.com crashes Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=248924">https://bugs.webkit.org/show_bug.cgi?id=248924</a>
rdar://103058005

Reviewed by Aditya Keerthi.

`KeyboardScroll` and `RequestedKeyboardScrollData` were not IPC encodable or
decodable, so they were initialized with arbitrary values with UI-side compositing,
causing unexpected behavior and crashing.

This PR makes both of these encodable and decodable, provides equality comparison
operators for both, and provides all fields of both data types with sensible
initial values.

* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
(WebCore::RequestedKeyboardScrollData::operator== const):
* Source/WebCore/platform/KeyboardScroll.h:
(WebCore::KeyboardScroll::operator== const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(ArgumentCoder&lt;KeyboardScroll&gt;::encode):
(ArgumentCoder&lt;KeyboardScroll&gt;::decode):
(WebKit::dump):

Canonical link: <a href="https://commits.webkit.org/257734@main">https://commits.webkit.org/257734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ead2d33e26b6a6b87269be72b74f7b3aa7fb446b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108896 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169131 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86013 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92006 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106813 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90548 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33990 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21900 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2552 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23414 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2482 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45803 "Build is being retried. Recent messages:validate-change running; Cleaned up git repository; 'git checkout ...'; Skipping applying patch since patch_id isn't provided; Checked out pull request; Pull request contains relevant changes; Skipped layout-tests; Ignored 1 pre-existing failure based on results-db; triggering crash log submission") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42889 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5315 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4341 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->