### PR TITLE
[WebGPU] Add support for GPU Frame capture

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -70,6 +70,7 @@ Ref<CommandEncoder> Device::createCommandEncoder(const WGPUCommandEncoderDescrip
     if (descriptor.nextInChain)
         return CommandEncoder::createInvalid(*this);
 
+    captureFrameIfNeeded();
     // https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcommandencoder
 
     auto *commandBufferDescriptor = [MTLCommandBufferDescriptor new];

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -127,6 +127,7 @@ private:
     void makeInvalid() { m_device = nil; }
 
     void loseTheDevice(WGPUDeviceLostReason);
+    void captureFrameIfNeeded() const;
 
     struct Error {
         WGPUErrorType type;

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -133,6 +133,9 @@ void Queue::commitMTLCommandBuffer(id<MTLCommandBuffer> commandBuffer)
 
     [commandBuffer commit];
     ++m_submittedCommandBufferCount;
+
+    if ([MTLCaptureManager sharedCaptureManager].isCapturing)
+        [[MTLCaptureManager sharedCaptureManager] stopCapture];
 }
 
 void Queue::submit(Vector<std::reference_wrapper<const CommandBuffer>>&& commands)


### PR DESCRIPTION
#### 1480312ebc0f511ed39478773c075cb1ab91e5a1
<pre>
[WebGPU] Add support for GPU Frame capture
<a href="https://bugs.webkit.org/show_bug.cgi?id=249011">https://bugs.webkit.org/show_bug.cgi?id=249011</a>
&lt;radar://103045608&gt;

Reviewed by Dean Jackson.

Add support for capturing the nth-frame during rendering
via notifyutil -p com.apple.WebKit.WebGPU.CaptureFrame as
well as the initial frame which includes all of the resource
creation commands in the gputrace via ...ToggleCaptureFirstFrame

Requires launching the process with __XPC_METAL_CAPTURE_ENABLED=1

These traces end up in /var/folders/.../com.apple.WebKit.GPU+org.webkit.MiniBrowser/

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::Device::createCommandEncoder):
Capture the frame starting before the command encoder is created.

* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::frameCaptureEnabled):
(WebGPU::captureFirstFrame):
(WebGPU::registerForFrameCapture):
(WebGPU::Device::Device):
(WebGPU::Device::captureFrameIfNeeded const):
Add support MTLCaptureManager.

* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::commitMTLCommandBuffer):
Stop frame capture after queue is committed.

Canonical link: <a href="https://commits.webkit.org/257770@main">https://commits.webkit.org/257770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e041a042cbf9d5b4668533127ca0f9b45bb8f56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109279 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86392 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92377 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107182 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105697 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34259 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22210 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2899 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23723 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46091 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5334 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8988 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43197 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4707 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->