### PR TITLE
[WebAssembly SIMD] Support bitwise operations on Intel

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -5137,7 +5137,7 @@ public:
         m_assembler.sshl(dest, input, shift, simdInfo.lane);
     }
 
-    void vectorSshr(SIMDInfo simdInfo, FPRegisterID input, TrustedImm32 shift, FPRegisterID dest)
+    void vectorSshr8(SIMDInfo simdInfo, FPRegisterID input, TrustedImm32 shift, FPRegisterID dest)
     {
         ASSERT(scalarTypeIsIntegral(simdInfo.lane));
         m_assembler.sshr_vi(dest, input, shift.m_value, simdInfo.lane);

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1680,8 +1680,11 @@ CompareFloatingPointVector U:G:32, U:G:Ptr, U:F:128, U:F:128, D:F:128
 CompareIntegerVector U:G:32, U:G:Ptr, U:F:128, U:F:128, D:F:128
     RelCond, SIMDInfo, Tmp, Tmp, Tmp
 
-CompareIntegerVectorWithZero U:G:32, U:G:Ptr, U:F:128, D:F:128
+arm64: CompareIntegerVectorWithZero U:G:32, U:G:Ptr, U:F:128, D:F:128
     RelCond, SIMDInfo, Tmp, Tmp
+
+x86_64: CompareIntegerVectorWithZero U:G:32, U:G:Ptr, U:F:128, D:F:128, S:G:8
+    RelCond, SIMDInfo, Tmp, Tmp, Tmp
 
 arm64: VectorUnsignedMax U:G:Ptr, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp
@@ -1725,7 +1728,7 @@ VectorNarrow U:G:Ptr, U:F:128, U:F:128, D:F:128, S:F:128
 VectorBitwiseSelect U:F:128, U:F:128, UD:F:128
     Tmp, Tmp, Tmp
 
-VectorNot U:G:Ptr, U:F:128, D:F:128
+arm64: VectorNot U:G:Ptr, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp
 
 VectorAnd U:G:Ptr, U:F:128, U:F:128, D:F:128
@@ -1743,13 +1746,19 @@ VectorXor U:G:Ptr, U:F:128, U:F:128, D:F:128
 MoveZeroToVector D:F:128
     Tmp
 
-arm64: VectorUshl U:G:Ptr, U:F:128, U:F:128, D:F:128
+VectorUshl U:G:Ptr, U:F:128, U:F:128, D:F:128
+    SIMDInfo, Tmp, Tmp, Tmp
+
+x86_64: VectorSshr U:G:Ptr, U:F:128, U:F:128, D:F:128
+    SIMDInfo, Tmp, Tmp, Tmp
+
+x86_64: VectorUshr U:G:Ptr, U:F:128, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp, Tmp
 
 arm64: VectorSshl U:G:Ptr, U:F:128, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp, Tmp
 
-arm64: VectorSshr U:G:Ptr, U:F:128, U:G:8, D:F:128
+arm64: VectorSshr8 U:G:Ptr, U:F:128, U:G:8, D:F:128
     SIMDInfo, Tmp, Imm, Tmp
 
 arm64: VectorHorizontalAdd U:G:Ptr, U:F:128, D:F:128
@@ -1851,11 +1860,17 @@ VectorStore64Lane U:F:128, U:G:64, U:G:8
 VectorAnyTrue U:F:128, ZD:G:32
     Tmp, Tmp
 
-VectorAllTrue U:G:8, U:F:128, ZD:G:32
+x86_64: VectorAllTrue U:G:8, U:F:128, ZD:G:32, S:F:128
+    SIMDInfo, Tmp, Tmp, Tmp
+
+arm64: VectorAllTrue U:G:8, U:F:128, ZD:G:32
     SIMDInfo, Tmp, Tmp
 
-VectorBitmask U:G:8, U:F:128, ZD:G:32
+arm64: VectorBitmask U:G:8, U:F:128, ZD:G:32
     SIMDInfo, Tmp, Tmp
+
+x86_64: VectorBitmask U:G:8, U:F:128, ZD:G:32, S:F:128
+    SIMDInfo, Tmp, Tmp, Tmp
 
 VectorExtaddPairwise U:G:8, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp


### PR DESCRIPTION
#### 4dea5d54cd4a77e83dbf3fb6de01cc7c81d23d22
<pre>
[WebAssembly SIMD] Support bitwise operations on Intel
<a href="https://bugs.webkit.org/show_bug.cgi?id=248639">https://bugs.webkit.org/show_bug.cgi?id=248639</a>
rdar://103089683

Reviewed by Yusuke Suzuki.

Adds support for SIMD bitwise operations (AND, OR, XOR, ANDN, NOT, shifts, any/all_true,
bitmask/select) to the Intel macro assembler. Currently omits shifts and popcnt for i8x16
vectors, since they aren&apos;t supported natively on Intel and are pretty involved to emulate.

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::compareIntegerVectorWithZero):
(JSC::MacroAssemblerX86_64::vectorAnd):
(JSC::MacroAssemblerX86_64::vectorAndnot):
(JSC::MacroAssemblerX86_64::vectorOr):
(JSC::MacroAssemblerX86_64::vectorXor):
(JSC::MacroAssemblerX86_64::vectorUshl):
(JSC::MacroAssemblerX86_64::vectorUshr):
(JSC::MacroAssemblerX86_64::vectorSshr):
(JSC::MacroAssemblerX86_64::vectorAnyTrue):
(JSC::MacroAssemblerX86_64::vectorAllTrue):
(JSC::MacroAssemblerX86_64::vectorNot): Deleted.
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::vandps_rrr):
(JSC::X86Assembler::vandpd_rrr):
(JSC::X86Assembler::vorps_rrr):
(JSC::X86Assembler::vorpd_rrr):
(JSC::X86Assembler::vxorps_rrr):
(JSC::X86Assembler::vxorpd_rrr):
(JSC::X86Assembler::vandnps_rrr):
(JSC::X86Assembler::vandnpd_rrr):
(JSC::X86Assembler::vpmovmskb_rr):
(JSC::X86Assembler::vmovmskps_rr):
(JSC::X86Assembler::vmovmskpd_rr):
(JSC::X86Assembler::vptest_rr):
(JSC::X86Assembler::vpsllw_rrr):
(JSC::X86Assembler::vpslld_rrr):
(JSC::X86Assembler::vpsllq_rrr):
(JSC::X86Assembler::vpsrlw_rrr):
(JSC::X86Assembler::vpsrld_rrr):
(JSC::X86Assembler::vpsrlq_rrr):
(JSC::X86Assembler::vpsraw_rrr):
(JSC::X86Assembler::vpsrad_rrr):
(JSC::X86Assembler::vpsraq_rrr):
(JSC::X86Assembler::andps_rr):
(JSC::X86Assembler::orps_rr):
* Source/JavaScriptCore/b3/air/AirLowerMacros.cpp:
(JSC::B3::Air::lowerMacros):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::addSIMDI_V):
(JSC::Wasm::AirIRGenerator::addSIMDV_V):
(JSC::Wasm::AirIRGenerator::addConstant):
(JSC::Wasm::AirIRGenerator::addSIMDShift):

Canonical link: <a href="https://commits.webkit.org/257640@main">https://commits.webkit.org/257640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab02adde90e1eae4fab873b1aea5476a0140a210

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108917 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86035 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106834 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105310 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90204 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86092 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2503 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28924 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/8654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42907 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88963 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5257 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4363 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19894 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->