### PR TITLE
[WK2] Reduce moves/copies when decoding through the general ArgumentCoder specializations

### DIFF
--- a/Source/WebKit/Platform/IPC/ArgumentCoders.cpp
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.cpp
@@ -54,8 +54,7 @@ template void ArgumentCoder<CString>::encode<Encoder>(Encoder&, const CString&);
 template<typename Decoder>
 std::optional<CString> ArgumentCoder<CString>::decode(Decoder& decoder)
 {
-    std::optional<uint32_t> length;
-    decoder >> length;
+    auto length = decoder.template decode<uint32_t>();
     if (!length)
         return std::nullopt;
 
@@ -120,8 +119,7 @@ static inline std::optional<String> decodeStringText(Decoder& decoder, uint32_t 
 template<typename Decoder>
 WARN_UNUSED_RETURN std::optional<String> ArgumentCoder<String>::decode(Decoder& decoder)
 {
-    std::optional<uint32_t> length;
-    decoder >> length;
+    auto length = decoder.template decode<uint32_t>();
     if (!length)
         return std::nullopt;
     
@@ -129,9 +127,8 @@ WARN_UNUSED_RETURN std::optional<String> ArgumentCoder<String>::decode(Decoder& 
         // This is the null string.
         return String();
     }
-    
-    std::optional<bool> is8Bit;
-    decoder >> is8Bit;
+
+    auto is8Bit = decoder.template decode<bool>();
     if (!is8Bit)
         return std::nullopt;
     

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -315,7 +315,7 @@ TEST_F(ArgumentCoderDecodingMoveCounterTest, DecodeOptional)
 
         auto& counter = *optional;
         ASSERT_TRUE(!!counter);
-        ASSERT_EQ(counter->moveCounter, 3u);
+        ASSERT_EQ(counter->moveCounter, 2u);
     }
     {
         auto optional = decoder->decode<std::optional<DecodingMoveCounter>>();
@@ -323,7 +323,7 @@ TEST_F(ArgumentCoderDecodingMoveCounterTest, DecodeOptional)
 
         auto& counter = *optional;
         ASSERT_TRUE(!!counter);
-        ASSERT_EQ(counter->moveCounter, 2u);
+        ASSERT_EQ(counter->moveCounter, 1u);
     }
 }
 
@@ -337,12 +337,12 @@ TEST_F(ArgumentCoderDecodingMoveCounterTest, DecodePair)
         std::optional<std::pair<uint64_t, DecodingMoveCounter>> pair;
         *decoder >> pair;
         ASSERT_TRUE(!!pair);
-        ASSERT_EQ(pair->second.moveCounter, 4u);
+        ASSERT_EQ(pair->second.moveCounter, 2u);
     }
     {
         auto pair = decoder->decode<std::pair<uint64_t, DecodingMoveCounter>>();
         ASSERT_TRUE(!!pair);
-        ASSERT_EQ(pair->second.moveCounter, 3u);
+        ASSERT_EQ(pair->second.moveCounter, 1u);
     }
 }
 
@@ -357,14 +357,14 @@ TEST_F(ArgumentCoderDecodingMoveCounterTest, DecodeTuple)
         std::optional<TupleType> tuple;
         *decoder >> tuple;
         ASSERT_TRUE(!!tuple);
-        ASSERT_EQ(std::get<0>(*tuple).moveCounter, 3u);
-        ASSERT_EQ(std::get<2>(*tuple).moveCounter, 3u);
+        ASSERT_EQ(std::get<0>(*tuple).moveCounter, 2u);
+        ASSERT_EQ(std::get<2>(*tuple).moveCounter, 2u);
     }
     {
         auto tuple = decoder->decode<TupleType>();
         ASSERT_TRUE(!!tuple);
-        ASSERT_EQ(std::get<0>(*tuple).moveCounter, 2u);
-        ASSERT_EQ(std::get<2>(*tuple).moveCounter, 2u);
+        ASSERT_EQ(std::get<0>(*tuple).moveCounter, 1u);
+        ASSERT_EQ(std::get<2>(*tuple).moveCounter, 1u);
     }
 }
 
@@ -401,14 +401,36 @@ TEST_F(ArgumentCoderDecodingMoveCounterTest, DecodeVector)
         ASSERT_TRUE(!!vector);
         ASSERT_EQ(vector->size(), 2u);
         for (auto&& entry : *vector)
-            ASSERT_EQ(entry.moveCounter, 3u);
+            ASSERT_EQ(entry.moveCounter, 2u);
     }
     {
         auto vector = decoder->decode<Vector<DecodingMoveCounter>>();
         ASSERT_TRUE(!!vector);
         ASSERT_EQ(vector->size(), 2u);
         for (auto&& entry : *vector)
-            ASSERT_EQ(entry.moveCounter, 3u);
+            ASSERT_EQ(entry.moveCounter, 2u);
+    }
+}
+
+TEST_F(ArgumentCoderDecodingMoveCounterTest, DecodeVariant)
+{
+    using VariantType = std::variant<DecodingMoveCounter, uint64_t>;
+    encoder() << VariantType { DecodingMoveCounter { } };
+    encoder() << VariantType { DecodingMoveCounter { } };
+
+    auto decoder = createDecoder();
+    {
+        std::optional<VariantType> variant;
+        *decoder >> variant;
+        ASSERT_TRUE(!!variant);
+        ASSERT_EQ(variant->index(), 0u);
+        ASSERT_EQ(std::get<0>(*variant).moveCounter, 2u);
+    }
+    {
+        auto variant = decoder->decode<VariantType>();
+        ASSERT_TRUE(!!variant);
+        ASSERT_EQ(variant->index(), 0u);
+        ASSERT_EQ(std::get<0>(*variant).moveCounter, 1u);
     }
 }
 


### PR DESCRIPTION
#### 1a7b36e70573fcf071a53c98058be7284154f61c
<pre>
[WK2] Reduce moves/copies when decoding through the general ArgumentCoder specializations
<a href="https://bugs.webkit.org/show_bug.cgi?id=248963">https://bugs.webkit.org/show_bug.cgi?id=248963</a>

Reviewed by Kimmo Kinnunen.

Improve decoding efficiency in the general ArgumentCoder specializations
by avoiding the stream extraction operator when decoding from a given
decoder object, and by utilizing in-place construction of objects
wrapped in std::optional&lt;&gt;.

Using the decoder&apos;s decode&lt;T&gt;() method to retrieve an object from the
decoder is beneficial to first default-constructing a std::optional&lt;&gt;
object and then targeting it with the stream extraction operator
invocation since it avoids one move or copy operation. This is adopted
through all the ArgumentCoder specializations in WebKit&apos;s ArgumentCoders
header and implementation file.

Where already possible, in-place construction of objects wrapped in
std::optional&lt;&gt; is done through the use of std::make_optional(). This
also avoids additional move or copy operations.

The reduction in those operations is reflected in the
decoding-of-move-counter unit tests, specifically in the lowering of
move operations for different types. A unit test covering std::variant&lt;&gt;
is also added.

Another unit test covering Expected&lt;ValueType, ErrorType&gt; types will be
added separately, along with move-semantics support for those types on
the encoding side.

* Source/WebKit/Platform/IPC/ArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;CString&gt;::decode):
(IPC::ArgumentCoder&lt;String&gt;::decode):
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
(IPC::ArgumentCoder&lt;OptionSet&lt;T&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;std::optional&lt;T&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;Box&lt;T&gt;&gt;::decode):
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/257621@main">https://commits.webkit.org/257621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4eea55bbc1320b57022febcee90247ed9d8ec8c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108747 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168997 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103360 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85881 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91852 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106674 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33876 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88718 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76752 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2432 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23304 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45706 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5241 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42779 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->