### PR TITLE
[WK2] Apply method signature validation to all types of IPC message handling

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -318,11 +318,11 @@ void RemoteDisplayListRecorder::drawNativeImageWithQualifiedIdentifier(Qualified
     handleItem(DisplayList::DrawNativeImage(imageIdentifier.object(), imageSize, destRect, srcRect, options), *image);
 }
 
-void RemoteDisplayListRecorder::drawSystemImage(SystemImage& systemImage, const FloatRect& destinationRect)
+void RemoteDisplayListRecorder::drawSystemImage(Ref<SystemImage> systemImage, const FloatRect& destinationRect)
 {
 #if USE(SYSTEM_PREVIEW)
-    if (is<ARKitBadgeSystemImage>(systemImage)) {
-        ARKitBadgeSystemImage& badge = downcast<ARKitBadgeSystemImage>(systemImage);
+    if (is<ARKitBadgeSystemImage>(systemImage.get())) {
+        ARKitBadgeSystemImage& badge = downcast<ARKitBadgeSystemImage>(systemImage.get());
         RefPtr nativeImage = resourceCache().cachedNativeImage({ badge.imageIdentifier(), m_webProcessIdentifier });
         if (!nativeImage) {
             ASSERT_NOT_REACHED();

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -85,7 +85,7 @@ public:
     void drawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, IPC::FilterReference);
     void drawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, const WebCore::FloatRect& destinationRect, const WebCore::FloatRect& srcRect, const WebCore::ImagePaintingOptions&);
     void drawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, const WebCore::FloatSize& imageSize, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, const WebCore::ImagePaintingOptions&);
-    void drawSystemImage(WebCore::SystemImage&, const WebCore::FloatRect&);
+    void drawSystemImage(Ref<WebCore::SystemImage>, const WebCore::FloatRect&);
     void drawPattern(WebCore::RenderingResourceIdentifier imageIdentifier, const WebCore::FloatRect& destRect, const WebCore::FloatRect& tileRect, const WebCore::AffineTransform&, const WebCore::FloatPoint&, const WebCore::FloatSize& spacing, const WebCore::ImagePaintingOptions&);
     void beginTransparencyLayer(float opacity);
     void endTransparencyLayer();

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -963,11 +963,11 @@ void NetworkProcess::domainIDExistsInDatabase(PAL::SessionID sessionID, int doma
     }
 }
 
-void NetworkProcess::mergeStatisticForTesting(PAL::SessionID sessionID, RegistrableDomain&& domain, RegistrableDomain&& topFrameDomain1, RegistrableDomain&& topFrameDomain2, Seconds lastSeen, bool hadUserInteraction, Seconds mostRecentUserInteraction, bool isGrandfathered, bool isPrevalent, bool isVeryPrevalent, unsigned dataRecordsRemoved, CompletionHandler<void()>&& completionHandler)
+void NetworkProcess::mergeStatisticForTesting(PAL::SessionID sessionID, RegistrableDomain&& domain, RegistrableDomain&& topFrameDomain1, RegistrableDomain&& topFrameDomain2, Seconds lastSeen, bool hadUserInteraction, Seconds mostRecentUserInteraction, bool isGrandfathered, bool isPrevalent, bool isVeryPrevalent, uint64_t dataRecordsRemoved, CompletionHandler<void()>&& completionHandler)
 {
     if (auto* session = networkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
-            resourceLoadStatistics->mergeStatisticForTesting(WTFMove(domain), WTFMove(topFrameDomain1), WTFMove(topFrameDomain2), lastSeen, hadUserInteraction, mostRecentUserInteraction, isGrandfathered, isPrevalent, isVeryPrevalent, dataRecordsRemoved, WTFMove(completionHandler));
+            resourceLoadStatistics->mergeStatisticForTesting(WTFMove(domain), WTFMove(topFrameDomain1), WTFMove(topFrameDomain2), lastSeen, hadUserInteraction, mostRecentUserInteraction, isGrandfathered, isPrevalent, isVeryPrevalent, unsigned(dataRecordsRemoved), WTFMove(completionHandler));
         else
             completionHandler();
     } else {
@@ -976,11 +976,11 @@ void NetworkProcess::mergeStatisticForTesting(PAL::SessionID sessionID, Registra
     }
 }
 
-void NetworkProcess::insertExpiredStatisticForTesting(PAL::SessionID sessionID, RegistrableDomain&& domain, unsigned numberOfOperatingDaysPassed, bool hadUserInteraction, bool isScheduledForAllButCookieDataRemoval, bool isPrevalent, CompletionHandler<void()>&& completionHandler)
+void NetworkProcess::insertExpiredStatisticForTesting(PAL::SessionID sessionID, RegistrableDomain&& domain, uint64_t numberOfOperatingDaysPassed, bool hadUserInteraction, bool isScheduledForAllButCookieDataRemoval, bool isPrevalent, CompletionHandler<void()>&& completionHandler)
 {
     if (auto* session = networkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
-            resourceLoadStatistics->insertExpiredStatisticForTesting(WTFMove(domain), numberOfOperatingDaysPassed, hadUserInteraction, isScheduledForAllButCookieDataRemoval, isPrevalent, WTFMove(completionHandler));
+            resourceLoadStatistics->insertExpiredStatisticForTesting(WTFMove(domain), unsigned(numberOfOperatingDaysPassed), hadUserInteraction, isScheduledForAllButCookieDataRemoval, isPrevalent, WTFMove(completionHandler));
         else
             completionHandler();
     } else {

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -239,8 +239,8 @@ public:
     void setGrandfatheringTime(PAL::SessionID, Seconds, CompletionHandler<void()>&&);
     void setLastSeen(PAL::SessionID, RegistrableDomain&&, Seconds, CompletionHandler<void()>&&);
     void domainIDExistsInDatabase(PAL::SessionID, int domainID, CompletionHandler<void(bool)>&&);
-    void mergeStatisticForTesting(PAL::SessionID, RegistrableDomain&&, TopFrameDomain&& topFrameDomain1, TopFrameDomain&& topFrameDomain2, Seconds lastSeen, bool hadUserInteraction, Seconds mostRecentUserInteraction, bool isGrandfathered, bool isPrevalent, bool isVeryPrevalent, unsigned dataRecordsRemoved, CompletionHandler<void()>&&);
-    void insertExpiredStatisticForTesting(PAL::SessionID, RegistrableDomain&&, unsigned numberOfOperatingDaysPassed, bool hadUserInteraction, bool isScheduledForAllButCookieDataRemoval, bool isPrevalent, CompletionHandler<void()>&&);
+    void mergeStatisticForTesting(PAL::SessionID, RegistrableDomain&&, TopFrameDomain&& topFrameDomain1, TopFrameDomain&& topFrameDomain2, Seconds lastSeen, bool hadUserInteraction, Seconds mostRecentUserInteraction, bool isGrandfathered, bool isPrevalent, bool isVeryPrevalent, uint64_t dataRecordsRemoved, CompletionHandler<void()>&&);
+    void insertExpiredStatisticForTesting(PAL::SessionID, RegistrableDomain&&, uint64_t numberOfOperatingDaysPassed, bool hadUserInteraction, bool isScheduledForAllButCookieDataRemoval, bool isPrevalent, CompletionHandler<void()>&&);
     void setMinimumTimeBetweenDataRecordsRemoval(PAL::SessionID, Seconds, CompletionHandler<void()>&&);
     void setNotifyPagesWhenDataRecordsWereScanned(PAL::SessionID, bool value, CompletionHandler<void()>&&);
     void setResourceLoadStatisticsTimeAdvanceForTesting(PAL::SessionID, Seconds, CompletionHandler<void()>&&);

--- a/Source/WebKit/Platform/IPC/HandleMessage.h
+++ b/Source/WebKit/Platform/IPC/HandleMessage.h
@@ -167,45 +167,59 @@ void callMemberFunction(T* object, MF U::* function, Connection& connection, Arg
         }, std::forward<ArgsTuple>(tuple));
 }
 
-// The two CompletionHandlerTypeDeduction partial specializations enable retrieval of the parameter type
-// at the specified index position. This allows retrieving the exact type of the parameter where the
-// CompletionHandler is expected in a given synchronous-reply method.
+// MethodSignatureValidation template works on function types of message-handling methods,
+// deducing the expected list of argument types that a given method is expecting along with
+// properly handling the possible initial Connection& argument and the possible final
+// CompletionHandler<>&& argument.
+// Once the template instantiations traverse across the method's arguments, the MessageArguments
+// type alias will present a tuple of method's expected argument types that the handleMessage()
+// variants can use for validation against the argument types specified by the message.
+// In case a CompletionHandler argument is present, the CompletionHandlerArguments type alias
+// will hold a list of the handler's expected argument types that again can be used for validation
+// against the message's specified reply types, and the CompletionHandlerType type alias will
+// provide that exact CompletionHandler type to enable proper construction of the object.
 
-template<typename T, size_t N> struct CompletionHandlerTypeDeduction { };
+template<typename MessageArgumentTypesTuple, typename MethodArgumentTypesTuple> struct MethodSignatureValidationImpl { };
 
-template<typename R, typename... Args, size_t N>
-struct CompletionHandlerTypeDeduction<R(Args...), N> {
-    using Type = std::remove_cvref_t<typename std::tuple_element_t<N, std::tuple<Args...>>>;
+template<typename... MessageArgumentTypes, typename MethodArgumentType, typename... MethodArgumentTypes>
+struct MethodSignatureValidationImpl<std::tuple<MessageArgumentTypes...>, std::tuple<MethodArgumentType, MethodArgumentTypes...>>
+    : MethodSignatureValidationImpl<std::tuple<MessageArgumentTypes..., MethodArgumentType>, std::tuple<MethodArgumentTypes...>> { };
+
+template<typename... MessageArgumentTypes>
+struct MethodSignatureValidationImpl<std::tuple<Connection&, MessageArgumentTypes...>, std::tuple<>>
+    : MethodSignatureValidationImpl<std::tuple<MessageArgumentTypes...>, std::tuple<>> { };
+
+template<typename... MessageArgumentTypes>
+struct MethodSignatureValidationImpl<std::tuple<MessageArgumentTypes...>, std::tuple<>> {
+    using MessageArguments = std::tuple<std::remove_cvref_t<MessageArgumentTypes>...>;
 };
 
-template<typename R, typename... Args, size_t N>
-struct CompletionHandlerTypeDeduction<R(Args...) const, N> : CompletionHandlerTypeDeduction<R(Args...), N> { };
+template<typename... MessageArgumentTypes, typename... CompletionHandlerArgumentTypes>
+struct MethodSignatureValidationImpl<std::tuple<MessageArgumentTypes...>, std::tuple<CompletionHandler<void(CompletionHandlerArgumentTypes...)>&&>>
+    : MethodSignatureValidationImpl<std::tuple<MessageArgumentTypes...>, std::tuple<>> {
+    using CompletionHandlerArguments = std::tuple<std::remove_cvref_t<CompletionHandlerArgumentTypes>...>;
+    using CompletionHandlerType = CompletionHandler<void(CompletionHandlerArgumentTypes...)>;
+};
 
-// The CompletionHandlerValidation is used to ensure that the provided completion handler's parameter
-// types match the types used in the IPC message definition.
+template<typename FunctionType> struct MethodSignatureValidation { };
 
-template<typename CHType, typename ReplyType> struct CompletionHandlerValidation : std::false_type { };
+template<typename R, typename... MethodArgumentTypes>
+struct MethodSignatureValidation<R(MethodArgumentTypes...)>
+    : MethodSignatureValidationImpl<std::tuple<>, std::tuple<MethodArgumentTypes...>> { };
 
-template<typename... CHArgumentTypes, typename ReplyArgumentsTupleType>
-struct CompletionHandlerValidation<CompletionHandler<void(CHArgumentTypes...)>, ReplyArgumentsTupleType>
-    : std::is_same<std::tuple<std::remove_cvref_t<CHArgumentTypes>...>, ReplyArgumentsTupleType> { };
+template<typename R, typename... MethodArgumentTypes>
+struct MethodSignatureValidation<R(MethodArgumentTypes...) const>
+    : MethodSignatureValidation<R(MethodArgumentTypes...)> { };
 
 // Main dispatch functions
-
-template<typename T>
-struct CodingType {
-    using Type = std::remove_cvref_t<T>;
-};
-
-template<typename... Ts>
-struct CodingType<std::tuple<Ts...>> {
-    using Type = std::tuple<typename CodingType<Ts>::Type...>;
-};
 
 template<typename MessageType, typename T, typename U, typename MF>
 void handleMessage(Connection& connection, Decoder& decoder, T* object, MF U::* function)
 {
-    auto arguments = decoder.decode<typename CodingType<typename MessageType::Arguments>::Type>();
+    using ValidationType = MethodSignatureValidation<MF>;
+    static_assert(std::is_same_v<typename ValidationType::MessageArguments, typename MessageType::Arguments>);
+
+    auto arguments = decoder.decode<typename MessageType::Arguments>();
     if (UNLIKELY(!arguments))
         return;
 
@@ -216,7 +230,10 @@ void handleMessage(Connection& connection, Decoder& decoder, T* object, MF U::* 
 template<typename MessageType, typename T, typename U, typename MF>
 void handleMessageWantsConnection(Connection& connection, Decoder& decoder, T* object, MF U::* function)
 {
-    auto arguments = decoder.decode<typename CodingType<typename MessageType::Arguments>::Type>();
+    using ValidationType = MethodSignatureValidation<MF>;
+    static_assert(std::is_same_v<typename ValidationType::MessageArguments, typename MessageType::Arguments>);
+
+    auto arguments = decoder.decode<typename MessageType::Arguments>();
     if (UNLIKELY(!arguments))
         return;
 
@@ -227,16 +244,19 @@ void handleMessageWantsConnection(Connection& connection, Decoder& decoder, T* o
 template<typename MessageType, typename T, typename U, typename MF>
 bool handleMessageSynchronous(Connection& connection, Decoder& decoder, UniqueRef<Encoder>& replyEncoder, T* object, MF U::* function)
 {
-    auto arguments = decoder.decode<typename CodingType<typename MessageType::Arguments>::Type>();
+    using ValidationType = MethodSignatureValidation<MF>;
+    static_assert(std::is_same_v<typename ValidationType::MessageArguments, typename MessageType::Arguments>);
+
+    auto arguments = decoder.decode<typename MessageType::Arguments>();
     if (UNLIKELY(!arguments))
         return false;
 
-    using CompletionHandlerFromMF = typename CompletionHandlerTypeDeduction<MF, std::tuple_size_v<typename MessageType::Arguments>>::Type;
-    static_assert(CompletionHandlerValidation<CompletionHandlerFromMF, typename MessageType::ReplyArguments>::value);
+    static_assert(std::is_same_v<typename ValidationType::CompletionHandlerArguments, typename MessageType::ReplyArguments>);
+    using CompletionHandlerType = typename ValidationType::CompletionHandlerType;
 
     logMessage(connection, MessageType::name(), object, *arguments);
     callMemberFunction(object, function, WTFMove(*arguments),
-        CompletionHandlerFromMF([replyEncoder = WTFMove(replyEncoder), connection = Ref { connection }] (auto&&... args) mutable {
+        CompletionHandlerType([replyEncoder = WTFMove(replyEncoder), connection = Ref { connection }] (auto&&... args) mutable {
             logReply(connection, MessageType::name(), args...);
             (replyEncoder.get() << ... << std::forward<decltype(args)>(args));
             connection->sendSyncReply(WTFMove(replyEncoder));
@@ -247,16 +267,19 @@ bool handleMessageSynchronous(Connection& connection, Decoder& decoder, UniqueRe
 template<typename MessageType, typename T, typename U, typename MF>
 bool handleMessageSynchronousWantsConnection(Connection& connection, Decoder& decoder, UniqueRef<Encoder>& replyEncoder, T* object, MF U::* function)
 {
-    auto arguments = decoder.decode<typename CodingType<typename MessageType::Arguments>::Type>();
+    using ValidationType = MethodSignatureValidation<MF>;
+    static_assert(std::is_same_v<typename ValidationType::MessageArguments, typename MessageType::Arguments>);
+
+    auto arguments = decoder.decode<typename MessageType::Arguments>();
     if (UNLIKELY(!arguments))
         return false;
     
-    using CompletionHandlerFromMF = typename CompletionHandlerTypeDeduction<MF, 1 + std::tuple_size_v<typename MessageType::Arguments>>::Type;
-    static_assert(CompletionHandlerValidation<CompletionHandlerFromMF, typename MessageType::ReplyArguments>::value);
+    static_assert(std::is_same_v<typename ValidationType::CompletionHandlerArguments, typename MessageType::ReplyArguments>);
+    using CompletionHandlerType = typename ValidationType::CompletionHandlerType;
 
     logMessage(connection, MessageType::name(), object, *arguments);
     callMemberFunction(object, function, connection, WTFMove(*arguments),
-        CompletionHandlerFromMF([replyEncoder = WTFMove(replyEncoder), connection = Ref { connection }] (auto&&... args) mutable {
+        CompletionHandlerType([replyEncoder = WTFMove(replyEncoder), connection = Ref { connection }] (auto&&... args) mutable {
             logReply(connection, MessageType::name(), args...);
             (replyEncoder.get() << ... << std::forward<decltype(args)>(args));
             connection->sendSyncReply(WTFMove(replyEncoder));
@@ -267,20 +290,23 @@ bool handleMessageSynchronousWantsConnection(Connection& connection, Decoder& de
 template<typename MessageType, typename T, typename U, typename MF>
 void handleMessageSynchronous(StreamServerConnection& connection, Decoder& decoder, T* object, MF U::* function)
 {
+    using ValidationType = MethodSignatureValidation<MF>;
+    static_assert(std::is_same_v<typename ValidationType::MessageArguments, typename MessageType::Arguments>);
+
     Connection::SyncRequestID syncRequestID;
     if (UNLIKELY(!decoder.decode(syncRequestID)))
         return;
 
-    auto arguments = decoder.decode<typename CodingType<typename MessageType::Arguments>::Type>();
+    auto arguments = decoder.decode<typename MessageType::Arguments>();
     if (UNLIKELY(!arguments))
         return;
 
-    using CompletionHandlerFromMF = typename CompletionHandlerTypeDeduction<MF, std::tuple_size_v<typename MessageType::Arguments>>::Type;
-    static_assert(CompletionHandlerValidation<CompletionHandlerFromMF, typename MessageType::ReplyArguments>::value);
+    static_assert(std::is_same_v<typename ValidationType::CompletionHandlerArguments, typename MessageType::ReplyArguments>);
+    using CompletionHandlerType = typename ValidationType::CompletionHandlerType;
 
     logMessage(connection.connection(), MessageType::name(), object, *arguments);
     callMemberFunction(object, function, WTFMove(*arguments),
-        CompletionHandlerFromMF([syncRequestID, connection = Ref { connection }] (auto&&... args) mutable {
+        CompletionHandlerType([syncRequestID, connection = Ref { connection }] (auto&&... args) mutable {
             logReply(connection->connection(), MessageType::name(), args...);
             connection->sendSyncReply<MessageType>(syncRequestID, std::forward<decltype(args)>(args)...);
         }));
@@ -289,19 +315,22 @@ void handleMessageSynchronous(StreamServerConnection& connection, Decoder& decod
 template<typename MessageType, typename T, typename U, typename MF>
 void handleMessageAsync(Connection& connection, Decoder& decoder, T* object, MF U::* function)
 {
-    auto arguments = decoder.decode<typename CodingType<typename MessageType::Arguments>::Type>();
+    using ValidationType = MethodSignatureValidation<MF>;
+    static_assert(std::is_same_v<typename ValidationType::MessageArguments, typename MessageType::Arguments>);
+
+    auto arguments = decoder.decode<typename MessageType::Arguments>();
     if (UNLIKELY(!arguments))
         return;
     auto replyID = decoder.decode<Connection::AsyncReplyID>();
     if (UNLIKELY(!replyID))
         return;
 
-    using CompletionHandlerFromMF = typename CompletionHandlerTypeDeduction<MF, std::tuple_size_v<typename MessageType::Arguments>>::Type;
-    static_assert(CompletionHandlerValidation<CompletionHandlerFromMF, typename MessageType::ReplyArguments>::value);
+    static_assert(std::is_same_v<typename ValidationType::CompletionHandlerArguments, typename MessageType::ReplyArguments>);
+    using CompletionHandlerType = typename ValidationType::CompletionHandlerType;
 
     logMessage(connection, MessageType::name(), object, *arguments);
     callMemberFunction(object, function, WTFMove(*arguments),
-        CompletionHandlerFromMF { [replyID = *replyID, connection = Ref { connection }] (auto&&... args) mutable {
+        CompletionHandlerType { [replyID = *replyID, connection = Ref { connection }] (auto&&... args) mutable {
             auto encoder = makeUniqueRef<Encoder>(MessageType::asyncMessageReplyName(), replyID.toUInt64());
             logReply(connection, MessageType::name(), args...);
             (encoder.get() << ... << std::forward<decltype(args)>(args));
@@ -312,19 +341,22 @@ void handleMessageAsync(Connection& connection, Decoder& decoder, T* object, MF 
 template<typename MessageType, typename T, typename U, typename MF>
 void handleMessageAsyncWantsConnection(Connection& connection, Decoder& decoder, T* object, MF U::* function)
 {
-    auto arguments = decoder.decode<typename CodingType<typename MessageType::Arguments>::Type>();
+    using ValidationType = MethodSignatureValidation<MF>;
+    static_assert(std::is_same_v<typename ValidationType::MessageArguments, typename MessageType::Arguments>);
+
+    auto arguments = decoder.decode<typename MessageType::Arguments>();
     if (UNLIKELY(!arguments))
         return;
     auto replyID = decoder.decode<Connection::AsyncReplyID>();
     if (UNLIKELY(!replyID))
         return;
 
-    using CompletionHandlerFromMF = typename CompletionHandlerTypeDeduction<MF, 1 + std::tuple_size_v<typename MessageType::Arguments>>::Type;
-    static_assert(CompletionHandlerValidation<CompletionHandlerFromMF, typename MessageType::ReplyArguments>::value);
+    static_assert(std::is_same_v<typename ValidationType::CompletionHandlerArguments, typename MessageType::ReplyArguments>);
+    using CompletionHandlerType = typename ValidationType::CompletionHandlerType;
 
     logMessage(connection, MessageType::name(), object, *arguments);
     callMemberFunction(object, function, connection, WTFMove(*arguments),
-        CompletionHandlerFromMF { [replyID = *replyID, connection = Ref { connection }] (auto&&... args) mutable {
+        CompletionHandlerType { [replyID = *replyID, connection = Ref { connection }] (auto&&... args) mutable {
             auto encoder = makeUniqueRef<Encoder>(MessageType::asyncMessageReplyName(), replyID.toUInt64());
             logReply(connection, MessageType::name(), args...);
             (encoder.get() << ... << std::forward<decltype(args)>(args));

--- a/Source/WebKit/Platform/IPC/JSIPCBinding.h
+++ b/Source/WebKit/Platform/IPC/JSIPCBinding.h
@@ -154,7 +154,7 @@ static std::optional<JSC::JSValue> jsValueForDecodedArguments(JSC::JSGlobalObjec
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     auto* array = JSC::constructEmptyArray(globalObject, nullptr);
     RETURN_IF_EXCEPTION(scope, JSC::JSValue());
-    typename IPC::CodingType<T>::Type* dummyArguments = nullptr;
+    T* dummyArguments = nullptr;
     return putJSValueForDecodeArgumentInArray<>(globalObject, decoder, array, 0, dummyArguments);
 }
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -146,21 +146,13 @@ def function_parameter_type(type, kind):
     return 'const %s&' % type
 
 
-def arguments_type(message):
-    return 'std::tuple<%s>' % ', '.join(function_parameter_type(parameter.type, parameter.kind) for parameter in message.parameters)
-
-
-def reply_arguments_type(message):
-    return 'std::tuple<%s>' % (', '.join(parameter.type for parameter in message.reply_parameters))
-
-
 def message_to_struct_declaration(receiver, message):
     result = []
     function_parameters = [(function_parameter_type(x.type, x.kind), x.name) for x in message.parameters]
 
     result.append('class %s {\n' % message.name)
     result.append('public:\n')
-    result.append('    using Arguments = %s;\n' % arguments_type(message))
+    result.append('    using Arguments = std::tuple<%s>;\n' % ', '.join([parameter.type for parameter in message.parameters]))
     result.append('\n')
     result.append('    static IPC::MessageName name() { return IPC::MessageName::%s_%s; }\n' % (receiver.name, message.name))
     result.append('    static constexpr bool isSync = %s;\n' % ('false', 'true')[message.reply_parameters is not None and message.has_attribute(SYNCHRONOUS_ATTRIBUTE)])
@@ -181,20 +173,20 @@ def message_to_struct_declaration(receiver, message):
             result.append('    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::MainThread;\n')
         else:
             result.append('    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;\n')
-        result.append('    using ReplyArguments = %s;\n' % reply_arguments_type(message))
+        result.append('    using ReplyArguments = std::tuple<%s>;\n' % ', '.join([parameter.type for parameter in message.reply_parameters]))
 
     if len(function_parameters):
         result.append('    %s%s(%s)' % (len(function_parameters) == 1 and 'explicit ' or '', message.name, ', '.join([' '.join(x) for x in function_parameters])))
         result.append('\n        : m_arguments(%s)\n' % ', '.join([x[1] for x in function_parameters]))
         result.append('    {\n')
         result.append('    }\n\n')
-    result.append('    const Arguments& arguments() const\n')
+    result.append('    const auto& arguments() const\n')
     result.append('    {\n')
     result.append('        return m_arguments;\n')
     result.append('    }\n')
     result.append('\n')
     result.append('private:\n')
-    result.append('    Arguments m_arguments;\n')
+    result.append('    std::tuple<%s> m_arguments;\n' % ', '.join([x[0] for x in function_parameters]))
     result.append('};\n')
     return surround_in_condition(''.join(result), message.condition)
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h
@@ -46,7 +46,7 @@ static inline IPC::ReceiverName messageReceiverName()
 #if USE(AVFOUNDATION)
 class SendCVPixelBuffer {
 public:
-    using Arguments = std::tuple<const RetainPtr<CVPixelBufferRef>&>;
+    using Arguments = std::tuple<RetainPtr<CVPixelBufferRef>>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer; }
     static constexpr bool isSync = false;
@@ -56,13 +56,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const RetainPtr<CVPixelBufferRef>&> m_arguments;
 };
 #endif
 
@@ -77,13 +77,13 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBufferReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<RetainPtr<CVPixelBufferRef>>;
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<> m_arguments;
 };
 #endif
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h
@@ -43,7 +43,7 @@ static inline IPC::ReceiverName messageReceiverName()
 #if PLATFORM(COCOA)
 class LoadURL {
 public:
-    using Arguments = std::tuple<const String&>;
+    using Arguments = std::tuple<String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithIfMessage_LoadURL; }
     static constexpr bool isSync = false;
@@ -53,20 +53,20 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&> m_arguments;
 };
 #endif
 
 #if PLATFORM(GTK)
 class LoadURL {
 public:
-    using Arguments = std::tuple<const String&, int64_t>;
+    using Arguments = std::tuple<String, int64_t>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithIfMessage_LoadURL; }
     static constexpr bool isSync = false;
@@ -76,13 +76,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&, int64_t> m_arguments;
 };
 #endif
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h
@@ -43,7 +43,7 @@ static inline IPC::ReceiverName messageReceiverName()
 
 class SendImageData {
 public:
-    using Arguments = std::tuple<const RefPtr<WebCore::ImageData>&>;
+    using Arguments = std::tuple<RefPtr<WebCore::ImageData>>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithImageData_SendImageData; }
     static constexpr bool isSync = false;
@@ -53,13 +53,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const RefPtr<WebCore::ImageData>&> m_arguments;
 };
 
 class ReceiveImageData {
@@ -72,13 +72,13 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithImageData_ReceiveImageDataReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<RefPtr<WebCore::ImageData>>;
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<> m_arguments;
 };
 
 } // namespace TestWithImageData

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
@@ -64,7 +64,7 @@ static inline IPC::ReceiverName messageReceiverName()
 
 class LoadURL {
 public:
-    using Arguments = std::tuple<const String&>;
+    using Arguments = std::tuple<String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_LoadURL; }
     static constexpr bool isSync = false;
@@ -74,19 +74,19 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&> m_arguments;
 };
 
 #if ENABLE(TOUCH_EVENTS)
 class LoadSomething {
 public:
-    using Arguments = std::tuple<const String&>;
+    using Arguments = std::tuple<String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_LoadSomething; }
     static constexpr bool isSync = false;
@@ -96,20 +96,20 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&> m_arguments;
 };
 #endif
 
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
 class TouchEvent {
 public:
-    using Arguments = std::tuple<const WebKit::WebTouchEvent&>;
+    using Arguments = std::tuple<WebKit::WebTouchEvent>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_TouchEvent; }
     static constexpr bool isSync = false;
@@ -119,20 +119,20 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const WebKit::WebTouchEvent&> m_arguments;
 };
 #endif
 
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
 class AddEvent {
 public:
-    using Arguments = std::tuple<const WebKit::WebTouchEvent&>;
+    using Arguments = std::tuple<WebKit::WebTouchEvent>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_AddEvent; }
     static constexpr bool isSync = false;
@@ -142,20 +142,20 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const WebKit::WebTouchEvent&> m_arguments;
 };
 #endif
 
 #if ENABLE(TOUCH_EVENTS)
 class LoadSomethingElse {
 public:
-    using Arguments = std::tuple<const String&>;
+    using Arguments = std::tuple<String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_LoadSomethingElse; }
     static constexpr bool isSync = false;
@@ -165,13 +165,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&> m_arguments;
 };
 #endif
 
@@ -187,13 +187,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<uint64_t, uint64_t, uint32_t> m_arguments;
 };
 
 class Close {
@@ -203,18 +203,18 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_Close; }
     static constexpr bool isSync = false;
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<> m_arguments;
 };
 
 class PreferencesDidChange {
 public:
-    using Arguments = std::tuple<const WebKit::WebPreferencesStore&>;
+    using Arguments = std::tuple<WebKit::WebPreferencesStore>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_PreferencesDidChange; }
     static constexpr bool isSync = false;
@@ -224,13 +224,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const WebKit::WebPreferencesStore&> m_arguments;
 };
 
 class SendDoubleAndFloat {
@@ -245,18 +245,18 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<double, float> m_arguments;
 };
 
 class SendInts {
 public:
-    using Arguments = std::tuple<const Vector<uint64_t>&, const Vector<Vector<uint64_t>>&>;
+    using Arguments = std::tuple<Vector<uint64_t>, Vector<Vector<uint64_t>>>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_SendInts; }
     static constexpr bool isSync = false;
@@ -266,18 +266,18 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const Vector<uint64_t>&, const Vector<Vector<uint64_t>>&> m_arguments;
 };
 
 class CreatePlugin {
 public:
-    using Arguments = std::tuple<uint64_t, const WebKit::Plugin::Parameters&>;
+    using Arguments = std::tuple<uint64_t, WebKit::Plugin::Parameters>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_CreatePlugin; }
     static constexpr bool isSync = false;
@@ -290,18 +290,18 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<uint64_t, const WebKit::Plugin::Parameters&> m_arguments;
 };
 
 class RunJavaScriptAlert {
 public:
-    using Arguments = std::tuple<uint64_t, const String&>;
+    using Arguments = std::tuple<uint64_t, String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_RunJavaScriptAlert; }
     static constexpr bool isSync = false;
@@ -314,13 +314,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<uint64_t, const String&> m_arguments;
 };
 
 class GetPlugins {
@@ -338,18 +338,18 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<bool> m_arguments;
 };
 
 class GetPluginProcessConnection {
 public:
-    using Arguments = std::tuple<const String&>;
+    using Arguments = std::tuple<String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_GetPluginProcessConnection; }
     static constexpr bool isSync = true;
@@ -361,13 +361,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&> m_arguments;
 };
 
 class TestMultipleAttributes {
@@ -379,13 +379,13 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<> m_arguments;
 };
 
 class TestParameterAttributes {
@@ -400,18 +400,18 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<uint64_t, double, double> m_arguments;
 };
 
 class TemplateTest {
 public:
-    using Arguments = std::tuple<const HashMap<String, std::pair<String, uint64_t>>&>;
+    using Arguments = std::tuple<HashMap<String, std::pair<String, uint64_t>>>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_TemplateTest; }
     static constexpr bool isSync = false;
@@ -421,18 +421,18 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const HashMap<String, std::pair<String, uint64_t>>&> m_arguments;
 };
 
 class SetVideoLayerID {
 public:
-    using Arguments = std::tuple<const WebCore::GraphicsLayer::PlatformLayerID&>;
+    using Arguments = std::tuple<WebCore::GraphicsLayer::PlatformLayerID>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_SetVideoLayerID; }
     static constexpr bool isSync = false;
@@ -442,19 +442,19 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const WebCore::GraphicsLayer::PlatformLayerID&> m_arguments;
 };
 
 #if PLATFORM(MAC)
 class DidCreateWebProcessConnection {
 public:
-    using Arguments = std::tuple<const MachSendRight&, const OptionSet<WebKit::SelectionFlags>&>;
+    using Arguments = std::tuple<MachSendRight, OptionSet<WebKit::SelectionFlags>>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection; }
     static constexpr bool isSync = false;
@@ -464,13 +464,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const MachSendRight&, const OptionSet<WebKit::SelectionFlags>&> m_arguments;
 };
 #endif
 
@@ -490,20 +490,20 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<uint32_t> m_arguments;
 };
 #endif
 
 #if ENABLE(DEPRECATED_FEATURE)
 class DeprecatedOperation {
 public:
-    using Arguments = std::tuple<const IPC::DummyType&>;
+    using Arguments = std::tuple<IPC::DummyType>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_DeprecatedOperation; }
     static constexpr bool isSync = false;
@@ -513,20 +513,20 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const IPC::DummyType&> m_arguments;
 };
 #endif
 
 #if ENABLE(FEATURE_FOR_TESTING)
 class ExperimentalOperation {
 public:
-    using Arguments = std::tuple<const IPC::DummyType&>;
+    using Arguments = std::tuple<IPC::DummyType>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_ExperimentalOperation; }
     static constexpr bool isSync = false;
@@ -536,13 +536,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const IPC::DummyType&> m_arguments;
 };
 #endif
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h
@@ -42,7 +42,7 @@ static inline IPC::ReceiverName messageReceiverName()
 
 class SendSemaphore {
 public:
-    using Arguments = std::tuple<const IPC::Semaphore&>;
+    using Arguments = std::tuple<IPC::Semaphore>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithSemaphore_SendSemaphore; }
     static constexpr bool isSync = false;
@@ -52,13 +52,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const IPC::Semaphore&> m_arguments;
 };
 
 class ReceiveSemaphore {
@@ -71,13 +71,13 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSemaphore_ReceiveSemaphoreReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<IPC::Semaphore>;
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<> m_arguments;
 };
 
 } // namespace TestWithSemaphore

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h
@@ -42,7 +42,7 @@ static inline IPC::ReceiverName messageReceiverName()
 
 class SendString {
 public:
-    using Arguments = std::tuple<const String&>;
+    using Arguments = std::tuple<String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithStreamBatched_SendString; }
     static constexpr bool isSync = false;
@@ -54,13 +54,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&> m_arguments;
 };
 
 } // namespace TestWithStreamBatched

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h
@@ -44,7 +44,7 @@ static inline IPC::ReceiverName messageReceiverName()
 
 class SendStreamBuffer {
 public:
-    using Arguments = std::tuple<const IPC::StreamConnectionBuffer&>;
+    using Arguments = std::tuple<IPC::StreamConnectionBuffer>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithStreamBuffer_SendStreamBuffer; }
     static constexpr bool isSync = false;
@@ -54,13 +54,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const IPC::StreamConnectionBuffer&> m_arguments;
 };
 
 } // namespace TestWithStreamBuffer

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
@@ -43,7 +43,7 @@ static inline IPC::ReceiverName messageReceiverName()
 
 class SendString {
 public:
-    using Arguments = std::tuple<const String&>;
+    using Arguments = std::tuple<String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendString; }
     static constexpr bool isSync = false;
@@ -55,18 +55,18 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&> m_arguments;
 };
 
 class SendStringAsync {
 public:
-    using Arguments = std::tuple<const String&>;
+    using Arguments = std::tuple<String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendStringAsync; }
     static constexpr bool isSync = false;
@@ -82,18 +82,18 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&> m_arguments;
 };
 
 class SendStringSync {
 public:
-    using Arguments = std::tuple<const String&>;
+    using Arguments = std::tuple<String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendStringSync; }
     static constexpr bool isSync = true;
@@ -108,19 +108,19 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&> m_arguments;
 };
 
 #if PLATFORM(COCOA)
 class SendMachSendRight {
 public:
-    using Arguments = std::tuple<const MachSendRight&>;
+    using Arguments = std::tuple<MachSendRight>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendMachSendRight; }
     static constexpr bool isSync = false;
@@ -132,13 +132,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const MachSendRight&> m_arguments;
 };
 #endif
 
@@ -155,20 +155,20 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<MachSendRight>;
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<> m_arguments;
 };
 #endif
 
 #if PLATFORM(COCOA)
 class SendAndReceiveMachSendRight {
 public:
-    using Arguments = std::tuple<const MachSendRight&>;
+    using Arguments = std::tuple<MachSendRight>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendAndReceiveMachSendRight; }
     static constexpr bool isSync = true;
@@ -183,13 +183,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const MachSendRight&> m_arguments;
 };
 #endif
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
@@ -47,7 +47,7 @@ static inline IPC::ReceiverName messageReceiverName()
 
 class LoadURL {
 public:
-    using Arguments = std::tuple<const String&>;
+    using Arguments = std::tuple<String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_LoadURL; }
     static constexpr bool isSync = false;
@@ -57,13 +57,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&> m_arguments;
 };
 
 #if ENABLE(TEST_FEATURE)
@@ -82,13 +82,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<WebKit::TestTwoStateEnum> m_arguments;
 };
 #endif
 
@@ -103,13 +103,13 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<> m_arguments;
 };
 #endif
 
@@ -124,20 +124,20 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool, uint64_t>;
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<> m_arguments;
 };
 #endif
 
 #if ENABLE(TEST_FEATURE)
 class TestAsyncMessageWithConnection {
 public:
-    using Arguments = std::tuple<const int&>;
+    using Arguments = std::tuple<int>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithConnection; }
     static constexpr bool isSync = false;
@@ -150,13 +150,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const int&> m_arguments;
 };
 #endif
 
@@ -174,13 +174,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<uint32_t> m_arguments;
 };
 
 class TestSynchronousMessage {
@@ -197,13 +197,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<bool> m_arguments;
 };
 
 } // namespace TestWithSuperclass

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
@@ -64,7 +64,7 @@ static inline IPC::ReceiverName messageReceiverName()
 
 class LoadURL {
 public:
-    using Arguments = std::tuple<const String&>;
+    using Arguments = std::tuple<String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_LoadURL; }
     static constexpr bool isSync = false;
@@ -74,19 +74,19 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&> m_arguments;
 };
 
 #if ENABLE(TOUCH_EVENTS)
 class LoadSomething {
 public:
-    using Arguments = std::tuple<const String&>;
+    using Arguments = std::tuple<String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_LoadSomething; }
     static constexpr bool isSync = false;
@@ -96,20 +96,20 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&> m_arguments;
 };
 #endif
 
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
 class TouchEvent {
 public:
-    using Arguments = std::tuple<const WebKit::WebTouchEvent&>;
+    using Arguments = std::tuple<WebKit::WebTouchEvent>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_TouchEvent; }
     static constexpr bool isSync = false;
@@ -119,20 +119,20 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const WebKit::WebTouchEvent&> m_arguments;
 };
 #endif
 
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
 class AddEvent {
 public:
-    using Arguments = std::tuple<const WebKit::WebTouchEvent&>;
+    using Arguments = std::tuple<WebKit::WebTouchEvent>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_AddEvent; }
     static constexpr bool isSync = false;
@@ -142,20 +142,20 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const WebKit::WebTouchEvent&> m_arguments;
 };
 #endif
 
 #if ENABLE(TOUCH_EVENTS)
 class LoadSomethingElse {
 public:
-    using Arguments = std::tuple<const String&>;
+    using Arguments = std::tuple<String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_LoadSomethingElse; }
     static constexpr bool isSync = false;
@@ -165,13 +165,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&> m_arguments;
 };
 #endif
 
@@ -187,13 +187,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<uint64_t, uint64_t, uint32_t> m_arguments;
 };
 
 class Close {
@@ -203,18 +203,18 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_Close; }
     static constexpr bool isSync = false;
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<> m_arguments;
 };
 
 class PreferencesDidChange {
 public:
-    using Arguments = std::tuple<const WebKit::WebPreferencesStore&>;
+    using Arguments = std::tuple<WebKit::WebPreferencesStore>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_PreferencesDidChange; }
     static constexpr bool isSync = false;
@@ -224,13 +224,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const WebKit::WebPreferencesStore&> m_arguments;
 };
 
 class SendDoubleAndFloat {
@@ -245,18 +245,18 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<double, float> m_arguments;
 };
 
 class SendInts {
 public:
-    using Arguments = std::tuple<const Vector<uint64_t>&, const Vector<Vector<uint64_t>>&>;
+    using Arguments = std::tuple<Vector<uint64_t>, Vector<Vector<uint64_t>>>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_SendInts; }
     static constexpr bool isSync = false;
@@ -266,18 +266,18 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const Vector<uint64_t>&, const Vector<Vector<uint64_t>>&> m_arguments;
 };
 
 class CreatePlugin {
 public:
-    using Arguments = std::tuple<uint64_t, const WebKit::Plugin::Parameters&>;
+    using Arguments = std::tuple<uint64_t, WebKit::Plugin::Parameters>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_CreatePlugin; }
     static constexpr bool isSync = false;
@@ -290,18 +290,18 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<uint64_t, const WebKit::Plugin::Parameters&> m_arguments;
 };
 
 class RunJavaScriptAlert {
 public:
-    using Arguments = std::tuple<uint64_t, const String&>;
+    using Arguments = std::tuple<uint64_t, String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_RunJavaScriptAlert; }
     static constexpr bool isSync = false;
@@ -314,13 +314,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<uint64_t, const String&> m_arguments;
 };
 
 class GetPlugins {
@@ -338,18 +338,18 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<bool> m_arguments;
 };
 
 class GetPluginProcessConnection {
 public:
-    using Arguments = std::tuple<const String&>;
+    using Arguments = std::tuple<String>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_GetPluginProcessConnection; }
     static constexpr bool isSync = true;
@@ -361,13 +361,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const String&> m_arguments;
 };
 
 class TestMultipleAttributes {
@@ -379,13 +379,13 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<> m_arguments;
 };
 
 class TestParameterAttributes {
@@ -400,18 +400,18 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<uint64_t, double, double> m_arguments;
 };
 
 class TemplateTest {
 public:
-    using Arguments = std::tuple<const HashMap<String, std::pair<String, uint64_t>>&>;
+    using Arguments = std::tuple<HashMap<String, std::pair<String, uint64_t>>>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_TemplateTest; }
     static constexpr bool isSync = false;
@@ -421,18 +421,18 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const HashMap<String, std::pair<String, uint64_t>>&> m_arguments;
 };
 
 class SetVideoLayerID {
 public:
-    using Arguments = std::tuple<const WebCore::GraphicsLayer::PlatformLayerID&>;
+    using Arguments = std::tuple<WebCore::GraphicsLayer::PlatformLayerID>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_SetVideoLayerID; }
     static constexpr bool isSync = false;
@@ -442,19 +442,19 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const WebCore::GraphicsLayer::PlatformLayerID&> m_arguments;
 };
 
 #if PLATFORM(MAC)
 class DidCreateWebProcessConnection {
 public:
-    using Arguments = std::tuple<const MachSendRight&, const OptionSet<WebKit::SelectionFlags>&>;
+    using Arguments = std::tuple<MachSendRight, OptionSet<WebKit::SelectionFlags>>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_DidCreateWebProcessConnection; }
     static constexpr bool isSync = false;
@@ -464,13 +464,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const MachSendRight&, const OptionSet<WebKit::SelectionFlags>&> m_arguments;
 };
 #endif
 
@@ -490,20 +490,20 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<uint32_t> m_arguments;
 };
 #endif
 
 #if ENABLE(DEPRECATED_FEATURE)
 class DeprecatedOperation {
 public:
-    using Arguments = std::tuple<const IPC::DummyType&>;
+    using Arguments = std::tuple<IPC::DummyType>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_DeprecatedOperation; }
     static constexpr bool isSync = false;
@@ -513,20 +513,20 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const IPC::DummyType&> m_arguments;
 };
 #endif
 
 #if ENABLE(FEATURE_FOR_TESTING)
 class ExperimentalOperation {
 public:
-    using Arguments = std::tuple<const IPC::DummyType&>;
+    using Arguments = std::tuple<IPC::DummyType>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_ExperimentalOperation; }
     static constexpr bool isSync = false;
@@ -536,13 +536,13 @@ public:
     {
     }
 
-    const Arguments& arguments() const
+    const auto& arguments() const
     {
         return m_arguments;
     }
 
 private:
-    Arguments m_arguments;
+    std::tuple<const IPC::DummyType&> m_arguments;
 };
 #endif
 

--- a/Source/WebKit/Shared/IPCTester.cpp
+++ b/Source/WebKit/Shared/IPCTester.cpp
@@ -128,7 +128,7 @@ void IPCTester::startMessageTesting(IPC::Connection& connection, String&& driver
     });
 }
 
-void IPCTester::stopMessageTesting(CompletionHandler<void()> completionHandler)
+void IPCTester::stopMessageTesting(CompletionHandler<void()>&& completionHandler)
 {
     stopIfNeeded();
     completionHandler();

--- a/Source/WebKit/Shared/IPCTester.h
+++ b/Source/WebKit/Shared/IPCTester.h
@@ -62,7 +62,7 @@ public:
 private:
     // Messages.
     void startMessageTesting(IPC::Connection&, String&& driverName);
-    void stopMessageTesting(CompletionHandler<void()>);
+    void stopMessageTesting(CompletionHandler<void()>&&);
     void createStreamTester(IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&);
     void releaseStreamTester(IPCStreamTesterIdentifier, CompletionHandler<void()>&&);
     void createConnectionTester(IPC::Connection&, IPCConnectionTesterIdentifier, IPC::Connection::Handle&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -543,7 +543,7 @@ public:
     void resourceLoadDidReceiveResponse(ResourceLoadInfo&&, WebCore::ResourceResponse&&);
     void resourceLoadDidCompleteWithError(ResourceLoadInfo&&, WebCore::ResourceResponse&&, WebCore::ResourceError&&);
 
-    void didChangeInspectorFrontendCount(unsigned count) { m_inspectorFrontendCount = count; }
+    void didChangeInspectorFrontendCount(uint32_t count) { m_inspectorFrontendCount = count; }
     unsigned inspectorFrontendCount() const { return m_inspectorFrontendCount; }
     bool hasInspectorFrontend() const { return m_inspectorFrontendCount > 0; }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -409,7 +409,7 @@ messages -> WebPageProxy {
     ShowDataDetectorsUIForPositionInformation(struct WebKit::InteractionInformationAtPosition information)
 #endif
 
-    DidChangeInspectorFrontendCount(uint64_t count)
+    DidChangeInspectorFrontendCount(uint32_t count)
 
     CreateInspectorTarget(String targetId, enum:uint8_t Inspector::InspectorTargetType type)
     DestroyInspectorTarget(String targetId)

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
@@ -32,11 +32,11 @@ messages -> WebPasteboardProxy NotRefCounted {
     WriteCustomData(Vector<WebCore::PasteboardCustomData> data, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
     TypesSafeForDOMToReadAndWrite(String pasteboardName, String origin, std::optional<WebCore::PageIdentifier> pageID) -> (Vector<String> types) Synchronous WantsConnection
     AllPasteboardItemInfo(String pasteboardName, int64_t changeCount, std::optional<WebCore::PageIdentifier> pageID) -> (std::optional<Vector<WebCore::PasteboardItemInfo>> allInfo) Synchronous WantsConnection
-    InformationForItemAtIndex(uint64_t index, String pasteboardName, int64_t changeCount, std::optional<WebCore::PageIdentifier> pageID) -> (std::optional<WebCore::PasteboardItemInfo> info) Synchronous WantsConnection
+    InformationForItemAtIndex(size_t index, String pasteboardName, int64_t changeCount, std::optional<WebCore::PageIdentifier> pageID) -> (std::optional<WebCore::PasteboardItemInfo> info) Synchronous WantsConnection
     GetPasteboardItemsCount(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (uint64_t itemsCount) Synchronous WantsConnection
-    ReadStringFromPasteboard(uint64_t index, String pasteboardType, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String string) Synchronous WantsConnection
-    ReadURLFromPasteboard(uint64_t index, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String url, String title) Synchronous WantsConnection
-    ReadBufferFromPasteboard(std::optional<uint64_t> index, String pasteboardType, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (RefPtr<WebCore::SharedBuffer> buffer) Synchronous WantsConnection
+    ReadStringFromPasteboard(size_t index, String pasteboardType, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String string) Synchronous WantsConnection
+    ReadURLFromPasteboard(size_t index, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String url, String title) Synchronous WantsConnection
+    ReadBufferFromPasteboard(std::optional<size_t> index, String pasteboardType, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (RefPtr<WebCore::SharedBuffer> buffer) Synchronous WantsConnection
     ContainsStringSafeForDOMToReadForType(String type, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (bool result) Synchronous WantsConnection
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -392,7 +392,7 @@ void MediaPlayerPrivateRemote::playbackStateChanged(bool paused, MediaTime&& med
         player->playbackStateChanged();
 }
 
-void MediaPlayerPrivateRemote::engineFailedToLoad(long platformErrorCode)
+void MediaPlayerPrivateRemote::engineFailedToLoad(int64_t platformErrorCode)
 {
     m_platformErrorCode = platformErrorCode;
     if (RefPtr player = m_player.get())

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -108,7 +108,7 @@ public:
     void durationChanged(RemoteMediaPlayerState&&);
     void rateChanged(double);
     void playbackStateChanged(bool, MediaTime&&, MonotonicTime&&);
-    void engineFailedToLoad(long);
+    void engineFailedToLoad(int64_t);
     void updateCachedState(RemoteMediaPlayerState&&);
     void characteristicChanged(RemoteMediaPlayerState&&);
     void sizeChanged(WebCore::FloatSize);

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
@@ -33,7 +33,7 @@ messages -> MediaPlayerPrivateRemote NotRefCounted {
     DurationChanged(struct WebKit::RemoteMediaPlayerState state)
     RateChanged(double rate)
     PlaybackStateChanged(bool paused, MediaTime mediaTime, MonotonicTime wallTime)
-    EngineFailedToLoad(int platformErrorCode)
+    EngineFailedToLoad(int64_t platformErrorCode)
     UpdateCachedState(struct WebKit::RemoteMediaPlayerState state)
     CharacteristicChanged(struct WebKit::RemoteMediaPlayerState state)
     SizeChanged(WebCore::FloatSize naturalSize)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.messages.in
@@ -28,7 +28,7 @@
 messages -> RemoteAudioHardwareListener {
     AudioHardwareDidBecomeActive()
     AudioHardwareDidBecomeInactive()
-    AudioOutputDeviceChanged(uint64_t bufferSizeMinimum, uint64_t bufferSizeMaximum)
+    AudioOutputDeviceChanged(size_t bufferSizeMinimum, size_t bufferSizeMaximum)
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.messages.in
@@ -28,7 +28,7 @@
 #if ENABLE(GPU_PROCESS) && HAVE(AVASSETREADER)
 
 messages -> RemoteImageDecoderAVFManager NotRefCounted {
-    EncodedDataStatusChanged(WebCore::ImageDecoderIdentifier identifier, uint32_t frameCount, WebCore::IntSize size, bool hasTrack)
+    EncodedDataStatusChanged(WebCore::ImageDecoderIdentifier identifier, size_t frameCount, WebCore::IntSize size, bool hasTrack)
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1789,7 +1789,7 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
 }
 
 // LoadRequestWaitingForProcessLaunch should never be sent to the WebProcess. It must always be converted to a LoadRequest message.
-NO_RETURN void WebPage::loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool)
+void WebPage::loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool)
 {
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1705,7 +1705,7 @@ private:
     void tryClose(CompletionHandler<void(bool)>&&);
     void platformDidReceiveLoadParameters(const LoadParameters&);
     void loadRequest(LoadParameters&&);
-    NO_RETURN void loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool);
+    [[noreturn]] void loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool);
     void loadData(LoadParameters&&);
     void loadAlternateHTML(LoadParameters&&);
     void loadSimulatedRequestAndResponse(LoadParameters&&, WebCore::ResourceResponse&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -416,7 +416,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     UserMediaAccessWasDenied(WebCore::UserMediaRequestIdentifier userMediaID, uint64_t reason, String invalidConstraint)
     CaptureDevicesChanged()
 #if USE(GSTREAMER)
-    SetOrientationForMediaCapture(int rotation)
+    SetOrientationForMediaCapture(uint64_t rotation)
     SetMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool isMicrophoneInterrupted)
 #endif
 #endif


### PR DESCRIPTION
#### c16b84bd344f2188fa548498b29c2b42a8448345
<pre>
[WK2] Apply method signature validation to all types of IPC message handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=248975">https://bugs.webkit.org/show_bug.cgi?id=248975</a>

Reviewed by Kimmo Kinnunen.

Validation of CompletionHandler argument types in IPC&apos;s message-handling
code is reworked and also applied to the messages&apos; argument types.

The MethodSignatureValidation template takes a message-handling method&apos;s
function type and works through the argument types, deducing the
argument types specified by the method as well as any CompletionHandler
object that&apos;s used in messages that require a reply. When done, the
template instantiation will provide a std::tuple&lt;&gt; alias of those
argument types as well as a std::tuple&lt;&gt; alias of argument types of any
CompletionHandler object.

The different IPC::handleMessage() variants now use those instantiations
to perform compile-time asserts, ensuring the desired message-handling
method works with the same types as those specified by the IPC message.
In case of messages with a reply, the CompletionHandler&apos;s argument types
are similarly compared to the IPC message&apos;s reply argument types.

This enables some simplifications in the messages.py generator. Some IPC
messages and message-handling methods also need to be adjusted, either
adopting argument types that perfectly match the current code, or in
some cases using a sized integer type.

WebPage::loadRequestWaitingForProcessLaunch() was so far using the
NO_RETURN macro to apply the noreturn attribute through the C-style
__attribute__ specifier. This caused some trouble with certain compilers
since that attribute is then ingrained into the function type, which
was then causing trouble in the MethodSignatureValidation template
specializations. To avoid that but also apply the necessary no-return
semantics to the method, the C++11-style [[noreturn]] attribute is used.

* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::drawSystemImage):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::mergeStatisticForTesting):
(WebKit::NetworkProcess::insertExpiredStatisticForTesting):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::MethodSignatureValidation&lt;R):
(IPC::handleMessage):
(IPC::handleMessageWantsConnection):
(IPC::handleMessageSynchronous):
(IPC::handleMessageSynchronousWantsConnection):
(IPC::handleMessageAsync):
(IPC::handleMessageAsyncWantsConnection):
(IPC::CompletionHandlerValidation&lt;CompletionHandler&lt;void): Deleted.
* Source/WebKit/Platform/IPC/JSIPCBinding.h:
(IPC::jsValueForDecodedArguments):
* Source/WebKit/Scripts/webkit/messages.py:
(function_parameter_type):
(message_to_struct_declaration):
(arguments_type): Deleted.
(reply_arguments_type): Deleted.
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h:
(Messages::TestWithCVPixelBuffer::SendCVPixelBuffer::arguments const):
(Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::arguments const):
* Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h:
(Messages::TestWithIfMessage::LoadURL::arguments const):
* Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h:
(Messages::TestWithImageData::SendImageData::arguments const):
(Messages::TestWithImageData::ReceiveImageData::arguments const):
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h:
(Messages::TestWithLegacyReceiver::LoadURL::arguments const):
(Messages::TestWithLegacyReceiver::LoadSomething::arguments const):
(Messages::TestWithLegacyReceiver::TouchEvent::arguments const):
(Messages::TestWithLegacyReceiver::AddEvent::arguments const):
(Messages::TestWithLegacyReceiver::LoadSomethingElse::arguments const):
(Messages::TestWithLegacyReceiver::DidReceivePolicyDecision::arguments const):
(Messages::TestWithLegacyReceiver::Close::arguments const):
(Messages::TestWithLegacyReceiver::PreferencesDidChange::arguments const):
(Messages::TestWithLegacyReceiver::SendDoubleAndFloat::arguments const):
(Messages::TestWithLegacyReceiver::SendInts::arguments const):
(Messages::TestWithLegacyReceiver::CreatePlugin::arguments const):
(Messages::TestWithLegacyReceiver::RunJavaScriptAlert::arguments const):
(Messages::TestWithLegacyReceiver::GetPlugins::arguments const):
(Messages::TestWithLegacyReceiver::GetPluginProcessConnection::arguments const):
(Messages::TestWithLegacyReceiver::TestMultipleAttributes::arguments const):
(Messages::TestWithLegacyReceiver::TestParameterAttributes::arguments const):
(Messages::TestWithLegacyReceiver::TemplateTest::arguments const):
(Messages::TestWithLegacyReceiver::SetVideoLayerID::arguments const):
(Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection::arguments const):
(Messages::TestWithLegacyReceiver::InterpretKeyEvent::arguments const):
(Messages::TestWithLegacyReceiver::DeprecatedOperation::arguments const):
(Messages::TestWithLegacyReceiver::ExperimentalOperation::arguments const):
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h:
(Messages::TestWithSemaphore::SendSemaphore::arguments const):
(Messages::TestWithSemaphore::ReceiveSemaphore::arguments const):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h:
(Messages::TestWithStreamBatched::SendString::arguments const):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h:
(Messages::TestWithStreamBuffer::SendStreamBuffer::arguments const):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h:
(Messages::TestWithStream::SendString::arguments const):
(Messages::TestWithStream::SendStringSync::arguments const):
(Messages::TestWithStream::SendMachSendRight::arguments const):
(Messages::TestWithStream::ReceiveMachSendRight::arguments const):
(Messages::TestWithStream::SendAndReceiveMachSendRight::arguments const):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h:
(Messages::TestWithSuperclass::LoadURL::arguments const):
(Messages::TestWithSuperclass::TestAsyncMessage::arguments const):
(Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::arguments const):
(Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::arguments const):
(Messages::TestWithSuperclass::TestAsyncMessageWithConnection::arguments const):
(Messages::TestWithSuperclass::TestSyncMessage::arguments const):
(Messages::TestWithSuperclass::TestSynchronousMessage::arguments const):
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h:
(Messages::TestWithoutAttributes::LoadURL::arguments const):
(Messages::TestWithoutAttributes::LoadSomething::arguments const):
(Messages::TestWithoutAttributes::TouchEvent::arguments const):
(Messages::TestWithoutAttributes::AddEvent::arguments const):
(Messages::TestWithoutAttributes::LoadSomethingElse::arguments const):
(Messages::TestWithoutAttributes::DidReceivePolicyDecision::arguments const):
(Messages::TestWithoutAttributes::Close::arguments const):
(Messages::TestWithoutAttributes::PreferencesDidChange::arguments const):
(Messages::TestWithoutAttributes::SendDoubleAndFloat::arguments const):
(Messages::TestWithoutAttributes::SendInts::arguments const):
(Messages::TestWithoutAttributes::CreatePlugin::arguments const):
(Messages::TestWithoutAttributes::RunJavaScriptAlert::arguments const):
(Messages::TestWithoutAttributes::GetPlugins::arguments const):
(Messages::TestWithoutAttributes::GetPluginProcessConnection::arguments const):
(Messages::TestWithoutAttributes::TestMultipleAttributes::arguments const):
(Messages::TestWithoutAttributes::TestParameterAttributes::arguments const):
(Messages::TestWithoutAttributes::TemplateTest::arguments const):
(Messages::TestWithoutAttributes::SetVideoLayerID::arguments const):
(Messages::TestWithoutAttributes::DidCreateWebProcessConnection::arguments const):
(Messages::TestWithoutAttributes::InterpretKeyEvent::arguments const):
(Messages::TestWithoutAttributes::DeprecatedOperation::arguments const):
(Messages::TestWithoutAttributes::ExperimentalOperation::arguments const):
* Source/WebKit/Shared/IPCTester.cpp:
(WebKit::IPCTester::stopMessageTesting):
* Source/WebKit/Shared/IPCTester.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPasteboardProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::engineFailedToLoad):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadRequestWaitingForProcessLaunch):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/257836@main">https://commits.webkit.org/257836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9be270cc27d41a190bbfe4608a02e791898fb34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109431 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86758 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107321 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7663 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34372 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/103604 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3036 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3001 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9133 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5381 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4847 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->