### PR TITLE
Continue refactoring caret animation and painting logic

### DIFF
--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -68,8 +68,7 @@ protected:
     void clearCaretRect();
     bool updateCaretRect(Document&, const VisiblePosition& caretPosition);
     bool shouldRepaintCaret(const RenderView*, bool isContentEditable) const;
-    void fillCaretRect(const Node&, GraphicsContext&, const FloatRect&, const Color&) const;
-    void paintCaret(const Node&, GraphicsContext&, const LayoutPoint&, const LayoutRect& clipRect) const;
+    void paintCaret(const Node&, GraphicsContext&, const LayoutPoint&, const LayoutRect& clipRect, const CaretAnimator::PresentationProperties&) const;
 
     const LayoutRect& localCaretRectWithoutUpdate() const { return m_caretLocalRect; }
 

--- a/Source/WebCore/platform/SimpleCaretAnimator.cpp
+++ b/Source/WebCore/platform/SimpleCaretAnimator.cpp
@@ -40,13 +40,13 @@ void SimpleCaretAnimator::updateAnimationProperties(ReducedResolutionSeconds cur
     auto caretBlinkInterval = RenderTheme::singleton().caretBlinkInterval();
 
     // Ensure the caret is always visible when blinking is suspended.
-    if (isBlinkingSuspended() && isVisible()) {
+    if (isBlinkingSuspended() && m_presentationProperties.blinkState == PresentationProperties::BlinkState::On) {
         m_blinkTimer.startOneShot(caretBlinkInterval);
         return;
     }
 
     if (currentTime - m_lastTimeCaretPaintWasToggled >= caretBlinkInterval) {
-        setVisible(m_blinkState == CaretBlinkState::Off);
+        setBlinkState(!m_presentationProperties.blinkState);
         m_lastTimeCaretPaintWasToggled = currentTime;
 
         m_blinkTimer.startOneShot(caretBlinkInterval);
@@ -62,7 +62,7 @@ void SimpleCaretAnimator::start(ReducedResolutionSeconds currentTime)
 String SimpleCaretAnimator::debugDescription() const
 {
     TextStream textStream;
-    textStream << "SimpleCaretAnimator " << this << " active " << isActive() << " blink state = " << (m_blinkState == CaretBlinkState::On ? "On" : "Off");
+    textStream << "SimpleCaretAnimator " << this << " active " << isActive() << " blink state = " << (m_presentationProperties.blinkState == PresentationProperties::BlinkState::On ? "On" : "Off");
     return textStream.release();
 }
 

--- a/Source/WebCore/platform/SimpleCaretAnimator.h
+++ b/Source/WebCore/platform/SimpleCaretAnimator.h
@@ -34,26 +34,22 @@ public:
     explicit SimpleCaretAnimator(CaretAnimationClient&);
 
 private:
-    enum class CaretBlinkState : bool { 
-        On, Off
-    };
-
     void updateAnimationProperties(ReducedResolutionSeconds) final;
     void start(ReducedResolutionSeconds) final;
 
     String debugDescription() const final;
 
-    bool isVisible() const final { return m_blinkState == CaretBlinkState::On; }
-    void setVisible(bool visible) final 
-    {
-        if ((visible && m_blinkState == CaretBlinkState::On) || (!visible && m_blinkState == CaretBlinkState::Off))
+    void setVisible(bool visible) final { setBlinkState(visible ? PresentationProperties::BlinkState::On : PresentationProperties::BlinkState::Off); }
+
+    void setBlinkState(PresentationProperties::BlinkState blinkState)
+    { 
+        if (m_presentationProperties.blinkState == blinkState)
             return;
 
-        m_blinkState = visible ? CaretBlinkState::On : CaretBlinkState::Off;
+        m_presentationProperties.blinkState = blinkState; 
         m_client.caretAnimationDidUpdate(*this);
     }
 
-    CaretBlinkState m_blinkState { CaretBlinkState::On };
     ReducedResolutionSeconds m_lastTimeCaretPaintWasToggled;
 };
 


### PR DESCRIPTION
#### 2e01488099a49125a027cf0e2103ba7c869e2269
<pre>
Continue refactoring caret animation and painting logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=248978">https://bugs.webkit.org/show_bug.cgi?id=248978</a>
rdar://102450089

Reviewed by Simon Fraser.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::paintCaret):
(WebCore::CaretBase::paintCaret const):
(WebCore::DragCaretController::paintDragCaret const):
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/platform/CaretAnimator.h:
(WebCore::CaretAnimator::presentationProperties const):
(WebCore::CaretAnimator::timeSinceStart const): Deleted.
* Source/WebCore/platform/SimpleCaretAnimator.cpp:
(WebCore::SimpleCaretAnimator::updateAnimationProperties):
(WebCore::SimpleCaretAnimator::debugDescription const):
* Source/WebCore/platform/SimpleCaretAnimator.h:

Canonical link: <a href="https://commits.webkit.org/257871@main">https://commits.webkit.org/257871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84c4a2952d25fcf85188c9f1369f87e35a5b2222

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100282 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/9448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/33355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109605 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10353 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106058 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/33355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/33355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/33355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3183 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/33355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2790 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->