### PR TITLE
Make CompositeEditCommand::prepareWhitespaceAtPositionForSplit() works at deleting SVG element

### DIFF
--- a/LayoutTests/editing/deleting/delete-svg-001-expected.txt
+++ b/LayoutTests/editing/deleting/delete-svg-001-expected.txt
@@ -1,0 +1,5 @@
+PASS sample.textContent.charCodeAt(0) is 160
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/deleting/delete-svg-001.html
+++ b/LayoutTests/editing/deleting/delete-svg-001.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<div id="container">
+    <p id="description"></p>
+    Manual steps (run in assertion enabled binary)
+    <ol>
+        <li>Place caret before "X".</li>
+        <li>Hit Delete key</li>
+        <li>See no assertion at Range constructor.</li>
+    </ol>
+    <div contenteditable="true">hello<span style="width: 10px; height: 10px;" id="sample">
+    <svg viewBox="0 0 100 100" width="20" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg"><text x="10" y="70" font-size="80">X</text><line x1="0" y1="2.5" x2="100" y2="2.5" stroke="red" stroke-width="5" color="yellow"></line><line x1="0" y1="97.5" x2="100" y2="97.5" stroke="red" stroke-width="5" color="yellow"></line></svg></span>world</div>
+    </div>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+    description('Delete SVG element without assertion');
+    function $(id) { return document.getElementById(id); }
+    
+    var sample = $('sample');
+    var range = document.createRange();
+    range.setStart(sample.firstChild, 1);
+    getSelection().addRange(range);
+    document.execCommand('forwardDelete');
+    shouldBe('sample.textContent.charCodeAt(0)', '160'); // U+00A0 &nbsp;
+    
+    if (window.testRunner)
+        $('container').outerHTML = '';
+    </script>

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2005, 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -165,6 +166,7 @@ protected:
     void rebalanceWhitespaceAt(const Position&);
     void rebalanceWhitespaceOnTextSubstring(Text&, int startOffset, int endOffset);
     void prepareWhitespaceAtPositionForSplit(Position&);
+    void replaceCollapsibleWhitespaceWithNonBreakingSpaceIfNeeded(const VisiblePosition&);
     RefPtr<Text> textNodeForRebalance(const Position&) const;
     bool shouldRebalanceLeadingWhitespaceFor(const String&) const;
     void removeNodeAttribute(Element&, const QualifiedName& attribute);


### PR DESCRIPTION
#### 99962e54b060098839e394bb1153ed7bfcb63925
<pre>
Make CompositeEditCommand::prepareWhitespaceAtPositionForSplit() works at deleting SVG element

Make CompositeEditCommand::prepareWhitespaceAtPositionForSplit() works at deleting SVG element
<a href="https://bugs.webkit.org/show_bug.cgi?id=62500">https://bugs.webkit.org/show_bug.cgi?id=62500</a>

Reviewed by Ryosuke Niwa.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=158002

CompositeEditCommand::prepareWhitespaceAtPositionForSplit() replaces collapsible whitespaces with non-breaking space around split position.
This patch changes it to work when split position is end of text node, e.g. VisualPosition.downstream().deprecatedNode() != VisualPostion.deprecateNode().

* Source/WebCore/editing/CompositeEditCommand.h: Add &quot;replaceCollapsibleWhitespaceWithNonBreakingSpaceIfNeeded&quot; header
* Source/WebCore/editing/CompositeEditCommand.cpp:
(CompositeEditCommand::prepareWhitespaceAtPositionForSplit):
(1) Add variable with &quot;previousVisiblePos&quot; and &quot;visiblePos&quot; return values
(2) Add &quot;replaceCollapsibleWhitespaceWithNonBreakingSpaceIfNeeded&quot; function and logic to work with &quot;SVG&quot; deletion
* LayoutTests/editing/deleting/delete-svg-001.html: Add Test Case
* LayoutTests/editing/deleting/delete-svg-001-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/257691@main">https://commits.webkit.org/257691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b7fac532bb8277639f665074f740ffd1a21e20c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109041 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169272 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86145 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92140 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106949 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105450 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90628 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34078 "An unexpected error occured. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Running find-modified-layout-tests; Running run-layout-tests-in-stress-mode; layout-tests (exception)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21990 "Found 1 new test failure: media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2678 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23506 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45889 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5288 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42980 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->