### PR TITLE
Update test262 bot to Ventura

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -150,7 +150,8 @@
                     "platform": "mac-ventura", "configuration": "release", "architectures": ["x86_64", "arm64"],
                     "triggers": [
                         "ventura-release-tests-wk1", "ventura-release-tests-wk2",
-                        "ventura-release-applesilicon-tests-wk1", "ventura-release-applesilicon-tests-wk2"
+                        "ventura-release-applesilicon-tests-wk1", "ventura-release-applesilicon-tests-wk2",
+                        "ventura-applesilicon-release-tests-test262"
                     ],
                     "workernames": ["bot245", "bot246"]
                     },
@@ -210,13 +211,13 @@
                     { "name": "Apple-Monterey-Release-Build", "factory": "BuildFactory",
                       "platform": "mac-monterey", "configuration": "release", "architectures": ["x86_64", "arm64"],
                       "triggers": [
-                          "monterey-applesilicon-release-tests-test262" ,"monterey-release-tests-test262", "monterey-release-tests-wk1", "monterey-release-tests-wk2",
+                          "monterey-release-tests-test262", "monterey-release-tests-wk1", "monterey-release-tests-wk2",
                           "monterey-release-applesilicon-tests-wk1", "monterey-release-applesilicon-tests-wk2", "monterey-applesilicon-release-tests-jsc",
                           "monterey-release-tests-wk2-accessibility-isolated-tree"
                       ],
                       "workernames": ["bot185", "bot187"]
                     },
-                    { "name": "Apple-Monterey-AppleSilicon-Release-Test262-Tests", "factory": "Test262Factory",
+                    { "name": "Apple-Ventura-AppleSilicon-Release-Test262-Tests", "factory": "Test262Factory",
                       "platform": "mac-monterey", "configuration": "release", "architectures": ["x86_64", "arm64"],
                       "workernames": ["bot165"]
                     },
@@ -766,8 +767,8 @@
                     { "type": "Triggerable", "name": "monterey-release-tests-test262",
                       "builderNames": ["Apple-Monterey-Release-Test262-Tests"]
                     },
-                    { "type": "Triggerable", "name": "monterey-applesilicon-release-tests-test262",
-                      "builderNames": ["Apple-Monterey-AppleSilicon-Release-Test262-Tests"]
+                    { "type": "Triggerable", "name": "ventura-applesilicon-release-tests-test262",
+                      "builderNames": ["Apple-Ventura-AppleSilicon-Release-Test262-Tests"]
                     },
                     { "type": "Triggerable", "name": "monterey-applesilicon-debug-tests-jsc",
                       "builderNames": ["Apple-Monterey-AppleSilicon-Debug-JSC-Tests"]

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -325,7 +325,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'transfer-to-s3',
             'trigger'
         ],
-        'Apple-Monterey-AppleSilicon-Release-Test262-Tests': [
+        'Apple-Ventura-AppleSilicon-Release-Test262-Tests': [
             'configure-build',
             'configuration',
             'clean-and-update-working-directory',

--- a/Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js
+++ b/Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js
@@ -36,6 +36,9 @@ WebKitBuildbot = function()
         "Apple-Ventura-Debug-AppleSilicon-WK2-Tests": {platform: Dashboard.Platform.macOSVentura, debug: true, tester: true, testCategory: Buildbot.TestCategory.WebKit2, heading: "Debug AppleSilicon"},
         "Apple-Ventura-Release-AppleSilicon-WK1-Tests": {platform: Dashboard.Platform.macOSVentura, debug: false, tester: true, testCategory: Buildbot.TestCategory.WebKit1, heading: "Release AppleSilicon"},
         "Apple-Ventura-Release-AppleSilicon-WK2-Tests": {platform: Dashboard.Platform.macOSVentura, debug: false, tester: true, testCategory: Buildbot.TestCategory.WebKit2, heading: "Release AppleSilicon"},
+        "Apple-Ventura JSC": {platform: Dashboard.Platform.macOSVentura, heading: "JavaScript", combinedQueues: {
+            "Apple-Ventura-AppleSilicon-Release-Test262-Tests": {heading: "Release arm64 Test262 (Tests)"},
+        }},
         "Apple-Monterey-Release-Build": {platform: Dashboard.Platform.macOSMonterey, debug: false, builder: true, architecture: Buildbot.BuildArchitecture.SixtyFourBit},
         "Apple-Monterey-Debug-Build": {platform: Dashboard.Platform.macOSMonterey, debug: true, builder: true, architecture: Buildbot.BuildArchitecture.SixtyFourBit},
         "Apple-Monterey-Debug-WK1-Tests": {platform: Dashboard.Platform.macOSMonterey, debug: true, tester: true, testCategory: Buildbot.TestCategory.WebKit1},
@@ -49,7 +52,6 @@ WebKitBuildbot = function()
         "Apple-Monterey JSC": {platform: Dashboard.Platform.macOSMonterey, heading: "JavaScript", combinedQueues: {
             "Apple-Monterey-Debug-Test262-Tests": {heading: "Debug Test262 (Tests)"},
             "Apple-Monterey-Release-Test262-Tests": {heading: "Release Test262 (Tests)"},
-            "Apple-Monterey-AppleSilicon-Release-Test262-Tests": {heading: "Release arm64 Test262 (Tests)"},
             "Apple-Monterey-AppleSilicon-Debug-JSC-Tests": {heading: "Debug arm64 JSC (Tests)"},
             "Apple-Monterey-AppleSilicon-Release-JSC-Tests": {heading: "Release arm64 JSC (Tests)"},
         }},


### PR DESCRIPTION
#### 802468c4036645aac3473ee5077ce81fab53adda
<pre>
Update test262 bot to Ventura
<a href="https://bugs.webkit.org/show_bug.cgi?id=248992">https://bugs.webkit.org/show_bug.cgi?id=248992</a>
rdar://102916599

Reviewed by Ryan Haddad.

Update test262 bot to Ventura

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js:
(WebKitBuildbot):

Canonical link: <a href="https://commits.webkit.org/257813@main">https://commits.webkit.org/257813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8ce3be7ab5014f088e8aedd8e4c82c4d34c474b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109443 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86771 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107333 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105873 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3014 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/99023 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43344 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5368 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->