### PR TITLE
Expand site isolation testing to cover timing of _webView:didCommitLoadWithRequest:inFrame: callback

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -32,35 +32,64 @@
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/_WKExperimentalFeature.h>
 #import <WebKit/_WKFrameTreeNode.h>
+#import <wtf/BlockPtr.h>
 
 namespace TestWebKitAPI {
 
-TEST(SiteIsolation, ProcessIdentifiers)
+TEST(SiteIsolation, LoadingCallbacksAndPostMessage)
 {
+    auto exampleHTML = "<script>"
+    "    window.addEventListener('message', (event) => {"
+    "        alert('parent frame received ' + event.data)"
+    "    }, false);"
+    "    onload = () => {"
+    "        document.getElementById('webkit_frame').contentWindow.postMessage('ping', '*');"
+    "        setTimeout(() => { alert('postMessage failed') }, 3000)"
+    "    }"
+    "</script>"
+    "<iframe id='webkit_frame' src='https://webkit.org/webkit'></iframe>"_s;
+
+    auto webkitHTML = "<script>"
+    "    window.addEventListener('message', (event) => {"
+    "        parent.window.postMessage('pong', '*')"
+    "    }, false)"
+    "</script>"_s;
+
     bool finishedLoading { false };
+    size_t framesCommitted { 0 };
     HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> Task {
         while (1) {
             auto request = co_await connection.awaitableReceiveHTTPRequest();
             auto path = HTTPServer::parsePath(request);
             if (path == "/example"_s) {
-                co_await connection.awaitableSend(HTTPResponse("<iframe src='https://webkit.org/webkit'></iframe>"_s).serialize());
+                co_await connection.awaitableSend(HTTPResponse(exampleHTML).serialize());
                 continue;
             }
             if (path == "/webkit"_s) {
-                co_await connection.awaitableSend("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n"_s);
+                size_t contentLength = 2000000 + webkitHTML.length();
+                co_await connection.awaitableSend(makeString("HTTP/1.1 200 OK\r\nContent-Length: "_s, contentLength, "\r\n\r\n"_s));
                 EXPECT_FALSE(finishedLoading);
                 Util::runFor(Seconds(0.1));
                 EXPECT_FALSE(finishedLoading);
-                // FIXME: Test that _webView:didCommitLoadWithRequest:inFrame: is called after beginning to receive the response body
-                // but didFinishNavigation does not get called until the entirety of the response body is received.
-                co_await connection.awaitableSend("hi"_s);
+                EXPECT_EQ(framesCommitted, 1u);
+                co_await connection.awaitableSend(webkitHTML);
+                co_await connection.awaitableSend(Vector<uint8_t>(1000000, ' '));
+                while (framesCommitted < 2)
+                    Util::spinRunLoop();
+                Util::runFor(Seconds(0.1));
+                EXPECT_FALSE(finishedLoading);
+                co_await connection.awaitableSend(Vector<uint8_t>(1000000, ' '));
                 continue;
             }
             EXPECT_FALSE(true);
         }
     }, HTTPServer::Protocol::HttpsProxy);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
-    [delegate allowAnyTLSCertificate];
+    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    navigationDelegate.get().didCommitLoadWithRequestInFrame = makeBlockPtr([&](WKWebView *, NSURLRequest *, WKFrameInfo *frameInfo) {
+        EXPECT_TRUE(frameInfo.isMainFrame); // FIXME: The second frame should not report that it is the main frame.
+        framesCommitted++;
+    }).get();
 
     auto configuration = server.httpsProxyConfiguration();
     auto preferences = [configuration preferences];
@@ -69,11 +98,23 @@ TEST(SiteIsolation, ProcessIdentifiers)
             [preferences _setEnabled:YES forExperimentalFeature:feature];
     }
 
+    __block RetainPtr<NSString> alert;
+    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *, void (^completionHandler)(void)) {
+        alert = message;
+        completionHandler();
+    };
+
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
-    webView.get().navigationDelegate = delegate.get();
+    webView.get().navigationDelegate = navigationDelegate.get();
+    webView.get().UIDelegate = uiDelegate.get();
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
-    [delegate waitForDidFinishNavigation];
+    [navigationDelegate waitForDidFinishNavigation];
     finishedLoading = true;
+
+    while (!alert)
+        Util::spinRunLoop();
+    EXPECT_WK_STREQ(alert.get(), "postMessage failed"); // FIXME: Hook up postMessage and this should become "parent frame received pong".
 
     __block bool done { false };
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {

--- a/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h
@@ -36,6 +36,7 @@
 @property (nonatomic, copy) void (^didFailProvisionalNavigation)(WKWebView *, WKNavigation *, NSError *);
 @property (nonatomic, copy) void (^didStartProvisionalNavigation)(WKWebView *, WKNavigation *);
 @property (nonatomic, copy) void (^didCommitNavigation)(WKWebView *, WKNavigation *);
+@property (nonatomic, copy) void (^didCommitLoadWithRequestInFrame)(WKWebView *, NSURLRequest *, WKFrameInfo *);
 @property (nonatomic, copy) void (^didFinishNavigation)(WKWebView *, WKNavigation *);
 @property (nonatomic, copy) void (^renderingProgressDidChange)(WKWebView *, _WKRenderingProgressEvents);
 @property (nonatomic, copy) void (^webContentProcessDidTerminate)(WKWebView *);

--- a/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm
@@ -67,6 +67,12 @@
         _didCommitNavigation(webView, navigation);
 }
 
+- (void)_webView:(WKWebView *)webView didCommitLoadWithRequest:(NSURLRequest *)request inFrame:(WKFrameInfo *)frame
+{
+    if (_didCommitLoadWithRequestInFrame)
+        _didCommitLoadWithRequestInFrame(webView, request, frame);
+}
+
 - (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error
 {
     if (_didFailProvisionalNavigation)


### PR DESCRIPTION
#### 591ba3643d0068fd9cfbbef10586f7048e8771cf
<pre>
Expand site isolation testing to cover timing of _webView:didCommitLoadWithRequest:inFrame: callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=249047">https://bugs.webkit.org/show_bug.cgi?id=249047</a>

Reviewed by Chris Dumez.

Also write 2 lines of code instead of using std::exchange with Ref, which asan doesn&apos;t seem to like right now.

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::commitProvisionalFrame):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm:
(-[TestNavigationDelegate _webView:didCommitLoadWithRequest:inFrame:]):

Canonical link: <a href="https://commits.webkit.org/257742@main">https://commits.webkit.org/257742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1094a48e1cb7d33fc6ec44ddb6a0012ec11436d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109026 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169257 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86130 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92125 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106934 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90618 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34064 "An unexpected error occured. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; extracting built product; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88920 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21977 "Found 3 new test failures: media/modern-media-controls/media-controls/media-controls-display-above-captions.html, media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html, media/modern-media-controls/status-support/status-support-error.html (failure)") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2664 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23493 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45876 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42967 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2724 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->