### PR TITLE
[Live Range Selection] editing/execCommand/reset-direction-after-breaking-blockquote.html fails

### DIFF
--- a/LayoutTests/editing/execCommand/reset-direction-after-breaking-blockquote-live-range-expected.txt
+++ b/LayoutTests/editing/execCommand/reset-direction-after-breaking-blockquote-live-range-expected.txt
@@ -1,0 +1,23 @@
+| "\n    "
+| <p>
+|   "Start of right to left content"
+| "\n    "
+| <blockquote>
+|   type="cite"
+|   "\n        "
+|   <p>
+|     dir="ltr"
+|     id="target"
+|     "Some quoted content"
+| <div>
+|   dir="auto"
+|   <#selection-caret>
+|   <br>
+| <blockquote>
+|   type="cite"
+|   "\n        "
+|   <p>
+|     dir="ltr"
+|     "End of quoted content"
+|   "\n    "
+| "\n"

--- a/LayoutTests/editing/execCommand/reset-direction-after-breaking-blockquote-live-range.html
+++ b/LayoutTests/editing/execCommand/reset-direction-after-breaking-blockquote-live-range.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/dump-as-markup.js"></script>
+<style>
+blockquote {
+    border-left: 2px solid lightblue;
+    padding-left: 1em;
+}
+</style>
+</head>
+<body>
+<p id="description">
+    This tests that the writing direction is reset to its natural value after breaking out of a blockquote in the case
+    where the writing direction at the previous selection differs from the writing direction of the newly inserted
+    paragraph.
+</p>
+<div contenteditable id="editor" dir="rtl">
+    <p>Start of right to left content</p>
+    <blockquote type="cite">
+        <p dir="ltr" id="target">Some quoted content</p>
+        <p dir="ltr">End of quoted content</p>
+    </blockquote>
+</div>
+<script>
+getSelection().setPosition(document.getElementById("target"), 1);
+document.execCommand("InsertNewlineInQuotedContent", true);
+Markup.dump("editor");
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/BreakBlockquoteCommand.cpp
+++ b/Source/WebCore/editing/BreakBlockquoteCommand.cpp
@@ -203,9 +203,10 @@ void BreakBlockquoteCommand::doApply()
     
     // Make sure the cloned block quote renders.
     addBlockPlaceholderIfNeeded(clonedBlockquote.ptr());
-    
-    // Put the selection right before the break.
-    setEndingSelection(VisibleSelection(positionBeforeNode(breakNode.ptr()), Affinity::Downstream, endingSelection().isDirectional()));
+
+    // Put the selection right before br or at the first position in div.
+    auto beforeBROrFirstPositionInDiv = isAtomicNode(breakNode.ptr()) ? positionBeforeNode(breakNode.ptr()) : firstPositionInNode(breakNode.ptr());
+    setEndingSelection(VisibleSelection(beforeBROrFirstPositionInDiv, Affinity::Downstream, endingSelection().isDirectional()));
     rebalanceWhitespace();
 }
 


### PR DESCRIPTION
#### b6621f17c494d644965239f7d5e79ca2b7cbd1df
<pre>
[Live Range Selection] editing/execCommand/reset-direction-after-breaking-blockquote.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248979">https://bugs.webkit.org/show_bug.cgi?id=248979</a>

Reviewed by Wenson Hsieh.

The bug was caused by BreakBlockquoteCommand always using the position before breakNode even when the element
in question is a div. In this case, we need to use the first position in div instead.

* LayoutTests/editing/execCommand/reset-direction-after-breaking-blockquote-live-range-expected.txt: Added.
* LayoutTests/editing/execCommand/reset-direction-after-breaking-blockquote-live-range.html: Added.
* Source/WebCore/editing/BreakBlockquoteCommand.cpp:
(WebCore::BreakBlockquoteCommand::doApply):

Canonical link: <a href="https://commits.webkit.org/257644@main">https://commits.webkit.org/257644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20a2796bb30bb519b11d6aaf47c0cd6752fa052e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32588 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108861 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169091 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85980 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91966 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106777 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33955 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88811 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21866 "Found 1 new test failure: media/remote-control-command-seek.html (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2522 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23381 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45779 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8602 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42859 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4309 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2690 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->