### PR TITLE
Split out IPC EnumTraits and Persistence EnumTraits so we can start porting the IPC usages to the new serialization format

### DIFF
--- a/Source/WTF/wtf/EnumTraits.h
+++ b/Source/WTF/wtf/EnumTraits.h
@@ -30,6 +30,7 @@
 namespace WTF {
 
 template<typename> struct EnumTraits;
+template<typename> struct EnumTraitsForPersistence;
 
 template<typename E, E...> struct EnumValues;
 
@@ -62,6 +63,19 @@ constexpr bool isValidEnum(bool t)
 {
     return !t || t == 1;
 }
+
+template<typename E, typename = std::enable_if_t<!std::is_same_v<std::underlying_type_t<E>, bool>>>
+bool isValidEnumForPersistence(std::underlying_type_t<E> t)
+{
+    return EnumValueChecker<std::underlying_type_t<E>, typename EnumTraitsForPersistence<E>::values>::isValidEnum(t);
+}
+
+template<typename E, typename = std::enable_if_t<std::is_same_v<std::underlying_type_t<E>, bool>>>
+constexpr bool isValidEnumForPersistence(bool t)
+{
+    return !t || t == 1;
+}
+
 
 template<typename E>
 constexpr auto enumToUnderlyingType(E e)

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -100,6 +100,7 @@ template<typename T, size_t inlineCapacity> struct DefaultHash<Vector<T, inlineC
 
 template<typename> struct RawValueTraits;
 template<typename> struct EnumTraits;
+template<typename> struct EnumTraitsForPersistence;
 template<typename E, E...> struct EnumValues;
 template<typename> struct HashTraits;
 

--- a/Source/WTF/wtf/persistence/PersistentDecoder.h
+++ b/Source/WTF/wtf/persistence/PersistentDecoder.h
@@ -75,7 +75,7 @@ public:
         *this >> value;
         if (!value)
             return *this;
-        if (!isValidEnum<E>(*value))
+        if (!isValidEnumForPersistence<E>(*value))
             return *this;
         result = static_cast<E>(*value);
         return *this;

--- a/Source/WebCore/Modules/fetch/FetchHeaders.h
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.h
@@ -130,4 +130,15 @@ template<> struct EnumTraits<WebCore::FetchHeaders::Guard> {
     >;
 };
 
+template<> struct EnumTraitsForPersistence<WebCore::FetchHeaders::Guard> {
+    using values = EnumValues<
+    WebCore::FetchHeaders::Guard,
+    WebCore::FetchHeaders::Guard::None,
+    WebCore::FetchHeaders::Guard::Immutable,
+    WebCore::FetchHeaders::Guard::Request,
+    WebCore::FetchHeaders::Guard::RequestNoCors,
+    WebCore::FetchHeaders::Guard::Response
+    >;
+};
+
 }

--- a/Source/WebCore/loader/FetchOptions.h
+++ b/Source/WebCore/loader/FetchOptions.h
@@ -117,6 +117,74 @@ inline bool isScriptLikeDestination(FetchOptions::Destination destination)
 
 namespace WTF {
 
+template<> struct EnumTraitsForPersistence<WebCore::FetchOptions::Destination> {
+    using values = EnumValues<
+        WebCore::FetchOptions::Destination,
+        WebCore::FetchOptions::Destination::EmptyString,
+        WebCore::FetchOptions::Destination::Audio,
+        WebCore::FetchOptions::Destination::Audioworklet,
+        WebCore::FetchOptions::Destination::Document,
+        WebCore::FetchOptions::Destination::Embed,
+        WebCore::FetchOptions::Destination::Font,
+        WebCore::FetchOptions::Destination::Image,
+        WebCore::FetchOptions::Destination::Iframe,
+        WebCore::FetchOptions::Destination::Manifest,
+        WebCore::FetchOptions::Destination::Model,
+        WebCore::FetchOptions::Destination::Object,
+        WebCore::FetchOptions::Destination::Paintworklet,
+        WebCore::FetchOptions::Destination::Report,
+        WebCore::FetchOptions::Destination::Script,
+        WebCore::FetchOptions::Destination::Serviceworker,
+        WebCore::FetchOptions::Destination::Sharedworker,
+        WebCore::FetchOptions::Destination::Style,
+        WebCore::FetchOptions::Destination::Track,
+        WebCore::FetchOptions::Destination::Video,
+        WebCore::FetchOptions::Destination::Worker,
+        WebCore::FetchOptions::Destination::Xslt
+    >;
+};
+
+template<> struct EnumTraitsForPersistence<WebCore::FetchOptions::Mode> {
+    using values = EnumValues<
+        WebCore::FetchOptions::Mode,
+        WebCore::FetchOptions::Mode::Navigate,
+        WebCore::FetchOptions::Mode::SameOrigin,
+        WebCore::FetchOptions::Mode::NoCors,
+        WebCore::FetchOptions::Mode::Cors
+    >;
+};
+
+
+template<> struct EnumTraitsForPersistence<WebCore::FetchOptions::Credentials> {
+    using values = EnumValues<
+        WebCore::FetchOptions::Credentials,
+        WebCore::FetchOptions::Credentials::Omit,
+        WebCore::FetchOptions::Credentials::SameOrigin,
+        WebCore::FetchOptions::Credentials::Include
+    >;
+};
+
+template<> struct EnumTraitsForPersistence<WebCore::FetchOptions::Cache> {
+    using values = EnumValues<
+        WebCore::FetchOptions::Cache,
+        WebCore::FetchOptions::Cache::Default,
+        WebCore::FetchOptions::Cache::NoStore,
+        WebCore::FetchOptions::Cache::Reload,
+        WebCore::FetchOptions::Cache::NoCache,
+        WebCore::FetchOptions::Cache::ForceCache,
+        WebCore::FetchOptions::Cache::OnlyIfCached
+    >;
+};
+
+template<> struct EnumTraitsForPersistence<WebCore::FetchOptions::Redirect> {
+    using values = EnumValues<
+        WebCore::FetchOptions::Redirect,
+        WebCore::FetchOptions::Redirect::Follow,
+        WebCore::FetchOptions::Redirect::Error,
+        WebCore::FetchOptions::Redirect::Manual
+    >;
+};
+
 template<> struct EnumTraits<WebCore::FetchOptions::Destination> {
     using values = EnumValues<
         WebCore::FetchOptions::Destination,

--- a/Source/WebCore/platform/ReferrerPolicy.h
+++ b/Source/WebCore/platform/ReferrerPolicy.h
@@ -73,4 +73,19 @@ template<> struct EnumTraits<WebCore::ReferrerPolicy> {
     >;
 };
 
+template<> struct EnumTraitsForPersistence<WebCore::ReferrerPolicy> {
+    using values = EnumValues<
+        WebCore::ReferrerPolicy,
+        WebCore::ReferrerPolicy::EmptyString,
+        WebCore::ReferrerPolicy::NoReferrer,
+        WebCore::ReferrerPolicy::NoReferrerWhenDowngrade,
+        WebCore::ReferrerPolicy::SameOrigin,
+        WebCore::ReferrerPolicy::Origin,
+        WebCore::ReferrerPolicy::StrictOrigin,
+        WebCore::ReferrerPolicy::OriginWhenCrossOrigin,
+        WebCore::ReferrerPolicy::StrictOriginWhenCrossOrigin,
+        WebCore::ReferrerPolicy::UnsafeUrl
+    >;
+};
+
 }

--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -294,7 +294,7 @@ enum class LegacyCertificateInfoType {
     Trust,
 };
 
-template<> struct EnumTraits<LegacyCertificateInfoType> {
+template<> struct EnumTraitsForPersistence<LegacyCertificateInfoType> {
     using values = EnumValues<
         LegacyCertificateInfoType,
         LegacyCertificateInfoType::None,

--- a/Source/WebCore/platform/generic/KeyedEncoderGeneric.h
+++ b/Source/WebCore/platform/generic/KeyedEncoderGeneric.h
@@ -85,7 +85,7 @@ private:
 } // namespace WebCore
 
 namespace WTF {
-template<> struct EnumTraits<WebCore::KeyedEncoderGeneric::Type> {
+template<> struct EnumTraitsForPersistence<WebCore::KeyedEncoderGeneric::Type> {
     using values = EnumValues<
         WebCore::KeyedEncoderGeneric::Type,
         WebCore::KeyedEncoderGeneric::Type::Bytes,

--- a/Source/WebCore/platform/network/ResourceLoadPriority.h
+++ b/Source/WebCore/platform/network/ResourceLoadPriority.h
@@ -70,4 +70,15 @@ template<> struct EnumTraits<WebCore::ResourceLoadPriority> {
     >;
 };
 
+template<> struct EnumTraitsForPersistence<WebCore::ResourceLoadPriority> {
+    using values = EnumValues<
+        WebCore::ResourceLoadPriority,
+        WebCore::ResourceLoadPriority::VeryLow,
+        WebCore::ResourceLoadPriority::Low,
+        WebCore::ResourceLoadPriority::Medium,
+        WebCore::ResourceLoadPriority::High,
+        WebCore::ResourceLoadPriority::VeryHigh
+    >;
+};
+
 } // namespace WTF

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -334,6 +334,18 @@ template<> struct EnumTraits<WebCore::ResourceRequestCachePolicy> {
     >;
 };
 
+template<> struct EnumTraitsForPersistence<WebCore::ResourceRequestCachePolicy> {
+    using values = EnumValues<
+        WebCore::ResourceRequestCachePolicy,
+        WebCore::ResourceRequestCachePolicy::UseProtocolCachePolicy,
+        WebCore::ResourceRequestCachePolicy::ReloadIgnoringCacheData,
+        WebCore::ResourceRequestCachePolicy::ReturnCacheDataElseLoad,
+        WebCore::ResourceRequestCachePolicy::ReturnCacheDataDontLoad,
+        WebCore::ResourceRequestCachePolicy::DoNotUseAnyCache,
+        WebCore::ResourceRequestCachePolicy::RefreshAnyCacheData
+    >;
+};
+
 template<> struct EnumTraits<WebCore::ResourceRequestBase::SameSiteDisposition> {
     using values = EnumValues<
         WebCore::ResourceRequestBase::SameSiteDisposition,
@@ -343,7 +355,31 @@ template<> struct EnumTraits<WebCore::ResourceRequestBase::SameSiteDisposition> 
     >;
 };
 
+template<> struct EnumTraitsForPersistence<WebCore::ResourceRequestBase::SameSiteDisposition> {
+    using values = EnumValues<
+        WebCore::ResourceRequestBase::SameSiteDisposition,
+        WebCore::ResourceRequestBase::SameSiteDisposition::Unspecified,
+        WebCore::ResourceRequestBase::SameSiteDisposition::SameSite,
+        WebCore::ResourceRequestBase::SameSiteDisposition::CrossSite
+    >;
+};
+
 template<> struct EnumTraits<WebCore::ResourceRequestRequester> {
+    using values = EnumValues<
+        WebCore::ResourceRequestRequester,
+        WebCore::ResourceRequestRequester::Unspecified,
+        WebCore::ResourceRequestRequester::Main,
+        WebCore::ResourceRequestRequester::XHR,
+        WebCore::ResourceRequestRequester::Fetch,
+        WebCore::ResourceRequestRequester::Media,
+        WebCore::ResourceRequestRequester::ImportScripts,
+        WebCore::ResourceRequestRequester::Ping,
+        WebCore::ResourceRequestRequester::Beacon,
+        WebCore::ResourceRequestRequester::EventSource
+    >;
+};
+
+template<> struct EnumTraitsForPersistence<WebCore::ResourceRequestRequester> {
     using values = EnumValues<
         WebCore::ResourceRequestRequester,
         WebCore::ResourceRequestRequester::Unspecified,

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -466,6 +466,18 @@ template<> struct EnumTraits<WebCore::ResourceResponseBase::Type> {
     >;
 };
 
+template<> struct EnumTraitsForPersistence<WebCore::ResourceResponseBase::Type> {
+    using values = EnumValues<
+        WebCore::ResourceResponseBase::Type,
+        WebCore::ResourceResponseBase::Type::Basic,
+        WebCore::ResourceResponseBase::Type::Cors,
+        WebCore::ResourceResponseBase::Type::Default,
+        WebCore::ResourceResponseBase::Type::Error,
+        WebCore::ResourceResponseBase::Type::Opaque,
+        WebCore::ResourceResponseBase::Type::Opaqueredirect
+    >;
+};
+
 template<> struct EnumTraits<WebCore::ResourceResponseBase::Tainting> {
     using values = EnumValues<
         WebCore::ResourceResponseBase::Tainting,
@@ -476,8 +488,33 @@ template<> struct EnumTraits<WebCore::ResourceResponseBase::Tainting> {
     >;
 };
 
+template<> struct EnumTraitsForPersistence<WebCore::ResourceResponseBase::Tainting> {
+    using values = EnumValues<
+        WebCore::ResourceResponseBase::Tainting,
+        WebCore::ResourceResponseBase::Tainting::Basic,
+        WebCore::ResourceResponseBase::Tainting::Cors,
+        WebCore::ResourceResponseBase::Tainting::Opaque,
+        WebCore::ResourceResponseBase::Tainting::Opaqueredirect
+    >;
+};
 
 template<> struct EnumTraits<WebCore::ResourceResponseBase::Source> {
+    using values = EnumValues<
+        WebCore::ResourceResponseBase::Source,
+        WebCore::ResourceResponseBase::Source::Unknown,
+        WebCore::ResourceResponseBase::Source::Network,
+        WebCore::ResourceResponseBase::Source::DiskCache,
+        WebCore::ResourceResponseBase::Source::DiskCacheAfterValidation,
+        WebCore::ResourceResponseBase::Source::MemoryCache,
+        WebCore::ResourceResponseBase::Source::MemoryCacheAfterValidation,
+        WebCore::ResourceResponseBase::Source::ServiceWorker,
+        WebCore::ResourceResponseBase::Source::ApplicationCache,
+        WebCore::ResourceResponseBase::Source::DOMCache,
+        WebCore::ResourceResponseBase::Source::InspectorOverride
+    >;
+};
+
+template<> struct EnumTraitsForPersistence<WebCore::ResourceResponseBase::Source> {
     using values = EnumValues<
         WebCore::ResourceResponseBase::Source,
         WebCore::ResourceResponseBase::Source::Unknown,


### PR DESCRIPTION
#### e865417a3903cd2f2dc5f3d0ec16331eb08bd757
<pre>
Split out IPC EnumTraits and Persistence EnumTraits so we can start porting the IPC usages to the new serialization format

<a href="https://bugs.webkit.org/show_bug.cgi?id=248874">https://bugs.webkit.org/show_bug.cgi?id=248874</a>
&lt;rdar://problem/103120664&gt;

Reviewed by Alex Christensen.

Split out IPC EnumTraits and Persistence EnumTraits so we can start
porting the IPC usages to the new serialization format.

* Source/WTF/wtf/EnumTraits.h:
(WTF::isValidEnumForPersistence):
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/persistence/PersistentDecoder.h:
(WTF::Persistence::Decoder::operator&gt;&gt;):
* Source/WebCore/Modules/fetch/FetchHeaders.h:
* Source/WebCore/loader/FetchOptions.h:
* Source/WebCore/platform/ReferrerPolicy.h:
* Source/WebCore/platform/WebCorePersistentCoders.cpp:
* Source/WebCore/platform/generic/KeyedEncoderGeneric.h:
* Source/WebCore/platform/network/ResourceLoadPriority.h:
* Source/WebCore/platform/network/ResourceRequestBase.h:
* Source/WebCore/platform/network/ResourceResponseBase.h:

Canonical link: <a href="https://commits.webkit.org/257729@main">https://commits.webkit.org/257729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4953019299e79f29634806cdc6ef7ba3ed1c37a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109195 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169433 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86303 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92294 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107105 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105601 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7417 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34199 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22130 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90476 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2824 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23640 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86367 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2771 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46020 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28975 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5310 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8906 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43113 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89248 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4632 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19948 "Passed tests") | 
<!--EWS-Status-Bubble-End-->