### PR TITLE
[GTK][WPE] Add webkit_web_hit_test_result_get_js_node() and deprecate the rest of the DOM APIs

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMNode.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMNode.cpp
@@ -33,6 +33,8 @@
 #include "WebKitDOMEventTarget.h"
 #endif
 
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
+
 #define WEBKIT_DOM_NODE_GET_PRIVATE(obj) G_TYPE_INSTANCE_GET_PRIVATE(obj, WEBKIT_DOM_TYPE_NODE, WebKitDOMNodePrivate)
 
 typedef struct _WebKitDOMNodePrivate {
@@ -77,9 +79,7 @@ WebKitDOMNode* wrapNode(WebCore::Node* coreObject)
 } // namespace WebKit
 
 #if PLATFORM(GTK)
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 G_DEFINE_TYPE_WITH_CODE(WebKitDOMNode, webkit_dom_node, WEBKIT_DOM_TYPE_OBJECT, G_IMPLEMENT_INTERFACE(WEBKIT_DOM_TYPE_EVENT_TARGET, webkitDOMNodeDOMEventTargetInit))
-G_GNUC_END_IGNORE_DEPRECATIONS;
 #else
 WEBKIT_DEFINE_TYPE(WebKitDOMNode, webkit_dom_node, WEBKIT_DOM_TYPE_OBJECT)
 #endif
@@ -144,6 +144,8 @@ WebCore::Node* webkitDOMNodeGetCoreObject(WebKitDOMNode* node)
  * Returns: (transfer none): a #WebKitDOMNode, or %NULL if @value doesn't reference a DOM node.
  *
  * Since: 2.22
+ *
+ * Deprecated: 2.40
  */
 WebKitDOMNode* webkit_dom_node_for_js_value(JSCValue* value)
 {
@@ -153,3 +155,5 @@ WebKitDOMNode* webkit_dom_node_for_js_value(JSCValue* value)
     auto* jsObject = JSValueToObject(jscContextGetJSContext(jsc_value_get_context(value)), jscValueGetJSValue(value), nullptr);
     return jsObject ? WebKit::kit(WebCore::JSNode::toWrapped(toJS(jsObject)->vm(), toJS(jsObject))) : nullptr;
 }
+
+G_GNUC_END_IGNORE_DEPRECATIONS;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMObject.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMObject.cpp
@@ -15,6 +15,8 @@ enum {
 };
 #endif
 
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
+
 G_DEFINE_TYPE(WebKitDOMObject, webkit_dom_object, G_TYPE_OBJECT)
 
 static void webkit_dom_object_init(WebKitDOMObject*)
@@ -51,3 +53,5 @@ static void webkit_dom_object_class_init(WebKitDOMObjectClass* klass)
             static_cast<GParamFlags>(G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB)));
 #endif
 }
+
+G_GNUC_END_IGNORE_DEPRECATIONS;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMPrivate.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMPrivate.cpp
@@ -30,6 +30,8 @@
 
 namespace WebKit {
 
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
+
 WebKitDOMNode* wrap(WebCore::Node* node)
 {
     ASSERT(node);
@@ -57,5 +59,7 @@ WebKitDOMNode* wrap(WebCore::Node* node)
 
     return wrapNode(node);
 }
+
+G_GNUC_END_IGNORE_DEPRECATIONS;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
@@ -242,10 +242,14 @@ JSCContext* webkit_frame_get_js_context_for_script_world(WebKitFrame* frame, Web
  * Returns: (transfer full): the #JSCValue referencing @dom_object.
  *
  * Since: 2.22
+ *
+ * Deprecated: 2.40
  */
 JSCValue* webkit_frame_get_js_value_for_dom_object(WebKitFrame* frame, WebKitDOMObject* domObject)
 {
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     return webkit_frame_get_js_value_for_dom_object_in_script_world(frame, domObject, webkit_script_world_get_default());
+    G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 /**
@@ -260,11 +264,15 @@ JSCValue* webkit_frame_get_js_value_for_dom_object(WebKitFrame* frame, WebKitDOM
  * Returns: (transfer full): the #JSCValue referencing @dom_object
  *
  * Since: 2.22
+ *
+ * Deprecated: 2.40
  */
 JSCValue* webkit_frame_get_js_value_for_dom_object_in_script_world(WebKitFrame* frame, WebKitDOMObject* domObject, WebKitScriptWorld* world)
 {
     g_return_val_if_fail(WEBKIT_IS_FRAME(frame), nullptr);
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     g_return_val_if_fail(WEBKIT_DOM_IS_OBJECT(domObject), nullptr);
+    G_GNUC_END_IGNORE_DEPRECATIONS;
     g_return_val_if_fail(WEBKIT_IS_SCRIPT_WORLD(world), nullptr);
 
     auto* wkWorld = webkitScriptWorldGetInjectedBundleScriptWorld(world);
@@ -273,8 +281,10 @@ JSCValue* webkit_frame_get_js_value_for_dom_object_in_script_world(WebKitFrame* 
     JSValueRef jsValue = nullptr;
     {
         JSC::JSLockHolder lock(globalObject);
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         if (WEBKIT_DOM_IS_NODE(domObject))
             jsValue = toRef(globalObject, toJS(globalObject, globalObject, WebKit::core(WEBKIT_DOM_NODE(domObject))));
+        G_GNUC_END_IGNORE_DEPRECATIONS;
     }
 
     return jsValue ? jscContextGetOrCreateValue(jsContext.get(), jsValue).leakRef() : nullptr;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.h.in
@@ -86,11 +86,11 @@ WEBKIT_API JSCContext *
 webkit_frame_get_js_context_for_script_world             (WebKitFrame       *frame,
                                                           WebKitScriptWorld *world);
 
-WEBKIT_API JSCValue *
+WEBKIT_DEPRECATED JSCValue *
 webkit_frame_get_js_value_for_dom_object                 (WebKitFrame       *frame,
                                                           WebKitDOMObject   *dom_object);
 
-WEBKIT_API JSCValue *
+WEBKIT_DEPRECATED JSCValue *
 webkit_frame_get_js_value_for_dom_object_in_script_world (WebKitFrame       *frame,
                                                           WebKitDOMObject   *dom_object,
                                                           WebKitScriptWorld *world);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp
@@ -21,9 +21,19 @@
 #include "WebKitWebHitTestResult.h"
 
 #include "InjectedBundleHitTestResult.h"
+#include "InjectedBundleScriptWorld.h"
 #include "WebKitDOMNodePrivate.h"
+#include "WebKitScriptWorldPrivate.h"
 #include "WebKitWebHitTestResultPrivate.h"
+#include <JavaScriptCore/APICast.h>
+#include <JavaScriptCore/JSGlobalObjectInlines.h>
+#include <JavaScriptCore/JSLock.h>
+#include <WebCore/Frame.h>
+#include <WebCore/JSNode.h>
+#include <WebCore/Node.h>
+#include <WebCore/ScriptController.h>
 #include <glib/gi18n-lib.h>
+#include <jsc/JSCContextPrivate.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CString.h>
@@ -43,25 +53,30 @@ using namespace WebCore;
  * Since: 2.8
  */
 
+#if !ENABLE(2022_GLIB_API)
 enum {
     PROP_0,
 
     PROP_NODE
 };
+#endif
 
 struct _WebKitWebHitTestResultPrivate {
-    GRefPtr<WebKitDOMNode> node;
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> node;
 };
 
 WEBKIT_DEFINE_TYPE(WebKitWebHitTestResult, webkit_web_hit_test_result, WEBKIT_TYPE_HIT_TEST_RESULT)
 
+#if !ENABLE(2022_GLIB_API)
 static void webkitWebHitTestResultGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
 {
     WebKitWebHitTestResult* webHitTestResult = WEBKIT_WEB_HIT_TEST_RESULT(object);
 
     switch (propId) {
     case PROP_NODE:
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         g_value_set_object(value, webkit_web_hit_test_result_get_node(webHitTestResult));
+        G_GNUC_END_IGNORE_DEPRECATIONS;
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
@@ -73,27 +88,33 @@ static void webkitWebHitTestResultSetProperty(GObject* object, guint propId, con
     WebKitWebHitTestResult* webHitTestResult = WEBKIT_WEB_HIT_TEST_RESULT(object);
 
     switch (propId) {
-    case PROP_NODE: {
-        gpointer node = g_value_get_object(value);
-        webHitTestResult->priv->node = node ? WEBKIT_DOM_NODE(node) : nullptr;
+    case PROP_NODE:
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
+        if (gpointer node = g_value_get_object(value))
+            webHitTestResult->priv->node = core(WEBKIT_DOM_NODE(node));
+        G_GNUC_END_IGNORE_DEPRECATIONS;
         break;
-    }
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
     }
 }
+#endif
 
 static void webkit_web_hit_test_result_class_init(WebKitWebHitTestResultClass* klass)
 {
+#if !ENABLE(2022_GLIB_API)
     GObjectClass* gObjectClass = G_OBJECT_CLASS(klass);
 
     gObjectClass->get_property = webkitWebHitTestResultGetProperty;
     gObjectClass->set_property = webkitWebHitTestResultSetProperty;
 
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     /**
      * WebKitWebHitTestResult:node:
      *
      * The #WebKitDOMNode
+     *
+     * Deprecated: 2.40
      */
     g_object_class_install_property(
         gObjectClass,
@@ -104,6 +125,8 @@ static void webkit_web_hit_test_result_class_init(WebKitWebHitTestResultClass* k
             _("The WebKitDOMNode"),
             WEBKIT_DOM_TYPE_NODE,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
+    G_GNUC_END_IGNORE_DEPRECATIONS;
+#endif
 }
 
 WebKitWebHitTestResult* webkitWebHitTestResultCreate(const HitTestResult& hitTestResult)
@@ -128,17 +151,24 @@ WebKitWebHitTestResult* webkitWebHitTestResultCreate(const HitTestResult& hitTes
     String linkTitle = hitTestResult.titleDisplayString();
     String linkLabel = hitTestResult.textContent();
 
-    return WEBKIT_WEB_HIT_TEST_RESULT(g_object_new(WEBKIT_TYPE_WEB_HIT_TEST_RESULT,
+    auto* result = WEBKIT_WEB_HIT_TEST_RESULT(g_object_new(WEBKIT_TYPE_WEB_HIT_TEST_RESULT,
         "context", context,
         "link-uri", context & WEBKIT_HIT_TEST_RESULT_CONTEXT_LINK ? absoluteLinkURL.utf8().data() : nullptr,
         "image-uri", context & WEBKIT_HIT_TEST_RESULT_CONTEXT_IMAGE ? absoluteImageURL.utf8().data() : nullptr,
         "media-uri", context & WEBKIT_HIT_TEST_RESULT_CONTEXT_MEDIA ? absoluteMediaURL.utf8().data() : nullptr,
         "link-title", !linkTitle.isEmpty() ? linkTitle.utf8().data() : nullptr,
         "link-label", !linkLabel.isEmpty() ? linkLabel.utf8().data() : nullptr,
+#if !ENABLE(2022_GLIB_API)
         "node", kit(hitTestResult.innerNonSharedNode()),
+#endif
         nullptr));
+#if ENABLE(2022_GLIB_API)
+    result->priv->node = hitTestResult.innerNonSharedNode();
+#endif
+    return result;
 }
 
+#if !ENABLE(2022_GLIB_API)
 /**
  * webkit_web_hit_test_result_get_node:
  * @hit_test_result: a #WebKitWebHitTestResult
@@ -148,10 +178,51 @@ WebKitWebHitTestResult* webkitWebHitTestResultCreate(const HitTestResult& hitTes
  * Returns: (transfer none): a #WebKitDOMNode
  *
  * Since: 2.8
+ *
+ * Deprecated: 2.40: Use webkit_web_hit_test_result_get_js_node() instead
  */
 WebKitDOMNode* webkit_web_hit_test_result_get_node(WebKitWebHitTestResult* webHitTestResult)
 {
     g_return_val_if_fail(WEBKIT_IS_WEB_HIT_TEST_RESULT(webHitTestResult), nullptr);
 
-    return webHitTestResult->priv->node.get();
+    return kit(webHitTestResult->priv->node.get());
+}
+#endif
+
+/**
+ * webkit_web_hit_test_result_get_js_node:
+ * @hit_test_result: a #WebKitWebHitTestResult
+ * @world: (nullable): a #WebKitScriptWorld, or %NULL to use the default
+ *
+ * Get the #JSCValue for the DOM node in @world at the coordinates of the Hit Test.
+ *
+ * Returns: (transfer full) (nullable): a #JSCValue for the DOM node, or %NULL
+ *
+ * Since: 2.40
+ */
+JSCValue* webkit_web_hit_test_result_get_js_node(WebKitWebHitTestResult* webHitTestResult, WebKitScriptWorld* world)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_HIT_TEST_RESULT(webHitTestResult), nullptr);
+    g_return_val_if_fail(!world || WEBKIT_IS_SCRIPT_WORLD(world), nullptr);
+
+    if (!webHitTestResult->priv->node)
+        return nullptr;
+
+    auto* frame = webHitTestResult->priv->node->document().frame();
+    if (!frame)
+        return nullptr;
+
+    if (!world)
+        world = webkit_script_world_get_default();
+
+    auto* wkWorld = webkitScriptWorldGetInjectedBundleScriptWorld(world);
+    JSDOMWindow* globalObject = frame->script().globalObject(wkWorld->coreWorld());
+    auto jsContext = jscContextGetOrCreate(toGlobalRef(globalObject));
+    JSValueRef jsValue = nullptr;
+    {
+        JSC::JSLockHolder lock(globalObject);
+        jsValue = toRef(globalObject, toJS(globalObject, globalObject, webHitTestResult->priv->node.get()));
+    }
+
+    return jsValue ? jscContextGetOrCreateValue(jsContext.get(), jsValue).leakRef() : nullptr;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.h.in
@@ -23,13 +23,17 @@
 #define WebKitWebHitTestResult_h
 
 #include <glib-object.h>
+#include <jsc/jsc.h>
 #include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
 #include <@API_INCLUDE_PREFIX@/WebKitHitTestResult.h>
+#include <@API_INCLUDE_PREFIX@/WebKitScriptWorld.h>
 
+#if !ENABLE(2022_GLIB_API)
 #if PLATFORM(GTK)
 #include <webkitdom/webkitdom.h>
 #elif PLATFORM(WPE)
 #include <wpe/webkitdom.h>
+#endif
 #endif
 
 G_BEGIN_DECLS
@@ -61,10 +65,16 @@ struct _WebKitWebHitTestResultClass {
 };
 
 WEBKIT_API GType
-webkit_web_hit_test_result_get_type (void);
+webkit_web_hit_test_result_get_type    (void);
 
-WEBKIT_API WebKitDOMNode *
-webkit_web_hit_test_result_get_node (WebKitWebHitTestResult *hit_test_result);
+#if !ENABLE(2022_GLIB_API)
+WEBKIT_DEPRECATED_FOR(webkit_web_hit_test_result_get_js_node) WebKitDOMNode *
+webkit_web_hit_test_result_get_node    (WebKitWebHitTestResult *hit_test_result);
+#endif
+
+WEBKIT_API JSCValue *
+webkit_web_hit_test_result_get_js_node (WebKitWebHitTestResult *hit_test_result,
+                                        WebKitScriptWorld      *world);
 
 G_END_DECLS
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMNode.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMNode.h
@@ -169,7 +169,7 @@ struct _WebKitDOMNodeClass {
 
 #endif /* WEBKIT_DISABLE_DEPRECATED */
 
-WEBKIT_API GType
+WEBKIT_DEPRECATED GType
 webkit_dom_node_get_type(void);
 
 /**
@@ -526,7 +526,7 @@ webkit_dom_node_set_text_content(WebKitDOMNode* self, const gchar* value, GError
 WEBKIT_DEPRECATED WebKitDOMElement*
 webkit_dom_node_get_parent_element(WebKitDOMNode* self);
 
-WEBKIT_API WebKitDOMNode *
+WEBKIT_DEPRECATED WebKitDOMNode *
 webkit_dom_node_for_js_value(JSCValue* value);
 
 G_END_DECLS

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMObject.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMObject.h
@@ -46,7 +46,7 @@ struct _WebKitDOMObjectClass {
     GObjectClass parentClass;
 };
 
-WEBKIT_API GType
+WEBKIT_DEPRECATED GType
 webkit_dom_object_get_type(void);
 
 G_END_DECLS

--- a/Source/WebKit/WebProcess/InjectedBundle/API/wpe/DOM/WebKitDOMNode.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/wpe/DOM/WebKitDOMNode.h
@@ -52,10 +52,10 @@ struct _WebKitDOMNodeClass {
     WebKitDOMObjectClass parent_class;
 };
 
-WEBKIT_API GType
+WEBKIT_DEPRECATED GType
 webkit_dom_node_get_type     (void);
 
-WEBKIT_API WebKitDOMNode *
+WEBKIT_DEPRECATED WebKitDOMNode *
 webkit_dom_node_for_js_value (JSCValue *value);
 
 G_END_DECLS

--- a/Source/WebKit/WebProcess/InjectedBundle/API/wpe/DOM/WebKitDOMObject.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/wpe/DOM/WebKitDOMObject.h
@@ -47,7 +47,7 @@ struct _WebKitDOMObjectClass {
     GObjectClass parentClass;
 };
 
-WEBKIT_API GType
+WEBKIT_DEPRECATED GType
 webkit_dom_object_get_type(void);
 
 G_END_DECLS

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/FrameTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/FrameTest.cpp
@@ -76,27 +76,17 @@ private:
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
-        G_GNUC_END_IGNORE_DEPRECATIONS;
 
         GRefPtr<JSCValue> jsDocument = adoptGRef(webkit_frame_get_js_value_for_dom_object(frame, WEBKIT_DOM_OBJECT(document)));
         g_assert_true(JSC_IS_VALUE(jsDocument.get()));
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsDocument.get()));
         g_assert_true(jsc_value_get_context(jsDocument.get()) == jsContext.get());
+        G_GNUC_END_IGNORE_DEPRECATIONS;
 
         GRefPtr<JSCValue> value = adoptGRef(jsc_context_get_value(jsContext.get(), "document"));
         g_assert_true(value.get() == jsDocument.get());
 
-#if PLATFORM(GTK)
-        G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
-        WebKitDOMElement* p = webkit_dom_document_get_element_by_id(document, "paragraph");
-        g_assert_true(WEBKIT_DOM_IS_ELEMENT(p));
-        G_GNUC_END_IGNORE_DEPRECATIONS;
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p));
-
-        GRefPtr<JSCValue> jsP = adoptGRef(webkit_frame_get_js_value_for_dom_object(frame, WEBKIT_DOM_OBJECT(p)));
-#else
         GRefPtr<JSCValue> jsP = adoptGRef(jsc_value_object_invoke_method(jsDocument.get(), "getElementById", G_TYPE_STRING, "paragraph", G_TYPE_NONE));
-#endif
         g_assert_true(JSC_IS_VALUE(jsP.get()));
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsP.get()));
         g_assert_true(jsc_value_is_object(jsP.get()));
@@ -104,10 +94,6 @@ private:
 
         value = adoptGRef(jsc_context_evaluate(jsContext.get(), "document.getElementById('paragraph')", -1));
         g_assert_true(value.get() == jsP.get());
-#if PLATFORM(GTK)
-        value = adoptGRef(jsc_value_object_invoke_method(jsDocument.get(), "getElementById", G_TYPE_STRING, "paragraph", G_TYPE_NONE));
-        g_assert_true(value.get() == jsP.get());
-#endif
 
         value = adoptGRef(jsc_value_object_get_property(jsP.get(), "innerText"));
         g_assert_true(JSC_IS_VALUE(value.get()));
@@ -121,8 +107,8 @@ private:
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsImage.get()));
         g_assert_true(jsc_value_is_object(jsImage.get()));
 
-        WebKitDOMNode* image = webkit_dom_node_for_js_value(jsImage.get());
         G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
+        WebKitDOMNode* image = webkit_dom_node_for_js_value(jsImage.get());
         g_assert_true(WEBKIT_DOM_IS_ELEMENT(image));
         G_GNUC_END_IGNORE_DEPRECATIONS;
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(image));

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/WebExtensionTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/WebExtensionTest.cpp
@@ -298,10 +298,7 @@ static gboolean contextMenuCallback(WebKitWebPage* page, WebKitContextMenu* menu
     }
 
     if (!g_strcmp0(pageURI, "ContextMenuTestNode")) {
-        WebKitDOMNode* node = webkit_web_hit_test_result_get_node(hitTestResult);
-        g_assert_true(WEBKIT_DOM_IS_NODE(node));
-        auto* frame = webkit_web_page_get_main_frame(page);
-        GRefPtr<JSCValue> jsNode = adoptGRef(webkit_frame_get_js_value_for_dom_object(frame, WEBKIT_DOM_OBJECT(node)));
+        GRefPtr<JSCValue> jsNode = adoptGRef(webkit_web_hit_test_result_get_js_node(hitTestResult, nullptr));
         webkit_context_menu_set_user_data(menu, serializeNode(jsNode.get()));
         return TRUE;
     }


### PR DESCRIPTION
#### b51fb227ee726aa93c621ad5d185a2ed1ee24dfa
<pre>
[GTK][WPE] Add webkit_web_hit_test_result_get_js_node() and deprecate the rest of the DOM APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=249020">https://bugs.webkit.org/show_bug.cgi?id=249020</a>

Reviewed by Michael Catanzaro.

* Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMNode.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMObject.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp:
(webkit_frame_get_js_value_for_dom_object):
(webkit_frame_get_js_value_for_dom_object_in_script_world):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.h.in:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp:
(webkitWebHitTestResultGetProperty):
(webkitWebHitTestResultSetProperty):
(webkit_web_hit_test_result_class_init):
(webkitWebHitTestResultCreate):
(webkit_web_hit_test_result_get_node):
(webkit_web_hit_test_result_get_js_node):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.h.in:
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMNode.h:
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMObject.h:
* Source/WebKit/WebProcess/InjectedBundle/API/wpe/DOM/WebKitDOMNode.h:
* Source/WebKit/WebProcess/InjectedBundle/API/wpe/DOM/WebKitDOMObject.h:
* Tools/TestWebKitAPI/Tests/WebKitGLib/FrameTest.cpp:
(WebKitFrameTest::testJavaScriptValues):
* Tools/TestWebKitAPI/Tests/WebKitGLib/WebExtensionTest.cpp:
(contextMenuCallback):

Canonical link: <a href="https://commits.webkit.org/257783@main">https://commits.webkit.org/257783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa426b062dec70d1d1ee74d28eafea0959c9026b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109356 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86508 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92456 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107256 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105778 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34318 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22279 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2973 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2933 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/46163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9066 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43272 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4782 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2747 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->