### PR TITLE
[GStreamer] refactor video decoder limit customization

### DIFF
--- a/Source/WebCore/platform/GStreamer.cmake
+++ b/Source/WebCore/platform/GStreamer.cmake
@@ -149,7 +149,7 @@ if (ENABLE_VIDEO OR ENABLE_WEB_AUDIO)
 
     if (VIDEO_DECODING_LIMIT)
         # Specify video decoding limits.
-        set_source_files_properties(platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp PROPERTIES COMPILE_DEFINITIONS VIDEO_DECODING_LIMIT="${VIDEO_DECODING_LIMIT}")
+        set_source_files_properties(platform/graphics/gstreamer/GStreamerRegistryScanner.cpp PROPERTIES COMPILE_DEFINITIONS VIDEO_DECODING_LIMIT="${VIDEO_DECODING_LIMIT}")
     endif ()
 endif ()
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -56,73 +56,6 @@
 #include <wtf/text/AtomStringHash.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
-namespace {
-struct VideoDecodingLimits {
-    unsigned mediaMaxWidth = 0;
-    unsigned mediaMaxHeight = 0;
-    unsigned mediaMaxFrameRate = 0;
-    VideoDecodingLimits(unsigned mediaMaxWidth, unsigned mediaMaxHeight, unsigned mediaMaxFrameRate)
-        : mediaMaxWidth(mediaMaxWidth)
-        , mediaMaxHeight(mediaMaxHeight)
-        , mediaMaxFrameRate(mediaMaxFrameRate)
-        {
-        }
-};
-}
-
-#ifdef VIDEO_DECODING_LIMIT
-static std::optional<VideoDecodingLimits> videoDecoderLimitsDefaults()
-{
-    // VIDEO_DECODING_LIMIT should be in format: WIDTHxHEIGHT@FRAMERATE.
-    String videoDecodingLimit(String::fromUTF8(VIDEO_DECODING_LIMIT));
-
-    if (videoDecodingLimit.isEmpty())
-        return { };
-
-    Vector<String> entries;
-
-    // Extract frame rate part from the VIDEO_DECODING_LIMIT: WIDTHxHEIGHT@FRAMERATE.
-    videoDecodingLimit.split('@', [&entries](StringView item) {
-        entries.append(item.toString());
-    });
-
-    if (entries.size() != 2)
-        return { };
-
-    auto frameRate = parseIntegerAllowingTrailingJunk<unsigned>(entries[1]);
-
-    if (!frameRate.has_value())
-        return { };
-
-    String widthAndHeight = entries[0];
-    entries.clear();
-
-    // Extract WIDTH and HEIGHT from: WIDTHxHEIGHT.
-    widthAndHeight.split('x', [&entries](StringView item) {
-        entries.append(item.toString());
-    });
-
-    if (entries.size() != 2)
-        return { };
-
-    auto width = parseIntegerAllowingTrailingJunk<unsigned>(entries[0]);
-
-    if (!width.has_value())
-        return { };
-
-    auto height = parseIntegerAllowingTrailingJunk<unsigned>(entries[1]);
-
-    if (!height.has_value())
-        return { };
-
-    return { VideoDecodingLimits(width.value(), height.value(), frameRate.value()) };
-}
-#endif
-
-// We shouldn't accept media that the player can't actually play.
-// AAC supports up to 96 channels.
-#define MEDIA_MAX_AAC_CHANNELS 96
-
 static const char* dumpReadyState(WebCore::MediaPlayer::ReadyState readyState)
 {
     switch (readyState) {
@@ -433,36 +366,6 @@ MediaPlayer::SupportsType MediaPlayerPrivateGStreamerMSE::supportsType(const Med
         GST_DEBUG("mime-type \"%s\" supported: %s", parameters.type.raw().utf8().data(), convertEnumerationToString(result).utf8().data());
         return result;
     }
-
-    unsigned channels = parseIntegerAllowingTrailingJunk<unsigned>(parameters.type.parameter("channels"_s)).value_or(0);
-    if (channels > MEDIA_MAX_AAC_CHANNELS)
-        return result;
-
-    bool ok;
-    float width = parameters.type.parameter("width"_s).toFloat(&ok);
-    if (!ok)
-        width = 0;
-    float height = parameters.type.parameter("height"_s).toFloat(&ok);
-    if (!ok)
-        height = 0;
-
-    static std::optional<VideoDecodingLimits> videoDecodingLimits;
-#ifdef VIDEO_DECODING_LIMIT
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [] {
-        videoDecodingLimits = videoDecoderLimitsDefaults();
-        if (!videoDecodingLimits)
-            GST_WARNING("Parsing VIDEO_DECODING_LIMIT failed");
-    });
-#endif
-
-    if (videoDecodingLimits && (width > videoDecodingLimits->mediaMaxWidth || height > videoDecodingLimits->mediaMaxHeight))
-        return result;
-
-    float frameRate = parameters.type.parameter("framerate"_s).toFloat(&ok);
-    // Limit frameRate only in case of highest supported resolution.
-    if (ok && videoDecodingLimits && width == videoDecodingLimits->mediaMaxWidth && height == videoDecodingLimits->mediaMaxHeight && frameRate > videoDecodingLimits->mediaMaxFrameRate)
-        return result;
 
     registerWebKitGStreamerElements();
 


### PR DESCRIPTION
#### c36758395b16531cacdf1dbdb1315a45c992ca87
<pre>
[GStreamer] refactor video decoder limit customization
<a href="https://bugs.webkit.org/show_bug.cgi?id=248961">https://bugs.webkit.org/show_bug.cgi?id=248961</a>

Reviewed by Philippe Normand.

Moved the same functionality to one place - from
MediaPlayerPrivateGStreamerMSE::supportsType to
GStreamerRegistryScanner::isContentTypeSupported.

* Source/WebCore/platform/GStreamer.cmake:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(videoDecoderLimitsDefaults):
(WebCore::GStreamerRegistryScanner::isContentTypeSupported const):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::supportsType):
(videoDecoderLimitsDefaults): Deleted.

Canonical link: <a href="https://commits.webkit.org/263408@main">https://commits.webkit.org/263408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e64ee9fe2b1c0dd664ce9f5c126fc78710cdb50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5852 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4589 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4459 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4816 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5851 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/7443 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5519 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3573 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3909 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1108 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7966 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->