### PR TITLE
[macOS UI-side compositing] Fix hit-testing in iframes (and some other things)

### DIFF
--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -803,7 +803,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
     IntPoint scrollOffset;
 
     FrameView* pageView = m_page.mainFrame().view();
-    if (!pageView->delegatesScrolling())
+    if (!pageView->delegatesScrollingToNativeView())
         scrollOffset = pageView->visibleContentRect().location();
 
     FloatSize viewportSize = pageView->sizeForVisibleContent();

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -2095,7 +2095,7 @@ void FrameView::viewportContentsChanged()
 IntRect FrameView::viewRectExpandedByContentInsets() const
 {
     FloatRect viewRect;
-    if (delegatesScrolling() && platformWidget())
+    if (delegatesScrollingToNativeView() && platformWidget())
         viewRect = unobscuredContentRect();
     else
         viewRect = visualViewportRect();
@@ -2735,7 +2735,7 @@ void FrameView::scrollRectToVisibleInTopLevelView(const LayoutRect& absoluteRect
 void FrameView::contentsResized()
 {
     // For non-delegated scrolling, updateTiledBackingAdaptiveSizing() is called via addedOrRemovedScrollbar() which occurs less often.
-    if (delegatesScrolling())
+    if (delegatesScrollingToNativeView())
         updateTiledBackingAdaptiveSizing();
 }
 
@@ -3209,7 +3209,7 @@ TiledBacking::Scrollability FrameView::computeScrollability() const
         clippedByAncestorView |= page->enclosedInScrollableAncestorView();
 #endif
 
-    if (delegatesScrolling()) {
+    if (delegatesScrollingToNativeView()) {
         IntSize documentSize = contentsSize();
         IntSize visibleSize = this->visibleSize();
 
@@ -5252,7 +5252,7 @@ IntPoint FrameView::convertFromContainingViewToRenderer(const RenderElement* ren
     IntPoint point = viewPoint;
 
     // Convert from FrameView coords into page ("absolute") coordinates.
-    if (!delegatesScrolling())
+    if (!delegatesScrollingToNativeView())
         point = viewToContents(point);
 
     return roundedIntPoint(renderer->absoluteToLocal(point, UseTransforms));
@@ -5608,7 +5608,7 @@ bool FrameView::handleWheelEventForScrolling(const PlatformWheelEvent& wheelEven
         return false;
 #endif
 
-    if (delegatesScrolling()) {
+    if (delegatesScrollingToNativeView()) {
         ScrollPosition oldPosition = scrollPosition();
         ScrollPosition newPosition = oldPosition - IntSize(wheelEvent.deltaX(), wheelEvent.deltaY());
         if (oldPosition != newPosition) {

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -635,7 +635,7 @@ static WebCore::Element* containerElementForElement(WebCore::Element& element)
 
 static WebCore::FloatRect convertRectFromFrameClientToRootView(WebCore::FrameView* frameView, WebCore::FloatRect clientRect)
 {
-    if (!frameView->delegatesScrolling())
+    if (!frameView->delegatesScrollingToNativeView())
         return frameView->contentsToRootView(frameView->clientToDocumentRect(clientRect));
 
     // If the frame delegates scrolling, contentsToRootView doesn't take into account scroll/zoom/scale.
@@ -647,7 +647,7 @@ static WebCore::FloatRect convertRectFromFrameClientToRootView(WebCore::FrameVie
 
 static WebCore::FloatPoint convertPointFromFrameClientToRootView(WebCore::FrameView* frameView, WebCore::FloatPoint clientPoint)
 {
-    if (!frameView->delegatesScrolling())
+    if (!frameView->delegatesScrollingToNativeView())
         return frameView->contentsToRootView(frameView->clientToDocumentPoint(clientPoint));
 
     // If the frame delegates scrolling, contentsToRootView doesn't take into account scroll/zoom/scale.

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -670,7 +670,7 @@ void WebChromeClient::contentsSizeChanged(Frame& frame, const IntSize& size) con
 
     m_page.drawingArea()->mainFrameContentSizeChanged(size);
 
-    if (frameView && !frameView->delegatesScrolling())  {
+    if (frameView && !frameView->delegatesScrollingToNativeView())  {
         bool hasHorizontalScrollbar = frameView->horizontalScrollbar();
         bool hasVerticalScrollbar = frameView->verticalScrollbar();
 


### PR DESCRIPTION
#### 8c589785e316b6a54022eee297868e5cc939dedb
<pre>
[macOS UI-side compositing] Fix hit-testing in iframes (and some other things)
<a href="https://bugs.webkit.org/show_bug.cgi?id=248930">https://bugs.webkit.org/show_bug.cgi?id=248930</a>
rdar://103080262

Reviewed by Tim Horton.

With UI-side compositing on macOS, events in iframes were offset because
`FrameView::convertFromContainingViewToRenderer()` failed to do the
`viewToContents()` conversion; checking `delegatesScrollingToNativeView()` fixes that.
Other fixes are noted below.

* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::drawRulers): Fixed drawing of rules in scrolled content.
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::viewRectExpandedByContentInsets const): Follow the same code
path as macOS
(WebCore::FrameView::contentsResized): We rely on the scrollbar-related code path.
(WebCore::FrameView::computeScrollability const): We rely on the scrollbar-related code path.
(WebCore::FrameView::convertFromContainingViewToRenderer const): Fixes event coordinates in subframes.
(WebCore::FrameView::handleWheelEventForScrolling): Fixes wheel event handling.
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::convertRectFromFrameClientToRootView): Follow the same code path as FrameView.
(WebKit::convertPointFromFrameClientToRootView): Ditto
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::contentsSizeChanged const): Ditto

Canonical link: <a href="https://commits.webkit.org/257581@main">https://commits.webkit.org/257581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62a8573832a09d0b60385558749e585adf164ffc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108661 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168908 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85794 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91766 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106589 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105034 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33810 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21717 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2353 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23233 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2251 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5219 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7916 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42712 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3855 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->