### PR TITLE
Simplify TimingFunction encoding and decoding

### DIFF
--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -1664,30 +1664,30 @@ std::optional<RefPtr<WebCore::ReportBody>> ArgumentCoder<RefPtr<WebCore::ReportB
     return std::nullopt;
 }
 
-void ArgumentCoder<Ref<WebCore::TimingFunction>>::encode(Encoder& encoder, const Ref<WebCore::TimingFunction>& timingFunction)
+void ArgumentCoder<WebCore::TimingFunction>::encode(Encoder& encoder, const WebCore::TimingFunction& timingFunction)
 {
-    encoder << timingFunction->type();
+    encoder << timingFunction.type();
 
-    switch (timingFunction->type()) {
+    switch (timingFunction.type()) {
     case TimingFunction::TimingFunctionType::LinearFunction:
-        encoder << downcast<LinearTimingFunction>(timingFunction.get());
+        encoder << downcast<LinearTimingFunction>(timingFunction);
         break;
 
     case TimingFunction::TimingFunctionType::CubicBezierFunction:
-        encoder << downcast<CubicBezierTimingFunction>(timingFunction.get());
+        encoder << downcast<CubicBezierTimingFunction>(timingFunction);
         break;
 
     case TimingFunction::TimingFunctionType::StepsFunction:
-        encoder << downcast<StepsTimingFunction>(timingFunction.get());
+        encoder << downcast<StepsTimingFunction>(timingFunction);
         break;
 
     case TimingFunction::TimingFunctionType::SpringFunction:
-        encoder << downcast<SpringTimingFunction>(timingFunction.get());
+        encoder << downcast<SpringTimingFunction>(timingFunction);
         break;
     }
 }
 
-std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<Ref<WebCore::TimingFunction>>::decode(Decoder& decoder)
+std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<WebCore::TimingFunction>::decode(Decoder& decoder)
 {
     std::optional<TimingFunction::TimingFunctionType> type;
     decoder >> type;
@@ -1730,32 +1730,6 @@ std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<Ref<WebCore::TimingFun
 
     ASSERT_NOT_REACHED();
     return std::nullopt;
-}
-
-void ArgumentCoder<RefPtr<WebCore::TimingFunction>>::encode(Encoder& encoder, const RefPtr<WebCore::TimingFunction>& timingFunction)
-{
-    bool hasTimingFunction = !!timingFunction;
-    encoder << hasTimingFunction;
-    if (!hasTimingFunction)
-        return;
-
-    encoder << Ref { *timingFunction };
-}
-
-std::optional<RefPtr<WebCore::TimingFunction>> ArgumentCoder<RefPtr<WebCore::TimingFunction>>::decode(Decoder& decoder)
-{
-    bool hasTimingFunction;
-    if (!decoder.decode(hasTimingFunction))
-        return std::nullopt;
-
-    if (!hasTimingFunction)
-        return nullptr;
-
-    std::optional<Ref<TimingFunction>> timingFunction;
-    decoder >> timingFunction;
-    if (!timingFunction)
-        return std::nullopt;
-    return WTFMove(*timingFunction);
 }
 
 void ArgumentCoder<WebCore::TransformOperation>::encode(Encoder& encoder, const WebCore::TransformOperation& transformOperation)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -564,14 +564,9 @@ template<> struct ArgumentCoder<RefPtr<WebCore::ReportBody>> {
     static std::optional<RefPtr<WebCore::ReportBody>> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<Ref<WebCore::TimingFunction>> {
-    static void encode(Encoder&, const Ref<WebCore::TimingFunction>&);
+template<> struct ArgumentCoder<WebCore::TimingFunction> {
+    static void encode(Encoder&, const WebCore::TimingFunction&);
     static std::optional<Ref<WebCore::TimingFunction>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<RefPtr<WebCore::TimingFunction>> {
-    static void encode(Encoder&, const RefPtr<WebCore::TimingFunction>&);
-    static std::optional<RefPtr<WebCore::TimingFunction>> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<WebCore::TransformOperation> {


### PR DESCRIPTION
#### 52696c5a554816fc2b2058153dbdb8b84f822528
<pre>
Simplify TimingFunction encoding and decoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=248936">https://bugs.webkit.org/show_bug.cgi?id=248936</a>

Reviewed by Antti Koivisto.

* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::TimingFunction&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::TimingFunction&gt;::decode):
(IPC::ArgumentCoder&lt;Ref&lt;WebCore::TimingFunction&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;Ref&lt;WebCore::TimingFunction&gt;&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::TimingFunction&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::TimingFunction&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:

Canonical link: <a href="https://commits.webkit.org/257557@main">https://commits.webkit.org/257557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/834364d5c9514b8d36bf6263b524aac54190b9a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108685 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85817 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91790 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106612 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105058 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90388 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2376 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23251 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2274 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8183 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42730 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2649 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3931 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->