### PR TITLE
Draw attachment element icon using GraphicsContext

### DIFF
--- a/LayoutTests/fast/attachment/mac/attachment-element-gpu-process-expected.html
+++ b/LayoutTests/fast/attachment/mac/attachment-element-gpu-process-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true UseGPUProcessForDOMRenderingEnabled=false ] -->
+<html>
+<body>
+<attachment title="title" subtitle="subtitle" action="action" progress="0.5"></attachment>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/mac/attachment-element-gpu-process.html
+++ b/LayoutTests/fast/attachment/mac/attachment-element-gpu-process.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true UseGPUProcessForDOMRenderingEnabled=true ] -->
+<html>
+<body>
+<attachment title="title" subtitle="subtitle" action="action" progress="0.5"></attachment>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -2442,17 +2442,11 @@ static void paintAttachmentIcon(const RenderAttachment& attachment, GraphicsCont
         attachment.attachmentElement().requestIconWithSize(layout.iconRect.size());
         return;
     }
-
-    auto image = icon->nsImage();
-    if (!image)
-        return;
     
     if (!shouldDrawIcon(attachment.attachmentElement().attachmentTitleForDisplay()))
         return;
 
-    LocalCurrentGraphicsContext localCurrentGC(context);
-
-    [image drawInRect:layout.iconRect fromRect:NSMakeRect(0, 0, [image size].width, [image size].height) operation:NSCompositingOperationSourceOver fraction:1.0f];
+    context.drawImage(*icon, layout.iconRect, { ImageOrientation::OriginBottomLeft });
 }
 
 static std::pair<RefPtr<Image>, float> createAttachmentPlaceholderImage(float deviceScaleFactor, const AttachmentLayout& layout)


### PR DESCRIPTION
#### 1f677f0ad352cc3f587e0a9ff1bdb779e318a52d
<pre>
Draw attachment element icon using GraphicsContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=248976">https://bugs.webkit.org/show_bug.cgi?id=248976</a>
rdar://103144926

Reviewed by Simon Fraser.

Now that we are flipping the geomtry of the icons again
after <a href="https://commits.webkit.org/257524@main">https://commits.webkit.org/257524@main</a>, reland the
attachment element icon drawing logic from
<a href="https://commits.webkit.org/255903@main">https://commits.webkit.org/255903@main</a>, calling with an
ImageOrientation::OriginBottomLeft since the icons have
their geometry flipped.

* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::paintAttachmentIcon):

Canonical link: <a href="https://commits.webkit.org/257666@main">https://commits.webkit.org/257666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45de4ac87ee2cd3869f59efdefab8aa47b973573

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108947 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169184 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86066 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92094 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106864 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105358 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21941 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2599 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23455 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2533 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42928 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4393 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2699 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->