### PR TITLE
Make requestFullscreen() consume user activation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-consume-user-activation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-consume-user-activation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Element#requestFullscreen() consumes user activation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-consume-user-activation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-consume-user-activation.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>Element#requestFullscreen() consumes user activation</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="log"></div>
+<script>
+promise_test(async (t) => {
+    t.add_cleanup(() => {
+        if (document.fullscreenElement) return document.exitFullscreen();
+    });
+    const div = document.querySelector("div");
+
+    await test_driver.bless("fullscreen");
+    assert_true(navigator.userActivation.isActive, "Activation must be active");
+    // Request fullscreen twice in a row. The first request should consume the
+    // user activation and succeed, and the second request should fail because
+    // of the user activation requirement.
+    const p1 = div.requestFullscreen();
+    assert_false(navigator.userActivation.isActive, "Transient activation is consumed");
+    const p2 = promise_rejects_js(t, TypeError, div.requestFullscreen());
+    await Promise.all([p1, p2]);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-same-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-same-element-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Element#requestFullscreen() on the current fullscreen element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-same-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-same-element.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>Element#requestFullscreen() on the current fullscreen element</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="log"></div>
+<script>
+promise_test(async (t) => {
+    t.add_cleanup(() => {
+        if (document.fullscreenElement) return document.exitFullscreen();
+    });
+
+    // Use the body element as the fullscreen element, because the second
+    // test_driver.bless() call needs to insert a button inside of it, which
+    // can't be clicked if another element is already fullscreen.
+    const target = document.body;
+
+    // First enter fullscreen.
+    await test_driver.bless("fullscreen", () => target.requestFullscreen());
+    assert_equals(document.fullscreenElement, target, "fullscreen element after first request");
+
+    // Now request fullscreen again, which should be a no-op.
+    await test_driver.bless("fullscreen", () => target.requestFullscreen());
+    assert_equals(document.fullscreenElement, target, "fullscreen element after second request");
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/w3c-import.log
@@ -24,10 +24,12 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/document-fullscreen-enabled.html
 /LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/document-onfullscreenerror.html
 /LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-active-document.html
+/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-consume-user-activation.html
 /LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-dialog.html
 /LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-not-allowed.html
 /LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-options.html
 /LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-options.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-same-element.html
 /LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen.html
 /LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-display-contents-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-display-contents-ref.html

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-same-element-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-same-element-expected.txt
@@ -1,0 +1,5 @@
+
+FAIL Element#requestFullscreen() on the current fullscreen element assert_equals: fullscreen element after first request expected Element node <body><div id="log"></div>
+<script>
+promise_test(async (t... but got null
+

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -100,7 +100,7 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
         return;
     }
 
-    if (!document().domWindow() || !document().domWindow()->hasTransientActivation()) {
+    if (!document().domWindow() || !document().domWindow()->consumeTransientActivation()) {
         ERROR_LOG(LOGIDENTIFIER, "!hasTransientActivation; failing.");
         failedPreflights(WTFMove(element), WTFMove(promise));
         return;


### PR DESCRIPTION
#### 823024a704caeaeeb05c1fc3cf8bd6a095081d5d
<pre>
Make requestFullscreen() consume user activation
<a href="https://bugs.webkit.org/show_bug.cgi?id=247920">https://bugs.webkit.org/show_bug.cgi?id=247920</a>
rdar://102355401

Reviewed by Youenn Fablet.

Matches Chrome &amp; Firefox implementations, we should reset the activation timestamps when requesting fullscreen.
This disallows double non-user initiated requestFullscreen calls.

Spec PR: <a href="https://github.com/whatwg/fullscreen/pull/153">https://github.com/whatwg/fullscreen/pull/153</a>

WPT upstream revision: <a href="https://github.com/web-platform-tests/wpt/commit/897b406f2925a22025d62001a5f7e97096e3f5a0">https://github.com/web-platform-tests/wpt/commit/897b406f2925a22025d62001a5f7e97096e3f5a0</a>

* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-consume-user-activation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-consume-user-activation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-same-element-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-same-element.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/w3c-import.log:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-same-element-expected.txt: Added.
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):

Canonical link: <a href="https://commits.webkit.org/257554@main">https://commits.webkit.org/257554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/688648bc7a6099fd2776cf12cbbee8e6b9b80a8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108679 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168925 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103292 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85811 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91784 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106606 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105051 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2370 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2268 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5191 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42726 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3927 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->