### PR TITLE
[Live Range Selection] Range-mutations-deleteData.html, Range-mutations-insertData.html,

### DIFF
--- a/LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-deleteData-expected.txt
+++ b/LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-deleteData-expected.txt
@@ -1,0 +1,566 @@
+
+PASS paras[0].firstChild.deleteData(376, 2), with unselected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.deleteData(376, 2), with selected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.deleteData(0, 2), with unselected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.deleteData(0, 2), with selected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.deleteData(1, 2), with unselected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.deleteData(1, 2), with selected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.deleteData(paras[0].firstChild.length, 2), with unselected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.deleteData(paras[0].firstChild.length, 2), with selected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.deleteData(1, 2), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(1, 2), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(2, 2), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(2, 2), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(3, 2), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(3, 2), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(376, 0), with unselected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.deleteData(376, 0), with selected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.deleteData(0, 0), with unselected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.deleteData(0, 0), with selected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.deleteData(1, 0), with unselected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.deleteData(1, 0), with selected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.deleteData(paras[0].firstChild.length, 0), with unselected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.deleteData(paras[0].firstChild.length, 0), with selected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.deleteData(1, 0), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(1, 0), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(2, 0), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(2, 0), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(3, 0), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(3, 0), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(376, 631), with unselected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.deleteData(376, 631), with selected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.deleteData(0, 631), with unselected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.deleteData(0, 631), with selected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.deleteData(1, 631), with unselected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.deleteData(1, 631), with selected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.deleteData(paras[0].firstChild.length, 631), with unselected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.deleteData(paras[0].firstChild.length, 631), with selected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.deleteData(1, 631), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(1, 631), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(2, 631), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(2, 631), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(3, 631), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.deleteData(3, 631), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(376, 2), with unselected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.deleteData(376, 2), with selected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.deleteData(0, 2), with unselected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.deleteData(0, 2), with selected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.deleteData(1, 2), with unselected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.deleteData(1, 2), with selected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.deleteData(paras[1].firstChild.length, 2), with unselected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.deleteData(paras[1].firstChild.length, 2), with selected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.deleteData(1, 2), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(1, 2), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(2, 2), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(2, 2), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(3, 2), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(3, 2), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(376, 0), with unselected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.deleteData(376, 0), with selected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.deleteData(0, 0), with unselected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.deleteData(0, 0), with selected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.deleteData(1, 0), with unselected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.deleteData(1, 0), with selected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.deleteData(paras[1].firstChild.length, 0), with unselected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.deleteData(paras[1].firstChild.length, 0), with selected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.deleteData(1, 0), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(1, 0), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(2, 0), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(2, 0), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(3, 0), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(3, 0), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(376, 631), with unselected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.deleteData(376, 631), with selected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.deleteData(0, 631), with unselected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.deleteData(0, 631), with selected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.deleteData(1, 631), with unselected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.deleteData(1, 631), with selected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.deleteData(paras[1].firstChild.length, 631), with unselected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.deleteData(paras[1].firstChild.length, 631), with selected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.deleteData(1, 631), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(1, 631), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(2, 631), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(2, 631), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(3, 631), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.deleteData(3, 631), with selected range on paras[1].firstChild from 1 to 3
+PASS foreignTextNode.deleteData(376, 2), with unselected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.deleteData(376, 2), with selected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.deleteData(0, 2), with unselected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.deleteData(0, 2), with selected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.deleteData(1, 2), with unselected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.deleteData(1, 2), with selected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.deleteData(foreignTextNode.length, 2), with unselected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.deleteData(foreignTextNode.length, 2), with selected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.deleteData(1, 2), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(1, 2), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(2, 2), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(2, 2), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(3, 2), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(3, 2), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(376, 0), with unselected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.deleteData(376, 0), with selected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.deleteData(0, 0), with unselected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.deleteData(0, 0), with selected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.deleteData(1, 0), with unselected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.deleteData(1, 0), with selected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.deleteData(foreignTextNode.length, 0), with unselected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.deleteData(foreignTextNode.length, 0), with selected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.deleteData(1, 0), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(1, 0), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(2, 0), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(2, 0), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(3, 0), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(3, 0), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(376, 631), with unselected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.deleteData(376, 631), with selected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.deleteData(0, 631), with unselected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.deleteData(0, 631), with selected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.deleteData(1, 631), with unselected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.deleteData(1, 631), with selected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.deleteData(foreignTextNode.length, 631), with unselected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.deleteData(foreignTextNode.length, 631), with selected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.deleteData(1, 631), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(1, 631), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(2, 631), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(2, 631), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(3, 631), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.deleteData(3, 631), with selected range on foreignTextNode from 1 to 3
+PASS xmlTextNode.deleteData(376, 2), with unselected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.deleteData(376, 2), with selected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.deleteData(0, 2), with unselected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.deleteData(0, 2), with selected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.deleteData(1, 2), with unselected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.deleteData(1, 2), with selected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.deleteData(xmlTextNode.length, 2), with unselected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.deleteData(xmlTextNode.length, 2), with selected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.deleteData(1, 2), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(1, 2), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(2, 2), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(2, 2), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(3, 2), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(3, 2), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(376, 0), with unselected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.deleteData(376, 0), with selected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.deleteData(0, 0), with unselected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.deleteData(0, 0), with selected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.deleteData(1, 0), with unselected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.deleteData(1, 0), with selected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.deleteData(xmlTextNode.length, 0), with unselected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.deleteData(xmlTextNode.length, 0), with selected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.deleteData(1, 0), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(1, 0), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(2, 0), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(2, 0), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(3, 0), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(3, 0), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(376, 631), with unselected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.deleteData(376, 631), with selected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.deleteData(0, 631), with unselected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.deleteData(0, 631), with selected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.deleteData(1, 631), with unselected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.deleteData(1, 631), with selected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.deleteData(xmlTextNode.length, 631), with unselected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.deleteData(xmlTextNode.length, 631), with selected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.deleteData(1, 631), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(1, 631), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(2, 631), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(2, 631), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(3, 631), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.deleteData(3, 631), with selected range on xmlTextNode from 1 to 3
+PASS detachedTextNode.deleteData(376, 2), with unselected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.deleteData(376, 2), with selected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.deleteData(0, 2), with unselected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.deleteData(0, 2), with selected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.deleteData(1, 2), with unselected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.deleteData(1, 2), with selected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.deleteData(detachedTextNode.length, 2), with unselected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.deleteData(detachedTextNode.length, 2), with selected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.deleteData(1, 2), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(1, 2), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(2, 2), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(2, 2), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(3, 2), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(3, 2), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(376, 0), with unselected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.deleteData(376, 0), with selected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.deleteData(0, 0), with unselected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.deleteData(0, 0), with selected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.deleteData(1, 0), with unselected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.deleteData(1, 0), with selected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.deleteData(detachedTextNode.length, 0), with unselected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.deleteData(detachedTextNode.length, 0), with selected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.deleteData(1, 0), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(1, 0), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(2, 0), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(2, 0), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(3, 0), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(3, 0), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(376, 631), with unselected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.deleteData(376, 631), with selected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.deleteData(0, 631), with unselected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.deleteData(0, 631), with selected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.deleteData(1, 631), with unselected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.deleteData(1, 631), with selected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.deleteData(detachedTextNode.length, 631), with unselected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.deleteData(detachedTextNode.length, 631), with selected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.deleteData(1, 631), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(1, 631), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(2, 631), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(2, 631), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(3, 631), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.deleteData(3, 631), with selected range on detachedTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(376, 2), with unselected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.deleteData(376, 2), with selected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.deleteData(0, 2), with unselected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.deleteData(0, 2), with selected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.deleteData(1, 2), with unselected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.deleteData(1, 2), with selected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.deleteData(detachedForeignTextNode.length, 2), with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.deleteData(detachedForeignTextNode.length, 2), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.deleteData(1, 2), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(1, 2), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(2, 2), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(2, 2), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(3, 2), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(3, 2), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(376, 0), with unselected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.deleteData(376, 0), with selected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.deleteData(0, 0), with unselected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.deleteData(0, 0), with selected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.deleteData(1, 0), with unselected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.deleteData(1, 0), with selected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.deleteData(detachedForeignTextNode.length, 0), with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.deleteData(detachedForeignTextNode.length, 0), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.deleteData(1, 0), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(1, 0), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(2, 0), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(2, 0), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(3, 0), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(3, 0), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(376, 631), with unselected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.deleteData(376, 631), with selected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.deleteData(0, 631), with unselected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.deleteData(0, 631), with selected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.deleteData(1, 631), with unselected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.deleteData(1, 631), with selected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.deleteData(detachedForeignTextNode.length, 631), with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.deleteData(detachedForeignTextNode.length, 631), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.deleteData(1, 631), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(1, 631), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(2, 631), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(2, 631), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(3, 631), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.deleteData(3, 631), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(376, 2), with unselected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.deleteData(376, 2), with selected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.deleteData(0, 2), with unselected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.deleteData(0, 2), with selected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.deleteData(1, 2), with unselected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.deleteData(1, 2), with selected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.deleteData(detachedXmlTextNode.length, 2), with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.deleteData(detachedXmlTextNode.length, 2), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.deleteData(1, 2), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(1, 2), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(2, 2), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(2, 2), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(3, 2), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(3, 2), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(376, 0), with unselected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.deleteData(376, 0), with selected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.deleteData(0, 0), with unselected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.deleteData(0, 0), with selected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.deleteData(1, 0), with unselected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.deleteData(1, 0), with selected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.deleteData(detachedXmlTextNode.length, 0), with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.deleteData(detachedXmlTextNode.length, 0), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.deleteData(1, 0), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(1, 0), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(2, 0), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(2, 0), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(3, 0), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(3, 0), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(376, 631), with unselected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.deleteData(376, 631), with selected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.deleteData(0, 631), with unselected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.deleteData(0, 631), with selected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.deleteData(1, 631), with unselected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.deleteData(1, 631), with selected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.deleteData(detachedXmlTextNode.length, 631), with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.deleteData(detachedXmlTextNode.length, 631), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.deleteData(1, 631), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(1, 631), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(2, 631), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(2, 631), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(3, 631), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.deleteData(3, 631), with selected range on detachedXmlTextNode from 1 to 3
+PASS comment.deleteData(376, 2), with unselected range on comment from 0 to 1
+PASS comment.deleteData(376, 2), with selected range on comment from 0 to 1
+PASS comment.deleteData(0, 2), with unselected range collapsed at (comment, 0)
+PASS comment.deleteData(0, 2), with selected range collapsed at (comment, 0)
+PASS comment.deleteData(1, 2), with unselected range collapsed at (comment, 1)
+PASS comment.deleteData(1, 2), with selected range collapsed at (comment, 1)
+PASS comment.deleteData(comment.length, 2), with unselected range collapsed at (comment, comment.length)
+PASS comment.deleteData(comment.length, 2), with selected range collapsed at (comment, comment.length)
+PASS comment.deleteData(1, 2), with unselected range on comment from 1 to 3
+PASS comment.deleteData(1, 2), with selected range on comment from 1 to 3
+PASS comment.deleteData(2, 2), with unselected range on comment from 1 to 3
+PASS comment.deleteData(2, 2), with selected range on comment from 1 to 3
+PASS comment.deleteData(3, 2), with unselected range on comment from 1 to 3
+PASS comment.deleteData(3, 2), with selected range on comment from 1 to 3
+PASS comment.deleteData(376, 0), with unselected range on comment from 0 to 1
+PASS comment.deleteData(376, 0), with selected range on comment from 0 to 1
+PASS comment.deleteData(0, 0), with unselected range collapsed at (comment, 0)
+PASS comment.deleteData(0, 0), with selected range collapsed at (comment, 0)
+PASS comment.deleteData(1, 0), with unselected range collapsed at (comment, 1)
+PASS comment.deleteData(1, 0), with selected range collapsed at (comment, 1)
+PASS comment.deleteData(comment.length, 0), with unselected range collapsed at (comment, comment.length)
+PASS comment.deleteData(comment.length, 0), with selected range collapsed at (comment, comment.length)
+PASS comment.deleteData(1, 0), with unselected range on comment from 1 to 3
+PASS comment.deleteData(1, 0), with selected range on comment from 1 to 3
+PASS comment.deleteData(2, 0), with unselected range on comment from 1 to 3
+PASS comment.deleteData(2, 0), with selected range on comment from 1 to 3
+PASS comment.deleteData(3, 0), with unselected range on comment from 1 to 3
+PASS comment.deleteData(3, 0), with selected range on comment from 1 to 3
+PASS comment.deleteData(376, 631), with unselected range on comment from 0 to 1
+PASS comment.deleteData(376, 631), with selected range on comment from 0 to 1
+PASS comment.deleteData(0, 631), with unselected range collapsed at (comment, 0)
+PASS comment.deleteData(0, 631), with selected range collapsed at (comment, 0)
+PASS comment.deleteData(1, 631), with unselected range collapsed at (comment, 1)
+PASS comment.deleteData(1, 631), with selected range collapsed at (comment, 1)
+PASS comment.deleteData(comment.length, 631), with unselected range collapsed at (comment, comment.length)
+PASS comment.deleteData(comment.length, 631), with selected range collapsed at (comment, comment.length)
+PASS comment.deleteData(1, 631), with unselected range on comment from 1 to 3
+PASS comment.deleteData(1, 631), with selected range on comment from 1 to 3
+PASS comment.deleteData(2, 631), with unselected range on comment from 1 to 3
+PASS comment.deleteData(2, 631), with selected range on comment from 1 to 3
+PASS comment.deleteData(3, 631), with unselected range on comment from 1 to 3
+PASS comment.deleteData(3, 631), with selected range on comment from 1 to 3
+PASS foreignComment.deleteData(376, 2), with unselected range on foreignComment from 0 to 1
+PASS foreignComment.deleteData(376, 2), with selected range on foreignComment from 0 to 1
+PASS foreignComment.deleteData(0, 2), with unselected range collapsed at (foreignComment, 0)
+PASS foreignComment.deleteData(0, 2), with selected range collapsed at (foreignComment, 0)
+PASS foreignComment.deleteData(1, 2), with unselected range collapsed at (foreignComment, 1)
+PASS foreignComment.deleteData(1, 2), with selected range collapsed at (foreignComment, 1)
+PASS foreignComment.deleteData(foreignComment.length, 2), with unselected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.deleteData(foreignComment.length, 2), with selected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.deleteData(1, 2), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(1, 2), with selected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(2, 2), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(2, 2), with selected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(3, 2), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(3, 2), with selected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(376, 0), with unselected range on foreignComment from 0 to 1
+PASS foreignComment.deleteData(376, 0), with selected range on foreignComment from 0 to 1
+PASS foreignComment.deleteData(0, 0), with unselected range collapsed at (foreignComment, 0)
+PASS foreignComment.deleteData(0, 0), with selected range collapsed at (foreignComment, 0)
+PASS foreignComment.deleteData(1, 0), with unselected range collapsed at (foreignComment, 1)
+PASS foreignComment.deleteData(1, 0), with selected range collapsed at (foreignComment, 1)
+PASS foreignComment.deleteData(foreignComment.length, 0), with unselected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.deleteData(foreignComment.length, 0), with selected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.deleteData(1, 0), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(1, 0), with selected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(2, 0), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(2, 0), with selected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(3, 0), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(3, 0), with selected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(376, 631), with unselected range on foreignComment from 0 to 1
+PASS foreignComment.deleteData(376, 631), with selected range on foreignComment from 0 to 1
+PASS foreignComment.deleteData(0, 631), with unselected range collapsed at (foreignComment, 0)
+PASS foreignComment.deleteData(0, 631), with selected range collapsed at (foreignComment, 0)
+PASS foreignComment.deleteData(1, 631), with unselected range collapsed at (foreignComment, 1)
+PASS foreignComment.deleteData(1, 631), with selected range collapsed at (foreignComment, 1)
+PASS foreignComment.deleteData(foreignComment.length, 631), with unselected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.deleteData(foreignComment.length, 631), with selected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.deleteData(1, 631), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(1, 631), with selected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(2, 631), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(2, 631), with selected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(3, 631), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.deleteData(3, 631), with selected range on foreignComment from 1 to 3
+PASS xmlComment.deleteData(376, 2), with unselected range on xmlComment from 0 to 1
+PASS xmlComment.deleteData(376, 2), with selected range on xmlComment from 0 to 1
+PASS xmlComment.deleteData(0, 2), with unselected range collapsed at (xmlComment, 0)
+PASS xmlComment.deleteData(0, 2), with selected range collapsed at (xmlComment, 0)
+PASS xmlComment.deleteData(1, 2), with unselected range collapsed at (xmlComment, 1)
+PASS xmlComment.deleteData(1, 2), with selected range collapsed at (xmlComment, 1)
+PASS xmlComment.deleteData(xmlComment.length, 2), with unselected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.deleteData(xmlComment.length, 2), with selected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.deleteData(1, 2), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(1, 2), with selected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(2, 2), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(2, 2), with selected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(3, 2), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(3, 2), with selected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(376, 0), with unselected range on xmlComment from 0 to 1
+PASS xmlComment.deleteData(376, 0), with selected range on xmlComment from 0 to 1
+PASS xmlComment.deleteData(0, 0), with unselected range collapsed at (xmlComment, 0)
+PASS xmlComment.deleteData(0, 0), with selected range collapsed at (xmlComment, 0)
+PASS xmlComment.deleteData(1, 0), with unselected range collapsed at (xmlComment, 1)
+PASS xmlComment.deleteData(1, 0), with selected range collapsed at (xmlComment, 1)
+PASS xmlComment.deleteData(xmlComment.length, 0), with unselected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.deleteData(xmlComment.length, 0), with selected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.deleteData(1, 0), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(1, 0), with selected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(2, 0), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(2, 0), with selected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(3, 0), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(3, 0), with selected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(376, 631), with unselected range on xmlComment from 0 to 1
+PASS xmlComment.deleteData(376, 631), with selected range on xmlComment from 0 to 1
+PASS xmlComment.deleteData(0, 631), with unselected range collapsed at (xmlComment, 0)
+PASS xmlComment.deleteData(0, 631), with selected range collapsed at (xmlComment, 0)
+PASS xmlComment.deleteData(1, 631), with unselected range collapsed at (xmlComment, 1)
+PASS xmlComment.deleteData(1, 631), with selected range collapsed at (xmlComment, 1)
+PASS xmlComment.deleteData(xmlComment.length, 631), with unselected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.deleteData(xmlComment.length, 631), with selected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.deleteData(1, 631), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(1, 631), with selected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(2, 631), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(2, 631), with selected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(3, 631), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.deleteData(3, 631), with selected range on xmlComment from 1 to 3
+PASS detachedComment.deleteData(376, 2), with unselected range on detachedComment from 0 to 1
+PASS detachedComment.deleteData(376, 2), with selected range on detachedComment from 0 to 1
+PASS detachedComment.deleteData(0, 2), with unselected range collapsed at (detachedComment, 0)
+PASS detachedComment.deleteData(0, 2), with selected range collapsed at (detachedComment, 0)
+PASS detachedComment.deleteData(1, 2), with unselected range collapsed at (detachedComment, 1)
+PASS detachedComment.deleteData(1, 2), with selected range collapsed at (detachedComment, 1)
+PASS detachedComment.deleteData(detachedComment.length, 2), with unselected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.deleteData(detachedComment.length, 2), with selected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.deleteData(1, 2), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(1, 2), with selected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(2, 2), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(2, 2), with selected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(3, 2), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(3, 2), with selected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(376, 0), with unselected range on detachedComment from 0 to 1
+PASS detachedComment.deleteData(376, 0), with selected range on detachedComment from 0 to 1
+PASS detachedComment.deleteData(0, 0), with unselected range collapsed at (detachedComment, 0)
+PASS detachedComment.deleteData(0, 0), with selected range collapsed at (detachedComment, 0)
+PASS detachedComment.deleteData(1, 0), with unselected range collapsed at (detachedComment, 1)
+PASS detachedComment.deleteData(1, 0), with selected range collapsed at (detachedComment, 1)
+PASS detachedComment.deleteData(detachedComment.length, 0), with unselected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.deleteData(detachedComment.length, 0), with selected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.deleteData(1, 0), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(1, 0), with selected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(2, 0), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(2, 0), with selected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(3, 0), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(3, 0), with selected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(376, 631), with unselected range on detachedComment from 0 to 1
+PASS detachedComment.deleteData(376, 631), with selected range on detachedComment from 0 to 1
+PASS detachedComment.deleteData(0, 631), with unselected range collapsed at (detachedComment, 0)
+PASS detachedComment.deleteData(0, 631), with selected range collapsed at (detachedComment, 0)
+PASS detachedComment.deleteData(1, 631), with unselected range collapsed at (detachedComment, 1)
+PASS detachedComment.deleteData(1, 631), with selected range collapsed at (detachedComment, 1)
+PASS detachedComment.deleteData(detachedComment.length, 631), with unselected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.deleteData(detachedComment.length, 631), with selected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.deleteData(1, 631), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(1, 631), with selected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(2, 631), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(2, 631), with selected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(3, 631), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.deleteData(3, 631), with selected range on detachedComment from 1 to 3
+PASS detachedForeignComment.deleteData(376, 2), with unselected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.deleteData(376, 2), with selected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.deleteData(0, 2), with unselected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.deleteData(0, 2), with selected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.deleteData(1, 2), with unselected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.deleteData(1, 2), with selected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.deleteData(detachedForeignComment.length, 2), with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.deleteData(detachedForeignComment.length, 2), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.deleteData(1, 2), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(1, 2), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(2, 2), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(2, 2), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(3, 2), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(3, 2), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(376, 0), with unselected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.deleteData(376, 0), with selected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.deleteData(0, 0), with unselected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.deleteData(0, 0), with selected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.deleteData(1, 0), with unselected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.deleteData(1, 0), with selected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.deleteData(detachedForeignComment.length, 0), with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.deleteData(detachedForeignComment.length, 0), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.deleteData(1, 0), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(1, 0), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(2, 0), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(2, 0), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(3, 0), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(3, 0), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(376, 631), with unselected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.deleteData(376, 631), with selected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.deleteData(0, 631), with unselected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.deleteData(0, 631), with selected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.deleteData(1, 631), with unselected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.deleteData(1, 631), with selected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.deleteData(detachedForeignComment.length, 631), with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.deleteData(detachedForeignComment.length, 631), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.deleteData(1, 631), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(1, 631), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(2, 631), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(2, 631), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(3, 631), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.deleteData(3, 631), with selected range on detachedForeignComment from 1 to 3
+PASS detachedXmlComment.deleteData(376, 2), with unselected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.deleteData(376, 2), with selected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.deleteData(0, 2), with unselected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.deleteData(0, 2), with selected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.deleteData(1, 2), with unselected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.deleteData(1, 2), with selected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.deleteData(detachedXmlComment.length, 2), with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.deleteData(detachedXmlComment.length, 2), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.deleteData(1, 2), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(1, 2), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(2, 2), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(2, 2), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(3, 2), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(3, 2), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(376, 0), with unselected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.deleteData(376, 0), with selected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.deleteData(0, 0), with unselected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.deleteData(0, 0), with selected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.deleteData(1, 0), with unselected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.deleteData(1, 0), with selected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.deleteData(detachedXmlComment.length, 0), with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.deleteData(detachedXmlComment.length, 0), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.deleteData(1, 0), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(1, 0), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(2, 0), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(2, 0), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(3, 0), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(3, 0), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(376, 631), with unselected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.deleteData(376, 631), with selected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.deleteData(0, 631), with unselected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.deleteData(0, 631), with selected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.deleteData(1, 631), with unselected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.deleteData(1, 631), with selected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.deleteData(detachedXmlComment.length, 631), with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.deleteData(detachedXmlComment.length, 631), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.deleteData(1, 631), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(1, 631), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(2, 631), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(2, 631), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(3, 631), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.deleteData(3, 631), with selected range on detachedXmlComment from 1 to 3
+PASS paras[0].firstChild.deleteData(1, 2), with unselected range collapsed at (paras[0], 0)
+PASS paras[0].firstChild.deleteData(1, 2), with selected range collapsed at (paras[0], 0)
+PASS paras[0].firstChild.deleteData(1, 2), with unselected range on paras[0] from 0 to 1
+PASS paras[0].firstChild.deleteData(1, 2), with selected range on paras[0] from 0 to 1
+PASS paras[0].firstChild.deleteData(1, 2), with unselected range collapsed at (paras[0], 1)
+PASS paras[0].firstChild.deleteData(1, 2), with selected range collapsed at (paras[0], 1)
+PASS paras[0].firstChild.deleteData(1, 2), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.deleteData(1, 2), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.deleteData(2, 2), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.deleteData(2, 2), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.deleteData(3, 2), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.deleteData(3, 2), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.deleteData(1, 2), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.deleteData(1, 2), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.deleteData(2, 2), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.deleteData(2, 2), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.deleteData(3, 2), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.deleteData(3, 2), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+

--- a/LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-deleteData.html
+++ b/LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-deleteData.html
@@ -1,0 +1,14 @@
+<!doctype html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<title>Range mutation tests - deleteData</title>
+<link rel="author" title="Aryeh Gregor" href=ayg@aryeh.name>
+<meta name=timeout content=long>
+
+<div id=log></div>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
+<script src="Range-mutations.js"></script>
+<script>
+doTests(deleteDataTests, function(params) { return params[0] + ".deleteData(" + params[1] + ", " + params[2] + ")" }, testDeleteData);
+testDiv.style.display = "none";
+</script>

--- a/LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-insertData-expected.txt
+++ b/LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-insertData-expected.txt
@@ -1,0 +1,384 @@
+
+PASS paras[0].firstChild.insertData(376, "foo"), with unselected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.insertData(376, "foo"), with selected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.insertData(0, "foo"), with unselected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.insertData(0, "foo"), with selected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.insertData(1, "foo"), with unselected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.insertData(1, "foo"), with selected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.insertData(paras[0].firstChild.length, "foo"), with unselected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.insertData(paras[0].firstChild.length, "foo"), with selected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.insertData(1, "foo"), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.insertData(1, "foo"), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.insertData(2, "foo"), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.insertData(2, "foo"), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.insertData(3, "foo"), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.insertData(3, "foo"), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.insertData(376, ""), with unselected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.insertData(376, ""), with selected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.insertData(0, ""), with unselected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.insertData(0, ""), with selected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.insertData(1, ""), with unselected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.insertData(1, ""), with selected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.insertData(paras[0].firstChild.length, ""), with unselected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.insertData(paras[0].firstChild.length, ""), with selected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.insertData(1, ""), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.insertData(1, ""), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.insertData(2, ""), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.insertData(2, ""), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.insertData(3, ""), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.insertData(3, ""), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[1].firstChild.insertData(376, "foo"), with unselected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.insertData(376, "foo"), with selected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.insertData(0, "foo"), with unselected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.insertData(0, "foo"), with selected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.insertData(1, "foo"), with unselected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.insertData(1, "foo"), with selected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.insertData(paras[1].firstChild.length, "foo"), with unselected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.insertData(paras[1].firstChild.length, "foo"), with selected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.insertData(1, "foo"), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.insertData(1, "foo"), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.insertData(2, "foo"), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.insertData(2, "foo"), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.insertData(3, "foo"), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.insertData(3, "foo"), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.insertData(376, ""), with unselected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.insertData(376, ""), with selected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.insertData(0, ""), with unselected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.insertData(0, ""), with selected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.insertData(1, ""), with unselected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.insertData(1, ""), with selected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.insertData(paras[1].firstChild.length, ""), with unselected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.insertData(paras[1].firstChild.length, ""), with selected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.insertData(1, ""), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.insertData(1, ""), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.insertData(2, ""), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.insertData(2, ""), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.insertData(3, ""), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.insertData(3, ""), with selected range on paras[1].firstChild from 1 to 3
+PASS foreignTextNode.insertData(376, "foo"), with unselected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.insertData(376, "foo"), with selected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.insertData(0, "foo"), with unselected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.insertData(0, "foo"), with selected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.insertData(1, "foo"), with unselected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.insertData(1, "foo"), with selected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.insertData(foreignTextNode.length, "foo"), with unselected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.insertData(foreignTextNode.length, "foo"), with selected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.insertData(1, "foo"), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.insertData(1, "foo"), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.insertData(2, "foo"), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.insertData(2, "foo"), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.insertData(3, "foo"), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.insertData(3, "foo"), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.insertData(376, ""), with unselected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.insertData(376, ""), with selected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.insertData(0, ""), with unselected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.insertData(0, ""), with selected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.insertData(1, ""), with unselected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.insertData(1, ""), with selected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.insertData(foreignTextNode.length, ""), with unselected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.insertData(foreignTextNode.length, ""), with selected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.insertData(1, ""), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.insertData(1, ""), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.insertData(2, ""), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.insertData(2, ""), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.insertData(3, ""), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.insertData(3, ""), with selected range on foreignTextNode from 1 to 3
+PASS xmlTextNode.insertData(376, "foo"), with unselected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.insertData(376, "foo"), with selected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.insertData(0, "foo"), with unselected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.insertData(0, "foo"), with selected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.insertData(1, "foo"), with unselected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.insertData(1, "foo"), with selected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.insertData(xmlTextNode.length, "foo"), with unselected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.insertData(xmlTextNode.length, "foo"), with selected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.insertData(1, "foo"), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.insertData(1, "foo"), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.insertData(2, "foo"), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.insertData(2, "foo"), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.insertData(3, "foo"), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.insertData(3, "foo"), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.insertData(376, ""), with unselected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.insertData(376, ""), with selected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.insertData(0, ""), with unselected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.insertData(0, ""), with selected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.insertData(1, ""), with unselected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.insertData(1, ""), with selected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.insertData(xmlTextNode.length, ""), with unselected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.insertData(xmlTextNode.length, ""), with selected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.insertData(1, ""), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.insertData(1, ""), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.insertData(2, ""), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.insertData(2, ""), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.insertData(3, ""), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.insertData(3, ""), with selected range on xmlTextNode from 1 to 3
+PASS detachedTextNode.insertData(376, "foo"), with unselected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.insertData(376, "foo"), with selected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.insertData(0, "foo"), with unselected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.insertData(0, "foo"), with selected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.insertData(1, "foo"), with unselected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.insertData(1, "foo"), with selected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.insertData(detachedTextNode.length, "foo"), with unselected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.insertData(detachedTextNode.length, "foo"), with selected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.insertData(1, "foo"), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.insertData(1, "foo"), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.insertData(2, "foo"), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.insertData(2, "foo"), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.insertData(3, "foo"), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.insertData(3, "foo"), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.insertData(376, ""), with unselected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.insertData(376, ""), with selected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.insertData(0, ""), with unselected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.insertData(0, ""), with selected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.insertData(1, ""), with unselected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.insertData(1, ""), with selected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.insertData(detachedTextNode.length, ""), with unselected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.insertData(detachedTextNode.length, ""), with selected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.insertData(1, ""), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.insertData(1, ""), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.insertData(2, ""), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.insertData(2, ""), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.insertData(3, ""), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.insertData(3, ""), with selected range on detachedTextNode from 1 to 3
+PASS detachedForeignTextNode.insertData(376, "foo"), with unselected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.insertData(376, "foo"), with selected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.insertData(0, "foo"), with unselected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.insertData(0, "foo"), with selected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.insertData(1, "foo"), with unselected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.insertData(1, "foo"), with selected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.insertData(detachedForeignTextNode.length, "foo"), with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.insertData(detachedForeignTextNode.length, "foo"), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.insertData(1, "foo"), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.insertData(1, "foo"), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.insertData(2, "foo"), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.insertData(2, "foo"), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.insertData(3, "foo"), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.insertData(3, "foo"), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.insertData(376, ""), with unselected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.insertData(376, ""), with selected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.insertData(0, ""), with unselected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.insertData(0, ""), with selected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.insertData(1, ""), with unselected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.insertData(1, ""), with selected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.insertData(detachedForeignTextNode.length, ""), with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.insertData(detachedForeignTextNode.length, ""), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.insertData(1, ""), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.insertData(1, ""), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.insertData(2, ""), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.insertData(2, ""), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.insertData(3, ""), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.insertData(3, ""), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedXmlTextNode.insertData(376, "foo"), with unselected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.insertData(376, "foo"), with selected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.insertData(0, "foo"), with unselected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.insertData(0, "foo"), with selected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.insertData(1, "foo"), with unselected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.insertData(1, "foo"), with selected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.insertData(detachedXmlTextNode.length, "foo"), with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.insertData(detachedXmlTextNode.length, "foo"), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.insertData(1, "foo"), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.insertData(1, "foo"), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.insertData(2, "foo"), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.insertData(2, "foo"), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.insertData(3, "foo"), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.insertData(3, "foo"), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.insertData(376, ""), with unselected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.insertData(376, ""), with selected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.insertData(0, ""), with unselected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.insertData(0, ""), with selected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.insertData(1, ""), with unselected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.insertData(1, ""), with selected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.insertData(detachedXmlTextNode.length, ""), with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.insertData(detachedXmlTextNode.length, ""), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.insertData(1, ""), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.insertData(1, ""), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.insertData(2, ""), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.insertData(2, ""), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.insertData(3, ""), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.insertData(3, ""), with selected range on detachedXmlTextNode from 1 to 3
+PASS comment.insertData(376, "foo"), with unselected range on comment from 0 to 1
+PASS comment.insertData(376, "foo"), with selected range on comment from 0 to 1
+PASS comment.insertData(0, "foo"), with unselected range collapsed at (comment, 0)
+PASS comment.insertData(0, "foo"), with selected range collapsed at (comment, 0)
+PASS comment.insertData(1, "foo"), with unselected range collapsed at (comment, 1)
+PASS comment.insertData(1, "foo"), with selected range collapsed at (comment, 1)
+PASS comment.insertData(comment.length, "foo"), with unselected range collapsed at (comment, comment.length)
+PASS comment.insertData(comment.length, "foo"), with selected range collapsed at (comment, comment.length)
+PASS comment.insertData(1, "foo"), with unselected range on comment from 1 to 3
+PASS comment.insertData(1, "foo"), with selected range on comment from 1 to 3
+PASS comment.insertData(2, "foo"), with unselected range on comment from 1 to 3
+PASS comment.insertData(2, "foo"), with selected range on comment from 1 to 3
+PASS comment.insertData(3, "foo"), with unselected range on comment from 1 to 3
+PASS comment.insertData(3, "foo"), with selected range on comment from 1 to 3
+PASS comment.insertData(376, ""), with unselected range on comment from 0 to 1
+PASS comment.insertData(376, ""), with selected range on comment from 0 to 1
+PASS comment.insertData(0, ""), with unselected range collapsed at (comment, 0)
+PASS comment.insertData(0, ""), with selected range collapsed at (comment, 0)
+PASS comment.insertData(1, ""), with unselected range collapsed at (comment, 1)
+PASS comment.insertData(1, ""), with selected range collapsed at (comment, 1)
+PASS comment.insertData(comment.length, ""), with unselected range collapsed at (comment, comment.length)
+PASS comment.insertData(comment.length, ""), with selected range collapsed at (comment, comment.length)
+PASS comment.insertData(1, ""), with unselected range on comment from 1 to 3
+PASS comment.insertData(1, ""), with selected range on comment from 1 to 3
+PASS comment.insertData(2, ""), with unselected range on comment from 1 to 3
+PASS comment.insertData(2, ""), with selected range on comment from 1 to 3
+PASS comment.insertData(3, ""), with unselected range on comment from 1 to 3
+PASS comment.insertData(3, ""), with selected range on comment from 1 to 3
+PASS foreignComment.insertData(376, "foo"), with unselected range on foreignComment from 0 to 1
+PASS foreignComment.insertData(376, "foo"), with selected range on foreignComment from 0 to 1
+PASS foreignComment.insertData(0, "foo"), with unselected range collapsed at (foreignComment, 0)
+PASS foreignComment.insertData(0, "foo"), with selected range collapsed at (foreignComment, 0)
+PASS foreignComment.insertData(1, "foo"), with unselected range collapsed at (foreignComment, 1)
+PASS foreignComment.insertData(1, "foo"), with selected range collapsed at (foreignComment, 1)
+PASS foreignComment.insertData(foreignComment.length, "foo"), with unselected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.insertData(foreignComment.length, "foo"), with selected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.insertData(1, "foo"), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.insertData(1, "foo"), with selected range on foreignComment from 1 to 3
+PASS foreignComment.insertData(2, "foo"), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.insertData(2, "foo"), with selected range on foreignComment from 1 to 3
+PASS foreignComment.insertData(3, "foo"), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.insertData(3, "foo"), with selected range on foreignComment from 1 to 3
+PASS foreignComment.insertData(376, ""), with unselected range on foreignComment from 0 to 1
+PASS foreignComment.insertData(376, ""), with selected range on foreignComment from 0 to 1
+PASS foreignComment.insertData(0, ""), with unselected range collapsed at (foreignComment, 0)
+PASS foreignComment.insertData(0, ""), with selected range collapsed at (foreignComment, 0)
+PASS foreignComment.insertData(1, ""), with unselected range collapsed at (foreignComment, 1)
+PASS foreignComment.insertData(1, ""), with selected range collapsed at (foreignComment, 1)
+PASS foreignComment.insertData(foreignComment.length, ""), with unselected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.insertData(foreignComment.length, ""), with selected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.insertData(1, ""), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.insertData(1, ""), with selected range on foreignComment from 1 to 3
+PASS foreignComment.insertData(2, ""), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.insertData(2, ""), with selected range on foreignComment from 1 to 3
+PASS foreignComment.insertData(3, ""), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.insertData(3, ""), with selected range on foreignComment from 1 to 3
+PASS xmlComment.insertData(376, "foo"), with unselected range on xmlComment from 0 to 1
+PASS xmlComment.insertData(376, "foo"), with selected range on xmlComment from 0 to 1
+PASS xmlComment.insertData(0, "foo"), with unselected range collapsed at (xmlComment, 0)
+PASS xmlComment.insertData(0, "foo"), with selected range collapsed at (xmlComment, 0)
+PASS xmlComment.insertData(1, "foo"), with unselected range collapsed at (xmlComment, 1)
+PASS xmlComment.insertData(1, "foo"), with selected range collapsed at (xmlComment, 1)
+PASS xmlComment.insertData(xmlComment.length, "foo"), with unselected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.insertData(xmlComment.length, "foo"), with selected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.insertData(1, "foo"), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.insertData(1, "foo"), with selected range on xmlComment from 1 to 3
+PASS xmlComment.insertData(2, "foo"), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.insertData(2, "foo"), with selected range on xmlComment from 1 to 3
+PASS xmlComment.insertData(3, "foo"), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.insertData(3, "foo"), with selected range on xmlComment from 1 to 3
+PASS xmlComment.insertData(376, ""), with unselected range on xmlComment from 0 to 1
+PASS xmlComment.insertData(376, ""), with selected range on xmlComment from 0 to 1
+PASS xmlComment.insertData(0, ""), with unselected range collapsed at (xmlComment, 0)
+PASS xmlComment.insertData(0, ""), with selected range collapsed at (xmlComment, 0)
+PASS xmlComment.insertData(1, ""), with unselected range collapsed at (xmlComment, 1)
+PASS xmlComment.insertData(1, ""), with selected range collapsed at (xmlComment, 1)
+PASS xmlComment.insertData(xmlComment.length, ""), with unselected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.insertData(xmlComment.length, ""), with selected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.insertData(1, ""), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.insertData(1, ""), with selected range on xmlComment from 1 to 3
+PASS xmlComment.insertData(2, ""), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.insertData(2, ""), with selected range on xmlComment from 1 to 3
+PASS xmlComment.insertData(3, ""), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.insertData(3, ""), with selected range on xmlComment from 1 to 3
+PASS detachedComment.insertData(376, "foo"), with unselected range on detachedComment from 0 to 1
+PASS detachedComment.insertData(376, "foo"), with selected range on detachedComment from 0 to 1
+PASS detachedComment.insertData(0, "foo"), with unselected range collapsed at (detachedComment, 0)
+PASS detachedComment.insertData(0, "foo"), with selected range collapsed at (detachedComment, 0)
+PASS detachedComment.insertData(1, "foo"), with unselected range collapsed at (detachedComment, 1)
+PASS detachedComment.insertData(1, "foo"), with selected range collapsed at (detachedComment, 1)
+PASS detachedComment.insertData(detachedComment.length, "foo"), with unselected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.insertData(detachedComment.length, "foo"), with selected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.insertData(1, "foo"), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.insertData(1, "foo"), with selected range on detachedComment from 1 to 3
+PASS detachedComment.insertData(2, "foo"), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.insertData(2, "foo"), with selected range on detachedComment from 1 to 3
+PASS detachedComment.insertData(3, "foo"), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.insertData(3, "foo"), with selected range on detachedComment from 1 to 3
+PASS detachedComment.insertData(376, ""), with unselected range on detachedComment from 0 to 1
+PASS detachedComment.insertData(376, ""), with selected range on detachedComment from 0 to 1
+PASS detachedComment.insertData(0, ""), with unselected range collapsed at (detachedComment, 0)
+PASS detachedComment.insertData(0, ""), with selected range collapsed at (detachedComment, 0)
+PASS detachedComment.insertData(1, ""), with unselected range collapsed at (detachedComment, 1)
+PASS detachedComment.insertData(1, ""), with selected range collapsed at (detachedComment, 1)
+PASS detachedComment.insertData(detachedComment.length, ""), with unselected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.insertData(detachedComment.length, ""), with selected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.insertData(1, ""), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.insertData(1, ""), with selected range on detachedComment from 1 to 3
+PASS detachedComment.insertData(2, ""), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.insertData(2, ""), with selected range on detachedComment from 1 to 3
+PASS detachedComment.insertData(3, ""), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.insertData(3, ""), with selected range on detachedComment from 1 to 3
+PASS detachedForeignComment.insertData(376, "foo"), with unselected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.insertData(376, "foo"), with selected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.insertData(0, "foo"), with unselected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.insertData(0, "foo"), with selected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.insertData(1, "foo"), with unselected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.insertData(1, "foo"), with selected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.insertData(detachedForeignComment.length, "foo"), with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.insertData(detachedForeignComment.length, "foo"), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.insertData(1, "foo"), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.insertData(1, "foo"), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.insertData(2, "foo"), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.insertData(2, "foo"), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.insertData(3, "foo"), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.insertData(3, "foo"), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.insertData(376, ""), with unselected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.insertData(376, ""), with selected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.insertData(0, ""), with unselected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.insertData(0, ""), with selected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.insertData(1, ""), with unselected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.insertData(1, ""), with selected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.insertData(detachedForeignComment.length, ""), with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.insertData(detachedForeignComment.length, ""), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.insertData(1, ""), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.insertData(1, ""), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.insertData(2, ""), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.insertData(2, ""), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.insertData(3, ""), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.insertData(3, ""), with selected range on detachedForeignComment from 1 to 3
+PASS detachedXmlComment.insertData(376, "foo"), with unselected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.insertData(376, "foo"), with selected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.insertData(0, "foo"), with unselected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.insertData(0, "foo"), with selected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.insertData(1, "foo"), with unselected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.insertData(1, "foo"), with selected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.insertData(detachedXmlComment.length, "foo"), with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.insertData(detachedXmlComment.length, "foo"), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.insertData(1, "foo"), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.insertData(1, "foo"), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.insertData(2, "foo"), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.insertData(2, "foo"), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.insertData(3, "foo"), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.insertData(3, "foo"), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.insertData(376, ""), with unselected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.insertData(376, ""), with selected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.insertData(0, ""), with unselected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.insertData(0, ""), with selected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.insertData(1, ""), with unselected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.insertData(1, ""), with selected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.insertData(detachedXmlComment.length, ""), with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.insertData(detachedXmlComment.length, ""), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.insertData(1, ""), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.insertData(1, ""), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.insertData(2, ""), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.insertData(2, ""), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.insertData(3, ""), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.insertData(3, ""), with selected range on detachedXmlComment from 1 to 3
+PASS paras[0].firstChild.insertData(1, "foo"), with unselected range collapsed at (paras[0], 0)
+PASS paras[0].firstChild.insertData(1, "foo"), with selected range collapsed at (paras[0], 0)
+PASS paras[0].firstChild.insertData(1, "foo"), with unselected range on paras[0] from 0 to 1
+PASS paras[0].firstChild.insertData(1, "foo"), with selected range on paras[0] from 0 to 1
+PASS paras[0].firstChild.insertData(1, "foo"), with unselected range collapsed at (paras[0], 1)
+PASS paras[0].firstChild.insertData(1, "foo"), with selected range collapsed at (paras[0], 1)
+PASS paras[0].firstChild.insertData(1, "foo"), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.insertData(1, "foo"), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.insertData(2, "foo"), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.insertData(2, "foo"), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.insertData(3, "foo"), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.insertData(3, "foo"), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.insertData(1, "foo"), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.insertData(1, "foo"), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.insertData(2, "foo"), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.insertData(2, "foo"), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.insertData(3, "foo"), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.insertData(3, "foo"), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+

--- a/LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-insertData.html
+++ b/LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-insertData.html
@@ -1,0 +1,14 @@
+<!doctype html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<title>Range mutation tests - insertData</title>
+<link rel="author" title="Aryeh Gregor" href=ayg@aryeh.name>
+<meta name=timeout content=long>
+
+<div id=log></div>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
+<script src="Range-mutations.js"></script>
+<script>
+doTests(insertDataTests, function(params) { return params[0] + ".insertData(" + params[1] + ", " + params[2] + ")" }, testInsertData);
+testDiv.style.display = "none";
+</script>

--- a/LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-replaceData-expected.txt
+++ b/LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-replaceData-expected.txt
@@ -1,0 +1,1148 @@
+
+PASS paras[0].firstChild.replaceData(376, 0, "foo"), with unselected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.replaceData(376, 0, "foo"), with selected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.replaceData(0, 0, "foo"), with unselected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.replaceData(0, 0, "foo"), with selected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.replaceData(1, 0, "foo"), with unselected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.replaceData(1, 0, "foo"), with selected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.replaceData(paras[0].firstChild.length, 0, "foo"), with unselected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.replaceData(paras[0].firstChild.length, 0, "foo"), with selected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.replaceData(1, 0, "foo"), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(1, 0, "foo"), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(2, 0, "foo"), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(2, 0, "foo"), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(3, 0, "foo"), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(3, 0, "foo"), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(376, 0, ""), with unselected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.replaceData(376, 0, ""), with selected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.replaceData(0, 0, ""), with unselected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.replaceData(0, 0, ""), with selected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.replaceData(1, 0, ""), with unselected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.replaceData(1, 0, ""), with selected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.replaceData(paras[0].firstChild.length, 0, ""), with unselected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.replaceData(paras[0].firstChild.length, 0, ""), with selected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.replaceData(1, 0, ""), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(1, 0, ""), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(2, 0, ""), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(2, 0, ""), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(3, 0, ""), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(3, 0, ""), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(376, 1, "foo"), with unselected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.replaceData(376, 1, "foo"), with selected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.replaceData(0, 1, "foo"), with unselected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.replaceData(0, 1, "foo"), with selected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.replaceData(1, 1, "foo"), with unselected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.replaceData(1, 1, "foo"), with selected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.replaceData(paras[0].firstChild.length, 1, "foo"), with unselected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.replaceData(paras[0].firstChild.length, 1, "foo"), with selected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.replaceData(1, 1, "foo"), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(1, 1, "foo"), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(2, 1, "foo"), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(2, 1, "foo"), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(3, 1, "foo"), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(3, 1, "foo"), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(376, 1, ""), with unselected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.replaceData(376, 1, ""), with selected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.replaceData(0, 1, ""), with unselected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.replaceData(0, 1, ""), with selected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.replaceData(1, 1, ""), with unselected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.replaceData(1, 1, ""), with selected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.replaceData(paras[0].firstChild.length, 1, ""), with unselected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.replaceData(paras[0].firstChild.length, 1, ""), with selected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.replaceData(1, 1, ""), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(1, 1, ""), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(2, 1, ""), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(2, 1, ""), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(3, 1, ""), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(3, 1, ""), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(376, 47, "foo"), with unselected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.replaceData(376, 47, "foo"), with selected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.replaceData(0, 47, "foo"), with unselected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.replaceData(0, 47, "foo"), with selected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.replaceData(1, 47, "foo"), with unselected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.replaceData(1, 47, "foo"), with selected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.replaceData(paras[0].firstChild.length, 47, "foo"), with unselected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.replaceData(paras[0].firstChild.length, 47, "foo"), with selected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.replaceData(1, 47, "foo"), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(1, 47, "foo"), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(2, 47, "foo"), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(2, 47, "foo"), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(3, 47, "foo"), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(3, 47, "foo"), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(376, 47, ""), with unselected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.replaceData(376, 47, ""), with selected range on paras[0].firstChild from 0 to 1
+PASS paras[0].firstChild.replaceData(0, 47, ""), with unselected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.replaceData(0, 47, ""), with selected range collapsed at (paras[0].firstChild, 0)
+PASS paras[0].firstChild.replaceData(1, 47, ""), with unselected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.replaceData(1, 47, ""), with selected range collapsed at (paras[0].firstChild, 1)
+PASS paras[0].firstChild.replaceData(paras[0].firstChild.length, 47, ""), with unselected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.replaceData(paras[0].firstChild.length, 47, ""), with selected range collapsed at (paras[0].firstChild, paras[0].firstChild.length)
+PASS paras[0].firstChild.replaceData(1, 47, ""), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(1, 47, ""), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(2, 47, ""), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(2, 47, ""), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(3, 47, ""), with unselected range on paras[0].firstChild from 1 to 3
+PASS paras[0].firstChild.replaceData(3, 47, ""), with selected range on paras[0].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(376, 0, "foo"), with unselected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.replaceData(376, 0, "foo"), with selected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.replaceData(0, 0, "foo"), with unselected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.replaceData(0, 0, "foo"), with selected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.replaceData(1, 0, "foo"), with unselected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.replaceData(1, 0, "foo"), with selected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.replaceData(paras[1].firstChild.length, 0, "foo"), with unselected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.replaceData(paras[1].firstChild.length, 0, "foo"), with selected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.replaceData(1, 0, "foo"), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(1, 0, "foo"), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(2, 0, "foo"), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(2, 0, "foo"), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(3, 0, "foo"), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(3, 0, "foo"), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(376, 0, ""), with unselected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.replaceData(376, 0, ""), with selected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.replaceData(0, 0, ""), with unselected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.replaceData(0, 0, ""), with selected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.replaceData(1, 0, ""), with unselected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.replaceData(1, 0, ""), with selected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.replaceData(paras[1].firstChild.length, 0, ""), with unselected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.replaceData(paras[1].firstChild.length, 0, ""), with selected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.replaceData(1, 0, ""), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(1, 0, ""), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(2, 0, ""), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(2, 0, ""), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(3, 0, ""), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(3, 0, ""), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(376, 1, "foo"), with unselected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.replaceData(376, 1, "foo"), with selected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.replaceData(0, 1, "foo"), with unselected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.replaceData(0, 1, "foo"), with selected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.replaceData(1, 1, "foo"), with unselected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.replaceData(1, 1, "foo"), with selected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.replaceData(paras[1].firstChild.length, 1, "foo"), with unselected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.replaceData(paras[1].firstChild.length, 1, "foo"), with selected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.replaceData(1, 1, "foo"), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(1, 1, "foo"), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(2, 1, "foo"), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(2, 1, "foo"), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(3, 1, "foo"), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(3, 1, "foo"), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(376, 1, ""), with unselected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.replaceData(376, 1, ""), with selected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.replaceData(0, 1, ""), with unselected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.replaceData(0, 1, ""), with selected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.replaceData(1, 1, ""), with unselected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.replaceData(1, 1, ""), with selected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.replaceData(paras[1].firstChild.length, 1, ""), with unselected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.replaceData(paras[1].firstChild.length, 1, ""), with selected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.replaceData(1, 1, ""), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(1, 1, ""), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(2, 1, ""), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(2, 1, ""), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(3, 1, ""), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(3, 1, ""), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(376, 47, "foo"), with unselected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.replaceData(376, 47, "foo"), with selected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.replaceData(0, 47, "foo"), with unselected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.replaceData(0, 47, "foo"), with selected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.replaceData(1, 47, "foo"), with unselected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.replaceData(1, 47, "foo"), with selected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.replaceData(paras[1].firstChild.length, 47, "foo"), with unselected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.replaceData(paras[1].firstChild.length, 47, "foo"), with selected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.replaceData(1, 47, "foo"), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(1, 47, "foo"), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(2, 47, "foo"), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(2, 47, "foo"), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(3, 47, "foo"), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(3, 47, "foo"), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(376, 47, ""), with unselected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.replaceData(376, 47, ""), with selected range on paras[1].firstChild from 0 to 1
+PASS paras[1].firstChild.replaceData(0, 47, ""), with unselected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.replaceData(0, 47, ""), with selected range collapsed at (paras[1].firstChild, 0)
+PASS paras[1].firstChild.replaceData(1, 47, ""), with unselected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.replaceData(1, 47, ""), with selected range collapsed at (paras[1].firstChild, 1)
+PASS paras[1].firstChild.replaceData(paras[1].firstChild.length, 47, ""), with unselected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.replaceData(paras[1].firstChild.length, 47, ""), with selected range collapsed at (paras[1].firstChild, paras[1].firstChild.length)
+PASS paras[1].firstChild.replaceData(1, 47, ""), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(1, 47, ""), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(2, 47, ""), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(2, 47, ""), with selected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(3, 47, ""), with unselected range on paras[1].firstChild from 1 to 3
+PASS paras[1].firstChild.replaceData(3, 47, ""), with selected range on paras[1].firstChild from 1 to 3
+PASS foreignTextNode.replaceData(376, 0, "foo"), with unselected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.replaceData(376, 0, "foo"), with selected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.replaceData(0, 0, "foo"), with unselected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.replaceData(0, 0, "foo"), with selected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.replaceData(1, 0, "foo"), with unselected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.replaceData(1, 0, "foo"), with selected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.replaceData(foreignTextNode.length, 0, "foo"), with unselected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.replaceData(foreignTextNode.length, 0, "foo"), with selected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.replaceData(1, 0, "foo"), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(1, 0, "foo"), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(2, 0, "foo"), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(2, 0, "foo"), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(3, 0, "foo"), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(3, 0, "foo"), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(376, 0, ""), with unselected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.replaceData(376, 0, ""), with selected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.replaceData(0, 0, ""), with unselected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.replaceData(0, 0, ""), with selected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.replaceData(1, 0, ""), with unselected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.replaceData(1, 0, ""), with selected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.replaceData(foreignTextNode.length, 0, ""), with unselected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.replaceData(foreignTextNode.length, 0, ""), with selected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.replaceData(1, 0, ""), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(1, 0, ""), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(2, 0, ""), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(2, 0, ""), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(3, 0, ""), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(3, 0, ""), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(376, 1, "foo"), with unselected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.replaceData(376, 1, "foo"), with selected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.replaceData(0, 1, "foo"), with unselected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.replaceData(0, 1, "foo"), with selected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.replaceData(1, 1, "foo"), with unselected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.replaceData(1, 1, "foo"), with selected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.replaceData(foreignTextNode.length, 1, "foo"), with unselected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.replaceData(foreignTextNode.length, 1, "foo"), with selected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.replaceData(1, 1, "foo"), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(1, 1, "foo"), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(2, 1, "foo"), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(2, 1, "foo"), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(3, 1, "foo"), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(3, 1, "foo"), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(376, 1, ""), with unselected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.replaceData(376, 1, ""), with selected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.replaceData(0, 1, ""), with unselected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.replaceData(0, 1, ""), with selected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.replaceData(1, 1, ""), with unselected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.replaceData(1, 1, ""), with selected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.replaceData(foreignTextNode.length, 1, ""), with unselected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.replaceData(foreignTextNode.length, 1, ""), with selected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.replaceData(1, 1, ""), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(1, 1, ""), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(2, 1, ""), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(2, 1, ""), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(3, 1, ""), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(3, 1, ""), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(376, 47, "foo"), with unselected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.replaceData(376, 47, "foo"), with selected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.replaceData(0, 47, "foo"), with unselected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.replaceData(0, 47, "foo"), with selected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.replaceData(1, 47, "foo"), with unselected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.replaceData(1, 47, "foo"), with selected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.replaceData(foreignTextNode.length, 47, "foo"), with unselected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.replaceData(foreignTextNode.length, 47, "foo"), with selected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.replaceData(1, 47, "foo"), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(1, 47, "foo"), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(2, 47, "foo"), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(2, 47, "foo"), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(3, 47, "foo"), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(3, 47, "foo"), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(376, 47, ""), with unselected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.replaceData(376, 47, ""), with selected range on foreignTextNode from 0 to 1
+PASS foreignTextNode.replaceData(0, 47, ""), with unselected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.replaceData(0, 47, ""), with selected range collapsed at (foreignTextNode, 0)
+PASS foreignTextNode.replaceData(1, 47, ""), with unselected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.replaceData(1, 47, ""), with selected range collapsed at (foreignTextNode, 1)
+PASS foreignTextNode.replaceData(foreignTextNode.length, 47, ""), with unselected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.replaceData(foreignTextNode.length, 47, ""), with selected range collapsed at (foreignTextNode, foreignTextNode.length)
+PASS foreignTextNode.replaceData(1, 47, ""), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(1, 47, ""), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(2, 47, ""), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(2, 47, ""), with selected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(3, 47, ""), with unselected range on foreignTextNode from 1 to 3
+PASS foreignTextNode.replaceData(3, 47, ""), with selected range on foreignTextNode from 1 to 3
+PASS xmlTextNode.replaceData(376, 0, "foo"), with unselected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.replaceData(376, 0, "foo"), with selected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.replaceData(0, 0, "foo"), with unselected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.replaceData(0, 0, "foo"), with selected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.replaceData(1, 0, "foo"), with unselected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.replaceData(1, 0, "foo"), with selected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.replaceData(xmlTextNode.length, 0, "foo"), with unselected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.replaceData(xmlTextNode.length, 0, "foo"), with selected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.replaceData(1, 0, "foo"), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(1, 0, "foo"), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(2, 0, "foo"), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(2, 0, "foo"), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(3, 0, "foo"), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(3, 0, "foo"), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(376, 0, ""), with unselected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.replaceData(376, 0, ""), with selected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.replaceData(0, 0, ""), with unselected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.replaceData(0, 0, ""), with selected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.replaceData(1, 0, ""), with unselected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.replaceData(1, 0, ""), with selected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.replaceData(xmlTextNode.length, 0, ""), with unselected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.replaceData(xmlTextNode.length, 0, ""), with selected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.replaceData(1, 0, ""), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(1, 0, ""), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(2, 0, ""), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(2, 0, ""), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(3, 0, ""), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(3, 0, ""), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(376, 1, "foo"), with unselected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.replaceData(376, 1, "foo"), with selected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.replaceData(0, 1, "foo"), with unselected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.replaceData(0, 1, "foo"), with selected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.replaceData(1, 1, "foo"), with unselected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.replaceData(1, 1, "foo"), with selected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.replaceData(xmlTextNode.length, 1, "foo"), with unselected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.replaceData(xmlTextNode.length, 1, "foo"), with selected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.replaceData(1, 1, "foo"), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(1, 1, "foo"), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(2, 1, "foo"), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(2, 1, "foo"), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(3, 1, "foo"), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(3, 1, "foo"), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(376, 1, ""), with unselected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.replaceData(376, 1, ""), with selected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.replaceData(0, 1, ""), with unselected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.replaceData(0, 1, ""), with selected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.replaceData(1, 1, ""), with unselected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.replaceData(1, 1, ""), with selected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.replaceData(xmlTextNode.length, 1, ""), with unselected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.replaceData(xmlTextNode.length, 1, ""), with selected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.replaceData(1, 1, ""), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(1, 1, ""), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(2, 1, ""), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(2, 1, ""), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(3, 1, ""), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(3, 1, ""), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(376, 47, "foo"), with unselected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.replaceData(376, 47, "foo"), with selected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.replaceData(0, 47, "foo"), with unselected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.replaceData(0, 47, "foo"), with selected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.replaceData(1, 47, "foo"), with unselected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.replaceData(1, 47, "foo"), with selected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.replaceData(xmlTextNode.length, 47, "foo"), with unselected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.replaceData(xmlTextNode.length, 47, "foo"), with selected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.replaceData(1, 47, "foo"), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(1, 47, "foo"), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(2, 47, "foo"), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(2, 47, "foo"), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(3, 47, "foo"), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(3, 47, "foo"), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(376, 47, ""), with unselected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.replaceData(376, 47, ""), with selected range on xmlTextNode from 0 to 1
+PASS xmlTextNode.replaceData(0, 47, ""), with unselected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.replaceData(0, 47, ""), with selected range collapsed at (xmlTextNode, 0)
+PASS xmlTextNode.replaceData(1, 47, ""), with unselected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.replaceData(1, 47, ""), with selected range collapsed at (xmlTextNode, 1)
+PASS xmlTextNode.replaceData(xmlTextNode.length, 47, ""), with unselected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.replaceData(xmlTextNode.length, 47, ""), with selected range collapsed at (xmlTextNode, xmlTextNode.length)
+PASS xmlTextNode.replaceData(1, 47, ""), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(1, 47, ""), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(2, 47, ""), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(2, 47, ""), with selected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(3, 47, ""), with unselected range on xmlTextNode from 1 to 3
+PASS xmlTextNode.replaceData(3, 47, ""), with selected range on xmlTextNode from 1 to 3
+PASS detachedTextNode.replaceData(376, 0, "foo"), with unselected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.replaceData(376, 0, "foo"), with selected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.replaceData(0, 0, "foo"), with unselected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.replaceData(0, 0, "foo"), with selected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.replaceData(1, 0, "foo"), with unselected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.replaceData(1, 0, "foo"), with selected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.replaceData(detachedTextNode.length, 0, "foo"), with unselected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.replaceData(detachedTextNode.length, 0, "foo"), with selected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.replaceData(1, 0, "foo"), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(1, 0, "foo"), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(2, 0, "foo"), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(2, 0, "foo"), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(3, 0, "foo"), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(3, 0, "foo"), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(376, 0, ""), with unselected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.replaceData(376, 0, ""), with selected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.replaceData(0, 0, ""), with unselected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.replaceData(0, 0, ""), with selected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.replaceData(1, 0, ""), with unselected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.replaceData(1, 0, ""), with selected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.replaceData(detachedTextNode.length, 0, ""), with unselected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.replaceData(detachedTextNode.length, 0, ""), with selected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.replaceData(1, 0, ""), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(1, 0, ""), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(2, 0, ""), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(2, 0, ""), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(3, 0, ""), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(3, 0, ""), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(376, 1, "foo"), with unselected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.replaceData(376, 1, "foo"), with selected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.replaceData(0, 1, "foo"), with unselected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.replaceData(0, 1, "foo"), with selected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.replaceData(1, 1, "foo"), with unselected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.replaceData(1, 1, "foo"), with selected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.replaceData(detachedTextNode.length, 1, "foo"), with unselected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.replaceData(detachedTextNode.length, 1, "foo"), with selected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.replaceData(1, 1, "foo"), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(1, 1, "foo"), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(2, 1, "foo"), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(2, 1, "foo"), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(3, 1, "foo"), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(3, 1, "foo"), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(376, 1, ""), with unselected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.replaceData(376, 1, ""), with selected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.replaceData(0, 1, ""), with unselected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.replaceData(0, 1, ""), with selected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.replaceData(1, 1, ""), with unselected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.replaceData(1, 1, ""), with selected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.replaceData(detachedTextNode.length, 1, ""), with unselected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.replaceData(detachedTextNode.length, 1, ""), with selected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.replaceData(1, 1, ""), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(1, 1, ""), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(2, 1, ""), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(2, 1, ""), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(3, 1, ""), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(3, 1, ""), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(376, 47, "foo"), with unselected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.replaceData(376, 47, "foo"), with selected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.replaceData(0, 47, "foo"), with unselected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.replaceData(0, 47, "foo"), with selected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.replaceData(1, 47, "foo"), with unselected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.replaceData(1, 47, "foo"), with selected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.replaceData(detachedTextNode.length, 47, "foo"), with unselected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.replaceData(detachedTextNode.length, 47, "foo"), with selected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.replaceData(1, 47, "foo"), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(1, 47, "foo"), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(2, 47, "foo"), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(2, 47, "foo"), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(3, 47, "foo"), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(3, 47, "foo"), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(376, 47, ""), with unselected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.replaceData(376, 47, ""), with selected range on detachedTextNode from 0 to 1
+PASS detachedTextNode.replaceData(0, 47, ""), with unselected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.replaceData(0, 47, ""), with selected range collapsed at (detachedTextNode, 0)
+PASS detachedTextNode.replaceData(1, 47, ""), with unselected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.replaceData(1, 47, ""), with selected range collapsed at (detachedTextNode, 1)
+PASS detachedTextNode.replaceData(detachedTextNode.length, 47, ""), with unselected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.replaceData(detachedTextNode.length, 47, ""), with selected range collapsed at (detachedTextNode, detachedTextNode.length)
+PASS detachedTextNode.replaceData(1, 47, ""), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(1, 47, ""), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(2, 47, ""), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(2, 47, ""), with selected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(3, 47, ""), with unselected range on detachedTextNode from 1 to 3
+PASS detachedTextNode.replaceData(3, 47, ""), with selected range on detachedTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(376, 0, "foo"), with unselected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.replaceData(376, 0, "foo"), with selected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.replaceData(0, 0, "foo"), with unselected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.replaceData(0, 0, "foo"), with selected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.replaceData(1, 0, "foo"), with unselected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.replaceData(1, 0, "foo"), with selected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 0, "foo"), with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 0, "foo"), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.replaceData(1, 0, "foo"), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(1, 0, "foo"), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(2, 0, "foo"), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(2, 0, "foo"), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(3, 0, "foo"), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(3, 0, "foo"), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(376, 0, ""), with unselected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.replaceData(376, 0, ""), with selected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.replaceData(0, 0, ""), with unselected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.replaceData(0, 0, ""), with selected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.replaceData(1, 0, ""), with unselected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.replaceData(1, 0, ""), with selected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 0, ""), with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 0, ""), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.replaceData(1, 0, ""), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(1, 0, ""), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(2, 0, ""), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(2, 0, ""), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(3, 0, ""), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(3, 0, ""), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(376, 1, "foo"), with unselected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.replaceData(376, 1, "foo"), with selected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.replaceData(0, 1, "foo"), with unselected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.replaceData(0, 1, "foo"), with selected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.replaceData(1, 1, "foo"), with unselected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.replaceData(1, 1, "foo"), with selected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 1, "foo"), with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 1, "foo"), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.replaceData(1, 1, "foo"), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(1, 1, "foo"), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(2, 1, "foo"), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(2, 1, "foo"), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(3, 1, "foo"), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(3, 1, "foo"), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(376, 1, ""), with unselected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.replaceData(376, 1, ""), with selected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.replaceData(0, 1, ""), with unselected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.replaceData(0, 1, ""), with selected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.replaceData(1, 1, ""), with unselected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.replaceData(1, 1, ""), with selected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 1, ""), with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 1, ""), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.replaceData(1, 1, ""), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(1, 1, ""), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(2, 1, ""), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(2, 1, ""), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(3, 1, ""), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(3, 1, ""), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(376, 47, "foo"), with unselected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.replaceData(376, 47, "foo"), with selected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.replaceData(0, 47, "foo"), with unselected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.replaceData(0, 47, "foo"), with selected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.replaceData(1, 47, "foo"), with unselected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.replaceData(1, 47, "foo"), with selected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 47, "foo"), with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 47, "foo"), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.replaceData(1, 47, "foo"), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(1, 47, "foo"), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(2, 47, "foo"), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(2, 47, "foo"), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(3, 47, "foo"), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(3, 47, "foo"), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(376, 47, ""), with unselected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.replaceData(376, 47, ""), with selected range on detachedForeignTextNode from 0 to 1
+PASS detachedForeignTextNode.replaceData(0, 47, ""), with unselected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.replaceData(0, 47, ""), with selected range collapsed at (detachedForeignTextNode, 0)
+PASS detachedForeignTextNode.replaceData(1, 47, ""), with unselected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.replaceData(1, 47, ""), with selected range collapsed at (detachedForeignTextNode, 1)
+PASS detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 47, ""), with unselected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.replaceData(detachedForeignTextNode.length, 47, ""), with selected range collapsed at (detachedForeignTextNode, detachedForeignTextNode.length)
+PASS detachedForeignTextNode.replaceData(1, 47, ""), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(1, 47, ""), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(2, 47, ""), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(2, 47, ""), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(3, 47, ""), with unselected range on detachedForeignTextNode from 1 to 3
+PASS detachedForeignTextNode.replaceData(3, 47, ""), with selected range on detachedForeignTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(376, 0, "foo"), with unselected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.replaceData(376, 0, "foo"), with selected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.replaceData(0, 0, "foo"), with unselected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.replaceData(0, 0, "foo"), with selected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.replaceData(1, 0, "foo"), with unselected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.replaceData(1, 0, "foo"), with selected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 0, "foo"), with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 0, "foo"), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.replaceData(1, 0, "foo"), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(1, 0, "foo"), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(2, 0, "foo"), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(2, 0, "foo"), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(3, 0, "foo"), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(3, 0, "foo"), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(376, 0, ""), with unselected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.replaceData(376, 0, ""), with selected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.replaceData(0, 0, ""), with unselected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.replaceData(0, 0, ""), with selected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.replaceData(1, 0, ""), with unselected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.replaceData(1, 0, ""), with selected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 0, ""), with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 0, ""), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.replaceData(1, 0, ""), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(1, 0, ""), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(2, 0, ""), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(2, 0, ""), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(3, 0, ""), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(3, 0, ""), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(376, 1, "foo"), with unselected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.replaceData(376, 1, "foo"), with selected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.replaceData(0, 1, "foo"), with unselected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.replaceData(0, 1, "foo"), with selected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.replaceData(1, 1, "foo"), with unselected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.replaceData(1, 1, "foo"), with selected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 1, "foo"), with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 1, "foo"), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.replaceData(1, 1, "foo"), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(1, 1, "foo"), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(2, 1, "foo"), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(2, 1, "foo"), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(3, 1, "foo"), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(3, 1, "foo"), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(376, 1, ""), with unselected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.replaceData(376, 1, ""), with selected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.replaceData(0, 1, ""), with unselected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.replaceData(0, 1, ""), with selected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.replaceData(1, 1, ""), with unselected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.replaceData(1, 1, ""), with selected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 1, ""), with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 1, ""), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.replaceData(1, 1, ""), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(1, 1, ""), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(2, 1, ""), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(2, 1, ""), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(3, 1, ""), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(3, 1, ""), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(376, 47, "foo"), with unselected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.replaceData(376, 47, "foo"), with selected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.replaceData(0, 47, "foo"), with unselected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.replaceData(0, 47, "foo"), with selected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.replaceData(1, 47, "foo"), with unselected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.replaceData(1, 47, "foo"), with selected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 47, "foo"), with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 47, "foo"), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.replaceData(1, 47, "foo"), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(1, 47, "foo"), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(2, 47, "foo"), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(2, 47, "foo"), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(3, 47, "foo"), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(3, 47, "foo"), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(376, 47, ""), with unselected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.replaceData(376, 47, ""), with selected range on detachedXmlTextNode from 0 to 1
+PASS detachedXmlTextNode.replaceData(0, 47, ""), with unselected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.replaceData(0, 47, ""), with selected range collapsed at (detachedXmlTextNode, 0)
+PASS detachedXmlTextNode.replaceData(1, 47, ""), with unselected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.replaceData(1, 47, ""), with selected range collapsed at (detachedXmlTextNode, 1)
+PASS detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 47, ""), with unselected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.replaceData(detachedXmlTextNode.length, 47, ""), with selected range collapsed at (detachedXmlTextNode, detachedXmlTextNode.length)
+PASS detachedXmlTextNode.replaceData(1, 47, ""), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(1, 47, ""), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(2, 47, ""), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(2, 47, ""), with selected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(3, 47, ""), with unselected range on detachedXmlTextNode from 1 to 3
+PASS detachedXmlTextNode.replaceData(3, 47, ""), with selected range on detachedXmlTextNode from 1 to 3
+PASS comment.replaceData(376, 0, "foo"), with unselected range on comment from 0 to 1
+PASS comment.replaceData(376, 0, "foo"), with selected range on comment from 0 to 1
+PASS comment.replaceData(0, 0, "foo"), with unselected range collapsed at (comment, 0)
+PASS comment.replaceData(0, 0, "foo"), with selected range collapsed at (comment, 0)
+PASS comment.replaceData(1, 0, "foo"), with unselected range collapsed at (comment, 1)
+PASS comment.replaceData(1, 0, "foo"), with selected range collapsed at (comment, 1)
+PASS comment.replaceData(comment.length, 0, "foo"), with unselected range collapsed at (comment, comment.length)
+PASS comment.replaceData(comment.length, 0, "foo"), with selected range collapsed at (comment, comment.length)
+PASS comment.replaceData(1, 0, "foo"), with unselected range on comment from 1 to 3
+PASS comment.replaceData(1, 0, "foo"), with selected range on comment from 1 to 3
+PASS comment.replaceData(2, 0, "foo"), with unselected range on comment from 1 to 3
+PASS comment.replaceData(2, 0, "foo"), with selected range on comment from 1 to 3
+PASS comment.replaceData(3, 0, "foo"), with unselected range on comment from 1 to 3
+PASS comment.replaceData(3, 0, "foo"), with selected range on comment from 1 to 3
+PASS comment.replaceData(376, 0, ""), with unselected range on comment from 0 to 1
+PASS comment.replaceData(376, 0, ""), with selected range on comment from 0 to 1
+PASS comment.replaceData(0, 0, ""), with unselected range collapsed at (comment, 0)
+PASS comment.replaceData(0, 0, ""), with selected range collapsed at (comment, 0)
+PASS comment.replaceData(1, 0, ""), with unselected range collapsed at (comment, 1)
+PASS comment.replaceData(1, 0, ""), with selected range collapsed at (comment, 1)
+PASS comment.replaceData(comment.length, 0, ""), with unselected range collapsed at (comment, comment.length)
+PASS comment.replaceData(comment.length, 0, ""), with selected range collapsed at (comment, comment.length)
+PASS comment.replaceData(1, 0, ""), with unselected range on comment from 1 to 3
+PASS comment.replaceData(1, 0, ""), with selected range on comment from 1 to 3
+PASS comment.replaceData(2, 0, ""), with unselected range on comment from 1 to 3
+PASS comment.replaceData(2, 0, ""), with selected range on comment from 1 to 3
+PASS comment.replaceData(3, 0, ""), with unselected range on comment from 1 to 3
+PASS comment.replaceData(3, 0, ""), with selected range on comment from 1 to 3
+PASS comment.replaceData(376, 1, "foo"), with unselected range on comment from 0 to 1
+PASS comment.replaceData(376, 1, "foo"), with selected range on comment from 0 to 1
+PASS comment.replaceData(0, 1, "foo"), with unselected range collapsed at (comment, 0)
+PASS comment.replaceData(0, 1, "foo"), with selected range collapsed at (comment, 0)
+PASS comment.replaceData(1, 1, "foo"), with unselected range collapsed at (comment, 1)
+PASS comment.replaceData(1, 1, "foo"), with selected range collapsed at (comment, 1)
+PASS comment.replaceData(comment.length, 1, "foo"), with unselected range collapsed at (comment, comment.length)
+PASS comment.replaceData(comment.length, 1, "foo"), with selected range collapsed at (comment, comment.length)
+PASS comment.replaceData(1, 1, "foo"), with unselected range on comment from 1 to 3
+PASS comment.replaceData(1, 1, "foo"), with selected range on comment from 1 to 3
+PASS comment.replaceData(2, 1, "foo"), with unselected range on comment from 1 to 3
+PASS comment.replaceData(2, 1, "foo"), with selected range on comment from 1 to 3
+PASS comment.replaceData(3, 1, "foo"), with unselected range on comment from 1 to 3
+PASS comment.replaceData(3, 1, "foo"), with selected range on comment from 1 to 3
+PASS comment.replaceData(376, 1, ""), with unselected range on comment from 0 to 1
+PASS comment.replaceData(376, 1, ""), with selected range on comment from 0 to 1
+PASS comment.replaceData(0, 1, ""), with unselected range collapsed at (comment, 0)
+PASS comment.replaceData(0, 1, ""), with selected range collapsed at (comment, 0)
+PASS comment.replaceData(1, 1, ""), with unselected range collapsed at (comment, 1)
+PASS comment.replaceData(1, 1, ""), with selected range collapsed at (comment, 1)
+PASS comment.replaceData(comment.length, 1, ""), with unselected range collapsed at (comment, comment.length)
+PASS comment.replaceData(comment.length, 1, ""), with selected range collapsed at (comment, comment.length)
+PASS comment.replaceData(1, 1, ""), with unselected range on comment from 1 to 3
+PASS comment.replaceData(1, 1, ""), with selected range on comment from 1 to 3
+PASS comment.replaceData(2, 1, ""), with unselected range on comment from 1 to 3
+PASS comment.replaceData(2, 1, ""), with selected range on comment from 1 to 3
+PASS comment.replaceData(3, 1, ""), with unselected range on comment from 1 to 3
+PASS comment.replaceData(3, 1, ""), with selected range on comment from 1 to 3
+PASS comment.replaceData(376, 47, "foo"), with unselected range on comment from 0 to 1
+PASS comment.replaceData(376, 47, "foo"), with selected range on comment from 0 to 1
+PASS comment.replaceData(0, 47, "foo"), with unselected range collapsed at (comment, 0)
+PASS comment.replaceData(0, 47, "foo"), with selected range collapsed at (comment, 0)
+PASS comment.replaceData(1, 47, "foo"), with unselected range collapsed at (comment, 1)
+PASS comment.replaceData(1, 47, "foo"), with selected range collapsed at (comment, 1)
+PASS comment.replaceData(comment.length, 47, "foo"), with unselected range collapsed at (comment, comment.length)
+PASS comment.replaceData(comment.length, 47, "foo"), with selected range collapsed at (comment, comment.length)
+PASS comment.replaceData(1, 47, "foo"), with unselected range on comment from 1 to 3
+PASS comment.replaceData(1, 47, "foo"), with selected range on comment from 1 to 3
+PASS comment.replaceData(2, 47, "foo"), with unselected range on comment from 1 to 3
+PASS comment.replaceData(2, 47, "foo"), with selected range on comment from 1 to 3
+PASS comment.replaceData(3, 47, "foo"), with unselected range on comment from 1 to 3
+PASS comment.replaceData(3, 47, "foo"), with selected range on comment from 1 to 3
+PASS comment.replaceData(376, 47, ""), with unselected range on comment from 0 to 1
+PASS comment.replaceData(376, 47, ""), with selected range on comment from 0 to 1
+PASS comment.replaceData(0, 47, ""), with unselected range collapsed at (comment, 0)
+PASS comment.replaceData(0, 47, ""), with selected range collapsed at (comment, 0)
+PASS comment.replaceData(1, 47, ""), with unselected range collapsed at (comment, 1)
+PASS comment.replaceData(1, 47, ""), with selected range collapsed at (comment, 1)
+PASS comment.replaceData(comment.length, 47, ""), with unselected range collapsed at (comment, comment.length)
+PASS comment.replaceData(comment.length, 47, ""), with selected range collapsed at (comment, comment.length)
+PASS comment.replaceData(1, 47, ""), with unselected range on comment from 1 to 3
+PASS comment.replaceData(1, 47, ""), with selected range on comment from 1 to 3
+PASS comment.replaceData(2, 47, ""), with unselected range on comment from 1 to 3
+PASS comment.replaceData(2, 47, ""), with selected range on comment from 1 to 3
+PASS comment.replaceData(3, 47, ""), with unselected range on comment from 1 to 3
+PASS comment.replaceData(3, 47, ""), with selected range on comment from 1 to 3
+PASS foreignComment.replaceData(376, 0, "foo"), with unselected range on foreignComment from 0 to 1
+PASS foreignComment.replaceData(376, 0, "foo"), with selected range on foreignComment from 0 to 1
+PASS foreignComment.replaceData(0, 0, "foo"), with unselected range collapsed at (foreignComment, 0)
+PASS foreignComment.replaceData(0, 0, "foo"), with selected range collapsed at (foreignComment, 0)
+PASS foreignComment.replaceData(1, 0, "foo"), with unselected range collapsed at (foreignComment, 1)
+PASS foreignComment.replaceData(1, 0, "foo"), with selected range collapsed at (foreignComment, 1)
+PASS foreignComment.replaceData(foreignComment.length, 0, "foo"), with unselected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.replaceData(foreignComment.length, 0, "foo"), with selected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.replaceData(1, 0, "foo"), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(1, 0, "foo"), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(2, 0, "foo"), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(2, 0, "foo"), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(3, 0, "foo"), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(3, 0, "foo"), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(376, 0, ""), with unselected range on foreignComment from 0 to 1
+PASS foreignComment.replaceData(376, 0, ""), with selected range on foreignComment from 0 to 1
+PASS foreignComment.replaceData(0, 0, ""), with unselected range collapsed at (foreignComment, 0)
+PASS foreignComment.replaceData(0, 0, ""), with selected range collapsed at (foreignComment, 0)
+PASS foreignComment.replaceData(1, 0, ""), with unselected range collapsed at (foreignComment, 1)
+PASS foreignComment.replaceData(1, 0, ""), with selected range collapsed at (foreignComment, 1)
+PASS foreignComment.replaceData(foreignComment.length, 0, ""), with unselected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.replaceData(foreignComment.length, 0, ""), with selected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.replaceData(1, 0, ""), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(1, 0, ""), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(2, 0, ""), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(2, 0, ""), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(3, 0, ""), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(3, 0, ""), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(376, 1, "foo"), with unselected range on foreignComment from 0 to 1
+PASS foreignComment.replaceData(376, 1, "foo"), with selected range on foreignComment from 0 to 1
+PASS foreignComment.replaceData(0, 1, "foo"), with unselected range collapsed at (foreignComment, 0)
+PASS foreignComment.replaceData(0, 1, "foo"), with selected range collapsed at (foreignComment, 0)
+PASS foreignComment.replaceData(1, 1, "foo"), with unselected range collapsed at (foreignComment, 1)
+PASS foreignComment.replaceData(1, 1, "foo"), with selected range collapsed at (foreignComment, 1)
+PASS foreignComment.replaceData(foreignComment.length, 1, "foo"), with unselected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.replaceData(foreignComment.length, 1, "foo"), with selected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.replaceData(1, 1, "foo"), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(1, 1, "foo"), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(2, 1, "foo"), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(2, 1, "foo"), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(3, 1, "foo"), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(3, 1, "foo"), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(376, 1, ""), with unselected range on foreignComment from 0 to 1
+PASS foreignComment.replaceData(376, 1, ""), with selected range on foreignComment from 0 to 1
+PASS foreignComment.replaceData(0, 1, ""), with unselected range collapsed at (foreignComment, 0)
+PASS foreignComment.replaceData(0, 1, ""), with selected range collapsed at (foreignComment, 0)
+PASS foreignComment.replaceData(1, 1, ""), with unselected range collapsed at (foreignComment, 1)
+PASS foreignComment.replaceData(1, 1, ""), with selected range collapsed at (foreignComment, 1)
+PASS foreignComment.replaceData(foreignComment.length, 1, ""), with unselected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.replaceData(foreignComment.length, 1, ""), with selected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.replaceData(1, 1, ""), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(1, 1, ""), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(2, 1, ""), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(2, 1, ""), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(3, 1, ""), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(3, 1, ""), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(376, 47, "foo"), with unselected range on foreignComment from 0 to 1
+PASS foreignComment.replaceData(376, 47, "foo"), with selected range on foreignComment from 0 to 1
+PASS foreignComment.replaceData(0, 47, "foo"), with unselected range collapsed at (foreignComment, 0)
+PASS foreignComment.replaceData(0, 47, "foo"), with selected range collapsed at (foreignComment, 0)
+PASS foreignComment.replaceData(1, 47, "foo"), with unselected range collapsed at (foreignComment, 1)
+PASS foreignComment.replaceData(1, 47, "foo"), with selected range collapsed at (foreignComment, 1)
+PASS foreignComment.replaceData(foreignComment.length, 47, "foo"), with unselected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.replaceData(foreignComment.length, 47, "foo"), with selected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.replaceData(1, 47, "foo"), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(1, 47, "foo"), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(2, 47, "foo"), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(2, 47, "foo"), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(3, 47, "foo"), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(3, 47, "foo"), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(376, 47, ""), with unselected range on foreignComment from 0 to 1
+PASS foreignComment.replaceData(376, 47, ""), with selected range on foreignComment from 0 to 1
+PASS foreignComment.replaceData(0, 47, ""), with unselected range collapsed at (foreignComment, 0)
+PASS foreignComment.replaceData(0, 47, ""), with selected range collapsed at (foreignComment, 0)
+PASS foreignComment.replaceData(1, 47, ""), with unselected range collapsed at (foreignComment, 1)
+PASS foreignComment.replaceData(1, 47, ""), with selected range collapsed at (foreignComment, 1)
+PASS foreignComment.replaceData(foreignComment.length, 47, ""), with unselected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.replaceData(foreignComment.length, 47, ""), with selected range collapsed at (foreignComment, foreignComment.length)
+PASS foreignComment.replaceData(1, 47, ""), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(1, 47, ""), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(2, 47, ""), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(2, 47, ""), with selected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(3, 47, ""), with unselected range on foreignComment from 1 to 3
+PASS foreignComment.replaceData(3, 47, ""), with selected range on foreignComment from 1 to 3
+PASS xmlComment.replaceData(376, 0, "foo"), with unselected range on xmlComment from 0 to 1
+PASS xmlComment.replaceData(376, 0, "foo"), with selected range on xmlComment from 0 to 1
+PASS xmlComment.replaceData(0, 0, "foo"), with unselected range collapsed at (xmlComment, 0)
+PASS xmlComment.replaceData(0, 0, "foo"), with selected range collapsed at (xmlComment, 0)
+PASS xmlComment.replaceData(1, 0, "foo"), with unselected range collapsed at (xmlComment, 1)
+PASS xmlComment.replaceData(1, 0, "foo"), with selected range collapsed at (xmlComment, 1)
+PASS xmlComment.replaceData(xmlComment.length, 0, "foo"), with unselected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.replaceData(xmlComment.length, 0, "foo"), with selected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.replaceData(1, 0, "foo"), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(1, 0, "foo"), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(2, 0, "foo"), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(2, 0, "foo"), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(3, 0, "foo"), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(3, 0, "foo"), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(376, 0, ""), with unselected range on xmlComment from 0 to 1
+PASS xmlComment.replaceData(376, 0, ""), with selected range on xmlComment from 0 to 1
+PASS xmlComment.replaceData(0, 0, ""), with unselected range collapsed at (xmlComment, 0)
+PASS xmlComment.replaceData(0, 0, ""), with selected range collapsed at (xmlComment, 0)
+PASS xmlComment.replaceData(1, 0, ""), with unselected range collapsed at (xmlComment, 1)
+PASS xmlComment.replaceData(1, 0, ""), with selected range collapsed at (xmlComment, 1)
+PASS xmlComment.replaceData(xmlComment.length, 0, ""), with unselected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.replaceData(xmlComment.length, 0, ""), with selected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.replaceData(1, 0, ""), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(1, 0, ""), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(2, 0, ""), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(2, 0, ""), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(3, 0, ""), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(3, 0, ""), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(376, 1, "foo"), with unselected range on xmlComment from 0 to 1
+PASS xmlComment.replaceData(376, 1, "foo"), with selected range on xmlComment from 0 to 1
+PASS xmlComment.replaceData(0, 1, "foo"), with unselected range collapsed at (xmlComment, 0)
+PASS xmlComment.replaceData(0, 1, "foo"), with selected range collapsed at (xmlComment, 0)
+PASS xmlComment.replaceData(1, 1, "foo"), with unselected range collapsed at (xmlComment, 1)
+PASS xmlComment.replaceData(1, 1, "foo"), with selected range collapsed at (xmlComment, 1)
+PASS xmlComment.replaceData(xmlComment.length, 1, "foo"), with unselected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.replaceData(xmlComment.length, 1, "foo"), with selected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.replaceData(1, 1, "foo"), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(1, 1, "foo"), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(2, 1, "foo"), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(2, 1, "foo"), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(3, 1, "foo"), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(3, 1, "foo"), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(376, 1, ""), with unselected range on xmlComment from 0 to 1
+PASS xmlComment.replaceData(376, 1, ""), with selected range on xmlComment from 0 to 1
+PASS xmlComment.replaceData(0, 1, ""), with unselected range collapsed at (xmlComment, 0)
+PASS xmlComment.replaceData(0, 1, ""), with selected range collapsed at (xmlComment, 0)
+PASS xmlComment.replaceData(1, 1, ""), with unselected range collapsed at (xmlComment, 1)
+PASS xmlComment.replaceData(1, 1, ""), with selected range collapsed at (xmlComment, 1)
+PASS xmlComment.replaceData(xmlComment.length, 1, ""), with unselected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.replaceData(xmlComment.length, 1, ""), with selected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.replaceData(1, 1, ""), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(1, 1, ""), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(2, 1, ""), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(2, 1, ""), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(3, 1, ""), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(3, 1, ""), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(376, 47, "foo"), with unselected range on xmlComment from 0 to 1
+PASS xmlComment.replaceData(376, 47, "foo"), with selected range on xmlComment from 0 to 1
+PASS xmlComment.replaceData(0, 47, "foo"), with unselected range collapsed at (xmlComment, 0)
+PASS xmlComment.replaceData(0, 47, "foo"), with selected range collapsed at (xmlComment, 0)
+PASS xmlComment.replaceData(1, 47, "foo"), with unselected range collapsed at (xmlComment, 1)
+PASS xmlComment.replaceData(1, 47, "foo"), with selected range collapsed at (xmlComment, 1)
+PASS xmlComment.replaceData(xmlComment.length, 47, "foo"), with unselected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.replaceData(xmlComment.length, 47, "foo"), with selected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.replaceData(1, 47, "foo"), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(1, 47, "foo"), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(2, 47, "foo"), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(2, 47, "foo"), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(3, 47, "foo"), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(3, 47, "foo"), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(376, 47, ""), with unselected range on xmlComment from 0 to 1
+PASS xmlComment.replaceData(376, 47, ""), with selected range on xmlComment from 0 to 1
+PASS xmlComment.replaceData(0, 47, ""), with unselected range collapsed at (xmlComment, 0)
+PASS xmlComment.replaceData(0, 47, ""), with selected range collapsed at (xmlComment, 0)
+PASS xmlComment.replaceData(1, 47, ""), with unselected range collapsed at (xmlComment, 1)
+PASS xmlComment.replaceData(1, 47, ""), with selected range collapsed at (xmlComment, 1)
+PASS xmlComment.replaceData(xmlComment.length, 47, ""), with unselected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.replaceData(xmlComment.length, 47, ""), with selected range collapsed at (xmlComment, xmlComment.length)
+PASS xmlComment.replaceData(1, 47, ""), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(1, 47, ""), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(2, 47, ""), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(2, 47, ""), with selected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(3, 47, ""), with unselected range on xmlComment from 1 to 3
+PASS xmlComment.replaceData(3, 47, ""), with selected range on xmlComment from 1 to 3
+PASS detachedComment.replaceData(376, 0, "foo"), with unselected range on detachedComment from 0 to 1
+PASS detachedComment.replaceData(376, 0, "foo"), with selected range on detachedComment from 0 to 1
+PASS detachedComment.replaceData(0, 0, "foo"), with unselected range collapsed at (detachedComment, 0)
+PASS detachedComment.replaceData(0, 0, "foo"), with selected range collapsed at (detachedComment, 0)
+PASS detachedComment.replaceData(1, 0, "foo"), with unselected range collapsed at (detachedComment, 1)
+PASS detachedComment.replaceData(1, 0, "foo"), with selected range collapsed at (detachedComment, 1)
+PASS detachedComment.replaceData(detachedComment.length, 0, "foo"), with unselected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.replaceData(detachedComment.length, 0, "foo"), with selected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.replaceData(1, 0, "foo"), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(1, 0, "foo"), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(2, 0, "foo"), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(2, 0, "foo"), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(3, 0, "foo"), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(3, 0, "foo"), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(376, 0, ""), with unselected range on detachedComment from 0 to 1
+PASS detachedComment.replaceData(376, 0, ""), with selected range on detachedComment from 0 to 1
+PASS detachedComment.replaceData(0, 0, ""), with unselected range collapsed at (detachedComment, 0)
+PASS detachedComment.replaceData(0, 0, ""), with selected range collapsed at (detachedComment, 0)
+PASS detachedComment.replaceData(1, 0, ""), with unselected range collapsed at (detachedComment, 1)
+PASS detachedComment.replaceData(1, 0, ""), with selected range collapsed at (detachedComment, 1)
+PASS detachedComment.replaceData(detachedComment.length, 0, ""), with unselected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.replaceData(detachedComment.length, 0, ""), with selected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.replaceData(1, 0, ""), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(1, 0, ""), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(2, 0, ""), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(2, 0, ""), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(3, 0, ""), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(3, 0, ""), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(376, 1, "foo"), with unselected range on detachedComment from 0 to 1
+PASS detachedComment.replaceData(376, 1, "foo"), with selected range on detachedComment from 0 to 1
+PASS detachedComment.replaceData(0, 1, "foo"), with unselected range collapsed at (detachedComment, 0)
+PASS detachedComment.replaceData(0, 1, "foo"), with selected range collapsed at (detachedComment, 0)
+PASS detachedComment.replaceData(1, 1, "foo"), with unselected range collapsed at (detachedComment, 1)
+PASS detachedComment.replaceData(1, 1, "foo"), with selected range collapsed at (detachedComment, 1)
+PASS detachedComment.replaceData(detachedComment.length, 1, "foo"), with unselected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.replaceData(detachedComment.length, 1, "foo"), with selected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.replaceData(1, 1, "foo"), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(1, 1, "foo"), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(2, 1, "foo"), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(2, 1, "foo"), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(3, 1, "foo"), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(3, 1, "foo"), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(376, 1, ""), with unselected range on detachedComment from 0 to 1
+PASS detachedComment.replaceData(376, 1, ""), with selected range on detachedComment from 0 to 1
+PASS detachedComment.replaceData(0, 1, ""), with unselected range collapsed at (detachedComment, 0)
+PASS detachedComment.replaceData(0, 1, ""), with selected range collapsed at (detachedComment, 0)
+PASS detachedComment.replaceData(1, 1, ""), with unselected range collapsed at (detachedComment, 1)
+PASS detachedComment.replaceData(1, 1, ""), with selected range collapsed at (detachedComment, 1)
+PASS detachedComment.replaceData(detachedComment.length, 1, ""), with unselected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.replaceData(detachedComment.length, 1, ""), with selected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.replaceData(1, 1, ""), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(1, 1, ""), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(2, 1, ""), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(2, 1, ""), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(3, 1, ""), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(3, 1, ""), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(376, 47, "foo"), with unselected range on detachedComment from 0 to 1
+PASS detachedComment.replaceData(376, 47, "foo"), with selected range on detachedComment from 0 to 1
+PASS detachedComment.replaceData(0, 47, "foo"), with unselected range collapsed at (detachedComment, 0)
+PASS detachedComment.replaceData(0, 47, "foo"), with selected range collapsed at (detachedComment, 0)
+PASS detachedComment.replaceData(1, 47, "foo"), with unselected range collapsed at (detachedComment, 1)
+PASS detachedComment.replaceData(1, 47, "foo"), with selected range collapsed at (detachedComment, 1)
+PASS detachedComment.replaceData(detachedComment.length, 47, "foo"), with unselected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.replaceData(detachedComment.length, 47, "foo"), with selected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.replaceData(1, 47, "foo"), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(1, 47, "foo"), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(2, 47, "foo"), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(2, 47, "foo"), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(3, 47, "foo"), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(3, 47, "foo"), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(376, 47, ""), with unselected range on detachedComment from 0 to 1
+PASS detachedComment.replaceData(376, 47, ""), with selected range on detachedComment from 0 to 1
+PASS detachedComment.replaceData(0, 47, ""), with unselected range collapsed at (detachedComment, 0)
+PASS detachedComment.replaceData(0, 47, ""), with selected range collapsed at (detachedComment, 0)
+PASS detachedComment.replaceData(1, 47, ""), with unselected range collapsed at (detachedComment, 1)
+PASS detachedComment.replaceData(1, 47, ""), with selected range collapsed at (detachedComment, 1)
+PASS detachedComment.replaceData(detachedComment.length, 47, ""), with unselected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.replaceData(detachedComment.length, 47, ""), with selected range collapsed at (detachedComment, detachedComment.length)
+PASS detachedComment.replaceData(1, 47, ""), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(1, 47, ""), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(2, 47, ""), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(2, 47, ""), with selected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(3, 47, ""), with unselected range on detachedComment from 1 to 3
+PASS detachedComment.replaceData(3, 47, ""), with selected range on detachedComment from 1 to 3
+PASS detachedForeignComment.replaceData(376, 0, "foo"), with unselected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.replaceData(376, 0, "foo"), with selected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.replaceData(0, 0, "foo"), with unselected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.replaceData(0, 0, "foo"), with selected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.replaceData(1, 0, "foo"), with unselected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.replaceData(1, 0, "foo"), with selected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.replaceData(detachedForeignComment.length, 0, "foo"), with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.replaceData(detachedForeignComment.length, 0, "foo"), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.replaceData(1, 0, "foo"), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(1, 0, "foo"), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(2, 0, "foo"), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(2, 0, "foo"), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(3, 0, "foo"), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(3, 0, "foo"), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(376, 0, ""), with unselected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.replaceData(376, 0, ""), with selected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.replaceData(0, 0, ""), with unselected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.replaceData(0, 0, ""), with selected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.replaceData(1, 0, ""), with unselected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.replaceData(1, 0, ""), with selected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.replaceData(detachedForeignComment.length, 0, ""), with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.replaceData(detachedForeignComment.length, 0, ""), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.replaceData(1, 0, ""), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(1, 0, ""), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(2, 0, ""), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(2, 0, ""), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(3, 0, ""), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(3, 0, ""), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(376, 1, "foo"), with unselected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.replaceData(376, 1, "foo"), with selected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.replaceData(0, 1, "foo"), with unselected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.replaceData(0, 1, "foo"), with selected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.replaceData(1, 1, "foo"), with unselected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.replaceData(1, 1, "foo"), with selected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.replaceData(detachedForeignComment.length, 1, "foo"), with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.replaceData(detachedForeignComment.length, 1, "foo"), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.replaceData(1, 1, "foo"), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(1, 1, "foo"), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(2, 1, "foo"), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(2, 1, "foo"), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(3, 1, "foo"), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(3, 1, "foo"), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(376, 1, ""), with unselected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.replaceData(376, 1, ""), with selected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.replaceData(0, 1, ""), with unselected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.replaceData(0, 1, ""), with selected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.replaceData(1, 1, ""), with unselected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.replaceData(1, 1, ""), with selected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.replaceData(detachedForeignComment.length, 1, ""), with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.replaceData(detachedForeignComment.length, 1, ""), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.replaceData(1, 1, ""), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(1, 1, ""), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(2, 1, ""), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(2, 1, ""), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(3, 1, ""), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(3, 1, ""), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(376, 47, "foo"), with unselected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.replaceData(376, 47, "foo"), with selected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.replaceData(0, 47, "foo"), with unselected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.replaceData(0, 47, "foo"), with selected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.replaceData(1, 47, "foo"), with unselected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.replaceData(1, 47, "foo"), with selected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.replaceData(detachedForeignComment.length, 47, "foo"), with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.replaceData(detachedForeignComment.length, 47, "foo"), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.replaceData(1, 47, "foo"), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(1, 47, "foo"), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(2, 47, "foo"), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(2, 47, "foo"), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(3, 47, "foo"), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(3, 47, "foo"), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(376, 47, ""), with unselected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.replaceData(376, 47, ""), with selected range on detachedForeignComment from 0 to 1
+PASS detachedForeignComment.replaceData(0, 47, ""), with unselected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.replaceData(0, 47, ""), with selected range collapsed at (detachedForeignComment, 0)
+PASS detachedForeignComment.replaceData(1, 47, ""), with unselected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.replaceData(1, 47, ""), with selected range collapsed at (detachedForeignComment, 1)
+PASS detachedForeignComment.replaceData(detachedForeignComment.length, 47, ""), with unselected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.replaceData(detachedForeignComment.length, 47, ""), with selected range collapsed at (detachedForeignComment, detachedForeignComment.length)
+PASS detachedForeignComment.replaceData(1, 47, ""), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(1, 47, ""), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(2, 47, ""), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(2, 47, ""), with selected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(3, 47, ""), with unselected range on detachedForeignComment from 1 to 3
+PASS detachedForeignComment.replaceData(3, 47, ""), with selected range on detachedForeignComment from 1 to 3
+PASS detachedXmlComment.replaceData(376, 0, "foo"), with unselected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.replaceData(376, 0, "foo"), with selected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.replaceData(0, 0, "foo"), with unselected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.replaceData(0, 0, "foo"), with selected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.replaceData(1, 0, "foo"), with unselected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.replaceData(1, 0, "foo"), with selected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.replaceData(detachedXmlComment.length, 0, "foo"), with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.replaceData(detachedXmlComment.length, 0, "foo"), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.replaceData(1, 0, "foo"), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(1, 0, "foo"), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(2, 0, "foo"), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(2, 0, "foo"), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(3, 0, "foo"), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(3, 0, "foo"), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(376, 0, ""), with unselected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.replaceData(376, 0, ""), with selected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.replaceData(0, 0, ""), with unselected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.replaceData(0, 0, ""), with selected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.replaceData(1, 0, ""), with unselected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.replaceData(1, 0, ""), with selected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.replaceData(detachedXmlComment.length, 0, ""), with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.replaceData(detachedXmlComment.length, 0, ""), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.replaceData(1, 0, ""), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(1, 0, ""), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(2, 0, ""), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(2, 0, ""), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(3, 0, ""), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(3, 0, ""), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(376, 1, "foo"), with unselected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.replaceData(376, 1, "foo"), with selected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.replaceData(0, 1, "foo"), with unselected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.replaceData(0, 1, "foo"), with selected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.replaceData(1, 1, "foo"), with unselected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.replaceData(1, 1, "foo"), with selected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.replaceData(detachedXmlComment.length, 1, "foo"), with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.replaceData(detachedXmlComment.length, 1, "foo"), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.replaceData(1, 1, "foo"), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(1, 1, "foo"), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(2, 1, "foo"), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(2, 1, "foo"), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(3, 1, "foo"), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(3, 1, "foo"), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(376, 1, ""), with unselected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.replaceData(376, 1, ""), with selected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.replaceData(0, 1, ""), with unselected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.replaceData(0, 1, ""), with selected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.replaceData(1, 1, ""), with unselected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.replaceData(1, 1, ""), with selected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.replaceData(detachedXmlComment.length, 1, ""), with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.replaceData(detachedXmlComment.length, 1, ""), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.replaceData(1, 1, ""), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(1, 1, ""), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(2, 1, ""), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(2, 1, ""), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(3, 1, ""), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(3, 1, ""), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(376, 47, "foo"), with unselected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.replaceData(376, 47, "foo"), with selected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.replaceData(0, 47, "foo"), with unselected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.replaceData(0, 47, "foo"), with selected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.replaceData(1, 47, "foo"), with unselected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.replaceData(1, 47, "foo"), with selected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.replaceData(detachedXmlComment.length, 47, "foo"), with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.replaceData(detachedXmlComment.length, 47, "foo"), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.replaceData(1, 47, "foo"), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(1, 47, "foo"), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(2, 47, "foo"), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(2, 47, "foo"), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(3, 47, "foo"), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(3, 47, "foo"), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(376, 47, ""), with unselected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.replaceData(376, 47, ""), with selected range on detachedXmlComment from 0 to 1
+PASS detachedXmlComment.replaceData(0, 47, ""), with unselected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.replaceData(0, 47, ""), with selected range collapsed at (detachedXmlComment, 0)
+PASS detachedXmlComment.replaceData(1, 47, ""), with unselected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.replaceData(1, 47, ""), with selected range collapsed at (detachedXmlComment, 1)
+PASS detachedXmlComment.replaceData(detachedXmlComment.length, 47, ""), with unselected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.replaceData(detachedXmlComment.length, 47, ""), with selected range collapsed at (detachedXmlComment, detachedXmlComment.length)
+PASS detachedXmlComment.replaceData(1, 47, ""), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(1, 47, ""), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(2, 47, ""), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(2, 47, ""), with selected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(3, 47, ""), with unselected range on detachedXmlComment from 1 to 3
+PASS detachedXmlComment.replaceData(3, 47, ""), with selected range on detachedXmlComment from 1 to 3
+PASS paras[0].firstChild.replaceData(1, 0, "foo"), with unselected range collapsed at (paras[0], 0)
+PASS paras[0].firstChild.replaceData(1, 0, "foo"), with selected range collapsed at (paras[0], 0)
+PASS paras[0].firstChild.replaceData(1, 0, "foo"), with unselected range on paras[0] from 0 to 1
+PASS paras[0].firstChild.replaceData(1, 0, "foo"), with selected range on paras[0] from 0 to 1
+PASS paras[0].firstChild.replaceData(1, 0, "foo"), with unselected range collapsed at (paras[0], 1)
+PASS paras[0].firstChild.replaceData(1, 0, "foo"), with selected range collapsed at (paras[0], 1)
+PASS paras[0].firstChild.replaceData(1, 0, "foo"), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(1, 0, "foo"), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(2, 0, "foo"), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(2, 0, "foo"), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(3, 0, "foo"), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(3, 0, "foo"), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(1, 0, "foo"), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(1, 0, "foo"), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(2, 0, "foo"), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(2, 0, "foo"), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(3, 0, "foo"), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(3, 0, "foo"), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(1, 1, "foo"), with unselected range collapsed at (paras[0], 0)
+PASS paras[0].firstChild.replaceData(1, 1, "foo"), with selected range collapsed at (paras[0], 0)
+PASS paras[0].firstChild.replaceData(1, 1, "foo"), with unselected range on paras[0] from 0 to 1
+PASS paras[0].firstChild.replaceData(1, 1, "foo"), with selected range on paras[0] from 0 to 1
+PASS paras[0].firstChild.replaceData(1, 1, "foo"), with unselected range collapsed at (paras[0], 1)
+PASS paras[0].firstChild.replaceData(1, 1, "foo"), with selected range collapsed at (paras[0], 1)
+PASS paras[0].firstChild.replaceData(1, 1, "foo"), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(1, 1, "foo"), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(2, 1, "foo"), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(2, 1, "foo"), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(3, 1, "foo"), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(3, 1, "foo"), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(1, 1, "foo"), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(1, 1, "foo"), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(2, 1, "foo"), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(2, 1, "foo"), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(3, 1, "foo"), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(3, 1, "foo"), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(1, 47, "foo"), with unselected range collapsed at (paras[0], 0)
+PASS paras[0].firstChild.replaceData(1, 47, "foo"), with selected range collapsed at (paras[0], 0)
+PASS paras[0].firstChild.replaceData(1, 47, "foo"), with unselected range on paras[0] from 0 to 1
+PASS paras[0].firstChild.replaceData(1, 47, "foo"), with selected range on paras[0] from 0 to 1
+PASS paras[0].firstChild.replaceData(1, 47, "foo"), with unselected range collapsed at (paras[0], 1)
+PASS paras[0].firstChild.replaceData(1, 47, "foo"), with selected range collapsed at (paras[0], 1)
+PASS paras[0].firstChild.replaceData(1, 47, "foo"), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(1, 47, "foo"), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(2, 47, "foo"), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(2, 47, "foo"), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(3, 47, "foo"), with unselected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(3, 47, "foo"), with selected range from (paras[0].firstChild, 1) to (paras[0], 1)
+PASS paras[0].firstChild.replaceData(1, 47, "foo"), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(1, 47, "foo"), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(2, 47, "foo"), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(2, 47, "foo"), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(3, 47, "foo"), with unselected range from (paras[0], 0) to (paras[0].firstChild, 3)
+PASS paras[0].firstChild.replaceData(3, 47, "foo"), with selected range from (paras[0], 0) to (paras[0].firstChild, 3)
+

--- a/LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-replaceData.html
+++ b/LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-replaceData.html
@@ -1,0 +1,14 @@
+<!doctype html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<title>Range mutation tests - replaceData</title>
+<link rel="author" title="Aryeh Gregor" href=ayg@aryeh.name>
+<meta name=timeout content=long>
+
+<div id=log></div>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
+<script src="Range-mutations.js"></script>
+<script>
+doTests(replaceDataTests, function(params) { return params[0] + ".replaceData(" + params[1] + ", " + params[2] + ", " + params[3] + ")" }, testReplaceData);
+testDiv.style.display = "none";
+</script>

--- a/LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations.js
+++ b/LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations.js
@@ -1,0 +1,921 @@
+"use strict";
+
+// These tests probably use too much abstraction and too little copy-paste.
+// Reader beware.
+//
+// TODO:
+//
+// * Lots and lots and lots more different types of ranges
+// * insertBefore() with DocumentFragments
+// * Fill out other insert/remove tests
+// * normalize() (https://www.w3.org/Bugs/Public/show_bug.cgi?id=13843)
+
+// Give a textual description of the range we're testing, for the test names.
+function describeRange(startContainer, startOffset, endContainer, endOffset) {
+  if (startContainer == endContainer && startOffset == endOffset) {
+    return "range collapsed at (" + startContainer + ", " + startOffset + ")";
+  } else if (startContainer == endContainer) {
+    return "range on " + startContainer + " from " + startOffset + " to " + endOffset;
+  } else {
+    return "range from (" + startContainer + ", " + startOffset + ") to (" + endContainer + ", " + endOffset + ")";
+  }
+}
+
+// Lists of the various types of nodes we'll want to use.  We use strings that
+// we can later eval(), so that we can produce legible test names.
+var textNodes = [
+  "paras[0].firstChild",
+  "paras[1].firstChild",
+  "foreignTextNode",
+  "xmlTextNode",
+  "detachedTextNode",
+  "detachedForeignTextNode",
+  "detachedXmlTextNode",
+];
+var commentNodes = [
+  "comment",
+  "foreignComment",
+  "xmlComment",
+  "detachedComment",
+  "detachedForeignComment",
+  "detachedXmlComment",
+];
+var characterDataNodes = textNodes.concat(commentNodes);
+
+// This function is slightly scary, but it works well enough, so . . .
+// sourceTests is an array of test data that will be altered in mysterious ways
+// before being passed off to doTest, descFn is something that takes an element
+// of sourceTests and produces the first part of a human-readable description
+// of the test, testFn is the function that doTest will call to do the actual
+// work and tell it what results to expect.
+function doTests(sourceTests, descFn, testFn) {
+  var tests = [];
+  for (var i = 0; i < sourceTests.length; i++) {
+    var params = sourceTests[i];
+    var len = params.length;
+    tests.push([
+      descFn(params) + ", with unselected " + describeRange(params[len - 4], params[len - 3], params[len - 2], params[len - 1]),
+      // The closure here ensures that the params that testFn get are the
+      // current version of params, not the version from the last
+      // iteration of this loop.  We test that none of the parameters
+      // evaluate to undefined to catch bugs in our eval'ing, like
+      // mistyping a property name.
+      function(params) { return function() {
+        var evaledParams = params.map(eval);
+        for (var i = 0; i < evaledParams.length; i++) {
+          assert_not_equals(typeof evaledParams[i], "undefined",
+            "Test bug: " + params[i] + " is undefined");
+        }
+        return testFn.apply(null, evaledParams);
+      } }(params),
+      false,
+      params[len - 4],
+      params[len - 3],
+      params[len - 2],
+      params[len - 1]
+    ]);
+    tests.push([
+      descFn(params) + ", with selected " + describeRange(params[len - 4], params[len - 3], params[len - 2], params[len - 1]),
+      function(params) { return function(selectedRange) {
+        var evaledParams = params.slice(0, len - 4).map(eval);
+        for (var i = 0; i < evaledParams.length; i++) {
+          assert_not_equals(typeof evaledParams[i], "undefined",
+            "Test bug: " + params[i] + " is undefined");
+        }
+        // Override input range with the one that was actually selected when computing the expected result.
+        evaledParams = evaledParams.concat([selectedRange.startContainer, selectedRange.startOffset, selectedRange.endContainer, selectedRange.endOffset]);
+        return testFn.apply(null, evaledParams);
+      } }(params),
+      true,
+      params[len - 4],
+      params[len - 3],
+      params[len - 2],
+      params[len - 1]
+    ]);
+  }
+  generate_tests(doTest, tests);
+}
+
+// Set up the range, call the callback function to do the DOM modification and
+// tell us what to expect.  The callback function needs to return a
+// four-element array with the expected start/end containers/offsets, and
+// receives no arguments.  useSelection tells us whether the Range should be
+// added to a Selection and the Selection tested to ensure that the mutation
+// affects user selections as well as other ranges; every test is run with this
+// both false and true, because when it's set to true WebKit and Opera fail all
+// tests' sanity checks, which is unhelpful.  The last four parameters just
+// tell us what range to build.
+function doTest(callback, useSelection, startContainer, startOffset, endContainer, endOffset) {
+  // Recreate all the test nodes in case they were altered by the last test
+  // run.
+  setupRangeTests();
+  startContainer = eval(startContainer);
+  startOffset = eval(startOffset);
+  endContainer = eval(endContainer);
+  endOffset = eval(endOffset);
+
+  var ownerDoc = startContainer.nodeType == Node.DOCUMENT_NODE
+    ? startContainer
+    : startContainer.ownerDocument;
+  var range = ownerDoc.createRange();
+  range.setStart(startContainer, startOffset);
+  range.setEnd(endContainer, endOffset);
+
+  if (useSelection) {
+    getSelection().removeAllRanges();
+    getSelection().addRange(range);
+
+    // Some browsers refuse to add a range unless it results in an actual visible selection.
+    if (!getSelection().rangeCount)
+        return;
+
+    // Override range with the one that was actually selected as it differs in some browsers.
+    range = getSelection().getRangeAt(0);
+  }
+
+  var expected = callback(range);
+
+  assert_equals(range.startContainer, expected[0],
+    "Wrong start container");
+  assert_equals(range.startOffset, expected[1],
+    "Wrong start offset");
+  assert_equals(range.endContainer, expected[2],
+    "Wrong end container");
+  assert_equals(range.endOffset, expected[3],
+    "Wrong end offset");
+}
+
+
+// Now we get to the specific tests.
+
+function testSplitText(oldNode, offset, startContainer, startOffset, endContainer, endOffset) {
+  // Save these for later
+  var originalStartOffset = startOffset;
+  var originalEndOffset = endOffset;
+  var originalLength = oldNode.length;
+
+  var newNode;
+  try {
+    newNode = oldNode.splitText(offset);
+  } catch (e) {
+    // Should only happen if offset is negative
+    return [startContainer, startOffset, endContainer, endOffset];
+  }
+
+  // First we adjust for replacing data:
+  //
+  // "Replace data with offset offset, count count, and data the empty
+  // string."
+  //
+  // That translates to offset = offset, count = originalLength - offset,
+  // data = "".  node is oldNode.
+  //
+  // "For every boundary point whose node is node, and whose offset is
+  // greater than offset but less than or equal to offset plus count, set its
+  // offset to offset."
+  if (startContainer == oldNode
+  && startOffset > offset
+  && startOffset <= originalLength) {
+    startOffset = offset;
+  }
+
+  if (endContainer == oldNode
+  && endOffset > offset
+  && endOffset <= originalLength) {
+    endOffset = offset;
+  }
+
+  // "For every boundary point whose node is node, and whose offset is
+  // greater than offset plus count, add the length of data to its offset,
+  // then subtract count from it."
+  //
+  // Can't happen: offset plus count is originalLength.
+
+  // Now we insert a node, if oldNode's parent isn't null: "For each boundary
+  // point whose node is the new parent of the affected node and whose offset
+  // is greater than the new index of the affected node, add one to the
+  // boundary point's offset."
+  if (startContainer == oldNode.parentNode
+  && startOffset > 1 + indexOf(oldNode)) {
+    startOffset++;
+  }
+
+  if (endContainer == oldNode.parentNode
+  && endOffset > 1 + indexOf(oldNode)) {
+    endOffset++;
+  }
+
+  // Finally, the splitText stuff itself:
+  //
+  // "If parent is not null, run these substeps:
+  //
+  //   * "For each range whose start node is node and start offset is greater
+  //   than offset, set its start node to new node and decrease its start
+  //   offset by offset.
+  //
+  //   * "For each range whose end node is node and end offset is greater
+  //   than offset, set its end node to new node and decrease its end offset
+  //   by offset.
+  //
+  //   * "For each range whose start node is parent and start offset is equal
+  //   to the index of node + 1, increase its start offset by one.
+  //
+  //   * "For each range whose end node is parent and end offset is equal to
+  //   the index of node + 1, increase its end offset by one."
+  if (oldNode.parentNode) {
+    if (startContainer == oldNode && originalStartOffset > offset) {
+      startContainer = newNode;
+      startOffset = originalStartOffset - offset;
+    }
+
+    if (endContainer == oldNode && originalEndOffset > offset) {
+      endContainer = newNode;
+      endOffset = originalEndOffset - offset;
+    }
+
+    if (startContainer == oldNode.parentNode
+    && startOffset == 1 + indexOf(oldNode)) {
+      startOffset++;
+    }
+
+    if (endContainer == oldNode.parentNode
+    && endOffset == 1 + indexOf(oldNode)) {
+      endOffset++;
+    }
+  }
+
+  return [startContainer, startOffset, endContainer, endOffset];
+}
+
+// The offset argument is unsigned, so per WebIDL -1 should wrap to 4294967295,
+// which is probably longer than the length, so it should throw an exception.
+// This is no different from the other cases where the offset is longer than
+// the length, and the wrapping complicates my testing slightly, so I won't
+// bother testing negative values here or in other cases.
+var splitTextTests = [];
+for (var i = 0; i < textNodes.length; i++) {
+  var node = textNodes[i];
+  splitTextTests.push([node, 376, node, 0, node, 1]);
+  splitTextTests.push([node, 0, node, 0, node, 0]);
+  splitTextTests.push([node, 1, node, 1, node, 1]);
+  splitTextTests.push([node, node + ".length", node, node + ".length", node, node + ".length"]);
+  splitTextTests.push([node, 1, node, 1, node, 3]);
+  splitTextTests.push([node, 2, node, 1, node, 3]);
+  splitTextTests.push([node, 3, node, 1, node, 3]);
+}
+
+splitTextTests.push(
+  ["paras[0].firstChild", 1, "paras[0]", 0, "paras[0]", 0],
+  ["paras[0].firstChild", 1, "paras[0]", 0, "paras[0]", 1],
+  ["paras[0].firstChild", 1, "paras[0]", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 1, "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 2, "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 3, "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 1, "paras[0]", 0, "paras[0].firstChild", 3],
+  ["paras[0].firstChild", 2, "paras[0]", 0, "paras[0].firstChild", 3],
+  ["paras[0].firstChild", 3, "paras[0]", 0, "paras[0].firstChild", 3]
+);
+
+
+function testReplaceDataAlgorithm(node, offset, count, data, callback, startContainer, startOffset, endContainer, endOffset) {
+  // Mutation works the same any time DOM Core's "replace data" algorithm is
+  // invoked.  node, offset, count, data are as in that algorithm.  The
+  // callback is what does the actual setting.  Not to be confused with
+  // testReplaceData, which tests the replaceData() method.
+
+  // Barring any provision to the contrary, the containers and offsets must
+  // not change.
+  var expectedStartContainer = startContainer;
+  var expectedStartOffset = startOffset;
+  var expectedEndContainer = endContainer;
+  var expectedEndOffset = endOffset;
+
+  var originalParent = node.parentNode;
+  var originalData = node.data;
+
+  var exceptionThrown = false;
+  try {
+    callback();
+  } catch (e) {
+    // Should only happen if offset is greater than length
+    exceptionThrown = true;
+  }
+
+  assert_equals(node.parentNode, originalParent,
+    "Sanity check failed: changing data changed the parent");
+
+  // "User agents must run the following steps whenever they replace data of
+  // a CharacterData node, as though they were written in the specification
+  // for that algorithm after all other steps. In particular, the steps must
+  // not be executed if the algorithm threw an exception."
+  if (exceptionThrown) {
+    assert_equals(node.data, originalData,
+      "Sanity check failed: exception thrown but data changed");
+  } else {
+    assert_equals(node.data,
+      originalData.substr(0, offset) + data + originalData.substr(offset + count),
+      "Sanity check failed: data not changed as expected");
+  }
+
+  // "For every boundary point whose node is node, and whose offset is
+  // greater than offset but less than or equal to offset plus count, set
+  // its offset to offset."
+  if (!exceptionThrown
+  && startContainer == node
+  && startOffset > offset
+  && startOffset <= offset + count) {
+    expectedStartOffset = offset;
+  }
+
+  if (!exceptionThrown
+  && endContainer == node
+  && endOffset > offset
+  && endOffset <= offset + count) {
+    expectedEndOffset = offset;
+  }
+
+  // "For every boundary point whose node is node, and whose offset is
+  // greater than offset plus count, add the length of data to its offset,
+  // then subtract count from it."
+  if (!exceptionThrown
+  && startContainer == node
+  && startOffset > offset + count) {
+    expectedStartOffset += data.length - count;
+  }
+
+  if (!exceptionThrown
+  && endContainer == node
+  && endOffset > offset + count) {
+    expectedEndOffset += data.length - count;
+  }
+
+  return [expectedStartContainer, expectedStartOffset, expectedEndContainer, expectedEndOffset];
+}
+
+function testInsertData(node, offset, data, startContainer, startOffset, endContainer, endOffset) {
+  return testReplaceDataAlgorithm(node, offset, 0, data,
+    function() { node.insertData(offset, data) },
+    startContainer, startOffset, endContainer, endOffset);
+}
+
+var insertDataTests = [];
+for (var i = 0; i < characterDataNodes.length; i++) {
+  var node = characterDataNodes[i];
+  insertDataTests.push([node, 376, '"foo"', node, 0, node, 1]);
+  insertDataTests.push([node, 0, '"foo"', node, 0, node, 0]);
+  insertDataTests.push([node, 1, '"foo"', node, 1, node, 1]);
+  insertDataTests.push([node, node + ".length", '"foo"', node, node + ".length", node, node + ".length"]);
+  insertDataTests.push([node, 1, '"foo"', node, 1, node, 3]);
+  insertDataTests.push([node, 2, '"foo"', node, 1, node, 3]);
+  insertDataTests.push([node, 3, '"foo"', node, 1, node, 3]);
+
+  insertDataTests.push([node, 376, '""', node, 0, node, 1]);
+  insertDataTests.push([node, 0, '""', node, 0, node, 0]);
+  insertDataTests.push([node, 1, '""', node, 1, node, 1]);
+  insertDataTests.push([node, node + ".length", '""', node, node + ".length", node, node + ".length"]);
+  insertDataTests.push([node, 1, '""', node, 1, node, 3]);
+  insertDataTests.push([node, 2, '""', node, 1, node, 3]);
+  insertDataTests.push([node, 3, '""', node, 1, node, 3]);
+}
+
+insertDataTests.push(
+  ["paras[0].firstChild", 1, '"foo"', "paras[0]", 0, "paras[0]", 0],
+  ["paras[0].firstChild", 1, '"foo"', "paras[0]", 0, "paras[0]", 1],
+  ["paras[0].firstChild", 1, '"foo"', "paras[0]", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 1, '"foo"', "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 2, '"foo"', "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 3, '"foo"', "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 1, '"foo"', "paras[0]", 0, "paras[0].firstChild", 3],
+  ["paras[0].firstChild", 2, '"foo"', "paras[0]", 0, "paras[0].firstChild", 3],
+  ["paras[0].firstChild", 3, '"foo"', "paras[0]", 0, "paras[0].firstChild", 3]
+);
+
+
+function testAppendData(node, data, startContainer, startOffset, endContainer, endOffset) {
+  return testReplaceDataAlgorithm(node, node.length, 0, data,
+    function() { node.appendData(data) },
+    startContainer, startOffset, endContainer, endOffset);
+}
+
+var appendDataTests = [];
+for (var i = 0; i < characterDataNodes.length; i++) {
+  var node = characterDataNodes[i];
+  appendDataTests.push([node, '"foo"', node, 0, node, 1]);
+  appendDataTests.push([node, '"foo"', node, 0, node, 0]);
+  appendDataTests.push([node, '"foo"', node, 1, node, 1]);
+  appendDataTests.push([node, '"foo"', node, 0, node, node + ".length"]);
+  appendDataTests.push([node, '"foo"', node, 1, node, node + ".length"]);
+  appendDataTests.push([node, '"foo"', node, node + ".length", node, node + ".length"]);
+  appendDataTests.push([node, '"foo"', node, 1, node, 3]);
+
+  appendDataTests.push([node, '""', node, 0, node, 1]);
+  appendDataTests.push([node, '""', node, 0, node, 0]);
+  appendDataTests.push([node, '""', node, 1, node, 1]);
+  appendDataTests.push([node, '""', node, 0, node, node + ".length"]);
+  appendDataTests.push([node, '""', node, 1, node, node + ".length"]);
+  appendDataTests.push([node, '""', node, node + ".length", node, node + ".length"]);
+  appendDataTests.push([node, '""', node, 1, node, 3]);
+}
+
+appendDataTests.push(
+  ["paras[0].firstChild", '""', "paras[0]", 0, "paras[0]", 0],
+  ["paras[0].firstChild", '""', "paras[0]", 0, "paras[0]", 1],
+  ["paras[0].firstChild", '""', "paras[0]", 1, "paras[0]", 1],
+  ["paras[0].firstChild", '""', "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", '""', "paras[0]", 0, "paras[0].firstChild", 3],
+
+  ["paras[0].firstChild", '"foo"', "paras[0]", 0, "paras[0]", 0],
+  ["paras[0].firstChild", '"foo"', "paras[0]", 0, "paras[0]", 1],
+  ["paras[0].firstChild", '"foo"', "paras[0]", 1, "paras[0]", 1],
+  ["paras[0].firstChild", '"foo"', "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", '"foo"', "paras[0]", 0, "paras[0].firstChild", 3]
+);
+
+
+function testDeleteData(node, offset, count, startContainer, startOffset, endContainer, endOffset) {
+  return testReplaceDataAlgorithm(node, offset, count, "",
+    function() { node.deleteData(offset, count) },
+    startContainer, startOffset, endContainer, endOffset);
+}
+
+var deleteDataTests = [];
+for (var i = 0; i < characterDataNodes.length; i++) {
+  var node = characterDataNodes[i];
+  deleteDataTests.push([node, 376, 2, node, 0, node, 1]);
+  deleteDataTests.push([node, 0, 2, node, 0, node, 0]);
+  deleteDataTests.push([node, 1, 2, node, 1, node, 1]);
+  deleteDataTests.push([node, node + ".length", 2, node, node + ".length", node, node + ".length"]);
+  deleteDataTests.push([node, 1, 2, node, 1, node, 3]);
+  deleteDataTests.push([node, 2, 2, node, 1, node, 3]);
+  deleteDataTests.push([node, 3, 2, node, 1, node, 3]);
+
+  deleteDataTests.push([node, 376, 0, node, 0, node, 1]);
+  deleteDataTests.push([node, 0, 0, node, 0, node, 0]);
+  deleteDataTests.push([node, 1, 0, node, 1, node, 1]);
+  deleteDataTests.push([node, node + ".length", 0, node, node + ".length", node, node + ".length"]);
+  deleteDataTests.push([node, 1, 0, node, 1, node, 3]);
+  deleteDataTests.push([node, 2, 0, node, 1, node, 3]);
+  deleteDataTests.push([node, 3, 0, node, 1, node, 3]);
+
+  deleteDataTests.push([node, 376, 631, node, 0, node, 1]);
+  deleteDataTests.push([node, 0, 631, node, 0, node, 0]);
+  deleteDataTests.push([node, 1, 631, node, 1, node, 1]);
+  deleteDataTests.push([node, node + ".length", 631, node, node + ".length", node, node + ".length"]);
+  deleteDataTests.push([node, 1, 631, node, 1, node, 3]);
+  deleteDataTests.push([node, 2, 631, node, 1, node, 3]);
+  deleteDataTests.push([node, 3, 631, node, 1, node, 3]);
+}
+
+deleteDataTests.push(
+  ["paras[0].firstChild", 1, 2, "paras[0]", 0, "paras[0]", 0],
+  ["paras[0].firstChild", 1, 2, "paras[0]", 0, "paras[0]", 1],
+  ["paras[0].firstChild", 1, 2, "paras[0]", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 1, 2, "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 2, 2, "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 3, 2, "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 1, 2, "paras[0]", 0, "paras[0].firstChild", 3],
+  ["paras[0].firstChild", 2, 2, "paras[0]", 0, "paras[0].firstChild", 3],
+  ["paras[0].firstChild", 3, 2, "paras[0]", 0, "paras[0].firstChild", 3]
+);
+
+
+function testReplaceData(node, offset, count, data, startContainer, startOffset, endContainer, endOffset) {
+  return testReplaceDataAlgorithm(node, offset, count, data,
+    function() { node.replaceData(offset, count, data) },
+    startContainer, startOffset, endContainer, endOffset);
+}
+
+var replaceDataTests = [];
+for (var i = 0; i < characterDataNodes.length; i++) {
+  var node = characterDataNodes[i];
+  replaceDataTests.push([node, 376, 0, '"foo"', node, 0, node, 1]);
+  replaceDataTests.push([node, 0, 0, '"foo"', node, 0, node, 0]);
+  replaceDataTests.push([node, 1, 0, '"foo"', node, 1, node, 1]);
+  replaceDataTests.push([node, node + ".length", 0, '"foo"', node, node + ".length", node, node + ".length"]);
+  replaceDataTests.push([node, 1, 0, '"foo"', node, 1, node, 3]);
+  replaceDataTests.push([node, 2, 0, '"foo"', node, 1, node, 3]);
+  replaceDataTests.push([node, 3, 0, '"foo"', node, 1, node, 3]);
+
+  replaceDataTests.push([node, 376, 0, '""', node, 0, node, 1]);
+  replaceDataTests.push([node, 0, 0, '""', node, 0, node, 0]);
+  replaceDataTests.push([node, 1, 0, '""', node, 1, node, 1]);
+  replaceDataTests.push([node, node + ".length", 0, '""', node, node + ".length", node, node + ".length"]);
+  replaceDataTests.push([node, 1, 0, '""', node, 1, node, 3]);
+  replaceDataTests.push([node, 2, 0, '""', node, 1, node, 3]);
+  replaceDataTests.push([node, 3, 0, '""', node, 1, node, 3]);
+
+  replaceDataTests.push([node, 376, 1, '"foo"', node, 0, node, 1]);
+  replaceDataTests.push([node, 0, 1, '"foo"', node, 0, node, 0]);
+  replaceDataTests.push([node, 1, 1, '"foo"', node, 1, node, 1]);
+  replaceDataTests.push([node, node + ".length", 1, '"foo"', node, node + ".length", node, node + ".length"]);
+  replaceDataTests.push([node, 1, 1, '"foo"', node, 1, node, 3]);
+  replaceDataTests.push([node, 2, 1, '"foo"', node, 1, node, 3]);
+  replaceDataTests.push([node, 3, 1, '"foo"', node, 1, node, 3]);
+
+  replaceDataTests.push([node, 376, 1, '""', node, 0, node, 1]);
+  replaceDataTests.push([node, 0, 1, '""', node, 0, node, 0]);
+  replaceDataTests.push([node, 1, 1, '""', node, 1, node, 1]);
+  replaceDataTests.push([node, node + ".length", 1, '""', node, node + ".length", node, node + ".length"]);
+  replaceDataTests.push([node, 1, 1, '""', node, 1, node, 3]);
+  replaceDataTests.push([node, 2, 1, '""', node, 1, node, 3]);
+  replaceDataTests.push([node, 3, 1, '""', node, 1, node, 3]);
+
+  replaceDataTests.push([node, 376, 47, '"foo"', node, 0, node, 1]);
+  replaceDataTests.push([node, 0, 47, '"foo"', node, 0, node, 0]);
+  replaceDataTests.push([node, 1, 47, '"foo"', node, 1, node, 1]);
+  replaceDataTests.push([node, node + ".length", 47, '"foo"', node, node + ".length", node, node + ".length"]);
+  replaceDataTests.push([node, 1, 47, '"foo"', node, 1, node, 3]);
+  replaceDataTests.push([node, 2, 47, '"foo"', node, 1, node, 3]);
+  replaceDataTests.push([node, 3, 47, '"foo"', node, 1, node, 3]);
+
+  replaceDataTests.push([node, 376, 47, '""', node, 0, node, 1]);
+  replaceDataTests.push([node, 0, 47, '""', node, 0, node, 0]);
+  replaceDataTests.push([node, 1, 47, '""', node, 1, node, 1]);
+  replaceDataTests.push([node, node + ".length", 47, '""', node, node + ".length", node, node + ".length"]);
+  replaceDataTests.push([node, 1, 47, '""', node, 1, node, 3]);
+  replaceDataTests.push([node, 2, 47, '""', node, 1, node, 3]);
+  replaceDataTests.push([node, 3, 47, '""', node, 1, node, 3]);
+}
+
+replaceDataTests.push(
+  ["paras[0].firstChild", 1, 0, '"foo"', "paras[0]", 0, "paras[0]", 0],
+  ["paras[0].firstChild", 1, 0, '"foo"', "paras[0]", 0, "paras[0]", 1],
+  ["paras[0].firstChild", 1, 0, '"foo"', "paras[0]", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 1, 0, '"foo"', "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 2, 0, '"foo"', "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 3, 0, '"foo"', "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 1, 0, '"foo"', "paras[0]", 0, "paras[0].firstChild", 3],
+  ["paras[0].firstChild", 2, 0, '"foo"', "paras[0]", 0, "paras[0].firstChild", 3],
+  ["paras[0].firstChild", 3, 0, '"foo"', "paras[0]", 0, "paras[0].firstChild", 3],
+
+  ["paras[0].firstChild", 1, 1, '"foo"', "paras[0]", 0, "paras[0]", 0],
+  ["paras[0].firstChild", 1, 1, '"foo"', "paras[0]", 0, "paras[0]", 1],
+  ["paras[0].firstChild", 1, 1, '"foo"', "paras[0]", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 1, 1, '"foo"', "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 2, 1, '"foo"', "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 3, 1, '"foo"', "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 1, 1, '"foo"', "paras[0]", 0, "paras[0].firstChild", 3],
+  ["paras[0].firstChild", 2, 1, '"foo"', "paras[0]", 0, "paras[0].firstChild", 3],
+  ["paras[0].firstChild", 3, 1, '"foo"', "paras[0]", 0, "paras[0].firstChild", 3],
+
+  ["paras[0].firstChild", 1, 47, '"foo"', "paras[0]", 0, "paras[0]", 0],
+  ["paras[0].firstChild", 1, 47, '"foo"', "paras[0]", 0, "paras[0]", 1],
+  ["paras[0].firstChild", 1, 47, '"foo"', "paras[0]", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 1, 47, '"foo"', "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 2, 47, '"foo"', "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 3, 47, '"foo"', "paras[0].firstChild", 1, "paras[0]", 1],
+  ["paras[0].firstChild", 1, 47, '"foo"', "paras[0]", 0, "paras[0].firstChild", 3],
+  ["paras[0].firstChild", 2, 47, '"foo"', "paras[0]", 0, "paras[0].firstChild", 3],
+  ["paras[0].firstChild", 3, 47, '"foo"', "paras[0]", 0, "paras[0].firstChild", 3]
+);
+
+
+// There are lots of ways to set data, so we pass a callback that does the
+// actual setting.
+function testDataChange(node, attr, op, rval, startContainer, startOffset, endContainer, endOffset) {
+  return testReplaceDataAlgorithm(node, 0, node.length, op == "=" ? rval : node[attr] + rval,
+    function() {
+      if (op == "=") {
+        node[attr] = rval;
+      } else if (op == "+=") {
+        node[attr] += rval;
+      } else {
+        throw "Unknown op " + op;
+      }
+    },
+    startContainer, startOffset, endContainer, endOffset);
+}
+
+var dataChangeTests = [];
+var dataChangeTestAttrs = ["data", "textContent", "nodeValue"];
+for (var i = 0; i < characterDataNodes.length; i++) {
+  var node = characterDataNodes[i];
+  var dataChangeTestRanges = [
+    [node, 0, node, 0],
+    [node, 0, node, 1],
+    [node, 1, node, 1],
+    [node, 0, node, node + ".length"],
+    [node, 1, node, node + ".length"],
+    [node, node + ".length", node, node + ".length"],
+  ];
+
+  for (var j = 0; j < dataChangeTestRanges.length; j++) {
+    for (var k = 0; k < dataChangeTestAttrs.length; k++) {
+      dataChangeTests.push([
+        node,
+        '"' + dataChangeTestAttrs[k] + '"',
+        '"="',
+        '""',
+      ].concat(dataChangeTestRanges[j]));
+
+      dataChangeTests.push([
+        node,
+        '"' + dataChangeTestAttrs[k] + '"',
+        '"="',
+        '"foo"',
+      ].concat(dataChangeTestRanges[j]));
+
+      dataChangeTests.push([
+        node,
+        '"' + dataChangeTestAttrs[k] + '"',
+        '"="',
+        node + "." + dataChangeTestAttrs[k],
+      ].concat(dataChangeTestRanges[j]));
+
+      dataChangeTests.push([
+        node,
+        '"' + dataChangeTestAttrs[k] + '"',
+        '"+="',
+        '""',
+      ].concat(dataChangeTestRanges[j]));
+
+      dataChangeTests.push([
+        node,
+        '"' + dataChangeTestAttrs[k] + '"',
+        '"+="',
+        '"foo"',
+      ].concat(dataChangeTestRanges[j]));
+
+      dataChangeTests.push([
+        node,
+        '"' + dataChangeTestAttrs[k] + '"',
+        '"+="',
+        node + "." + dataChangeTestAttrs[k]
+      ].concat(dataChangeTestRanges[j]));
+    }
+  }
+}
+
+
+// Now we test node insertions and deletions, as opposed to just data changes.
+// To avoid loads of repetition, we define modifyForRemove() and
+// modifyForInsert().
+
+// If we were to remove removedNode from its parent, what would the boundary
+// point [node, offset] become?  Returns [new node, new offset].  Must be
+// called BEFORE the node is actually removed, so its parent is not null.  (If
+// the parent is null, it will do nothing.)
+function modifyForRemove(removedNode, point) {
+  var oldParent = removedNode.parentNode;
+  var oldIndex = indexOf(removedNode);
+  if (!oldParent) {
+    return point;
+  }
+
+  // "For each boundary point whose node is removed node or a descendant of
+  // it, set the boundary point to (old parent, old index)."
+  if (point[0] == removedNode || isDescendant(point[0], removedNode)) {
+    return [oldParent, oldIndex];
+  }
+
+  // "For each boundary point whose node is old parent and whose offset is
+  // greater than old index, subtract one from its offset."
+  if (point[0] == oldParent && point[1] > oldIndex) {
+    return [point[0], point[1] - 1];
+  }
+
+  return point;
+}
+
+// Update the given boundary point [node, offset] to account for the fact that
+// insertedNode was just inserted into its current position.  This must be
+// called AFTER insertedNode was already inserted.
+function modifyForInsert(insertedNode, point) {
+  // "For each boundary point whose node is the new parent of the affected
+  // node and whose offset is greater than the new index of the affected
+  // node, add one to the boundary point's offset."
+  if (point[0] == insertedNode.parentNode && point[1] > indexOf(insertedNode)) {
+    return [point[0], point[1] + 1];
+  }
+
+  return point;
+}
+
+
+function testInsertBefore(newParent, affectedNode, refNode, startContainer, startOffset, endContainer, endOffset) {
+  var expectedStart = [startContainer, startOffset];
+  var expectedEnd = [endContainer, endOffset];
+
+  expectedStart = modifyForRemove(affectedNode, expectedStart);
+  expectedEnd = modifyForRemove(affectedNode, expectedEnd);
+
+  try {
+    newParent.insertBefore(affectedNode, refNode);
+  } catch (e) {
+    // For our purposes, assume that DOM Core is true -- i.e., ignore
+    // mutation events and similar.
+    return [startContainer, startOffset, endContainer, endOffset];
+  }
+
+  expectedStart = modifyForInsert(affectedNode, expectedStart);
+  expectedEnd = modifyForInsert(affectedNode, expectedEnd);
+
+  return expectedStart.concat(expectedEnd);
+}
+
+var insertBeforeTests = [
+  // Moving a node to its current position
+  ["testDiv", "paras[0]", "paras[1]", "paras[0]", 0, "paras[0]", 0],
+  ["testDiv", "paras[0]", "paras[1]", "paras[0]", 0, "paras[0]", 1],
+  ["testDiv", "paras[0]", "paras[1]", "paras[0]", 1, "paras[0]", 1],
+  ["testDiv", "paras[0]", "paras[1]", "testDiv", 0, "testDiv", 2],
+  ["testDiv", "paras[0]", "paras[1]", "testDiv", 1, "testDiv", 1],
+  ["testDiv", "paras[0]", "paras[1]", "testDiv", 1, "testDiv", 2],
+  ["testDiv", "paras[0]", "paras[1]", "testDiv", 2, "testDiv", 2],
+
+  // Stuff that actually moves something.  Note that paras[0] and paras[1]
+  // are both children of testDiv.
+  ["paras[0]", "paras[1]", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 0],
+  ["paras[0]", "paras[1]", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "paras[1]", "paras[0].firstChild", "paras[0]", 1, "paras[0]", 1],
+  ["paras[0]", "paras[1]", "paras[0].firstChild", "testDiv", 0, "testDiv", 1],
+  ["paras[0]", "paras[1]", "paras[0].firstChild", "testDiv", 0, "testDiv", 2],
+  ["paras[0]", "paras[1]", "paras[0].firstChild", "testDiv", 1, "testDiv", 1],
+  ["paras[0]", "paras[1]", "paras[0].firstChild", "testDiv", 1, "testDiv", 2],
+  ["paras[0]", "paras[1]", "null", "paras[0]", 0, "paras[0]", 0],
+  ["paras[0]", "paras[1]", "null", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "paras[1]", "null", "paras[0]", 1, "paras[0]", 1],
+  ["paras[0]", "paras[1]", "null", "testDiv", 0, "testDiv", 1],
+  ["paras[0]", "paras[1]", "null", "testDiv", 0, "testDiv", 2],
+  ["paras[0]", "paras[1]", "null", "testDiv", 1, "testDiv", 1],
+  ["paras[0]", "paras[1]", "null", "testDiv", 1, "testDiv", 2],
+  ["foreignDoc", "detachedComment", "foreignDoc.documentElement", "foreignDoc", 0, "foreignDoc", 0],
+  ["foreignDoc", "detachedComment", "foreignDoc.documentElement", "foreignDoc", 0, "foreignDoc", 1],
+  ["foreignDoc", "detachedComment", "foreignDoc.documentElement", "foreignDoc", 0, "foreignDoc", 2],
+  ["foreignDoc", "detachedComment", "foreignDoc.documentElement", "foreignDoc", 1, "foreignDoc", 1],
+  ["foreignDoc", "detachedComment", "foreignDoc.doctype", "foreignDoc", 0, "foreignDoc", 0],
+  ["foreignDoc", "detachedComment", "foreignDoc.doctype", "foreignDoc", 0, "foreignDoc", 1],
+  ["foreignDoc", "detachedComment", "foreignDoc.doctype", "foreignDoc", 0, "foreignDoc", 2],
+  ["foreignDoc", "detachedComment", "foreignDoc.doctype", "foreignDoc", 1, "foreignDoc", 1],
+  ["foreignDoc", "detachedComment", "null", "foreignDoc", 0, "foreignDoc", 1],
+  ["paras[0]", "xmlTextNode", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 0],
+  ["paras[0]", "xmlTextNode", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "xmlTextNode", "paras[0].firstChild", "paras[0]", 1, "paras[0]", 1],
+
+  // Stuff that throws exceptions
+  ["paras[0]", "paras[0]", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "testDiv", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "document", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "foreignDoc", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "document.doctype", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 1],
+];
+
+
+function testReplaceChild(newParent, newChild, oldChild, startContainer, startOffset, endContainer, endOffset) {
+  var expectedStart = [startContainer, startOffset];
+  var expectedEnd = [endContainer, endOffset];
+
+  expectedStart = modifyForRemove(oldChild, expectedStart);
+  expectedEnd = modifyForRemove(oldChild, expectedEnd);
+
+  if (newChild != oldChild) {
+    // Don't do this twice, if they're the same!
+    expectedStart = modifyForRemove(newChild, expectedStart);
+    expectedEnd = modifyForRemove(newChild, expectedEnd);
+  }
+
+  try {
+    newParent.replaceChild(newChild, oldChild);
+  } catch (e) {
+    return [startContainer, startOffset, endContainer, endOffset];
+  }
+
+  expectedStart = modifyForInsert(newChild, expectedStart);
+  expectedEnd = modifyForInsert(newChild, expectedEnd);
+
+  return expectedStart.concat(expectedEnd);
+}
+
+var replaceChildTests = [
+  // Moving a node to its current position.  Doesn't match most browsers'
+  // behavior, but we probably want to keep the spec the same anyway:
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=647603
+  ["testDiv", "paras[0]", "paras[0]", "paras[0]", 0, "paras[0]", 0],
+  ["testDiv", "paras[0]", "paras[0]", "paras[0]", 0, "paras[0]", 1],
+  ["testDiv", "paras[0]", "paras[0]", "paras[0]", 1, "paras[0]", 1],
+  ["testDiv", "paras[0]", "paras[0]", "testDiv", 0, "testDiv", 2],
+  ["testDiv", "paras[0]", "paras[0]", "testDiv", 1, "testDiv", 1],
+  ["testDiv", "paras[0]", "paras[0]", "testDiv", 1, "testDiv", 2],
+  ["testDiv", "paras[0]", "paras[0]", "testDiv", 2, "testDiv", 2],
+
+  // Stuff that actually moves something.
+  ["paras[0]", "paras[1]", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 0],
+  ["paras[0]", "paras[1]", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "paras[1]", "paras[0].firstChild", "paras[0]", 1, "paras[0]", 1],
+  ["paras[0]", "paras[1]", "paras[0].firstChild", "testDiv", 0, "testDiv", 1],
+  ["paras[0]", "paras[1]", "paras[0].firstChild", "testDiv", 0, "testDiv", 2],
+  ["paras[0]", "paras[1]", "paras[0].firstChild", "testDiv", 1, "testDiv", 1],
+  ["paras[0]", "paras[1]", "paras[0].firstChild", "testDiv", 1, "testDiv", 2],
+  ["foreignDoc", "detachedComment", "foreignDoc.documentElement", "foreignDoc", 0, "foreignDoc", 0],
+  ["foreignDoc", "detachedComment", "foreignDoc.documentElement", "foreignDoc", 0, "foreignDoc", 1],
+  ["foreignDoc", "detachedComment", "foreignDoc.documentElement", "foreignDoc", 0, "foreignDoc", 2],
+  ["foreignDoc", "detachedComment", "foreignDoc.documentElement", "foreignDoc", 1, "foreignDoc", 1],
+  ["foreignDoc", "detachedComment", "foreignDoc.doctype", "foreignDoc", 0, "foreignDoc", 0],
+  ["foreignDoc", "detachedComment", "foreignDoc.doctype", "foreignDoc", 0, "foreignDoc", 1],
+  ["foreignDoc", "detachedComment", "foreignDoc.doctype", "foreignDoc", 0, "foreignDoc", 2],
+  ["foreignDoc", "detachedComment", "foreignDoc.doctype", "foreignDoc", 1, "foreignDoc", 1],
+  ["paras[0]", "xmlTextNode", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 0],
+  ["paras[0]", "xmlTextNode", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "xmlTextNode", "paras[0].firstChild", "paras[0]", 1, "paras[0]", 1],
+
+  // Stuff that throws exceptions
+  ["paras[0]", "paras[0]", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "testDiv", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "document", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "foreignDoc", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "document.doctype", "paras[0].firstChild", "paras[0]", 0, "paras[0]", 1],
+];
+
+
+function testAppendChild(newParent, affectedNode, startContainer, startOffset, endContainer, endOffset) {
+  var expectedStart = [startContainer, startOffset];
+  var expectedEnd = [endContainer, endOffset];
+
+  expectedStart = modifyForRemove(affectedNode, expectedStart);
+  expectedEnd = modifyForRemove(affectedNode, expectedEnd);
+
+  try {
+    newParent.appendChild(affectedNode);
+  } catch (e) {
+    return [startContainer, startOffset, endContainer, endOffset];
+  }
+
+  // These two lines will actually never do anything, if you think about it,
+  // but let's leave them in so correctness is more obvious.
+  expectedStart = modifyForInsert(affectedNode, expectedStart);
+  expectedEnd = modifyForInsert(affectedNode, expectedEnd);
+
+  return expectedStart.concat(expectedEnd);
+}
+
+var appendChildTests = [
+  // Moving a node to its current position
+  ["testDiv", "testDiv.lastChild", "testDiv.lastChild", 0, "testDiv.lastChild", 0],
+  ["testDiv", "testDiv.lastChild", "testDiv.lastChild", 0, "testDiv.lastChild", 1],
+  ["testDiv", "testDiv.lastChild", "testDiv.lastChild", 1, "testDiv.lastChild", 1],
+  ["testDiv", "testDiv.lastChild", "testDiv", "testDiv.childNodes.length - 2", "testDiv", "testDiv.childNodes.length"],
+  ["testDiv", "testDiv.lastChild", "testDiv", "testDiv.childNodes.length - 2", "testDiv", "testDiv.childNodes.length - 1"],
+  ["testDiv", "testDiv.lastChild", "testDiv", "testDiv.childNodes.length - 1", "testDiv", "testDiv.childNodes.length"],
+  ["testDiv", "testDiv.lastChild", "testDiv", "testDiv.childNodes.length - 1", "testDiv", "testDiv.childNodes.length - 1"],
+  ["testDiv", "testDiv.lastChild", "testDiv", "testDiv.childNodes.length", "testDiv", "testDiv.childNodes.length"],
+  ["detachedDiv", "detachedDiv.lastChild", "detachedDiv.lastChild", 0, "detachedDiv.lastChild", 0],
+  ["detachedDiv", "detachedDiv.lastChild", "detachedDiv.lastChild", 0, "detachedDiv.lastChild", 1],
+  ["detachedDiv", "detachedDiv.lastChild", "detachedDiv.lastChild", 1, "detachedDiv.lastChild", 1],
+  ["detachedDiv", "detachedDiv.lastChild", "detachedDiv", "detachedDiv.childNodes.length - 2", "detachedDiv", "detachedDiv.childNodes.length"],
+  ["detachedDiv", "detachedDiv.lastChild", "detachedDiv", "detachedDiv.childNodes.length - 2", "detachedDiv", "detachedDiv.childNodes.length - 1"],
+  ["detachedDiv", "detachedDiv.lastChild", "detachedDiv", "detachedDiv.childNodes.length - 1", "detachedDiv", "detachedDiv.childNodes.length"],
+  ["detachedDiv", "detachedDiv.lastChild", "detachedDiv", "detachedDiv.childNodes.length - 1", "detachedDiv", "detachedDiv.childNodes.length - 1"],
+  ["detachedDiv", "detachedDiv.lastChild", "detachedDiv", "detachedDiv.childNodes.length", "detachedDiv", "detachedDiv.childNodes.length"],
+
+  // Stuff that actually moves something
+  ["paras[0]", "paras[1]", "paras[0]", 0, "paras[0]", 0],
+  ["paras[0]", "paras[1]", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "paras[1]", "paras[0]", 1, "paras[0]", 1],
+  ["paras[0]", "paras[1]", "testDiv", 0, "testDiv", 1],
+  ["paras[0]", "paras[1]", "testDiv", 0, "testDiv", 2],
+  ["paras[0]", "paras[1]", "testDiv", 1, "testDiv", 1],
+  ["paras[0]", "paras[1]", "testDiv", 1, "testDiv", 2],
+  ["foreignDoc", "detachedComment", "foreignDoc", "foreignDoc.childNodes.length - 1", "foreignDoc", "foreignDoc.childNodes.length"],
+  ["foreignDoc", "detachedComment", "foreignDoc", "foreignDoc.childNodes.length - 1", "foreignDoc", "foreignDoc.childNodes.length - 1"],
+  ["foreignDoc", "detachedComment", "foreignDoc", "foreignDoc.childNodes.length", "foreignDoc", "foreignDoc.childNodes.length"],
+  ["foreignDoc", "detachedComment", "detachedComment", 0, "detachedComment", 5],
+  ["paras[0]", "xmlTextNode", "paras[0]", 0, "paras[0]", 0],
+  ["paras[0]", "xmlTextNode", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "xmlTextNode", "paras[0]", 1, "paras[0]", 1],
+
+  // Stuff that throws exceptions
+  ["paras[0]", "paras[0]", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "testDiv", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "document", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "foreignDoc", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "document.doctype", "paras[0]", 0, "paras[0]", 1],
+];
+
+
+function testRemoveChild(affectedNode, startContainer, startOffset, endContainer, endOffset) {
+  var expectedStart = [startContainer, startOffset];
+  var expectedEnd = [endContainer, endOffset];
+
+  expectedStart = modifyForRemove(affectedNode, expectedStart);
+  expectedEnd = modifyForRemove(affectedNode, expectedEnd);
+
+  // We don't test cases where the parent is wrong, so this should never
+  // throw an exception.
+  affectedNode.parentNode.removeChild(affectedNode);
+
+  return expectedStart.concat(expectedEnd);
+}
+
+var removeChildTests = [
+  ["paras[0]", "paras[0]", 0, "paras[0]", 0],
+  ["paras[0]", "paras[0]", 0, "paras[0]", 1],
+  ["paras[0]", "paras[0]", 1, "paras[0]", 1],
+  ["paras[0]", "testDiv", 0, "testDiv", 0],
+  ["paras[0]", "testDiv", 0, "testDiv", 1],
+  ["paras[0]", "testDiv", 1, "testDiv", 1],
+  ["paras[0]", "testDiv", 0, "testDiv", 2],
+  ["paras[0]", "testDiv", 1, "testDiv", 2],
+  ["paras[0]", "testDiv", 2, "testDiv", 2],
+
+  ["foreignDoc.documentElement", "foreignDoc", 0, "foreignDoc", "foreignDoc.childNodes.length"],
+];

--- a/LayoutTests/http/wpt/dom-ranges-live-range/common.js
+++ b/LayoutTests/http/wpt/dom-ranges-live-range/common.js
@@ -1,0 +1,1083 @@
+"use strict";
+// Written by Aryeh Gregor <ayg@aryeh.name>
+
+// TODO: iframes, contenteditable/designMode
+
+// Everything is done in functions in this test harness, so we have to declare
+// all the variables before use to make sure they can be reused.
+var testDiv, paras, detachedDiv, detachedPara1, detachedPara2,
+    foreignDoc, foreignPara1, foreignPara2, xmlDoc, xmlElement,
+    detachedXmlElement, detachedTextNode, foreignTextNode,
+    detachedForeignTextNode, xmlTextNode, detachedXmlTextNode,
+    processingInstruction, detachedProcessingInstruction, comment,
+    detachedComment, foreignComment, detachedForeignComment, xmlComment,
+    detachedXmlComment, docfrag, foreignDocfrag, xmlDocfrag, doctype,
+    foreignDoctype, xmlDoctype;
+var testRangesShort, testRanges, testPoints, testNodesShort, testNodes;
+
+function setupRangeTests() {
+    testDiv = document.querySelector("#test");
+    if (testDiv) {
+        testDiv.parentNode.removeChild(testDiv);
+    }
+    testDiv = document.createElement("div");
+    testDiv.id = "test";
+    document.body.insertBefore(testDiv, document.body.firstChild);
+
+    paras = [];
+    paras.push(document.createElement("p"));
+    paras[0].setAttribute("id", "a");
+    // Test some diacritics, to make sure browsers are using code units here
+    // and not something like grapheme clusters.
+    paras[0].textContent = "A\u0308b\u0308c\u0308d\u0308e\u0308f\u0308g\u0308h\u0308\n";
+    testDiv.appendChild(paras[0]);
+
+    paras.push(document.createElement("p"));
+    paras[1].setAttribute("id", "b");
+    paras[1].setAttribute("style", "display:none");
+    paras[1].textContent = "Ijklmnop\n";
+    testDiv.appendChild(paras[1]);
+
+    paras.push(document.createElement("p"));
+    paras[2].setAttribute("id", "c");
+    paras[2].textContent = "Qrstuvwx";
+    testDiv.appendChild(paras[2]);
+
+    paras.push(document.createElement("p"));
+    paras[3].setAttribute("id", "d");
+    paras[3].setAttribute("style", "display:none");
+    paras[3].textContent = "Yzabcdef";
+    testDiv.appendChild(paras[3]);
+
+    paras.push(document.createElement("p"));
+    paras[4].setAttribute("id", "e");
+    paras[4].setAttribute("style", "display:none");
+    paras[4].textContent = "Ghijklmn";
+    testDiv.appendChild(paras[4]);
+
+    detachedDiv = document.createElement("div");
+    detachedPara1 = document.createElement("p");
+    detachedPara1.appendChild(document.createTextNode("Opqrstuv"));
+    detachedPara2 = document.createElement("p");
+    detachedPara2.appendChild(document.createTextNode("Wxyzabcd"));
+    detachedDiv.appendChild(detachedPara1);
+    detachedDiv.appendChild(detachedPara2);
+
+    // Opera doesn't automatically create a doctype for a new HTML document,
+    // contrary to spec.  It also doesn't let you add doctypes to documents
+    // after the fact through any means I've tried.  So foreignDoc in Opera
+    // will have no doctype, foreignDoctype will be null, and Opera will fail
+    // some tests somewhat mysteriously as a result.
+    foreignDoc = document.implementation.createHTMLDocument("");
+    foreignPara1 = foreignDoc.createElement("p");
+    foreignPara1.appendChild(foreignDoc.createTextNode("Efghijkl"));
+    foreignPara2 = foreignDoc.createElement("p");
+    foreignPara2.appendChild(foreignDoc.createTextNode("Mnopqrst"));
+    foreignDoc.body.appendChild(foreignPara1);
+    foreignDoc.body.appendChild(foreignPara2);
+
+    // Now we get to do really silly stuff, which nobody in the universe is
+    // ever going to actually do, but the spec defines behavior, so too bad.
+    // Testing is fun!
+    xmlDoctype = document.implementation.createDocumentType("qorflesnorf", "abcde", "x\"'y");
+    xmlDoc = document.implementation.createDocument(null, null, xmlDoctype);
+    detachedXmlElement = xmlDoc.createElement("everyone-hates-hyphenated-element-names");
+    detachedTextNode = document.createTextNode("Uvwxyzab");
+    detachedForeignTextNode = foreignDoc.createTextNode("Cdefghij");
+    detachedXmlTextNode = xmlDoc.createTextNode("Klmnopqr");
+    // PIs only exist in XML documents, so don't bother with document or
+    // foreignDoc.
+    detachedProcessingInstruction = xmlDoc.createProcessingInstruction("whippoorwill", "chirp chirp chirp");
+    detachedComment = document.createComment("Stuvwxyz");
+    // Hurrah, we finally got to "z" at the end!
+    detachedForeignComment = foreignDoc.createComment("אריה יהודה");
+    detachedXmlComment = xmlDoc.createComment("בן חיים אליעזר");
+
+    // We should also test with document fragments that actually contain stuff
+    // . . . but, maybe later.
+    docfrag = document.createDocumentFragment();
+    foreignDocfrag = foreignDoc.createDocumentFragment();
+    xmlDocfrag = xmlDoc.createDocumentFragment();
+
+    xmlElement = xmlDoc.createElement("igiveuponcreativenames");
+    xmlTextNode = xmlDoc.createTextNode("do re mi fa so la ti");
+    xmlElement.appendChild(xmlTextNode);
+    processingInstruction = xmlDoc.createProcessingInstruction("somePI", 'Did you know that ":syn sync fromstart" is very useful when using vim to edit large amounts of JavaScript embedded in HTML?');
+    xmlDoc.appendChild(xmlElement);
+    xmlDoc.appendChild(processingInstruction);
+    xmlComment = xmlDoc.createComment("I maliciously created a comment that will break incautious XML serializers, but Firefox threw an exception, so all I got was this lousy T-shirt");
+    xmlDoc.appendChild(xmlComment);
+
+    comment = document.createComment("Alphabet soup?");
+    testDiv.appendChild(comment);
+
+    foreignComment = foreignDoc.createComment('"Commenter" and "commentator" mean different things.  I\'ve seen non-native speakers trip up on this.');
+    foreignDoc.appendChild(foreignComment);
+    foreignTextNode = foreignDoc.createTextNode("I admit that I harbor doubts about whether we really need so many things to test, but it's too late to stop now.");
+    foreignDoc.body.appendChild(foreignTextNode);
+
+    doctype = document.doctype;
+    foreignDoctype = foreignDoc.doctype;
+
+    testRangesShort = [
+        // Various ranges within the text node children of different
+        // paragraphs.  All should be valid.
+        "[paras[0].firstChild, 0, paras[0].firstChild, 0]",
+        "[paras[0].firstChild, 0, paras[0].firstChild, 1]",
+        "[paras[0].firstChild, 2, paras[0].firstChild, 8]",
+        "[paras[0].firstChild, 2, paras[0].firstChild, 9]",
+        "[paras[1].firstChild, 0, paras[1].firstChild, 0]",
+        "[paras[1].firstChild, 2, paras[1].firstChild, 9]",
+        "[detachedPara1.firstChild, 0, detachedPara1.firstChild, 0]",
+        "[detachedPara1.firstChild, 2, detachedPara1.firstChild, 8]",
+        "[foreignPara1.firstChild, 0, foreignPara1.firstChild, 0]",
+        "[foreignPara1.firstChild, 2, foreignPara1.firstChild, 8]",
+        // Now try testing some elements, not just text nodes.
+        "[document.documentElement, 0, document.documentElement, 1]",
+        "[document.documentElement, 0, document.documentElement, 2]",
+        "[document.documentElement, 1, document.documentElement, 2]",
+        "[document.head, 1, document.head, 1]",
+        "[document.body, 4, document.body, 5]",
+        "[foreignDoc.documentElement, 0, foreignDoc.documentElement, 1]",
+        "[paras[0], 0, paras[0], 1]",
+        "[detachedPara1, 0, detachedPara1, 1]",
+        // Now try some ranges that span elements.
+        "[paras[0].firstChild, 0, paras[1].firstChild, 0]",
+        "[paras[0].firstChild, 0, paras[1].firstChild, 8]",
+        "[paras[0].firstChild, 3, paras[3], 1]",
+        // How about something that spans a node and its descendant?
+        "[paras[0], 0, paras[0].firstChild, 7]",
+        "[testDiv, 2, paras[4], 1]",
+        // Then a few more interesting things just for good measure.
+        "[document, 0, document, 1]",
+        "[document, 0, document, 2]",
+        "[comment, 2, comment, 3]",
+        "[testDiv, 0, comment, 5]",
+        "[foreignDoc, 1, foreignComment, 2]",
+        "[foreignDoc.body, 0, foreignTextNode, 36]",
+        "[xmlDoc, 1, xmlComment, 0]",
+        "[detachedTextNode, 0, detachedTextNode, 8]",
+        "[detachedForeignTextNode, 0, detachedForeignTextNode, 8]",
+        "[detachedXmlTextNode, 0, detachedXmlTextNode, 8]",
+        "[detachedComment, 3, detachedComment, 4]",
+        "[detachedForeignComment, 0, detachedForeignComment, 1]",
+        "[detachedXmlComment, 2, detachedXmlComment, 6]",
+        "[docfrag, 0, docfrag, 0]",
+        "[processingInstruction, 0, processingInstruction, 4]",
+    ];
+
+    testRanges = testRangesShort.concat([
+        "[paras[1].firstChild, 0, paras[1].firstChild, 1]",
+        "[paras[1].firstChild, 2, paras[1].firstChild, 8]",
+        "[detachedPara1.firstChild, 0, detachedPara1.firstChild, 1]",
+        "[foreignPara1.firstChild, 0, foreignPara1.firstChild, 1]",
+        "[foreignDoc.head, 1, foreignDoc.head, 1]",
+        "[foreignDoc.body, 0, foreignDoc.body, 0]",
+        "[paras[0], 0, paras[0], 0]",
+        "[detachedPara1, 0, detachedPara1, 0]",
+        "[testDiv, 1, paras[2].firstChild, 5]",
+        "[document.documentElement, 1, document.body, 0]",
+        "[foreignDoc.documentElement, 1, foreignDoc.body, 0]",
+        "[document, 1, document, 2]",
+        "[paras[2].firstChild, 4, comment, 2]",
+        "[paras[3], 1, comment, 8]",
+        "[foreignDoc, 0, foreignDoc, 0]",
+        "[xmlDoc, 0, xmlDoc, 0]",
+        "[detachedForeignTextNode, 7, detachedForeignTextNode, 7]",
+        "[detachedXmlTextNode, 7, detachedXmlTextNode, 7]",
+        "[detachedComment, 5, detachedComment, 5]",
+        "[detachedForeignComment, 4, detachedForeignComment, 4]",
+        "[foreignDocfrag, 0, foreignDocfrag, 0]",
+        "[xmlDocfrag, 0, xmlDocfrag, 0]",
+    ]);
+
+    testPoints = [
+        // Various positions within the page, some invalid.  Remember that
+        // paras[0] is visible, and paras[1] is display: none.
+        "[paras[0].firstChild, -1]",
+        "[paras[0].firstChild, 0]",
+        "[paras[0].firstChild, 1]",
+        "[paras[0].firstChild, 2]",
+        "[paras[0].firstChild, 8]",
+        "[paras[0].firstChild, 9]",
+        "[paras[0].firstChild, 10]",
+        "[paras[0].firstChild, 65535]",
+        "[paras[1].firstChild, -1]",
+        "[paras[1].firstChild, 0]",
+        "[paras[1].firstChild, 1]",
+        "[paras[1].firstChild, 2]",
+        "[paras[1].firstChild, 8]",
+        "[paras[1].firstChild, 9]",
+        "[paras[1].firstChild, 10]",
+        "[paras[1].firstChild, 65535]",
+        "[detachedPara1.firstChild, 0]",
+        "[detachedPara1.firstChild, 1]",
+        "[detachedPara1.firstChild, 8]",
+        "[detachedPara1.firstChild, 9]",
+        "[foreignPara1.firstChild, 0]",
+        "[foreignPara1.firstChild, 1]",
+        "[foreignPara1.firstChild, 8]",
+        "[foreignPara1.firstChild, 9]",
+        // Now try testing some elements, not just text nodes.
+        "[document.documentElement, -1]",
+        "[document.documentElement, 0]",
+        "[document.documentElement, 1]",
+        "[document.documentElement, 2]",
+        "[document.documentElement, 7]",
+        "[document.head, 1]",
+        "[document.body, 3]",
+        "[foreignDoc.documentElement, 0]",
+        "[foreignDoc.documentElement, 1]",
+        "[foreignDoc.head, 0]",
+        "[foreignDoc.body, 1]",
+        "[paras[0], 0]",
+        "[paras[0], 1]",
+        "[paras[0], 2]",
+        "[paras[1], 0]",
+        "[paras[1], 1]",
+        "[paras[1], 2]",
+        "[detachedPara1, 0]",
+        "[detachedPara1, 1]",
+        "[testDiv, 0]",
+        "[testDiv, 3]",
+        // Then a few more interesting things just for good measure.
+        "[document, -1]",
+        "[document, 0]",
+        "[document, 1]",
+        "[document, 2]",
+        "[document, 3]",
+        "[comment, -1]",
+        "[comment, 0]",
+        "[comment, 4]",
+        "[comment, 96]",
+        "[foreignDoc, 0]",
+        "[foreignDoc, 1]",
+        "[foreignComment, 2]",
+        "[foreignTextNode, 0]",
+        "[foreignTextNode, 36]",
+        "[xmlDoc, -1]",
+        "[xmlDoc, 0]",
+        "[xmlDoc, 1]",
+        "[xmlDoc, 5]",
+        "[xmlComment, 0]",
+        "[xmlComment, 4]",
+        "[processingInstruction, 0]",
+        "[processingInstruction, 5]",
+        "[processingInstruction, 9]",
+        "[detachedTextNode, 0]",
+        "[detachedTextNode, 8]",
+        "[detachedForeignTextNode, 0]",
+        "[detachedForeignTextNode, 8]",
+        "[detachedXmlTextNode, 0]",
+        "[detachedXmlTextNode, 8]",
+        "[detachedProcessingInstruction, 12]",
+        "[detachedComment, 3]",
+        "[detachedComment, 5]",
+        "[detachedForeignComment, 0]",
+        "[detachedForeignComment, 4]",
+        "[detachedXmlComment, 2]",
+        "[docfrag, 0]",
+        "[foreignDocfrag, 0]",
+        "[xmlDocfrag, 0]",
+        "[doctype, 0]",
+        "[doctype, -17]",
+        "[doctype, 1]",
+        "[foreignDoctype, 0]",
+        "[xmlDoctype, 0]",
+    ];
+
+    testNodesShort = [
+        "paras[0]",
+        "paras[0].firstChild",
+        "paras[1].firstChild",
+        "foreignPara1",
+        "foreignPara1.firstChild",
+        "detachedPara1",
+        "detachedPara1.firstChild",
+        "document",
+        "detachedDiv",
+        "foreignDoc",
+        "foreignPara2",
+        "xmlDoc",
+        "xmlElement",
+        "detachedTextNode",
+        "foreignTextNode",
+        "processingInstruction",
+        "detachedProcessingInstruction",
+        "comment",
+        "detachedComment",
+        "docfrag",
+        "doctype",
+        "foreignDoctype",
+    ];
+
+    testNodes = testNodesShort.concat([
+        "paras[1]",
+        "detachedPara2",
+        "detachedPara2.firstChild",
+        "testDiv",
+        "detachedXmlElement",
+        "detachedForeignTextNode",
+        "xmlTextNode",
+        "detachedXmlTextNode",
+        "xmlComment",
+        "foreignComment",
+        "detachedForeignComment",
+        "detachedXmlComment",
+        "foreignDocfrag",
+        "xmlDocfrag",
+        "xmlDoctype",
+    ]);
+}
+if ("setup" in window) {
+    setup(setupRangeTests);
+} else {
+    // Presumably we're running from within an iframe or something
+    setupRangeTests();
+}
+
+/**
+ * The "length" of a node as defined by the Ranges section of DOM4.
+ */
+function nodeLength(node) {
+    // "The length of a node node depends on node:
+    //
+    // "DocumentType
+    //   "0."
+    if (node.nodeType == Node.DOCUMENT_TYPE_NODE) {
+        return 0;
+    }
+    // "Text
+    // "ProcessingInstruction
+    // "Comment
+    //   "Its length attribute value."
+    // Browsers don't historically support the length attribute on
+    // ProcessingInstruction, so to avoid spurious failures, do
+    // node.data.length instead of node.length.
+    if (node.nodeType == Node.TEXT_NODE || node.nodeType == Node.PROCESSING_INSTRUCTION_NODE || node.nodeType == Node.COMMENT_NODE) {
+        return node.data.length;
+    }
+    // "Any other node
+    //   "Its number of children."
+    return node.childNodes.length;
+}
+
+/**
+ * Returns the furthest ancestor of a Node as defined by the spec.
+ */
+function furthestAncestor(node) {
+    var root = node;
+    while (root.parentNode != null) {
+        root = root.parentNode;
+    }
+    return root;
+}
+
+/**
+ * "The ancestor containers of a Node are the Node itself and all its
+ * ancestors."
+ *
+ * Is node1 an ancestor container of node2?
+ */
+function isAncestorContainer(node1, node2) {
+    return node1 == node2 ||
+        (node2.compareDocumentPosition(node1) & Node.DOCUMENT_POSITION_CONTAINS);
+}
+
+/**
+ * Returns the first Node that's after node in tree order, or null if node is
+ * the last Node.
+ */
+function nextNode(node) {
+    if (node.hasChildNodes()) {
+        return node.firstChild;
+    }
+    return nextNodeDescendants(node);
+}
+
+/**
+ * Returns the last Node that's before node in tree order, or null if node is
+ * the first Node.
+ */
+function previousNode(node) {
+    if (node.previousSibling) {
+        node = node.previousSibling;
+        while (node.hasChildNodes()) {
+            node = node.lastChild;
+        }
+        return node;
+    }
+    return node.parentNode;
+}
+
+/**
+ * Returns the next Node that's after node and all its descendants in tree
+ * order, or null if node is the last Node or an ancestor of it.
+ */
+function nextNodeDescendants(node) {
+    while (node && !node.nextSibling) {
+        node = node.parentNode;
+    }
+    if (!node) {
+        return null;
+    }
+    return node.nextSibling;
+}
+
+/**
+ * Returns the ownerDocument of the Node, or the Node itself if it's a
+ * Document.
+ */
+function ownerDocument(node) {
+    return node.nodeType == Node.DOCUMENT_NODE
+        ? node
+        : node.ownerDocument;
+}
+
+/**
+ * Returns true if ancestor is an ancestor of descendant, false otherwise.
+ */
+function isAncestor(ancestor, descendant) {
+    if (!ancestor || !descendant) {
+        return false;
+    }
+    while (descendant && descendant != ancestor) {
+        descendant = descendant.parentNode;
+    }
+    return descendant == ancestor;
+}
+
+/**
+ * Returns true if ancestor is an inclusive ancestor of descendant, false
+ * otherwise.
+ */
+function isInclusiveAncestor(ancestor, descendant) {
+    return ancestor === descendant || isAncestor(ancestor, descendant);
+}
+
+/**
+ * Returns true if descendant is a descendant of ancestor, false otherwise.
+ */
+function isDescendant(descendant, ancestor) {
+    return isAncestor(ancestor, descendant);
+}
+
+/**
+ * Returns true if descendant is an inclusive descendant of ancestor, false
+ * otherwise.
+ */
+function isInclusiveDescendant(descendant, ancestor) {
+    return descendant === ancestor || isDescendant(descendant, ancestor);
+}
+
+/**
+ * The position of two boundary points relative to one another, as defined by
+ * the spec.
+ */
+function getPosition(nodeA, offsetA, nodeB, offsetB) {
+    // "If node A is the same as node B, return equal if offset A equals offset
+    // B, before if offset A is less than offset B, and after if offset A is
+    // greater than offset B."
+    if (nodeA == nodeB) {
+        if (offsetA == offsetB) {
+            return "equal";
+        }
+        if (offsetA < offsetB) {
+            return "before";
+        }
+        if (offsetA > offsetB) {
+            return "after";
+        }
+    }
+
+    // "If node A is after node B in tree order, compute the position of (node
+    // B, offset B) relative to (node A, offset A). If it is before, return
+    // after. If it is after, return before."
+    if (nodeB.compareDocumentPosition(nodeA) & Node.DOCUMENT_POSITION_FOLLOWING) {
+        var pos = getPosition(nodeB, offsetB, nodeA, offsetA);
+        if (pos == "before") {
+            return "after";
+        }
+        if (pos == "after") {
+            return "before";
+        }
+    }
+
+    // "If node A is an ancestor of node B:"
+    if (nodeB.compareDocumentPosition(nodeA) & Node.DOCUMENT_POSITION_CONTAINS) {
+        // "Let child equal node B."
+        var child = nodeB;
+
+        // "While child is not a child of node A, set child to its parent."
+        while (child.parentNode != nodeA) {
+            child = child.parentNode;
+        }
+
+        // "If the index of child is less than offset A, return after."
+        if (indexOf(child) < offsetA) {
+            return "after";
+        }
+    }
+
+    // "Return before."
+    return "before";
+}
+
+/**
+ * "contained" as defined by DOM Range: "A Node node is contained in a range
+ * range if node's furthest ancestor is the same as range's root, and (node, 0)
+ * is after range's start, and (node, length of node) is before range's end."
+ */
+function isContained(node, range) {
+    var pos1 = getPosition(node, 0, range.startContainer, range.startOffset);
+    var pos2 = getPosition(node, nodeLength(node), range.endContainer, range.endOffset);
+
+    return furthestAncestor(node) == furthestAncestor(range.startContainer)
+        && pos1 == "after"
+        && pos2 == "before";
+}
+
+/**
+ * "partially contained" as defined by DOM Range: "A Node is partially
+ * contained in a range if it is an ancestor container of the range's start but
+ * not its end, or vice versa."
+ */
+function isPartiallyContained(node, range) {
+    var cond1 = isAncestorContainer(node, range.startContainer);
+    var cond2 = isAncestorContainer(node, range.endContainer);
+    return (cond1 && !cond2) || (cond2 && !cond1);
+}
+
+/**
+ * Index of a node as defined by the spec.
+ */
+function indexOf(node) {
+    if (!node.parentNode) {
+        // No preceding sibling nodes, right?
+        return 0;
+    }
+    var i = 0;
+    while (node != node.parentNode.childNodes[i]) {
+        i++;
+    }
+    return i;
+}
+
+/**
+ * extractContents() implementation, following the spec.  If an exception is
+ * supposed to be thrown, will return a string with the name (e.g.,
+ * "HIERARCHY_REQUEST_ERR") instead of a document fragment.  It might also
+ * return an arbitrary human-readable string if a condition is hit that implies
+ * a spec bug.
+ */
+function myExtractContents(range) {
+    // "Let frag be a new DocumentFragment whose ownerDocument is the same as
+    // the ownerDocument of the context object's start node."
+    var ownerDoc = range.startContainer.nodeType == Node.DOCUMENT_NODE
+        ? range.startContainer
+        : range.startContainer.ownerDocument;
+    var frag = ownerDoc.createDocumentFragment();
+
+    // "If the context object's start and end are the same, abort this method,
+    // returning frag."
+    if (range.startContainer == range.endContainer
+    && range.startOffset == range.endOffset) {
+        return frag;
+    }
+
+    // "Let original start node, original start offset, original end node, and
+    // original end offset be the context object's start and end nodes and
+    // offsets, respectively."
+    var originalStartNode = range.startContainer;
+    var originalStartOffset = range.startOffset;
+    var originalEndNode = range.endContainer;
+    var originalEndOffset = range.endOffset;
+
+    // "If original start node is original end node, and they are a Text,
+    // ProcessingInstruction, or Comment node:"
+    if (range.startContainer == range.endContainer
+    && (range.startContainer.nodeType == Node.TEXT_NODE
+    || range.startContainer.nodeType == Node.PROCESSING_INSTRUCTION_NODE
+    || range.startContainer.nodeType == Node.COMMENT_NODE)) {
+        // "Let clone be the result of calling cloneNode(false) on original
+        // start node."
+        var clone = originalStartNode.cloneNode(false);
+
+        // "Set the data of clone to the result of calling
+        // substringData(original start offset, original end offset − original
+        // start offset) on original start node."
+        clone.data = originalStartNode.substringData(originalStartOffset,
+            originalEndOffset - originalStartOffset);
+
+        // "Append clone as the last child of frag."
+        frag.appendChild(clone);
+
+        // "Call deleteData(original start offset, original end offset −
+        // original start offset) on original start node."
+        originalStartNode.deleteData(originalStartOffset,
+            originalEndOffset - originalStartOffset);
+
+        // "Abort this method, returning frag."
+        return frag;
+    }
+
+    // "Let common ancestor equal original start node."
+    var commonAncestor = originalStartNode;
+
+    // "While common ancestor is not an ancestor container of original end
+    // node, set common ancestor to its own parent."
+    while (!isAncestorContainer(commonAncestor, originalEndNode)) {
+        commonAncestor = commonAncestor.parentNode;
+    }
+
+    // "If original start node is an ancestor container of original end node,
+    // let first partially contained child be null."
+    var firstPartiallyContainedChild;
+    if (isAncestorContainer(originalStartNode, originalEndNode)) {
+        firstPartiallyContainedChild = null;
+    // "Otherwise, let first partially contained child be the first child of
+    // common ancestor that is partially contained in the context object."
+    } else {
+        for (var i = 0; i < commonAncestor.childNodes.length; i++) {
+            if (isPartiallyContained(commonAncestor.childNodes[i], range)) {
+                firstPartiallyContainedChild = commonAncestor.childNodes[i];
+                break;
+            }
+        }
+        if (!firstPartiallyContainedChild) {
+            throw "Spec bug: no first partially contained child!";
+        }
+    }
+
+    // "If original end node is an ancestor container of original start node,
+    // let last partially contained child be null."
+    var lastPartiallyContainedChild;
+    if (isAncestorContainer(originalEndNode, originalStartNode)) {
+        lastPartiallyContainedChild = null;
+    // "Otherwise, let last partially contained child be the last child of
+    // common ancestor that is partially contained in the context object."
+    } else {
+        for (var i = commonAncestor.childNodes.length - 1; i >= 0; i--) {
+            if (isPartiallyContained(commonAncestor.childNodes[i], range)) {
+                lastPartiallyContainedChild = commonAncestor.childNodes[i];
+                break;
+            }
+        }
+        if (!lastPartiallyContainedChild) {
+            throw "Spec bug: no last partially contained child!";
+        }
+    }
+
+    // "Let contained children be a list of all children of common ancestor
+    // that are contained in the context object, in tree order."
+    //
+    // "If any member of contained children is a DocumentType, raise a
+    // HIERARCHY_REQUEST_ERR exception and abort these steps."
+    var containedChildren = [];
+    for (var i = 0; i < commonAncestor.childNodes.length; i++) {
+        if (isContained(commonAncestor.childNodes[i], range)) {
+            if (commonAncestor.childNodes[i].nodeType
+            == Node.DOCUMENT_TYPE_NODE) {
+                return "HIERARCHY_REQUEST_ERR";
+            }
+            containedChildren.push(commonAncestor.childNodes[i]);
+        }
+    }
+
+    // "If original start node is an ancestor container of original end node,
+    // set new node to original start node and new offset to original start
+    // offset."
+    var newNode, newOffset;
+    if (isAncestorContainer(originalStartNode, originalEndNode)) {
+        newNode = originalStartNode;
+        newOffset = originalStartOffset;
+    // "Otherwise:"
+    } else {
+        // "Let reference node equal original start node."
+        var referenceNode = originalStartNode;
+
+        // "While reference node's parent is not null and is not an ancestor
+        // container of original end node, set reference node to its parent."
+        while (referenceNode.parentNode
+        && !isAncestorContainer(referenceNode.parentNode, originalEndNode)) {
+            referenceNode = referenceNode.parentNode;
+        }
+
+        // "Set new node to the parent of reference node, and new offset to one
+        // plus the index of reference node."
+        newNode = referenceNode.parentNode;
+        newOffset = 1 + indexOf(referenceNode);
+    }
+
+    // "If first partially contained child is a Text, ProcessingInstruction, or
+    // Comment node:"
+    if (firstPartiallyContainedChild
+    && (firstPartiallyContainedChild.nodeType == Node.TEXT_NODE
+    || firstPartiallyContainedChild.nodeType == Node.PROCESSING_INSTRUCTION_NODE
+    || firstPartiallyContainedChild.nodeType == Node.COMMENT_NODE)) {
+        // "Let clone be the result of calling cloneNode(false) on original
+        // start node."
+        var clone = originalStartNode.cloneNode(false);
+
+        // "Set the data of clone to the result of calling substringData() on
+        // original start node, with original start offset as the first
+        // argument and (length of original start node − original start offset)
+        // as the second."
+        clone.data = originalStartNode.substringData(originalStartOffset,
+            nodeLength(originalStartNode) - originalStartOffset);
+
+        // "Append clone as the last child of frag."
+        frag.appendChild(clone);
+
+        // "Call deleteData() on original start node, with original start
+        // offset as the first argument and (length of original start node −
+        // original start offset) as the second."
+        originalStartNode.deleteData(originalStartOffset,
+            nodeLength(originalStartNode) - originalStartOffset);
+    // "Otherwise, if first partially contained child is not null:"
+    } else if (firstPartiallyContainedChild) {
+        // "Let clone be the result of calling cloneNode(false) on first
+        // partially contained child."
+        var clone = firstPartiallyContainedChild.cloneNode(false);
+
+        // "Append clone as the last child of frag."
+        frag.appendChild(clone);
+
+        // "Let subrange be a new Range whose start is (original start node,
+        // original start offset) and whose end is (first partially contained
+        // child, length of first partially contained child)."
+        var subrange = ownerDoc.createRange();
+        subrange.setStart(originalStartNode, originalStartOffset);
+        subrange.setEnd(firstPartiallyContainedChild,
+            nodeLength(firstPartiallyContainedChild));
+
+        // "Let subfrag be the result of calling extractContents() on
+        // subrange."
+        var subfrag = myExtractContents(subrange);
+
+        // "For each child of subfrag, in order, append that child to clone as
+        // its last child."
+        for (var i = 0; i < subfrag.childNodes.length; i++) {
+            clone.appendChild(subfrag.childNodes[i]);
+        }
+    }
+
+    // "For each contained child in contained children, append contained child
+    // as the last child of frag."
+    for (var i = 0; i < containedChildren.length; i++) {
+        frag.appendChild(containedChildren[i]);
+    }
+
+    // "If last partially contained child is a Text, ProcessingInstruction, or
+    // Comment node:"
+    if (lastPartiallyContainedChild
+    && (lastPartiallyContainedChild.nodeType == Node.TEXT_NODE
+    || lastPartiallyContainedChild.nodeType == Node.PROCESSING_INSTRUCTION_NODE
+    || lastPartiallyContainedChild.nodeType == Node.COMMENT_NODE)) {
+        // "Let clone be the result of calling cloneNode(false) on original
+        // end node."
+        var clone = originalEndNode.cloneNode(false);
+
+        // "Set the data of clone to the result of calling substringData(0,
+        // original end offset) on original end node."
+        clone.data = originalEndNode.substringData(0, originalEndOffset);
+
+        // "Append clone as the last child of frag."
+        frag.appendChild(clone);
+
+        // "Call deleteData(0, original end offset) on original end node."
+        originalEndNode.deleteData(0, originalEndOffset);
+    // "Otherwise, if last partially contained child is not null:"
+    } else if (lastPartiallyContainedChild) {
+        // "Let clone be the result of calling cloneNode(false) on last
+        // partially contained child."
+        var clone = lastPartiallyContainedChild.cloneNode(false);
+
+        // "Append clone as the last child of frag."
+        frag.appendChild(clone);
+
+        // "Let subrange be a new Range whose start is (last partially
+        // contained child, 0) and whose end is (original end node, original
+        // end offset)."
+        var subrange = ownerDoc.createRange();
+        subrange.setStart(lastPartiallyContainedChild, 0);
+        subrange.setEnd(originalEndNode, originalEndOffset);
+
+        // "Let subfrag be the result of calling extractContents() on
+        // subrange."
+        var subfrag = myExtractContents(subrange);
+
+        // "For each child of subfrag, in order, append that child to clone as
+        // its last child."
+        for (var i = 0; i < subfrag.childNodes.length; i++) {
+            clone.appendChild(subfrag.childNodes[i]);
+        }
+    }
+
+    // "Set the context object's start and end to (new node, new offset)."
+    range.setStart(newNode, newOffset);
+    range.setEnd(newNode, newOffset);
+
+    // "Return frag."
+    return frag;
+}
+
+/**
+ * insertNode() implementation, following the spec.  If an exception is meant
+ * to be thrown, will return a string with the expected exception name, for
+ * instance "HIERARCHY_REQUEST_ERR".
+ */
+function myInsertNode(range, node) {
+    // "If range's start node is a ProcessingInstruction or Comment node, or is
+    // a Text node whose parent is null, or is node, throw an
+    // "HierarchyRequestError" exception and terminate these steps."
+    if (range.startContainer.nodeType == Node.PROCESSING_INSTRUCTION_NODE
+            || range.startContainer.nodeType == Node.COMMENT_NODE
+            || (range.startContainer.nodeType == Node.TEXT_NODE
+                && !range.startContainer.parentNode)
+            || range.startContainer == node) {
+                    return "HIERARCHY_REQUEST_ERR";
+    }
+
+    // "Let referenceNode be null."
+    var referenceNode = null;
+
+    // "If range's start node is a Text node, set referenceNode to that Text node."
+    if (range.startContainer.nodeType == Node.TEXT_NODE) {
+        referenceNode = range.startContainer;
+
+        // "Otherwise, set referenceNode to the child of start node whose index is
+        // start offset, and null if there is no such child."
+    } else {
+        if (range.startOffset < range.startContainer.childNodes.length) {
+            referenceNode = range.startContainer.childNodes[range.startOffset];
+        } else {
+            referenceNode = null;
+        }
+    }
+
+    // "Let parent be range's start node if referenceNode is null, and
+    // referenceNode's parent otherwise."
+    var parent_ = referenceNode === null ? range.startContainer :
+        referenceNode.parentNode;
+
+    // "Ensure pre-insertion validity of node into parent before
+    // referenceNode."
+    var error = ensurePreInsertionValidity(node, parent_, referenceNode);
+    if (error) {
+        return error;
+    }
+
+    // "If range's start node is a Text node, set referenceNode to the result
+    // of splitting it with offset range's start offset."
+    if (range.startContainer.nodeType == Node.TEXT_NODE) {
+        referenceNode = range.startContainer.splitText(range.startOffset);
+    }
+
+    // "If node is referenceNode, set referenceNode to its next sibling."
+    if (node == referenceNode) {
+        referenceNode = referenceNode.nextSibling;
+    }
+
+    // "If node's parent is not null, remove node from its parent."
+    if (node.parentNode) {
+        node.parentNode.removeChild(node);
+    }
+
+    // "Let newOffset be parent's length if referenceNode is null, and
+    // referenceNode's index otherwise."
+    var newOffset = referenceNode === null ? nodeLength(parent_) :
+        indexOf(referenceNode);
+
+    // "Increase newOffset by node's length if node is a DocumentFragment node,
+    // and one otherwise."
+    newOffset += node.nodeType == Node.DOCUMENT_FRAGMENT_NODE ?
+        nodeLength(node) : 1;
+
+    // "Pre-insert node into parent before referenceNode."
+    parent_.insertBefore(node, referenceNode);
+
+    // "If range's start and end are the same, set range's end to (parent,
+    // newOffset)."
+    if (range.startContainer == range.endContainer
+    && range.startOffset == range.endOffset) {
+        range.setEnd(parent_, newOffset);
+    }
+}
+
+// To make filter() calls more readable
+function isElement(node) {
+    return node.nodeType == Node.ELEMENT_NODE;
+}
+
+function isText(node) {
+    return node.nodeType == Node.TEXT_NODE;
+}
+
+function isDoctype(node) {
+    return node.nodeType == Node.DOCUMENT_TYPE_NODE;
+}
+
+function ensurePreInsertionValidity(node, parent_, child) {
+    // "If parent is not a Document, DocumentFragment, or Element node, throw a
+    // HierarchyRequestError."
+    if (parent_.nodeType != Node.DOCUMENT_NODE
+            && parent_.nodeType != Node.DOCUMENT_FRAGMENT_NODE
+            && parent_.nodeType != Node.ELEMENT_NODE) {
+                return "HIERARCHY_REQUEST_ERR";
+    }
+
+    // "If node is a host-including inclusive ancestor of parent, throw a
+    // HierarchyRequestError."
+    //
+    // XXX Does not account for host
+    if (isInclusiveAncestor(node, parent_)) {
+        return "HIERARCHY_REQUEST_ERR";
+    }
+
+    // "If child is not null and its parent is not parent, throw a NotFoundError
+    // exception."
+    if (child && child.parentNode != parent_) {
+        return "NOT_FOUND_ERR";
+    }
+
+    // "If node is not a DocumentFragment, DocumentType, Element, Text,
+    // ProcessingInstruction, or Comment node, throw a HierarchyRequestError."
+    if (node.nodeType != Node.DOCUMENT_FRAGMENT_NODE
+            && node.nodeType != Node.DOCUMENT_TYPE_NODE
+            && node.nodeType != Node.ELEMENT_NODE
+            && node.nodeType != Node.TEXT_NODE
+            && node.nodeType != Node.PROCESSING_INSTRUCTION_NODE
+            && node.nodeType != Node.COMMENT_NODE) {
+                return "HIERARCHY_REQUEST_ERR";
+    }
+
+    // "If either node is a Text node and parent is a document, or node is a
+    // doctype and parent is not a document, throw a HierarchyRequestError."
+    if ((node.nodeType == Node.TEXT_NODE
+                && parent_.nodeType == Node.DOCUMENT_NODE)
+            || (node.nodeType == Node.DOCUMENT_TYPE_NODE
+                && parent_.nodeType != Node.DOCUMENT_NODE)) {
+                    return "HIERARCHY_REQUEST_ERR";
+    }
+
+    // "If parent is a document, and any of the statements below, switched on
+    // node, are true, throw a HierarchyRequestError."
+    if (parent_.nodeType == Node.DOCUMENT_NODE) {
+        switch (node.nodeType) {
+        case Node.DOCUMENT_FRAGMENT_NODE:
+            // "If node has more than one element child or has a Text node
+            // child.  Otherwise, if node has one element child and either
+            // parent has an element child, child is a doctype, or child is not
+            // null and a doctype is following child."
+            if ([].filter.call(node.childNodes, isElement).length > 1) {
+                return "HIERARCHY_REQUEST_ERR";
+            }
+
+            if ([].some.call(node.childNodes, isText)) {
+                return "HIERARCHY_REQUEST_ERR";
+            }
+
+            if ([].filter.call(node.childNodes, isElement).length == 1) {
+                if ([].some.call(parent_.childNodes, isElement)) {
+                    return "HIERARCHY_REQUEST_ERR";
+                }
+
+                if (child && child.nodeType == Node.DOCUMENT_TYPE_NODE) {
+                    return "HIERARCHY_REQUEST_ERR";
+                }
+
+                if (child && [].slice.call(parent_.childNodes, indexOf(child) + 1)
+                               .filter(isDoctype)) {
+                    return "HIERARCHY_REQUEST_ERR";
+                }
+            }
+            break;
+
+        case Node.ELEMENT_NODE:
+            // "parent has an element child, child is a doctype, or child is
+            // not null and a doctype is following child."
+            if ([].some.call(parent_.childNodes, isElement)) {
+                return "HIERARCHY_REQUEST_ERR";
+            }
+
+            if (child.nodeType == Node.DOCUMENT_TYPE_NODE) {
+                return "HIERARCHY_REQUEST_ERR";
+            }
+
+            if (child && [].slice.call(parent_.childNodes, indexOf(child) + 1)
+                           .filter(isDoctype)) {
+                return "HIERARCHY_REQUEST_ERR";
+            }
+            break;
+
+        case Node.DOCUMENT_TYPE_NODE:
+            // "parent has a doctype child, an element is preceding child, or
+            // child is null and parent has an element child."
+            if ([].some.call(parent_.childNodes, isDoctype)) {
+                return "HIERARCHY_REQUEST_ERR";
+            }
+
+            if (child && [].slice.call(parent_.childNodes, 0, indexOf(child))
+                           .some(isElement)) {
+                return "HIERARCHY_REQUEST_ERR";
+            }
+
+            if (!child && [].some.call(parent_.childNodes, isElement)) {
+                return "HIERARCHY_REQUEST_ERR";
+            }
+            break;
+        }
+    }
+}
+
+/**
+ * Asserts that two nodes are equal, in the sense of isEqualNode().  If they
+ * aren't, tries to print a relatively informative reason why not.  TODO: Move
+ * this to testharness.js?
+ */
+function assertNodesEqual(actual, expected, msg) {
+    if (!actual.isEqualNode(expected)) {
+        msg = "Actual and expected mismatch for " + msg + ".  ";
+
+        while (actual && expected) {
+            assert_true(actual.nodeType === expected.nodeType
+                && actual.nodeName === expected.nodeName
+                && actual.nodeValue === expected.nodeValue,
+                "First differing node: expected " + format_value(expected)
+                + ", got " + format_value(actual) + " [" + msg + "]");
+            actual = nextNode(actual);
+            expected = nextNode(expected);
+        }
+
+        assert_unreached("DOMs were not equal but we couldn't figure out why");
+    }
+}
+
+/**
+ * Given a DOMException, return the name (e.g., "HIERARCHY_REQUEST_ERR").
+ */
+function getDomExceptionName(e) {
+    var ret = null;
+    for (var prop in e) {
+        if (/^[A-Z_]+_ERR$/.test(prop) && e[prop] == e.code) {
+            return prop;
+        }
+    }
+
+    throw "Exception seems to not be a DOMException?  " + e;
+}
+
+/**
+ * Given an array of endpoint data [start container, start offset, end
+ * container, end offset], returns a Range with those endpoints.
+ */
+function rangeFromEndpoints(endpoints) {
+    // If we just use document instead of the ownerDocument of endpoints[0],
+    // WebKit will throw on setStart/setEnd.  This is a WebKit bug, but it's in
+    // range, not selection, so we don't want to fail anything for it.
+    var range = ownerDocument(endpoints[0]).createRange();
+    range.setStart(endpoints[0], endpoints[1]);
+    range.setEnd(endpoints[2], endpoints[3]);
+    return range;
+}

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -108,7 +108,13 @@ Position VisibleSelection::uncanonicalizedEnd() const
 
 std::optional<SimpleRange> VisibleSelection::range() const
 {
-    return makeSimpleRange(uncanonicalizedStart().parentAnchoredEquivalent(), uncanonicalizedEnd().parentAnchoredEquivalent());
+    auto start = uncanonicalizedStart();
+    auto end = uncanonicalizedEnd();
+    ASSERT(!start.document() || !end.document()
+        || start.document()->settings().liveRangeSelectionEnabled() == end.document()->settings().liveRangeSelectionEnabled());
+    if (start.document() && start.document()->settings().liveRangeSelectionEnabled())
+        return makeSimpleRange(start, end);
+    return makeSimpleRange(start.parentAnchoredEquivalent(), end.parentAnchoredEquivalent());
 }
 
 void VisibleSelection::setBase(const Position& position)


### PR DESCRIPTION
#### d5c5146455d1db1c98ab29d2c92de7c9fa1600cc
<pre>
[Live Range Selection] Range-mutations-deleteData.html, Range-mutations-insertData.html,
and Range-mutations-replaceData.html fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=249012">https://bugs.webkit.org/show_bug.cgi?id=249012</a>

Reviewed by Darin Adler and Wenson Hsieh.

The bug was caused by FrameSelection::textWasReplaced updating the associated range using
base &amp; extent instead of focus &amp; anchor. Fixed the bug by using focus &amp; anchor in these cases.

Also fixed a bug in VisibleSelection::range() that it always uses the parent anchored equivalent
even when the selection ends are set by author scripts. Fixed it by using m_focus &amp; m_anchor
directly when the live range selection is enabled.

* LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-deleteData-expected.txt: Added.
* LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-deleteData.html: Added.
* LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-insertData-expected.txt: Added.
* LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-insertData.html: Added.
* LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-replaceData-expected.txt: Added.
* LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations-replaceData.html: Added.
* LayoutTests/http/wpt/dom-ranges-live-range/Range-mutations.js: Added.
* LayoutTests/http/wpt/dom-ranges-live-range/common.js: Added.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::textWasReplaced):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::range const):

Canonical link: <a href="https://commits.webkit.org/257670@main">https://commits.webkit.org/257670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68d515087cb163fbde344676968957ff86c4be36

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108957 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169194 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86074 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92072 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106874 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105371 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34034 "An unexpected error occured. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21947 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2608 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23461 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2543 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42934 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4403 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2701 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->