### PR TITLE
[EWS] Layout test results should still be and extracted even if failure is ignored based on results db data

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3327,18 +3327,18 @@ class RunWebKitTests(shell.Test, AddToLogMixin):
 
     def evaluateCommand(self, cmd):
         rc = self.evaluateResult(cmd)
-        if (self.preexisting_failures_in_results_db and len(self.failing_tests_filtered) == 0):
-            # This means all the tests which failed in this run were also failing or flaky in results database
-            message = f"Ignored pre-existing failure: {', '.join(self.preexisting_failures_in_results_db)}"
-            self.descriptionDone = message
-            self.finished(WARNINGS)
-            self.build.buildFinished([message], SUCCESS)
-
         if rc == SUCCESS or rc == WARNINGS:
             message = 'Passed layout tests'
             self.descriptionDone = message
             self.build.results = SUCCESS
             self.setProperty('build_summary', message)
+        elif (self.preexisting_failures_in_results_db and len(self.failing_tests_filtered) == 0):
+            # This means all the tests which failed in this run were also failing or flaky in results database
+            message = f"Ignored pre-existing failure: {', '.join(self.preexisting_failures_in_results_db)}"
+            self.descriptionDone = message
+            self.build.results = SUCCESS
+            self.setProperty('build_summary', message)
+            self.finished(WARNINGS)
         else:
             self.build.addStepsAfterCurrentStep([
                 ArchiveTestResults(),


### PR DESCRIPTION
#### 9506ddb0c52cc821368763c8d832f70ceb887054
<pre>
[EWS] Layout test results should still be and extracted even if failure is ignored based on results db data
<a href="https://bugs.webkit.org/show_bug.cgi?id=248952">https://bugs.webkit.org/show_bug.cgi?id=248952</a>
rdar://103120038

Reviewed by Jonathan Bedard.

* Tools/CISupport/ews-build/steps.py:
(RunWebKitTests.evaluateCommand):

Canonical link: <a href="https://commits.webkit.org/257578@main">https://commits.webkit.org/257578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6403a0f7217682e3abef8c2cd6589b0cbd53d7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99361 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/8561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/32483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/108746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103358 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/9123 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/105120 "The change is no longer eligible for processing.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/9123 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/32483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/91851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/9123 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/32483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/32483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/98290 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/2335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/8495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/32483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2658 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->