### PR TITLE
[Lockdown mode] Add telemetry for kernel MIG routines

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2090,77 +2090,79 @@
                 (mach-bootstrap-message-numbers)))))
 #endif
 
+(define (kernel-mig-routines-common) (kernel-mig-routine
+    _mach_make_memory_entry
+    host_get_io_master
+    host_info
+    io_connect_async_method
+    io_connect_method
+    io_connect_method_var_output
+    io_connect_set_notification_port_64
+    io_iterator_is_valid
+    io_iterator_next
+    io_object_conforms_to
+    io_registry_entry_create_iterator
+    io_registry_entry_from_path
+    io_registry_entry_get_parent_iterator
+    io_registry_entry_get_property_bin_buf
+    io_registry_entry_get_property_bytes
+    io_registry_entry_get_registry_entry_id
+    io_server_version
+    io_service_add_interest_notification_64
+    io_service_add_notification_bin_64
+    io_service_get_matching_service_bin
+    io_service_open_extended
+    mach_exception_raise
+    mach_memory_entry_ownership
+    mach_port_extract_right
+    mach_port_get_refs
+    mach_port_request_notification
+    mach_port_set_attributes
+    mach_vm_copy
+    mach_vm_map_external
+    mach_vm_region
+    mach_vm_remap_external
+    semaphore_create
+    semaphore_destroy
+    task_create_identity_token
+    task_get_special_port_from_user
+    task_info_from_user
+    task_policy_set
+    task_restartable_ranges_synchronize
+    thread_resume
+    thread_set_exception_ports
+    thread_suspend))
+
+(define (kernel-mig-routines-blocked-in-lockdown-mode) (kernel-mig-routine
+    clock_get_time
+    host_request_notification
+    io_connect_add_client
+    io_connect_map_memory_into_task
+    io_registry_create_iterator
+    io_registry_entry_get_child_iterator
+    io_registry_entry_get_name
+    io_registry_entry_get_name_in_plane
+    io_registry_entry_get_properties_bin_buf
+    io_registry_get_root_entry
+    io_service_close
+    io_service_get_matching_services_bin
+    mach_port_get_context_from_user
+    mach_vm_region_recurse
+    task_threads_from_user
+    thread_get_state_to_user
+    thread_info
+    thread_policy
+    thread_policy_set))
+
 (if (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'mach-kernel-endpoint))
     (allow mach-kernel-endpoint
         (apply-message-filter
             (deny mach-message-send)
-            (allow mach-message-send
-                (kernel-mig-routine
-                    _mach_make_memory_entry
-                    clock_get_time
-                    host_get_io_master
-                    host_info
-                    host_request_notification
-                    io_connect_add_client
-                    io_connect_async_method
-                    io_connect_map_memory_into_task
-                    io_connect_method
-                    io_connect_method_var_output
-                    io_connect_set_notification_port_64
-                    io_iterator_is_valid
-                    io_iterator_next
-                    io_object_conforms_to
-                    io_registry_create_iterator
-                    io_registry_entry_create_iterator
-                    io_registry_entry_from_path
-                    io_registry_entry_get_child_iterator
-                    io_registry_entry_get_name
-                    io_registry_entry_get_name_in_plane
-                    io_registry_entry_get_parent_iterator
-                    io_registry_entry_get_properties_bin_buf
-                    io_registry_entry_get_property_bin_buf
-                    io_registry_entry_get_property_bytes
-                    io_registry_entry_get_registry_entry_id
-                    io_registry_get_root_entry
-                    io_server_version
-                    io_service_add_interest_notification_64
-                    io_service_add_notification_bin_64
-                    io_service_close
-                    io_service_get_matching_service_bin
-                    io_service_get_matching_services_bin
-                    io_service_open_extended
-                    mach_exception_raise
-                    mach_memory_entry_ownership
-                    mach_port_extract_right
-                    mach_port_get_context_from_user
-                    mach_port_get_refs
-                    mach_port_request_notification
-                    mach_port_set_attributes
-                    mach_vm_copy
-                    mach_vm_map_external
-                    mach_vm_region
-                    mach_vm_region_recurse
-                    mach_vm_remap_external
-                    semaphore_create
-                    semaphore_destroy
-                    task_create_identity_token
-                    task_get_special_port_from_user
-                    task_info_from_user
-                    task_policy_set
-                    task_restartable_ranges_synchronize
-                    task_threads_from_user
-                    thread_get_state_to_user
-                    thread_info
-                    thread_policy
-                    thread_policy_set
-                    thread_resume
-                    thread_set_exception_ports
-                    thread_suspend
-                )
-            )
-        )
-    )
-)
+            (allow mach-message-send (kernel-mig-routines-common))
+            (with-filter (require-entitlement "com.apple.security.cs.allow-jit")
+                (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode)))
+            (with-filter (require-not (require-entitlement "com.apple.security.cs.allow-jit"))
+                (allow mach-message-send (with report) (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode))))))
 
 (define (syscall-mach-common) (machtrap-number
     MSC__kernelrpc_mach_port_allocate_trap


### PR DESCRIPTION
#### 6d6cad3a850c47b2ce62615fc182b6fc77ca64cc
<pre>
[Lockdown mode] Add telemetry for kernel MIG routines
<a href="https://bugs.webkit.org/show_bug.cgi?id=248934">https://bugs.webkit.org/show_bug.cgi?id=248934</a>
rdar://103107451

Reviewed by Brent Fulgham.

Add telemetry for kernel MIG routines in Lockdown mode on macOS.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/257629@main">https://commits.webkit.org/257629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ead3de4e6037afdb0fe15a74445e0b239b7473a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108883 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85999 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91990 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106799 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105274 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33979 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21891 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2541 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23405 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2469 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8621 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42880 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5247 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4328 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->