### PR TITLE
Don't implement DisplayList::ResourceHeap in QualifiedResourceHeap.

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h
+++ b/Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h
@@ -28,16 +28,17 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "QualifiedRenderingResourceIdentifier.h"
-#include <WebCore/DisplayListResourceHeap.h>
+#include <WebCore/DecomposedGlyphs.h>
 #include <WebCore/Font.h>
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/NativeImage.h>
 #include <WebCore/ProcessIdentifier.h>
+#include <WebCore/SourceImage.h>
 #include <wtf/HashMap.h>
 
 namespace WebKit {
 
-class QualifiedResourceHeap : public WebCore::DisplayList::ResourceHeap {
+class QualifiedResourceHeap {
 public:
     QualifiedResourceHeap(WebCore::ProcessIdentifier webProcessIdentifier)
         : m_webProcessIdentifier(webProcessIdentifier)
@@ -62,31 +63,6 @@ public:
     void add(QualifiedRenderingResourceIdentifier renderingResourceIdentifier, Ref<WebCore::DecomposedGlyphs>&& decomposedGlyphs)
     {
         add(renderingResourceIdentifier, WTFMove(decomposedGlyphs), m_decomposedGlyphsCount);
-    }
-
-    WebCore::ImageBuffer* getImageBuffer(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) const final
-    {
-        return get<WebCore::ImageBuffer>({ renderingResourceIdentifier, m_webProcessIdentifier });
-    }
-
-    WebCore::NativeImage* getNativeImage(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) const final
-    {
-        return get<WebCore::NativeImage>({ renderingResourceIdentifier, m_webProcessIdentifier });
-    }
-
-    std::optional<WebCore::SourceImage> getSourceImage(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) const final
-    {
-        return getSourceImage({ renderingResourceIdentifier, m_webProcessIdentifier });
-    }
-
-    WebCore::Font* getFont(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) const final
-    {
-        return get<WebCore::Font>({ renderingResourceIdentifier, m_webProcessIdentifier });
-    }
-
-    WebCore::DecomposedGlyphs* getDecomposedGlyphs(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) const final
-    {
-        return get<WebCore::DecomposedGlyphs>({ renderingResourceIdentifier, m_webProcessIdentifier });
     }
 
     WebCore::ImageBuffer* getImageBuffer(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -30,6 +30,7 @@
 #include "QualifiedRenderingResourceIdentifier.h"
 #include "RemoteRenderingBackend.h"
 #include "ScopedActiveMessageReceiveQueue.h"
+#include "ScopedRenderingResourcesRequest.h"
 #include <WebCore/ImageBuffer.h>
 
 namespace WebKit {

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -179,7 +179,7 @@ void RemoteRenderingBackend::createImageBufferWithQualifiedIdentifier(const Floa
 {
     ASSERT(!RunLoop::isMain());
 
-    RefPtr<ImageBuffer> imageBuffer;
+    RefPtr<WebCore::ImageBuffer> imageBuffer;
 
     if (renderingMode == RenderingMode::Accelerated) {
         if (auto acceleratedImageBuffer = RemoteImageBuffer::create<AcceleratedImageBufferShareableMappedBackend>(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, *this, imageBufferResourceIdentifier)) {


### PR DESCRIPTION
#### d8c8e323ec248b3c8b0899d9b3cd2a047dcd8d34
<pre>
Don&apos;t implement DisplayList::ResourceHeap in QualifiedResourceHeap.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249001">https://bugs.webkit.org/show_bug.cgi?id=249001</a>

Reviewed by Simon Fraser.

None of the base class gets used, so we might as well skip it.

* Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h:
(WebKit::QualifiedResourceHeap::add):
(WebKit::QualifiedResourceHeap::getImageBuffer const):
(WebKit::QualifiedResourceHeap::removeImageBuffer):
(WebKit::QualifiedResourceHeap::checkInvariants const):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::transferImageBuffer):

Canonical link: <a href="https://commits.webkit.org/257693@main">https://commits.webkit.org/257693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b96dd4f3c9adfa4463249de785f455356e4eb25a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109064 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86168 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92163 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106972 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105473 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7166 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34100 "An unexpected error occured. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22014 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-004.html, media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2701 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23529 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45911 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5289 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43003 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4508 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->