### PR TITLE
Add missing null check in ThreadSafeWeakPtr

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -2016,4 +2016,15 @@ TEST(WTF_ThreadSafeWeakPtr, ThreadSafety)
     EXPECT_EQ(ThreadSafeInstanceCounter::instanceCount, 0u);
 }
 
+TEST(WTF_ThreadSafeWeakPtr, UseAfterMoveResistance)
+{
+    auto counter = adoptRef(*new ThreadSafeInstanceCounter());
+    auto weakPtr = ThreadSafeWeakPtr { counter.get() };
+    auto movedTo = WTFMove(weakPtr);
+    EXPECT_NULL(weakPtr.get());
+    EXPECT_NOT_NULL(movedTo.get());
+    ThreadSafeWeakPtr<ThreadSafeInstanceCounter> emptyConstructor;
+    EXPECT_NULL(emptyConstructor.get());
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 6fe0ea88b0e9257ead770bc0a99f531ef9cfd1f6
<pre>
Add missing null check in ThreadSafeWeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=248977">https://bugs.webkit.org/show_bug.cgi?id=248977</a>
rdar://103044234

Reviewed by Chris Dumez.

When a ThreadSafeWeakPtr is used after it is moved, we still want ThreadSafeWeakPtr::get
to return null instead of dereferencing null.  I added a missing null check there.

I also made ThreadSafeWeakPtrControlBlock store a void* instead of a T* to avoid an unnecessary
reinterpret_cast, which I got feedback indicating that was scary.

I also make ProcessLauncher::launchProcess a little safer by removing the assumption that the
block passed to xpc_connection_set_event_handler would only be called once in case of error.
That assumption turned out to not be true in some exotic cases, which caused this investigation
in the first place.

* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakPtrControlBlock::strongDeref const):
(WTF::ThreadSafeWeakPtrControlBlock::makeStrongReferenceIfPossible const):
(WTF::ThreadSafeWeakPtrControlBlock::ThreadSafeWeakPtrControlBlock):
(WTF::ThreadSafeWeakPtrControlBlock::WTF_GUARDED_BY_LOCK):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref const):
(WTF::ThreadSafeWeakPtr::get const):
(WTF::ThreadSafeWeakPtr::controlBlock):
(WTF::ThreadSafeWeakPtr::ThreadSafeWeakPtr):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::launchProcess):
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/257598@main">https://commits.webkit.org/257598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20c23e8bfc28e52db95722d804fe07c3a0451586

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108785 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85911 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91889 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106708 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105157 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/90085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85938 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2373 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28895 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42810 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88805 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2671 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19863 "Passed tests") | 
<!--EWS-Status-Bubble-End-->