### PR TITLE
Update isValueOutOfRangeForProperty() to account for more CSS properties

### DIFF
--- a/LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value-expected.txt
+++ b/LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value-expected.txt
@@ -3,10 +3,130 @@ Checks that calling StylePropertyMap.set() with a negative value wraps it into a
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS target.attributeStyleMap.set('width', new CSSUnitValue(-3.14, 'percent')) did not throw exception.
-PASS target.style.width is "calc(-3.14%)"
+PASS target.attributeStyleMap.set('border-block-start-width', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.borderBlockStartWidth is "calc(-32px)"
+PASS target.attributeStyleMap.set('border-block-end-width', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.borderBlockEndWidth is "calc(-32px)"
+PASS target.attributeStyleMap.set('border-inline-start-width', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.borderInlineStartWidth is "calc(-32px)"
+PASS target.attributeStyleMap.set('border-inline-end-width', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.borderInlineEndWidth is "calc(-32px)"
+PASS target.attributeStyleMap.set('border-top-left-radius', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.borderTopLeftRadius is "calc(-32px)"
+PASS target.attributeStyleMap.set('border-top-right-radius', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.borderTopRightRadius is "calc(-32px)"
+PASS target.attributeStyleMap.set('border-bottom-right-radius', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.borderBottomRightRadius is "calc(-32px)"
+PASS target.attributeStyleMap.set('border-bottom-left-radius', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.borderBottomLeftRadius is "calc(-32px)"
+PASS target.attributeStyleMap.set('border-top-width', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.borderTopWidth is "calc(-32px)"
+PASS target.attributeStyleMap.set('border-right-width', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.borderRightWidth is "calc(-32px)"
+PASS target.attributeStyleMap.set('border-bottom-width', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.borderBottomWidth is "calc(-32px)"
+PASS target.attributeStyleMap.set('border-left-width', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.borderLeftWidth is "calc(-32px)"
+PASS target.attributeStyleMap.set('border-image-outset', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.borderImageOutset is "calc(-32px)"
+PASS target.attributeStyleMap.set('border-image-width', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.borderImageWidth is "calc(-32px)"
+PASS target.attributeStyleMap.set('column-width', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.columnWidth is "calc(-32px)"
+PASS target.attributeStyleMap.set('flex-basis', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.flexBasis is "calc(-32px)"
+PASS target.attributeStyleMap.set('grid-auto-columns', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.gridAutoColumns is "calc(-32px)"
+PASS target.attributeStyleMap.set('grid-auto-rows', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.gridAutoRows is "calc(-32px)"
+PASS target.attributeStyleMap.set('line-height', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.lineHeight is "calc(-32px)"
+PASS target.attributeStyleMap.set('max-height', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.maxHeight is "calc(-32px)"
+PASS target.attributeStyleMap.set('max-width', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.maxWidth is "calc(-32px)"
+PASS target.attributeStyleMap.set('outline-width', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.outlineWidth is "calc(-32px)"
 PASS target.attributeStyleMap.set('perspective', new CSSUnitValue(-32, 'px')) did not throw exception.
 PASS target.style.perspective is "calc(-32px)"
+PASS target.attributeStyleMap.set('row-gap', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.rowGap is "calc(-32px)"
+PASS target.attributeStyleMap.set('column-gap', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.columnGap is "calc(-32px)"
+PASS target.attributeStyleMap.set('scroll-padding-inline-start', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.scrollPaddingInlineStart is "calc(-32px)"
+PASS target.attributeStyleMap.set('scroll-padding-block-start', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.scrollPaddingBlockStart is "calc(-32px)"
+PASS target.attributeStyleMap.set('scroll-padding-inline-end', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.scrollPaddingInlineEnd is "calc(-32px)"
+PASS target.attributeStyleMap.set('scroll-padding-block-end', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.scrollPaddingBlockEnd is "calc(-32px)"
+PASS target.attributeStyleMap.set('width', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.width is "calc(-32px)"
+PASS target.attributeStyleMap.set('border-top-left-radius', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.borderTopLeftRadius is "calc(-32%)"
+PASS target.attributeStyleMap.set('border-top-right-radius', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.borderTopRightRadius is "calc(-32%)"
+PASS target.attributeStyleMap.set('border-bottom-right-radius', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.borderBottomRightRadius is "calc(-32%)"
+PASS target.attributeStyleMap.set('border-bottom-left-radius', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.borderBottomLeftRadius is "calc(-32%)"
+PASS target.attributeStyleMap.set('border-image-slice', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.borderImageSlice is "calc(-32%)"
+PASS target.attributeStyleMap.set('border-image-width', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.borderImageWidth is "calc(-32%)"
+PASS target.attributeStyleMap.set('flex-basis', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.flexBasis is "calc(-32%)"
+PASS target.attributeStyleMap.set('grid-auto-columns', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.gridAutoColumns is "calc(-32%)"
+PASS target.attributeStyleMap.set('grid-auto-rows', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.gridAutoRows is "calc(-32%)"
+PASS target.attributeStyleMap.set('line-height', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.lineHeight is "calc(-32%)"
+PASS target.attributeStyleMap.set('max-height', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.maxHeight is "calc(-32%)"
+PASS target.attributeStyleMap.set('max-width', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.maxWidth is "calc(-32%)"
+PASS target.attributeStyleMap.set('row-gap', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.rowGap is "calc(-32%)"
+PASS target.attributeStyleMap.set('column-gap', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.columnGap is "calc(-32%)"
+PASS target.attributeStyleMap.set('scroll-padding-inline-start', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.scrollPaddingInlineStart is "calc(-32%)"
+PASS target.attributeStyleMap.set('scroll-padding-block-start', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.scrollPaddingBlockStart is "calc(-32%)"
+PASS target.attributeStyleMap.set('scroll-padding-inline-end', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.scrollPaddingInlineEnd is "calc(-32%)"
+PASS target.attributeStyleMap.set('scroll-padding-block-end', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.scrollPaddingBlockEnd is "calc(-32%)"
+PASS target.attributeStyleMap.set('width', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.width is "calc(-32%)"
+PASS target.attributeStyleMap.set('animation-iteration-count', new CSSUnitValue(-32, 'number')) did not throw exception.
+PASS target.style.animationIterationCount is "calc(-32)"
+PASS target.attributeStyleMap.set('border-image-outset', new CSSUnitValue(-32, 'number')) did not throw exception.
+PASS target.style.borderImageOutset is "calc(-32)"
+PASS target.attributeStyleMap.set('border-image-slice', new CSSUnitValue(-32, 'number')) did not throw exception.
+PASS target.style.borderImageSlice is "calc(-32)"
+PASS target.attributeStyleMap.set('border-image-width', new CSSUnitValue(-32, 'number')) did not throw exception.
+PASS target.style.borderImageWidth is "calc(-32)"
+PASS target.attributeStyleMap.set('line-height', new CSSUnitValue(-32, 'number')) did not throw exception.
+PASS target.style.lineHeight is "calc(-32)"
+PASS target.attributeStyleMap.set('stroke-miterlimit', new CSSUnitValue(-32, 'number')) did not throw exception.
+PASS target.style.strokeMiterlimit is "calc(-32)"
+PASS target.attributeStyleMap.set('animation-duration', new CSSUnitValue(-32, 's')) did not throw exception.
+PASS target.style.animationDuration is "calc(-32s)"
+PASS target.attributeStyleMap.set('background-size', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.backgroundSize is "calc(-32%) auto"
+PASS target.attributeStyleMap.set('background-size', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.backgroundSize is "calc(-32px) auto"
+PASS target.attributeStyleMap.set('font-weight', new CSSUnitValue(0, 'number')) did not throw exception.
+PASS target.style.fontWeight is "1"
+PASS target.attributeStyleMap.set('font-weight', new CSSUnitValue(-32, 'number')) did not throw exception.
+PASS target.style.fontWeight is "1"
+PASS target.attributeStyleMap.set('font-weight', new CSSUnitValue(100, 'number')) did not throw exception.
+PASS target.style.fontWeight is "100"
+PASS target.attributeStyleMap.set('font-weight', new CSSUnitValue(1001, 'number')) did not throw exception.
+PASS target.style.fontWeight is "1000"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value.html
+++ b/LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value.html
@@ -6,12 +6,95 @@
 <script>
 description("Checks that calling StylePropertyMap.set() with a negative value wraps it into a calc.");
 
-target = document.getElementById("target");
-shouldNotThrow("target.attributeStyleMap.set('width', new CSSUnitValue(-3.14, 'percent'))");
-shouldBeEqualToString("target.style.width", "calc(-3.14%)");
+function toCamelCase(variable)
+{
+    return variable.replace(/-([a-z])/g, function(str, letter) {
+        return letter.toUpperCase();
+    });
+}
 
-shouldNotThrow("target.attributeStyleMap.set('perspective', new CSSUnitValue(-32, 'px'))");
-shouldBeEqualToString("target.style.perspective", "calc(-32px)");
+target = document.getElementById("target");
+
+negative_length_properties = [
+    'border-block-start-width', 'border-block-end-width', 'border-inline-start-width', 'border-inline-end-width', // https://w3c.github.io/csswg-drafts/css-logical/#border-width
+    'border-top-left-radius', 'border-top-right-radius', 'border-bottom-right-radius', 'border-bottom-left-radius', // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-radius
+    'border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width', // https://w3c.github.io/csswg-drafts/css-backgrounds/#the-border-width
+    'border-image-outset', // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-outset
+    'border-image-width', // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-width
+    'column-width', // https://w3c.github.io/csswg-drafts/css-multicol-1/#propdef-column-width
+    'flex-basis', // https://w3c.github.io/csswg-drafts/css-flexbox/#flex-basis-property
+    'grid-auto-columns', 'grid-auto-rows', // https://w3c.github.io/csswg-drafts/css-grid/#auto-tracks
+    'line-height', // https://w3c.github.io/csswg-drafts/css-inline/#line-height-property
+    'max-height', // https://w3c.github.io/csswg-drafts/css2/#propdef-max-height
+    'max-width', // https://w3c.github.io/csswg-drafts/css2/#propdef-max-width
+    'outline-width', // https://w3c.github.io/csswg-drafts/css-ui/#outline-width
+    'perspective', // https://w3c.github.io/csswg-drafts/css-transforms-2/#perspective-property
+    'row-gap', 'column-gap', // https://w3c.github.io/csswg-drafts/css-align/#column-row-gap
+    'scroll-padding-inline-start', 'scroll-padding-block-start', 'scroll-padding-inline-end', 'scroll-padding-block-end', // https://w3c.github.io/csswg-drafts/css-scroll-snap/#padding-longhands-logical
+    'width', // https://w3c.github.io/csswg-drafts/css-sizing-3/#propdef-width
+];
+negative_percent_properties = [
+    'border-top-left-radius', 'border-top-right-radius', 'border-bottom-right-radius', 'border-bottom-left-radius', // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-radius
+    'border-image-slice', // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-slice
+    'border-image-width', // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-width
+    'flex-basis', // https://w3c.github.io/csswg-drafts/css-flexbox/#flex-basis-property
+    'grid-auto-columns', 'grid-auto-rows', // https://w3c.github.io/csswg-drafts/css-grid/#auto-tracks
+    'line-height', // https://w3c.github.io/csswg-drafts/css-inline/#line-height-property
+    'max-height', // https://w3c.github.io/csswg-drafts/css2/#propdef-max-height
+    'max-width', // https://w3c.github.io/csswg-drafts/css2/#propdef-max-width
+    'row-gap', 'column-gap', // https://w3c.github.io/csswg-drafts/css-align/#column-row-gap
+    'scroll-padding-inline-start', 'scroll-padding-block-start', 'scroll-padding-inline-end', 'scroll-padding-block-end', // https://w3c.github.io/csswg-drafts/css-scroll-snap/#padding-longhands-logical
+    'width', // https://w3c.github.io/csswg-drafts/css-sizing-3/#propdef-width
+];
+negative_number_properties = [
+    'animation-iteration-count', // https://w3c.github.io/csswg-drafts/css-animations/#animation-iteration-count
+    'border-image-outset', // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-outset
+    'border-image-slice', // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-slice
+    'border-image-width', // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-width
+    'line-height', // https://w3c.github.io/csswg-drafts/css-inline/#line-height-property
+    'stroke-miterlimit', // https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty
+];
+negative_time_properties = [
+    'animation-duration', // https://w3c.github.io/csswg-drafts/css-animations/#animation-duration
+];
+
+for (let property of negative_length_properties) {
+  shouldNotThrow("target.attributeStyleMap.set('" + property + "', new CSSUnitValue(-32, 'px'))");
+  shouldBeEqualToString("target.style." + toCamelCase(property), "calc(-32px)");
+}
+
+for (let property of negative_percent_properties) {
+  shouldNotThrow("target.attributeStyleMap.set('" + property + "', new CSSUnitValue(-32, 'percent'))");
+  shouldBeEqualToString("target.style." + toCamelCase(property), "calc(-32%)");
+}
+
+for (let property of negative_number_properties) {
+  shouldNotThrow("target.attributeStyleMap.set('" + property + "', new CSSUnitValue(-32, 'number'))");
+  shouldBeEqualToString("target.style." + toCamelCase(property), "calc(-32)");
+}
+
+for (let property of negative_time_properties) {
+  shouldNotThrow("target.attributeStyleMap.set('" + property + "', new CSSUnitValue(-32, 's'))");
+  shouldBeEqualToString("target.style." + toCamelCase(property), "calc(-32s)");
+}
+
+// Special cases.
+
+// https://w3c.github.io/csswg-drafts/css-backgrounds/#the-background-size
+shouldNotThrow("target.attributeStyleMap.set('background-size', new CSSUnitValue(-32, 'percent'))");
+shouldBeEqualToString("target.style.backgroundSize", "calc(-32%) auto");
+shouldNotThrow("target.attributeStyleMap.set('background-size', new CSSUnitValue(-32, 'px'))");
+shouldBeEqualToString("target.style.backgroundSize", "calc(-32px) auto");
+
+// https://w3c.github.io/csswg-drafts/css-fonts/#font-weight-prop
+shouldNotThrow("target.attributeStyleMap.set('font-weight', new CSSUnitValue(0, 'number'))");
+shouldBeEqualToString("target.style.fontWeight", "1");
+shouldNotThrow("target.attributeStyleMap.set('font-weight', new CSSUnitValue(-32, 'number'))");
+shouldBeEqualToString("target.style.fontWeight", "1");
+shouldNotThrow("target.attributeStyleMap.set('font-weight', new CSSUnitValue(100, 'number'))");
+shouldBeEqualToString("target.style.fontWeight", "100");
+shouldNotThrow("target.attributeStyleMap.set('font-weight', new CSSUnitValue(1001, 'number'))");
+shouldBeEqualToString("target.style.fontWeight", "1000");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'animation-duration' to CSS-wide keywords
 FAIL Can set 'animation-duration' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'animation-duration' to a time Invalid values
+FAIL Can set 'animation-duration' to a time assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'animation-duration' to a length throws TypeError
 PASS Setting 'animation-duration' to a percent throws TypeError
 PASS Setting 'animation-duration' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt
@@ -2,7 +2,7 @@
 PASS Can set 'animation-iteration-count' to CSS-wide keywords
 FAIL Can set 'animation-iteration-count' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'animation-iteration-count' to the 'infinite' keyword
-FAIL Can set 'animation-iteration-count' to a number Invalid values
+FAIL Can set 'animation-iteration-count' to a number assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'animation-iteration-count' to a length throws TypeError
 PASS Setting 'animation-iteration-count' to a percent throws TypeError
 PASS Setting 'animation-iteration-count' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt
@@ -4,7 +4,7 @@ FAIL Can set 'border-top-width' to var() references assert_equals: expected 2 bu
 PASS Can set 'border-top-width' to the 'thin' keyword
 PASS Can set 'border-top-width' to the 'medium' keyword
 PASS Can set 'border-top-width' to the 'thick' keyword
-FAIL Can set 'border-top-width' to a length Invalid values
+FAIL Can set 'border-top-width' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'border-top-width' to a percent throws TypeError
 PASS Setting 'border-top-width' to a time throws TypeError
 PASS Setting 'border-top-width' to an angle throws TypeError
@@ -17,7 +17,7 @@ FAIL Can set 'border-left-width' to var() references assert_equals: expected 2 b
 PASS Can set 'border-left-width' to the 'thin' keyword
 PASS Can set 'border-left-width' to the 'medium' keyword
 PASS Can set 'border-left-width' to the 'thick' keyword
-FAIL Can set 'border-left-width' to a length Invalid values
+FAIL Can set 'border-left-width' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'border-left-width' to a percent throws TypeError
 PASS Setting 'border-left-width' to a time throws TypeError
 PASS Setting 'border-left-width' to an angle throws TypeError
@@ -30,7 +30,7 @@ FAIL Can set 'border-right-width' to var() references assert_equals: expected 2 
 PASS Can set 'border-right-width' to the 'thin' keyword
 PASS Can set 'border-right-width' to the 'medium' keyword
 PASS Can set 'border-right-width' to the 'thick' keyword
-FAIL Can set 'border-right-width' to a length Invalid values
+FAIL Can set 'border-right-width' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'border-right-width' to a percent throws TypeError
 PASS Setting 'border-right-width' to a time throws TypeError
 PASS Setting 'border-right-width' to an angle throws TypeError
@@ -43,7 +43,7 @@ FAIL Can set 'border-bottom-width' to var() references assert_equals: expected 2
 PASS Can set 'border-bottom-width' to the 'thin' keyword
 PASS Can set 'border-bottom-width' to the 'medium' keyword
 PASS Can set 'border-bottom-width' to the 'thick' keyword
-FAIL Can set 'border-bottom-width' to a length Invalid values
+FAIL Can set 'border-bottom-width' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'border-bottom-width' to a percent throws TypeError
 PASS Setting 'border-bottom-width' to a time throws TypeError
 PASS Setting 'border-bottom-width' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt
@@ -2,7 +2,7 @@
 PASS Can set 'column-width' to CSS-wide keywords
 FAIL Can set 'column-width' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'column-width' to the 'auto' keyword
-FAIL Can set 'column-width' to a length Invalid values
+FAIL Can set 'column-width' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'column-width' to a percent throws TypeError
 PASS Setting 'column-width' to a time throws TypeError
 PASS Setting 'column-width' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt
@@ -6,8 +6,8 @@ PASS Can set 'flex-basis' to the 'content' keyword
 PASS Can set 'flex-basis' to the 'fit-content' keyword
 PASS Can set 'flex-basis' to the 'min-content' keyword
 PASS Can set 'flex-basis' to the 'max-content' keyword
-FAIL Can set 'flex-basis' to a length Invalid values
-FAIL Can set 'flex-basis' to a percent Invalid values
+FAIL Can set 'flex-basis' to a length assert_equals: expected "px" but got "em"
+FAIL Can set 'flex-basis' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Setting 'flex-basis' to a time throws TypeError
 PASS Setting 'flex-basis' to an angle throws TypeError
 PASS Setting 'flex-basis' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'font-weight' to the 'normal' keyword
 PASS Can set 'font-weight' to the 'bold' keyword
 PASS Can set 'font-weight' to the 'bolder' keyword
 PASS Can set 'font-weight' to the 'lighter' keyword
-FAIL Can set 'font-weight' to a number Invalid values
+FAIL Can set 'font-weight' to a number assert_approx_equals: expected 0 +/- 0.000001 but got 1
 PASS Setting 'font-weight' to a length throws TypeError
 PASS Setting 'font-weight' to a percent throws TypeError
 PASS Setting 'font-weight' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt
@@ -2,8 +2,8 @@
 PASS Can set 'column-gap' to CSS-wide keywords
 FAIL Can set 'column-gap' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'column-gap' to the 'normal' keyword
-FAIL Can set 'column-gap' to a length Invalid values
-FAIL Can set 'column-gap' to a percent Invalid values
+FAIL Can set 'column-gap' to a length assert_equals: expected "px" but got "em"
+FAIL Can set 'column-gap' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Setting 'column-gap' to a time throws TypeError
 PASS Setting 'column-gap' to an angle throws TypeError
 PASS Setting 'column-gap' to a flexible length throws TypeError
@@ -13,8 +13,8 @@ PASS Setting 'column-gap' to a transform throws TypeError
 PASS Can set 'row-gap' to CSS-wide keywords
 FAIL Can set 'row-gap' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'row-gap' to the 'normal' keyword
-FAIL Can set 'row-gap' to a length Invalid values
-FAIL Can set 'row-gap' to a percent Invalid values
+FAIL Can set 'row-gap' to a length assert_equals: expected "px" but got "em"
+FAIL Can set 'row-gap' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Setting 'row-gap' to a time throws TypeError
 PASS Setting 'row-gap' to an angle throws TypeError
 PASS Setting 'row-gap' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
@@ -4,8 +4,8 @@ FAIL Can set 'grid-auto-columns' to var() references assert_equals: expected 2 b
 PASS Can set 'grid-auto-columns' to the 'min-content' keyword
 PASS Can set 'grid-auto-columns' to the 'max-content' keyword
 PASS Can set 'grid-auto-columns' to the 'auto' keyword
-FAIL Can set 'grid-auto-columns' to a length Invalid values
-FAIL Can set 'grid-auto-columns' to a percent Invalid values
+FAIL Can set 'grid-auto-columns' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'grid-auto-columns' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 FAIL Can set 'grid-auto-columns' to a flexible length Invalid values
 PASS Setting 'grid-auto-columns' to a time throws TypeError
 PASS Setting 'grid-auto-columns' to an angle throws TypeError
@@ -19,8 +19,8 @@ FAIL Can set 'grid-auto-rows' to var() references assert_equals: expected 2 but 
 PASS Can set 'grid-auto-rows' to the 'min-content' keyword
 PASS Can set 'grid-auto-rows' to the 'max-content' keyword
 PASS Can set 'grid-auto-rows' to the 'auto' keyword
-FAIL Can set 'grid-auto-rows' to a length Invalid values
-FAIL Can set 'grid-auto-rows' to a percent Invalid values
+FAIL Can set 'grid-auto-rows' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'grid-auto-rows' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 FAIL Can set 'grid-auto-rows' to a flexible length Invalid values
 PASS Setting 'grid-auto-rows' to a time throws TypeError
 PASS Setting 'grid-auto-rows' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt
@@ -23,8 +23,8 @@ PASS Setting 'min-height' to a transform throws TypeError
 PASS Can set 'max-height' to CSS-wide keywords
 FAIL Can set 'max-height' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'max-height' to the 'none' keyword
-FAIL Can set 'max-height' to a percent Invalid values
-FAIL Can set 'max-height' to a length Invalid values
+FAIL Can set 'max-height' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'max-height' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'max-height' to a time throws TypeError
 PASS Setting 'max-height' to an angle throws TypeError
 PASS Setting 'max-height' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-expected.txt
@@ -2,9 +2,9 @@
 PASS Can set 'line-height' to CSS-wide keywords
 FAIL Can set 'line-height' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'line-height' to the 'normal' keyword
-FAIL Can set 'line-height' to a length Invalid values
-FAIL Can set 'line-height' to a number Invalid values
-FAIL Can set 'line-height' to a percent Invalid values
+FAIL Can set 'line-height' to a length assert_equals: expected "px" but got "em"
+FAIL Can set 'line-height' to a number assert_equals: expected 2 but got 1
+FAIL Can set 'line-height' to a percent assert_equals: expected 2 but got 1
 PASS Setting 'line-height' to a time throws TypeError
 PASS Setting 'line-height' to an angle throws TypeError
 PASS Setting 'line-height' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
@@ -195,7 +195,7 @@ FAIL Can set 'border-block-start-width' to var() references assert_equals: expec
 FAIL Can set 'border-block-start-width' to the 'thin' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-block-start-width' to the 'medium' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-block-start-width' to the 'thick' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-block-start-width' to a length Invalid values
+FAIL Can set 'border-block-start-width' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'border-block-start-width' to a percent throws TypeError
 PASS Setting 'border-block-start-width' to a time throws TypeError
 PASS Setting 'border-block-start-width' to an angle throws TypeError
@@ -242,7 +242,7 @@ FAIL Can set 'border-block-end-width' to var() references assert_equals: expecte
 FAIL Can set 'border-block-end-width' to the 'thin' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-block-end-width' to the 'medium' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-block-end-width' to the 'thick' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-block-end-width' to a length Invalid values
+FAIL Can set 'border-block-end-width' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'border-block-end-width' to a percent throws TypeError
 PASS Setting 'border-block-end-width' to a time throws TypeError
 PASS Setting 'border-block-end-width' to an angle throws TypeError
@@ -289,7 +289,7 @@ FAIL Can set 'border-inline-start-width' to var() references assert_equals: expe
 FAIL Can set 'border-inline-start-width' to the 'thin' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-inline-start-width' to the 'medium' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-inline-start-width' to the 'thick' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-inline-start-width' to a length Invalid values
+FAIL Can set 'border-inline-start-width' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'border-inline-start-width' to a percent throws TypeError
 PASS Setting 'border-inline-start-width' to a time throws TypeError
 PASS Setting 'border-inline-start-width' to an angle throws TypeError
@@ -336,7 +336,7 @@ FAIL Can set 'border-inline-end-width' to var() references assert_equals: expect
 FAIL Can set 'border-inline-end-width' to the 'thin' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-inline-end-width' to the 'medium' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-inline-end-width' to the 'thick' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-inline-end-width' to a length Invalid values
+FAIL Can set 'border-inline-end-width' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'border-inline-end-width' to a percent throws TypeError
 PASS Setting 'border-inline-end-width' to a time throws TypeError
 PASS Setting 'border-inline-end-width' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt
@@ -4,7 +4,7 @@ FAIL Can set 'outline-width' to var() references assert_equals: expected 2 but g
 PASS Can set 'outline-width' to the 'thin' keyword
 PASS Can set 'outline-width' to the 'medium' keyword
 PASS Can set 'outline-width' to the 'thick' keyword
-FAIL Can set 'outline-width' to a length Invalid values
+FAIL Can set 'outline-width' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'outline-width' to a percent throws TypeError
 PASS Setting 'outline-width' to a time throws TypeError
 PASS Setting 'outline-width' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Can set 'scroll-padding-top' to CSS-wide keywords
 FAIL Can set 'scroll-padding-top' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-top' to a percent Invalid values
-FAIL Can set 'scroll-padding-top' to a length Invalid values
+FAIL Can set 'scroll-padding-top' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-top' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'scroll-padding-top' to a time throws TypeError
 PASS Setting 'scroll-padding-top' to an angle throws TypeError
 PASS Setting 'scroll-padding-top' to a flexible length throws TypeError
@@ -11,8 +11,8 @@ PASS Setting 'scroll-padding-top' to a URL throws TypeError
 PASS Setting 'scroll-padding-top' to a transform throws TypeError
 PASS Can set 'scroll-padding-left' to CSS-wide keywords
 FAIL Can set 'scroll-padding-left' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-left' to a percent Invalid values
-FAIL Can set 'scroll-padding-left' to a length Invalid values
+FAIL Can set 'scroll-padding-left' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-left' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'scroll-padding-left' to a time throws TypeError
 PASS Setting 'scroll-padding-left' to an angle throws TypeError
 PASS Setting 'scroll-padding-left' to a flexible length throws TypeError
@@ -21,8 +21,8 @@ PASS Setting 'scroll-padding-left' to a URL throws TypeError
 PASS Setting 'scroll-padding-left' to a transform throws TypeError
 PASS Can set 'scroll-padding-right' to CSS-wide keywords
 FAIL Can set 'scroll-padding-right' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-right' to a percent Invalid values
-FAIL Can set 'scroll-padding-right' to a length Invalid values
+FAIL Can set 'scroll-padding-right' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-right' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'scroll-padding-right' to a time throws TypeError
 PASS Setting 'scroll-padding-right' to an angle throws TypeError
 PASS Setting 'scroll-padding-right' to a flexible length throws TypeError
@@ -31,8 +31,8 @@ PASS Setting 'scroll-padding-right' to a URL throws TypeError
 PASS Setting 'scroll-padding-right' to a transform throws TypeError
 PASS Can set 'scroll-padding-bottom' to CSS-wide keywords
 FAIL Can set 'scroll-padding-bottom' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-bottom' to a percent Invalid values
-FAIL Can set 'scroll-padding-bottom' to a length Invalid values
+FAIL Can set 'scroll-padding-bottom' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-bottom' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'scroll-padding-bottom' to a time throws TypeError
 PASS Setting 'scroll-padding-bottom' to an angle throws TypeError
 PASS Setting 'scroll-padding-bottom' to a flexible length throws TypeError
@@ -41,8 +41,8 @@ PASS Setting 'scroll-padding-bottom' to a URL throws TypeError
 PASS Setting 'scroll-padding-bottom' to a transform throws TypeError
 PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords
 FAIL Can set 'scroll-padding-inline-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-inline-start' to a percent Invalid values
-FAIL Can set 'scroll-padding-inline-start' to a length Invalid values
+FAIL Can set 'scroll-padding-inline-start' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-inline-start' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'scroll-padding-inline-start' to a time throws TypeError
 PASS Setting 'scroll-padding-inline-start' to an angle throws TypeError
 PASS Setting 'scroll-padding-inline-start' to a flexible length throws TypeError
@@ -51,8 +51,8 @@ PASS Setting 'scroll-padding-inline-start' to a URL throws TypeError
 PASS Setting 'scroll-padding-inline-start' to a transform throws TypeError
 PASS Can set 'scroll-padding-block-start' to CSS-wide keywords
 FAIL Can set 'scroll-padding-block-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-block-start' to a percent Invalid values
-FAIL Can set 'scroll-padding-block-start' to a length Invalid values
+FAIL Can set 'scroll-padding-block-start' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-block-start' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'scroll-padding-block-start' to a time throws TypeError
 PASS Setting 'scroll-padding-block-start' to an angle throws TypeError
 PASS Setting 'scroll-padding-block-start' to a flexible length throws TypeError
@@ -61,8 +61,8 @@ PASS Setting 'scroll-padding-block-start' to a URL throws TypeError
 PASS Setting 'scroll-padding-block-start' to a transform throws TypeError
 PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords
 FAIL Can set 'scroll-padding-inline-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-inline-end' to a percent Invalid values
-FAIL Can set 'scroll-padding-inline-end' to a length Invalid values
+FAIL Can set 'scroll-padding-inline-end' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-inline-end' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'scroll-padding-inline-end' to a time throws TypeError
 PASS Setting 'scroll-padding-inline-end' to an angle throws TypeError
 PASS Setting 'scroll-padding-inline-end' to a flexible length throws TypeError
@@ -71,8 +71,8 @@ PASS Setting 'scroll-padding-inline-end' to a URL throws TypeError
 PASS Setting 'scroll-padding-inline-end' to a transform throws TypeError
 PASS Can set 'scroll-padding-block-end' to CSS-wide keywords
 FAIL Can set 'scroll-padding-block-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-block-end' to a percent Invalid values
-FAIL Can set 'scroll-padding-block-end' to a length Invalid values
+FAIL Can set 'scroll-padding-block-end' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-block-end' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'scroll-padding-block-end' to a time throws TypeError
 PASS Setting 'scroll-padding-block-end' to an angle throws TypeError
 PASS Setting 'scroll-padding-block-end' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Can set 'stroke-miterlimit' to CSS-wide keywords
 FAIL Can set 'stroke-miterlimit' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'stroke-miterlimit' to a number Invalid values
+FAIL Can set 'stroke-miterlimit' to a number assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Setting 'stroke-miterlimit' to a length throws TypeError
 PASS Setting 'stroke-miterlimit' to a percent throws TypeError
 PASS Setting 'stroke-miterlimit' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt
@@ -23,8 +23,8 @@ PASS Setting 'min-width' to a transform throws TypeError
 PASS Can set 'max-width' to CSS-wide keywords
 FAIL Can set 'max-width' to var() references assert_equals: expected 2 but got 1
 PASS Can set 'max-width' to the 'none' keyword
-FAIL Can set 'max-width' to a percent Invalid values
-FAIL Can set 'max-width' to a length Invalid values
+FAIL Can set 'max-width' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'max-width' to a length assert_equals: expected "px" but got "em"
 PASS Setting 'max-width' to a time throws TypeError
 PASS Setting 'max-width' to an angle throws TypeError
 PASS Setting 'max-width' to a flexible length throws TypeError

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -180,6 +180,7 @@ RefPtr<CSSValue> CSSUnitValue::toCSSValue() const
     return CSSPrimitiveValue::create(m_value, m_unit);
 }
 
+// FIXME: This function could be mostly generated from CSSProperties.json.
 static bool isValueOutOfRangeForProperty(CSSPropertyID propertyID, double value, CSSUnitType unit)
 {
     bool acceptsNegativeNumbers = true;
@@ -196,25 +197,62 @@ static bool isValueOutOfRangeForProperty(CSSPropertyID propertyID, double value,
     case CSSPropertyWidows:
     case CSSPropertyColumnCount:
         return round(value) != value || value < 1;
+    case CSSPropertyAnimationDuration:
+    case CSSPropertyAnimationIterationCount:
+    case CSSPropertyBackgroundSize:
     case CSSPropertyBlockSize:
+    case CSSPropertyBorderBlockEndWidth:
+    case CSSPropertyBorderBlockStartWidth:
+    case CSSPropertyBorderBottomLeftRadius:
+    case CSSPropertyBorderBottomRightRadius:
+    case CSSPropertyBorderBottomWidth:
+    case CSSPropertyBorderImageOutset:
+    case CSSPropertyBorderImageSlice:
+    case CSSPropertyBorderImageWidth:
+    case CSSPropertyBorderInlineEndWidth:
+    case CSSPropertyBorderInlineStartWidth:
+    case CSSPropertyBorderLeftWidth:
+    case CSSPropertyBorderRightWidth:
+    case CSSPropertyBorderTopLeftRadius:
+    case CSSPropertyBorderTopRightRadius:
+    case CSSPropertyBorderTopWidth:
+    case CSSPropertyColumnGap:
     case CSSPropertyColumnRuleWidth:
+    case CSSPropertyColumnWidth:
+    case CSSPropertyFlexBasis:
     case CSSPropertyFlexGrow:
     case CSSPropertyFlexShrink:
     case CSSPropertyFontSize:
     case CSSPropertyFontSizeAdjust:
     case CSSPropertyFontStretch:
+    case CSSPropertyGridAutoColumns:
+    case CSSPropertyGridAutoRows:
     case CSSPropertyInlineSize:
+    case CSSPropertyLineHeight:
     case CSSPropertyMaxBlockSize:
     case CSSPropertyMaxInlineSize:
+    case CSSPropertyMaxHeight:
+    case CSSPropertyMaxWidth:
     case CSSPropertyMinBlockSize:
     case CSSPropertyMinInlineSize:
+    case CSSPropertyOutlineWidth:
     case CSSPropertyPerspective:
     case CSSPropertyR:
+    case CSSPropertyRowGap:
     case CSSPropertyRx:
     case CSSPropertyRy:
+    case CSSPropertyScrollPaddingBlockEnd:
+    case CSSPropertyScrollPaddingBlockStart:
+    case CSSPropertyScrollPaddingBottom:
+    case CSSPropertyScrollPaddingInlineEnd:
+    case CSSPropertyScrollPaddingInlineStart:
+    case CSSPropertyScrollPaddingLeft:
+    case CSSPropertyScrollPaddingRight:
+    case CSSPropertyScrollPaddingTop:
+    case CSSPropertyStrokeMiterlimit:
         return value < 0;
     case CSSPropertyFontWeight:
-        return value < 0 || value > 1000;
+        return value < 1 || value > 1000;
     default:
         return false;
     }


### PR DESCRIPTION
#### e864f3817fb82d58b9a9c874ab45e35c8c40e0ae
<pre>
Update isValueOutOfRangeForProperty() to account for more CSS properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=249050">https://bugs.webkit.org/show_bug.cgi?id=249050</a>

Reviewed by Sam Weinig.

Update isValueOutOfRangeForProperty() to account for more CSS properties that
have range limits:
- border-image-width: length or percentage or number &gt;= 0
  <a href="https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-width">https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-width</a>

- border-top-width, border-right-width, border-bottom-width, border-left-width: length &gt;= 0
  <a href="https://w3c.github.io/csswg-drafts/css-backgrounds/#the-border-width">https://w3c.github.io/csswg-drafts/css-backgrounds/#the-border-width</a>

- row-gap, column-gap: length or percentage &gt;= 0
  <a href="https://w3c.github.io/csswg-drafts/css-align/#column-row-gap">https://w3c.github.io/csswg-drafts/css-align/#column-row-gap</a>

- column-width: length &gt;= 0
  <a href="https://w3c.github.io/csswg-drafts/css-multicol-1/#propdef-column-width">https://w3c.github.io/csswg-drafts/css-multicol-1/#propdef-column-width</a>

- flex-basis: length or percentage &gt;= 0
  <a href="https://w3c.github.io/csswg-drafts/css-flexbox/#flex-basis-property">https://w3c.github.io/csswg-drafts/css-flexbox/#flex-basis-property</a>

- grid-auto-columns, grid-auto-rows: length or percentage &gt;= 0
  <a href="https://w3c.github.io/csswg-drafts/css-grid/#auto-tracks">https://w3c.github.io/csswg-drafts/css-grid/#auto-tracks</a>

- line-height: length, number or percentage &gt;= 0
  <a href="https://w3c.github.io/csswg-drafts/css-inline/#line-height-property">https://w3c.github.io/csswg-drafts/css-inline/#line-height-property</a>

- max-height: length or percentage &gt;= 0
  <a href="https://w3c.github.io/csswg-drafts/css2/#propdef-max-height">https://w3c.github.io/csswg-drafts/css2/#propdef-max-height</a>

- max-width: length or percentage &gt;= 0
  <a href="https://w3c.github.io/csswg-drafts/css2/#propdef-max-width">https://w3c.github.io/csswg-drafts/css2/#propdef-max-width</a>

- outline-width: length &gt;= 0
  <a href="https://w3c.github.io/csswg-drafts/css-ui/#outline-width">https://w3c.github.io/csswg-drafts/css-ui/#outline-width</a>

- scroll-padding-inline-start, scroll-padding-block-start, scroll-padding-inline-end, scroll-padding-block-end: length or percentage &gt;= 0
  <a href="https://w3c.github.io/csswg-drafts/css-scroll-snap/#padding-longhands-logical">https://w3c.github.io/csswg-drafts/css-scroll-snap/#padding-longhands-logical</a>

- stroke-miterlimit: number &gt;= 0
  <a href="https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty">https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty</a>

- font-weight: number in range [1, 1000]
  <a href="https://w3c.github.io/csswg-drafts/css-fonts/#font-weight-prop">https://w3c.github.io/csswg-drafts/css-fonts/#font-weight-prop</a>

All these properties are covered by the WPT tests but the tests still fail because of:
- <a href="https://github.com/WebKit/WebKit/pull/7387">https://github.com/WebKit/WebKit/pull/7387</a> (a lot more tests start passing with this PR)

For now, I have extracted these test cases into their own layout test.

* LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value-expected.txt:
* LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt:
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::isValueOutOfRangeForProperty):

Canonical link: <a href="https://commits.webkit.org/257757@main">https://commits.webkit.org/257757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e41fe3c534b35716555a53a53ea18762b23a22bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109264 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169502 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103913 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86377 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92361 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107167 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105678 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34246 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2884 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23709 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2840 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/46081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43182 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2733 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->