### PR TITLE
[GStreamer] Properly report video frame pixel format

### DIFF
--- a/Source/WebCore/platform/VideoPixelFormat.cpp
+++ b/Source/WebCore/platform/VideoPixelFormat.cpp
@@ -26,6 +26,10 @@
 #include "config.h"
 #include "VideoPixelFormat.h"
 
+#if USE(GSTREAMER)
+#include <gst/video/video-format.h>
+#endif
+
 #if PLATFORM(COCOA)
 #include <pal/cf/CoreMediaSoftLink.h>
 #include "CoreVideoSoftLink.h"
@@ -43,6 +47,34 @@ VideoPixelFormat convertVideoFramePixelFormat(uint32_t format, bool shouldDiscar
     if (format == kCVPixelFormatType_32ARGB)
         return shouldDiscardAlpha ? VideoPixelFormat::RGBX : VideoPixelFormat::RGBA;
     ASSERT_NOT_REACHED();
+#elif USE(GSTREAMER)
+    switch (format) {
+    case GST_VIDEO_FORMAT_I420:
+        return VideoPixelFormat::I420;
+    case GST_VIDEO_FORMAT_A420:
+        return VideoPixelFormat::I420A;
+    case GST_VIDEO_FORMAT_I422_10BE:
+    case GST_VIDEO_FORMAT_I422_10LE:
+    case GST_VIDEO_FORMAT_I422_12BE:
+    case GST_VIDEO_FORMAT_I422_12LE:
+        return VideoPixelFormat::I422;
+    case GST_VIDEO_FORMAT_Y444:
+        return VideoPixelFormat::I444;
+    case GST_VIDEO_FORMAT_NV12:
+        return VideoPixelFormat::NV12;
+    case GST_VIDEO_FORMAT_RGBA:
+        return shouldDiscardAlpha ? VideoPixelFormat::RGBX : VideoPixelFormat::RGBA;
+    case GST_VIDEO_FORMAT_RGBx:
+        return VideoPixelFormat::RGBX;
+    case GST_VIDEO_FORMAT_BGRA:
+        return shouldDiscardAlpha ? VideoPixelFormat::BGRX : VideoPixelFormat::BGRA;
+    case GST_VIDEO_FORMAT_ARGB:
+        return shouldDiscardAlpha ? VideoPixelFormat::RGBX : VideoPixelFormat::RGBA;
+    case GST_VIDEO_FORMAT_BGRx:
+        return VideoPixelFormat::BGRX;
+    default:
+        break;
+    }
 #else
     UNUSED_PARAM(format);
     UNUSED_PARAM(shouldDiscardAlpha);

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -23,6 +23,7 @@
 
 #include "VideoFrame.h"
 #include "VideoFrameMetadataGStreamer.h"
+#include <gst/video/video-format.h>
 #include <wtf/glib/GRefPtr.h>
 
 typedef struct _GstSample GstSample;
@@ -58,16 +59,17 @@ public:
     GstSample* sample() const { return m_sample.get(); }
     RefPtr<JSC::Uint8ClampedArray> computeRGBAImageData() const;
 
+    FloatSize presentationSize() const final { return m_presentationSize; }
+    uint32_t pixelFormat() const final;
 private:
     VideoFrameGStreamer(GRefPtr<GstSample>&&, const FloatSize& presentationSize, const MediaTime& presentationTime = MediaTime::invalidTime(), Rotation = Rotation::None, bool videoMirrored = false, std::optional<VideoFrameTimeMetadata>&& = std::nullopt);
     VideoFrameGStreamer(const GRefPtr<GstSample>&, const MediaTime& presentationTime, Rotation = Rotation::None);
 
-    FloatSize presentationSize() const final { return m_presentationSize; }
-    uint32_t pixelFormat() const final { return 0; }
     bool isGStreamer() const final { return true; }
 
     GRefPtr<GstSample> m_sample;
     FloatSize m_presentationSize;
+    mutable GstVideoFormat m_cachedVideoFormat { GST_VIDEO_FORMAT_UNKNOWN };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### fb297855a9fc6b37f8d1ec2faaa09f6eaa365d2a
<pre>
[GStreamer] Properly report video frame pixel format
<a href="https://bugs.webkit.org/show_bug.cgi?id=248953">https://bugs.webkit.org/show_bug.cgi?id=248953</a>

Reviewed by Xabier Rodriguez-Calvar.

The VideoFrameGStreamer::pixelFormat() method is now properly implemented and the mapping between
GStreamer and WebCore pixel formats is fulfilled.

* Source/WebCore/platform/VideoPixelFormat.cpp:
(WebCore::convertVideoFramePixelFormat):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/257909@main">https://commits.webkit.org/257909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c06c5612b9afbf3d615671985edd9d1b1761cec2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109698 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169937 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/96 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92786 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107576 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106160 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91180 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34566 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22571 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3285 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3277 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43580 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5432 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5093 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->