### PR TITLE
[WPE] Non-unified build fix at MediaRecorderProvider

### DIFF
--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp
@@ -30,6 +30,7 @@
 
 #include "ContentType.h"
 #include "HTMLParserIdioms.h"
+#include "MediaRecorderPrivate.h"
 
 #if PLATFORM(COCOA) && USE(AVFOUNDATION)
 #include "MediaRecorderPrivateAVFImpl.h"


### PR DESCRIPTION
#### 62a1022e05c672741ca5cd152ea48f0395fac591
<pre>
[WPE] Non-unified build fix at MediaRecorderProvider
<a href="https://bugs.webkit.org/show_bug.cgi?id=248996">https://bugs.webkit.org/show_bug.cgi?id=248996</a>

Reviewed by Xabier Rodriguez-Calvar.

Add missing include to avoid incomplete type build error.

* Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp:

Canonical link: <a href="https://commits.webkit.org/257623@main">https://commits.webkit.org/257623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fd02a15908ead17c428e544af383b721121e53c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108816 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169052 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85940 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106739 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90492 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33923 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88770 "Found 4 new API test failures: TestWebKitAPI.WKWebExtensionControllerConfiguration.Initialization, TestWebKitAPI.WKWebExtensionControllerConfiguration.SecureCoding, TestWebKitAPI.WKWebExtensionControllerConfiguration.Copying, TestWebKitAPI.WKWebExtensionController.Configuration (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21839 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2485 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23356 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2405 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8562 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42831 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2684 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4272 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->