### PR TITLE
Use references during Masonry Layout.

### DIFF
--- a/Source/WebCore/rendering/GridMasonryLayout.h
+++ b/Source/WebCore/rendering/GridMasonryLayout.h
@@ -43,23 +43,23 @@ public:
     LayoutUnit gridContentSize() const { return m_gridContentSize; };
 private:
 
-    GridArea nextMasonryPositionForItem(const RenderBox* item);
+    GridArea nextMasonryPositionForItem(const RenderBox& item);
 
     void collectMasonryItems();
     void addItemsToFirstTrack(const HashMap<RenderBox*, GridArea>& firstTrackItems); 
     void placeItemsWithDefiniteGridAxisPosition(const Vector<RenderBox*>& itemsWithDefinitePosition);
     void placeItemsWithIndefiniteGridAxisPosition(const Vector<RenderBox*>& itemsWithIndefinitePosition);
-    void setItemGridAxisContainingBlockToGridArea(RenderBox*);
-    void insertIntoGridAndLayoutItem(RenderBox*, const GridArea&);
+    void setItemGridAxisContainingBlockToGridArea(RenderBox&);
+    void insertIntoGridAndLayoutItem(RenderBox&, const GridArea&);
 
     void resizeAndResetRunningPositions();
     void allocateCapacityForMasonryVectors();
-    LayoutUnit masonryAxisMarginBoxForItem(const RenderBox* child);
-    void updateRunningPositions(const RenderBox* child, const GridArea&);
-    void updateItemOffset(const RenderBox* child, LayoutUnit offset);
+    LayoutUnit masonryAxisMarginBoxForItem(const RenderBox& child);
+    void updateRunningPositions(const RenderBox& child, const GridArea&);
+    void updateItemOffset(const RenderBox& child, LayoutUnit offset);
     inline GridTrackSizingDirection gridAxisDirection() const;
 
-    bool hasDefiniteGridAxisPosition(const RenderBox* child, GridTrackSizingDirection masonryDirection) const;
+    bool hasDefiniteGridAxisPosition(const RenderBox& child, GridTrackSizingDirection masonryDirection) const;
     static bool itemGridAreaStartsAtFirstLine(const GridArea& area, GridTrackSizingDirection masonryDirection)
     {
         return !(masonryDirection == ForRows ? area.rows.startLine() : area.columns.startLine());


### PR DESCRIPTION
#### c1ac9659b7aedcc68107ae695e5637c740550354
<pre>
Use references during Masonry Layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248504">https://bugs.webkit.org/show_bug.cgi?id=248504</a>
rdar://102789603

Reviewed by Brent Fulgham.

Instead of passing around pointers everywhere during Masonry, we can
instead use a reference to them whenever we pass them from one of
our data structures to a method that is going to do something related
to layout with it. This way we can avoid null checking everywhere and
only do it when we start trying to position the item inside the grid.

In the few remaining scenarios where we actually need to perform a
null check we can also use a debug assert since having a nullptr
at this point would be very unexpected.

* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::collectMasonryItems):
(WebCore::GridMasonryLayout::addItemsToFirstTrack):
(WebCore::GridMasonryLayout::placeItemsWithDefiniteGridAxisPosition):
(WebCore::GridMasonryLayout::placeItemsWithIndefiniteGridAxisPosition):
(WebCore::GridMasonryLayout::setItemGridAxisContainingBlockToGridArea):
(WebCore::GridMasonryLayout::insertIntoGridAndLayoutItem):
(WebCore::GridMasonryLayout::masonryAxisMarginBoxForItem):
(WebCore::GridMasonryLayout::updateRunningPositions):
(WebCore::GridMasonryLayout::updateItemOffset):
(WebCore::GridMasonryLayout::nextMasonryPositionForItem):
(WebCore::GridMasonryLayout::hasDefiniteGridAxisPosition const):
* Source/WebCore/rendering/GridMasonryLayout.h:

Canonical link: <a href="https://commits.webkit.org/257631@main">https://commits.webkit.org/257631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf450f9f5f30828ee8c8b5c6c075a56caba1cf17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108804 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169040 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85928 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91908 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106726 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33915 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88763 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21830 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2473 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23347 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45739 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5248 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42822 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->