### PR TITLE
[css-contain-intrinsic-size] Introduce last remembered size to Element

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4414,6 +4414,22 @@ ResizeObserverData* Element::resizeObserverData()
     return hasRareData() ? elementRareData()->resizeObserverData() : nullptr;
 }
 
+ResizeObserverSize* Element::lastRememberedSize() const
+{
+    return hasRareData() ? elementRareData()->lastRememberedSize() : nullptr;
+}
+
+void Element::setLastRememberedSize(Ref<ResizeObserverSize>&& size)
+{
+    ensureElementRareData().setLastRememberedSize(WTFMove(size));
+}
+
+void Element::clearLastRememberedSize()
+{
+    if (hasRareData())
+        elementRareData()->clearLastRememberedSize();
+}
+
 bool Element::isSpellCheckingEnabled() const
 {
     for (auto* ancestor = this; ancestor; ancestor = ancestor->parentOrShadowHostElement()) {

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -73,6 +73,7 @@ class PlatformWheelEvent;
 class PseudoElement;
 class RenderStyle;
 class RenderTreePosition;
+class ResizeObserverSize;
 class SpaceSplitString;
 class StylePropertyMap;
 class StylePropertyMapReadOnly;
@@ -679,6 +680,10 @@ public:
 
     ResizeObserverData& ensureResizeObserverData();
     ResizeObserverData* resizeObserverData();
+
+    ResizeObserverSize* lastRememberedSize() const;
+    void setLastRememberedSize(Ref<ResizeObserverSize>&&);
+    void clearLastRememberedSize();
 
     Element* findAnchorElementForLink(String& outAnchorName);
 

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -40,6 +40,7 @@ struct SameSizeAsElementRareData : NodeRareData {
     void* intersectionObserverData;
     void* typedOMData[2];
     void* resizeObserverData;
+    void* resizeObserverSize;
     ExplicitlySetAttrElementsMap explicitlySetAttrElementsMap;
 };
 

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -33,6 +33,7 @@
 #include "PseudoElement.h"
 #include "RenderElement.h"
 #include "ResizeObserver.h"
+#include "ResizeObserverSize.h"
 #include "ShadowRoot.h"
 #include "SpaceSplitString.h"
 #include "StylePropertyMap.h"
@@ -103,6 +104,10 @@ public:
     ResizeObserverData* resizeObserverData() { return m_resizeObserverData.get(); }
     void setResizeObserverData(std::unique_ptr<ResizeObserverData>&& data) { m_resizeObserverData = WTFMove(data); }
 
+    ResizeObserverSize* lastRememberedSize() const { return m_lastRememberedSize.get(); }
+    void setLastRememberedSize(RefPtr<ResizeObserverSize>&& size) { m_lastRememberedSize = WTFMove(size); }
+    void clearLastRememberedSize() { m_lastRememberedSize = nullptr; }
+
     const AtomString& nonce() const { return m_nonce; }
     void setNonce(const AtomString& value) { m_nonce = value; }
 
@@ -140,7 +145,7 @@ public:
             result.add(UseType::AttributeMap);
         if (m_intersectionObserverData)
             result.add(UseType::InteractionObserver);
-        if (m_resizeObserverData)
+        if (m_resizeObserverData || m_lastRememberedSize)
             result.add(UseType::ResizeObserver);
         if (!m_animationRareData.isEmpty())
             result.add(UseType::Animations);
@@ -177,6 +182,7 @@ private:
     std::unique_ptr<IntersectionObserverData> m_intersectionObserverData;
 
     std::unique_ptr<ResizeObserverData> m_resizeObserverData;
+    RefPtr<ResizeObserverSize> m_lastRememberedSize;
 
     Vector<std::unique_ptr<ElementAnimationRareData>> m_animationRareData;
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -75,6 +75,7 @@
 #include "RenderTableCell.h"
 #include "RenderTheme.h"
 #include "RenderView.h"
+#include "ResizeObserverSize.h"
 #include "RuntimeApplicationChecks.h"
 #include "SVGClipPathElement.h"
 #include "SVGElementTypeHelpers.h"
@@ -5540,6 +5541,11 @@ std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerWidth() const
     if (style().containIntrinsicWidthType() == ContainIntrinsicSizeType::None)
         return std::nullopt;
 
+    if (element() && style().containIntrinsicWidthType() == ContainIntrinsicSizeType::AutoAndLength && shouldSkipContent()) {
+        if (auto lastRememberedSize = element()->lastRememberedSize())
+            return isHorizontalWritingMode() ? LayoutUnit(lastRememberedSize->inlineSize()) : LayoutUnit(lastRememberedSize->blockSize());
+    }
+
     auto width = style().containIntrinsicWidth();
     ASSERT(width.has_value());
     return std::optional<LayoutUnit> { width->value() };
@@ -5550,6 +5556,11 @@ std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerHeight() const
     ASSERT(shouldApplySizeContainment());
     if (style().containIntrinsicHeightType() == ContainIntrinsicSizeType::None)
         return std::nullopt;
+
+    if (element() && style().containIntrinsicHeightType() == ContainIntrinsicSizeType::AutoAndLength && shouldSkipContent()) {
+        if (auto lastRememberedSize = element()->lastRememberedSize())
+            return isHorizontalWritingMode() ? LayoutUnit(lastRememberedSize->blockSize()) : LayoutUnit(lastRememberedSize->inlineSize());
+    }
 
     auto height = style().containIntrinsicHeight();
     ASSERT(height.has_value());


### PR DESCRIPTION
#### 0ef6378c4923a62d3ea1cf172308b9a8ffd2431e
<pre>
[css-contain-intrinsic-size] Introduce last remembered size to Element
<a href="https://bugs.webkit.org/show_bug.cgi?id=248998">https://bugs.webkit.org/show_bug.cgi?id=248998</a>

Reviewed by Cameron McCormack.

Per[1], when contain-intrinsic-size is with the auto-length value, the last remembered size could be its explicit intrinsic inner size.
This patch introduce last remembered size to Element, and the work related to ResizeObserver will be done in the follow-up patches.

[1] <a href="https://w3c.github.io/csswg-drafts/css-sizing-4/#valdef-contain-intrinsic-width-auto-length">https://w3c.github.io/csswg-drafts/css-sizing-4/#valdef-contain-intrinsic-width-auto-length</a>

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::lastRememberedSize const):
(WebCore::Element::setLastRememberedSize):
(WebCore::Element::clearLastRememberedSize):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::lastRememberedSize const): The lastRememberedSize is a RefPtr of ResizeObserverSize, and is stored it in ElementRareData.
(WebCore::ElementRareData::setLastRememberedSize):
(WebCore::ElementRareData::clearLastRememberedSize):
(WebCore::ElementRareData::useTypes const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::explicitIntrinsicInnerWidth const): Handle AutoAndLength and use lastRememberedSize if exist.
(WebCore::RenderBox::explicitIntrinsicInnerHeight const):

Canonical link: <a href="https://commits.webkit.org/258183@main">https://commits.webkit.org/258183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d5b99d3d4905c5a08de3f345f5bceca866f1e6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110405 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170655 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1138 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93515 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108235 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35079 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23137 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78072 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3917 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24654 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1062 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44163 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5717 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->