### PR TITLE
[iOS] Add release logging for text interaction assistant-driven selection changes

### DIFF
--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -104,6 +104,7 @@ extern "C" {
     M(Storage) \
     M(StorageAPI) \
     M(TextInput) \
+    M(TextInteraction) \
     M(Translation) \
     M(UIHitTesting) \
     M(ViewGestures) \


### PR DESCRIPTION
#### ca905b9282f2eef05324e19e42a94c92e35bc1f7
<pre>
[iOS] Add release logging for text interaction assistant-driven selection changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=248955">https://bugs.webkit.org/show_bug.cgi?id=248955</a>
rdar://103120563

Reviewed by Wenson Hsieh.

Add logging to diagnose a rarely reproducing issue where all taps over text extend the selection.

* Source/WebKit/Platform/Logging.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(operator&lt;&lt;):
(-[WKContentView changeSelectionWithGestureAt:withGesture:withState:withFlags:]):
(-[WKContentView changeSelectionWithTouchAt:withSelectionTouch:baseIsStart:withFlags:]):
(-[WKContentView changeSelectionWithTouchesFrom:to:withGesture:withState:]):
(logTextInteractionAssistantSelectionChange):
(-[WKContentView _selectPositionAtPoint:stayingWithinFocusedElement:completionHandler:]):
(-[WKContentView selectPositionAtBoundary:inDirection:fromPoint:completionHandler:]):
(-[WKContentView moveSelectionAtBoundary:inDirection:completionHandler:]):
(-[WKContentView selectTextWithGranularity:atPoint:completionHandler:]):
(-[WKContentView beginSelectionInDirection:completionHandler:]):
(-[WKContentView updateSelectionWithExtentPoint:completionHandler:]):
(-[WKContentView updateSelectionWithExtentPoint:withBoundary:completionHandler:]):
(-[WKContentView selectPositionAtPoint:withContextRequest:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/257583@main">https://commits.webkit.org/257583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d92fa57a8837047c13afbc53bc04585f44873540

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108728 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85862 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91834 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106656 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105099 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90426 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33862 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21773 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2415 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23290 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2316 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5220 "Built successfully and passed tests") | [💥 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8479 "An unexpected error occured. Recent messages:Failed to print configuration") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42764 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4184 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->