### PR TITLE
Don't call getDDActionContextClass if we don't have a DDActionContext to decode

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -515,6 +515,44 @@ std::optional<WebCore::FloatBoxExtent> ArgumentCoder<WebCore::FloatBoxExtent>::d
     };
 }
 
+
+void ArgumentCoder<NullableSoftLinkedMember>::encode(Encoder& encoder, const NullableSoftLinkedMember& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.firstMember)>, RetainPtr<DDActionContext>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.secondMember)>, RetainPtr<DDActionContext>>);
+    encoder << !!instance.firstMember;
+    if (!!instance.firstMember)
+        encoder << instance.firstMember;
+    encoder << instance.secondMember;
+}
+
+std::optional<NullableSoftLinkedMember> ArgumentCoder<NullableSoftLinkedMember>::decode(Decoder& decoder)
+{
+    std::optional<RetainPtr<DDActionContext>> firstMember;
+    std::optional<bool> hasfirstMember;
+    decoder >> hasfirstMember;
+    if (!hasfirstMember)
+        return std::nullopt;
+    if (*hasfirstMember) {
+        firstMember = IPC::decode<DDActionContext>(decoder, PAL::getDDActionContextClass());
+        if (!firstMember)
+            return std::nullopt;
+    } else
+        firstMember = std::optional<RetainPtr<DDActionContext>> { RetainPtr<DDActionContext> { } };
+
+    std::optional<RetainPtr<DDActionContext>> secondMember;
+    secondMember = IPC::decode<DDActionContext>(decoder, PAL::getDDActionContextClass());
+    if (!secondMember)
+        return std::nullopt;
+
+    return {
+        NullableSoftLinkedMember {
+            WTFMove(*firstMember),
+            WTFMove(*secondMember)
+        }
+    };
+}
+
 } // namespace IPC
 
 namespace WTF {

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -51,6 +51,7 @@ namespace WebCore {
 template<typename> class RectEdges;
 using FloatBoxExtent = RectEdges<float>;
 }
+struct NullableSoftLinkedMember;
 
 namespace IPC {
 
@@ -115,6 +116,11 @@ template<> struct ArgumentCoder<WTF::CreateUsingClass> {
 template<> struct ArgumentCoder<WebCore::FloatBoxExtent> {
     static void encode(Encoder&, const WebCore::FloatBoxExtent&);
     static std::optional<WebCore::FloatBoxExtent> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<NullableSoftLinkedMember> {
+    static void encode(Encoder&, const NullableSoftLinkedMember&);
+    static std::optional<NullableSoftLinkedMember> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -100,6 +100,10 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             "float"_s,
             "float"_s,
         } },
+        { "NullableSoftLinkedMember"_s, {
+            "RetainPtr<DDActionContext>"_s,
+            "RetainPtr<DDActionContext>"_s,
+        } },
     };
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -96,3 +96,8 @@ class WTF::Seconds {
     float bottom()
     float left()
 };
+
+struct NullableSoftLinkedMember {
+    [Nullable, SoftLinkedClass='PAL::getDDActionContextClass()'] RetainPtr<DDActionContext> firstMember;
+    [SoftLinkedClass='PAL::getDDActionContextClass()'] RetainPtr<DDActionContext> secondMember;
+}

--- a/Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in
+++ b/Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in
@@ -25,7 +25,7 @@ headers: <WebCore/TextIndicator.h>
 #if PLATFORM(MAC)
 header: "WebHitTestResultData.h" <pal/mac/DataDetectorsSoftLink.h>
 [CustomHeader] struct WebKit::WebHitTestResultPlatformData {
-    [SoftLinkedClass='PAL::getDDActionContextClass()'] RetainPtr<DDActionContext> detectedDataActionContext;
+    [Nullable, SoftLinkedClass='PAL::getDDActionContextClass()'] RetainPtr<DDActionContext> detectedDataActionContext;
     WebCore::FloatRect detectedDataBoundingBox;
     RefPtr<WebCore::TextIndicator> detectedDataTextIndicator;
     WebCore::PageOverlay::PageOverlayID detectedDataOriginatingPageOverlay;


### PR DESCRIPTION
#### 5e92b798c222801e991cf39aa378593bbc7f325e
<pre>
Don&apos;t call getDDActionContextClass if we don&apos;t have a DDActionContext to decode
<a href="https://bugs.webkit.org/show_bug.cgi?id=248931">https://bugs.webkit.org/show_bug.cgi?id=248931</a>
rdar://103099864

Reviewed by Aditya Keerthi.

This fixes a regression from 257087@main, before which we would only call getDDActionContextClass
if hasActionContext was true.  This restores equivalent behavior by supporting the Nullable attribute
when encoding soft linked ObjC classes.

* Source/WebKit/Scripts/generate-serializers.py:
(decode_type):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;NullableSoftLinkedMember&gt;::encode):
(IPC::ArgumentCoder&lt;NullableSoftLinkedMember&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in:

Canonical link: <a href="https://commits.webkit.org/257575@main">https://commits.webkit.org/257575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f4e5d52b2621bb32dd47e460b891ece995813ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108665 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85798 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91769 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106593 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33812 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/102806 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88641 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21719 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2357 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23235 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45636 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42713 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2656 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->