### PR TITLE
Make fullscreen elements match the :modal pseudo-class

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has-expected.txt
@@ -1,6 +1,8 @@
 This is some text.
 
 PASS :modal pseudo-class is not active with dialog.show()
-PASS :modal pseudo-class invalidation with showModal+close
-PASS :modal pseudo-class invalidation with showModal+remove
+PASS :modal pseudo-class invalidation with showModal + close
+PASS :modal pseudo-class invalidation with showModal + remove
+PASS :modal pseudo-class invalidation with requestFullscreen + exitFullscreen
+PASS :modal pseudo-class invalidation with requestFullscreen + remove
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has.html
@@ -5,14 +5,19 @@
 <link rel="help" href="https://drafts.csswg.org/selectors/#relational">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <style>
-  #subject:has(#dialog:modal) { color: green }
+  #subject:has(#dialog:modal) { color: green; }
+  #subject:has(#fullscreenTarget:modal) { color: blue; }
 </style>
 <div id="subject">
   This is some text.
   <dialog id="dialog">This is a dialog</dialog>
+  <div id="fullscreenTarget">This is going to be fullscreened</div>
 </div>
 <script>
+  // Dialog tests
   test(function() {
     assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
                   "ancestor should be black since dialog is not modal");
@@ -30,7 +35,7 @@
     dialog.close();
     assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
                   "ancestor should be black since dialog is closed");
-  }, ":modal pseudo-class invalidation with showModal+close");
+  }, ":modal pseudo-class invalidation with showModal + close");
   test(function() {
     assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
                   "ancestor should be black");
@@ -39,6 +44,37 @@
                   "ancestor should be green since dialog is shown modally");
     dialog.remove();
     assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
-                  "ancestor should be black since dialog is closed");
-  }, ":modal pseudo-class invalidation with showModal+remove");
+                  "ancestor should be black since dialog is removed");
+  }, ":modal pseudo-class invalidation with showModal + remove");
+
+  // Fullscreen tests
+  let waitForFullscreenChange = () => {
+    return new Promise((resolve) => {
+      document.addEventListener("fullscreenchange", resolve, { once: true });
+    });
+  };
+  promise_test(async function() {
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    test_driver.bless("fullscreen", () => fullscreenTarget.requestFullscreen());
+    await waitForFullscreenChange();
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 255)",
+                  "ancestor should be blue since target is fullscreen");
+    document.exitFullscreen();
+    await waitForFullscreenChange();
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black since target is no longer fullscreen");
+  }, ":modal pseudo-class invalidation with requestFullscreen + exitFullscreen");
+  promise_test(async function() {
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    test_driver.bless("fullscreen", () => fullscreenTarget.requestFullscreen());
+    await waitForFullscreenChange();
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 255)",
+                  "ancestor should be blue since target is fullscreen");
+    fullscreenTarget.remove();
+    await waitForFullscreenChange();
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black since target is removed");
+  }, ":modal pseudo-class invalidation with requestFullscreen + remove");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/modal-pseudo-class-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/modal-pseudo-class-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Test that :modal matches modal <dialog>
+PASS Test that :modal matches the fullscreen element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/modal-pseudo-class.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/modal-pseudo-class.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<meta charset="utf-8"/>
+<title>:modal pseudo-class</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="author" title="Jihwan Marc Kim" href="mailto:bluewhale.marc@gmail.com" />
+<link rel="help" href="https://drafts.csswg.org/selectors/#modal-state">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<dialog id="dialog">Just another dialog.</dialog>
+<div id="container">
+  <button id="btn"/>
+</div>
+
+<script>
+  test(() => {
+    const dialog = document.getElementById("dialog");
+    assert_false(dialog.matches(":modal"), "dialog is initially closed (does not match :modal)");
+
+    dialog.showModal();
+    assert_true(dialog.matches(":modal"), "dialog should match :modal after showModal() call");
+
+    dialog.close();
+    assert_false(dialog.matches(":modal"), "dialog should no longer match :modal after close() call");
+
+    dialog.show();
+    assert_false(dialog.matches(":modal"), "dialog shouldn't match :modal after show() call");
+
+    dialog.close();
+    dialog.showModal();
+    assert_true(dialog.matches(":modal"), "dialog should match :modal after showModal() call");
+
+    dialog.remove();
+    assert_false(dialog.matches(":modal"), "dialog shouldn't match :modal after being removed from document");
+    document.body.append(dialog);
+    assert_false(dialog.matches(":modal"), "dialog shouldn't match :modal after being re-appended to document");
+
+    dialog.close();
+  }, "Test that :modal matches modal <dialog>");
+
+  promise_test(async () => {
+    const container = document.getElementById("container");
+    const btn = document.getElementById("btn");
+
+    assert_false(container.matches(":modal"), "before requestFullscreen (does not match :modal)");
+
+    await test_driver.click(btn);
+
+    await container.requestFullscreen();
+
+    assert_true(container.matches(":modal"), ":fullscreen should match :modal");
+
+    await document.exitFullscreen();
+
+    assert_false(container.matches(":modal"), "after exitFullscreen (does not match :modal)");
+  }, "Test that :modal matches the fullscreen element");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/w3c-import.log
@@ -215,6 +215,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/last-child.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/last-of-type.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/missing-right-token.html
+/LayoutTests/imported/w3c/web-platform-tests/css/selectors/modal-pseudo-class.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/nesting-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/nesting-parsing.html
 /LayoutTests/imported/w3c/web-platform-tests/css/selectors/nesting-ref.html

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/selectors/modal-pseudo-class-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/selectors/modal-pseudo-class-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Test that :modal matches modal <dialog>
+FAIL Test that :modal matches the fullscreen element assert_true: :fullscreen should match :modal expected true got false
+

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -566,7 +566,11 @@ ALWAYS_INLINE bool matchesModalPseudoClass(const Element& element)
 {
     if (is<HTMLDialogElement>(element))
         return downcast<HTMLDialogElement>(element).isModal();
+#if ENABLE(FULLSCREEN_API)
+    return element.hasFullscreenFlag();
+#else
     return false;
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4169,7 +4169,7 @@ void Element::requestFullscreen(FullscreenOptions&&, RefPtr<DeferredPromise>&& p
 
 void Element::setFullscreenFlag(bool flag)
 {
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassFullscreen, flag);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, { { CSSSelector::PseudoClassFullscreen, flag }, { CSSSelector::PseudoClassModal, flag } });
     if (flag)
         setNodeFlag(NodeFlag::IsFullscreen);
     else


### PR DESCRIPTION
#### 56d7f894da59a5d699530cb396dbc9400f1836d1
<pre>
Make fullscreen elements match the :modal pseudo-class
<a href="https://bugs.webkit.org/show_bug.cgi?id=246004">https://bugs.webkit.org/show_bug.cgi?id=246004</a>
rdar://100782746

Reviewed by Antti Koivisto.

<a href="https://w3c.github.io/csswg-drafts/selectors/#modal-state">https://w3c.github.io/csswg-drafts/selectors/#modal-state</a>
&gt; For example, the dialog element is :modal when opened with the showModal() API.
&gt; Similarly, a :fullscreen element is also :modal when opened with the requestFullscreen() API, since this prevents interaction with the rest of the page.

We implemented the &quot;prevents interaction with the rest of the page&quot; part in <a href="https://commits.webkit.org/253803@main">https://commits.webkit.org/253803@main</a>

Relevant CSSWG discussion: <a href="https://github.com/w3c/csswg-drafts/issues/7311">https://github.com/w3c/csswg-drafts/issues/7311</a>

Also, we don&apos;t need to worry about the modal dialog in fullscreen mode case, since the fullscreen API forbids &lt;dialog&gt; elements.

* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/selectors/modal-pseudo-class-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/modal-pseudo-class-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/modal-pseudo-class.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/w3c-import.log:
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesModalPseudoClass):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setFullscreenFlag):

Canonical link: <a href="https://commits.webkit.org/257572@main">https://commits.webkit.org/257572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61dde7eebbc7a77ca9bec55ae7c99dbb620ce0e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108711 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168958 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85844 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91816 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106638 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105084 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33844 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88687 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21754 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2402 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23271 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2300 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42750 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2654 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4019 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->