### PR TITLE
Add abstract decoder support in LibWebRTCCodecsProxy

### DIFF
--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp
@@ -52,6 +52,7 @@ SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBlockBufferGetDataLe
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBlockBufferIsRangeContiguous, Boolean, (CMBlockBufferRef theBuffer, size_t offset, size_t length), (theBuffer, offset, length), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBlockBufferReplaceDataBytes, OSStatus, (const void* sourceBytes, CMBlockBufferRef destinationBuffer, size_t offsetIntoDestination, size_t dataLength), (sourceBytes, destinationBuffer, offsetIntoDestination, dataLength), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMFormatDescriptionGetExtension, CFPropertyListRef, (CMFormatDescriptionRef desc, CFStringRef extensionKey), (desc, extensionKey), PAL_EXPORT)
+SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMFormatDescriptionEqual, Boolean, (CMFormatDescriptionRef desc, CMFormatDescriptionRef other), (desc, other), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMFormatDescriptionGetExtensions, CFDictionaryRef, (CMFormatDescriptionRef desc), (desc), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMSampleBufferGetTypeID, CFTypeID, (void), (), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMSampleBufferGetDataBuffer, CMBlockBufferRef, (CMSampleBufferRef sbuf), (sbuf), PAL_EXPORT)

--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
@@ -58,6 +58,8 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMFormatDescriptionGetExtensions, 
 #define CMFormatDescriptionGetExtensions softLink_CoreMedia_CMFormatDescriptionGetExtensions
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMFormatDescriptionGetExtension, CFPropertyListRef, (CMFormatDescriptionRef desc, CFStringRef extensionKey), (desc, extensionKey))
 #define CMFormatDescriptionGetExtension softLink_CoreMedia_CMFormatDescriptionGetExtension
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMFormatDescriptionEqual, Boolean, (CMFormatDescriptionRef desc, CMFormatDescriptionRef other), (desc, other))
+#define CMFormatDescriptionEqual softLink_CoreMedia_CMFormatDescriptionEqual
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMSampleBufferGetTypeID, CFTypeID, (void), ())
 #define CMSampleBufferGetTypeID softLink_CoreMedia_CMSampleBufferGetTypeID
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMSampleBufferGetDataBuffer, CMBlockBufferRef, (CMSampleBufferRef sbuf), (sbuf))

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -36,6 +36,7 @@
 #include "LayoutRect.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/Seconds.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/platform/cocoa/CoreVideoSoftLink.cpp
+++ b/Source/WebCore/platform/cocoa/CoreVideoSoftLink.cpp
@@ -100,6 +100,10 @@ SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CoreVideo, CVOpenGLTextureGetCleanTexCoor
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelBufferIOSurfaceOpenGLFBOCompatibilityKey, CFStringRef)
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelBufferOpenGLESCompatibilityKey, CFStringRef)
+#endif
+
 #if PLATFORM(MAC)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelBufferExtendedPixelsRightKey, CFStringRef)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelBufferExtendedPixelsBottomKey, CFStringRef)

--- a/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
+++ b/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
@@ -164,6 +164,11 @@ SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreVideo, kCVPixelBufferIOSurfaceOpenGLF
 #define kCVPixelBufferIOSurfaceOpenGLFBOCompatibilityKey get_CoreVideo_kCVPixelBufferIOSurfaceOpenGLFBOCompatibilityKey()
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreVideo, kCVPixelBufferOpenGLESCompatibilityKey, CFStringRef)
+#define kCVPixelBufferExtendedPixelsRightKey get_CoreVideo_kCVPixelBufferOpenGLESCompatibilityKey()
+#endif
+
 #if PLATFORM(MAC)
 SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreVideo, kCVPixelBufferExtendedPixelsRightKey, CFStringRef)
 #define kCVPixelBufferExtendedPixelsRightKey get_CoreVideo_kCVPixelBufferExtendedPixelsRightKey()

--- a/Source/WebCore/platform/mediastream/cocoa/WebRTCVideoDecoder.h
+++ b/Source/WebCore/platform/mediastream/cocoa/WebRTCVideoDecoder.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(LIBWEBRTC)
+
+#include <wtf/UniqueRef.h>
+
+namespace webrtc {
+using LocalDecoder = void*;
+}
+
+namespace WebCore {
+
+class WebRTCVideoDecoder {
+public:
+    virtual ~WebRTCVideoDecoder() = default;
+
+#if USE(LIBWEBRTC)
+    WEBCORE_EXPORT static UniqueRef<WebRTCVideoDecoder> createFromLocalDecoder(webrtc::LocalDecoder);
+#endif
+
+    virtual void flush() = 0;
+    virtual void setFormat(const uint8_t*, size_t, uint16_t width, uint16_t height) = 0;
+    virtual int32_t decodeFrame(int64_t timeStamp, const uint8_t*, size_t) = 0;
+    virtual void setFrameSize(uint16_t width, uint16_t height) = 0;
+};
+
+}
+
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/WebRTCVideoDecoderAdditions.h>
+#endif
+
+#endif // USE(LIBWEBRTC)

--- a/Source/WebCore/platform/mediastream/cocoa/WebRTCVideoDecoder.mm
+++ b/Source/WebCore/platform/mediastream/cocoa/WebRTCVideoDecoder.mm
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebRTCVideoDecoder.h"
+
+#if USE(LIBWEBRTC)
+
+ALLOW_UNUSED_PARAMETERS_BEGIN
+ALLOW_COMMA_BEGIN
+
+#include <webrtc/sdk/WebKit/WebKitDecoder.h>
+
+ALLOW_UNUSED_PARAMETERS_END
+ALLOW_COMMA_END
+
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/WebRTCVideoDecoderAdditions.mm>
+#endif
+
+namespace WebCore {
+
+class WebRTCLocalVideoDecoder final : public WebRTCVideoDecoder {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit WebRTCLocalVideoDecoder(webrtc::LocalDecoder decoder)
+        : m_decoder(decoder)
+    {
+    }
+    ~WebRTCLocalVideoDecoder()
+    {
+        webrtc::releaseLocalDecoder(m_decoder);
+    }
+
+private:
+    void flush() final { webrtc::flushLocalDecoder(m_decoder); }
+    void setFormat(const uint8_t* data, size_t size, uint16_t width, uint16_t height) final { webrtc::setDecodingFormat(m_decoder, data, size, width, height); }
+    int32_t decodeFrame(int64_t timeStamp, const uint8_t* data, size_t size) final { return webrtc::decodeFrame(m_decoder, timeStamp, data, size); }
+    void setFrameSize(uint16_t width, uint16_t height) final { webrtc::setDecoderFrameSize(m_decoder, width, height); }
+
+    webrtc::LocalDecoder m_decoder;
+};
+
+UniqueRef<WebRTCVideoDecoder> WebRTCVideoDecoder::createFromLocalDecoder(webrtc::LocalDecoder decoder)
+{
+    return makeUniqueRef<WebRTCLocalVideoDecoder>(decoder);
+}
+
+}
+
+#endif
+

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
@@ -81,8 +81,7 @@ void LibWebRTCCodecsProxy::stopListeningForIPC(Ref<LibWebRTCCodecsProxy>&& refFr
     m_queue->dispatch([this, protectedThis = WTFMove(refFromConnection)] {
         assertIsCurrent(workQueue());
         auto decoders = WTFMove(m_decoders);
-        for (auto decoder : decoders.values())
-            webrtc::releaseLocalDecoder(decoder);
+        decoders.clear();
         auto encoders = WTFMove(m_encoders);
         for (auto& encoder : encoders.values())
             webrtc::releaseLocalEncoder(encoder.webrtcEncoder);
@@ -116,16 +115,21 @@ auto LibWebRTCCodecsProxy::createDecoderCallback(VideoDecoderIdentifier identifi
     };
 }
 
-void* LibWebRTCCodecsProxy::createLocalDecoder(VideoDecoderIdentifier identifier, VideoCodecType codecType, bool useRemoteFrames)
+std::unique_ptr<WebCore::WebRTCVideoDecoder> LibWebRTCCodecsProxy::createLocalDecoder(VideoDecoderIdentifier identifier, VideoCodecType codecType, bool useRemoteFrames)
 {
     auto block = makeBlockPtr(createDecoderCallback(identifier, useRemoteFrames));
+
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/LibWebRTCCodecsProxyAdditions.mm>
+#endif
+
     switch (codecType) {
     case VideoCodecType::H264:
-        return webrtc::createLocalH264Decoder(block.get());
+        return WebRTCVideoDecoder::createFromLocalDecoder(webrtc::createLocalH264Decoder(block.get())).moveToUniquePtr();
     case VideoCodecType::H265:
-        return webrtc::createLocalH265Decoder(block.get());
+        return WebRTCVideoDecoder::createFromLocalDecoder(webrtc::createLocalH265Decoder(block.get())).moveToUniquePtr();
     case VideoCodecType::VP9:
-        return webrtc::createLocalVP9Decoder(block.get());
+        return WebRTCVideoDecoder::createFromLocalDecoder(webrtc::createLocalVP9Decoder(block.get())).moveToUniquePtr();
     default:
         break;
     }
@@ -136,7 +140,12 @@ void* LibWebRTCCodecsProxy::createLocalDecoder(VideoDecoderIdentifier identifier
 void LibWebRTCCodecsProxy::createDecoder(VideoDecoderIdentifier identifier, VideoCodecType codecType, bool useRemoteFrames)
 {
     assertIsCurrent(workQueue());
-    auto result = m_decoders.add(identifier, createLocalDecoder(identifier, codecType, useRemoteFrames));
+    auto decoder = createLocalDecoder(identifier, codecType, useRemoteFrames);
+    if (!decoder) {
+        ASSERT(IPC::isTestingIPC());
+        return;
+    }
+    auto result = m_decoders.add(identifier,  makeUniqueRefFromNonNullUniquePtr(WTFMove(decoder)));
     ASSERT_UNUSED(result, result.isNewEntry || IPC::isTestingIPC());
     m_hasEncodersOrDecoders = true;
 }
@@ -149,7 +158,6 @@ void LibWebRTCCodecsProxy::releaseDecoder(VideoDecoderIdentifier identifier)
         ASSERT_IS_TESTING_IPC();
         return;
     }
-    webrtc::releaseLocalDecoder(decoder);
     m_hasEncodersOrDecoders = !m_encoders.isEmpty() || !m_decoders.isEmpty();
 }
 
@@ -161,7 +169,7 @@ void LibWebRTCCodecsProxy::flushDecoder(VideoDecoderIdentifier identifier)
         ASSERT_IS_TESTING_IPC();
         return;
     }
-    webrtc::flushLocalDecoder(decoder);
+    decoder->flush();
     m_connection->send(Messages::LibWebRTCCodecs::FlushDecoderCompleted { identifier }, 0);
 }
 
@@ -173,7 +181,7 @@ void LibWebRTCCodecsProxy::setDecoderFormatDescription(VideoDecoderIdentifier id
         ASSERT_IS_TESTING_IPC();
         return;
     }
-    webrtc::setDecodingFormat(decoder, data.data(), data.size(), width, height);
+    decoder->setFormat(data.data(), data.size(), width, height);
 }
 
 void LibWebRTCCodecsProxy::decodeFrame(VideoDecoderIdentifier identifier, int64_t timeStamp, const IPC::DataReference& data) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
@@ -184,7 +192,7 @@ void LibWebRTCCodecsProxy::decodeFrame(VideoDecoderIdentifier identifier, int64_
         ASSERT_IS_TESTING_IPC();
         return;
     }
-    if (webrtc::decodeFrame(decoder, timeStamp, data.data(), data.size()))
+    if (decoder->decodeFrame(timeStamp, data.data(), data.size()))
         m_connection->send(Messages::LibWebRTCCodecs::FailedDecoding { identifier }, 0);
 }
 
@@ -196,7 +204,7 @@ void LibWebRTCCodecsProxy::setFrameSize(VideoDecoderIdentifier identifier, uint1
         ASSERT_IS_TESTING_IPC();
         return;
     }
-    webrtc::setDecoderFrameSize(decoder, width, height);
+    decoder->setFrameSize(width, height);
 }
 
 void LibWebRTCCodecsProxy::createEncoder(VideoEncoderIdentifier identifier, VideoCodecType codecType, const Vector<std::pair<String, String>>& parameters, bool useLowLatency, bool useAnnexB)

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -57,6 +57,10 @@ ALLOW_COMMA_END
 namespace WebKit {
 using namespace WebCore;
 
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/LibWebRTCCodecsAdditions.mm>
+#else
+
 static webrtc::WebKitVideoDecoder createVideoDecoder(const webrtc::SdpVideoFormat& format)
 {
     auto& codecs = WebProcess::singleton().libWebRTCCodecs();
@@ -91,6 +95,8 @@ std::optional<VideoCodecType> LibWebRTCCodecs::videoCodecTypeFromWebCodec(const 
     // FIXME: Expose H265 if available.
     return { };
 }
+
+#endif
 
 static int32_t releaseVideoDecoder(webrtc::WebKitVideoDecoder::Value decoder)
 {


### PR DESCRIPTION
#### 18c55a96d72a7803f29356f3f17f361a568b1c2b
<pre>
Add abstract decoder support in LibWebRTCCodecsProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=248753">https://bugs.webkit.org/show_bug.cgi?id=248753</a>
rdar://problem/102976377

Reviewed by Eric Carlson.

Add WebRTCVideoDecoder interface to allow moving WebRTC decoders from libwebrtc to WebCore.
This is better to do this since we are now using these decoders for WebCodecs.
Add a specific class to wrap existing libwebrtc decoders with the new interface.

* Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp:
* Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/agents/InspectorPageAgent.h:
* Source/WebCore/platform/mediastream/cocoa/WebRTCVideoDecoder.h: Added.
* Source/WebCore/platform/mediastream/cocoa/WebRTCVideoDecoder.mm: Added.
(WebCore::WebRTCVideoDecoder::createFromLocalDecoder):
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::LibWebRTCCodecsProxy::stopListeningForIPC):
(WebKit::LibWebRTCCodecsProxy::createLocalDecoder):
(WebKit::LibWebRTCCodecsProxy::createDecoder):
(WebKit::LibWebRTCCodecsProxy::releaseDecoder):
(WebKit::LibWebRTCCodecsProxy::flushDecoder):
(WebKit::LibWebRTCCodecsProxy::setDecoderFormatDescription):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:

Canonical link: <a href="https://commits.webkit.org/257582@main">https://commits.webkit.org/257582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8edeab7c1cfe57d162538b63705819ba1bd5776

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108702 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168949 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85834 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91807 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106629 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90400 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33841 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21746 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2393 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23263 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2291 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45669 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5222 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42742 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3964 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->