### PR TITLE
[Curl] Rename some functions in ResourceErrorCurl.

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlRequest.cpp
+++ b/Source/WebCore/platform/network/curl/CurlRequest.cpp
@@ -490,7 +490,7 @@ void CurlRequest::didCompleteTransfer(CURLcode result)
         });
     } else {
         auto type = (result == CURLE_OPERATION_TIMEDOUT && timeoutInterval()) ? ResourceError::Type::Timeout : ResourceError::Type::General;
-        auto resourceError = ResourceError::httpError(result, m_request.url(), type);
+        auto resourceError = ResourceError(result, m_request.url(), type);
 
         CertificateInfo certificateInfo;
         if (auto info = m_curlHandle->certificateInfo())

--- a/Source/WebCore/platform/network/curl/ResourceError.h
+++ b/Source/WebCore/platform/network/curl/ResourceError.h
@@ -42,9 +42,9 @@ public:
     {
     }
 
-    WEBCORE_EXPORT static ResourceError httpError(int errorCode, const URL& failingURL, Type = Type::General);
+    WEBCORE_EXPORT ResourceError(int curlCode, const URL& failingURL, Type = Type::General);
 
-    WEBCORE_EXPORT bool isSSLCertVerificationError() const;
+    WEBCORE_EXPORT bool isCertificationVerificationError() const;
 
     static bool platformCompare(const ResourceError& a, const ResourceError& b);
 

--- a/Source/WebCore/platform/network/curl/ResourceErrorCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceErrorCurl.cpp
@@ -38,12 +38,12 @@ static const String& curlErrorDomain()
     return errorDomain;
 }
 
-ResourceError ResourceError::httpError(int errorCode, const URL& failingURL, Type type)
+ResourceError::ResourceError(int curlCode, const URL& failingURL, Type type)
+    : ResourceErrorBase(curlErrorDomain(), curlCode, failingURL, CurlHandle::errorDescription(static_cast<CURLcode>(curlCode)), type, IsSanitized::No)
 {
-    return ResourceError(curlErrorDomain(), errorCode, failingURL, CurlHandle::errorDescription(static_cast<CURLcode>(errorCode)), type);
 }
 
-bool ResourceError::isSSLCertVerificationError() const
+bool ResourceError::isCertificationVerificationError() const
 {
     return domain() == curlErrorDomain() && errorCode() == CURLE_PEER_FAILED_VERIFICATION;
 }

--- a/Source/WebCore/platform/network/curl/ResourceHandleCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceHandleCurl.cpp
@@ -449,7 +449,7 @@ void ResourceHandle::willSendRequest()
     static const int maxRedirects = 20;
 
     if (d->m_redirectCount++ > maxRedirects) {
-        client()->didFail(this, ResourceError::httpError(CURLE_TOO_MANY_REDIRECTS, delegate()->response().url()));
+        client()->didFail(this, ResourceError(CURLE_TOO_MANY_REDIRECTS, delegate()->response().url()));
         return;
     }
 

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -204,7 +204,7 @@ void NetworkDataTaskCurl::curlDidReceiveData(CurlRequest&, const SharedBuffer& b
         uint64_t bytesWritten = 0;
         for (auto& segment : buffer) {
             if (-1 == FileSystem::writeToFile(m_downloadDestinationFile, segment.segment->data(), segment.segment->size())) {
-                download->didFail(ResourceError::httpError(CURLE_WRITE_ERROR, m_response.url()), IPC::DataReference());
+                download->didFail(ResourceError(CURLE_WRITE_ERROR, m_response.url()), IPC::DataReference());
                 invalidateAndCancel();
                 return;
             }
@@ -251,7 +251,7 @@ void NetworkDataTaskCurl::curlDidFailWithError(CurlRequest& request, ResourceErr
     if (state() == State::Canceling || state() == State::Completed || (!m_client && !isDownload()))
         return;
 
-    if (resourceError.isSSLCertVerificationError()) {
+    if (resourceError.isCertificationVerificationError()) {
         tryServerTrustEvaluation(AuthenticationChallenge(request.resourceRequest().url(), certificateInfo, resourceError));
         return;
     }
@@ -305,7 +305,7 @@ void NetworkDataTaskCurl::invokeDidReceiveResponse()
             m_downloadDestinationFile = FileSystem::openFile(m_pendingDownloadLocation, FileSystem::FileOpenMode::Write);
             if (!FileSystem::isHandleValid(m_downloadDestinationFile)) {
                 if (m_client)
-                    m_client->didCompleteWithError(ResourceError::httpError(CURLE_WRITE_ERROR, m_response.url()));
+                    m_client->didCompleteWithError(ResourceError(CURLE_WRITE_ERROR, m_response.url()));
                 invalidateAndCancel();
                 return;
             }
@@ -331,7 +331,7 @@ void NetworkDataTaskCurl::willPerformHTTPRedirection()
     static const int maxRedirects = 20;
 
     if (m_redirectCount++ > maxRedirects) {
-        m_client->didCompleteWithError(ResourceError::httpError(CURLE_TOO_MANY_REDIRECTS, m_response.url()));
+        m_client->didCompleteWithError(ResourceError(CURLE_TOO_MANY_REDIRECTS, m_response.url()));
         return;
     }
 

--- a/Source/WebKit/UIProcess/Inspector/win/InspectorResourceURLSchemeHandler.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/InspectorResourceURLSchemeHandler.cpp
@@ -51,7 +51,7 @@ void InspectorResourceURLSchemeHandler::platformStartTask(WebPageProxy&, WebURLS
     bool success;
     FileSystem::MappedFileData file(path, FileSystem::MappedFileMode::Private, success);
     if (!success) {
-        task.didComplete(WebCore::ResourceError::httpError(CURLE_READ_ERROR, requestURL));
+        task.didComplete(WebCore::ResourceError(CURLE_READ_ERROR, requestURL));
         return;
     }
     auto contentType = WebCore::File::contentTypeForFile(path);


### PR DESCRIPTION
#### f18b00486195a6af490d102c26811b5e0e280849
<pre>
[Curl] Rename some functions in ResourceErrorCurl.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249009">https://bugs.webkit.org/show_bug.cgi?id=249009</a>

Reviewed by Fujii Hironori.

Rename the ResourceError::httpError and
ResourceError::isSSLCertVerificationError functions.

* Source/WebCore/platform/network/curl/CurlRequest.cpp:
(WebCore::CurlRequest::didCompleteTransfer):
* Source/WebCore/platform/network/curl/ResourceError.h:
* Source/WebCore/platform/network/curl/ResourceErrorCurl.cpp:
(WebCore::ResourceError::ResourceError):
(WebCore::ResourceError::isCertificationVerificationError const):
(WebCore::ResourceError::httpError): Deleted.
(WebCore::ResourceError::isSSLCertVerificationError const): Deleted.
* Source/WebCore/platform/network/curl/ResourceHandleCurl.cpp:
(WebCore::ResourceHandle::willSendRequest):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::curlDidReceiveData):
(WebKit::NetworkDataTaskCurl::curlDidFailWithError):
(WebKit::NetworkDataTaskCurl::invokeDidReceiveResponse):
(WebKit::NetworkDataTaskCurl::willPerformHTTPRedirection):
* Source/WebKit/UIProcess/Inspector/win/InspectorResourceURLSchemeHandler.cpp:
(WebKit::InspectorResourceURLSchemeHandler::platformStartTask):

Canonical link: <a href="https://commits.webkit.org/257611@main">https://commits.webkit.org/257611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1577eca17ffbe0c077bde52904e0ac3206a89e14

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108847 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85966 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91951 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106764 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105239 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33945 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21855 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2510 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23372 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2434 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42848 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5233 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4297 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->