### PR TITLE
Potential Crash fix by making InsertListCommand check endingSelection() editabilitybuild fix

### DIFF
--- a/LayoutTests/editing/execCommand/insert-ordered-list-crash2-expected.txt
+++ b/LayoutTests/editing/execCommand/insert-ordered-list-crash2-expected.txt
@@ -1,0 +1,7 @@
+
+PASS insert-ordered-list-crash2
+AAA
+
+BBB
+CCC
+DDD

--- a/LayoutTests/editing/execCommand/insert-ordered-list-crash2.html
+++ b/LayoutTests/editing/execCommand/insert-ordered-list-crash2.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+
+<div contenteditable="true" id="div"><ol>
+<li>AAA<br><br></li>
+<li><br></li>
+<li>BBB<br>CCC</li>
+</ol></div>
+<div>DDD</div>
+<script>
+test(function () {
+    getSelection().selectAllChildren(div);
+    document.execCommand("insertOrderedList");
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/InsertListCommand.cpp
+++ b/Source/WebCore/editing/InsertListCommand.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -178,7 +179,7 @@ void InsertListCommand::doApply()
                         // If endOfSelection is null, then some contents have been deleted from the document.
                         // This should never happen and if it did, exit early immediately because we've lost the loop invariant.
                         ASSERT(endOfSelection.isNotNull());
-                        if (endOfSelection.isNull())
+                        if (endOfSelection.isNull() || !endOfSelection.rootEditableElement())
                             return;
                         startOfLastParagraph = startOfParagraph(endOfSelection, CanSkipOverEditingBoundary);
                     }


### PR DESCRIPTION
#### 5da6fc9173aa1c247933d258be719598554a7d90
<pre>
Potential Crash fix by making InsertListCommand check endingSelection() editabilitybuild fix

Potential Crash fix by making InsertListCommand check endingSelection() editability
<a href="https://bugs.webkit.org/show_bug.cgi?id=249039">https://bugs.webkit.org/show_bug.cgi?id=249039</a>

Reviewed by Ryosuke Niwa.

Merge - <a href="https://src.chromium.org/viewvc/blink?revision=200709&amp">https://src.chromium.org/viewvc/blink?revision=200709&amp</a>;view=revision

This patch is to add early return condition to endOfSelection whether it has
rootEditableElement since L177 does not take assumption about this via endingSelection() in endOfSelection.

* Source/WebCore/editing/InsertListCommand.cpp:
(InsertListCommand::doApply): Add early return about &quot;rootEditableElement&quot;
* LayoutTests/editing/execCommand/insert-ordered-list-crash2.html: Add Test Case
* LayoutTests/editing/execCommand/insert-ordered-list-crash2-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/257811@main">https://commits.webkit.org/257811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8513ffee3a7f7df0b3980cefd3e839026fb790e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109146 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169385 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86251 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92244 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107056 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34163 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22087 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2776 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23599 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45979 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43068 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5363 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4585 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->