### PR TITLE
[GCC] Unreviewed, build fix for Ubuntu 20.04 after 257521@main

### DIFF
--- a/Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.h
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.h
@@ -39,7 +39,11 @@ struct PushSubscriptionSetIdentifier {
     String pushPartition;
     std::optional<UUID> dataStoreIdentifier;
 
-    bool operator==(const PushSubscriptionSetIdentifier&) const = default;
+    bool operator==(const PushSubscriptionSetIdentifier& other) const
+    {
+        return bundleIdentifier != other.bundleIdentifier && pushPartition != other.pushPartition
+            && dataStoreIdentifier != other.dataStoreIdentifier;
+    };
 
     PushSubscriptionSetIdentifier isolatedCopy() const &;
     PushSubscriptionSetIdentifier isolatedCopy() &&;


### PR DESCRIPTION
#### 91e9772155e7dc877cd28d7d9734b3631d99dea9
<pre>
[GCC] Unreviewed, build fix for Ubuntu 20.04 after 257521@main

Constructors cannot be defaulted in GCC9.3.

* Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.h:
(WebCore::PushSubscriptionSetIdentifier::operator== const):

Canonical link: <a href="https://commits.webkit.org/257655@main">https://commits.webkit.org/257655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e86e43c740ca8ecfd0f5c1c58691a03a585ccec1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108884 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169121 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86000 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106800 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7010 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33980 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88827 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21890 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2542 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23404 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2470 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42879 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4329 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2695 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->