### PR TITLE
[css-grid] Fix track sizing for masonry grid axis

### DIFF
--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -47,7 +47,6 @@ void GridMasonryLayout::performMasonryPlacement(unsigned gridAxisTracks, GridTra
     // 2.4 Masonry Layout Algorithm
     addItemsToFirstTrack(m_firstTrackItems);
     placeItemsWithDefiniteGridAxisPosition(m_itemsWithDefiniteGridAxisPosition);
-    placeItemsWithIndefiniteGridAxisPosition(m_itemsWithIndefiniteGridAxisPosition);
 }
 
 void GridMasonryLayout::collectMasonryItems()
@@ -113,9 +112,9 @@ void GridMasonryLayout::placeItemsWithDefiniteGridAxisPosition(const Vector<Rend
     }
 }
 
-void GridMasonryLayout::placeItemsWithIndefiniteGridAxisPosition(const Vector<RenderBox*>& itemsWithIndefinitePosition)
+void GridMasonryLayout::placeItemsWithIndefiniteGridAxisPosition()
 {
-    for (auto* item : itemsWithIndefinitePosition) {
+    for (auto* item : m_itemsWithIndefiniteGridAxisPosition) {
         ASSERT(item);
         if (!item)
             continue;

--- a/Source/WebCore/rendering/GridMasonryLayout.h
+++ b/Source/WebCore/rendering/GridMasonryLayout.h
@@ -40,7 +40,9 @@ public:
 
     void performMasonryPlacement(unsigned gridAxisTracks, GridTrackSizingDirection masonryAxisDirection);
     LayoutUnit offsetForChild(const RenderBox&) const;
-    LayoutUnit gridContentSize() const { return m_gridContentSize; };
+    LayoutUnit gridContentSize() const { return m_gridContentSize; }
+    void placeItemsWithIndefiniteGridAxisPosition();
+
 private:
 
     GridArea nextMasonryPositionForItem(const RenderBox& item);
@@ -48,7 +50,6 @@ private:
     void collectMasonryItems();
     void addItemsToFirstTrack(const HashMap<RenderBox*, GridArea>& firstTrackItems); 
     void placeItemsWithDefiniteGridAxisPosition(const Vector<RenderBox*>& itemsWithDefinitePosition);
-    void placeItemsWithIndefiniteGridAxisPosition(const Vector<RenderBox*>& itemsWithIndefinitePosition);
     void setItemGridAxisContainingBlockToGridArea(RenderBox&);
     void insertIntoGridAndLayoutItem(RenderBox&, const GridArea&);
 


### PR DESCRIPTION
#### ae6712a816e99777f3fc56f36452a8b51f6b8617
<pre>
[css-grid] Fix track sizing for masonry grid axis
<a href="https://bugs.webkit.org/show_bug.cgi?id=248287">https://bugs.webkit.org/show_bug.cgi?id=248287</a>
rdar://102632991

Reviewed by NOBODY (OOPS!).

This is super broken right now. The layout engine is giving awful results when resizing the browser.

* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::performMasonryPlacement):
(WebCore::GridMasonryLayout::placeItemsWithIndefiniteGridAxisPosition):
* Source/WebCore/rendering/GridMasonryLayout.h:
(WebCore::GridMasonryLayout::gridContentSize const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutBlock):
(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):
(WebCore::RenderGrid::placeItems):
(WebCore::RenderGrid::placeItemsOnGrid):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae6712a816e99777f3fc56f36452a8b51f6b8617

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99592 "Failed to checkout and rebase branch from PR 7404") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8767 "Failed to checkout and rebase branch from PR 7404") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/32688 "The change is no longer eligible for processing.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108954 "Failed to checkout and rebase branch from PR 7404") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169191 "The change is no longer eligible for processing.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103588 "Failed to checkout and rebase branch from PR 7404") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/9355 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/86072 "The change is no longer eligible for processing.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92064 "The change is no longer eligible for processing.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106871 "The change is no longer eligible for processing.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/105367 "The change is no longer eligible for processing.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/9355 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/32688 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92064 "The change is no longer eligible for processing.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/9355 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/32688 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92064 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2605 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/32688 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/2540 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/86072 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/8684 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/32688 "The change is no longer eligible for processing.") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4400 "Failed to checkout and rebase branch from PR 7404") | | | 
<!--EWS-Status-Bubble-End-->