### PR TITLE
[Live Range Selection] editing/execCommand/insert-list-nested-with-orphaned.html ends with wrong selection

### DIFF
--- a/LayoutTests/editing/execCommand/insert-list-nested-with-orphaned-expected.txt
+++ b/LayoutTests/editing/execCommand/insert-list-nested-with-orphaned-expected.txt
@@ -3,7 +3,7 @@ This tests hang when listifying nested lists with an orphaned list child in betw
 | <ol>
 |   <ol>
 |     <li>
-|       "hello"
+|       "<#selection-anchor>hello"
 |   "\n    world\n    "
 |   <ol>
 |     <li>
@@ -13,6 +13,6 @@ This tests hang when listifying nested lists with an orphaned list child in betw
 |     "\n        "
 |     <ol>
 |       <li>
-|         "<#selection-caret>because of you"
+|         "because of you<#selection-focus>"
 |   "\n    "
 | "\n"

--- a/LayoutTests/editing/execCommand/insert-list-nested-with-orphaned-live-range-expected.txt
+++ b/LayoutTests/editing/execCommand/insert-list-nested-with-orphaned-live-range-expected.txt
@@ -3,7 +3,7 @@ This tests hang when listifying nested lists with an orphaned list child in betw
 | <ol>
 |   <ol>
 |     <li>
-|       "hello"
+|       "<#selection-anchor>hello"
 |   "\n    world\n    "
 |   <ol>
 |     <li>
@@ -13,7 +13,6 @@ This tests hang when listifying nested lists with an orphaned list child in betw
 |     "\n        "
 |     <ol>
 |       <li>
-|         "because of you"
+|         "because of you<#selection-focus>"
 |   "\n    "
-| <#selection-caret>
 | "\n"

--- a/Source/WebCore/editing/InsertListCommand.cpp
+++ b/Source/WebCore/editing/InsertListCommand.cpp
@@ -145,6 +145,9 @@ void InsertListCommand::doApply()
             VisiblePosition endOfSelection = selection.visibleEnd();
             VisiblePosition startOfLastParagraph = startOfParagraph(endOfSelection, CanSkipOverEditingBoundary);
 
+            RefPtr<ContainerNode> startScope;
+            int startIndex = indexForVisiblePosition(startOfSelection, startScope);
+
             if (startOfLastParagraph.isNotNull() && startOfParagraph(startOfSelection, CanSkipOverEditingBoundary) != startOfLastParagraph) {
                 bool forceCreateList = !selectionHasListOfType(selection, listTag);
 
@@ -193,6 +196,8 @@ void InsertListCommand::doApply()
                 doApplyForSingleParagraph(forceCreateList, listTag, currentSelection);
                 // Fetch the end of the selection, for the reason mentioned above.
                 endOfSelection = endingSelection().visibleEnd();
+                if (startOfSelection.isOrphan())
+                    startOfSelection = visiblePositionForIndex(startIndex, startScope.get());
                 setEndingSelection(VisibleSelection(startOfSelection, endOfSelection, endingSelection().isDirectional()));
                 return;
             }
@@ -268,7 +273,8 @@ void InsertListCommand::doApplyForSingleParagraph(bool forceCreateList, const HT
             if (rangeEndIsInList && newList)
                 currentSelection.end = makeBoundaryPointAfterNodeContents(*newList);
 
-            setEndingSelection(VisiblePosition(firstPositionInNode(newList.get())));
+            setEndingSelection(VisibleSelection(makeContainerOffsetPosition(currentSelection.start),
+                makeContainerOffsetPosition(currentSelection.end)));
 
             return;
         }


### PR DESCRIPTION
#### 57714dd1461f8f99bbf6525cf183eaa3a471faa9
<pre>
[Live Range Selection] editing/execCommand/insert-list-nested-with-orphaned.html ends with wrong selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=248981">https://bugs.webkit.org/show_bug.cgi?id=248981</a>

Reviewed by Darin Adler.

Fixed the bug that these two tests were leaving caret selection instead of selecting across the lists as they should.
New behavior matches that of Firefox &amp; Chrome as well as user&apos;s expectation.

* LayoutTests/editing/execCommand/insert-list-nested-with-orphaned-expected.txt:
* LayoutTests/editing/execCommand/insert-list-nested-with-orphaned-live-range-expected.txt:
* Source/WebCore/editing/InsertListCommand.cpp:
(WebCore::InsertListCommand::doApply): Added the code to recover from orphaned selection start.
(WebCore::InsertListCommand::doApplyForSingleParagraph): Fixed the bug that this code was always setting
the ending selection to be in the first position in the new list. Select the entire list instead.

Canonical link: <a href="https://commits.webkit.org/257613@main">https://commits.webkit.org/257613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa5564ddefd54e17bee9cb791b309f48928362de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108805 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169041 "Found 1 new test failure: editing/execCommand/insert-list-nested-with-orphaned-live-range.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85929 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91909 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106727 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105180 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90479 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33926 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88765 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21826 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2474 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23343 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2394 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42818 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2682 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->