### PR TITLE
[WK2] Add ArgumentCoder<std::unique_ptr<T>> specialization

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -176,9 +176,7 @@ void ArgumentCoder<Namespace::ReturnRefClass>::encode(Encoder& encoder, const Na
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.uniqueMember)>, std::unique_ptr<int>>);
     encoder << instance.functionCall().member1;
     encoder << instance.functionCall().member2;
-    encoder << !!instance.uniqueMember;
-    if (!!instance.uniqueMember)
-        encoder << *instance.uniqueMember;
+    encoder << instance.uniqueMember;
 }
 
 std::optional<Ref<Namespace::ReturnRefClass>> ArgumentCoder<Namespace::ReturnRefClass>::decode(Decoder& decoder)
@@ -191,17 +189,9 @@ std::optional<Ref<Namespace::ReturnRefClass>> ArgumentCoder<Namespace::ReturnRef
     if (!functionCallmember2)
         return std::nullopt;
 
-    auto hasuniqueMember = decoder.decode<bool>();
-    if (!hasuniqueMember)
+    auto uniqueMember = decoder.decode<std::unique_ptr<int>>();
+    if (!uniqueMember)
         return std::nullopt;
-    std::optional<std::unique_ptr<int>> uniqueMember;
-    if (*hasuniqueMember) {
-        auto contents = decoder.decode<int>();
-        if (!contents)
-            return std::nullopt;
-        uniqueMember= makeUnique<int>(WTFMove(*contents));
-    } else
-        uniqueMember = std::optional<std::unique_ptr<int>> { std::unique_ptr<int> { } };
 
     return {
         Namespace::ReturnRefClass::create(


### PR DESCRIPTION
#### 04253f86f805ac7b882535bdfc2feb3f148a3808
<pre>
[WK2] Add ArgumentCoder&lt;std::unique_ptr&lt;T&gt;&gt; specialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=249022">https://bugs.webkit.org/show_bug.cgi?id=249022</a>

Reviewed by Kimmo Kinnunen.

Add the ArgumentCoder&lt;std::unique_ptr&lt;T&gt;&gt; specialization, supporting
encoding and decoding such objects. The logic follows similar
specializations like the ones for std::optional&lt;T&gt; or RefPtr&lt;T&gt;.

This can be used to replace std::unique_ptr&lt;T&gt; special-casing in the
generate-serializers.py script, since the logic of encoding and decoding
is identical.

The testing baseline for the generated serializers code is updated. Test
cases covering std::unique_ptr&lt;T&gt; variants in ArgumentCoderTests suite
are added.

* Source/WebKit/Platform/IPC/ArgumentCoders.h:
(IPC::ArgumentCoder&lt;std::unique_ptr&lt;T&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;std::unique_ptr&lt;T&gt;&gt;::decode):
* Source/WebKit/Scripts/generate-serializers.py:
(MemberVariable.__init__):
(encode_type):
(decode_type):
(MemberVariable.unique_ptr_type): Deleted.
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::ReturnRefClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::ReturnRefClass&gt;::decode):
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::TEST_P):
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/257682@main">https://commits.webkit.org/257682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e58ac7d50bb6628ef53aef8806c2804f82bdfa3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109035 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169266 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103676 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86139 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92134 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106943 "Hash e58ac7d5 for PR 7389 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105444 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34072 "An unexpected error occured. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/103183 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21985 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2672 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23501 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5286 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42975 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4479 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->