### PR TITLE
Use RefPtr and WeakPtr with WebPageProxy in more places

### DIFF
--- a/Source/WebKit/UIProcess/API/APIFrameInfo.cpp
+++ b/Source/WebKit/UIProcess/API/APIFrameInfo.cpp
@@ -30,17 +30,18 @@
 #include "FrameInfoData.h"
 #include "WebFrameProxy.h"
 #include "WebPageProxy.h"
+#include <utility>
 
 namespace API {
 
-Ref<FrameInfo> FrameInfo::create(WebKit::FrameInfoData&& frameInfoData, WebKit::WebPageProxy* page)
+Ref<FrameInfo> FrameInfo::create(WebKit::FrameInfoData&& frameInfoData, RefPtr<WebKit::WebPageProxy>&& page)
 {
-    return adoptRef(*new FrameInfo(WTFMove(frameInfoData), page));
+    return adoptRef(*new FrameInfo(WTFMove(frameInfoData), std::forward<RefPtr<WebKit::WebPageProxy>&&>(page)));
 }
 
-FrameInfo::FrameInfo(WebKit::FrameInfoData&& data, WebKit::WebPageProxy* page)
+FrameInfo::FrameInfo(WebKit::FrameInfoData&& data, RefPtr<WebKit::WebPageProxy>&& page)
     : m_data(WTFMove(data))
-    , m_page(page) { }
+    , m_page(WTFMove(page)) { }
 
 FrameInfo::~FrameInfo() = default;
 

--- a/Source/WebKit/UIProcess/API/APIFrameInfo.h
+++ b/Source/WebKit/UIProcess/API/APIFrameInfo.h
@@ -46,7 +46,7 @@ class SecurityOrigin;
 
 class FrameInfo final : public ObjectImpl<Object::Type::FrameInfo> {
 public:
-    static Ref<FrameInfo> create(WebKit::FrameInfoData&&, WebKit::WebPageProxy*);
+    static Ref<FrameInfo> create(WebKit::FrameInfoData&&, RefPtr<WebKit::WebPageProxy>&&);
     virtual ~FrameInfo();
 
     bool isMainFrame() const { return m_data.isMainFrame; }
@@ -57,7 +57,7 @@ public:
     RefPtr<FrameHandle> parentFrameHandle() const;
 
 private:
-    FrameInfo(WebKit::FrameInfoData&&, WebKit::WebPageProxy*);
+    FrameInfo(WebKit::FrameInfoData&&, RefPtr<WebKit::WebPageProxy>&&);
 
     WebKit::FrameInfoData m_data;
     RefPtr<WebKit::WebPageProxy> m_page;

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -2880,7 +2880,7 @@ WKArrayRef WKPageCopyRelatedPages(WKPageRef pageRef)
     Vector<RefPtr<API::Object>> relatedPages;
 
     for (auto& page : toImpl(pageRef)->process().pages()) {
-        if (page != toImpl(pageRef))
+        if (page.get() != toImpl(pageRef))
             relatedPages.append(page);
     }
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -233,7 +233,7 @@ public:
     void didDestroyFrame(WebCore::FrameIdentifier);
 
 private:
-    WebPageProxy* webPageProxyForHandle(const String&);
+    RefPtr<WebPageProxy> webPageProxyForHandle(const String&);
     String handleForWebPageProxy(const WebPageProxy&);
     Ref<Inspector::Protocol::Automation::BrowsingContext> buildBrowsingContextForPage(WebPageProxy&, WebCore::FloatRect windowFrame);
     void getNextContext(Ref<WebAutomationSession>&&, Vector<Ref<WebPageProxy>>&&, Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>, Ref<WebAutomationSession::GetBrowsingContextsCallback>&&);

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -49,7 +49,7 @@ using namespace WebCore;
 
 void WebAutomationSession::inspectBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, std::optional<bool>&& enableAutoCapturing, Ref<InspectBrowsingContextCallback>&& callback)
 {
-    WebPageProxy* page = webPageProxyForHandle(handle);
+    auto page = webPageProxyForHandle(handle);
     if (!page)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR(WindowNotFound);
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -104,7 +104,9 @@ std::optional<WebPasteboardProxy::PasteboardAccessType> WebPasteboardProxy::acce
     auto* process = webProcessProxyForConnection(connection);
     MESSAGE_CHECK_WITH_RETURN_VALUE(process, std::nullopt);
 
-    for (auto* page : process->pages()) {
+    for (auto& page : process->pages()) {
+        if (!page)
+            continue;
         auto& preferences = page->preferences();
         if (!preferences.domPasteAllowed() || !preferences.javaScriptCanAccessClipboard())
             continue;
@@ -636,8 +638,8 @@ std::optional<DataOwnerType> WebPasteboardProxy::determineDataOwner(IPC::Connect
         return DataOwnerType::Undefined;
 
     std::optional<DataOwnerType> result;
-    for (auto* page : process->pages()) {
-        if (page->webPageID() == *pageID) {
+    for (auto& page : process->pages()) {
+        if (page && page->webPageID() == *pageID) {
             result = page->dataOwnerForPasteboard(intent);
             break;
         }

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -106,9 +106,9 @@ RefPtr<ObjCObjectGraph> WebProcessProxy::transformHandlesToObjects(ObjCObjectGra
         RetainPtr<id> transformObject(id object) const override
         {
             if (auto* handle = dynamic_objc_cast<WKBrowsingContextHandle>(object)) {
-                if (auto* webPageProxy = m_webProcessProxy.webPage(handle.pageProxyID)) {
+                if (auto webPageProxy = m_webProcessProxy.webPage(handle.pageProxyID)) {
                     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-                    return [WKBrowsingContextController _browsingContextControllerForPageRef:toAPI(webPageProxy)];
+                    return [WKBrowsingContextController _browsingContextControllerForPageRef:toAPI(webPageProxy.get())];
                     ALLOW_DEPRECATED_DECLARATIONS_END
                 }
 

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -611,7 +611,7 @@ void GPUProcessProxy::terminateWebProcess(WebCore::ProcessIdentifier webProcessI
 void GPUProcessProxy::didCreateContextForVisibilityPropagation(WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier pageID, LayerHostingContextID contextID)
 {
     RELEASE_LOG(Process, "GPUProcessProxy::didCreateContextForVisibilityPropagation: webPageProxyID: %" PRIu64 ", pagePID: %" PRIu64 ", contextID: %u", webPageProxyID.toUInt64(), pageID.toUInt64(), contextID);
-    auto* page = WebProcessProxy::webPage(webPageProxyID);
+    auto page = WebProcessProxy::webPage(webPageProxyID);
     if (!page) {
         RELEASE_LOG(Process, "GPUProcessProxy::didCreateContextForVisibilityPropagation() No WebPageProxy with this identifier");
         return;
@@ -694,7 +694,7 @@ void GPUProcessProxy::requestBitmapImageForCurrentTime(ProcessIdentifier process
 #if ENABLE(MEDIA_STREAM) && PLATFORM(IOS_FAMILY)
 void GPUProcessProxy::statusBarWasTapped(CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* page = WebProcessProxy::audioCapturingWebPage())
+    if (auto page = WebProcessProxy::audioCapturingWebPage())
         page->statusBarWasTapped();
     // Find the web page capturing audio and put focus on it.
     completionHandler();

--- a/Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.cpp
+++ b/Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.cpp
@@ -47,9 +47,11 @@ void HighPerformanceGraphicsUsageSampler::timerFired()
     bool isUsingHighPerformanceWebGL = false;
     bool isUsingHighPerformanceWebGLInVisibleView = false;
 
-    WebPageProxy* firstPage = nullptr;
+    RefPtr<WebPageProxy> firstPage;
     for (auto& webProcess : m_webProcessPool.processes()) {
         for (auto& page : webProcess->pages()) {
+            if (!page)
+                continue;
             if (!firstPage)
                 firstPage = page;
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -505,7 +505,7 @@ void NetworkProcessProxy::didReceiveAuthenticationChallenge(PAL::SessionID sessi
     auto authenticationChallenge = AuthenticationChallengeProxy::create(WTFMove(coreChallenge), challengeID, *connection(), nullptr);
 #endif
 
-    WebPageProxy* page = nullptr;
+    RefPtr<WebPageProxy> page;
     if (pageID)
         page = WebProcessProxy::webPage(pageID);
 
@@ -519,7 +519,7 @@ void NetworkProcessProxy::didReceiveAuthenticationChallenge(PAL::SessionID sessi
         return;
     }
 
-    WebPageProxy::forMostVisibleWebPageIfAny(sessionID, *topOrigin, [this, weakThis = WeakPtr { *this }, sessionID, authenticationChallenge = WTFMove(authenticationChallenge), negotiatedLegacyTLS](auto* page) mutable {
+    WebPageProxy::forMostVisibleWebPageIfAny(sessionID, *topOrigin, [this, weakThis = WeakPtr { *this }, sessionID, authenticationChallenge = WTFMove(authenticationChallenge), negotiatedLegacyTLS](WebPageProxy* page) mutable {
         if (!weakThis)
             return;
 
@@ -533,7 +533,7 @@ void NetworkProcessProxy::didReceiveAuthenticationChallenge(PAL::SessionID sessi
 
 void NetworkProcessProxy::negotiatedLegacyTLS(WebPageProxyIdentifier pageID)
 {
-    WebPageProxy* page = nullptr;
+    RefPtr<WebPageProxy> page;
     if (pageID)
         page = WebProcessProxy::webPage(pageID);
     if (page)
@@ -542,14 +542,14 @@ void NetworkProcessProxy::negotiatedLegacyTLS(WebPageProxyIdentifier pageID)
 
 void NetworkProcessProxy::didNegotiateModernTLS(WebPageProxyIdentifier pageID, const URL& url)
 {
-    if (auto* page = pageID ? WebProcessProxy::webPage(pageID) : nullptr)
+    if (auto page = pageID ? WebProcessProxy::webPage(pageID) : nullptr)
         page->didNegotiateModernTLS(url);
 }
 
 void NetworkProcessProxy::triggerBrowsingContextGroupSwitchForNavigation(WebPageProxyIdentifier pageID, uint64_t navigationID, BrowsingContextGroupSwitchDecision browsingContextGroupSwitchDecision, const WebCore::RegistrableDomain& responseDomain, NetworkResourceLoadIdentifier existingNetworkResourceLoadIdentifierToResume, CompletionHandler<void(bool success)>&& completionHandler)
 {
     RELEASE_LOG(ProcessSwapping, "%p - NetworkProcessProxy::triggerBrowsingContextGroupSwitchForNavigation: pageID=%" PRIu64 ", navigationID=%" PRIu64 ", browsingContextGroupSwitchDecision=%u, existingNetworkResourceLoadIdentifierToResume=%" PRIu64, this, pageID.toUInt64(), navigationID, (unsigned)browsingContextGroupSwitchDecision, existingNetworkResourceLoadIdentifierToResume.toUInt64());
-    if (auto* page = pageID ? WebProcessProxy::webPage(pageID) : nullptr)
+    if (auto page = pageID ? WebProcessProxy::webPage(pageID) : nullptr)
         page->triggerBrowsingContextGroupSwitchForNavigation(navigationID, browsingContextGroupSwitchDecision, responseDomain, existingNetworkResourceLoadIdentifierToResume, WTFMove(completionHandler));
     else
         completionHandler(false);
@@ -574,7 +574,7 @@ void NetworkProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Con
 
 void NetworkProcessProxy::logDiagnosticMessage(WebPageProxyIdentifier pageID, const String& message, const String& description, WebCore::ShouldSample shouldSample)
 {
-    WebPageProxy* page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     // FIXME: We do this null-check because by the time the decision to log is made, the page may be gone. We should refactor to avoid this,
     // but for now we simply drop the message in the rare case this happens.
     if (!page)
@@ -599,7 +599,7 @@ void NetworkProcessProxy::terminateUnresponsiveServiceWorkerProcesses(WebCore::P
 
 void NetworkProcessProxy::logDiagnosticMessageWithResult(WebPageProxyIdentifier pageID, const String& message, const String& description, uint32_t result, WebCore::ShouldSample shouldSample)
 {
-    WebPageProxy* page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     // FIXME: We do this null-check because by the time the decision to log is made, the page may be gone. We should refactor to avoid this,
     // but for now we simply drop the message in the rare case this happens.
     if (!page)
@@ -610,7 +610,7 @@ void NetworkProcessProxy::logDiagnosticMessageWithResult(WebPageProxyIdentifier 
 
 void NetworkProcessProxy::logDiagnosticMessageWithValue(WebPageProxyIdentifier pageID, const String& message, const String& description, double value, unsigned significantFigures, WebCore::ShouldSample shouldSample)
 {
-    WebPageProxy* page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     // FIXME: We do this null-check because by the time the decision to log is made, the page may be gone. We should refactor to avoid this,
     // but for now we simply drop the message in the rare case this happens.
     if (!page)
@@ -621,7 +621,7 @@ void NetworkProcessProxy::logDiagnosticMessageWithValue(WebPageProxyIdentifier p
 
 void NetworkProcessProxy::resourceLoadDidSendRequest(WebPageProxyIdentifier pageID, ResourceLoadInfo&& loadInfo, WebCore::ResourceRequest&& request, std::optional<IPC::FormDataReference>&& httpBody)
 {
-    auto* page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page)
         return;
 
@@ -635,7 +635,7 @@ void NetworkProcessProxy::resourceLoadDidSendRequest(WebPageProxyIdentifier page
 
 void NetworkProcessProxy::resourceLoadDidPerformHTTPRedirection(WebPageProxyIdentifier pageID, ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response, WebCore::ResourceRequest&& request)
 {
-    auto* page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page)
         return;
 
@@ -644,7 +644,7 @@ void NetworkProcessProxy::resourceLoadDidPerformHTTPRedirection(WebPageProxyIden
 
 void NetworkProcessProxy::resourceLoadDidReceiveChallenge(WebPageProxyIdentifier pageID, ResourceLoadInfo&& loadInfo, WebCore::AuthenticationChallenge&& challenge)
 {
-    auto* page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page)
         return;
 
@@ -653,7 +653,7 @@ void NetworkProcessProxy::resourceLoadDidReceiveChallenge(WebPageProxyIdentifier
 
 void NetworkProcessProxy::resourceLoadDidReceiveResponse(WebPageProxyIdentifier pageID, ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response)
 {
-    auto* page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page)
         return;
 
@@ -662,7 +662,7 @@ void NetworkProcessProxy::resourceLoadDidReceiveResponse(WebPageProxyIdentifier 
 
 void NetworkProcessProxy::resourceLoadDidCompleteWithError(WebPageProxyIdentifier pageID, ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response, WebCore::ResourceError&& error)
 {
-    auto* page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page)
         return;
 
@@ -1016,7 +1016,7 @@ void NetworkProcessProxy::setGrandfathered(PAL::SessionID sessionID, const Regis
 
 void NetworkProcessProxy::requestStorageAccessConfirm(WebPageProxyIdentifier pageID, FrameIdentifier frameID, const RegistrableDomain& subFrameDomain, const RegistrableDomain& topFrameDomain, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto* page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page) {
         completionHandler(false);
         return;
@@ -1205,7 +1205,7 @@ void NetworkProcessProxy::didCommitCrossSiteLoadWithDataTransferFromPrevalentRes
     if (!canSendMessage())
         return;
 
-    WebPageProxy* page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page)
         return;
 
@@ -1614,7 +1614,7 @@ void NetworkProcessProxy::setWebProcessHasUploads(WebCore::ProcessIdentifier pro
 
 void NetworkProcessProxy::testProcessIncomingSyncMessagesWhenWaitingForSyncReply(WebPageProxyIdentifier pageID, CompletionHandler<void(bool)>&& reply)
 {
-    auto* page = WebProcessProxy::webPage(pageID);
+    auto page = WebProcessProxy::webPage(pageID);
     if (!page)
         return reply(false);
 

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
@@ -70,7 +70,7 @@ static inline String loggingKeyForActivityState(ActivityStateForCPUSampling stat
 
 void PerActivityStateCPUUsageSampler::loggingTimerFired()
 {
-    auto* page = pageForLogging();
+    auto page = pageForLogging();
     if (!page) {
         m_cpuTimeInActivityState.clear();
         return;
@@ -90,12 +90,12 @@ void PerActivityStateCPUUsageSampler::loggingTimerFired()
     m_lastCPUTime = currentCPUTime;
 }
 
-WebPageProxy* PerActivityStateCPUUsageSampler::pageForLogging() const
+RefPtr<WebPageProxy> PerActivityStateCPUUsageSampler::pageForLogging() const
 {
     for (auto& webProcess : m_processPool.processes()) {
         if (!webProcess->pageCount())
             continue;
-        return *webProcess->pages().begin();
+        return webProcess->pages()[0]; // FIXME: Iterate to pick the first non-nullptr WebPageProxy?
     }
     return nullptr;
 }

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
@@ -44,7 +44,7 @@ public:
 
 private:
     void loggingTimerFired();
-    WebPageProxy* pageForLogging() const;
+    RefPtr<WebPageProxy> pageForLogging() const;
 
     WebProcessPool& m_processPool;
     RunLoop::Timer<PerActivityStateCPUUsageSampler> m_loggingTimer;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -57,7 +57,7 @@ private:
 void RemoteLayerTreeDisplayLinkClient::displayLinkFired(WebCore::PlatformDisplayID /* displayID */, WebCore::DisplayUpdate /* displayUpdate */, bool /* wantsFullSpeedUpdates */, bool /* anyObserverWantsCallback */)
 {
     RunLoop::main().dispatch([pageIdentifier = m_pageIdentifier]() {
-        auto* page = WebProcessProxy::webPage(pageIdentifier);
+        auto page = WebProcessProxy::webPage(pageIdentifier);
         if (!page)
             return;
 

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -35,6 +35,7 @@
 #include "NetworkContentRuleListManagerMessages.h"
 #include "NetworkProcessProxy.h"
 #include "WebPageCreationParameters.h"
+#include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include "WebScriptMessageHandler.h"
 #include "WebUserContentControllerDataTypes.h"
@@ -328,7 +329,7 @@ void WebUserContentControllerProxy::removeAllUserMessageHandlers()
 
 void WebUserContentControllerProxy::didPostMessage(WebPageProxyIdentifier pageProxyID, FrameInfoData&& frameInfoData, uint64_t messageHandlerID, const IPC::DataReference& dataReference, CompletionHandler<void(IPC::DataReference&&, const String&)>&& reply)
 {
-    WebPageProxy* page = WebProcessProxy::webPage(pageProxyID);
+    auto page = WebProcessProxy::webPage(pageProxyID);
     if (!page)
         return;
 

--- a/Source/WebKit/UIProcess/VisitedLinkStore.cpp
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.cpp
@@ -102,8 +102,8 @@ void VisitedLinkStore::removeAll()
 
 void VisitedLinkStore::addVisitedLinkHashFromPage(WebPageProxyIdentifier pageProxyID, SharedStringHash linkHash)
 {
-    if (auto* webPageProxy = WebProcessProxy::webPage(pageProxyID)) {
-        if (!webPageProxy->addsVisitedLinks())
+    if (auto page = WebProcessProxy::webPage(pageProxyID)) {
+        if (!page || !page->addsVisitedLinks())
             return;
     }
 

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
@@ -134,8 +134,8 @@ void WebGeolocationManagerProxy::startUpdating(IPC::Connection& connection, cons
 
 void WebGeolocationManagerProxy::startUpdatingWithProxy(WebProcessProxy& proxy, const WebCore::RegistrableDomain& registrableDomain, WebPageProxyIdentifier pageProxyID, const String& authorizationToken, bool enableHighAccuracy)
 {
-    auto* page = WebProcessProxy::webPage(pageProxyID);
-    MESSAGE_CHECK(proxy.connection(), page);
+    auto page = WebProcessProxy::webPage(pageProxyID);
+    MESSAGE_CHECK(proxy.connection(), !!page);
 
     auto isValidAuthorizationToken = page->geolocationPermissionRequestManager().isValidAuthorizationToken(authorizationToken);
     MESSAGE_CHECK(proxy.connection(), isValidAuthorizationToken);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1793,7 +1793,7 @@ public:
     void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&);
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
-    static WebPageProxy* nonEphemeralWebPageProxy();
+    static RefPtr<WebPageProxy> nonEphemeralWebPageProxy();
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     RefPtr<API::Attachment> attachmentForIdentifier(const String& identifier) const;

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
@@ -51,7 +51,7 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
 private:
-    WebPageProxy* mostReasonableWebPageProxy(const WebCore::SecurityOriginData&, WebCore::PermissionQuerySource) const;
+    RefPtr<WebPageProxy> mostReasonableWebPageProxy(const WebCore::SecurityOriginData&, WebCore::PermissionQuerySource) const;
 
     // IPC Message handlers.
     void query(const WebCore::ClientOrigin&, const WebCore::PermissionDescriptor&, std::optional<WebPageProxyIdentifier>, WebCore::PermissionQuerySource, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&&);

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -137,8 +137,7 @@ enum class CheckBackForwardList : bool { No, Yes };
 
 class WebProcessProxy : public AuxiliaryProcessProxy, private ProcessThrottlerClient {
 public:
-    // FIXME: This should be a WeakPtr<WebPageProxy> as the key.
-    typedef HashMap<WebPageProxyIdentifier, WebPageProxy*> WebPageProxyMap;
+    using WebPageProxyMap = HashMap<WebPageProxyIdentifier, WeakPtr<WebPageProxy>>;
     typedef HashMap<WebCore::FrameIdentifier, WeakPtr<WebFrameProxy>> WebFrameProxyMap;
     typedef HashMap<uint64_t, RefPtr<API::UserInitiatedAction>> UserInitiatedActionMap;
 
@@ -191,8 +190,8 @@ public:
     static void setProcessCountLimit(unsigned);
 
     static WebProcessProxy* processForIdentifier(WebCore::ProcessIdentifier);
-    static WebPageProxy* webPage(WebPageProxyIdentifier);
-    static WebPageProxy* audioCapturingWebPage();
+    static RefPtr<WebPageProxy> webPage(WebPageProxyIdentifier);
+    static RefPtr<WebPageProxy> audioCapturingWebPage();
     Ref<WebPageProxy> createWebPage(PageClient&, Ref<API::PageConfiguration>&&);
 
     enum class BeginsUsingDataStore : bool { No, Yes };
@@ -208,7 +207,7 @@ public:
     void provisionalFrameCommitted(WebFrameProxy&);
     void removeFrameWithRemoteFrameProcess(WebFrameProxy&);
 
-    typename WebPageProxyMap::ValuesConstIteratorRange pages() const { return m_pageMap.values(); }
+    Vector<RefPtr<WebPageProxy>> pages() const;
     unsigned pageCount() const { return m_pageMap.size(); }
     unsigned provisionalPageCount() const { return m_provisionalPages.computeSize(); }
     unsigned visiblePageCount() const { return m_visiblePageCounter.value(); }

--- a/Source/WebKit/UIProcess/WebURLSchemeTask.cpp
+++ b/Source/WebKit/UIProcess/WebURLSchemeTask.cpp
@@ -93,7 +93,7 @@ auto WebURLSchemeTask::willPerformRedirection(ResourceResponse&& response, Resou
         m_request = request;
     }
 
-    auto* page = WebProcessProxy::webPage(m_pageProxyID);
+    auto page = WebProcessProxy::webPage(m_pageProxyID);
     if (!page)
         return ExceptionType::None;
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1221,8 +1221,8 @@ void WebsiteDataStore::setIsRunningResourceLoadStatisticsTest(bool value, Comple
 
 void WebsiteDataStore::getAllStorageAccessEntries(WebPageProxyIdentifier pageID, CompletionHandler<void(Vector<String>&& domains)>&& completionHandler)
 {
-    auto* webPage = WebProcessProxy::webPage(pageID);
-    if (!webPage) {
+    auto page = WebProcessProxy::webPage(pageID);
+    if (!page) {
         completionHandler({ });
         return;
     }


### PR DESCRIPTION
#### 858c1233fb2f5c3e4b714915d984d975c961b2da
<pre>
Use RefPtr and WeakPtr with WebPageProxy in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=248912">https://bugs.webkit.org/show_bug.cgi?id=248912</a>
&lt;rdar://103087074&gt;

Reviewed by Geoffrey Garen.

Replace uses of raw pointers for WebPageProxy with RefPtr&lt;&gt; and
WeakPtr&lt;&gt;.  Started by addressing a FIXME comment in
WebProcessProxy.h to make WebPageProxyMap use a WeakPtr&lt;&gt;, then
continued pulling &quot;the thread&quot; to change other uses of raw
pointers.

Most changes below are the result of changing a few methods to
return RefPtr&lt;&gt; instead of a raw pointer and to add nullptr
checks.  WebProcessProxy::pages() was changed to return
Vector&lt;RefPtr&lt;&gt;&gt; instead of an iterator since most of the code
used the iterator to create a Vector&lt;RefPtr&lt;&gt;&gt; anyway, or should
have been doing that anyway.

* Source/WebKit/UIProcess/API/APIFrameInfo.cpp:
(API::FrameInfo::create):
(API::FrameInfo::FrameInfo):
* Source/WebKit/UIProcess/API/APIFrameInfo.h:
- Change parameters to take a RefPtr&lt;&gt;&amp;&amp; since the instance
  variable was a RefPtr&lt;&gt;, too.
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageCopyRelatedPages):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::webPageProxyForHandle):
- Change turn return RefPtr&lt;&gt; instead of raw pointer.
(WebKit::WebAutomationSession::getBrowsingContexts):
(WebKit::WebAutomationSession::getBrowsingContext):
(WebKit::WebAutomationSession::closeBrowsingContext):
(WebKit::WebAutomationSession::switchToBrowsingContext):
(WebKit::WebAutomationSession::setWindowFrameOfBrowsingContext):
(WebKit::WebAutomationSession::waitForNavigationToComplete):
(WebKit::WebAutomationSession::maximizeWindowOfBrowsingContext):
(WebKit::WebAutomationSession::hideWindowOfBrowsingContext):
(WebKit::WebAutomationSession::navigateBrowsingContext):
(WebKit::WebAutomationSession::goBackInBrowsingContext):
(WebKit::WebAutomationSession::goForwardInBrowsingContext):
(WebKit::WebAutomationSession::reloadBrowsingContext):
(WebKit::WebAutomationSession::evaluateJavaScriptFunction):
(WebKit::WebAutomationSession::resolveChildFrameHandle):
(WebKit::WebAutomationSession::resolveParentFrameHandle):
(WebKit::WebAutomationSession::computeElementLayout):
(WebKit::WebAutomationSession::getComputedRole):
(WebKit::WebAutomationSession::getComputedLabel):
(WebKit::WebAutomationSession::selectOptionElement):
(WebKit::WebAutomationSession::isShowingJavaScriptDialog):
(WebKit::WebAutomationSession::dismissCurrentJavaScriptDialog):
(WebKit::WebAutomationSession::acceptCurrentJavaScriptDialog):
(WebKit::WebAutomationSession::messageOfCurrentJavaScriptDialog):
(WebKit::WebAutomationSession::setUserInputForCurrentJavaScriptPrompt):
(WebKit::WebAutomationSession::setFilesForInputFileUpload):
(WebKit::WebAutomationSession::getAllCookies):
(WebKit::WebAutomationSession::deleteSingleCookie):
(WebKit::WebAutomationSession::addSingleCookie):
(WebKit::WebAutomationSession::deleteAllCookies):
(WebKit::WebAutomationSession::generateTestReport):
(WebKit::WebAutomationSession::performMouseInteraction):
(WebKit::WebAutomationSession::performKeyboardInteractions):
(WebKit::WebAutomationSession::performInteractionSequence):
(WebKit::WebAutomationSession::cancelInteractionSequence):
(WebKit::WebAutomationSession::takeScreenshot):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::WebAutomationSession::inspectBrowsingContext):
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::accessType const):
(WebKit::WebPasteboardProxy::determineDataOwner const):
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::transformHandlesToObjects):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::didCreateContextForVisibilityPropagation):
(WebKit::GPUProcessProxy::statusBarWasTapped):
* Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.cpp:
(WebKit::HighPerformanceGraphicsUsageSampler::timerFired):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::didReceiveAuthenticationChallenge):
(WebKit::NetworkProcessProxy::negotiatedLegacyTLS):
(WebKit::NetworkProcessProxy::didNegotiateModernTLS):
(WebKit::NetworkProcessProxy::triggerBrowsingContextGroupSwitchForNavigation):
(WebKit::NetworkProcessProxy::logDiagnosticMessage):
(WebKit::NetworkProcessProxy::logDiagnosticMessageWithResult):
(WebKit::NetworkProcessProxy::logDiagnosticMessageWithValue):
(WebKit::NetworkProcessProxy::resourceLoadDidSendRequest):
(WebKit::NetworkProcessProxy::resourceLoadDidPerformHTTPRedirection):
(WebKit::NetworkProcessProxy::resourceLoadDidReceiveChallenge):
(WebKit::NetworkProcessProxy::resourceLoadDidReceiveResponse):
(WebKit::NetworkProcessProxy::resourceLoadDidCompleteWithError):
(WebKit::NetworkProcessProxy::requestStorageAccessConfirm):
(WebKit::NetworkProcessProxy::didCommitCrossSiteLoadWithDataTransferFromPrevalentResource):
(WebKit::NetworkProcessProxy::testProcessIncomingSyncMessagesWhenWaitingForSyncReply):
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp:
(WebKit::PerActivityStateCPUUsageSampler::loggingTimerFired):
(WebKit::PerActivityStateCPUUsageSampler::pageForLogging const):
- Change turn return RefPtr&lt;&gt; instead of raw pointer.
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDisplayLinkClient::displayLinkFired):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::didPostMessage):
* Source/WebKit/UIProcess/VisitedLinkStore.cpp:
(WebKit::VisitedLinkStore::addVisitedLinkHashFromPage):
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp:
(WebKit::WebGeolocationManagerProxy::startUpdatingWithProxy):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::forMostVisibleWebPageIfAny):
(WebKit::WebPageProxy::~WebPageProxy):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::nonEphemeralWebPageProxy):
- Change turn return RefPtr&lt;&gt; instead of raw pointer.
(WebKit::WebPageProxy::createNewPage):
- Avoid a use-after-move by getting WebPageProxy* from
  originatingFrameInfo-&gt;page() to call
  page-&gt;lastNavigationWasAppInitiated().
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp:
(WebKit::WebPermissionControllerProxy::query):
(WebKit::WebPermissionControllerProxy::mostReasonableWebPageProxy const):
- Change turn return RefPtr&lt;&gt; instead of raw pointer.
* Source/WebKit/UIProcess/WebPermissionControllerProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::globalPages): Add.
- Implement convenience method in place of calling
  `globalPageMap().values()` and converting to a
  Vector&lt;RefPtr&lt;&gt;&gt; structure.
(WebKit::WebProcessProxy::pages const):
- Move implementation to source file since it requires the full
  class definition of WebPageProxy, and WebProcessProxy.h only
  predeclares WebPageProxy as a class since each class refers to
  the other class.
- Change return type from a value iterator to Vector&lt;RefPtr&lt;&gt;&gt;
  since the code that called this was doing that anyway (or
  should have been doing that).
(WebKit::WebProcessProxy::forWebPagesWithOrigin):
(WebKit::WebProcessProxy::allowedFirstPartiesForCookies):
(WebKit::WebProcessProxy::shouldSendPendingMessage):
(WebKit::WebProcessProxy::shutDown):
(WebKit::WebProcessProxy::webPage):
- Change turn return RefPtr&lt;&gt; instead of raw pointer.
(WebKit::WebProcessProxy::audioCapturingWebPage):
- Change turn return RefPtr&lt;&gt; instead of raw pointer.
(WebKit::WebProcessProxy::notifyPageStatisticsAndDataRecordsProcessed):
(WebKit::WebProcessProxy::notifyWebsiteDataScanForRegistrableDomainsFinished):
(WebKit::WebProcessProxy::notifyWebsiteDataDeletionForRegistrableDomainsFinished):
(WebKit::WebProcessProxy::addExistingWebPage):
(WebKit::WebProcessProxy::removeWebPage):
(WebKit::WebProcessProxy::gpuProcessDidFinishLaunching):
(WebKit::WebProcessProxy::gpuProcessExited):
(WebKit::WebProcessProxy::processDidTerminateOrFailedToLaunch):
(WebKit::WebProcessProxy::didBecomeUnresponsive):
(WebKit::WebProcessProxy::didBecomeResponsive):
(WebKit::WebProcessProxy::willChangeIsResponsive):
(WebKit::WebProcessProxy::didChangeIsResponsive):
(WebKit::WebProcessProxy::didFinishLaunching):
(WebKit::WebProcessProxy::didDestroyFrame):
(WebKit::WebProcessProxy::windowServerConnectionStateChanged):
(WebKit::WebProcessProxy::didChangeThrottleState):
(WebKit::WebProcessProxy::updateAudibleMediaAssertions):
(WebKit::WebProcessProxy::logDiagnosticMessageForResourceLimitTermination):
(WebKit::WebProcessProxy::didExceedCPULimit):
(WebKit::WebProcessProxy::createSpeechRecognitionServer):
(WebKit::WebProcessProxy::muteCaptureInPagesExcept):
* Source/WebKit/UIProcess/WebProcessProxy.h:
(WebKit::WebProcessProxy::pages const): Deleted.
* Source/WebKit/UIProcess/WebURLSchemeTask.cpp:
(WebKit::WebURLSchemeTask::willPerformRedirection):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::getAllStorageAccessEntries):

Canonical link: <a href="https://commits.webkit.org/257681@main">https://commits.webkit.org/257681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afd7e8713dd2a53f50e21318e5e649ec3ca58f31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108998 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86103 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92102 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106909 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7086 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34058 "An unexpected error occured. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21957 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2638 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23471 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45862 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42944 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5285 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4444 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->