### PR TITLE
Rename TimingFunction::TimingFunctionType enum to TimingFunction::Type

### DIFF
--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1609,7 +1609,7 @@ static Ref<CSSPrimitiveValue> valueForAnimationName(const Animation::Name& name)
 static Ref<CSSValue> valueForAnimationTimingFunction(const TimingFunction& timingFunction)
 {
     switch (timingFunction.type()) {
-    case TimingFunction::TimingFunctionType::CubicBezierFunction: {
+    case TimingFunction::Type::CubicBezierFunction: {
         auto& function = downcast<CubicBezierTimingFunction>(timingFunction);
         if (function.timingFunctionPreset() != CubicBezierTimingFunction::TimingFunctionPreset::Custom) {
             CSSValueID valueId = CSSValueInvalid;
@@ -1633,15 +1633,15 @@ static Ref<CSSValue> valueForAnimationTimingFunction(const TimingFunction& timin
         }
         return CSSCubicBezierTimingFunctionValue::create(function.x1(), function.y1(), function.x2(), function.y2());
     }
-    case TimingFunction::TimingFunctionType::StepsFunction: {
+    case TimingFunction::Type::StepsFunction: {
         auto& function = downcast<StepsTimingFunction>(timingFunction);
         return CSSStepsTimingFunctionValue::create(function.numberOfSteps(), function.stepPosition());
     }
-    case TimingFunction::TimingFunctionType::SpringFunction: {
+    case TimingFunction::Type::SpringFunction: {
         auto& function = downcast<SpringTimingFunction>(timingFunction);
         return CSSSpringTimingFunctionValue::create(function.mass(), function.stiffness(), function.damping(), function.initialVelocity());
     }
-    case TimingFunction::TimingFunctionType::LinearFunction:
+    case TimingFunction::Type::LinearFunction:
         return CSSValuePool::singleton().createIdentifierValue(CSSValueLinear);
     }
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/animation/TimingFunction.cpp
+++ b/Source/WebCore/platform/animation/TimingFunction.cpp
@@ -38,15 +38,15 @@ namespace WebCore {
 TextStream& operator<<(TextStream& ts, const TimingFunction& timingFunction)
 {
     switch (timingFunction.type()) {
-    case TimingFunction::TimingFunctionType::LinearFunction:
+    case TimingFunction::Type::LinearFunction:
         ts << "linear";
         break;
-    case TimingFunction::TimingFunctionType::CubicBezierFunction: {
+    case TimingFunction::Type::CubicBezierFunction: {
         auto& function = downcast<CubicBezierTimingFunction>(timingFunction);
         ts << "cubic-bezier(" << function.x1() << ", " << function.y1() << ", " <<  function.x2() << ", " << function.y2() << ")";
         break;
     }
-    case TimingFunction::TimingFunctionType::StepsFunction: {
+    case TimingFunction::Type::StepsFunction: {
         auto& function = downcast<StepsTimingFunction>(timingFunction);
         ts << "steps(" << function.numberOfSteps();
         if (auto stepPosition = function.stepPosition()) {
@@ -80,7 +80,7 @@ TextStream& operator<<(TextStream& ts, const TimingFunction& timingFunction)
         ts << ")";
         break;
     }
-    case TimingFunction::TimingFunctionType::SpringFunction: {
+    case TimingFunction::Type::SpringFunction: {
         auto& function = downcast<SpringTimingFunction>(timingFunction);
         ts << "spring(" << function.mass() << " " << function.stiffness() << " " <<  function.damping() << " " << function.initialVelocity() << ")";
         break;
@@ -92,7 +92,7 @@ TextStream& operator<<(TextStream& ts, const TimingFunction& timingFunction)
 double TimingFunction::transformProgress(double progress, double duration, bool before) const
 {
     switch (type()) {
-    case TimingFunctionType::CubicBezierFunction: {
+    case Type::CubicBezierFunction: {
         auto& function = downcast<CubicBezierTimingFunction>(*this);
         if (function.isLinear())
             return progress;
@@ -101,7 +101,7 @@ double TimingFunction::transformProgress(double progress, double duration, bool 
         auto epsilon = 1.0 / (1000.0 * duration);
         return UnitBezier(function.x1(), function.y1(), function.x2(), function.y2()).solve(progress, epsilon);
     }
-    case TimingFunctionType::StepsFunction: {
+    case Type::StepsFunction: {
         // https://drafts.csswg.org/css-easing-1/#step-timing-functions
         auto& function = downcast<StepsTimingFunction>(*this);
         auto steps = function.numberOfSteps();
@@ -131,11 +131,11 @@ double TimingFunction::transformProgress(double progress, double duration, bool 
         // 7. The output progress value is current step / jumps.
         return currentStep / steps;
     }
-    case TimingFunctionType::SpringFunction: {
+    case Type::SpringFunction: {
         auto& function = downcast<SpringTimingFunction>(*this);
         return SpringSolver(function.mass(), function.stiffness(), function.damping(), function.initialVelocity()).solve(progress * duration);
     }
-    case TimingFunctionType::LinearFunction:
+    case Type::LinearFunction:
         return progress;
     }
 
@@ -195,7 +195,7 @@ RefPtr<TimingFunction> TimingFunction::createFromCSSValue(const CSSValue& value)
 
 String TimingFunction::cssText() const
 {
-    if (type() == TimingFunctionType::CubicBezierFunction) {
+    if (type() == Type::CubicBezierFunction) {
         auto& function = downcast<CubicBezierTimingFunction>(*this);
         if (function.x1() == 0.25 && function.y1() == 0.1 && function.x2() == 0.25 && function.y2() == 1.0)
             return "ease"_s;
@@ -208,7 +208,7 @@ String TimingFunction::cssText() const
         return makeString("cubic-bezier(", function.x1(), ", ", function.y1(), ", ", function.x2(), ", ", function.y2(), ')');
     }
 
-    if (type() == TimingFunctionType::StepsFunction) {
+    if (type() == Type::StepsFunction) {
         auto& function = downcast<StepsTimingFunction>(*this);
         if (function.stepPosition() == StepsTimingFunction::StepPosition::JumpEnd || function.stepPosition() == StepsTimingFunction::StepPosition::End)
             return makeString("steps(", function.numberOfSteps(), ')');

--- a/Source/WebCore/platform/animation/TimingFunction.h
+++ b/Source/WebCore/platform/animation/TimingFunction.h
@@ -42,13 +42,13 @@ public:
 
     virtual ~TimingFunction() = default;
 
-    enum class TimingFunctionType { LinearFunction, CubicBezierFunction, StepsFunction, SpringFunction };
-    virtual TimingFunctionType type() const = 0;
+    enum class Type { LinearFunction, CubicBezierFunction, StepsFunction, SpringFunction };
+    virtual Type type() const = 0;
 
-    bool isLinearTimingFunction() const { return type() == TimingFunctionType::LinearFunction; }
-    bool isCubicBezierTimingFunction() const { return type() == TimingFunctionType::CubicBezierFunction; }
-    bool isStepsTimingFunction() const { return type() == TimingFunctionType::StepsFunction; }
-    bool isSpringTimingFunction() const { return type() == TimingFunctionType::SpringFunction; }
+    bool isLinearTimingFunction() const { return type() == Type::LinearFunction; }
+    bool isCubicBezierTimingFunction() const { return type() == Type::CubicBezierFunction; }
+    bool isStepsTimingFunction() const { return type() == Type::StepsFunction; }
+    bool isSpringTimingFunction() const { return type() == Type::SpringFunction; }
 
     virtual bool operator==(const TimingFunction&) const = 0;
     bool operator!=(const TimingFunction& other) const { return !(*this == other); }
@@ -78,7 +78,7 @@ public:
     }
 
 private:
-    TimingFunctionType type() const final { return TimingFunctionType::LinearFunction; }
+    Type type() const final { return Type::LinearFunction; }
     Ref<TimingFunction> clone() const final
     {
         return adoptRef(*new LinearTimingFunction);
@@ -163,7 +163,7 @@ private:
     {
     }
 
-    TimingFunctionType type() const final { return TimingFunctionType::CubicBezierFunction; }
+    Type type() const final { return Type::CubicBezierFunction; }
     Ref<TimingFunction> clone() const final
     {
         return adoptRef(*new CubicBezierTimingFunction(m_timingFunctionPreset, m_x1, m_y1, m_x2, m_y2));
@@ -228,7 +228,7 @@ private:
     {
     }
 
-    TimingFunctionType type() const final { return TimingFunctionType::StepsFunction; }
+    Type type() const final { return Type::StepsFunction; }
     Ref<TimingFunction> clone() const final
     {
         return adoptRef(*new StepsTimingFunction(m_steps, m_stepPosition));
@@ -274,7 +274,7 @@ private:
     {
     }
 
-    TimingFunctionType type() const final { return TimingFunctionType::SpringFunction; }
+    Type type() const final { return Type::SpringFunction; }
     Ref<TimingFunction> clone() const final
     {
         return adoptRef(*new SpringTimingFunction(m_mass, m_stiffness, m_damping, m_initialVelocity));
@@ -325,13 +325,13 @@ template<> struct EnumTraits<WebCore::StepsTimingFunction::StepPosition> {
     >;
 };
 
-template<> struct EnumTraits<WebCore::TimingFunction::TimingFunctionType> {
+template<> struct EnumTraits<WebCore::TimingFunction::Type> {
     using values = EnumValues<
-        WebCore::TimingFunction::TimingFunctionType,
-        WebCore::TimingFunction::TimingFunctionType::LinearFunction,
-        WebCore::TimingFunction::TimingFunctionType::CubicBezierFunction,
-        WebCore::TimingFunction::TimingFunctionType::StepsFunction,
-        WebCore::TimingFunction::TimingFunctionType::SpringFunction
+        WebCore::TimingFunction::Type,
+        WebCore::TimingFunction::Type::LinearFunction,
+        WebCore::TimingFunction::Type::CubicBezierFunction,
+        WebCore::TimingFunction::Type::StepsFunction,
+        WebCore::TimingFunction::Type::SpringFunction
     >;
 };
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
@@ -145,7 +145,7 @@ CAMediaTimingFunction* toCAMediaTimingFunction(const TimingFunction& timingFunct
         return [CAMediaTimingFunction functionWithControlPoints: x1 : y1 : x2 : y2];
     }
     
-    ASSERT(timingFunction.type() == TimingFunction::TimingFunctionType::LinearFunction);
+    ASSERT(timingFunction.type() == TimingFunction::Type::LinearFunction);
     return [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
 }
 

--- a/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp
+++ b/Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp
@@ -139,7 +139,7 @@ static RetainPtr<CACFTimingFunctionRef> toCACFTimingFunction(const TimingFunctio
         return adoptCF(CACFTimingFunctionCreate(x1, y1, x2, y2));
     }
 
-    ASSERT(timingFunction.type() == TimingFunction::TimingFunctionType::LinearFunction);
+    ASSERT(timingFunction.type() == TimingFunction::Type::LinearFunction);
     return CACFTimingFunctionGetFunctionWithName(kCACFTimingFunctionLinear);
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -1669,19 +1669,19 @@ void ArgumentCoder<WebCore::TimingFunction>::encode(Encoder& encoder, const WebC
     encoder << timingFunction.type();
 
     switch (timingFunction.type()) {
-    case TimingFunction::TimingFunctionType::LinearFunction:
+    case TimingFunction::Type::LinearFunction:
         encoder << downcast<LinearTimingFunction>(timingFunction);
         break;
 
-    case TimingFunction::TimingFunctionType::CubicBezierFunction:
+    case TimingFunction::Type::CubicBezierFunction:
         encoder << downcast<CubicBezierTimingFunction>(timingFunction);
         break;
 
-    case TimingFunction::TimingFunctionType::StepsFunction:
+    case TimingFunction::Type::StepsFunction:
         encoder << downcast<StepsTimingFunction>(timingFunction);
         break;
 
-    case TimingFunction::TimingFunctionType::SpringFunction:
+    case TimingFunction::Type::SpringFunction:
         encoder << downcast<SpringTimingFunction>(timingFunction);
         break;
     }
@@ -1689,13 +1689,13 @@ void ArgumentCoder<WebCore::TimingFunction>::encode(Encoder& encoder, const WebC
 
 std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<WebCore::TimingFunction>::decode(Decoder& decoder)
 {
-    std::optional<TimingFunction::TimingFunctionType> type;
+    std::optional<TimingFunction::Type> type;
     decoder >> type;
     if (!type)
         return std::nullopt;
 
     switch (*type) {
-    case TimingFunction::TimingFunctionType::LinearFunction: {
+    case TimingFunction::Type::LinearFunction: {
         std::optional<Ref<LinearTimingFunction>> function;
         decoder >> function;
         if (!function)
@@ -1703,7 +1703,7 @@ std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<WebCore::TimingFunctio
         return WTFMove(*function);
     }
 
-    case TimingFunction::TimingFunctionType::CubicBezierFunction: {
+    case TimingFunction::Type::CubicBezierFunction: {
         std::optional<Ref<CubicBezierTimingFunction>> function;
         decoder >> function;
         if (!function)
@@ -1711,7 +1711,7 @@ std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<WebCore::TimingFunctio
         return WTFMove(*function);
     }
 
-    case TimingFunction::TimingFunctionType::StepsFunction: {
+    case TimingFunction::Type::StepsFunction: {
         std::optional<Ref<StepsTimingFunction>> function;
         decoder >> function;
         if (!function)
@@ -1719,7 +1719,7 @@ std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<WebCore::TimingFunctio
         return WTFMove(*function);
     }
 
-    case TimingFunction::TimingFunctionType::SpringFunction: {
+    case TimingFunction::Type::SpringFunction: {
         std::optional<Ref<SpringTimingFunction>> function;
         decoder >> function;
         if (!function)


### PR DESCRIPTION
#### 5cba08de38f1b487dda38b0cf39afbf704cc957c
<pre>
Rename TimingFunction::TimingFunctionType enum to TimingFunction::Type
<a href="https://bugs.webkit.org/show_bug.cgi?id=248941">https://bugs.webkit.org/show_bug.cgi?id=248941</a>

Reviewed by Antti Koivisto.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForAnimationTimingFunction):
* Source/WebCore/platform/animation/TimingFunction.cpp:
(WebCore::operator&lt;&lt;):
(WebCore::TimingFunction::transformProgress const):
(WebCore::TimingFunction::cssText const):
* Source/WebCore/platform/animation/TimingFunction.h:
(WebCore::TimingFunction::isLinearTimingFunction const):
(WebCore::TimingFunction::isCubicBezierTimingFunction const):
(WebCore::TimingFunction::isStepsTimingFunction const):
(WebCore::TimingFunction::isSpringTimingFunction const):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm:
(WebCore::toCAMediaTimingFunction):
* Source/WebCore/platform/graphics/ca/win/PlatformCAAnimationWin.cpp:
(toCACFTimingFunction):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;Ref&lt;WebCore::TimingFunction&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;Ref&lt;WebCore::TimingFunction&gt;&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/257558@main">https://commits.webkit.org/257558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff753dfefc43d3037bd45b59e8140ede658b5f6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108699 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168946 "Failed to checkout and rebase branch from PR 7316") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85831 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91804 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106626 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105072 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2390 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2288 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8303 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/42738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2650 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->