### PR TITLE
Handle special case of merging lists in mergeParagraphs()

### DIFF
--- a/LayoutTests/editing/deleting/merge-list-items-in-same-list-expected.txt
+++ b/LayoutTests/editing/deleting/merge-list-items-in-same-list-expected.txt
@@ -1,0 +1,9 @@
+| "\n"
+| <ul>
+|   contenteditable=""
+|   <li>
+|     "one"
+|   <li>
+|     "<#selection-caret>three"
+|     <br>
+| "\n"

--- a/LayoutTests/editing/deleting/merge-list-items-in-same-list.html
+++ b/LayoutTests/editing/deleting/merge-list-items-in-same-list.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div>
+<ul contenteditable><li>one</li><li></li><li id="li">three</li></ul>
+</div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+var li = document.getElementById('li');
+var selection = window.getSelection();
+selection.collapse(li, 0);
+document.execCommand('Delete');
+Markup.dump(document.querySelector('div'));
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/merge-lists-expected.txt
+++ b/LayoutTests/editing/deleting/merge-lists-expected.txt
@@ -1,0 +1,17 @@
+Placing cursor at the end of first list and executing forward delete should merge the second list with the first one.
+| "\n"
+| <ol>
+|   <li>
+|     "one"
+|   <li>
+|     "two"
+|   <li>
+|     id="li"
+|     "three<#selection-caret>"
+|   <li>
+|     "four"
+|   <li>
+|     "five"
+|   <li>
+|     "six"
+| "\n"

--- a/LayoutTests/editing/deleting/merge-lists.html
+++ b/LayoutTests/editing/deleting/merge-lists.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p id="description">Placing cursor at the end of first list and executing forward delete should merge the second list with the first one.</p>
+<div contenteditable>
+<ol><li>one</li><li>two</li><li id="li">three</li></ol>
+<ol><li>four</li><li>five</li><li>six</li></ol>
+</div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+var li = document.getElementById("li");
+var selection = window.getSelection();
+selection.collapse(li, li.childNodes.length);
+document.execCommand("forwardDelete");
+Markup.description(document.getElementById('description').textContent);
+Markup.dump(document.querySelector('div'));
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2005 Apple Inc.  All rights reserved.
+ * Copyright (C) 2005-2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -814,6 +815,16 @@ void DeleteSelectionCommand::mergeParagraphs()
     
     if (mergeDestination == endOfParagraphToMove)
         return;
+    
+    // If the merge destination and source to be moved are both list items of different lists, merge them into single list.
+    auto* listItemInFirstParagraph = enclosingNodeOfType(m_upstreamStart, isListItem);
+    auto* listItemInSecondParagraph = enclosingNodeOfType(m_downstreamEnd, isListItem);
+    if (listItemInFirstParagraph && listItemInSecondParagraph && listItemInFirstParagraph->parentElement() != listItemInSecondParagraph->parentElement()
+    && canMergeLists(listItemInFirstParagraph->parentElement(), listItemInSecondParagraph->parentElement())) {
+        mergeIdenticalElements(*listItemInFirstParagraph->parentElement(), *listItemInSecondParagraph->parentElement());
+        m_endingPosition = mergeDestination.deepEquivalent();
+        return;
+    }
     
     // The rule for merging into an empty block is: only do so if its farther to the right.
     // FIXME: Consider RTL.


### PR DESCRIPTION
#### 31be36f212e4872dfd9761736dba5814453ac8a2
<pre>
Handle special case of merging lists in mergeParagraphs()

Handle special case of merging lists in mergeParagraphs()
<a href="https://bugs.webkit.org/show_bug.cgi?id=248709">https://bugs.webkit.org/show_bug.cgi?id=248709</a>

Reviewed by Ryosuke Niwa.

This patch to align Webkit behavior with Gecko / Firefox and Blink / Chromium by merging these two patches from Blink:

&gt; <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=165218
&gt; <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=172941

Consider a html content with two consecutive lists. When cursor is placed
at the end of first list and forward delete is executed, we should
merge the second list with the first one.

Currently, the content of the first &lt;li&gt; of second list is appended to
the content of last &lt;li&gt; of first list and two lists are still retained.
This is incorrect. Uploaded patch fixes this erroneous behavior.

This issue is reproduced only when list is the only visible element
present. In this case, visible positions after &amp; before the list&apos;s
parent node would be NULL and hence are treated as equal. Because of
this, isVisiblyAdjacent() and therefore canMergeLists() would return
true. This results in invoking mergeIdenticalElements where things go
wrong as we try to delete the second list and add its content to first
list, while we actually have only one list and should be merging the
list items of the same list.

In canMergeLists(), calling
isVisiblyAdjacent(positionInParentAfterNode(*firstList), positionInParentBeforeNode(*secondList)
makes sense only if firstList &amp; secondList are different lists. Hence,
before invoking isVisiblyAdjacent() we need to check if the lists are
identical in which case return false from canMergeLists().

* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(DeleteSelectionCommand:mergePargraph): Add logic to merge list aligned with other browsers
* LayoutTests/editing/deleting/merge-lists.html: Add Test Case
* LayoutTests/editing/deleting/merge-lists-expected.txt: Add Test Case Expectation
* LayoutTests/editing/deleting/merge-list-items-in-same-list.html: Add Test Case
* LayoutTests/editing/deleting/merge-list-items-in-same-list-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/257650@main">https://commits.webkit.org/257650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/194c17a2203e44449626853455fb4b9351857899

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108867 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169097 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85985 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91973 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106783 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90524 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33962 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21873 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2527 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23388 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2454 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45783 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8607 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42866 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5270 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4314 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->