### PR TITLE
CSS `::marker` does not support defining CSS variables

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable-computed-style-expected.txt
@@ -1,0 +1,6 @@
+Item 1
+Item 2
+
+PASS getComputedStyle() for opacity defined by variable in ::marker
+PASS getComputedStyle() for color defined by variable in ::marker
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable-computed-style.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <link rel="author" title="Karl Dubost" href="https://github.com/karlcow" />
+    <link rel="help" href="https://w3c.github.io/csswg-drafts/css-pseudo/#marker-pseudo" />
+    <link rel="help" href="https://w3c.github.io/csswg-drafts/css-variables/#defining-variables" />
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <title>::marker with variables</title>
+    <style>
+        .firstTest::marker {
+            --alpha: 0.75;
+            color: rgba(0 128 0 / var(--alpha));
+        }
+
+        .secondTest::marker {
+            --color: rgb(0 128 0);
+            color: var(--color);
+        }
+    </style>
+</head>
+
+<body>
+    <ul>
+        <li class="firstTest">Item 1</li>
+        <li class="secondTest">Item 2</li>
+    </ul>
+    <script>
+        test(() => {
+            let firstTest = document.querySelector('.firstTest');
+            let markerStyle = getComputedStyle(firstTest, '::marker');
+            assert_equals(markerStyle.color, "rgba(0, 128, 0, 0.75)", "color is green with 0.75 opacity.");
+        }, `getComputedStyle() for opacity defined by variable in ::marker`);
+        test(() => {
+            let secondTest = document.querySelector('.secondTest');
+            let markerStyle = getComputedStyle(secondTest, '::marker');
+            assert_equals(markerStyle.color, "rgb(0, 128, 0)", "color is green.");
+        }, `getComputedStyle() for color defined by variable in ::marker`);
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="author" title="Karl Dubost" href="https://github.com/karlcow" />
+    <link
+      rel="help"
+      href="https://w3c.github.io/csswg-drafts/css-pseudo/#marker-pseudo"
+    />
+    <link
+      rel="help"
+      href="https://w3c.github.io/csswg-drafts/css-variables/#defining-variables"
+    />
+    <title>::marker with variables</title>
+    <style>
+      .firstTest::marker {
+        color: rgb(255 119 0 / 0.75);
+      }
+
+      .secondTest::marker {
+        color: rgb(255 119 0);
+      }
+    </style>
+  </head>
+  <body>
+    <ul>
+      <li class="firstTest">Item 1</li>
+      <li class="secondTest">Item 2</li>
+    </ul>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="author" title="Karl Dubost" href="https://github.com/karlcow" />
+    <link
+      rel="help"
+      href="https://w3c.github.io/csswg-drafts/css-pseudo/#marker-pseudo"
+    />
+    <link
+      rel="help"
+      href="https://w3c.github.io/csswg-drafts/css-variables/#defining-variables"
+    />
+    <title>::marker with variables</title>
+    <style>
+      .firstTest::marker {
+        color: rgb(255 119 0 / 0.75);
+      }
+
+      .secondTest::marker {
+        color: rgb(255 119 0);
+      }
+    </style>
+  </head>
+  <body>
+    <ul>
+      <li class="firstTest">Item 1</li>
+      <li class="secondTest">Item 2</li>
+    </ul>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="author" title="Karl Dubost" href="https://github.com/karlcow" />
+  <link rel="help" href="https://w3c.github.io/csswg-drafts/css-pseudo/#marker-pseudo" />
+  <link rel="help" href="https://w3c.github.io/csswg-drafts/css-variables/#defining-variables" />
+  <link rel="match" href="marker-variable-ref.html">
+  <title>::marker with variables</title>
+  <style>
+    .firstTest::marker {
+      --alpha: 0.75;
+      color: rgb(255 119 0 / var(--alpha));
+    }
+
+    .secondTest::marker {
+      --color: rgb(255 119 0);
+      color: var(--color);
+    }
+  </style>
+</head>
+
+<body>
+  <ul>
+    <li class="firstTest">Item 1</li>
+    <li class="secondTest">Item 2</li>
+  </ul>
+</body>
+
+</html>

--- a/Source/WebCore/style/PropertyAllowlist.cpp
+++ b/Source/WebCore/style/PropertyAllowlist.cpp
@@ -43,6 +43,7 @@ bool isValidMarkerStyleProperty(CSSPropertyID id)
     switch (id) {
     case CSSPropertyColor:
     case CSSPropertyContent:
+    case CSSPropertyCustom:
     case CSSPropertyDirection:
     case CSSPropertyFont:
     case CSSPropertyFontFamily:
@@ -122,6 +123,7 @@ bool isValidCueStyleProperty(CSSPropertyID id)
     case CSSPropertyBackgroundRepeat:
     case CSSPropertyBackgroundSize:
     case CSSPropertyColor:
+    case CSSPropertyCustom:
     case CSSPropertyFont:
     case CSSPropertyFontFamily:
     case CSSPropertyFontSize:


### PR DESCRIPTION
#### 52052a276f0d26946f17681a53b2e2339d6b24ca
<pre>
CSS `::marker` does not support defining CSS variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=241566">https://bugs.webkit.org/show_bug.cgi?id=241566</a>
rdar://problem/95551387

Reviewed by Tim Nguyen and Antti Koivisto.

This aligns WebKit with Firefox and Chrome. It adds
CSSPropertyCustom into isValidMarkerStyleProperty
and isValidCueStyleProperty. This also adds two new
Web Platform Tests for css marker.

* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable-computed-style-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable-computed-style.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/marker-variable.html: Added.
* Source/WebCore/style/PropertyAllowlist.cpp:
(WebCore::Style::isValidMarkerStyleProperty):
(WebCore::Style::isValidCueStyleProperty):

Canonical link: <a href="https://commits.webkit.org/257711@main">https://commits.webkit.org/257711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eab5e35e8e613dd793e44b5344ad47e5195570ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109152 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169391 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86257 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92250 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107062 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105553 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34170 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22092 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2782 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23604 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2728 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45984 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5296 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8863 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43073 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4591 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->