### PR TITLE
[ macOS wk2 ] gamepad/gamepad-polling-access.html : com.apple.WebKit:  WebKit::WebGamepadProvider::setInitialGamepads

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1809,5 +1809,3 @@ webkit.org/b/247982 [ Ventura+ ] fast/images/animated-heics-draw.html [ Timeout 
 
 webkit.org/b/248997 [ BigSur+ ] http/tests/navigation/fragment-navigation-policy-ignore.html [ Pass Failure ]
 
-webkit.org/b/249023 [ BigSur+ ] gamepad/gamepad-polling-access.html  [ Pass Failure Crash ]
-

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1623,8 +1623,9 @@ void WebProcessPool::startedUsingGamepads(IPC::Connection& connection)
     proxy->send(Messages::WebProcess::SetInitialGamepads(UIGamepadProvider::singleton().snapshotGamepads()), 0);
 }
 
-void WebProcessPool::stoppedUsingGamepads(IPC::Connection& connection)
+void WebProcessPool::stoppedUsingGamepads(IPC::Connection& connection, CompletionHandler<void()>&& completionHandler)
 {
+    CompletionHandlerCallingScope callCompletionHandlerOnExit(WTFMove(completionHandler));
     auto* proxy = webProcessProxyFromConnection(connection, m_processes);
     if (!proxy)
         return;

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -551,7 +551,7 @@ private:
 
 #if ENABLE(GAMEPAD)
     void startedUsingGamepads(IPC::Connection&);
-    void stoppedUsingGamepads(IPC::Connection&);
+    void stoppedUsingGamepads(IPC::Connection&, CompletionHandler<void()>&&);
 
     void processStoppedUsingGamepads(WebProcessProxy&);
 #endif

--- a/Source/WebKit/UIProcess/WebProcessPool.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessPool.messages.in
@@ -26,7 +26,7 @@ messages -> WebProcessPool {
 
 #if ENABLE(GAMEPAD)
     StartedUsingGamepads() WantsConnection
-    StoppedUsingGamepads() WantsConnection
+    StoppedUsingGamepads() -> () WantsConnection
 #endif
 
     ReportWebContentCPUTime(Seconds cpuTime, uint64_t activityState)


### PR DESCRIPTION
#### e94e205403f594c33c11f9db9d2165f254f4037d
<pre>
[ macOS wk2 ] gamepad/gamepad-polling-access.html : com.apple.WebKit:  WebKit::WebGamepadProvider::setInitialGamepads
<a href="https://bugs.webkit.org/show_bug.cgi?id=249023">https://bugs.webkit.org/show_bug.cgi?id=249023</a>
rdar://103182584

Reviewed by Brady Eidson.

When the first client get added to the WebGamepadProvider, it sends a
StartedUsingGamepads IPC to the UIProcess. In turn, the UIProcess will set a
SetInitialGamepads back to initialize WebGamepadProvider&apos;s m_gamepads. This
also turns on monitoring in the UIProcess so that GamepadConnected /
GamepadDisconnected IPCs will get sent by the UIProcess to keep
WebGamepadProvider::m_gamepads up to date.

When the last client gets removed from the WebGamepadProvider, it would send a
StoppedUsingGamepads IPC to the UIProcess to stop the monitoring (and the
sending of GamepadConnected / GamepadDisconnected IPCs). However, we wouldn&apos;t
clear m_gamepads. As a result, if a new client would get added later on, we
would send the StartedUsingGamepads again to the UIProcess, which would send
up calling SetInitialGamepads() and would hit the assertion because m_gamepads
is not empty.

To address the issue, we now clear m_gamepads after sending the
StoppedUsingGamepads to the UIProcess. Note that I had to make the
StoppedUsingGamepads async with a reply so that we only clear m_gamepads once
we know that the UIProcess has stopped monitoring for us and will no longer
send GamepadConnected / GamepadDisconnected IPCs. Otherwise, we would carry the
risk of getting GamepadConnected / GamepadDisconnected IPCs after clearing
m_gamepads, which would hit assertions in those IPC handlers.

The fix is speculative since I wasn&apos;t able to reproduce the crash. This is
- I think - the most logical explanation for the crash though.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::stoppedUsingGamepads):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessPool.messages.in:
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp:
(WebKit::WebGamepadProvider::stopMonitoringGamepads):

Canonical link: <a href="https://commits.webkit.org/257651@main">https://commits.webkit.org/257651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3606e63ff73806ac7022f26397ac9a71f570563e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108923 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169160 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86041 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92035 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106840 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105316 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34010 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21921 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2577 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23436 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2509 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42911 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5269 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4369 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->