### PR TITLE
Make PushService aware of data store identifiers and push partitions

### DIFF
--- a/Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.cpp
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PushSubscriptionIdentifier.h"
+
+#include <wtf/text/StringBuilder.h>
+
+namespace WebCore {
+
+// Do not change this without thinking about backwards compatibility. Topics are persisted in both PushDatabase and APS.
+String makePushTopic(const PushSubscriptionSetIdentifier& set, const String& scope)
+{
+    StringBuilder builder;
+    builder.reserveCapacity(
+        set.bundleIdentifier.length() +
+        (!set.pushPartition.isEmpty() ? 6 + set.pushPartition.length() : 0) +
+        (set.dataStoreIdentifier ? 40 : 0) +
+        1 + scope.length());
+    builder.append(set.bundleIdentifier);
+    if (!set.pushPartition.isEmpty())
+        builder.append(" part:"_s, set.pushPartition);
+    if (set.dataStoreIdentifier)
+        builder.append(" ds:"_s, set.dataStoreIdentifier->toString());
+    builder.append(" "_s, scope);
+    return builder.toString();
+}
+
+String PushSubscriptionSetIdentifier::debugDescription() const
+{
+    StringBuilder builder;
+    builder.reserveCapacity(
+        1 + bundleIdentifier.length() +
+        (!pushPartition.isEmpty() ? 6 + pushPartition.length() : 0) +
+        (dataStoreIdentifier ? 12 : 0) + 1);
+    builder.append("["_s, bundleIdentifier);
+    if (!pushPartition.isEmpty())
+        builder.append(" part:"_s, pushPartition);
+    if (dataStoreIdentifier)
+        builder.append(" ds:"_s, dataStoreIdentifier->toString(), 0, 8);
+    builder.append("]"_s);
+    return builder.toString();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -270,6 +270,7 @@ Modules/push-api/PushMessageData.cpp
 Modules/push-api/PushSubscription.cpp
 Modules/push-api/PushSubscriptionChangeEvent.cpp
 Modules/push-api/PushSubscriptionData.cpp
+Modules/push-api/PushSubscriptionIdentifier.cpp
 Modules/push-api/PushSubscriptionOptions.cpp
 Modules/push-api/PushManager.cpp
 Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -113,6 +113,7 @@ static Ref<NetworkStorageManager> createNetworkStorageManager(IPC::Connection* c
 
 NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)
     : m_sessionID(parameters.sessionID)
+    , m_dataStoreIdentifier(parameters.dataStoreIdentifier)
     , m_networkProcess(networkProcess)
 #if ENABLE(TRACKING_PREVENTION)
     , m_resourceLoadStatisticsDirectory(parameters.resourceLoadStatisticsParameters.directory)

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -47,6 +47,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Ref.h>
 #include <wtf/Seconds.h>
+#include <wtf/UUID.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -112,6 +113,7 @@ public:
     virtual void clearAlternativeServices(WallTime) { }
 
     PAL::SessionID sessionID() const { return m_sessionID; }
+    std::optional<UUID> dataStoreIdentifier() const { return m_dataStoreIdentifier; }
     NetworkProcess& networkProcess() { return m_networkProcess; }
     WebCore::NetworkStorageSession* networkStorageSession() const;
 
@@ -260,6 +262,7 @@ protected:
 #endif
 
     PAL::SessionID m_sessionID;
+    std::optional<UUID> m_dataStoreIdentifier;
     Ref<NetworkProcess> m_networkProcess;
     WeakHashSet<NetworkDataTask> m_dataTaskSet;
 #if ENABLE(TRACKING_PREVENTION)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
@@ -41,6 +41,7 @@ namespace WebKit {
 void NetworkSessionCreationParameters::encode(IPC::Encoder& encoder) const
 {
     encoder << sessionID;
+    encoder << dataStoreIdentifier;
     encoder << boundInterfaceIdentifier;
     encoder << allowsCellularAccess;
 #if PLATFORM(COCOA)
@@ -91,6 +92,7 @@ void NetworkSessionCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << allowsHSTSWithUntrustedRootCertificate;
     encoder << pcmMachServiceName;
     encoder << webPushMachServiceName;
+    encoder << webPushPartitionString;
     encoder << enablePrivateClickMeasurementDebugMode;
 #if !HAVE(NSURLSESSION_WEBSOCKET)
     encoder << shouldAcceptInsecureCertificatesForWebSockets;
@@ -115,6 +117,11 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
     if (!sessionID)
         return std::nullopt;
     
+    std::optional<std::optional<UUID>> dataStoreIdentifier;
+    decoder >> dataStoreIdentifier;
+    if (!dataStoreIdentifier)
+        return std::nullopt;
+
     std::optional<String> boundInterfaceIdentifier;
     decoder >> boundInterfaceIdentifier;
     if (!boundInterfaceIdentifier)
@@ -332,6 +339,11 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
     if (!webPushMachServiceName)
         return std::nullopt;
     
+    std::optional<String> webPushPartitionString;
+    decoder >> webPushPartitionString;
+    if (!webPushPartitionString)
+        return std::nullopt;
+
     std::optional<bool> enablePrivateClickMeasurementDebugMode;
     decoder >> enablePrivateClickMeasurementDebugMode;
     if (!enablePrivateClickMeasurementDebugMode)
@@ -423,6 +435,7 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
 
     return {{
         *sessionID
+        , WTFMove(*dataStoreIdentifier)
         , WTFMove(*boundInterfaceIdentifier)
         , WTFMove(*allowsCellularAccess)
 #if PLATFORM(COCOA)
@@ -473,6 +486,7 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
         , WTFMove(*allowsHSTSWithUntrustedRootCertificate)
         , WTFMove(*pcmMachServiceName)
         , WTFMove(*webPushMachServiceName)
+        , WTFMove(*webPushPartitionString)
         , WTFMove(*enablePrivateClickMeasurementDebugMode)
 #if !HAVE(NSURLSESSION_WEBSOCKET)
         , WTFMove(*shouldAcceptInsecureCertificatesForWebSockets)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -31,6 +31,7 @@
 #include <pal/SessionID.h>
 #include <wtf/Seconds.h>
 #include <wtf/URL.h>
+#include <wtf/UUID.h>
 
 #if USE(SOUP)
 #include "SoupCookiePersistentStorageType.h"
@@ -56,6 +57,7 @@ struct NetworkSessionCreationParameters {
     static std::optional<NetworkSessionCreationParameters> decode(IPC::Decoder&);
     
     PAL::SessionID sessionID { PAL::SessionID::defaultSessionID() };
+    std::optional<UUID> dataStoreIdentifier;
     String boundInterfaceIdentifier;
     AllowsCellularAccess allowsCellularAccess { AllowsCellularAccess::Yes };
 #if PLATFORM(COCOA)
@@ -107,6 +109,7 @@ struct NetworkSessionCreationParameters {
     bool allowsHSTSWithUntrustedRootCertificate { false };
     String pcmMachServiceName;
     String webPushMachServiceName;
+    String webPushPartitionString;
     bool enablePrivateClickMeasurementDebugMode { false };
 #if !HAVE(NSURLSESSION_WEBSOCKET)
     bool shouldAcceptInsecureCertificatesForWebSockets { false };

--- a/Source/WebKit/Platform/IPC/DaemonCoders.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.cpp
@@ -355,25 +355,12 @@ std::optional<WebCore::PCM::AttributionTriggerData> Coder<WebCore::PCM::Attribut
 
 void Coder<WebPushD::WebPushDaemonConnectionConfiguration, void>::encode(Encoder& encoder, const WebPushD::WebPushDaemonConnectionConfiguration& instance)
 {
-    encoder << instance.useMockBundlesForTesting << instance.hostAppAuditTokenData;
+    instance.encode(encoder);
 }
 
 std::optional<WebPushD::WebPushDaemonConnectionConfiguration> Coder<WebPushD::WebPushDaemonConnectionConfiguration, void>::decode(Decoder& decoder)
 {
-    std::optional<bool> useMockBundlesForTesting;
-    decoder >> useMockBundlesForTesting;
-    if (!useMockBundlesForTesting)
-        return std::nullopt;
-
-    std::optional<std::optional<Vector<uint8_t>>> hostAppAuditTokenData;
-    decoder >> hostAppAuditTokenData;
-    if (!hostAppAuditTokenData)
-        return std::nullopt;
-
-    return { {
-        WTFMove(*useMockBundlesForTesting),
-        WTFMove(*hostAppAuditTokenData)
-    } };
+    return WebPushD::WebPushDaemonConnectionConfiguration::decode(decoder);
 }
 
 void Coder<WebPushMessage, void>::encode(Encoder& encoder, const WebPushMessage& instance)
@@ -474,6 +461,17 @@ void Coder<WebCore::PushSubscriptionIdentifier>::encode(Encoder& encoder, const 
 std::optional<WebCore::PushSubscriptionIdentifier> Coder<WebCore::PushSubscriptionIdentifier>::decode(Decoder& decoder)
 {
     return WebCore::PushSubscriptionIdentifier::decode(decoder);
+}
+
+void Coder<WTF::UUID>::encode(Encoder& encoder, const WTF::UUID& instance)
+{
+    instance.encode(encoder);
+}
+
+std::optional<WTF::UUID>
+    Coder<WTF::UUID>::decode(Decoder& decoder)
+{
+    return UUID::decode(decoder);
 }
 
 }

--- a/Source/WebKit/Platform/IPC/DaemonCoders.h
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.h
@@ -31,6 +31,7 @@
 #include <optional>
 #include <wtf/Forward.h>
 #include <wtf/URL.h>
+#include <wtf/UUID.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -125,6 +126,7 @@ DECLARE_CODER(WebCore::SecurityOriginData);
 DECLARE_CODER(WebKit::WebPushMessage);
 DECLARE_CODER(WebPushD::WebPushDaemonConnectionConfiguration);
 DECLARE_CODER(WTF::WallTime);
+DECLARE_CODER(WTF::UUID);
 
 #undef DECLARE_CODER
 

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
@@ -26,13 +26,56 @@
 #pragma once
 
 #include <optional>
+#include <wtf/UUID.h>
 #include <wtf/Vector.h>
 
 namespace WebKit::WebPushD {
 
 struct WebPushDaemonConnectionConfiguration {
+    template<class Encoder> void encode(Encoder&) const;
+    template<class Decoder> static std::optional<WebPushDaemonConnectionConfiguration> decode(Decoder&);
+
     bool useMockBundlesForTesting { false };
     std::optional<Vector<uint8_t>> hostAppAuditTokenData;
+    String pushPartitionString;
+    std::optional<UUID> dataStoreIdentifier;
 };
+
+template<class Encoder>
+void WebPushDaemonConnectionConfiguration::encode(Encoder& encoder) const
+{
+    encoder << useMockBundlesForTesting << hostAppAuditTokenData << pushPartitionString << dataStoreIdentifier;
+}
+
+template<class Decoder>
+std::optional<WebPushDaemonConnectionConfiguration> WebPushDaemonConnectionConfiguration::decode(Decoder& decoder)
+{
+    std::optional<bool> useMockBundlesForTesting;
+    decoder >> useMockBundlesForTesting;
+    if (!useMockBundlesForTesting)
+        return std::nullopt;
+
+    std::optional<std::optional<Vector<uint8_t>>> hostAppAuditTokenData;
+    decoder >> hostAppAuditTokenData;
+    if (!hostAppAuditTokenData)
+        return std::nullopt;
+
+    std::optional<String> pushPartitionString;
+    decoder >> pushPartitionString;
+    if (!pushPartitionString)
+        return std::nullopt;
+
+    std::optional<std::optional<UUID>> dataStoreIdentifier;
+    decoder >> dataStoreIdentifier;
+    if (!dataStoreIdentifier)
+        return std::nullopt;
+
+    return { {
+        WTFMove(*useMockBundlesForTesting),
+        WTFMove(*hostAppAuditTokenData),
+        WTFMove(*pushPartitionString),
+        WTFMove(*dataStoreIdentifier)
+    } };
+}
 
 } // namespace WebKit::WebPushD

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
@@ -24,4 +24,6 @@ header: "WebPushDaemonConnectionConfiguration.h"
 [CustomHeader] struct WebKit::WebPushD::WebPushDaemonConnectionConfiguration {
     bool useMockBundlesForTesting;
     std::optional<Vector<uint8_t>> hostAppAuditTokenData;
+    String pushPartitionString;
+    std::optional<UUID> dataStoreIdentifier;
 };

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -89,6 +89,7 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @property (nonatomic, nullable, copy) NSURL *standaloneApplicationURL WK_API_AVAILABLE(macos(11.0), ios(14.0));
 @property (nonatomic, nullable, copy) NSURL *generalStorageDirectory WK_API_AVAILABLE(macos(13.0), ios(16.0));
 @property (nonatomic) BOOL shouldUseCustomStoragePaths WK_API_AVAILABLE(macos(13.0), ios(16.0));
+@property (nonatomic, nullable, copy, setter=setWebPushPartitionString:) NSString *webPushPartitionString WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 // Testing only.
 @property (nonatomic) BOOL allLoadsBlockedByDeviceManagementRestrictionsForTesting WK_API_AVAILABLE(macos(10.15), ios(13.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -423,6 +423,16 @@ static void checkURLArgument(NSURL *url)
     _configuration->setShouldUseCustomStoragePaths(use);
 }
 
+- (NSString *)webPushPartitionString
+{
+    return _configuration->webPushPartitionString();
+}
+
+- (void)setWebPushPartitionString:(NSString *)string
+{
+    _configuration->setWebPushPartitionString(string);
+}
+
 - (BOOL)deviceManagementRestrictionsEnabled
 {
     return _configuration->deviceManagementRestrictionsEnabled();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1843,6 +1843,7 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
 
     NetworkSessionCreationParameters networkSessionParameters;
     networkSessionParameters.sessionID = m_sessionID;
+    networkSessionParameters.dataStoreIdentifier = configuration().identifier();
     networkSessionParameters.boundInterfaceIdentifier = configuration().boundInterfaceIdentifier();
     networkSessionParameters.allowsCellularAccess = configuration().allowsCellularAccess() ? AllowsCellularAccess::Yes : AllowsCellularAccess::No;
     networkSessionParameters.deviceManagementRestrictionsEnabled = m_configuration->deviceManagementRestrictionsEnabled();
@@ -1868,6 +1869,7 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
     networkSessionParameters.allowsHSTSWithUntrustedRootCertificate = m_configuration->allowsHSTSWithUntrustedRootCertificate();
     networkSessionParameters.pcmMachServiceName = m_configuration->pcmMachServiceName();
     networkSessionParameters.webPushMachServiceName = m_configuration->webPushMachServiceName();
+    networkSessionParameters.webPushPartitionString = m_configuration->webPushPartitionString();
 #if !HAVE(NSURLSESSION_WEBSOCKET)
     networkSessionParameters.shouldAcceptInsecureCertificatesForWebSockets = m_configuration->shouldAcceptInsecureCertificatesForWebSockets();
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -165,6 +165,7 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
     copy->m_allowsHSTSWithUntrustedRootCertificate = this->m_allowsHSTSWithUntrustedRootCertificate;
     copy->m_pcmMachServiceName = this->m_pcmMachServiceName;
     copy->m_webPushMachServiceName = this->m_webPushMachServiceName;
+    copy->m_webPushPartitionString = this->m_webPushPartitionString;
     copy->m_trackingPreventionDebugModeEnabled = this->m_trackingPreventionDebugModeEnabled;
     copy->m_identifier = m_identifier;
 #if PLATFORM(COCOA)
@@ -183,7 +184,7 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
 
 WebPushD::WebPushDaemonConnectionConfiguration WebsiteDataStoreConfiguration::webPushDaemonConnectionConfiguration() const
 {
-    return { m_webPushDaemonUsesMockBundlesForTesting, { } };
+    return { m_webPushDaemonUsesMockBundlesForTesting, { }, m_webPushPartitionString, m_identifier };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -153,6 +153,9 @@ public:
     bool shouldUseCustomStoragePaths() const { return m_shouldUseCustomStoragePaths; }
     void setShouldUseCustomStoragePaths(bool use) { m_shouldUseCustomStoragePaths = use; }
 
+    const String& webPushPartitionString() const { return m_webPushPartitionString; }
+    void setWebPushPartitionString(String&& string) { m_webPushPartitionString = WTFMove(string); }
+
     const String& applicationCacheFlatFileSubdirectoryName() const { return m_applicationCacheFlatFileSubdirectoryName; }
     void setApplicationCacheFlatFileSubdirectoryName(String&& directory) { m_applicationCacheFlatFileSubdirectoryName = WTFMove(directory); }
     
@@ -290,6 +293,7 @@ private:
     bool m_trackingPreventionDebugModeEnabled { false };
     String m_pcmMachServiceName;
     String m_webPushMachServiceName;
+    String m_webPushPartitionString;
 #if !HAVE(NSURLSESSION_WEBSOCKET)
     bool m_shouldAcceptInsecureCertificatesForWebSockets { false };
 #endif

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -25,12 +25,13 @@
 
 #pragma once
 
-#include <optional>
+#include <WebCore/PushSubscriptionIdentifier.h>
 #include <wtf/Deque.h>
 #include <wtf/Forward.h>
 #include <wtf/Identified.h>
 #include <wtf/OSObjectPtr.h>
 #include <wtf/RefCounted.h>
+#include <wtf/UUID.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 #include <wtf/text/WTFString.h>
@@ -58,9 +59,14 @@ public:
 
     bool hasHostAppAuditToken() const { return !!m_hostAppAuditToken; }
 
+    WebCore::PushSubscriptionSetIdentifier subscriptionSetIdentifier();
+
     const String& hostAppCodeSigningIdentifier();
     bool hostAppHasPushEntitlement();
     bool hostAppHasPushInjectEntitlement();
+
+    String pushPartitionString() const { return m_pushPartitionString; }
+    std::optional<UUID> dataStoreIdentifier() const { return m_dataStoreIdentifier; }
 
     bool debugModeIsEnabled() const { return m_debugModeEnabled; }
     void setDebugModeIsEnabled(bool);
@@ -91,6 +97,9 @@ private:
     std::optional<audit_token_t> m_hostAppAuditToken;
     std::optional<String> m_hostAppCodeSigningIdentifier;
     std::optional<bool> m_hostAppHasPushEntitlement;
+
+    String m_pushPartitionString;
+    std::optional<UUID> m_dataStoreIdentifier;
 
     Deque<std::unique_ptr<AppBundleRequest>> m_pendingBundleRequests;
     std::unique_ptr<AppBundleRequest> m_currentBundleRequest;

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -57,6 +57,8 @@ void ClientConnection::updateConnectionConfiguration(const WebPushDaemonConnecti
     if (configuration.hostAppAuditTokenData)
         setHostAppAuditTokenData(*configuration.hostAppAuditTokenData);
 
+    m_pushPartitionString = configuration.pushPartitionString;
+    m_dataStoreIdentifier = configuration.dataStoreIdentifier;
     m_useMockBundlesForTesting = configuration.useMockBundlesForTesting;
 }
 
@@ -79,6 +81,15 @@ void ClientConnection::setHostAppAuditTokenData(const Vector<uint8_t>& tokenData
 
     m_hostAppAuditToken = WTFMove(token);
     Daemon::singleton().broadcastAllConnectionIdentities();
+}
+
+WebCore::PushSubscriptionSetIdentifier ClientConnection::subscriptionSetIdentifier()
+{
+    return {
+        hostAppCodeSigningIdentifier(),
+        pushPartitionString(),
+        dataStoreIdentifier()
+    };
 }
 
 const String& ClientConnection::hostAppCodeSigningIdentifier()

--- a/Source/WebKit/webpushd/PushService.h
+++ b/Source/WebKit/webpushd/PushService.h
@@ -48,7 +48,7 @@ class UnsubscribeRequest;
 class PushService {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    using IncomingPushMessageHandler = Function<void(const String& bundleIdentifier, WebKit::WebPushMessage&&)>;
+    using IncomingPushMessageHandler = Function<void(const WebCore::PushSubscriptionSetIdentifier&, WebKit::WebPushMessage&&)>;
 
     static void create(const String& incomingPushServiceName, const String& databasePath, IncomingPushMessageHandler&&, CompletionHandler<void(std::unique_ptr<PushService>&&)>&&);
     static void createMockService(IncomingPushMessageHandler&&, CompletionHandler<void(std::unique_ptr<PushService>&&)>&&);
@@ -60,16 +60,16 @@ public:
     Vector<String> enabledTopics() { return m_connection->enabledTopics(); }
     Vector<String> ignoredTopics() { return m_connection->ignoredTopics(); }
 
-    void getSubscription(const String& bundleIdentifier, const String& scope, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&&);
-    void subscribe(const String& bundleIdentifier, const String& scope, const Vector<uint8_t>& vapidPublicKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&&);
-    void unsubscribe(const String& bundleIdentifier, const String& scope, std::optional<WebCore::PushSubscriptionIdentifier>, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&&);
+    void getSubscription(const WebCore::PushSubscriptionSetIdentifier&, const String& scope, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&&);
+    void subscribe(const WebCore::PushSubscriptionSetIdentifier&, const String& scope, const Vector<uint8_t>& vapidPublicKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&&);
+    void unsubscribe(const WebCore::PushSubscriptionSetIdentifier&, const String& scope, std::optional<WebCore::PushSubscriptionIdentifier>, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&&);
 
-    void setPushesEnabledForBundleIdentifierAndOrigin(const String& bundleIdentifier, const String& securityOrigin, bool, CompletionHandler<void()>&&);
+    void incrementSilentPushCount(const WebCore::PushSubscriptionSetIdentifier&, const String& securityOrigin, CompletionHandler<void(unsigned)>&&);
 
-    void removeRecordsForBundleIdentifier(const String& bundleIdentifier, CompletionHandler<void(unsigned)>&&);
-    void removeRecordsForBundleIdentifierAndOrigin(const String& bundleIdentifier, const String& securityOrigin, CompletionHandler<void(unsigned)>&&);
+    void setPushesEnabledForSubscriptionSetAndOrigin(const WebCore::PushSubscriptionSetIdentifier&, const String& securityOrigin, bool, CompletionHandler<void()>&&);
 
-    void incrementSilentPushCount(const String& bundleIdentifier, const String& securityOrigin, CompletionHandler<void(unsigned)>&&);
+    void removeRecordsForSubscriptionSet(const WebCore::PushSubscriptionSetIdentifier&, CompletionHandler<void(unsigned)>&&);
+    void removeRecordsForSubscriptionSetAndOrigin(const WebCore::PushSubscriptionSetIdentifier&, const String& securityOrigin, CompletionHandler<void(unsigned)>&&);
 
     void didCompleteGetSubscriptionRequest(GetSubscriptionRequest&);
     void didCompleteSubscribeRequest(SubscribeRequest&);
@@ -82,11 +82,11 @@ public:
 private:
     PushService(UniqueRef<PushServiceConnection>&&, UniqueRef<WebCore::PushDatabase>&&, IncomingPushMessageHandler&&);
 
-    using PushServiceRequestMap = HashMap<std::tuple<String, String>, Deque<std::unique_ptr<PushServiceRequest>>>;
+    using PushServiceRequestMap = HashMap<String, Deque<std::unique_ptr<PushServiceRequest>>>;
     void enqueuePushServiceRequest(PushServiceRequestMap&, std::unique_ptr<PushServiceRequest>&&);
     void finishedPushServiceRequest(PushServiceRequestMap&, PushServiceRequest&);
-    
-    void removeRecordsImpl(const String& bundleIdentifier, const std::optional<String>& securityOrigin, CompletionHandler<void(unsigned)>&&);
+
+    void removeRecordsImpl(const WebCore::PushSubscriptionSetIdentifier&, const std::optional<String>& securityOrigin, CompletionHandler<void(unsigned)>&&);
 
     UniqueRef<PushServiceConnection> m_connection;
     UniqueRef<WebCore::PushDatabase> m_database;

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -69,14 +69,13 @@ public:
 
     void startMockPushService();
     void startPushService(const String& incomingPushServiceName, const String& pushDatabasePath);
-    void handleIncomingPush(const String& bundleIdentifier, WebKit::WebPushMessage&&);
+    void handleIncomingPush(const WebCore::PushSubscriptionSetIdentifier&, WebKit::WebPushMessage&&);
 
     // Message handlers
     void echoTwice(ClientConnection*, const String&, CompletionHandler<void(const String&)>&& replySender);
     void requestSystemNotificationPermission(ClientConnection*, const String&, CompletionHandler<void(bool)>&& replySender);
     void getOriginsWithPushAndNotificationPermissions(ClientConnection*, CompletionHandler<void(const Vector<String>&)>&& replySender);
     void setPushAndNotificationsEnabledForOrigin(ClientConnection*, const String& originString, bool, CompletionHandler<void()>&& replySender);
-    void deletePushRegistration(const String&, const String&, CompletionHandler<void()>&&);
     void deletePushAndNotificationRegistration(ClientConnection*, const String& originString, CompletionHandler<void(const String&)>&& replySender);
     void setDebugModeIsEnabled(ClientConnection*, bool);
     void updateConnectionConfiguration(ClientConnection*, const WebPushDaemonConnectionConfiguration&);
@@ -105,7 +104,7 @@ private:
 
     bool canRegisterForNotifications(ClientConnection&);
 
-    void notifyClientPushMessageIsAvailable(const String& clientCodeSigningIdentifier);
+    void notifyClientPushMessageIsAvailable(const WebCore::PushSubscriptionSetIdentifier&);
 
     void setPushService(std::unique_ptr<PushService>&&);
     void runAfterStartingPushService(Function<void()>&&);
@@ -114,6 +113,8 @@ private:
     void releaseIncomingPushTransaction();
     void incomingPushTransactionTimerFired();
 
+    void deletePushRegistration(const WebCore::PushSubscriptionSetIdentifier&, const String&, CompletionHandler<void()>&&);
+
     ClientConnection* toClientConnection(xpc_connection_t);
     HashMap<xpc_connection_t, Ref<ClientConnection>> m_connectionMap;
 
@@ -121,7 +122,7 @@ private:
     bool m_pushServiceStarted { false };
     Deque<Function<void()>> m_pendingPushServiceFunctions;
 
-    HashMap<String, Vector<WebKit::WebPushMessage>> m_pushMessages;
+    HashMap<WebCore::PushSubscriptionSetIdentifier, Vector<WebKit::WebPushMessage>> m_pushMessages;
     HashMap<String, Deque<PushMessageForTesting>> m_testingPushMessages;
     
     WebCore::Timer m_incomingPushTransactionTimer;


### PR DESCRIPTION
#### bc9d83a37f645bc8d118d84b8b557426af4bede2
<pre>
Make PushService aware of data store identifiers and push partitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=249032">https://bugs.webkit.org/show_bug.cgi?id=249032</a>
&lt;rdar://problem/103187488&gt;

Reviewed by Brady Eidson.

This changes PushService to identify push subscriptions using the tuple (bundleID, pushPartition,
dataStoreUUID, serviceWorkerScopeURL). Previously, push subscriptions were identified by only
(bundleID, serviceWorkerScopeURL).

This mostly entails replacing all methods that take bundleIDs in PushService with methods that take
a PushSubscriptionSetIdentifier (which is (bundleID, pushPartition, dataStoreUUID)).

Additionally, I changed the WebPushDaemon integration tests to test multiple subscription set
identifiers. There was a massive amount of boilerplate in the tests that made that ugly to do, so I
refactored the tests to remove the boilerplate.

* Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.cpp: Added.
(WebCore::makePushTopic):
(WebCore::PushSubscriptionSetIdentifier::debugDescription const):
* Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.h:
(WebCore::PushSubscriptionSetIdentifier::operator== const):
(WebCore::add):
(WebCore::PushSubscriptionSetIdentifier::isHashTableDeletedValue const):
(WTF::PushSubscriptionSetIdentifierHash::hash):
(WTF::PushSubscriptionSetIdentifierHash::equal):
(WTF::HashTraits&lt;WebCore::PushSubscriptionSetIdentifier&gt;::emptyValue):
(WTF::HashTraits&lt;WebCore::PushSubscriptionSetIdentifier&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebCore::PushSubscriptionSetIdentifier&gt;::isDeletedValue):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::NetworkSession):
* Source/WebKit/NetworkProcess/NetworkSession.h:
(WebKit::NetworkSession::dataStoreIdentifier const):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp:
(WebKit::NetworkSessionCreationParameters::encode const):
(WebKit::NetworkSessionCreationParameters::decode):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/Platform/IPC/DaemonCoders.cpp:
(WebKit::Daemon::void&gt;::encode):
(WebKit::Daemon::void&gt;::decode):
(WebKit::Daemon::Coder&lt;WTF::UUID&gt;::encode):
(WebKit::Daemon::Coder&lt;WTF::UUID&gt;::decode):
* Source/WebKit/Platform/IPC/DaemonCoders.h:
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h:
(WebKit::WebPushD::WebPushDaemonConnectionConfiguration::encode const):
(WebKit::WebPushD::WebPushDaemonConnectionConfiguration::decode):
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration webPushPartitionString]):
(-[_WKWebsiteDataStoreConfiguration setWebPushPartitionString:]):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::setPushesAndNotificationsEnabledForOrigin):
(WebKit::removePushSubscriptionsForOrigins):
(WebKit::persistentDataStoreIfExists): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::copy const):
(WebKit::WebsiteDataStoreConfiguration::webPushDaemonConnectionConfiguration const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::webPushPartitionString const):
(WebKit::WebsiteDataStoreConfiguration::setWebPushPartitionString):
* Source/WebKit/webpushd/PushClientConnection.h:
(WebPushD::ClientConnection::pushPartitionString const):
(WebPushD::ClientConnection::dataStoreIdentifier const):
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::ClientConnection::updateConnectionConfiguration):
(WebPushD::ClientConnection::subscriptionSetIdentifier):
* Source/WebKit/webpushd/PushService.h:
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushServiceRequest::subscriptionSetIdentifier const):
(WebPushD::PushServiceRequest::scope const):
(WebPushD::PushServiceRequest::key const):
(WebPushD::PushServiceRequest::PushServiceRequest):
(WebPushD::PushServiceRequestImpl::PushServiceRequestImpl):
(WebPushD::PushServiceRequestImpl::fulfill):
(WebPushD::PushServiceRequestImpl::reject):
(WebPushD::GetSubscriptionRequest::GetSubscriptionRequest):
(WebPushD::GetSubscriptionRequest::startInternal):
(WebPushD::SubscribeRequest::SubscribeRequest):
(WebPushD::SubscribeRequest::startImpl):
(WebPushD::UnsubscribeRequest::UnsubscribeRequest):
(WebPushD::UnsubscribeRequest::startInternal):
(WebPushD::PushService::enqueuePushServiceRequest):
(WebPushD::PushService::finishedPushServiceRequest):
(WebPushD::PushService::getSubscription):
(WebPushD::PushService::subscribe):
(WebPushD::PushService::unsubscribe):
(WebPushD::PushService::incrementSilentPushCount):
(WebPushD::PushService::setPushesEnabledForSubscriptionSetAndOrigin):
(WebPushD::PushService::removeRecordsForSubscriptionSet):
(WebPushD::PushService::removeRecordsForSubscriptionSetAndOrigin):
(WebPushD::PushService::removeRecordsImpl):
(WebPushD::PushService::didReceivePushMessage):
(WebPushD::makeSubscriptionSet): Deleted.
(WebPushD::makePushTopic): Deleted.
(WebPushD::PushServiceRequest::bundleIdentifier): Deleted.
(WebPushD::PushServiceRequest::scope): Deleted.
(WebPushD::PushService::setPushesEnabledForBundleIdentifierAndOrigin): Deleted.
(WebPushD::PushService::removeRecordsForBundleIdentifier): Deleted.
(WebPushD::PushService::removeRecordsForBundleIdentifierAndOrigin): Deleted.
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::Daemon::startMockPushService):
(WebPushD::Daemon::startPushService):
(WebPushD::Daemon::canRegisterForNotifications):
(WebPushD::Daemon::deletePushRegistration):
(WebPushD::Daemon::setPushAndNotificationsEnabledForOrigin):
(WebPushD::Daemon::deletePushAndNotificationRegistration):
(WebPushD::Daemon::injectPushMessageForTesting):
(WebPushD::Daemon::handleIncomingPush):
(WebPushD::Daemon::notifyClientPushMessageIsAvailable):
(WebPushD::Daemon::getPendingPushMessages):
(WebPushD::Daemon::subscribeToPushService):
(WebPushD::Daemon::unsubscribeFromPushService):
(WebPushD::Daemon::getPushSubscription):
(WebPushD::Daemon::incrementSilentPushCount):
(WebPushD::Daemon::removeAllPushSubscriptions):
(WebPushD::Daemon::removePushSubscriptionsForOrigin):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::sendConfigurationWithAuditToken):
(TestWebKitAPI::log):
(TestWebKitAPI::then):
(TestWebKitAPI::catch):
(TestWebKitAPI::subscribe):
(TestWebKitAPI::unsubscribe):
(TestWebKitAPI::getPushSubscription):
(TestWebKitAPI::disableShowNotifications):
(-[NotificationScriptMessageHandler setMessageHandler:]): Deleted.
(-[NotificationScriptMessageHandler userContentController:didReceiveScriptMessage:]): Deleted.
(TestWebKitAPI::function): Deleted.

Canonical link: <a href="https://commits.webkit.org/257669@main">https://commits.webkit.org/257669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf1baedc14aa65cd1cf4c9f5ad12097d9cc2da17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99631 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108992 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169230 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86100 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92099 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106906 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105403 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34045 "An unexpected error occured. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21955 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2635 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23469 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2576 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8715 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42942 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5278 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4439 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->