### PR TITLE
Add temporary web navigation event to test interface.

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
@@ -184,6 +184,22 @@ void WebExtensionAPITest::assertThrows(JSContextRef context, JSValue *function, 
     assertTrue(context, [expectedError isEqualWithTypeCoercionToObject:exceptionMessageValue], [NSString stringWithFormat:@"Function throw an exception (%@) that didn't equal %@.", debugString(exceptionMessageValue), debugString(expectedError)]);
 }
 
+WebExtensionAPIWebNavigationEvent& WebExtensionAPITest::testWebNavigationEvent()
+{
+    if (!m_webNavigationEvent)
+        m_webNavigationEvent = WebExtensionAPIWebNavigationEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebNavigationOnCompleted);
+
+    return *m_webNavigationEvent;
+}
+
+void WebExtensionAPITest::fireTestWebNavigationEvent(NSString *urlString)
+{
+    NSURL *targetURL = [NSURL URLWithString:urlString];
+
+    WebExtensionAPIWebNavigationEvent& testEvent = testWebNavigationEvent();
+    testEvent.invokeListenersWithArgument(@{ @"url": urlString }, targetURL);
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
@@ -29,6 +29,7 @@
 
 #include "JSWebExtensionAPITest.h"
 #include "WebExtensionAPIObject.h"
+#include "WebExtensionAPIWebNavigationEvent.h"
 
 OBJC_CLASS NSString;
 
@@ -59,6 +60,12 @@ public:
 
     JSValue *assertRejects(JSContextRef, JSValue *promise, JSValue *expectedError, NSString *message);
     void assertThrows(JSContextRef, JSValue *function, JSValue *expectedError, NSString *message);
+
+    WebExtensionAPIWebNavigationEvent& testWebNavigationEvent();
+    void fireTestWebNavigationEvent(NSString *urlString);
+
+private:
+    RefPtr<WebExtensionAPIWebNavigationEvent> m_webNavigationEvent;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
@@ -55,6 +55,12 @@ public:
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
 private:
+    explicit WebExtensionAPIWebNavigationEvent(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionEventListenerType type)
+        : WebExtensionAPIObject(forMainWorld, runtime, context)
+    {
+        m_type = type;
+    }
+
     WebExtensionEventListenerType m_type;
     ListenerVector m_listeners;
 };

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
@@ -64,4 +64,9 @@
     // Asserts the function throws an exception.
     [NeedsScriptContext, ProcessArgumentsLeftToRight] void assertThrows(any function, [Optional, ValuesAllowed] any expectedError, [Optional] DOMString message);
 
+    // Temporary webNavigation event for bring-up.
+    // FIXME: Remove this.
+    readonly attribute WebExtensionAPIWebNavigationEvent testWebNavigationEvent;
+    void fireTestWebNavigationEvent(DOMString targetUrl);
+
 };


### PR DESCRIPTION
#### c1ab7bf237fb87a9dc77fecc7c7e76a21419e6f4
<pre>
Add temporary web navigation event to test interface.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248969">https://bugs.webkit.org/show_bug.cgi?id=248969</a>
rdar://102820594

Reviewed by Timothy Hatcher.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::WebExtensionAPITest::testWebNavigationEvent):
(WebKit::WebExtensionAPITest::fireTestWebNavigationEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h:
(WebKit::WebExtensionAPIWebNavigationEvent::setEventType):
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl:

Canonical link: <a href="https://commits.webkit.org/257588@main">https://commits.webkit.org/257588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/548d4b6e2e34f92c64ea6b187d4bb9854d8c2f84

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108767 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9144 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91872 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106692 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105140 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2355 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5223 "Built successfully and passed tests") | [💥 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8514 "An unexpected error occured. Recent messages:Failed to print configuration") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42795 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4221 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->