### PR TITLE
[JSC] Fix X86Assembler namings

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -1551,7 +1551,7 @@ public:
     void addDouble(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vaddsd_rr(op1, op2, dest);
+            m_assembler.vaddsd_rrr(op1, op2, dest);
         else {
             if (op1 == dest)
                 m_assembler.addsd_rr(op2, dest);
@@ -1614,7 +1614,7 @@ public:
     void addFloat(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vaddss_rr(op1, op2, dest);
+            m_assembler.vaddss_rrr(op1, op2, dest);
         else {
             if (op1 == dest)
                 m_assembler.addss_rr(op2, dest);
@@ -1696,7 +1696,7 @@ public:
     void subDouble(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vsubsd_rr(op1, op2, dest);
+            m_assembler.vsubsd_rrr(op1, op2, dest);
         else {
             // B := A - B is invalid.
             ASSERT(op1 == dest || op2 != dest);
@@ -1738,7 +1738,7 @@ public:
     void subFloat(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vsubss_rr(op1, op2, dest);
+            m_assembler.vsubss_rrr(op1, op2, dest);
         else {
             // B := A - B is invalid.
             ASSERT(op1 == dest || op2 != dest);
@@ -1780,7 +1780,7 @@ public:
     void mulDouble(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vmulsd_rr(op1, op2, dest);
+            m_assembler.vmulsd_rrr(op1, op2, dest);
         else {
             if (op1 == dest)
                 m_assembler.mulsd_rr(op2, dest);
@@ -1842,7 +1842,7 @@ public:
     void mulFloat(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vmulss_rr(op1, op2, dest);
+            m_assembler.vmulss_rrr(op1, op2, dest);
         else {
             if (op1 == dest)
                 m_assembler.mulss_rr(op2, dest);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -2266,39 +2266,39 @@ public:
         switch (cond) {
         case DoubleEqualAndOrdered:
             if (simdInfo.lane == SIMDLane::f32x4)
-                m_assembler.vcmpps_rr(PackedCompareCondition::Equal, left, right, dest);
+                m_assembler.vcmpps_rrr(PackedCompareCondition::Equal, left, right, dest);
             else
-                m_assembler.vcmppd_rr(PackedCompareCondition::Equal, left, right, dest);
+                m_assembler.vcmppd_rrr(PackedCompareCondition::Equal, left, right, dest);
             break;
         case DoubleNotEqualOrUnordered:
             if (simdInfo.lane == SIMDLane::f32x4)
-                m_assembler.vcmpps_rr(PackedCompareCondition::NotEqual, left, right, dest);
+                m_assembler.vcmpps_rrr(PackedCompareCondition::NotEqual, left, right, dest);
             else
-                m_assembler.vcmppd_rr(PackedCompareCondition::NotEqual, left, right, dest);
+                m_assembler.vcmppd_rrr(PackedCompareCondition::NotEqual, left, right, dest);
             break;
         case DoubleGreaterThanAndOrdered:
             if (simdInfo.lane == SIMDLane::f32x4)
-                m_assembler.vcmpps_rr(PackedCompareCondition::GreaterThan, left, right, dest);
+                m_assembler.vcmpps_rrr(PackedCompareCondition::GreaterThan, left, right, dest);
             else
-                m_assembler.vcmppd_rr(PackedCompareCondition::GreaterThan, left, right, dest);
+                m_assembler.vcmppd_rrr(PackedCompareCondition::GreaterThan, left, right, dest);
             break;
         case DoubleGreaterThanOrEqualAndOrdered:
             if (simdInfo.lane == SIMDLane::f32x4)
-                m_assembler.vcmpps_rr(PackedCompareCondition::GreaterThanOrEqual, left, right, dest);
+                m_assembler.vcmpps_rrr(PackedCompareCondition::GreaterThanOrEqual, left, right, dest);
             else
-                m_assembler.vcmppd_rr(PackedCompareCondition::GreaterThanOrEqual, left, right, dest);
+                m_assembler.vcmppd_rrr(PackedCompareCondition::GreaterThanOrEqual, left, right, dest);
             break;
         case DoubleLessThanAndOrdered:
             if (simdInfo.lane == SIMDLane::f32x4)
-                m_assembler.vcmpps_rr(PackedCompareCondition::LessThan, left, right, dest);
+                m_assembler.vcmpps_rrr(PackedCompareCondition::LessThan, left, right, dest);
             else
-                m_assembler.vcmppd_rr(PackedCompareCondition::LessThan, left, right, dest);
+                m_assembler.vcmppd_rrr(PackedCompareCondition::LessThan, left, right, dest);
             break;
         case DoubleLessThanOrEqualAndOrdered:
             if (simdInfo.lane == SIMDLane::f32x4)
-                m_assembler.vcmpps_rr(PackedCompareCondition::LessThanOrEqual, left, right, dest);
+                m_assembler.vcmpps_rrr(PackedCompareCondition::LessThanOrEqual, left, right, dest);
             else
-                m_assembler.vcmppd_rr(PackedCompareCondition::LessThanOrEqual, left, right, dest);
+                m_assembler.vcmppd_rrr(PackedCompareCondition::LessThanOrEqual, left, right, dest);
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();
@@ -2314,16 +2314,16 @@ public:
         case Equal:
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpcmpeqb_rr(left, right, dest);
+                m_assembler.vpcmpeqb_rrr(left, right, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpcmpeqw_rr(left, right, dest);
+                m_assembler.vpcmpeqw_rrr(left, right, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpcmpeqd_rr(left, right, dest);
+                m_assembler.vpcmpeqd_rrr(left, right, dest);
                 break;
             case SIMDLane::i64x2:
-                m_assembler.vpcmpeqq_rr(left, right, dest);
+                m_assembler.vpcmpeqq_rrr(left, right, dest);
                 break;
             default:
                 RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unsupported SIMD lane for comparison");
@@ -2342,16 +2342,16 @@ public:
         case AboveOrEqual:
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpmaxub_rr(left, right, dest);
-                m_assembler.vpcmpeqb_rr(left, dest, dest);
+                m_assembler.vpmaxub_rrr(left, right, dest);
+                m_assembler.vpcmpeqb_rrr(left, dest, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpmaxuw_rr(left, right, dest);
-                m_assembler.vpcmpeqw_rr(left, dest, dest);
+                m_assembler.vpmaxuw_rrr(left, right, dest);
+                m_assembler.vpcmpeqw_rrr(left, dest, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpmaxud_rr(left, right, dest);
-                m_assembler.vpcmpeqd_rr(left, dest, dest);
+                m_assembler.vpmaxud_rrr(left, right, dest);
+                m_assembler.vpcmpeqd_rrr(left, dest, dest);
                 break;
             case SIMDLane::i64x2:
                 RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("i64x2 unsigned comparisons are not supported.");
@@ -2368,16 +2368,16 @@ public:
         case BelowOrEqual:
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpminub_rr(left, right, dest);
-                m_assembler.vpcmpeqb_rr(left, dest, dest);
+                m_assembler.vpminub_rrr(left, right, dest);
+                m_assembler.vpcmpeqb_rrr(left, dest, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpminuw_rr(left, right, dest);
-                m_assembler.vpcmpeqw_rr(left, dest, dest);
+                m_assembler.vpminuw_rrr(left, right, dest);
+                m_assembler.vpcmpeqw_rrr(left, dest, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpminud_rr(left, right, dest);
-                m_assembler.vpcmpeqd_rr(left, dest, dest);
+                m_assembler.vpminud_rrr(left, right, dest);
+                m_assembler.vpcmpeqd_rrr(left, dest, dest);
                 break;
             case SIMDLane::i64x2:
                 RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("i64x2 unsigned comparisons are not supported.");
@@ -2389,16 +2389,16 @@ public:
         case GreaterThan:
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpcmpgtb_rr(left, right, dest);
+                m_assembler.vpcmpgtb_rrr(left, right, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpcmpgtw_rr(left, right, dest);
+                m_assembler.vpcmpgtw_rrr(left, right, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpcmpgtd_rr(left, right, dest);
+                m_assembler.vpcmpgtd_rrr(left, right, dest);
                 break;
             case SIMDLane::i64x2:
-                m_assembler.vpcmpgtq_rr(left, right, dest);
+                m_assembler.vpcmpgtq_rrr(left, right, dest);
                 break;
             default:
                 RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unsupported SIMD lane for comparison");
@@ -2407,16 +2407,16 @@ public:
         case GreaterThanOrEqual:
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpmaxsb_rr(left, right, dest);
-                m_assembler.vpcmpeqb_rr(left, dest, dest);
+                m_assembler.vpmaxsb_rrr(left, right, dest);
+                m_assembler.vpcmpeqb_rrr(left, dest, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpmaxsw_rr(left, right, dest);
-                m_assembler.vpcmpeqw_rr(left, dest, dest);
+                m_assembler.vpmaxsw_rrr(left, right, dest);
+                m_assembler.vpcmpeqw_rrr(left, dest, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpmaxsd_rr(left, right, dest);
-                m_assembler.vpcmpeqd_rr(left, dest, dest);
+                m_assembler.vpmaxsd_rrr(left, right, dest);
+                m_assembler.vpcmpeqd_rrr(left, dest, dest);
                 break;
             case SIMDLane::i64x2:
                 // Intel doesn't support 64-bit packed maximum/minimum without AVX512, so this condition should have been transformed
@@ -2430,16 +2430,16 @@ public:
         case LessThan:
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpcmpgtb_rr(right, left, dest);
+                m_assembler.vpcmpgtb_rrr(right, left, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpcmpgtw_rr(right, left, dest);
+                m_assembler.vpcmpgtw_rrr(right, left, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpcmpgtd_rr(right, left, dest);
+                m_assembler.vpcmpgtd_rrr(right, left, dest);
                 break;
             case SIMDLane::i64x2:
-                m_assembler.vpcmpgtq_rr(right, left, dest);
+                m_assembler.vpcmpgtq_rrr(right, left, dest);
                 break;
             default:
                 RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unsupported SIMD lane for comparison");
@@ -2448,16 +2448,16 @@ public:
         case LessThanOrEqual:
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpminsb_rr(left, right, dest);
-                m_assembler.vpcmpeqb_rr(left, dest, dest);
+                m_assembler.vpminsb_rrr(left, right, dest);
+                m_assembler.vpcmpeqb_rrr(left, dest, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpminsw_rr(left, right, dest);
-                m_assembler.vpcmpeqw_rr(left, dest, dest);
+                m_assembler.vpminsw_rrr(left, right, dest);
+                m_assembler.vpcmpeqw_rrr(left, dest, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpminsd_rr(left, right, dest);
-                m_assembler.vpcmpeqd_rr(left, dest, dest);
+                m_assembler.vpminsd_rrr(left, right, dest);
+                m_assembler.vpcmpeqd_rrr(left, dest, dest);
                 break;
             case SIMDLane::i64x2:
                 // Intel doesn't support 64-bit packed maximum/minimum without AVX512, so this condition should have been transformed
@@ -2584,9 +2584,9 @@ public:
         case SIMDLane::i8x16:
             if (supportsAVXForSIMD()) {
                 if (simdInfo.signMode == SIMDSignMode::Signed)
-                    m_assembler.vpmaxsb_rr(right, left, dest);
+                    m_assembler.vpmaxsb_rrr(right, left, dest);
                 else
-                    m_assembler.vpmaxub_rr(right, left, dest);
+                    m_assembler.vpmaxub_rrr(right, left, dest);
             } else {
                 if (left != dest)
                     m_assembler.movapd_rr(left, dest);
@@ -2602,9 +2602,9 @@ public:
         case SIMDLane::i16x8:
             if (supportsAVXForSIMD()) {
                 if (simdInfo.signMode == SIMDSignMode::Signed)
-                    m_assembler.vpmaxsw_rr(right, left, dest);
+                    m_assembler.vpmaxsw_rrr(right, left, dest);
                 else
-                    m_assembler.vpmaxuw_rr(right, left, dest);
+                    m_assembler.vpmaxuw_rrr(right, left, dest);
             } else {
                 if (left != dest)
                     m_assembler.movapd_rr(left, dest);
@@ -2621,9 +2621,9 @@ public:
         case SIMDLane::i32x4:
             if (supportsAVXForSIMD()) {
                 if (simdInfo.signMode == SIMDSignMode::Signed)
-                    m_assembler.vpmaxsd_rr(right, left, dest);
+                    m_assembler.vpmaxsd_rrr(right, left, dest);
                 else
-                    m_assembler.vpmaxud_rr(right, left, dest);
+                    m_assembler.vpmaxud_rrr(right, left, dest);
             } else {
                 if (left != dest)
                     m_assembler.movapd_rr(left, dest);
@@ -2649,9 +2649,9 @@ public:
         case SIMDLane::i8x16:
             if (supportsAVXForSIMD()) {
                 if (simdInfo.signMode == SIMDSignMode::Signed)
-                    m_assembler.vpminsb_rr(right, left, dest);
+                    m_assembler.vpminsb_rrr(right, left, dest);
                 else
-                    m_assembler.vpminub_rr(right, left, dest);
+                    m_assembler.vpminub_rrr(right, left, dest);
             } else {
                 if (left != dest)
                     m_assembler.movapd_rr(left, dest);
@@ -2667,9 +2667,9 @@ public:
         case SIMDLane::i16x8:
             if (supportsAVXForSIMD()) {
                 if (simdInfo.signMode == SIMDSignMode::Signed)
-                    m_assembler.vpminsw_rr(right, left, dest);
+                    m_assembler.vpminsw_rrr(right, left, dest);
                 else
-                    m_assembler.vpminuw_rr(right, left, dest);
+                    m_assembler.vpminuw_rrr(right, left, dest);
             } else {
                 if (left != dest)
                     m_assembler.movapd_rr(left, dest);
@@ -2686,9 +2686,9 @@ public:
         case SIMDLane::i32x4:
             if (supportsAVXForSIMD()) {
                 if (simdInfo.signMode == SIMDSignMode::Signed)
-                    m_assembler.vpminsd_rr(right, left, dest);
+                    m_assembler.vpminsd_rrr(right, left, dest);
                 else
-                    m_assembler.vpminud_rr(right, left, dest);
+                    m_assembler.vpminud_rrr(right, left, dest);
             } else {
                 if (left != dest)
                     m_assembler.movapd_rr(left, dest);
@@ -2790,9 +2790,9 @@ public:
         case SIMDLane::i64x2:
             // https://github.com/WebAssembly/simd/pull/413
             if (supportsAVXForSIMD()) {
-                m_assembler.vpxor_rr(dest, dest, dest);
-                m_assembler.vpsubq_rr(input, dest, dest);
-                m_assembler.vblendvpd_rr(input, dest, input, dest);
+                m_assembler.vpxor_rrr(dest, dest, dest);
+                m_assembler.vpsubq_rrr(input, dest, dest);
+                m_assembler.vblendvpd_rrrr(input, dest, input, dest);
             } else if (supportsSSE4_1()) {
                 // FIXME: SSE4_1
                 RELEASE_ASSERT_NOT_REACHED();
@@ -2859,9 +2859,9 @@ public:
     {
         if (supportsAVXForSIMD()) {
             // https://github.com/WebAssembly/simd/pull/383
-            m_assembler.vcmpeqpd_rr(x, x, tmp);
-            m_assembler.vandpd_rr(f62x2, tmp, tmp);
-            m_assembler.vminpd_rr(tmp, x, y);
+            m_assembler.vcmpeqpd_rrr(x, x, tmp);
+            m_assembler.vandpd_rrr(f62x2, tmp, tmp);
+            m_assembler.vminpd_rrr(tmp, x, y);
             m_assembler.vcvttpd2dq_rr(y, y);
         } else
             RELEASE_ASSERT_NOT_REACHED();
@@ -2871,12 +2871,12 @@ public:
     {
         if (supportsAVXForSIMD()) {
             // https://github.com/WebAssembly/simd/pull/383
-            m_assembler.vxorpd_rr(tmp, tmp, tmp);
-            m_assembler.vmaxpd_rr(tmp, x, y);
-            m_assembler.vminpd_rr(f62x2_1, y, y);
+            m_assembler.vxorpd_rrr(tmp, tmp, tmp);
+            m_assembler.vmaxpd_rrr(tmp, x, y);
+            m_assembler.vminpd_rrr(f62x2_1, y, y);
             m_assembler.vroundpd_rr(0x0B, y, y);
-            m_assembler.vaddpd_rr(f62x2_2, y, y);
-            m_assembler.vshufps_rr(0x88, tmp, y, y);
+            m_assembler.vaddpd_rrr(f62x2_2, y, y);
+            m_assembler.vshufps_rrr(0x88, tmp, y, y);
         } else
             RELEASE_ASSERT_NOT_REACHED();
     }
@@ -2995,7 +2995,7 @@ public:
         case SIMDLane::i16x8:
             if (simdInfo.signMode == SIMDSignMode::Signed) {
                 if (supportsAVXForSIMD())
-                    m_assembler.vpacksswb_rr(upper, lower, dest);
+                    m_assembler.vpacksswb_rrr(upper, lower, dest);
                 else {
                     if (lower != dest)
                         m_assembler.movapd_rr(lower, dest);
@@ -3003,7 +3003,7 @@ public:
                 }
             } else {
                 if (supportsAVXForSIMD())
-                    m_assembler.vpackuswb_rr(upper, lower, dest);
+                    m_assembler.vpackuswb_rrr(upper, lower, dest);
                 else {
                     if (lower != dest)
                         m_assembler.movapd_rr(lower, dest);
@@ -3014,7 +3014,7 @@ public:
         case SIMDLane::i32x4:
             if (simdInfo.signMode == SIMDSignMode::Signed) {
                 if (supportsAVXForSIMD())
-                    m_assembler.vpackssdw_rr(upper, lower, dest);
+                    m_assembler.vpackssdw_rrr(upper, lower, dest);
                 else {
                     if (lower != dest)
                         m_assembler.movapd_rr(lower, dest);
@@ -3022,7 +3022,7 @@ public:
                 }
             } else {
                 if (supportsAVXForSIMD())
-                    m_assembler.vpackusdw_rr(upper, lower, dest);
+                    m_assembler.vpackusdw_rrr(upper, lower, dest);
                 else if (supportsSSE4_1()) {
                     if (lower != dest)
                         m_assembler.movapd_rr(lower, dest);
@@ -3065,8 +3065,8 @@ public:
         } else {
             if (supportsAVXForSIMD()) {
                 // https://github.com/WebAssembly/simd/pull/383
-                m_assembler.vunpcklps_rr(scratch1, input, dest);
-                m_assembler.vsubpd_rr(scratch2, dest, dest);
+                m_assembler.vunpcklps_rrr(scratch1, input, dest);
+                m_assembler.vsubpd_rrr(scratch2, dest, dest);
             } else
                 RELEASE_ASSERT_NOT_REACHED();
         }
@@ -3139,9 +3139,9 @@ public:
         case SIMDLane::i8x16:
             if (supportsAVXForSIMD()) {
                 if (simdInfo.signMode == SIMDSignMode::Signed)
-                    m_assembler.vpaddsb_rr(right, left, dest);
+                    m_assembler.vpaddsb_rrr(right, left, dest);
                 else
-                    m_assembler.vpaddusb_rr(right, left, dest);
+                    m_assembler.vpaddusb_rrr(right, left, dest);
             } else {
                 if (left != dest)
                     m_assembler.movapd_rr(left, dest);
@@ -3154,9 +3154,9 @@ public:
         case SIMDLane::i16x8:
             if (supportsAVXForSIMD()) {
                 if (simdInfo.signMode == SIMDSignMode::Signed)
-                    m_assembler.vpaddsw_rr(right, left, dest);
+                    m_assembler.vpaddsw_rrr(right, left, dest);
                 else
-                    m_assembler.vpaddusw_rr(right, left, dest);
+                    m_assembler.vpaddusw_rrr(right, left, dest);
             } else {
                 if (left != dest)
                     m_assembler.movapd_rr(left, dest);
@@ -3179,9 +3179,9 @@ public:
         case SIMDLane::i8x16:
             if (supportsAVXForSIMD()) {
                 if (simdInfo.signMode == SIMDSignMode::Signed)
-                    m_assembler.vpsubsb_rr(right, left, dest);
+                    m_assembler.vpsubsb_rrr(right, left, dest);
                 else
-                    m_assembler.vpsubusb_rr(right, left, dest);
+                    m_assembler.vpsubusb_rrr(right, left, dest);
             } else {
                 if (left != dest)
                     m_assembler.movapd_rr(left, dest);
@@ -3194,9 +3194,9 @@ public:
         case SIMDLane::i16x8:
             if (supportsAVXForSIMD()) {
                 if (simdInfo.signMode == SIMDSignMode::Signed)
-                    m_assembler.vpsubsw_rr(right, left, dest);
+                    m_assembler.vpsubsw_rrr(right, left, dest);
                 else
-                    m_assembler.vpsubusw_rr(right, left, dest);
+                    m_assembler.vpsubusw_rrr(right, left, dest);
             } else {
                 if (left != dest)
                     m_assembler.movapd_rr(left, dest);
@@ -3231,7 +3231,7 @@ public:
         switch (simdInfo.lane) {
         case SIMDLane::i8x16:
             if (supportsAVXForSIMD())
-                m_assembler.vpavgb_rr(b, a, dest);
+                m_assembler.vpavgb_rrr(b, a, dest);
             else {
                 if (a != dest)
                     m_assembler.movapd_rr(a, dest);
@@ -3240,7 +3240,7 @@ public:
             return;
         case SIMDLane::i16x8:
             if (supportsAVXForSIMD())
-                m_assembler.vpavgw_rr(b, a, dest);
+                m_assembler.vpavgw_rrr(b, a, dest);
             else {
                 if (a != dest)
                     m_assembler.movapd_rr(a, dest);
@@ -3256,11 +3256,11 @@ public:
     {
         // https://github.com/WebAssembly/simd/pull/365
         if (supportsAVXForSIMD()) {
-            m_assembler.vpmulhrsw_rr(b, a, dest);
+            m_assembler.vpmulhrsw_rrr(b, a, dest);
             m_assembler.movq_i64r(0x8000, scratchGPR);
             vectorSplat(SIMDLane::i16x8, scratchGPR, scratchFPR);
-            m_assembler.vpcmpeqw_rr(scratchFPR, dest, scratchFPR);
-            m_assembler.vpxor_rr(scratchFPR, dest, dest);
+            m_assembler.vpcmpeqw_rrr(scratchFPR, dest, scratchFPR);
+            m_assembler.vpxor_rrr(scratchFPR, dest, dest);
         } else if (supportsSupplementalSSE3()) {
             // FIXME: SSSE3
             RELEASE_ASSERT_NOT_REACHED();
@@ -3274,7 +3274,7 @@ public:
     void vectorSwizzle(FPRegisterID a, FPRegisterID b, FPRegisterID dest)
     {
         if (supportsAVXForSIMD())
-            m_assembler.vpshufb_rr(b, a, dest);
+            m_assembler.vpshufb_rrr(b, a, dest);
         else {
             if (a != dest)
                 m_assembler.movapd_rr(a, dest);

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -2521,7 +2521,7 @@ public:
         m_formatter.twoByteOp(OP2_UNPCKLPD_VpdWpd, (RegisterID)vd, (RegisterID)rn);
     }
 
-    void vunpcklps_rr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vunpcklps_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/unpcklps
         // VEX.128.0F.WIG 14 /r VUNPCKLPS xmm1,xmm2, xmm3/m128
@@ -2627,7 +2627,7 @@ public:
         m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PSHUFB_VdqWdq, (RegisterID)vd, (RegisterID)vn);
     }
 
-    void vpshufb_rr(XMMRegisterID vm, XMMRegisterID vn, XMMRegisterID vd)
+    void vpshufb_rrr(XMMRegisterID vm, XMMRegisterID vn, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pshufb
         // VEX.128.66.0F38.WIG 00 /r VPSHUFB xmm1, xmm2, xmm3/m128
@@ -2670,7 +2670,7 @@ public:
         m_formatter.immediate8((uint8_t)controlBits);
     }
 
-    void vshufps_rr(uint8_t controlBits, XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vshufps_rrr(uint8_t controlBits, XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/shufps
         // VEX.128.0F.WIG C6 /r ib VSHUFPS xmm1, xmm2, xmm3/m128, imm8
@@ -2696,7 +2696,7 @@ public:
         m_formatter.twoByteOp(OP2_PADDSB_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpaddsb_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpaddsb_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/paddsb:paddsw
         // VEX.128.66.0F.WIG EC /r VPADDSB xmm1, xmm2, xmm3/m128
@@ -2713,7 +2713,7 @@ public:
         m_formatter.twoByteOp(OP2_PADDUSB_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpaddusb_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpaddusb_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/paddusb:paddusw
         // VEX.128.66.0F.WIG DC /r VPADDUSB xmm1, xmm2, xmm3/m128
@@ -2730,7 +2730,7 @@ public:
         m_formatter.twoByteOp(OP2_PADDSW_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpaddsw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpaddsw_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/paddsb:paddsw
         // VEX.128.66.0F.WIG ED /r VPADDSW xmm1, xmm2, xmm3/m128
@@ -2747,7 +2747,7 @@ public:
         m_formatter.twoByteOp(OP2_PADDUSW_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpaddusw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpaddusw_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/paddusb:paddusw
         // VEX.128.66.0F.WIG DD /r VPADDUSW xmm1, xmm2, xmm3/m128
@@ -2764,7 +2764,7 @@ public:
         m_formatter.twoByteOp(OP2_PSUBSB_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpsubsb_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpsubsb_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/psubsb:psubsw
         // VEX.128.66.0F.WIG E8 /r VPSUBSB xmm1, xmm2, xmm3/m128
@@ -2781,7 +2781,7 @@ public:
         m_formatter.twoByteOp(OP2_PSUBUSB_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpsubusb_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpsubusb_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/psubusb:psubusw
         // VEX.128.66.0F.WIG D8 /r VPSUBUSB xmm1, xmm2, xmm3/m128
@@ -2798,7 +2798,7 @@ public:
         m_formatter.twoByteOp(OP2_PSUBSW_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpsubsw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpsubsw_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/psubsb:psubsw
         // VEX.128.66.0F.WIG E9 /r VPSUBSW xmm1, xmm2, xmm3/m128
@@ -2815,7 +2815,7 @@ public:
         m_formatter.twoByteOp(OP2_PSUBUSW_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpsubusw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpsubusw_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/psubusb:psubusw
         // VEX.128.66.0F.WIG D9 /r VPSUBUSW xmm1, xmm2, xmm3/m128
@@ -2832,7 +2832,7 @@ public:
         m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMAXSB_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpmaxsb_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpmaxsb_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pmaxsb:pmaxsw:pmaxsd:pmaxsq
         // VEX.128.66.0F38.WIG 3C /r VPMAXSB xmm1, xmm2, xmm3/m128
@@ -2849,7 +2849,7 @@ public:
         m_formatter.twoByteOp(OP2_PMAXSW_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpmaxsw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpmaxsw_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pmaxsb:pmaxsw:pmaxsd:pmaxsq
         // VEX.128.66.0F.WIG EE /r VPMAXSW xmm1, xmm2, xmm3/m128
@@ -2866,7 +2866,7 @@ public:
         m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMAXSD_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpmaxsd_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpmaxsd_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pmaxsb:pmaxsw:pmaxsd:pmaxsq
         // VEX.128.66.0F38.WIG 3D /r VPMAXSD xmm1, xmm2, xmm3/m128
@@ -2883,7 +2883,7 @@ public:
         m_formatter.twoByteOp(OP2_PMAXUB_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpmaxub_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpmaxub_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pmaxub:pmaxuw
         // VEX.128.66.0F DE /r VPMAXUB xmm1, xmm2, xmm3/m128
@@ -2899,7 +2899,7 @@ public:
         m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMAXUW_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpmaxuw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpmaxuw_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pmaxub:pmaxuw
         // VEX.128.66.0F38 3E /r VPMAXUW xmm1, xmm2, xmm3/m128
@@ -2916,7 +2916,7 @@ public:
         m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMAXUD_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpmaxud_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpmaxud_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pmaxud:pmaxuq
         // VEX.128.66.0F38.WIG 3F /r VPMAXUD xmm1, xmm2, xmm3/m128
@@ -2933,7 +2933,7 @@ public:
         m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMINSB_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpminsb_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpminsb_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pminsb:pminsw
         // VEX.128.66.0F38 38 /r VPMINSB xmm1, xmm2, xmm3/m128
@@ -2950,7 +2950,7 @@ public:
         m_formatter.twoByteOp(OP2_PMINSW_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpminsw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpminsw_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pminsb:pminsw
         // VEX.128.66.0F EA /r VPMINSW xmm1, xmm2, xmm3/m128
@@ -2966,7 +2966,7 @@ public:
         m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMINSD_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpminsd_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpminsd_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pminsd:pminsq
         // VEX.128.66.0F38.WIG 39 /r VPMINSD xmm1, xmm2, xmm3/m128
@@ -2983,7 +2983,7 @@ public:
         m_formatter.twoByteOp(OP2_PMINUB_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpminub_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpminub_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pminub:pminuw
         // VEX.128.66.0F DA /r VPMINUB xmm1, xmm2, xmm3/m128
@@ -2999,7 +2999,7 @@ public:
         m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMINUW_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpminuw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpminuw_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pminub:pminuw
         // VEX.128.66.0F38 3A /r VPMINUW xmm1, xmm2, xmm3/m128
@@ -3016,7 +3016,7 @@ public:
         m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMINUD_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpminud_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpminud_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pminud:pminuq
         // VEX.128.66.0F38.WIG 3B /r VPMINUD xmm1, xmm2, xmm3/m128
@@ -3033,7 +3033,7 @@ public:
         m_formatter.twoByteOp(OP2_PAVGB_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpavgb_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpavgb_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pavgb:pavgw
         // VEX.128.66.0F.WIG E0 /r VPAVGB xmm1, xmm2, xmm3/m128
@@ -3050,7 +3050,7 @@ public:
         m_formatter.twoByteOp(OP2_PAVGW_VdqWdq, (RegisterID)vd, (RegisterID)right);
     }
 
-    void vpavgw_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpavgw_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pavgb:pavgw
         // VEX.128.66.0F.WIG E3 /r VPAVGW xmm1, xmm2, xmm3/m128
@@ -3118,7 +3118,7 @@ public:
         m_formatter.twoByteOp(OP2_PXOR_VdqWdq, (RegisterID)vd, (RegisterID)vn);
     }
 
-    void vpxor_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpxor_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pxor
         // VEX.128.66.0F.WIG EF /r VPXOR xmm1, xmm2, xmm3/m128
@@ -3127,21 +3127,19 @@ public:
         m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PXOR_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
     }
 
-    void vpsubq_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
+    void vpsubq_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/psubq
         // VEX.128.66.0F.WIG FB /r VPSUBQ xmm1, xmm2, xmm3/m128
-        bool isVEX256 = false;
-        bool isW1 = false;
-        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_PSUBQ_VdqWdq, (RegisterID)vd, (RegisterID)right, (RegisterID)left);
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_PSUBQ_VdqWdq, (RegisterID)vd, (RegisterID)left, (RegisterID)right);
     }
 
-    void vblendvpd_rr(XMMRegisterID xmm4, XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vblendvpd_rrrr(XMMRegisterID xmm4, XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/blendvpd
         // VEX.128.66.0F3A.W0 4B /r /is4 VBLENDVPD xmm1, xmm2, xmm3/m128, xmm4
         bool isVEX256 = false;
-        bool isW1 = false;    
+        bool isW1 = false;
         m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, isW1, OP3_BLENDVPD_VpdWpdXMM0, xmm4, (RegisterID)xmm1, (RegisterID)xmm3, (RegisterID)xmm2);
     }
 
@@ -3154,7 +3152,7 @@ public:
         m_formatter.immediate8((uint8_t)imm8);
     }
 
-    void vpmulhrsw_rr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vpmulhrsw_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/pmulhrsw
         // VEX.128.66.0F38.WIG 0B /r VPMULHRSW xmm1, xmm2, xmm3/m128
@@ -3163,7 +3161,7 @@ public:
         m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, isW1, OP3_ROUNDSD_VsdWsdIb, (RegisterID)xmm1, (RegisterID)xmm3, (RegisterID)xmm2);
     }
 
-    void vpcmpeqw_rr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vpcmpeqw_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/pcmpeqb:pcmpeqw:pcmpeqd
         // VEX.128.66.0F.WIG 75 /r VPCMPEQW xmm1, xmm2, xmm3/m128
@@ -3186,47 +3184,42 @@ public:
 
     void vaddpd_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_ADDPD_VpdWpd, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_66, OP2_ADDPD_VpdWpd, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
     void vpaddb_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_PADDB_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_66, OP2_PADDB_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
     void vpaddw_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_PADDW_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_66, OP2_PADDW_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
     void vpaddd_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_PADDD_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_66, OP2_PADDD_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
     void vpaddq_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_PADDQ_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_66, OP2_PADDQ_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
     void vsubps_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigCommutativeTwoByteOp((OneByteOpcodeID)0, OP2_SUBPS_VpsWps, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
-    }
-
-    void vsubpd_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
-    {
-        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_SUBPD_VpdWpd, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+        m_formatter.vexNdsLigWigTwoByteOp((OneByteOpcodeID)0, OP2_SUBPS_VpsWps, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
     void vpsubb_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigTwoByteOp(PRE_OPERAND_SIZE, OP2_PSUBB_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_PSUBB_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
     void vpsubw_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigTwoByteOp(PRE_OPERAND_SIZE, OP2_PSUBW_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_PSUBW_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
     void psubd_rr(XMMRegisterID vn, XMMRegisterID vd)
@@ -3239,12 +3232,7 @@ public:
 
     void vpsubd_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigTwoByteOp(PRE_OPERAND_SIZE, OP2_PSUBD_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
-    }
-
-    void vpsubq_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
-    {
-        m_formatter.vexNdsLigWigTwoByteOp(PRE_OPERAND_SIZE, OP2_PSUBQ_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_PSUBD_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
     void vmulps_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
@@ -3254,17 +3242,17 @@ public:
 
     void vmulpd_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_MULPD_VpdWpd, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_66, OP2_MULPD_VpdWpd, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
     void vpmullw_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_PMULLW_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_66, OP2_PMULLW_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
     void vpmulld_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigThreeByteOp(PRE_OPERAND_SIZE, VexImpliedBytes::ThreeBytesOp38, OP3_PMULLD_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PMULLD_VdqWdq, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
     void vdivps_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
@@ -3274,7 +3262,7 @@ public:
 
     void vdivpd_rrr(XMMRegisterID left, XMMRegisterID right, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_DIVPD_VpdWpd, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_66, OP2_DIVPD_VpdWpd, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
     enum class RoundingType : uint8_t {
@@ -3286,54 +3274,54 @@ public:
 
     void vroundps_rr(FPRegisterID src, FPRegisterID dest, RoundingType rounding)
     {
-        m_formatter.vexNdsLigWigThreeByteOp(PRE_OPERAND_SIZE, VexImpliedBytes::ThreeBytesOp3A, OP3_ROUNDPS_VpsWpsIb, (RegisterID)dest, (RegisterID)0, (RegisterID)src);
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, OP3_ROUNDPS_VpsWpsIb, (RegisterID)dest, (RegisterID)0, (RegisterID)src);
         m_formatter.immediate8(static_cast<uint8_t>(rounding));
     }
 
     void vroundpd_rr(FPRegisterID src, FPRegisterID dest, RoundingType rounding)
     {
-        m_formatter.vexNdsLigWigThreeByteOp(PRE_OPERAND_SIZE, VexImpliedBytes::ThreeBytesOp3A, OP3_ROUNDPD_VpdWpdIb, (RegisterID)dest, (RegisterID)0, (RegisterID)src);
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, OP3_ROUNDPD_VpdWpdIb, (RegisterID)dest, (RegisterID)0, (RegisterID)src);
         m_formatter.immediate8(static_cast<uint8_t>(rounding));
     }
 
     void vpmaddwd_rrr(FPRegisterID a, FPRegisterID b, FPRegisterID dest)
     {
-        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_PMADDWD_VdqWdq, (RegisterID)dest, (RegisterID)a, (RegisterID)b);
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_66, OP2_PMADDWD_VdqWdq, (RegisterID)dest, (RegisterID)a, (RegisterID)b);
     }
 
-    void vpcmpeqb_rr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
+    void vpcmpeqb_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_PCMPEQB_VdqWdq, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_66, OP2_PCMPEQB_VdqWdq, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
     }
 
-    void vpcmpeqd_rr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
+    void vpcmpeqd_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_PCMPEQD_VdqWdq, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
+        m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_66, OP2_PCMPEQD_VdqWdq, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
     }
 
-    void vpcmpeqq_rr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
+    void vpcmpeqq_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigThreeByteOp(PRE_OPERAND_SIZE, VexImpliedBytes::ThreeBytesOp38, OP3_PCMPEQQ_VdqWdq, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PCMPEQQ_VdqWdq, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
     }
 
-    void vpcmpgtb_rr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
+    void vpcmpgtb_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigTwoByteOp(PRE_OPERAND_SIZE, OP2_PCMPGTB_VdqWdq, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_PCMPGTB_VdqWdq, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
     }
 
-    void vpcmpgtw_rr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
+    void vpcmpgtw_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigTwoByteOp(PRE_OPERAND_SIZE, OP2_PCMPGTW_VdqWdq, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_PCMPGTW_VdqWdq, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
     }
 
-    void vpcmpgtd_rr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
+    void vpcmpgtd_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigTwoByteOp(PRE_OPERAND_SIZE, OP2_PCMPGTD_VdqWdq, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_PCMPGTD_VdqWdq, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
     }
 
-    void vpcmpgtq_rr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
+    void vpcmpgtq_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
     {
-        m_formatter.vexNdsLigWigThreeByteOp(PRE_OPERAND_SIZE, VexImpliedBytes::ThreeBytesOp38, OP3_PCMPGTQ_VdqWdq, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PCMPGTQ_VdqWdq, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
     }
 
     enum class PackedCompareCondition : uint8_t {
@@ -3347,7 +3335,7 @@ public:
         Ordered = 7
     };
 
-    void vcmpps_rr(PackedCompareCondition condition, XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
+    void vcmpps_rrr(PackedCompareCondition condition, XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
     {
         if (condition == PackedCompareCondition::Equal || condition == PackedCompareCondition::NotEqual)
             m_formatter.vexNdsLigWigCommutativeTwoByteOp((OneByteOpcodeID)0, OP2_CMPPS_VpsWpsIb, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
@@ -3356,12 +3344,12 @@ public:
         m_formatter.immediate8(static_cast<uint8_t>(condition));
     }
 
-    void vcmppd_rr(PackedCompareCondition condition, XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
+    void vcmppd_rrr(PackedCompareCondition condition, XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
     {
         if (condition == PackedCompareCondition::Equal || condition == PackedCompareCondition::NotEqual)
-            m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_OPERAND_SIZE, OP2_CMPPD_VpdWpdIb, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
+            m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_66, OP2_CMPPD_VpdWpdIb, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
         else
-            m_formatter.vexNdsLigWigTwoByteOp(PRE_OPERAND_SIZE, OP2_CMPPD_VpdWpdIb, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
+            m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_CMPPD_VpdWpdIb, (RegisterID)a, (RegisterID)b, (RegisterID)dest);
         m_formatter.immediate8(static_cast<uint8_t>(condition));
     }
 
@@ -3377,7 +3365,7 @@ public:
         // https://www.felixcloutier.com/x86/cvtdq2ps
         // VEX.128.0F.WIG 5B /r VCVTDQ2PS xmm1, xmm2/m128
         bool isVEX256 = false;
-        bool isW1 = false;    
+        bool isW1 = false;
         m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_00, VexImpliedBytes::TwoBytesOp, isW1, OP2_CVTDQ2PS_VsdWsd, (RegisterID)vd, (RegisterID)vn, (RegisterID)0);
     }
 
@@ -3394,43 +3382,42 @@ public:
         // https://www.felixcloutier.com/x86/cvtdq2pd
         // VEX.128.F3.0F.WIG E6 /r VCVTDQ2PD xmm1, xmm2/m64
         bool isVEX256 = false;
-        bool isW1 = false;    
+        bool isW1 = false;
         m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_F3, VexImpliedBytes::TwoBytesOp, isW1, OP2_CVTDQ2PD_VdqWdq, (RegisterID)vd, (RegisterID)vn, (RegisterID)0);
     }
 
-    void vsubpd_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID dest)
+    void vsubpd_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID dest)
     {
         // https://www.felixcloutier.com/x86/subpd
         // VEX.128.66.0F.WIG 5C /r VSUBPD xmm1,xmm2, xmm3/m128
-        bool isVEX256 = false;
-        bool isW1 = false;    
-        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_SUBSD_VsdWsd, (RegisterID)dest, (RegisterID)right, (RegisterID)left);
+        // Sub is xmm1 = xmm2 - xmm3
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_SUBPD_VpdWpd, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
-    void vxorpd_rr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vxorpd_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/xorpd
         // VEX.128.66.0F.WIG 57 /r VXORPD xmm1, xmm2, xmm3/m128
         bool isVEX256 = false;
-        bool isW1 = false;    
+        bool isW1 = false;
         m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_XORPD_VpdWpd, (RegisterID)xmm1, (RegisterID)xmm3, (RegisterID)xmm2);
     }
 
-    void vmaxpd_rr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vmaxpd_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/maxpd
         // VEX.128.66.0F.WIG 5F /r VMAXPD xmm1, xmm2, xmm3/m128
         bool isVEX256 = false;
-        bool isW1 = false;    
+        bool isW1 = false;
         m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_MAXPD_VsdWsd, (RegisterID)xmm1, (RegisterID)xmm3, (RegisterID)xmm2);
     }
 
-    void vminpd_rr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vminpd_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/minpd
         // VEX.128.66.0F.WIG 5D /r VMINPD xmm1, xmm2, xmm3/m128
         bool isVEX256 = false;
-        bool isW1 = false;    
+        bool isW1 = false;
         m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_MINPD_VsdWsd, (RegisterID)xmm1, (RegisterID)xmm3, (RegisterID)xmm2);
     }
 
@@ -3439,20 +3426,11 @@ public:
         // https://www.felixcloutier.com/x86/roundpd
         // VEX.128.66.0F3A.WIG 09 /r ib VROUNDPD xmm1, xmm2/m128, imm8
         bool isVEX256 = false;
-        bool isW1 = false;    
+        bool isW1 = false;
         m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, isW1, OP3_ROUNDPD_MbVdqIb, imm8, (RegisterID)xmm1, (RegisterID)xmm2);
     }
 
-    void vaddpd_rr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID dest)
-    {
-        // https://www.felixcloutier.com/x86/addpd
-        // VEX.128.66.0F.WIG 58 /r VADDPD xmm1, xmm2, xmm3/m128
-        bool isVEX256 = false;
-        bool isW1 = false;
-        m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_ADDSD_VsdWsd, (RegisterID)dest, (RegisterID)right, (RegisterID)left);
-    }
-
-    void vcmppd_rr(uint8_t imm8, XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vcmppd_rrr(uint8_t imm8, XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/cmppd
         // VEX.128.66.0F.WIG C2 /r ib VCMPPD xmm1, xmm2, xmm3/m128, imm8
@@ -3461,10 +3439,10 @@ public:
         m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_CMPPD_VpdWpdIb, imm8, (RegisterID)xmm1, (RegisterID)xmm3, (RegisterID)xmm2);
     }
 
-    void vcmpeqpd_rr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vcmpeqpd_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/cmppd
-        vcmppd_rr(0, xmm3, xmm2, xmm1);
+        vcmppd_rrr(0, xmm3, xmm2, xmm1);
     }
 
     void vcvttpd2dq_rr(XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -3476,7 +3454,7 @@ public:
         m_formatter.vexThreeByteOp(isVEX256, PRE_SSE_66, VexImpliedBytes::TwoBytesOp, isW1, OP2_CVTDQ2PD_VdqWdq, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)0);
     }
 
-    void vandpd_rr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vandpd_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/andpd
         // VEX.128.66.0F 54 /r VANDPD xmm1, xmm2, xmm3/m128
@@ -3511,7 +3489,7 @@ public:
         m_formatter.twoByteOp(OP2_PACKSSWB_VdqWdq, (RegisterID)xmm1, (RegisterID)xmm2);
     }
 
-    void vpacksswb_rr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vpacksswb_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/packsswb:packssdw
         // VEX.128.66.0F.WIG 63 /r VPACKSSWB xmm1,xmm2, xmm3/m128
@@ -3528,7 +3506,7 @@ public:
         m_formatter.twoByteOp(OP2_PACKUSWB_VdqWdq, (RegisterID)dest, (RegisterID)upper);
     }
 
-    void vpackuswb_rr(XMMRegisterID upper, XMMRegisterID lower, XMMRegisterID dest)
+    void vpackuswb_rrr(XMMRegisterID upper, XMMRegisterID lower, XMMRegisterID dest)
     {
         // https://www.felixcloutier.com/x86/packuswb
         // VEX.128.66.0F.WIG 67 /r VPACKUSWB xmm1, xmm2, xmm3/m128
@@ -3545,7 +3523,7 @@ public:
         m_formatter.twoByteOp(OP2_PACKSSDW_VdqWdq, (RegisterID)xmm1, (RegisterID)xmm2);
     }
 
-    void vpackssdw_rr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vpackssdw_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/packsswb:packssdw
         // VEX.128.66.0F.WIG 6B /r VPACKSSDW xmm1,xmm2, xmm3/m128
@@ -3562,7 +3540,7 @@ public:
         m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PACKUSDW, (RegisterID)xmm1, (RegisterID)xmm2);
     }
 
-    void vpackusdw_rr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vpackusdw_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/packusdw
         // VEX.128.66.0F38 2B /r VPACKUSDW xmm1,xmm2, xmm3/m128
@@ -4282,7 +4260,7 @@ public:
         m_formatter.twoByteOp(OP2_ADDSD_VsdWsd, (RegisterID)dst, (RegisterID)src);
     }
 
-    void vaddsd_rr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dst)
+    void vaddsd_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dst)
     {
         m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_F2, OP2_ADDSD_VsdWsd, (RegisterID)dst, (RegisterID)a, (RegisterID)b);
     }
@@ -4315,7 +4293,7 @@ public:
         m_formatter.twoByteOp(OP2_ADDSD_VsdWsd, (RegisterID)dst, (RegisterID)src);
     }
 
-    void vaddss_rr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dst)
+    void vaddss_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dst)
     {
         m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_F3, OP2_ADDSD_VsdWsd, (RegisterID)dst, (RegisterID)a, (RegisterID)b);
     }
@@ -4631,7 +4609,7 @@ public:
         m_formatter.twoByteOp(OP2_MULSD_VsdWsd, (RegisterID)dst, (RegisterID)src);
     }
 
-    void vmulsd_rr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dst)
+    void vmulsd_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dst)
     {
         m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_F2, OP2_MULSD_VsdWsd, (RegisterID)dst, (RegisterID)a, (RegisterID)b);
     }
@@ -4664,7 +4642,7 @@ public:
         m_formatter.twoByteOp(OP2_MULSD_VsdWsd, (RegisterID)dst, (RegisterID)src);
     }
 
-    void vmulss_rr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dst)
+    void vmulss_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dst)
     {
         m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_F3, OP2_MULSD_VsdWsd, (RegisterID)dst, (RegisterID)a, (RegisterID)b);
     }
@@ -4733,7 +4711,7 @@ public:
         m_formatter.twoByteOp(OP2_SUBSD_VsdWsd, (RegisterID)dst, (RegisterID)src);
     }
 
-    void vsubsd_rr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dst)
+    void vsubsd_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dst)
     {
         m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_SUBSD_VsdWsd, (RegisterID)dst, (RegisterID)a, (RegisterID)b);
     }
@@ -4766,7 +4744,7 @@ public:
         m_formatter.twoByteOp(OP2_SUBSD_VsdWsd, (RegisterID)dst, (RegisterID)src);
     }
 
-    void vsubss_rr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dst)
+    void vsubss_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dst)
     {
         m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_SUBSD_VsdWsd, (RegisterID)dst, (RegisterID)a, (RegisterID)b);
     }


### PR DESCRIPTION
#### 7a283b10d320b433d6ebb1f7dce4df1c5c508059
<pre>
[JSC] Fix X86Assembler namings
<a href="https://bugs.webkit.org/show_bug.cgi?id=249000">https://bugs.webkit.org/show_bug.cgi?id=249000</a>
rdar://103160841

Reviewed by Ross Kirsling and Justin Michaud.

1. AVX instructions taking three registers should have _rrr postfix.
2. AVX&apos;s 0x66 is not PRE_OPERAND_SIZE, coming from PRE_SSE_66.

* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h:
(JSC::MacroAssemblerX86Common::addDouble):
(JSC::MacroAssemblerX86Common::addFloat):
(JSC::MacroAssemblerX86Common::subDouble):
(JSC::MacroAssemblerX86Common::subFloat):
(JSC::MacroAssemblerX86Common::mulDouble):
(JSC::MacroAssemblerX86Common::mulFloat):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::compareFloatingPointVector):
(JSC::MacroAssemblerX86_64::compareIntegerVector):
(JSC::MacroAssemblerX86_64::vectorMax):
(JSC::MacroAssemblerX86_64::vectorMin):
(JSC::MacroAssemblerX86_64::vectorAbs):
(JSC::MacroAssemblerX86_64::vectorSignedTruncSatF64):
(JSC::MacroAssemblerX86_64::vectorUnsignedTruncSatF64):
(JSC::MacroAssemblerX86_64::vectorNarrow):
(JSC::MacroAssemblerX86_64::vectorConvertLow):
(JSC::MacroAssemblerX86_64::vectorAddSat):
(JSC::MacroAssemblerX86_64::vectorSubSat):
(JSC::MacroAssemblerX86_64::vectorAvgRound):
(JSC::MacroAssemblerX86_64::vectorMulSat):
(JSC::MacroAssemblerX86_64::vectorSwizzle):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::vunpcklps_rrr):
(JSC::X86Assembler::vpshufb_rrr):
(JSC::X86Assembler::vshufps_rrr):
(JSC::X86Assembler::vpaddsb_rrr):
(JSC::X86Assembler::vpaddusb_rrr):
(JSC::X86Assembler::vpaddsw_rrr):
(JSC::X86Assembler::vpaddusw_rrr):
(JSC::X86Assembler::vpsubsb_rrr):
(JSC::X86Assembler::vpsubusb_rrr):
(JSC::X86Assembler::vpsubsw_rrr):
(JSC::X86Assembler::vpsubusw_rrr):
(JSC::X86Assembler::vpmaxsb_rrr):
(JSC::X86Assembler::vpmaxsw_rrr):
(JSC::X86Assembler::vpmaxsd_rrr):
(JSC::X86Assembler::vpmaxub_rrr):
(JSC::X86Assembler::vpmaxuw_rrr):
(JSC::X86Assembler::vpmaxud_rrr):
(JSC::X86Assembler::vpminsb_rrr):
(JSC::X86Assembler::vpminsw_rrr):
(JSC::X86Assembler::vpminsd_rrr):
(JSC::X86Assembler::vpminub_rrr):
(JSC::X86Assembler::vpminuw_rrr):
(JSC::X86Assembler::vpminud_rrr):
(JSC::X86Assembler::vpavgb_rrr):
(JSC::X86Assembler::vpavgw_rrr):
(JSC::X86Assembler::vpxor_rrr):
(JSC::X86Assembler::vpsubq_rrr):
(JSC::X86Assembler::vblendvpd_rrrr):
(JSC::X86Assembler::vpmulhrsw_rrr):
(JSC::X86Assembler::vpcmpeqw_rrr):
(JSC::X86Assembler::vaddpd_rrr):
(JSC::X86Assembler::vpaddb_rrr):
(JSC::X86Assembler::vpaddw_rrr):
(JSC::X86Assembler::vpaddd_rrr):
(JSC::X86Assembler::vpaddq_rrr):
(JSC::X86Assembler::vsubpd_rrr):
(JSC::X86Assembler::vpsubb_rrr):
(JSC::X86Assembler::vpsubw_rrr):
(JSC::X86Assembler::vpsubd_rrr):
(JSC::X86Assembler::vmulpd_rrr):
(JSC::X86Assembler::vpmullw_rrr):
(JSC::X86Assembler::vpmulld_rrr):
(JSC::X86Assembler::vdivpd_rrr):
(JSC::X86Assembler::vroundps_rr):
(JSC::X86Assembler::vroundpd_rr):
(JSC::X86Assembler::vpmaddwd_rrr):
(JSC::X86Assembler::vpcmpeqb_rrr):
(JSC::X86Assembler::vpcmpeqd_rrr):
(JSC::X86Assembler::vpcmpeqq_rrr):
(JSC::X86Assembler::vpcmpgtb_rrr):
(JSC::X86Assembler::vpcmpgtw_rrr):
(JSC::X86Assembler::vpcmpgtd_rrr):
(JSC::X86Assembler::vpcmpgtq_rrr):
(JSC::X86Assembler::vcmpps_rrr):
(JSC::X86Assembler::vcmppd_rrr):
(JSC::X86Assembler::vxorpd_rrr):
(JSC::X86Assembler::vmaxpd_rrr):
(JSC::X86Assembler::vminpd_rrr):
(JSC::X86Assembler::vcmpeqpd_rrr):
(JSC::X86Assembler::vandpd_rrr):
(JSC::X86Assembler::vpacksswb_rrr):
(JSC::X86Assembler::vpackuswb_rrr):
(JSC::X86Assembler::vpackssdw_rrr):
(JSC::X86Assembler::vpackusdw_rrr):
(JSC::X86Assembler::vaddsd_rrr):
(JSC::X86Assembler::vaddss_rrr):
(JSC::X86Assembler::vmulsd_rrr):
(JSC::X86Assembler::vmulss_rrr):
(JSC::X86Assembler::vsubsd_rrr):
(JSC::X86Assembler::vsubss_rrr):
(JSC::X86Assembler::vunpcklps_rr): Deleted.
(JSC::X86Assembler::vpshufb_rr): Deleted.
(JSC::X86Assembler::vshufps_rr): Deleted.
(JSC::X86Assembler::vpaddsb_rr): Deleted.
(JSC::X86Assembler::vpaddusb_rr): Deleted.
(JSC::X86Assembler::vpaddsw_rr): Deleted.
(JSC::X86Assembler::vpaddusw_rr): Deleted.
(JSC::X86Assembler::vpsubsb_rr): Deleted.
(JSC::X86Assembler::vpsubusb_rr): Deleted.
(JSC::X86Assembler::vpsubsw_rr): Deleted.
(JSC::X86Assembler::vpsubusw_rr): Deleted.
(JSC::X86Assembler::vpmaxsb_rr): Deleted.
(JSC::X86Assembler::vpmaxsw_rr): Deleted.
(JSC::X86Assembler::vpmaxsd_rr): Deleted.
(JSC::X86Assembler::vpmaxub_rr): Deleted.
(JSC::X86Assembler::vpmaxuw_rr): Deleted.
(JSC::X86Assembler::vpmaxud_rr): Deleted.
(JSC::X86Assembler::vpminsb_rr): Deleted.
(JSC::X86Assembler::vpminsw_rr): Deleted.
(JSC::X86Assembler::vpminsd_rr): Deleted.
(JSC::X86Assembler::vpminub_rr): Deleted.
(JSC::X86Assembler::vpminuw_rr): Deleted.
(JSC::X86Assembler::vpminud_rr): Deleted.
(JSC::X86Assembler::vpavgb_rr): Deleted.
(JSC::X86Assembler::vpavgw_rr): Deleted.
(JSC::X86Assembler::vpxor_rr): Deleted.
(JSC::X86Assembler::vpsubq_rr): Deleted.
(JSC::X86Assembler::vblendvpd_rr): Deleted.
(JSC::X86Assembler::vpmulhrsw_rr): Deleted.
(JSC::X86Assembler::vpcmpeqw_rr): Deleted.
(JSC::X86Assembler::vpcmpeqb_rr): Deleted.
(JSC::X86Assembler::vpcmpeqd_rr): Deleted.
(JSC::X86Assembler::vpcmpeqq_rr): Deleted.
(JSC::X86Assembler::vpcmpgtb_rr): Deleted.
(JSC::X86Assembler::vpcmpgtw_rr): Deleted.
(JSC::X86Assembler::vpcmpgtd_rr): Deleted.
(JSC::X86Assembler::vpcmpgtq_rr): Deleted.
(JSC::X86Assembler::vcmpps_rr): Deleted.
(JSC::X86Assembler::vcmppd_rr): Deleted.
(JSC::X86Assembler::vsubpd_rr): Deleted.
(JSC::X86Assembler::vxorpd_rr): Deleted.
(JSC::X86Assembler::vmaxpd_rr): Deleted.
(JSC::X86Assembler::vminpd_rr): Deleted.
(JSC::X86Assembler::vaddpd_rr): Deleted.
(JSC::X86Assembler::vcmpeqpd_rr): Deleted.
(JSC::X86Assembler::vandpd_rr): Deleted.
(JSC::X86Assembler::vpacksswb_rr): Deleted.
(JSC::X86Assembler::vpackuswb_rr): Deleted.
(JSC::X86Assembler::vpackssdw_rr): Deleted.
(JSC::X86Assembler::vpackusdw_rr): Deleted.
(JSC::X86Assembler::vaddsd_rr): Deleted.
(JSC::X86Assembler::vaddss_rr): Deleted.
(JSC::X86Assembler::vmulsd_rr): Deleted.
(JSC::X86Assembler::vmulss_rr): Deleted.
(JSC::X86Assembler::vsubsd_rr): Deleted.
(JSC::X86Assembler::vsubss_rr): Deleted.

Canonical link: <a href="https://commits.webkit.org/257610@main">https://commits.webkit.org/257610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dac1dce1306327249374bd05e55a226a541e0694

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8657 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32573 "Failed to checkout and rebase branch from PR 7370") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/108846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169076 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85965 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105238 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/32573 "Failed to checkout and rebase branch from PR 7370") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/91950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/32573 "Failed to checkout and rebase branch from PR 7370") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/90137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/32573 "Failed to checkout and rebase branch from PR 7370") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86022 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2433 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28916 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/8587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/32573 "Failed to checkout and rebase branch from PR 7370") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88891 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2681 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19883 "Passed tests") | 
<!--EWS-Status-Bubble-End-->