### PR TITLE
[GStreamer] Support for custom framerate in video encoder

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoEncoder.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoEncoder.cpp
@@ -126,6 +126,7 @@ struct _WebKitWebrtcVideoEncoderPrivate {
     GRefPtr<GstElement> inputCapsFilter;
     GRefPtr<GstElement> outputCapsFilter;
     GRefPtr<GstElement> videoConvert;
+    GRefPtr<GstElement> videoRate;
     GRefPtr<GstCaps> encodedCaps;
     unsigned bitrate;
 };
@@ -245,6 +246,11 @@ static void webrtcVideoEncoderSetEncoder(WebKitWebrtcVideoEncoder* self, Encoder
         gst_bin_add(GST_BIN_CAST(self), priv->inputCapsFilter.get());
     }
 
+    if (!priv->videoRate) {
+        priv->videoRate = makeGStreamerElement("videorate", nullptr);
+        gst_bin_add(GST_BIN_CAST(self), priv->videoRate.get());
+    }
+
     if (!priv->videoConvert) {
         priv->videoConvert = makeGStreamerElement("videoconvert", nullptr);
         gst_bin_add(GST_BIN_CAST(self), priv->videoConvert.get());
@@ -269,7 +275,7 @@ static void webrtcVideoEncoderSetEncoder(WebKitWebrtcVideoEncoder* self, Encoder
 
     encoderDefinition->setupEncoder(self);
 
-    gst_element_link(priv->videoConvert.get(), priv->inputCapsFilter.get());
+    gst_element_link_many(priv->videoConvert.get(), priv->videoRate.get(), priv->inputCapsFilter.get(), nullptr);
     if (shouldLinkEncoder)
         gst_element_link(priv->inputCapsFilter.get(), priv->encoder.get());
 


### PR DESCRIPTION
#### c4612e0417415505c6da4c316d96dd4445f65999
<pre>
[GStreamer] Support for custom framerate in video encoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=248950">https://bugs.webkit.org/show_bug.cgi?id=248950</a>

Reviewed by Xabier Rodriguez-Calvar.

Custom destination framerate can now be negotiated with output caps format. This is not a strict
requirement for WebRTC but it will be useful for the upcoming WebCodecs GStreamer backend.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoEncoder.cpp:
(webrtcVideoEncoderSetEncoder):

Canonical link: <a href="https://commits.webkit.org/257614@main">https://commits.webkit.org/257614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cddd87bb148364b6a92aa69a45c26f1b625033a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108716 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168963 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85849 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91821 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106647 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33854 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21767 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76726 "Found 4 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/console-api, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/js-exception, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2407 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23284 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2305 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45683 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5236 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8472 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42758 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->