### PR TITLE
[GStreamer] Minimal codec parsing module

### DIFF
--- a/Source/WebCore/platform/GStreamer.cmake
+++ b/Source/WebCore/platform/GStreamer.cmake
@@ -4,6 +4,7 @@ if (ENABLE_VIDEO OR ENABLE_WEB_AUDIO)
         "${WEBCORE_DIR}/platform/graphics/gstreamer"
         "${WEBCORE_DIR}/platform/graphics/gstreamer/mse"
         "${WEBCORE_DIR}/platform/graphics/gstreamer/eme"
+        "${WEBCORE_DIR}/platform/gstreamer"
         "${WEBCORE_DIR}/platform/mediarecorder/gstreamer"
     )
 
@@ -64,6 +65,8 @@ if (ENABLE_VIDEO OR ENABLE_WEB_AUDIO)
         platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
         platform/graphics/gstreamer/mse/TrackQueue.cpp
         platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+
+        platform/gstreamer/GStreamerCodecUtilities.cpp
 
         platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
 

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2022 Igalia S.L
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "GStreamerCodecUtilities.h"
+
+#if USE(GSTREAMER)
+
+#include <gst/pbutils/codec-utils.h>
+#include <wtf/text/StringToIntegerConversion.h>
+#include <wtf/text/WTFString.h>
+
+GST_DEBUG_CATEGORY(webkit_gst_codec_utilities_debug);
+#define GST_CAT_DEFAULT webkit_gst_codec_utilities_debug
+
+namespace WebCore {
+
+static void ensureDebugCategoryInitialized()
+{
+    static std::once_flag debugRegisteredFlag;
+    std::call_once(debugRegisteredFlag, [] {
+        GST_DEBUG_CATEGORY_INIT(webkit_gst_codec_utilities_debug, "webkitcodec", 0, "WebKit Codecs Utilities");
+    });
+}
+
+std::pair<const char*, const char*> GStreamerCodecUtilities::parseH264ProfileAndLevel(const String& codec)
+{
+    ensureDebugCategoryInitialized();
+
+    auto components = codec.split('.');
+    long int spsAsInteger = strtol(components[1].utf8().data(), nullptr, 16);
+    uint8_t sps[3];
+    sps[0] = spsAsInteger >> 16;
+    sps[1] = spsAsInteger >> 8;
+    sps[2] = spsAsInteger;
+
+    const char* profile = gst_codec_utils_h264_get_profile(sps, 3);
+    const char* level = gst_codec_utils_h264_get_level(sps, 3);
+
+    // To avoid going through a class hierarchy for such a simple
+    // string conversion, we use a little trick here: See
+    // https://bugs.webkit.org/show_bug.cgi?id=201870.
+    char levelAsStringFallback[2] = { '\0', '\0' };
+    if (!level && sps[2] > 0 && sps[2] <= 5) {
+        levelAsStringFallback[0] = static_cast<char>('0' + sps[2]);
+        level = levelAsStringFallback;
+    }
+
+    GST_DEBUG("Codec %s translates to H.264 profile %s and level %s", codec.utf8().data(), GST_STR_NULL(profile), GST_STR_NULL(level));
+    return { profile, level };
+}
+
+uint8_t GStreamerCodecUtilities::parseVP9Profile(const String& codec)
+{
+    ensureDebugCategoryInitialized();
+
+    auto components = codec.split('.');
+    auto profile = parseInteger<uint8_t>(components[1]).value_or(0);
+    GST_DEBUG("Codec %s translates to VP9 profile %u", codec.utf8().data(), profile);
+    return profile;
+}
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Igalia S.L
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if USE(GSTREAMER)
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+namespace GStreamerCodecUtilities {
+
+std::pair<const char*, const char*> parseH264ProfileAndLevel(const String& codec);
+uint8_t parseVP9Profile(const String& codec);
+
+} // namespace GStreamerCodecUtilities
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER)


### PR DESCRIPTION
#### cf92dc1de95a7620e873987eed9cd096d1a65851
<pre>
[GStreamer] Minimal codec parsing module
<a href="https://bugs.webkit.org/show_bug.cgi?id=248948">https://bugs.webkit.org/show_bug.cgi?id=248948</a>

Reviewed by Xabier Rodriguez-Calvar.

This patch exposes API for parsing H.264 profile and level from a codec string, this code existed in
the registry scanner before but can now be reused for eg. the upcoming WebCodecs backend. A minimal
VP9 profile parsing utility is also part of this patch.

The new file is stored in platform/gstreamer, we should gradually add new GStreamer modules there
when appropriate. Some of the platform/graphics/gstreamer files could also move there at some point.

* Source/WebCore/platform/GStreamer.cmake:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::isAVC1CodecSupported const):
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp: Added.
(WebCore::ensureDebugCategoryInitialized):
(WebCore::GStreamerCodecUtilities::parseVP9Profile):
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h: Added.

Canonical link: <a href="https://commits.webkit.org/257615@main">https://commits.webkit.org/257615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be12e3440e46e14a37227acb0ba569b627038b63

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108714 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168972 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85847 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91819 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106641 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33853 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76725 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2404 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23273 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45681 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5235 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42752 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->