### PR TITLE
Support callbacks on multiple threads in DisplayConfigurationMonitor

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -34,6 +34,7 @@
 #include "Image.h"
 #include "IntRect.h"
 #include "IntSize.h"
+#include <wtf/FunctionDispatcher.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
@@ -1601,7 +1602,7 @@ private:
     GraphicsContextGLAttributes m_attrs;
 };
 
-WEBCORE_EXPORT RefPtr<GraphicsContextGL> createWebProcessGraphicsContextGL(const GraphicsContextGLAttributes&);
+WEBCORE_EXPORT RefPtr<GraphicsContextGL> createWebProcessGraphicsContextGL(const GraphicsContextGLAttributes&, SerialFunctionDispatcher* = nullptr);
 
 inline GCGLfloat GraphicsContextGL::getFloat(GCGLenum pname)
 {

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp
@@ -44,7 +44,7 @@ static inline bool isDMABufSupportedByNativePlatform(const PlatformDisplay::EGLE
 }
 #endif
 
-RefPtr<GraphicsContextGL> createWebProcessGraphicsContextGL(const GraphicsContextGLAttributes& attributes)
+RefPtr<GraphicsContextGL> createWebProcessGraphicsContextGL(const GraphicsContextGLAttributes& attributes, SerialFunctionDispatcher*)
 {
 #if USE(TEXTURE_MAPPER_DMABUF) && USE(EGL)
     if (isDMABufSupportedByNativePlatform(PlatformDisplay::sharedDisplayForCompositing().eglExtensions())) {

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -101,7 +101,7 @@ RefPtr<PixelBuffer> GraphicsContextGLANGLE::readCompositedResults()
     return readRenderingResults();
 }
 
-RefPtr<GraphicsContextGL> createWebProcessGraphicsContextGL(const GraphicsContextGLAttributes& attributes)
+RefPtr<GraphicsContextGL> createWebProcessGraphicsContextGL(const GraphicsContextGLAttributes& attributes, SerialFunctionDispatcher*)
 {
     return GraphicsContextGLTextureMapperANGLE::create(GraphicsContextGLAttributes { attributes });
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
@@ -113,7 +113,7 @@ RefPtr<GraphicsContextGL> WebWorkerClient::createGraphicsContextGL(const Graphic
     if (WebProcess::singleton().shouldUseRemoteRenderingForWebGL())
         return RemoteGraphicsContextGLProxy::create(m_connection, attributes, ensureRenderingBackend());
 #endif
-    return WebCore::createWebProcessGraphicsContextGL(attributes);
+    return WebCore::createWebProcessGraphicsContextGL(attributes, &m_dispatcher);
 }
 #endif
 


### PR DESCRIPTION
#### f517ea74ce7f0448baf00066743c606e1e0b4b50
<pre>
Support callbacks on multiple threads in DisplayConfigurationMonitor
<a href="https://bugs.webkit.org/show_bug.cgi?id=248993">https://bugs.webkit.org/show_bug.cgi?id=248993</a>

Reviewed by Cameron McCormack.

* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm:
(WebCore::createWebProcessGraphicsContextGL):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp:
(WebCore::createWebProcessGraphicsContextGL):
* Source/WebCore/platform/graphics/mac/DisplayConfigurationMonitor.cpp:
(WebCore::DisplayConfigurationMonitor::singleton):
(WebCore::DisplayConfigurationMonitor::addClient):
(WebCore::DisplayConfigurationMonitor::removeClient):
(WebCore::DisplayConfigurationMonitor::dispatchDisplayWasReconfigured):
* Source/WebCore/platform/graphics/mac/DisplayConfigurationMonitor.h:
(WebCore::DisplayConfigurationMonitor::ClientEntry::operator== const):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::createWebProcessGraphicsContextGL):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
(WebKit::WebWorkerClient::createGraphicsContextGL const):

Canonical link: <a href="https://commits.webkit.org/257616@main">https://commits.webkit.org/257616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c566926390ded269a7aa3906267f5cb0e4b6fbe6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108852 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169082 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85971 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91954 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106768 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105244 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33947 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21861 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2513 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23376 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2439 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8593 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42854 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5237 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4300 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->