### PR TITLE
[WK2] Avoid stream-extracting from the decoder in generated-serializers code

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -89,25 +89,22 @@ void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(OtherEncoder& en
 
 std::optional<Namespace::Subnamespace::StructName> ArgumentCoder<Namespace::Subnamespace::StructName>::decode(Decoder& decoder)
 {
-    std::optional<FirstMemberType> firstMemberName;
-    decoder >> firstMemberName;
+    auto firstMemberName = decoder.decode<FirstMemberType>();
     if (!firstMemberName)
         return std::nullopt;
 
 #if ENABLE(SECOND_MEMBER)
-    std::optional<SecondMemberType> secondMemberName;
-    decoder >> secondMemberName;
+    auto secondMemberName = decoder.decode<SecondMemberType>();
     if (!secondMemberName)
         return std::nullopt;
 #endif
 
-    std::optional<RetainPtr<CFTypeRef>> nullableTestMember;
-    std::optional<bool> hasnullableTestMember;
-    decoder >> hasnullableTestMember;
+    auto hasnullableTestMember = decoder.decode<bool>();
     if (!hasnullableTestMember)
         return std::nullopt;
+    std::optional<RetainPtr<CFTypeRef>> nullableTestMember;
     if (*hasnullableTestMember) {
-        decoder >> nullableTestMember;
+        nullableTestMember = decoder.decode<RetainPtr<CFTypeRef>>();
         if (!nullableTestMember)
             return std::nullopt;
     } else
@@ -143,25 +140,21 @@ void ArgumentCoder<Namespace::OtherClass>::encode(Encoder& encoder, const Namesp
 
 std::optional<Namespace::OtherClass> ArgumentCoder<Namespace::OtherClass>::decode(Decoder& decoder)
 {
-    std::optional<bool> isNull;
-    decoder >> isNull;
+    auto isNull = decoder.decode<bool>();
     if (!isNull)
         return std::nullopt;
     if (*isNull)
         return { Namespace::OtherClass { } };
 
-    std::optional<int> a;
-    decoder >> a;
+    auto a = decoder.decode<int>();
     if (!a)
         return std::nullopt;
 
-    std::optional<bool> b;
-    decoder >> b;
+    auto b = decoder.decode<bool>();
     if (!b)
         return std::nullopt;
 
-    std::optional<RetainPtr<NSArray>> dataDetectorResults;
-    dataDetectorResults = IPC::decode<NSArray>(decoder, @[ NSArray.class, PAL::getDDScannerResultClass() ]);
+    auto dataDetectorResults = IPC::decode<NSArray>(decoder, @[ NSArray.class, PAL::getDDScannerResultClass() ]);
     if (!dataDetectorResults)
         return std::nullopt;
 
@@ -190,24 +183,20 @@ void ArgumentCoder<Namespace::ReturnRefClass>::encode(Encoder& encoder, const Na
 
 std::optional<Ref<Namespace::ReturnRefClass>> ArgumentCoder<Namespace::ReturnRefClass>::decode(Decoder& decoder)
 {
-    std::optional<double> functionCallmember1;
-    decoder >> functionCallmember1;
+    auto functionCallmember1 = decoder.decode<double>();
     if (!functionCallmember1)
         return std::nullopt;
 
-    std::optional<double> functionCallmember2;
-    decoder >> functionCallmember2;
+    auto functionCallmember2 = decoder.decode<double>();
     if (!functionCallmember2)
         return std::nullopt;
 
-    std::optional<std::unique_ptr<int>> uniqueMember;
-    std::optional<bool> hasuniqueMember;
-    decoder >> hasuniqueMember;
+    auto hasuniqueMember = decoder.decode<bool>();
     if (!hasuniqueMember)
         return std::nullopt;
+    std::optional<std::unique_ptr<int>> uniqueMember;
     if (*hasuniqueMember) {
-        std::optional<int> contents;
-        decoder >> contents;
+        auto contents = decoder.decode<int>();
         if (!contents)
             return std::nullopt;
         uniqueMember= makeUnique<int>(WTFMove(*contents));
@@ -234,13 +223,11 @@ void ArgumentCoder<Namespace::EmptyConstructorStruct>::encode(Encoder& encoder, 
 
 std::optional<Namespace::EmptyConstructorStruct> ArgumentCoder<Namespace::EmptyConstructorStruct>::decode(Decoder& decoder)
 {
-    std::optional<int> m_int;
-    decoder >> m_int;
+    auto m_int = decoder.decode<int>();
     if (!m_int)
         return std::nullopt;
 
-    std::optional<double> m_double;
-    decoder >> m_double;
+    auto m_double = decoder.decode<double>();
     if (!m_double)
         return std::nullopt;
 
@@ -273,23 +260,20 @@ void ArgumentCoder<Namespace::EmptyConstructorNullable>::encode(Encoder& encoder
 
 std::optional<Namespace::EmptyConstructorNullable> ArgumentCoder<Namespace::EmptyConstructorNullable>::decode(Decoder& decoder)
 {
-    std::optional<bool> m_isNull;
-    decoder >> m_isNull;
+    auto m_isNull = decoder.decode<bool>();
     if (!m_isNull)
         return std::nullopt;
     if (*m_isNull)
         return { Namespace::EmptyConstructorNullable { } };
 
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
-    std::optional<MemberType> m_type;
-    decoder >> m_type;
+    auto m_type = decoder.decode<MemberType>();
     if (!m_type)
         return std::nullopt;
 #endif
 
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
-    std::optional<OtherMemberType> m_value;
-    decoder >> m_value;
+    auto m_value = decoder.decode<OtherMemberType>();
     if (!m_value)
         return std::nullopt;
 #endif
@@ -314,8 +298,7 @@ void ArgumentCoder<WithoutNamespace>::encode(Encoder& encoder, const WithoutName
 
 std::optional<WithoutNamespace> ArgumentCoder<WithoutNamespace>::decode(Decoder& decoder)
 {
-    std::optional<int> a;
-    decoder >> a;
+    auto a = decoder.decode<int>();
     if (!a)
         return std::nullopt;
 
@@ -341,8 +324,7 @@ void ArgumentCoder<WithoutNamespaceWithAttributes>::encode(OtherEncoder& encoder
 
 std::optional<WithoutNamespaceWithAttributes> ArgumentCoder<WithoutNamespaceWithAttributes>::decode(Decoder& decoder)
 {
-    std::optional<int> a;
-    decoder >> a;
+    auto a = decoder.decode<int>();
     if (!a)
         return std::nullopt;
 
@@ -364,13 +346,11 @@ void ArgumentCoder<WebCore::InheritsFrom>::encode(Encoder& encoder, const WebCor
 
 std::optional<WebCore::InheritsFrom> ArgumentCoder<WebCore::InheritsFrom>::decode(Decoder& decoder)
 {
-    std::optional<int> a;
-    decoder >> a;
+    auto a = decoder.decode<int>();
     if (!a)
         return std::nullopt;
 
-    std::optional<float> b;
-    decoder >> b;
+    auto b = decoder.decode<float>();
     if (!b)
         return std::nullopt;
 
@@ -397,18 +377,15 @@ void ArgumentCoder<WebCore::InheritanceGrandchild>::encode(Encoder& encoder, con
 
 std::optional<WebCore::InheritanceGrandchild> ArgumentCoder<WebCore::InheritanceGrandchild>::decode(Decoder& decoder)
 {
-    std::optional<int> a;
-    decoder >> a;
+    auto a = decoder.decode<int>();
     if (!a)
         return std::nullopt;
 
-    std::optional<float> b;
-    decoder >> b;
+    auto b = decoder.decode<float>();
     if (!b)
         return std::nullopt;
 
-    std::optional<double> c;
-    decoder >> c;
+    auto c = decoder.decode<double>();
     if (!c)
         return std::nullopt;
 
@@ -434,8 +411,7 @@ void ArgumentCoder<WTF::Seconds>::encode(Encoder& encoder, const WTF::Seconds& i
 
 std::optional<WTF::Seconds> ArgumentCoder<WTF::Seconds>::decode(Decoder& decoder)
 {
-    std::optional<double> value;
-    decoder >> value;
+    auto value = decoder.decode<double>();
     if (!value)
         return std::nullopt;
 
@@ -455,8 +431,7 @@ void ArgumentCoder<WTF::CreateUsingClass>::encode(Encoder& encoder, const WTF::C
 
 std::optional<WTF::CreateUsingClass> ArgumentCoder<WTF::CreateUsingClass>::decode(Decoder& decoder)
 {
-    std::optional<double> value;
-    decoder >> value;
+    auto value = decoder.decode<double>();
     if (!value)
         return std::nullopt;
 
@@ -482,23 +457,19 @@ void ArgumentCoder<WebCore::FloatBoxExtent>::encode(Encoder& encoder, const WebC
 
 std::optional<WebCore::FloatBoxExtent> ArgumentCoder<WebCore::FloatBoxExtent>::decode(Decoder& decoder)
 {
-    std::optional<float> top;
-    decoder >> top;
+    auto top = decoder.decode<float>();
     if (!top)
         return std::nullopt;
 
-    std::optional<float> right;
-    decoder >> right;
+    auto right = decoder.decode<float>();
     if (!right)
         return std::nullopt;
 
-    std::optional<float> bottom;
-    decoder >> bottom;
+    auto bottom = decoder.decode<float>();
     if (!bottom)
         return std::nullopt;
 
-    std::optional<float> left;
-    decoder >> left;
+    auto left = decoder.decode<float>();
     if (!left)
         return std::nullopt;
 
@@ -525,11 +496,10 @@ void ArgumentCoder<NullableSoftLinkedMember>::encode(Encoder& encoder, const Nul
 
 std::optional<NullableSoftLinkedMember> ArgumentCoder<NullableSoftLinkedMember>::decode(Decoder& decoder)
 {
-    std::optional<RetainPtr<DDActionContext>> firstMember;
-    std::optional<bool> hasfirstMember;
-    decoder >> hasfirstMember;
+    auto hasfirstMember = decoder.decode<bool>();
     if (!hasfirstMember)
         return std::nullopt;
+    std::optional<RetainPtr<DDActionContext>> firstMember;
     if (*hasfirstMember) {
         firstMember = IPC::decode<DDActionContext>(decoder, PAL::getDDActionContextClass());
         if (!firstMember)
@@ -537,8 +507,7 @@ std::optional<NullableSoftLinkedMember> ArgumentCoder<NullableSoftLinkedMember>:
     } else
         firstMember = std::optional<RetainPtr<DDActionContext>> { RetainPtr<DDActionContext> { } };
 
-    std::optional<RetainPtr<DDActionContext>> secondMember;
-    secondMember = IPC::decode<DDActionContext>(decoder, PAL::getDDActionContextClass());
+    auto secondMember = IPC::decode<DDActionContext>(decoder, PAL::getDDActionContextClass());
     if (!secondMember)
         return std::nullopt;
 


### PR DESCRIPTION
#### 0a587109bc724819728c860f1c9d044ecbc4d745
<pre>
[WK2] Avoid stream-extracting from the decoder in generated-serializers code
<a href="https://bugs.webkit.org/show_bug.cgi?id=249018">https://bugs.webkit.org/show_bug.cgi?id=249018</a>

Reviewed by Kimmo Kinnunen.

Instead of using the stream extraction operator to retrieve objects from
the decoder, the decoder&apos;s decode&lt;T&gt;() method is called to retrieve the
resulting std::optional&lt;&gt; object more efficiently.

This requires some modifications to how and where the target
std::optional&lt;T&gt; object is defined. The sanitized-string member name in
the decoding-code generator is cached in a variable and used throughout.

Testing baseline is updated to reflect the changes.

* Source/WebKit/Scripts/generate-serializers.py:
(decode_type):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::Subnamespace::StructName&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::ReturnRefClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorStruct&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorNullable&gt;::decode):
(IPC::ArgumentCoder&lt;WithoutNamespace&gt;::decode):
(IPC::ArgumentCoder&lt;WithoutNamespaceWithAttributes&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::InheritsFrom&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::InheritanceGrandchild&gt;::decode):
(IPC::ArgumentCoder&lt;WTF::Seconds&gt;::decode):
(IPC::ArgumentCoder&lt;WTF::CreateUsingClass&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::FloatBoxExtent&gt;::decode):
(IPC::ArgumentCoder&lt;NullableSoftLinkedMember&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/257677@main">https://commits.webkit.org/257677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cf05588d7a06067c4e7d4eb93a5d78b3afc13b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108890 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86006 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91999 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106807 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33982 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/103032 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21893 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2544 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23407 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45808 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42882 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5282 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4331 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->