### PR TITLE
AudioSession category should be sticky if DOMAudioSession.type is set

### DIFF
--- a/LayoutTests/media/audioSession/audioSessionType-web-audio-expected.txt
+++ b/LayoutTests/media/audioSession/audioSessionType-web-audio-expected.txt
@@ -1,0 +1,3 @@
+
+PASS AudioSession type with web audio
+

--- a/LayoutTests/media/audioSession/audioSessionType-web-audio.html
+++ b/LayoutTests/media/audioSession/audioSessionType-web-audio.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+        <script src="../media-file.js"></script>
+        <script src="../video-test.js"></script>
+    </head>
+    <body>
+        <audio id="audio"></audio>
+        <script>
+promise_test(async (test) => {
+    assert_equals(navigator.audioSession.type, "auto");
+
+    if (!window.internals)
+        return;
+
+    navigator.audioSession.type = "play-and-record";
+    assert_equals(internals.audioSessionCategory(), "PlayAndRecord");
+
+    const audioCtx = new AudioContext();
+    const oscillator = audioCtx.createOscillator();
+    oscillator.type = 'square';
+    oscillator.frequency.setValueAtTime(440, audioCtx.currentTime); // value in hertz
+    oscillator.connect(audioCtx.destination);
+    oscillator.start();
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    assert_equals(navigator.audioSession.type, "play-and-record");
+    assert_equals(internals.audioSessionCategory(), "PlayAndRecord");
+}, "AudioSession type with web audio");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -179,7 +179,9 @@ void MediaSessionManagerCocoa::updateSessionState()
         return;
 
     auto category = AudioSession::CategoryType::None;
-    if (captureCount || (isPlayingAudio && AudioSession::sharedSession().category() == AudioSession::CategoryType::PlayAndRecord))
+    if (AudioSession::sharedSession().categoryOverride() != AudioSession::CategoryType::None)
+        category = AudioSession::sharedSession().categoryOverride();
+    else if (captureCount || (isPlayingAudio && AudioSession::sharedSession().category() == AudioSession::CategoryType::PlayAndRecord))
         category = AudioSession::CategoryType::PlayAndRecord;
     else if (hasAudibleAudioOrVideoMediaType)
         category = AudioSession::CategoryType::MediaPlayback;


### PR DESCRIPTION
#### b666a12becd8a3f8c66e5d0bcd9e09cea7207a40
<pre>
AudioSession category should be sticky if DOMAudioSession.type is set
<a href="https://bugs.webkit.org/show_bug.cgi?id=248943">https://bugs.webkit.org/show_bug.cgi?id=248943</a>
rdar://problem/103115866

Reviewed by Eric Carlson.

Force the category to mtch the override category if the override category is set.
F
* LayoutTests/media/audioSession/audioSessionType-web-audio-expected.txt: Added.
* LayoutTests/media/audioSession/audioSessionType-web-audio.html: Added.
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateSessionState):

Canonical link: <a href="https://commits.webkit.org/257568@main">https://commits.webkit.org/257568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17b2fb20be2196f9faf97aa541bdfd620f59c81f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108700 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168947 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85832 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91805 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106627 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90399 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33837 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21745 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2391 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23262 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2289 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5208 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8304 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42741 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3962 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->