### PR TITLE
Add more HeaderDoc comments to Web Extension headers.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -81,7 +81,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 
 /*!
  @abstract Returns a web extension initialized with a specified app extension bundle.
- @param bundle The bundle to use for the new web extension.
+ @param appExtensionBundle The bundle to use for the new web extension.
  @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
  @seealso initWithAppExtensionBundle:error:
  */
@@ -97,7 +97,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 
 /*!
  @abstract Returns a web extension initialized with a specified app extension bundle.
- @param bundle The bundle to use for the new web extension.
+ @param appExtensionBundle The bundle to use for the new web extension.
  @param error Set to \c nil or an \c NSError instance if an error occurred.
  @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
  @discussion This is a designated initializer.
@@ -109,63 +109,71 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
  @param resourceBaseURL The directory URL to use for the new web extension.
  @param error Set to \c nil or an \c NSError instance if an error occurred.
  @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
- @discussion This is a designated initializer. The URL must be a file URL that points
- to a directory containing a `manifest.json` file.
+ @discussion This is a designated initializer. The URL must be a file URL that points to a directory containing a `manifest.json` file.
  */
 - (nullable instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
-/*! @abstract The active errors for the extension. Returns `nil` if there are no errors. */
+/*!
+ @abstract The active errors for the extension.
+ @discussion This property returns an array of NSError objects if there are any errors, or `nil` if there are no errors.
+ */
 @property (nonatomic, nullable, readonly, copy) NSArray<NSError *> *errors;
 
-/*! @abstract The parsed manifest as a dictionary. Returns `nil` if the manifest was unable to be parsed. */
-@property (nonatomic, nullable, readonly, copy) NSDictionary<NSString *, id> *manifest;
+/*! @abstract The parsed manifest as a dictionary. */
+@property (nonatomic, readonly, copy) NSDictionary<NSString *, id> *manifest;
 
-/*! @abstract The parsed manifest version. */
+/*!
+ @abstract The parsed manifest version, or `0` is if there is no version specified in the manifest.
+ @note An `WKWebExtensionErrorUnsupportedManifestVersion` error will be reported if the manifest version isn't specified.
+ */
 @property (nonatomic, readonly) double manifestVersion;
 
 /*!
- @abstract Checks if a maniferst version is supported by the extension.
+ @abstract Checks if a manifest version is supported by the extension.
  @param manifestVersion The version number to check.
  @result Returns `YES` if the extension specified a manifest version that is is greater than or equal to `manifestVersion`.
  */
 - (BOOL)usesManifestVersion:(double)manifestVersion;
 
-/*! @abstract The parsed and localized extension name. Returns `nil` if the manifest was unable to be parsed or there was no name specified. */
+/*! @abstract The default locale for the extension. Returns `nil` if there was no default locale specified. */
+@property (nonatomic, readonly, copy) NSLocale *defaultLocale;
+
+/*! @abstract The localized extension name. Returns `nil` if there was no name specified. */
 @property (nonatomic, nullable, readonly, copy) NSString *displayName;
 
-/*! @abstract The parsed and localized extension short name. Returns `nil` if the manifest was unable to be parsed or there was no short name specified. */
+/*! @abstract The localized extension short name. Returns `nil` if there was no short name specified. */
 @property (nonatomic, nullable, readonly, copy) NSString *displayShortName;
 
-/*! @abstract The parsed and localized extension display version. Returns `nil` if the manifest was unable to be parsed or there was no display version specified. */
+/*! @abstract The localized extension display version. Returns `nil` if there was no display version specified. */
 @property (nonatomic, nullable, readonly, copy) NSString *displayVersion;
 
-/*! @abstract The parsed and localized extension description. Returns `nil` if the manifest was unable to be parsed or there was no description specified. */
+/*! @abstract The localized extension description. Returns `nil` if there was no description specified. */
 @property (nonatomic, nullable, readonly, copy) NSString *displayDescription;
 
-/*! @abstract The parsed and localized extension action label. Returns `nil` if the manifest was unable to be parsed or there was no action label specified. */
+/*! @abstract The localized extension action label. Returns `nil` if there was no action label specified. */
 @property (nonatomic, nullable, readonly, copy) NSString *displayActionLabel;
 
-/*! @abstract The parsed extension version. Returns `nil` if the manifest was unable to be parsed or there was no version specified. */
+/*! @abstract The extension version. Returns `nil` if there was no version specified. */
 @property (nonatomic, nullable, readonly, copy) NSString *version;
 
 #if TARGET_OS_IPHONE
 
 /*!
- @abstract Returns an icon for the extension that is best for the specified size.
- @param size The size the image should be able to fill.
- @result An image that is best for the size. Returns `nil` if the manifest was unable to be parsed or no icons were specified.
- @discussion This icon should respesent the extension in Settings or other general user interface areas. If the extension does not specify an icon large enough
- for the size, then the largest icon specified will be returned. No image scaling is performed.
+ @abstract Returns the extension's icon image for the specified size.
+ @param size The size to use when looking up the icon.
+ @result The extension's icon image, or `nil` if the icon was unable to be loaded.
+ @discussion This icon should represent the extension in settings or other areas that show the extension. The returned image will be the best
+ match for the specified size that is available in the extension's icon set. If no matching icon can be found, the method will return `nil`.
  @seealso actionIconForSize:
  */
 - (nullable UIImage *)iconForSize:(CGSize)size;
 
 /*!
- @abstract Returns an action icon for the extension that is best for the specified size.
- @param size The size the image should be able to fill.
- @result An image that is best for the size. Returns `nil` if the manifest was unable to be parsed or no icons were specified.
- @discussion This icon should respesent the extension in action sheets or toolbars. If the extension does not specify an icon large enough
- for the size, then the largest icon specified will be returned. No image scaling is performed.
+ @abstract Returns the action icon for the specified size.
+ @param size The size to use when looking up the action icon.
+ @result The action icon, or `nil` if the icon was unable to be loaded.
+ @discussion This icon should represent the extension in action sheets or toolbars. The returned image will be the best match for the specified
+ size that is available in the extension's action icon set. If no matching icon is available, the method will fall back to the extension's icon.
  @seealso iconForSize:
  */
 - (nullable UIImage *)actionIconForSize:(CGSize)size;
@@ -173,46 +181,53 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 #else
 
 /*!
- @abstract Returns an icon for the extension that is best for the specified size.
- @param size The size the image should be able to fill.
- @result An image that is best for the size. Returns `nil` if the manifest was unable to be parsed or no icons were specified.
- @discussion This icon should respesent the extension in Settings or other general user interface areas. If the extension does not specify an icon large enough
- for the size, then the largest icon specified will be returned. No image scaling is performed.
+ @abstract Returns the extension's icon image for the specified size.
+ @param size The size to use when looking up the icon.
+ @result The extension's icon image, or `nil` if the icon was unable to be loaded.
+ @discussion This icon should represent the extension in settings or other areas that show the extension. The returned image will be the best
+ match for the specified size that is available in the extension's icon set. If no matching icon can be found, the method will return `nil`.
  @seealso actionIconForSize:
  */
 - (nullable NSImage *)iconForSize:(CGSize)size;
 
 /*!
- @abstract Returns an action icon for the extension that is best for the specified size.
- @param size The size the image should be able to fill.
- @result An image that is best for the size. Returns `nil` if the manifest was unable to be parsed or no icons were specified.
- @discussion This icon should respesent the extension in action sheets or toolbars. If the extension does not specify an icon large enough
- for the size, then the largest icon specified will be returned. No image scaling is performed.
+ @abstract Returns the action icon for the specified size.
+ @param size The size to use when looking up the action icon.
+ @result The action icon, or `nil` if the icon was unable to be loaded.
+ @discussion This icon should represent the extension in action sheets or toolbars. The returned image will be the best match for the specified
+ size that is available in the extension's action icon set. If no matching icon is available, the method will fall back to the extension's icon.
  @seealso iconForSize:
  */
 - (nullable NSImage *)actionIconForSize:(CGSize)size;
 
 #endif
 
-/*! @abstract The permissions that the extension needs for base functionality. */
+/*! @abstract The set of permissions that the extension requires for its base functionality. */
 @property (nonatomic, readonly, copy) NSSet<_WKWebExtensionPermission> *requestedPermissions;
 
-/*! @abstract The permissions that the extension might need for optional functionality. These can be requested later by the extension when needed. */
+/*! @abstract The set of permissions that the extension may need for optional functionality. These permissions can be requested by the extension at a later time. */
 @property (nonatomic, readonly, copy) NSSet<_WKWebExtensionPermission> *optionalPermissions;
 
-/*! @abstract The websites that the extension needs to access for base functionality. */
+/*! @abstract The set of websites that the extension requires access to for its base functionality. */
 @property (nonatomic, readonly, copy) NSSet<_WKWebExtensionMatchPattern *> *requestedPermissionMatchPatterns;
 
-/*! @abstract The websites that the extension might need to access for optional functionality. */
+/*! @abstract The set of websites that the extension may need access to for optional functionality. These match patterns can be requested by the extension at a later time. */
 @property (nonatomic, readonly, copy) NSSet<_WKWebExtensionMatchPattern *> *optionalPermissionMatchPatterns;
 
-/*! @abstract The websites that the extension needs to access for base functionality, including injected content and websites that can send messages to the extension. */
+/*! @abstract The set of websites that the extension requires access to for injected content and for receiving messages from websites. */
 @property (nonatomic, readonly, copy) NSSet<_WKWebExtensionMatchPattern *> *allRequestedMatchPatterns;
 
-/*! @abstract A Boolean value indicating whether the extension has background content that can run when needed. */
+/*!
+ @abstract A Boolean value indicating whether the extension has background content that can run when needed.
+ @discussion If this property is `YES`, the extension can run in the background even when no web pages are open.
+ */
 @property (nonatomic, readonly) BOOL hasBackgroundContent;
 
-/*! @abstract A Boolean value indicating whether the extension has background content that stays in memory as long as the extension is loaded. */
+/*!
+ @abstract A Boolean value indicating whether the extension has background content that stays in memory as long as the extension is loaded.
+ @note Note that extensions are only allowed to have persistent background content on macOS. An `WKWebExtensionErrorInvalidBackgroundPersistence`
+ error will be reported on iOS if an attempt is made to load a persistent extension.
+ */
 @property (nonatomic, readonly) BOOL backgroundContentIsPersistent;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -164,6 +164,12 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
     return _webExtension->usesManifestVersion(version);
 }
 
+- (NSLocale *)defaultLocale
+{
+    // FIXME: <https://webkit.org/b/246488> Handle manifest localization.
+    return nil;
+}
+
 - (NSString *)displayName
 {
     return _webExtension->displayName();
@@ -318,6 +324,11 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 - (BOOL)usesManifestVersion:(double)version
 {
     return NO;
+}
+
+- (NSLocale *)defaultLocale
+{
+    return nil;
 }
 
 - (NSString *)displayName

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -118,8 +118,9 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotificationUserInfoKeyMatchPatterns;
 
 /*!
- @abstract A `WKWebExtensionContext` object encapsulates a web extension’s runtime environment.
- @discussion This class handles the access permissions, content injection, storage, and background logic for the extension.
+ @abstract A `WKWebExtensionContext` object represents the runtime environment for a web extension.
+ @discussion This class provides methods for managing the extension's permissions, allowing it to inject content, run
+ background logic, show popovers, and display other web-based UI to the user.
  */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @interface _WKWebExtensionContext : NSObject
@@ -143,10 +144,10 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 - (instancetype)initWithExtension:(_WKWebExtension *)extension NS_DESIGNATED_INITIALIZER;
 
 /*! @abstract The extension this context represents. */
-@property (nonatomic, readonly, strong) _WKWebExtension *extension;
+@property (nonatomic, readonly, strong) _WKWebExtension *webExtension;
 
 /*! @abstract The extension controller this context is loaded in, otherwise `nil` if it isn't loaded. */
-@property (nonatomic, readonly, weak) _WKWebExtensionController *extensionController;
+@property (nonatomic, readonly, weak) _WKWebExtensionController *webExtensionController;
 
 /*! @abstract A Boolean value indicating if this context is loaded in an extension controller. */
 @property (nonatomic, readonly, getter=isLoaded) BOOL loaded;
@@ -164,8 +165,8 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
  @discussion The default value is a unique value that matches the host in the default base URL. The identifier can be any
  value that is unique. Setting is only allowed when the context is not loaded.
 
- This value is accessable by the extension via `browser.runtime.id` and is used for messaging the extension as the first
- argumet of `browser.runtime.sendMessage(extensionId, message, options)`.
+ This value is accessible by the extension via `browser.runtime.id` and is used for messaging the extension as the first
+ argument of `browser.runtime.sendMessage(extensionId, message, options)`.
  */
 @property (nonatomic, copy) NSString *uniqueIdentifier;
 
@@ -220,7 +221,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 /*!
  @abstract A Boolean value indicating if the extension has requested optional access to all hosts.
  @discussion When this value is `YES` the extension has asked for access to all hosts in a call to `browser.runtime.permissions.request()`
- and future permission checks will present discrete hosts for approval as being implicty requested. This value should be saved and restored as needed.
+ and future permission checks will present discrete hosts for approval as being implicitly requested. This value should be saved and restored as needed.
  */
 @property (nonatomic) BOOL requestedOptionalAccessToAllHosts;
 
@@ -281,7 +282,6 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 /*!
  @abstract Checks if the currently granted permission match patterns set contains the `<all_urls>` pattern.
  @discussion This does not check for any `*` host patterns. In most cases you should use the broader `hasAccessToAllHosts`.
- This check is primarily needed for APIs like `browser.tabs.captureVisibleTab()` that need to check specifically for `<all_urls>`.
  @seealso currentPermissionMatchPatterns
  @seealso hasAccessToAllHosts
  */
@@ -411,27 +411,11 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 - (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern expirationDate:(nullable NSDate *)expirationDate;
 
 /*!
- @abstract Notes that a user gesture has been performed in the specified tab (e.g. interacting with a toolbar button, menu item, etc.)
- @discussion This method might grant per-tab permissions and/or match patterns for the current website if the extension has the `activeTab` permission.
- This method can also propagate the user gesture state to the tab's page when the extension sends a message to the tab.
- @seealso hasActiveUserGestureInTab:
- @seealso cancelUserGestureForTab:
-*/
-- (void)userGesturePerformedInTab:(id <_WKWebExtensionTab>)tab;
-
-/*!
  @abstract Returns a Boolean value indicating if a user gesture has been noted for the specified tab.
  @seealso userGesturePerformedInTab:
  @seealso cancelUserGestureForTab:
 */
 - (BOOL)hasActiveUserGestureInTab:(id <_WKWebExtensionTab>)tab;
-
-/*!
- @abstract Clears the current user gesture state for the specified tab.
- @seealso userGesturePerformedInTab:
- @seealso hasActiveUserGestureInTab:
-*/
-- (void)cancelUserGestureForTab:(id <_WKWebExtensionTab>)tab;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -87,12 +87,12 @@ _WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotifi
     _webExtensionContext->~WebExtensionContext();
 }
 
-- (_WKWebExtension *)extension
+- (_WKWebExtension *)webExtension
 {
     return wrapper(&_webExtensionContext->extension());
 }
 
-- (_WKWebExtensionController *)extensionController
+- (_WKWebExtensionController *)webExtensionController
 {
     return wrapper(_webExtensionContext->extensionController());
 }
@@ -439,25 +439,11 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
     return _webExtensionContext->hasInjectedContentForURL(url);
 }
 
-- (void)userGesturePerformedInTab:(id<_WKWebExtensionTab>)tab
-{
-    NSParameterAssert(tab);
-
-    _webExtensionContext->userGesturePerformed(tab);
-}
-
 - (BOOL)hasActiveUserGestureInTab:(id<_WKWebExtensionTab>)tab
 {
     NSParameterAssert(tab);
 
     return _webExtensionContext->hasActiveUserGesture(tab);
-}
-
-- (void)cancelUserGestureForTab:(id<_WKWebExtensionTab>)tab
-{
-    NSParameterAssert(tab);
-
-    _webExtensionContext->cancelUserGesture(tab);
 }
 
 - (BOOL)_inTestingMode
@@ -494,12 +480,12 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
     return nil;
 }
 
-- (_WKWebExtension *)extension
+- (_WKWebExtension *)webExtension
 {
     return nil;
 }
 
-- (_WKWebExtensionController *)extensionController
+- (_WKWebExtensionController *)webExtensionController
 {
     return nil;
 }
@@ -671,17 +657,9 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
     return NO;
 }
 
-- (void)userGesturePerformedInTab:(id<_WKWebExtensionTab>)tab
-{
-}
-
 - (BOOL)hasActiveUserGestureInTab:(id<_WKWebExtensionTab>)tab
 {
     return NO;
-}
-
-- (void)cancelUserGestureForTab:(id<_WKWebExtensionTab>)tab
-{
 }
 
 - (BOOL)_inTestingMode

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
@@ -27,10 +27,11 @@
 
 #import <Foundation/Foundation.h>
 
+#import <WebKit/_WKWebExtensionControllerDelegate.h>
+
 @class _WKWebExtension;
 @class _WKWebExtensionContext;
 @class _WKWebExtensionControllerConfiguration;
-@protocol _WKWebExtensionControllerDelegate;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -74,27 +75,11 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 /*!
  @abstract Loads the specified extension context.
  @discussion Causes the context to start, loading any background content, and injecting any content into relevant tabs.
- @result A Boolean value indicating if the context was successfully loaded.
- @seealso loadExtensionContext:error:
-*/
-- (BOOL)loadExtensionContext:(_WKWebExtensionContext *)extensionContext NS_SWIFT_UNAVAILABLE("Use error version");
-
-/*!
- @abstract Loads the specified extension context.
- @discussion Causes the context to start, loading any background content, and injecting any content into relevant tabs.
  @param error Set to \c nil or an \c NSError instance if an error occurred.
  @result A Boolean value indicating if the context was successfully loaded.
  @seealso loadExtensionContext:
 */
 - (BOOL)loadExtensionContext:(_WKWebExtensionContext *)extensionContext error:(NSError **)error;
-
-/*!
- @abstract Unloads the specified extension context.
- @discussion Causes the context to stop running.
- @result A Boolean value indicating if the context was successfully unloaded.
- @seealso unloadExtensionContext:error:
-*/
-- (BOOL)unloadExtensionContext:(_WKWebExtensionContext *)extensionContext NS_SWIFT_UNAVAILABLE("Use error version");
 
 /*!
  @abstract Unloads the specified extension context.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
@@ -75,25 +75,11 @@
     return _webExtensionController->configuration().copy()->wrapper();
 }
 
-- (BOOL)loadExtensionContext:(_WKWebExtensionContext *)extensionContext
-{
-    NSParameterAssert(extensionContext);
-
-    return [self loadExtensionContext:extensionContext error:nullptr];
-}
-
 - (BOOL)loadExtensionContext:(_WKWebExtensionContext *)extensionContext error:(NSError **)outError
 {
     NSParameterAssert(extensionContext);
 
     return _webExtensionController->load(extensionContext._webExtensionContext, outError);
-}
-
-- (BOOL)unloadExtensionContext:(_WKWebExtensionContext *)extensionContext
-{
-    NSParameterAssert(extensionContext);
-
-    return [self unloadExtensionContext:extensionContext error:nullptr];
 }
 
 - (BOOL)unloadExtensionContext:(_WKWebExtensionContext *)extensionContext error:(NSError **)outError
@@ -166,17 +152,7 @@ static inline NSSet *toAPI(const T& inputSet)
     return nil;
 }
 
-- (BOOL)loadExtensionContext:(_WKWebExtensionContext *)extensionContext
-{
-    return NO;
-}
-
 - (BOOL)loadExtensionContext:(_WKWebExtensionContext *)extensionContext error:(NSError **)error
-{
-    return NO;
-}
-
-- (BOOL)unloadExtensionContext:(_WKWebExtensionContext *)extensionContext
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h
@@ -63,9 +63,11 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 */
 + (instancetype)configurationWithIdentifier:(NSUUID *)identifier;
 
-@property (nonatomic, readonly, getter=isPersistent) BOOL persistent WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+/*! @abstract A Boolean value indicating if this context will write data to the the file system. */
+@property (nonatomic, readonly, getter=isPersistent) BOOL persistent;
 
-@property (nonatomic, nullable, readonly) NSUUID *identifier WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+/*! @abstract A unique identifier used for persistent configuration storage, or `nil` when it is the default or not persistent. */
+@property (nonatomic, nullable, readonly) NSUUID *identifier;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h
@@ -78,28 +78,21 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 + (instancetype)allHostsAndSchemesMatchPattern;
 
 /*!
- @abstract Returns a pattern object for the speficied pattern string.
+ @abstract Returns a pattern object for the specified pattern string.
  @result Returns `nil` if the pattern string is invalid.
  @seealso initWithString:error:
  */
-+ (nullable instancetype)matchPatternWithString:(NSString *)string NS_SWIFT_UNAVAILABLE("Use error version");
++ (nullable instancetype)matchPatternWithString:(NSString *)string;
 
 /*!
- @abstract Returns a pattern object for the speficied scheme, host, and path strings.
+ @abstract Returns a pattern object for the specified scheme, host, and path strings.
  @result A pattern object, or `nil` if any of the strings are invalid.
  @seealso initWithScheme:host:path:error:
  */
-+ (nullable instancetype)matchPatternWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path NS_SWIFT_UNAVAILABLE("Use error version");
++ (nullable instancetype)matchPatternWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path;
 
 /*!
- @abstract Returns a pattern object for the speficied pattern string.
- @result A pattern object, or `nil` if the pattern string is invalid.
- @seealso initWithString:error:
- */
-- (nullable instancetype)initWithString:(NSString *)string NS_SWIFT_UNAVAILABLE("Use error version");
-
-/*!
- @abstract Returns a pattern object for the speficied pattern string.
+ @abstract Returns a pattern object for the specified pattern string.
  @param error Set to \c nil or an \c NSError instance if an error occurred.
  @result A pattern object, or `nil` if the pattern string is invalid and `error` will be set.
  @seealso initWithString:
@@ -107,14 +100,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 - (nullable instancetype)initWithString:(NSString *)string error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
 /*!
- @abstract Returns a pattern object for the speficied scheme, host, and path strings.
- @result A pattern object, or `nil` if any of the strings are invalid.
- @seealso initWithScheme:host:path:error:
- */
-- (nullable instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path NS_SWIFT_UNAVAILABLE("Use error version");
-
-/*!
- @abstract Returns a pattern object for the speficied scheme, host, and path strings.
+ @abstract Returns a pattern object for the specified scheme, host, and path strings.
  @param error Set to \c nil or an \c NSError instance if an error occurred.
  @result A pattern object, or `nil` if any of the strings are invalid and `error` will be set.
  @seealso initWithScheme:host:path:
@@ -142,7 +128,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 /*!
  @abstract Matches the reciever pattern against the specified URL.
  @param url The URL to match the against the reciever pattern.
- @result A Boolean value indicating if pattern matches the speficied URL.
+ @result A Boolean value indicating if pattern matches the specified URL.
  @seealso matchesURL:options:
  */
 - (BOOL)matchesURL:(NSURL *)url NS_SWIFT_NAME(matches(url:));
@@ -151,7 +137,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
  @abstract Matches the reciever pattern against the specified URL with options.
  @param url The URL to match the against the reciever pattern.
  @param options The options to use while matching.
- @result A Boolean value indicating if pattern matches the speficied URL.
+ @result A Boolean value indicating if pattern matches the specified URL.
  @seealso matchesURL:
  */
 - (BOOL)matchesURL:(NSURL *)url options:(_WKWebExtensionMatchPatternOptions)options NS_SWIFT_NAME(matches(url:options:));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
@@ -48,7 +48,7 @@ NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMa
 {
     NSParameterAssert(coder);
 
-    return [self initWithString:[coder decodeObjectOfClass:[NSString class] forKey:stringCodingKey]];
+    return [self initWithString:[coder decodeObjectOfClass:[NSString class] forKey:stringCodingKey] error:nullptr];
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder
@@ -92,11 +92,6 @@ NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMa
     return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(scheme, host, path));
 }
 
-- (instancetype)initWithString:(NSString *)string
-{
-    return [self initWithString:string error:nullptr];
-}
-
 - (instancetype)initWithString:(NSString *)string error:(NSError **)error
 {
     NSParameterAssert(string);
@@ -112,11 +107,6 @@ NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMa
     API::Object::constructInWrapper<WebKit::WebExtensionMatchPattern>(self, string, error);
 
     return _webExtensionMatchPattern->isValid() ? self : nil;
-}
-
-- (instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path
-{
-    return [self initWithScheme:scheme host:host path:path error:nullptr];
 }
 
 - (instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path error:(NSError **)error
@@ -277,19 +267,9 @@ static OptionSet<WebKit::WebExtensionMatchPattern::Options> toImpl(_WKWebExtensi
     return nil;
 }
 
-- (instancetype)initWithString:(NSString *)string
-{
-    return [self initWithString:string error:nullptr];
-}
-
 - (instancetype)initWithString:(NSString *)string error:(NSError **)error
 {
     return nil;
-}
-
-- (instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path
-{
-    return [self initWithScheme:scheme host:host path:path error:nullptr];
 }
 
 - (instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path error:(NSError **)error

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
@@ -33,6 +33,20 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*!
+ @abstract Constants used by @link WKWebExtensionController @/link to indicate tab changes.
+ @constant WKWebExtensionTabChangedPropertiesNone  Indicates nothing changed.
+ @constant WKWebExtensionTabChangedPropertiesLoading  Indicates the loading state changed.
+ @constant WKWebExtensionTabChangedPropertiesTitle  Indicates the title changed.
+ @constant WKWebExtensionTabChangedPropertiesURL  Indicates the URL changed.
+ @constant WKWebExtensionTabChangedPropertiesSize  Indicates the size changed.
+ @constant WKWebExtensionTabChangedPropertiesZoomFactor  Indicates the zoom factor changed.
+ @constant WKWebExtensionTabChangedPropertiesAudible  Indicates the audible state changed.
+ @constant WKWebExtensionTabChangedPropertiesMuted  Indicates the muted state changed.
+ @constant WKWebExtensionTabChangedPropertiesPinned  Indicates the pinned state changed.
+ @constant WKWebExtensionTabChangedPropertiesReaderMode  Indicates the reader mode state changed.
+ @constant WKWebExtensionTabChangedPropertiesAll  Indicates all properties changed.
+ */
 typedef NS_OPTIONS(NSUInteger, _WKWebExtensionTabChangedProperties) {
     _WKWebExtensionTabChangedPropertiesNone       = 0,
     _WKWebExtensionTabChangedPropertiesLoading    = 1 << 1,
@@ -51,48 +65,222 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @protocol _WKWebExtensionTab <NSObject>
 @optional
 
+/*!
+ @abstract Called when the parent tab for the tab is needed.
+ @param context The context in which the web extension is running.
+ @return The parent tab of the tab, if the tab was opened from another tab.
+ @discussion Defaults to `nil` if not implemented.
+ */
 - (id <_WKWebExtensionTab>)parentTabForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called when the window containing the tab is needed.
+ @param context The context in which the web extension is running.
+ @return The window containing the tab.
+ @discussion Defaults to `nil` if not implemented.
+ */
 - (id <_WKWebExtensionWindow>)windowForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called when the main web view for the window is needed.
+ @param context The context in which the web extension is running.
+ @return The main web view for the tab.
+ @discussion Defaults to `nil` if not implemented.
+ */
 - (WKWebView *)mainWebViewForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called when the web views for the window are needed.
+ @param context The context in which the web extension is running.
+ @return An array of web views for the tab.
+ @discussion Defaults to an empty array if not implemented.
+ */
 - (NSArray<WKWebView *> *)webViewsForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called when the title of the tab is needed.
+ @param context The context in which the web extension is running.
+ @return The title of the tab.
+ @discussion Defaults to an empty string if not implemented.
+ */
 - (NSString *)tabTitleForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called when the selected state of the tab is needed.
+ @param context The context in which the web extension is running.
+ @return `YES` if the tab is selected, `NO` otherwise.
+ @discussion Defaults to `NO` if not implemented.
+ */
 - (BOOL)isSelectedForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called when the pinned state of the tab is needed.
+ @param context The context in which the web extension is running.
+ @return `YES` if the tab is pinned, `NO` otherwise.
+ @discussion Defaults to `NO` if not implemented.
+ */
 - (BOOL)isPinnedTabForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called when the ephemeral state of the tab is needed.
+ @param context The context in which the web extension is running.
+ @return `YES` if the tab is ephemeral, `NO` otherwise.
+ @discussion Used to indicated "private browsing" windows. Defaults to `NO` if not implemented.
+ */
 - (BOOL)isEphemeralForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called to check if reader mode is available for the tab.
+ @param context The context in which the web extension is running.
+ @return `YES` if reader mode is available for the tab, `NO` otherwise.
+ @discussion Defaults to `NO` if not implemented.
+ */
 - (BOOL)isReaderModeAvailableForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called to check if the tab is currently showing reader mode.
+ @param context The context in which the web extension is running.
+ @return `YES` if the tab is showing reader mode, `NO` otherwise.
+ @discussion Defaults to `NO` if not implemented.
+ */
 - (BOOL)isShowingReaderModeForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called to toggle reader mode for the tab.
+ @param context The context in which the web extension is running.
+ @discussion No action is performed if not implemented.
+ */
 - (void)toggleReaderModeForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called to check if the tab is currently playing audio.
+ @param context The context in which the web extension is running.
+ @return `YES` if the tab is playing audio, `NO` otherwise.
+ @discussion Defaults to `NO` if not implemented.
+ */
 - (BOOL)isAudibleForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called to check if the tab is currently muted.
+ @param context The context in which the web extension is running.
+ @return `YES` if the tab is muted, `NO` otherwise.
+ @discussion Defaults to `NO` if not implemented.
+ */
 - (BOOL)isMutedForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called to mute the tab.
+ @param context The context in which the web extension is running.
+ @discussion No action is performed if not implemented.
+ */
 - (void)muteForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called to unmute the tab.
+ @param context The context in which the web extension is running.
+ @discussion No action is performed if not implemented.
+ */
 - (void)unmuteForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called when the size of the tab in the window is needed.
+ @param context The context in which the web extension is running.
+ @return The size of the tab.
+ @discussion Defaults to `CGSizeZero` if not implemented.
+ */
 - (CGSize)sizeForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called when the zoom factor of the tab is needed.
+ @param context The context in which the web extension is running.
+ @return The zoom factor of the tab.
+ @discussion Defaults to `1.0` if not implemented.
+ */
 - (double)zoomFactorForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called when the URL of the tab is needed.
+ @param context The context in which the web extension is running.
+ @return The URL of the tab.
+ @discussion Defaults to `nil` if not implemented.
+ */
 - (NSURL *)urlForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called when the pending URL of the tab is needed.
+ @param context The context in which the web extension is running.
+ @return The pending URL of the tab.
+ @discussion The pending URL is the URL of a page that is in the process of loading. If there is no pending URL, return `nil`.
+ Defaults to `nil` if not implemented.
+ */
 - (NSURL *)pendingURLForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called to check if the tab has finished loading.
+ @param context The context in which the web extension is running.
+ @return `YES` if the tab has finished loading, `NO` otherwise.
+ @discussion Defaults to `YES` if not implemented.
+ */
 - (BOOL)isLoadingCompleteForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called to detect the locale of the webpage currently loaded in the tab.
+ @param context The context in which the web extension is running.
+ @param completionHandler A block to be called when the locale has been detected. The block takes a single argument, the
+ detected locale, which may be `nil` if no locale could be detected.
+ @discussion No language detection is performed if not implemented.
+ */
 - (void)detectWebpageLocaleForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSLocale * _Nullable locale))completionHandler;
 
+/*!
+ @abstract Called to load a URL in the tab.
+ @param url The URL to be loaded in the tab.
+ @param context The context in which the web extension is running.
+ @discussion If the tab is already loading a page, calling this method should stop the current page from loading and start loading the new URL.
+ Loads the URL in the main web view if not implemented.
+ */
 - (void)loadURL:(NSURL *)url forWebExtensionContext:(_WKWebExtensionContext *)context NS_SWIFT_NAME(load(url:forWebExtensionContext:));
+
+/*!
+ @abstract Called to reload the current page in the tab.
+ @param context The context in which the web extension is running.
+ @discussion Reloads the main web view if not implemented.
+ */
 - (void)reloadForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called to reload the current page in the tab, bypassing the cache.
+ @param context The context in which the web extension is running.
+ @discussion Reloads the main web view, bypassing the cache, if not implemented.
+ */
 - (void)reloadFromOriginForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called to navigate the tab to the previous page in its history.
+ @param context The context in which the web extension is running.
+ @discussion Navigates to the previous page in the main web view if not implemented.
+ */
 - (void)goBackForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called to navigate the tab to the next page in its history.
+ @param context The context in which the web extension is running.
+ @discussion Navigates to the next page in the main web view if not implemented.
+ */
 - (void)goForwardForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called to close the tab.
+ @param context The context in which the web extension is running.
+ @discussion No action is performed if not implemented.
+ */
 - (void)closeForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called to select the tab.
+ @param context The context in which the web extension is running.
+ @discussion This is equivalent to the user clicking on the tab in a tab bar. No action is performed if not implemented.
+ */
 - (void)selectForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
@@ -32,11 +32,23 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*!
+ @abstract Constants used by @link WKWebExtensionWindow @/link to indicate the type of a window.
+ @constant WKWebExtensionWindowTypeNormal  Indicates a normal window.
+ @constant WKWebExtensionWindowTypePopup  Indicates a popup window.
+ */
 typedef NS_ENUM(NSInteger, _WKWebExtensionWindowType) {
     _WKWebExtensionWindowTypeNormal,
     _WKWebExtensionWindowTypePopup,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+/*!
+ @abstract Constants used by @link WKWebExtensionWindow @/link to indicate possible states of a window.
+ @constant WKWebExtensionWindowStateNormal  Indicates a window is in its normal state.
+ @constant WKWebExtensionWindowStateMinimized  Indicates a window is minimized.
+ @constant WKWebExtensionWindowStateMaximized  Indicates a window is maximized.
+ @constant WKWebExtensionWindowStateFullscreen  Indicates a window is in fullscreen mode.
+ */
 typedef NS_ENUM(NSInteger, _WKWebExtensionWindowState) {
     _WKWebExtensionWindowStateNormal,
     _WKWebExtensionWindowStateMinimized,
@@ -44,21 +56,66 @@ typedef NS_ENUM(NSInteger, _WKWebExtensionWindowState) {
     _WKWebExtensionWindowStateFullscreen,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+/*! @abstract A class conforming to the `WKWebExtensionWindow` protocol represents a window to web extensions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @protocol _WKWebExtensionWindow <NSObject>
 @optional
 
+/*!
+ @abstract Called when an array of tabs is needed for the window.
+ @param context The context in which the web extension is running.
+ @return An array of tabs in the window.
+ @discussion Defaults to an empty array if not implemented.
+ */
 - (NSArray<id <_WKWebExtensionTab>> *)tabsForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called when the active tab is needed for the window.
+ @param context The context in which the web extension is running.
+ @return The active tab in the window.
+ @discussion Defaults to `nil` if not implemented.
+ */
 - (id <_WKWebExtensionTab>)activeTabForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called when the type of the window is needed.
+ @param context The context in which the web extension is running.
+ @return The type of the window.
+ @discussion Defaults to`WKWebExtensionWindowTypeNormal` if not implemented.
+ */
 - (_WKWebExtensionWindowType)windowTypeForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called when the state of the window is needed.
+ @param context The context in which the web extension is running.
+ @return The state of the window.
+ @discussion Defaults to`WKWebExtensionWindowStateNormal` if not implemented.
+ */
 - (_WKWebExtensionWindowState)windowStateForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+/*!
+ @abstract Called when the focused state of the window is needed.
+ @param context The context in which the web extension is running.
+ @return `YES` if the window is focused, `NO` otherwise.
+ @discussion Defaults to `NO` if not implemented.
+ */
 - (BOOL)isFocusedForWebExtensionContext:(_WKWebExtensionContext *)context;
-- (BOOL)isEphemeralForWebExtensionContext:(_WKWebExtensionContext *)context;
-- (BOOL)isPopupWindowForWebExtensionContext:(_WKWebExtensionContext *)context;
 
-- (NSRect)frameForWebExtensionContext:(_WKWebExtensionContext *)context;
+/*!
+ @abstract Called when the ephemeral state of the window is needed.
+ @param context The context in which the web extension is running.
+ @return `YES` if the window is ephemeral, `NO` otherwise.
+ @discussion Used to indicated "private browsing" windows. Defaults to `NO` if not implemented.
+ */
+- (BOOL)isEphemeralForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called when the frame of the window is needed.
+ @param context The context in which the web extension is running.
+ @return The frame of the window.
+ @discussion The frame is the bounding rectangle of the window, in screen coordinates. Defaults to `CGRectZero` if not implemented.
+ */
+- (CGRect)frameForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 @end
 


### PR DESCRIPTION
#### 59e644d90509b88a3098f47f71cbf0f88de74d95
<pre>
Add more HeaderDoc comments to Web Extension headers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249046">https://bugs.webkit.org/show_bug.cgi?id=249046</a>

Reviewed by Brian Weinstein.

Also tweak some methods based on review feedback.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
(-[_WKWebExtension defaultLocale]): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext webExtension]):
(-[_WKWebExtensionContext webExtensionController]):
(-[_WKWebExtensionContext extension]): Deleted.
(-[_WKWebExtensionContext extensionController]): Deleted.
(-[_WKWebExtensionContext userGesturePerformedInTab:]): Deleted.
(-[_WKWebExtensionContext cancelUserGestureForTab:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm:
(-[_WKWebExtensionController loadExtensionContext:]): Deleted.
(-[_WKWebExtensionController unloadExtensionContext:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm:
(-[_WKWebExtensionMatchPattern initWithCoder:]):
(-[_WKWebExtensionMatchPattern initWithString:]): Deleted.
(-[_WKWebExtensionMatchPattern initWithScheme:host:path:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h:

Canonical link: <a href="https://commits.webkit.org/257652@main">https://commits.webkit.org/257652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60bcaa4f204e664a0a5218d759e2510ceff75bf3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/99626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/8801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/32711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/108985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/9389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/86095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/105398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/9389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/32711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/9389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/32711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/32711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/2571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/86095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/8710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/32711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2693 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->