### PR TITLE
Creating a _WKWebExtension with an invalid path should return nil.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -82,19 +82,37 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 /*!
  @abstract Returns a web extension initialized with a specified app extension bundle.
  @param bundle The bundle to use for the new web extension.
- @result An initialized web extension, or nil if the object could not be initialized.
- @discussion This is a designated initializer.
+ @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
+ @seealso initWithAppExtensionBundle:error:
  */
-- (instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle NS_DESIGNATED_INITIALIZER;
++ (nullable instancetype)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle;
 
 /*!
  @abstract Returns a web extension initialized with a specified resource base URL.
  @param resourceBaseURL The directory URL to use for the new web extension.
- @result An initialized web extension, or nil if the object could not be initialized.
+ @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
+ @seealso initWithResourceBaseURL:error:
+ */
++ (nullable instancetype)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL;
+
+/*!
+ @abstract Returns a web extension initialized with a specified app extension bundle.
+ @param bundle The bundle to use for the new web extension.
+ @param error Set to \c nil or an \c NSError instance if an error occurred.
+ @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
+ @discussion This is a designated initializer.
+ */
+- (nullable instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+
+/*!
+ @abstract Returns a web extension initialized with a specified resource base URL.
+ @param resourceBaseURL The directory URL to use for the new web extension.
+ @param error Set to \c nil or an \c NSError instance if an error occurred.
+ @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
  @discussion This is a designated initializer. The URL must be a file URL that points
  to a directory containing a `manifest.json` file.
  */
-- (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
 /*! @abstract The active errors for the extension. Returns `nil` if there are no errors. */
 @property (nonatomic, nullable, readonly, copy) NSArray<NSError *> *errors;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -42,34 +42,78 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-- (instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle
++ (instancetype)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle
+{
+    NSError * __autoreleasing internalError;
+    auto result = WebKit::WebExtension::create(appExtensionBundle, &internalError);
+
+    if (internalError)
+        return nil;
+
+    return result->wrapper();
+}
+
++ (instancetype)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL
+{
+    NSError * __autoreleasing internalError;
+    auto result = WebKit::WebExtension::create(resourceBaseURL, &internalError);
+
+    if (internalError)
+        return nil;
+
+    return result->wrapper();
+}
+
+- (instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error
 {
     NSParameterAssert(appExtensionBundle);
+
+    if (error)
+        *error = nil;
 
     if (!(self = [super init]))
         return nil;
 
-    API::Object::constructInWrapper<WebKit::WebExtension>(self, appExtensionBundle);
+    NSError * __autoreleasing internalError;
+    API::Object::constructInWrapper<WebKit::WebExtension>(self, appExtensionBundle, &internalError);
+
+    if (internalError) {
+        if (error)
+            *error = internalError;
+        return nil;
+    }
 
     return self;
 }
 
-- (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL
+- (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
 {
     NSParameterAssert(resourceBaseURL);
     NSParameterAssert([resourceBaseURL isFileURL]);
     NSParameterAssert([resourceBaseURL hasDirectoryPath]);
 
+    if (error)
+        *error = nil;
+
     if (!(self = [super init]))
         return nil;
 
-    API::Object::constructInWrapper<WebKit::WebExtension>(self, resourceBaseURL);
+    NSError * __autoreleasing internalError;
+    API::Object::constructInWrapper<WebKit::WebExtension>(self, resourceBaseURL, &internalError);
+
+    if (internalError) {
+        if (error)
+            *error = internalError;
+        return nil;
+    }
 
     return self;
 }
 
 - (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest
 {
+    NSParameterAssert(manifest);
+
     return [self _initWithManifestDictionary:manifest resources:nil];
 }
 
@@ -226,12 +270,22 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 
 #else // ENABLE(WK_WEB_EXTENSIONS)
 
-- (instancetype)initWithAppExtensionBundle:(NSBundle *)bundle
++ (instancetype)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle
 {
     return nil;
 }
 
-- (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL
++ (instancetype)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL
+{
+    return nil;
+}
+
+- (instancetype)initWithAppExtensionBundle:(NSBundle *)bundle error:(NSError **)error
+{
+    return nil;
+}
+
+- (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
 {
     return nil;
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -108,19 +108,35 @@ static NSString * const optionalPermissionsManifestKey = @"optional_permissions"
 static NSString * const hostPermissionsManifestKey = @"host_permissions";
 static NSString * const optionalHostPermissionsManifestKey = @"optional_host_permissions";
 
-WebExtension::WebExtension(NSBundle *appExtensionBundle)
+WebExtension::WebExtension(NSBundle *appExtensionBundle, NSError **outError)
     : m_bundle(appExtensionBundle)
     , m_resourceBaseURL(appExtensionBundle.resourceURL.URLByStandardizingPath.absoluteURL)
 {
     ASSERT(appExtensionBundle);
+
+    if (outError)
+        *outError = nil;
+
+    if (!manifestParsedSuccessfully()) {
+        ASSERT(m_errors.get().count);
+        *outError = m_errors.get().lastObject;
+    }
 }
 
-WebExtension::WebExtension(NSURL *resourceBaseURL)
+WebExtension::WebExtension(NSURL *resourceBaseURL, NSError **outError)
     : m_resourceBaseURL(resourceBaseURL.URLByStandardizingPath.absoluteURL)
 {
     ASSERT(resourceBaseURL);
     ASSERT([resourceBaseURL isFileURL]);
     ASSERT([resourceBaseURL hasDirectoryPath]);
+
+    if (outError)
+        *outError = nil;
+
+    if (!manifestParsedSuccessfully()) {
+        ASSERT(m_errors.get().count);
+        *outError = m_errors.get().lastObject;
+    }
 }
 
 WebExtension::WebExtension(NSDictionary *manifest, NSDictionary *resources)

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -69,8 +69,8 @@ public:
         return adoptRef(*new WebExtension(std::forward<Args>(args)...));
     }
 
-    explicit WebExtension(NSBundle *appExtensionBundle);
-    explicit WebExtension(NSURL *resourceBaseURL);
+    explicit WebExtension(NSBundle *appExtensionBundle, NSError ** = nullptr);
+    explicit WebExtension(NSURL *resourceBaseURL, NSError ** = nullptr);
     explicit WebExtension(NSDictionary *manifest, NSDictionary *resources);
     explicit WebExtension(NSDictionary *resources);
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -157,7 +157,7 @@ RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSDictionary *resources)
 
 RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSURL *baseURL)
 {
-    return loadAndRunExtension([[_WKWebExtension alloc] initWithResourceBaseURL:baseURL]);
+    return loadAndRunExtension([[_WKWebExtension alloc] initWithResourceBaseURL:baseURL error:nullptr]);
 }
 
 } // namespace Util


### PR DESCRIPTION
#### c893edaa156c8a67f63eee27e62b3d8e283fb7a8
<pre>
Creating a _WKWebExtension with an invalid path should return nil.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248960">https://bugs.webkit.org/show_bug.cgi?id=248960</a>

Reviewed by Brian Weinstein.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
(+[_WKWebExtension extensionWithAppExtensionBundle:]): Added.
(+[_WKWebExtension extensionWithResourceBaseURL:]): Added.
(-[_WKWebExtension initWithAppExtensionBundle:error:]): Added error param.
(-[_WKWebExtension initWithResourceBaseURL:error:]): Added error param.
(-[_WKWebExtension _initWithManifestDictionary:]): Added assert.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::WebExtension): Added error param.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(TestWebKitAPI::Util::loadAndRunExtension): Use initWithResourceBaseURL:error:.

Canonical link: <a href="https://commits.webkit.org/257584@main">https://commits.webkit.org/257584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99f0b9a12bbb0114dd667820d08b8a26dbfb138c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108750 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103363 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9127 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91855 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106677 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105124 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2339 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5221 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42780 "Passed tests") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->