### PR TITLE
[Cocoa] Extend networkConnectionIntegrity with support for FailClosed and HTTPSOnlyExplicitlyBypassedForDomain

### DIFF
--- a/Source/WebCore/platform/network/NetworkConnectionIntegrity.h
+++ b/Source/WebCore/platform/network/NetworkConnectionIntegrity.h
@@ -31,6 +31,8 @@ enum class NetworkConnectionIntegrity : uint8_t {
     Enabled = 1 << 0,
     HTTPSFirst = 1 << 1,
     HTTPSOnly = 1 << 2,
+    HTTPSOnlyExplicitlyBypassedForDomain = 1 << 3,
+    FailClosed = 1 << 4,
 };
 
 }
@@ -42,7 +44,9 @@ template<> struct EnumTraits<WebCore::NetworkConnectionIntegrity> {
         WebCore::NetworkConnectionIntegrity,
         WebCore::NetworkConnectionIntegrity::Enabled,
         WebCore::NetworkConnectionIntegrity::HTTPSFirst,
-        WebCore::NetworkConnectionIntegrity::HTTPSOnly
+        WebCore::NetworkConnectionIntegrity::HTTPSOnly,
+        WebCore::NetworkConnectionIntegrity::HTTPSOnlyExplicitlyBypassedForDomain,
+        WebCore::NetworkConnectionIntegrity::FailClosed
     >;
 };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -612,6 +612,12 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
     if (webCorePolicy.contains(WebCore::NetworkConnectionIntegrity::HTTPSOnly))
         policy |= _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly;
 
+    if (webCorePolicy.contains(WebCore::NetworkConnectionIntegrity::HTTPSOnlyExplicitlyBypassedForDomain))
+        policy |= _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnlyExplicitlyBypassedForDomain;
+
+    if (webCorePolicy.contains(WebCore::NetworkConnectionIntegrity::FailClosed))
+        policy |= _WKWebsiteNetworkConnectionIntegrityPolicyFailClosed;
+
     return policy;
 }
 
@@ -627,6 +633,12 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
     if (networkConnectionIntegrityPolicy & _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly)
         webCorePolicy.add(WebCore::NetworkConnectionIntegrity::HTTPSOnly);
+
+    if (networkConnectionIntegrityPolicy & _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnlyExplicitlyBypassedForDomain)
+        webCorePolicy.add(WebCore::NetworkConnectionIntegrity::HTTPSOnlyExplicitlyBypassedForDomain);
+
+    if (networkConnectionIntegrityPolicy & _WKWebsiteNetworkConnectionIntegrityPolicyFailClosed)
+        webCorePolicy.add(WebCore::NetworkConnectionIntegrity::FailClosed);
 
     _websitePolicies->setNetworkConnectionIntegrityPolicy(webCorePolicy);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -80,6 +80,8 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
     _WKWebsiteNetworkConnectionIntegrityPolicyEnabled = 1 << 0,
     _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSFirst = 1 << 1,
     _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly = 1 << 2,
+    _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnlyExplicitlyBypassedForDomain = 1 << 3,
+    _WKWebsiteNetworkConnectionIntegrityPolicyFailClosed = 1 << 4,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @class _WKCustomHeaderFields;


### PR DESCRIPTION
#### 8aa946fe15de7a9261f684054994029f5f92abca
<pre>
[Cocoa] Extend networkConnectionIntegrity with support for FailClosed and HTTPSOnlyExplicitlyBypassedForDomain
<a href="https://bugs.webkit.org/show_bug.cgi?id=248896">https://bugs.webkit.org/show_bug.cgi?id=248896</a>
rdar://103083653

Reviewed by Wenson Hsieh.

Add two more options in the NetworkConnectionIntegrity OptionSet for FailClosed
and HTTPSOnlyExplicitlyBypassedForDomain.

* Source/WebCore/platform/network/NetworkConnectionIntegrity.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _networkConnectionIntegrityPolicy]):
(-[WKWebpagePreferences _setNetworkConnectionIntegrityPolicy:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:

Canonical link: <a href="https://commits.webkit.org/257660@main">https://commits.webkit.org/257660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/249cec5a1fb43f95562ba0430ab59b5396ea91f9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108945 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169182 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86065 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92056 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106862 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105354 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34031 "An unexpected error occured. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21940 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2597 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23454 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2531 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42927 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5275 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4391 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->