### PR TITLE
[WK2] Adjust generate-serializers.py for style and rebaseline its test output

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -413,7 +413,9 @@ def construct_type(type, indentation):
     else:
         result.append(indent(indentation) + type.namespace_and_name() + ' {')
     if type.parent_class is not None:
-        result = result + construct_type(type.parent_class, indentation + 1) + [indent(indentation + 1) + ',']
+        result = result + construct_type(type.parent_class, indentation + 1)
+        if len(type.members) != 0:
+            result[-1] += ','
     for i in range(len(type.members)):
         member = type.members[i]
         if type.members[i].condition is not None:

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -115,11 +115,11 @@ std::optional<Namespace::Subnamespace::StructName> ArgumentCoder<Namespace::Subn
 
     return {
         Namespace::Subnamespace::StructName {
-            WTFMove(*firstMemberName)
+            WTFMove(*firstMemberName),
 #if ENABLE(SECOND_MEMBER)
-            , WTFMove(*secondMemberName)
+            WTFMove(*secondMemberName),
 #endif
-            , WTFMove(*nullableTestMember)
+            WTFMove(*nullableTestMember)
         }
     };
 }
@@ -167,10 +167,10 @@ std::optional<Namespace::OtherClass> ArgumentCoder<Namespace::OtherClass>::decod
 
     return {
         Namespace::OtherClass {
-            WTFMove(*isNull)
-            , WTFMove(*a)
-            , WTFMove(*b)
-            , WTFMove(*dataDetectorResults)
+            WTFMove(*isNull),
+            WTFMove(*a),
+            WTFMove(*b),
+            WTFMove(*dataDetectorResults)
         }
     };
 }
@@ -216,9 +216,9 @@ std::optional<Ref<Namespace::ReturnRefClass>> ArgumentCoder<Namespace::ReturnRef
 
     return {
         Namespace::ReturnRefClass::create(
-            WTFMove(*functionCallmember1)
-            , WTFMove(*functionCallmember2)
-            , WTFMove(*uniqueMember)
+            WTFMove(*functionCallmember1),
+            WTFMove(*functionCallmember2),
+            WTFMove(*uniqueMember)
         )
     };
 }
@@ -378,9 +378,8 @@ std::optional<WebCore::InheritsFrom> ArgumentCoder<WebCore::InheritsFrom>::decod
         WebCore::InheritsFrom {
             WithoutNamespace {
                 WTFMove(*a)
-            }
-            
-            , WTFMove(*b)
+            },
+            WTFMove(*b)
         }
     };
 }
@@ -418,12 +417,10 @@ std::optional<WebCore::InheritanceGrandchild> ArgumentCoder<WebCore::Inheritance
             WebCore::InheritsFrom {
                 WithoutNamespace {
                     WTFMove(*a)
-                }
-                
-                , WTFMove(*b)
-            }
-            
-            , WTFMove(*c)
+                },
+                WTFMove(*b)
+            },
+            WTFMove(*c)
         }
     };
 }


### PR DESCRIPTION
#### ef205efc374d6d88783caed6bea863944ec418fe
<pre>
[WK2] Adjust generate-serializers.py for style and rebaseline its test output
<a href="https://bugs.webkit.org/show_bug.cgi?id=248945">https://bugs.webkit.org/show_bug.cgi?id=248945</a>

Reviewed by Kimmo Kinnunen.

In generate-serializers.py, when forming code for object construction
during output, in case of a parent class that has to be constructed,
append a comma at the end of that parent&apos;s construction, if necessary.
This avoids having lines with only one indented comma.

The testing output is also rebaselined, both for this specific change
as well as previous changes that went without a rebaseline.

* Source/WebKit/Scripts/generate-serializers.py:
(construct_type.is):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::Subnamespace::StructName&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::ReturnRefClass&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::InheritsFrom&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::InheritanceGrandchild&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/257618@main">https://commits.webkit.org/257618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f8079360013119ccddc7fa27ab77e6714cad789

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108703 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85836 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91808 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106630 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90402 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33838 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/102843 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76715 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2394 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23265 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2292 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45670 "Found 1 new test failure: fast/events/blur-remove-parent-crash.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5239 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42744 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->