### PR TITLE
Drop shouldForceEnclosingCalcInCSSText flag recently added to CSSCalcExpressionNode

### DIFF
--- a/Source/WebCore/css/calc/CSSCalcExpressionNode.h
+++ b/Source/WebCore/css/calc/CSSCalcExpressionNode.h
@@ -61,9 +61,6 @@ public:
     virtual void collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>&) const = 0;
     virtual bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const = 0;
 
-    bool shouldForceEnclosingCalcInCSSText() const { return m_shouldForceEnclosingCalcInCSSText; }
-    void setShouldForceEnclosingCalcInCSSText() { m_shouldForceEnclosingCalcInCSSText = true; }
-
     CalculationCategory category() const { return m_category; }
 
     virtual void dump(TextStream&) const = 0;
@@ -76,7 +73,6 @@ protected:
 
 private:
     CalculationCategory m_category;
-    bool m_shouldForceEnclosingCalcInCSSText { false };
 };
 
 TextStream& operator<<(TextStream&, const CSSCalcExpressionNode&);

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -1091,8 +1091,6 @@ bool CSSCalcOperationNode::convertingToLengthRequiresNonNullStyle(int lengthConv
 void CSSCalcOperationNode::buildCSSText(const CSSCalcExpressionNode& node, StringBuilder& builder)
 {
     auto shouldOutputEnclosingCalc = [](const CSSCalcExpressionNode& rootNode) {
-        if (rootNode.shouldForceEnclosingCalcInCSSText())
-            return true;
         if (is<CSSCalcOperationNode>(rootNode)) {
             auto& operationNode = downcast<CSSCalcOperationNode>(rootNode);
             return operationNode.isCalcSumNode() || operationNode.isCalcProductNode();

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "CSSUnitValue.h"
 
+#include "CSSCalcOperationNode.h"
 #include "CSSCalcPrimitiveValueNode.h"
 #include "CSSCalcValue.h"
 #include "CSSParserFastPaths.h"
@@ -235,10 +236,10 @@ RefPtr<CSSValue> CSSUnitValue::toCSSValueWithProperty(CSSPropertyID propertyID) 
         // Wrap out of range values with a calc.
         auto node = toCalcExpressionNode();
         ASSERT(node);
-        // By default, cssText() will drop the enclosing `calc()` for simple expressions. However, it is important we
-        // keep it here or setting the value will fail.
-        node->setShouldForceEnclosingCalcInCSSText();
-        return CSSCalcValue::create(node.releaseNonNull(), true /* allowsNegativePercentage */);
+        auto sumNode = CSSCalcOperationNode::createSum(Vector { node.releaseNonNull() });
+        if (!sumNode)
+            return nullptr;
+        return CSSCalcValue::create(sumNode.releaseNonNull(), true /* allowsNegativePercentage */);
     }
     return toCSSValue();
 }


### PR DESCRIPTION
#### 0476db43bf13052a41ccd19ef45f2e5f044f714c
<pre>
Drop shouldForceEnclosingCalcInCSSText flag recently added to CSSCalcExpressionNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=248966">https://bugs.webkit.org/show_bug.cgi?id=248966</a>

Reviewed by Antoine Quint.

Drop shouldForceEnclosingCalcInCSSText flag that was recently added to
CSSCalcExpressionNode in 257485@main. We don&apos;t need it, we can simply wrap the
number in a sum to make sure that the surrounding `calc()` isn&apos;t dropped during
serialization.

* Source/WebCore/css/calc/CSSCalcExpressionNode.h:
(WebCore::CSSCalcExpressionNode::shouldForceEnclosingCalcInCSSText const): Deleted.
(WebCore::CSSCalcExpressionNode::setShouldForceEnclosingCalcInCSSText): Deleted.
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::CSSCalcOperationNode::buildCSSText):
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::CSSUnitValue::toCSSValueWithProperty const):

Canonical link: <a href="https://commits.webkit.org/257619@main">https://commits.webkit.org/257619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccf87013825b62df5b03b04acbf9be656d2a983d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108749 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168999 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85883 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106676 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33878 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76754 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2434 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23306 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45709 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8498 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42781 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2683 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->