### PR TITLE
Introduce ThreadSafeWeakHashSet

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		53FC70D023FB950C005B1990 /* OSLogPrintStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53FC70CF23FB950C005B1990 /* OSLogPrintStream.cpp */; };
 		5C1F05932164356B0039302C /* CFURLExtras.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C1F05912164356B0039302C /* CFURLExtras.cpp */; };
 		5C1F0595216437B30039302C /* URLCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C1F0594216437B30039302C /* URLCF.cpp */; };
+		5C6552C029423F85008CD0F3 /* ThreadSafeWeakHashSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C6552BF29423F85008CD0F3 /* ThreadSafeWeakHashSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5CB8CB6D28C16CB700539906 /* ArgumentCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CB8CB6C28C16CB700539906 /* ArgumentCoder.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5CC0EE7521629F1900A1A842 /* URLParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CC0EE7321629F1900A1A842 /* URLParser.cpp */; };
 		5CC0EE7621629F1900A1A842 /* URL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CC0EE7421629F1900A1A842 /* URL.cpp */; };
@@ -1156,6 +1157,7 @@
 		5C1F05922164356B0039302C /* CFURLExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFURLExtras.h; sourceTree = "<group>"; };
 		5C1F0594216437B30039302C /* URLCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = URLCF.cpp; sourceTree = "<group>"; };
 		5C1F0597216439940039302C /* URLHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = URLHash.h; sourceTree = "<group>"; };
+		5C6552BF29423F85008CD0F3 /* ThreadSafeWeakHashSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadSafeWeakHashSet.h; sourceTree = "<group>"; };
 		5C7C88D31D0A3A0A009D2F6D /* UniqueRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UniqueRef.h; sourceTree = "<group>"; };
 		5CB8CB6C28C16CB700539906 /* ArgumentCoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArgumentCoder.h; sourceTree = "<group>"; };
 		5CC0EE7121629F1800A1A842 /* URL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = URL.h; sourceTree = "<group>"; };
@@ -2317,6 +2319,7 @@
 				5311BD591EA81A9600525281 /* ThreadMessage.h */,
 				A8A4733E151A825B004123FF /* ThreadSafeRefCounted.h */,
 				7B2739DC2624DAAA0040F182 /* ThreadSafetyAnalysis.h */,
+				5C6552BF29423F85008CD0F3 /* ThreadSafeWeakHashSet.h */,
 				5CFF32562925A2EB001050F2 /* ThreadSafeWeakPtr.h */,
 				4468567225094FE8008CCA05 /* ThreadSanitizerSupport.h */,
 				A8A4733F151A825B004123FF /* ThreadSpecific.h */,
@@ -3283,6 +3286,7 @@
 				DD3DC92227A4BF8E007E5B61 /* ThreadMessage.h in Headers */,
 				DD3DC96927A4BF8E007E5B61 /* ThreadSafeRefCounted.h in Headers */,
 				DD3DC97C27A4BF8E007E5B61 /* ThreadSafetyAnalysis.h in Headers */,
+				5C6552C029423F85008CD0F3 /* ThreadSafeWeakHashSet.h in Headers */,
 				5CFF32572925A2EC001050F2 /* ThreadSafeWeakPtr.h in Headers */,
 				DD3DC90F27A4BF8E007E5B61 /* ThreadSanitizerSupport.h in Headers */,
 				DD3DC99327A4BF8E007E5B61 /* ThreadSpecific.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -293,6 +293,7 @@ set(WTF_PUBLIC_HEADERS
     ThreadMessage.h
     ThreadSafetyAnalysis.h
     ThreadSafeRefCounted.h
+    ThreadSafeWeakHashSet.h
     ThreadSafeWeakPtr.h
     ThreadSanitizerSupport.h
     ThreadSpecific.h

--- a/Source/WTF/wtf/ThreadSafeWeakHashSet.h
+++ b/Source/WTF/wtf/ThreadSafeWeakHashSet.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Algorithms.h>
+#include <wtf/HashSet.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+
+namespace WTF {
+
+template<typename T>
+class ThreadSafeWeakHashSet final {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+
+    template<typename U, std::enable_if_t<std::is_convertible_v<U*, T*>>* = nullptr>
+    typename HashSet<Ref<ThreadSafeWeakPtrControlBlock<T>>>::AddResult add(const U& value)
+    {
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!value.m_controlBlock.objectHasBeenDeleted());
+        Locker locker { m_lock };
+        amortizedCleanupIfNeeded();
+        return m_set.add(reinterpret_cast<ThreadSafeWeakPtrControlBlock<T>&>(value.m_controlBlock));
+    }
+
+    template<typename U, std::enable_if_t<std::is_convertible_v<U*, T*>>* = nullptr>
+    bool remove(const U& value)
+    {
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!value.m_controlBlock.objectHasBeenDeleted());
+        Locker locker { m_lock };
+        amortizedCleanupIfNeeded();
+        return m_set.remove(reinterpret_cast<ThreadSafeWeakPtrControlBlock<T>&>(value.m_controlBlock));
+    }
+
+    void clear()
+    {
+        Locker locker { m_lock };
+        m_set.clear();
+        m_operationCountSinceLastCleanup = 0;
+    }
+
+    template<typename U, std::enable_if_t<std::is_convertible_v<U*, T*>>* = nullptr>
+    bool contains(const U& value) const
+    {
+        Locker locker { m_lock };
+        amortizedCleanupIfNeeded();
+        return m_set.contains(value.m_controlBlock);
+    }
+
+    bool computesEmpty() const
+    {
+        Locker locker { m_lock };
+        amortizedCleanupIfNeeded();
+        for (auto& controlBlock : m_set) {
+            if (!controlBlock->objectHasBeenDeleted())
+                return false;
+        }
+        return true;
+    }
+
+    void forEach(const Function<void(T&)>& callback)
+    {
+        Vector<Ref<T>> strongReferences;
+        {
+            Locker locker { m_lock };
+            strongReferences.reserveInitialCapacity(m_set.size());
+            m_set.removeIf([&] (auto& controlBlock) {
+                if (auto refPtr = controlBlock->makeStrongReferenceIfPossible()) {
+                    strongReferences.uncheckedAppend(refPtr.releaseNonNull());
+                    return false;
+                }
+                return true;
+            });
+            m_operationCountSinceLastCleanup = 0;
+        }
+
+        for (auto& item : strongReferences)
+            callback(item.get());
+    }
+
+private:
+
+    ALWAYS_INLINE void amortizedCleanupIfNeeded() const WTF_REQUIRES_LOCK(m_lock)
+    {
+        if (++m_operationCountSinceLastCleanup / 2 > m_set.size()) {
+            m_set.removeIf([] (auto& value) {
+                return value.get().objectHasBeenDeleted();
+            });
+            m_operationCountSinceLastCleanup = 0;
+        }
+    }
+
+    mutable HashSet<Ref<ThreadSafeWeakPtrControlBlock<T>>> m_set WTF_GUARDED_BY_LOCK(m_lock);
+    mutable unsigned m_operationCountSinceLastCleanup WTF_GUARDED_BY_LOCK(m_lock) { 0 };
+    mutable Lock m_lock;
+};
+
+} // namespace WTF
+
+using WTF::ThreadSafeWeakHashSet;

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -32,6 +32,7 @@
 namespace WTF {
 
 template<typename> class ThreadSafeWeakPtr;
+template<typename> class ThreadSafeWeakHashSet;
 template<typename, DestructionThread> class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
 
 template<typename T>
@@ -139,6 +140,7 @@ protected:
     ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr() = default;
 private:
     template<typename> friend class ThreadSafeWeakPtr;
+    template<typename> friend class ThreadSafeWeakHashSet;
     ThreadSafeWeakPtrControlBlock<T>& m_controlBlock { *new ThreadSafeWeakPtrControlBlock<T>(static_cast<T&>(*this)) };
 };
 
@@ -152,7 +154,7 @@ public:
     ThreadSafeWeakPtr(const ThreadSafeWeakPtr<T>& other)
         : m_controlBlock(other.m_controlBlock) { }
 
-    template<typename U>
+    template<typename U, std::enable_if_t<!std::is_pointer_v<U>>* = nullptr>
     ThreadSafeWeakPtr(const U& retainedReference)
         : m_controlBlock(controlBlock(retainedReference))
     {
@@ -223,6 +225,7 @@ private:
     }
 
     template<typename, DestructionThread> friend class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
+    template<typename> friend class ThreadSafeWeakHashSet;
     explicit ThreadSafeWeakPtr(ThreadSafeWeakPtrControlBlock<T>& controlBlock)
         : m_controlBlock(&controlBlock) { }
 

--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -160,6 +160,8 @@ public:
             return WeakPtr<T, WeakPtrImpl> { pointer };
         });
         for (auto& item : items) {
+            // FIXME: This contains check is only necessary if the set is being mutated during iteration.
+            // Change it to an assertion, or make this function use begin() and end().
             if (item && m_set.contains(*item.m_impl))
                 callback(*item);
         }

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
@@ -55,11 +55,12 @@ void FileSystemDirectoryHandle::getFileHandle(const String& name, std::optional<
         return promise.reject(Exception { InvalidStateError, "Handle is closed"_s });
 
     bool createIfNecessary = options ? options->create : false;
-    connection().getFileHandle(identifier(), name, createIfNecessary, [weakThis = WeakPtr { *this }, connection = Ref { connection() }, name, promise = WTFMove(promise)](auto result) mutable {
+    connection().getFileHandle(identifier(), name, createIfNecessary, [weakThis = ThreadSafeWeakPtr { *this }, connection = Ref { connection() }, name, promise = WTFMove(promise)](auto result) mutable {
         if (result.hasException())
             return promise.reject(result.releaseException());
 
-        auto* context = weakThis ? weakThis->scriptExecutionContext() : nullptr;
+        auto strongThis = weakThis.get();
+        auto* context = strongThis ? strongThis->scriptExecutionContext() : nullptr;
         if (!context)
             return promise.reject(Exception { InvalidStateError, "Context has stopped"_s });
 
@@ -75,11 +76,12 @@ void FileSystemDirectoryHandle::getDirectoryHandle(const String& name, std::opti
         return promise.reject(Exception { InvalidStateError, "Handle is closed"_s });
 
     bool createIfNecessary = options ? options->create : false;
-    connection().getDirectoryHandle(identifier(), name, createIfNecessary, [weakThis = WeakPtr { *this }, connection = Ref { connection() }, name, promise = WTFMove(promise)](auto result) mutable {
+    connection().getDirectoryHandle(identifier(), name, createIfNecessary, [weakThis = ThreadSafeWeakPtr { *this }, connection = Ref { connection() }, name, promise = WTFMove(promise)](auto result) mutable {
         if (result.hasException())
             return promise.reject(result.releaseException());
 
-        auto* context = weakThis ? weakThis->scriptExecutionContext() : nullptr;
+        auto strongThis = weakThis.get();
+        auto* context = strongThis ? strongThis->scriptExecutionContext() : nullptr;
         if (!context)
             return promise.reject(Exception { InvalidStateError, "Context has stopped"_s });
 
@@ -123,12 +125,13 @@ void FileSystemDirectoryHandle::getHandle(const String& name, CompletionHandler<
     if (isClosed())
         return completionHandler(Exception { InvalidStateError, "Handle is closed"_s });
 
-    connection().getHandle(identifier(), name, [weakThis = WeakPtr { *this }, name, connection = Ref { connection() }, completionHandler = WTFMove(completionHandler)](auto result) mutable {
+    connection().getHandle(identifier(), name, [weakThis = ThreadSafeWeakPtr { *this }, name, connection = Ref { connection() }, completionHandler = WTFMove(completionHandler)](auto result) mutable {
         if (result.hasException())
             return completionHandler(result.releaseException());
 
         auto [identifier, isDirectory] = result.returnValue()->release();
-        auto* context = weakThis ? weakThis->scriptExecutionContext() : nullptr;
+        auto strongThis = weakThis.get();
+        auto* context = strongThis ? strongThis->scriptExecutionContext() : nullptr;
         if (!context)
             return completionHandler(Exception { InvalidStateError, "Context has stopped"_s });
 

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemHandle.h
@@ -29,6 +29,7 @@
 #include "FileSystemHandleIdentifier.h"
 #include "IDLTypes.h"
 #include <wtf/IsoMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ template<typename> class DOMPromiseDeferred;
 
 class FileSystemStorageConnection;
 
-class FileSystemHandle : public ActiveDOMObject, public CanMakeWeakPtr<FileSystemHandle>, public ThreadSafeRefCounted<FileSystemHandle> {
+class FileSystemHandle : public ActiveDOMObject, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<FileSystemHandle> {
     WTF_MAKE_ISO_ALLOCATED(FileSystemHandle);
 public:
     virtual ~FileSystemHandle();

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
@@ -157,11 +157,7 @@ RefPtr<AudioWorkletProcessor> AudioWorkletGlobalScope::createProcessor(const Str
     if (!jsProcessor)
         return nullptr;
 
-    {
-        Locker locker { m_processorsLock };
-        m_processors.add(jsProcessor->wrapped());
-    }
-
+    m_processors.add(jsProcessor->wrapped());
     return &jsProcessor->wrapped();
 }
 
@@ -207,13 +203,11 @@ void AudioWorkletGlobalScope::handlePostRenderTasks(size_t currentFrame)
 
 void AudioWorkletGlobalScope::processorIsNoLongerNeeded(AudioWorkletProcessor& processor)
 {
-    Locker locker { m_processorsLock };
     m_processors.remove(processor);
 }
 
 void AudioWorkletGlobalScope::visitProcessors(JSC::AbstractSlotVisitor& visitor)
 {
-    Locker locker { m_processorsLock };
     m_processors.forEach([&](auto& processor) {
         addWebCoreOpaqueRoot(visitor, processor);
     });

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
@@ -33,7 +33,7 @@
 #include "MessagePort.h"
 #include "WorkletGlobalScope.h"
 #include <wtf/RobinHoodHashMap.h>
-#include <wtf/WeakHashSet.h>
+#include <wtf/ThreadSafeWeakHashSet.h>
 
 namespace JSC {
 class VM;
@@ -83,8 +83,7 @@ private:
     size_t m_currentFrame { 0 };
     const float m_sampleRate;
     MemoryCompactRobinHoodHashMap<String, RefPtr<JSAudioWorkletProcessorConstructor>> m_processorConstructorMap;
-    Lock m_processorsLock;
-    WeakHashSet<AudioWorkletProcessor, WTF::DefaultWeakPtrImpl, EnableWeakPtrThreadingAssertions::No> m_processors WTF_GUARDED_BY_LOCK(m_processorsLock);
+    ThreadSafeWeakHashSet<AudioWorkletProcessor> m_processors;
     std::unique_ptr<AudioWorkletProcessorConstructionData> m_pendingProcessorConstructionData;
     std::optional<JSC::JSLockHolder> m_lockDuringRendering;
 };

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.h
@@ -36,7 +36,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RobinHoodHashMap.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace JSC {
@@ -54,7 +54,7 @@ class MessagePort;
 class ScriptExecutionContext;
 class WebCoreOpaqueRoot;
 
-class AudioWorkletProcessor : public ScriptWrappable, public ThreadSafeRefCounted<AudioWorkletProcessor>, public CanMakeWeakPtr<AudioWorkletProcessor> {
+class AudioWorkletProcessor : public ScriptWrappable, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AudioWorkletProcessor> {
     WTF_MAKE_ISO_ALLOCATED(AudioWorkletProcessor);
 public:
     static ExceptionOr<Ref<AudioWorkletProcessor>> create(ScriptExecutionContext&);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -537,7 +537,7 @@ private:
     String innerHTML() const override;
     String outerHTML() const override;
 
-    // Ideally this would be a WeakPtr<AXIsolatedTree>, but WebKit's WeakPtr is not currently thread-safe.
+    // FIXME: Make this a ThreadSafeWeakPtr<AXIsolatedTree>.
     RefPtr<AXIsolatedTree> m_cachedTree;
     AXID m_parentID;
     Vector<AXID> m_childrenIDs;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -278,7 +278,7 @@ struct AXPropertyChange {
     AXPropertyMap properties; // Changed properties.
 };
 
-class AXIsolatedTree : public ThreadSafeRefCounted<AXIsolatedTree>, public CanMakeWeakPtr<AXIsolatedTree> {
+class AXIsolatedTree : public ThreadSafeRefCounted<AXIsolatedTree> {
     WTF_MAKE_NONCOPYABLE(AXIsolatedTree); WTF_MAKE_FAST_ALLOCATED;
     friend WTF::TextStream& operator<<(WTF::TextStream&, AXIsolatedTree&);
     friend void streamIsolatedSubtreeOnMainThread(TextStream&, const AXIsolatedTree&, AXID, const OptionSet<AXStreamOptions>&);

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.h
@@ -33,8 +33,7 @@
 #include <wtf/Deque.h>
 #include <wtf/Lock.h>
 #include <wtf/RetainPtr.h>
-#include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/threads/BinarySemaphore.h>
 
 #include <CoreAudio/CoreAudioTypes.h>
@@ -62,7 +61,7 @@ class VideoFrame;
 class VideoSampleBufferCompressor;
 struct MediaRecorderPrivateOptions;
 
-class WEBCORE_EXPORT MediaRecorderPrivateWriter : public ThreadSafeRefCounted<MediaRecorderPrivateWriter, WTF::DestructionThread::Main>, public CanMakeWeakPtr<MediaRecorderPrivateWriter, WeakPtrFactoryInitialization::Eager> {
+class WEBCORE_EXPORT MediaRecorderPrivateWriter : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivateWriter, WTF::DestructionThread::Main> {
 public:
     static RefPtr<MediaRecorderPrivateWriter> create(bool hasAudio, bool hasVideo, const MediaRecorderPrivateOptions&);
     ~MediaRecorderPrivateWriter();

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm
@@ -104,17 +104,17 @@ RefPtr<MediaRecorderPrivateWriter> MediaRecorderPrivateWriter::create(bool hasAu
 
 void MediaRecorderPrivateWriter::compressedVideoOutputBufferCallback(void *mediaRecorderPrivateWriter, CMBufferQueueTriggerToken)
 {
-    callOnMainThread([weakWriter = WeakPtr { static_cast<MediaRecorderPrivateWriter*>(mediaRecorderPrivateWriter) }] {
-        if (weakWriter)
-            weakWriter->processNewCompressedVideoSampleBuffers();
+    callOnMainThread([weakWriter = ThreadSafeWeakPtr<MediaRecorderPrivateWriter> { static_cast<MediaRecorderPrivateWriter*>(mediaRecorderPrivateWriter) }] {
+        if (auto strongWriter = weakWriter.get())
+            strongWriter->processNewCompressedVideoSampleBuffers();
     });
 }
 
 void MediaRecorderPrivateWriter::compressedAudioOutputBufferCallback(void *mediaRecorderPrivateWriter, CMBufferQueueTriggerToken)
 {
-    callOnMainThread([weakWriter = WeakPtr { static_cast<MediaRecorderPrivateWriter*>(mediaRecorderPrivateWriter) }] {
-        if (weakWriter)
-            weakWriter->processNewCompressedAudioSampleBuffers();
+    callOnMainThread([weakWriter = ThreadSafeWeakPtr<MediaRecorderPrivateWriter> { static_cast<MediaRecorderPrivateWriter*>(mediaRecorderPrivateWriter) }] {
+        if (auto strongWriter = weakWriter.get())
+            strongWriter->processNewCompressedAudioSampleBuffers();
     });
 }
 
@@ -349,8 +349,9 @@ void MediaRecorderPrivateWriter::flushCompressedSampleBuffers(Function<void()>&&
 
     ASSERT(!m_isFlushingSamples);
     m_isFlushingSamples = true;
-    auto block = makeBlockPtr([this, weakThis = WeakPtr { *this }, hasPendingAudioSamples, hasPendingVideoSamples, audioSampleQueue = WTFMove(m_pendingAudioSampleQueue), videoSampleQueue = WTFMove(m_pendingVideoFrameQueue), callback = WTFMove(callback)]() mutable {
-        if (!weakThis) {
+    auto block = makeBlockPtr([this, weakThis = ThreadSafeWeakPtr { *this }, hasPendingAudioSamples, hasPendingVideoSamples, audioSampleQueue = WTFMove(m_pendingAudioSampleQueue), videoSampleQueue = WTFMove(m_pendingVideoFrameQueue), callback = WTFMove(callback)]() mutable {
+        auto strongThis = weakThis.get();
+        if (!strongThis) {
             callback();
             return;
         }
@@ -431,12 +432,14 @@ void MediaRecorderPrivateWriter::stopRecording()
 
     m_isStopping = true;
     // We hop to the main thread since finishing the video compressor might trigger starting the writer asynchronously.
-    callOnMainThread([this, weakThis = WeakPtr { *this }]() mutable {
-        if (!weakThis)
+    callOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }]() mutable {
+        auto strongThis = weakThis.get();
+        if (!strongThis)
             return;
 
         auto whenFinished = [this, weakThis] {
-            if (!weakThis)
+            auto strongThis = weakThis.get();
+            if (!strongThis)
                 return;
 
             m_isStopping = false;
@@ -459,7 +462,8 @@ void MediaRecorderPrivateWriter::stopRecording()
 
         ASSERT([m_writer status] == AVAssetWriterStatusWriting);
         flushCompressedSampleBuffers([this, weakThis = WTFMove(weakThis), whenFinished = WTFMove(whenFinished)]() mutable {
-            if (!weakThis)
+            auto strongThis = weakThis.get();
+            if (!strongThis)
                 return;
 
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -491,18 +495,19 @@ void MediaRecorderPrivateWriter::fetchData(CompletionHandler<void(RefPtr<Fragmen
         m_audioCompressor->flush();
 
     // We hop to the main thread since flushing the video compressor might trigger starting the writer asynchronously.
-    callOnMainThread([this, weakThis = WeakPtr { *this }]() mutable {
+    callOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }]() mutable {
         flushCompressedSampleBuffers([weakThis = WTFMove(weakThis)]() mutable {
-            if (!weakThis)
+            auto strongThis = weakThis.get();
+            if (!strongThis)
                 return;
 
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            [weakThis->m_writer flush];
+            [strongThis->m_writer flush];
             ALLOW_DEPRECATED_DECLARATIONS_END
 
             callOnMainThread([weakThis = WTFMove(weakThis)] {
-                if (weakThis)
-                    weakThis->completeFetchData();
+                if (auto strongThis = weakThis.get())
+                    strongThis->completeFetchData();
             });
         });
     });

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -102,8 +102,9 @@ NetworkDataTask::~NetworkDataTask()
 void NetworkDataTask::scheduleFailure(FailureType type)
 {
     m_failureScheduled = true;
-    RunLoop::main().dispatch([this, weakThis = WeakPtr { *this }, type] {
-        if (!weakThis || !m_client)
+    RunLoop::main().dispatch([this, weakThis = ThreadSafeWeakPtr { *this }, type] {
+        auto strongThis = weakThis.get();
+        if (!strongThis || !m_client)
             return;
 
         switch (type) {

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -36,7 +36,7 @@
 #include <WebCore/StoredCredentialsPolicy.h>
 #include <pal/SessionID.h>
 #include <wtf/CompletionHandler.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -85,7 +85,7 @@ public:
     virtual ~NetworkDataTaskClient() { }
 };
 
-class NetworkDataTask : public ThreadSafeRefCounted<NetworkDataTask, WTF::DestructionThread::Main>, public CanMakeWeakPtr<NetworkDataTask> {
+class NetworkDataTask : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<NetworkDataTask, WTF::DestructionThread::Main> {
 public:
     static Ref<NetworkDataTask> create(NetworkSession&, NetworkDataTaskClient&, const NetworkLoadParameters&);
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -89,8 +89,6 @@ NetworkDataTaskBlob::~NetworkDataTaskBlob()
         fileReference->revokeFileAccess();
 
     clearStream();
-    if (m_session)
-        m_session->unregisterNetworkDataTask(*this);
 }
 
 void NetworkDataTaskBlob::clearStream()

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -213,8 +213,9 @@ void NetworkSession::destroyResourceLoadStatistics(CompletionHandler<void()>&& c
 
 void NetworkSession::invalidateAndCancel()
 {
-    for (auto& task : m_dataTaskSet)
+    m_dataTaskSet.forEach([] (auto& task) {
         task.invalidateAndCancel();
+    });
 #if ENABLE(TRACKING_PREVENTION)
     if (m_resourceLoadStatistics)
         m_resourceLoadStatistics->invalidateAndCancel();
@@ -573,16 +574,13 @@ std::unique_ptr<WebSocketTask> NetworkSession::createWebSocketTask(WebPageProxyI
 
 void NetworkSession::registerNetworkDataTask(NetworkDataTask& task)
 {
+    // Unregistration happens automatically in ThreadSafeWeakHashSet::amortizedCleanupIfNeeded.
     m_dataTaskSet.add(task);
 
+    // FIXME: This is not in a good place. It should probably be in the NetworkDataTask constructor.
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     task.setEmulatedConditions(m_bytesPerSecondLimit);
 #endif
-}
-
-void NetworkSession::unregisterNetworkDataTask(NetworkDataTask& task)
-{
-    m_dataTaskSet.remove(task);
 }
 
 NetworkLoadScheduler& NetworkSession::networkLoadScheduler()
@@ -712,8 +710,9 @@ void NetworkSession::setEmulatedConditions(std::optional<int64_t>&& bytesPerSeco
 {
     m_bytesPerSecondLimit = WTFMove(bytesPerSecondLimit);
 
-    for (auto& task : m_dataTaskSet)
+    m_dataTaskSet.forEach([&] (auto& task) {
         task.setEmulatedConditions(m_bytesPerSecondLimit);
+    });
 }
 
 #endif // ENABLE(INSPECTOR_NETWORK_THROTTLING)

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -47,9 +47,9 @@
 #include <wtf/HashSet.h>
 #include <wtf/Ref.h>
 #include <wtf/Seconds.h>
+#include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/UUID.h>
 #include <wtf/UniqueRef.h>
-#include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -118,7 +118,6 @@ public:
     WebCore::NetworkStorageSession* networkStorageSession() const;
 
     void registerNetworkDataTask(NetworkDataTask&);
-    void unregisterNetworkDataTask(NetworkDataTask&);
 
     void destroyPrivateClickMeasurementStore(CompletionHandler<void()>&&);
 
@@ -264,7 +263,7 @@ protected:
     PAL::SessionID m_sessionID;
     std::optional<UUID> m_dataStoreIdentifier;
     Ref<NetworkProcess> m_networkProcess;
-    WeakHashSet<NetworkDataTask> m_dataTaskSet;
+    ThreadSafeWeakHashSet<NetworkDataTask> m_dataTaskSet;
 #if ENABLE(TRACKING_PREVENTION)
     String m_resourceLoadStatisticsDirectory;
     RefPtr<WebResourceLoadStatisticsStore> m_resourceLoadStatistics;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
@@ -64,10 +64,6 @@ public:
     void start();
     void stop() { cancel(); }
 
-    using NetworkDataTask::weakPtrFactory;
-    using NetworkDataTask::WeakValueType;
-    using NetworkDataTask::WeakPtrImplType;
-
 private:
     ServiceWorkerDownloadTask(NetworkSession&, NetworkDataTaskClient&, WebSWServerToContextConnection&, WebCore::ServiceWorkerIdentifier, WebCore::SWServerConnectionIdentifier, WebCore::FetchIdentifier, const WebCore::ResourceRequest&, DownloadID);
     void startListeningForIPC();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -61,8 +61,10 @@ WebSWServerToContextConnection::~WebSWServerToContextConnection()
         fetch->contextClosed();
 
     auto downloads = WTFMove(m_ongoingDownloads);
-    for (auto& download : downloads.values())
-        download->contextClosed();
+    for (auto& weakPtr : downloads.values()) {
+        if (auto download = weakPtr.get())
+            download->contextClosed();
+    }
 
     if (auto* server = this->server(); server && server->contextConnectionForRegistrableDomain(registrableDomain()) == this)
         server->removeContextConnection(*this);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -33,6 +33,7 @@
 #include "ServiceWorkerFetchTask.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/SWServerToContextConnection.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/URLHash.h>
 #include <wtf/WeakPtr.h>
 
@@ -111,7 +112,7 @@ private:
 
     NetworkConnectionToWebProcess& m_connection;
     HashMap<WebCore::FetchIdentifier, WeakPtr<ServiceWorkerFetchTask>> m_ongoingFetches;
-    HashMap<WebCore::FetchIdentifier, WeakPtr<ServiceWorkerDownloadTask>> m_ongoingDownloads;
+    HashMap<WebCore::FetchIdentifier, ThreadSafeWeakPtr<ServiceWorkerDownloadTask>> m_ongoingDownloads;
     bool m_isThrottleable { true };
     WebPageProxyIdentifier m_webPageProxyID;
     size_t m_processingFunctionalEventCount { 0 };

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -484,9 +484,6 @@ NetworkDataTaskCocoa::~NetworkDataTaskCocoa()
         auto dataTask = m_sessionWrapper->dataTaskMap.take([m_task taskIdentifier]);
         RELEASE_ASSERT(dataTask == this);
     }
-
-    if (m_session)
-        m_session->unregisterNetworkDataTask(*this);
 }
 
 void NetworkDataTaskCocoa::didSendData(uint64_t totalBytesSent, uint64_t totalBytesExpectedToSend)
@@ -627,7 +624,7 @@ void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&
     updateTaskWithFirstPartyForSameSiteCookies(m_task.get(), request);
 
     if (m_client)
-        m_client->willPerformHTTPRedirection(WTFMove(redirectResponse), WTFMove(request), [completionHandler = WTFMove(completionHandler), this, weakThis = WeakPtr { *this }] (auto&& request) mutable {
+        m_client->willPerformHTTPRedirection(WTFMove(redirectResponse), WTFMove(request), [completionHandler = WTFMove(completionHandler), this, weakThis = ThreadSafeWeakPtr { *this }] (auto&& request) mutable {
             auto strongThis = weakThis.get();
             if (!strongThis || !m_session)
                 return completionHandler({ });

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -95,9 +95,6 @@ NetworkDataTaskCurl::NetworkDataTaskCurl(NetworkSession& session, NetworkDataTas
 NetworkDataTaskCurl::~NetworkDataTaskCurl()
 {
     invalidateAndCancel();
-
-    if (m_session)
-        m_session->unregisterNetworkDataTask(*this);
 }
 
 void NetworkDataTaskCurl::resume()

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -91,8 +91,6 @@ NetworkDataTaskSoup::NetworkDataTaskSoup(NetworkSession& session, NetworkDataTas
 NetworkDataTaskSoup::~NetworkDataTaskSoup()
 {
     clearRequest();
-    if (m_session)
-        m_session->unregisterNetworkDataTask(*this);
 }
 
 String NetworkDataTaskSoup::suggestedFilename() const

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -226,8 +226,9 @@ void NetworkStorageManager::close(CompletionHandler<void()>&& completionHandler)
     ASSERT(!m_closed);
 
     m_closed = true;
-    for (auto& connection : m_connections)
+    m_connections.forEach([] (auto& connection) {
         connection.removeWorkQueueMessageReceiver(Messages::NetworkStorageManager::messageReceiverName());
+    });
 
     m_queue->dispatch([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
         m_originStorageManagers.clear();

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -42,6 +42,7 @@
 #include <WebCore/IndexedDB.h>
 #include <pal/SessionID.h>
 #include <wtf/Forward.h>
+#include <wtf/ThreadSafeWeakHashSet.h>
 
 namespace IPC {
 class SharedFileHandle;
@@ -187,7 +188,7 @@ private:
     FileSystem::Salt m_salt;
     bool m_closed { false };
     HashMap<WebCore::ClientOrigin, std::unique_ptr<OriginStorageManager>> m_originStorageManagers;
-    WeakHashSet<IPC::Connection> m_connections; // Main thread only.
+    ThreadSafeWeakHashSet<IPC::Connection> m_connections;
     std::unique_ptr<FileSystemStorageHandleRegistry> m_fileSystemStorageHandleRegistry;
     std::unique_ptr<StorageAreaRegistry> m_storageAreaRegistry;
     std::unique_ptr<IDBStorageRegistry> m_idbStorageRegistry;

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -44,6 +44,7 @@
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RunLoop.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WorkQueue.h>
 #include <wtf/text/CString.h>
@@ -128,7 +129,7 @@ class MachMessage;
 class UnixMessage;
 class WorkQueueMessageReceiver;
 
-class Connection : public ThreadSafeRefCounted<Connection, WTF::DestructionThread::MainRunLoop>, public CanMakeWeakPtr<Connection> {
+class Connection : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Connection, WTF::DestructionThread::MainRunLoop> {
 public:
     enum SyncRequestIDType { };
     using SyncRequestID = ObjectIdentifier<SyncRequestIDType>;

--- a/Source/WebKit/UIProcess/Notifications/WebNotification.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotification.h
@@ -74,7 +74,7 @@ private:
     WebCore::NotificationData m_data;
     RefPtr<API::SecurityOrigin> m_origin;
     WebPageProxyIdentifier m_pageIdentifier;
-    WeakPtr<IPC::Connection> m_sourceConnection;
+    ThreadSafeWeakPtr<IPC::Connection> m_sourceConnection;
 };
 
 inline bool isNotificationIDValid(uint64_t id)

--- a/Source/WebKit/UIProcess/ProcessAssertion.h
+++ b/Source/WebKit/UIProcess/ProcessAssertion.h
@@ -28,8 +28,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
 #include <wtf/ProcessID.h>
-#include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 #if !OS(WINDOWS)
@@ -56,7 +55,7 @@ enum class ProcessAssertionType {
 
 ASCIILiteral processAssertionTypeDescription(ProcessAssertionType);
 
-class ProcessAssertion : public ThreadSafeRefCounted<ProcessAssertion>, public CanMakeWeakPtr<ProcessAssertion, WeakPtrFactoryInitialization::Eager> {
+class ProcessAssertion : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ProcessAssertion> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Mode : bool { Sync, Async };


### PR DESCRIPTION
#### 1d67c0b3b7db5d76ebf7743380d9b5f289689902
<pre>
Introduce ThreadSafeWeakHashSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=249005">https://bugs.webkit.org/show_bug.cgi?id=249005</a>

Reviewed by Chris Dumez.

It&apos;s like WeakHashSet but thread safe!  This will allow us to expand our use of
ThreadSafeWeakPtr to classes that used to use WeakHashSet.  I tried hard to use
SFINAE to make WeakHashSet just know if it&apos;s thread safe or not, but cases like
NetworkSession.m_dataTaskSet made that not work.  It needs to instantiate the
template based on only a forward declaration of class NetworkDataTask.  So we
need a different type.  It&apos;s also a fundamentally different structure, with
things like computeSize being immediately useless.  Iteration also needs to
happen differently: we take a thread-safe snapshot of all the members of the
set, then keep them alive during iteration.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/ThreadSafeWeakHashSet.h: Added.
(WTF::copyToVector):
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
* Source/WTF/wtf/WeakHashSet.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp:
(WebCore::FileSystemDirectoryHandle::getFileHandle):
(WebCore::FileSystemDirectoryHandle::getDirectoryHandle):
(WebCore::FileSystemDirectoryHandle::getHandle):
* Source/WebCore/Modules/filesystemaccess/FileSystemHandle.h:
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h:
* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm:
(WebCore::MediaRecorderPrivateWriter::compressedVideoOutputBufferCallback):
(WebCore::MediaRecorderPrivateWriter::compressedAudioOutputBufferCallback):
(WebCore::MediaRecorderPrivateWriter::flushCompressedSampleBuffers):
(WebCore::MediaRecorderPrivateWriter::stopRecording):
(WebCore::MediaRecorderPrivateWriter::fetchData):
* Source/WebKit/NetworkProcess/NetworkDataTask.cpp:
(WebKit::NetworkDataTask::scheduleFailure):
* Source/WebKit/NetworkProcess/NetworkDataTask.h:
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::~WebSWServerToContextConnection):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(WebKit::ProcessAssertion::acquireSync):
* Source/WebKit/UIProcess/Notifications/WebNotification.h:
* Source/WebKit/UIProcess/ProcessAssertion.h:
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/257817@main">https://commits.webkit.org/257817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90191c5c0d722db4edd15660ec579ac86d9843bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109457 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169692 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10173 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92554 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107347 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105891 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90705 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3061 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86667 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/490 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3031 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29047 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43364 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89547 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5371 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20020 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->