### PR TITLE
[CSS-Typed-OM] Fix reification of calc() operations with more than 2 operands

### DIFF
--- a/LayoutTests/http/wpt/css/css-typed-om/parse-calc-expressions-expected.txt
+++ b/LayoutTests/http/wpt/css/css-typed-om/parse-calc-expressions-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Parsing calc(1% + 2em + 3px)
+PASS Parsing calc(1px + 2% + 3em)
+

--- a/LayoutTests/http/wpt/css/css-typed-om/parse-calc-expressions.html
+++ b/LayoutTests/http/wpt/css/css-typed-om/parse-calc-expressions.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Tests parsing of calc() expressions via CSSStyleValue.parse()</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/css-typed-om/resources/testhelper.js"></script>
+<body>
+<script>
+'use strict';
+
+test(t => {
+  assert_style_value_equals(CSSStyleValue.parse('width', 'calc(1% + 2em + 3px)'),  new CSSMathSum(CSS.percent(1), CSS.em(2), CSS.px(3)));
+}, 'Parsing calc(1% + 2em + 3px)');
+
+test(t => {
+  assert_style_value_equals(CSSStyleValue.parse('width', 'calc(1px + 2% + 3em)'),  new CSSMathSum(CSS.px(1), CSS.percent(2), CSS.em(3)));
+}, 'Parsing calc(1px + 2% + 3em)');
+</script>
+</body>

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4411,6 +4411,7 @@ css-custom-properties-api [ Skip ]
 fast/css-custom-paint [ Skip ]
 css-typedom [ Skip ]
 fast/css/css-typed-om [ Skip ]
+http/wpt/css/css-typed-om [ Skip ]
 
 editing/pasteboard/drag-and-drop-color-input-events.html [ Skip ]
 


### PR DESCRIPTION
#### fc94bf07f09bb331986f4023959baaa06bbd5dfc
<pre>
[CSS-Typed-OM] Fix reification of calc() operations with more than 2 operands
<a href="https://bugs.webkit.org/show_bug.cgi?id=248962">https://bugs.webkit.org/show_bug.cgi?id=248962</a>

Reviewed by Antoine Quint.

The logic inside reifyMathExpression() was assuming that our
CSSCalcExpressionNodes were part of a binary tree and trying to convert
the structure into a n-ary tree. As a result, we would drop operands when
there are more than 2 present.

This patch simplifies the logic since we don&apos;t need to convert the tree
structure and since our internal representation of calc() expressions is
already simplified. This fixes the issue where we would drop operands
when more than 2 are present.

* LayoutTests/http/wpt/css/css-typed-om/parse-calc-expressions-expected.txt: Added.
* LayoutTests/http/wpt/css/css-typed-om/parse-calc-expressions.html: Added.
* Source/WebCore/css/typedom/CSSNumericValue.cpp:
(WebCore::reifyMathExpression):
(WebCore::canonicalOperator): Deleted.
(WebCore::canCombineNodes): Deleted.

Canonical link: <a href="https://commits.webkit.org/257635@main">https://commits.webkit.org/257635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/700fabca0305838093741ee6131ebbd441ad673b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108891 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169124 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86007 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92000 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106804 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105279 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33981 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21894 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2546 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23408 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2477 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8629 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42883 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5254 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4335 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->