### PR TITLE
Add more fullscreen release logging

### DIFF
--- a/Source/WebCore/platform/graphics/FloatRect.h
+++ b/Source/WebCore/platform/graphics/FloatRect.h
@@ -317,3 +317,16 @@ WEBCORE_EXPORT id makeNSArrayElement(const FloatRect&);
 #endif
 
 }
+
+namespace WTF {
+
+template<typename Type> struct LogArgument;
+template <>
+struct LogArgument<WebCore::FloatRect> {
+    static String toString(const WebCore::FloatRect& rect)
+    {
+        return makeString("location: (", rect.x(), ", ", rect.y(), "), size: (", rect.width(), " x ", rect.height(), ")");
+    }
+};
+
+}

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1967,6 +1967,22 @@ String convertEnumerationToString(MediaPlayer::BufferingPolicy enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
+String convertEnumerationToString(MediaPlayer::VideoFullscreenMode mode)
+{
+    if (mode == MediaPlayer::VideoFullscreenModeNone)
+        return "[None]"_s;
+
+    StringBuilder builder;
+    builder.append("[ ");
+    if (mode & MediaPlayer::VideoFullscreenModeStandard)
+        builder.append("Standard");
+    if (mode & MediaPlayer::VideoFullscreenModePictureInPicture)
+        builder.append("PictureInPicture");
+    builder.append(" ]");
+
+    return builder.toString();
+}
+
 String MediaPlayer::lastErrorMessage() const
 {
     return m_lastErrorMessage;

--- a/Source/WebCore/platform/graphics/MediaPlayerEnums.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerEnums.h
@@ -119,6 +119,7 @@ String convertEnumerationToString(MediaPlayerEnums::NetworkState);
 String convertEnumerationToString(MediaPlayerEnums::Preload);
 String convertEnumerationToString(MediaPlayerEnums::SupportsType);
 String convertEnumerationToString(MediaPlayerEnums::BufferingPolicy);
+WEBCORE_EXPORT String convertEnumerationToString(MediaPlayerEnums::VideoFullscreenMode);
 
 } // namespace WebCore
 
@@ -149,6 +150,14 @@ struct LogArgument<WebCore::MediaPlayerEnums::BufferingPolicy> {
     static String toString(const WebCore::MediaPlayerEnums::BufferingPolicy policy)
     {
         return convertEnumerationToString(policy);
+    }
+};
+
+template <>
+struct LogArgument<WebCore::MediaPlayerEnums::VideoFullscreenMode> {
+    static String toString(const WebCore::MediaPlayerEnums::VideoFullscreenMode mode)
+    {
+        return WebCore::convertEnumerationToString(mode);
     }
 };
 

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
@@ -79,10 +79,19 @@ public:
 
     WebAVPlayerController *playerController() const { return m_playerController.get(); }
 
+    WEBCORE_EXPORT void setLogger(const Logger&, const void*);
+    const Logger* loggerPtr() const { return m_logger.get(); }
+    const void* logIdentifier() const { return m_logIdentifier; }
+    const char* logClassName() const { return "PlaybackSessionInterfaceAVKit"; }
+    WTFLogChannel& logChannel() const;
+
 private:
     PlaybackSessionInterfaceAVKit(PlaybackSessionModel&);
     RetainPtr<WebAVPlayerController> m_playerController;
     PlaybackSessionModel* m_playbackSessionModel { nullptr };
+
+    RefPtr<const WTF::Logger> m_logger;
+    const void* m_logIdentifier;
 };
 
 }

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
@@ -254,6 +254,17 @@ void PlaybackSessionInterfaceAVKit::modelDestroyed()
     ASSERT(!m_playbackSessionModel);
 }
 
+void PlaybackSessionInterfaceAVKit::setLogger(const Logger& logger, const void* logIdentifier)
+{
+    m_logger = &logger;
+    m_logIdentifier = logIdentifier;
+}
+
+WTFLogChannel& PlaybackSessionInterfaceAVKit::logChannel() const
+{
+    return LogFullscreen;
+}
+
 }
 
 #endif // PLATFORM(COCOA) && HAVE(AVKIT)

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h
@@ -167,6 +167,19 @@ public:
     std::optional<MediaPlayerIdentifier> playerIdentifier() const { return m_playerIdentifier; }
     WEBCORE_EXPORT AVPlayerViewController *avPlayerViewController() const;
 
+    const Logger* loggerPtr();
+    const void* logIdentifier();
+    const char* logClassName() const { return "VideoFullscreenInterfaceAVKit"; }
+    WTFLogChannel& logChannel() const;
+
+    enum class NextAction {
+        NeedsEnterFullScreen = 1 << 0,
+        NeedsExitFullScreen = 1 << 1,
+    };
+    using NextActions = OptionSet<NextAction>;
+
+    static String nextActionToString(NextActions);
+
 protected:
     WEBCORE_EXPORT VideoFullscreenInterfaceAVKit(PlaybackSessionInterfaceAVKit&);
 
@@ -197,6 +210,9 @@ protected:
     FloatRect m_inlineRect;
     RouteSharingPolicy m_routeSharingPolicy { RouteSharingPolicy::Default };
     String m_routingContextUID;
+    RefPtr<const WTF::Logger> m_logger;
+    const void* m_logIdentifier { nullptr };
+
     bool m_allowsPictureInPicturePlayback { false };
     bool m_wirelessVideoPlaybackDisabled { true };
     bool m_shouldReturnToFullscreenWhenStoppingPictureInPicture { false };
@@ -234,17 +250,26 @@ protected:
     bool m_exitingPictureInPicture { false };
 
 private:
-    enum class NextAction {
-        NeedsEnterFullScreen = 1 << 0,
-        NeedsExitFullScreen = 1 << 1,
-    };
-    using NextActions = OptionSet<NextAction>;
-
     void exitFullscreenHandler(BOOL success, NSError *, NextActions = NextActions());
     void enterFullscreenHandler(BOOL success, NSError *, NextActions = NextActions());
 };
 
 }
+
+namespace WTF {
+
+template<typename Type>
+struct LogArgument;
+
+template <>
+struct LogArgument<WebCore::VideoFullscreenInterfaceAVKit::NextActions> {
+    static String toString(const WebCore::VideoFullscreenInterfaceAVKit::NextActions actions)
+    {
+        return WebCore::VideoFullscreenInterfaceAVKit::nextActionToString(actions);
+    }
+};
+
+}; // namespace WTF
 
 #endif // PLATFORM(IOS_FAMILY)
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -253,10 +253,18 @@ private:
     void setPlayingOnSecondScreen(PlaybackSessionContextIdentifier, bool);
     void sendRemoteCommand(PlaybackSessionContextIdentifier, WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&);
 
+    const Logger& logger() const { return m_logger; }
+    const void* logIdentifier() const { return m_logIdentifier; }
+    const char* logClassName() const { return "PlaybackSessionManagerProxy"; }
+    WTFLogChannel& logChannel() const;
+
     WebPageProxy* m_page;
     HashMap<PlaybackSessionContextIdentifier, ModelInterfaceTuple> m_contextMap;
     PlaybackSessionContextIdentifier m_controlsManagerContextId;
     HashCountedSet<PlaybackSessionContextIdentifier> m_clientCounts;
+
+    Ref<const Logger> m_logger;
+    const void* m_logIdentifier { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
 
+#import "Logging.h"
 #import "PlaybackSessionManagerMessages.h"
 #import "PlaybackSessionManagerProxyMessages.h"
 #import "WebPageProxy.h"
@@ -318,6 +319,7 @@ Ref<PlaybackSessionManagerProxy> PlaybackSessionManagerProxy::create(WebPageProx
 
 PlaybackSessionManagerProxy::PlaybackSessionManagerProxy(WebPageProxy& page)
     : m_page(&page)
+    , m_logger(page.logger())
 {
     m_page->process().addMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), m_page->webPageID(), *this);
 }
@@ -345,6 +347,8 @@ PlaybackSessionManagerProxy::ModelInterfaceTuple PlaybackSessionManagerProxy::cr
 {
     Ref<PlaybackSessionModelContext> model = PlaybackSessionModelContext::create(*this, contextId);
     Ref<PlatformPlaybackSessionInterface> interface = PlatformPlaybackSessionInterface::create(model);
+
+    interface->setLogger(logger(), reinterpret_cast<const void*>(contextId.toUInt64()));
 
     return std::make_tuple(WTFMove(model), WTFMove(interface));
 }
@@ -653,6 +657,11 @@ bool PlaybackSessionManagerProxy::isPaused(PlaybackSessionContextIdentifier iden
 
     auto& model = *std::get<0>(iterator->value);
     return !model.isPlaying() && !model.isStalled();
+}
+
+WTFLogChannel& PlaybackSessionManagerProxy::logChannel() const
+{
+    return WebKit2LogMedia;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
@@ -211,6 +211,11 @@ private:
     void requestCloseAllMediaPresentations(PlaybackSessionContextIdentifier, bool finishedWithMedia, CompletionHandler<void()>&&);
     void callCloseCompletionHandlers();
 
+    const Logger& logger() const { return m_logger; }
+    const void* logIdentifier() const { return m_logIdentifier; }
+    const char* logClassName() const { return "VideoFullscreenManagerProxy"; }
+    WTFLogChannel& logChannel() const;
+
     bool m_mockVideoPresentationModeEnabled { false };
     WebCore::FloatSize m_mockPictureInPictureWindowSize { DefaultMockPictureInPictureWindowWidth, DefaultMockPictureInPictureWindowHeight };
 
@@ -220,6 +225,8 @@ private:
     HashMap<PlaybackSessionContextIdentifier, int> m_clientCounts;
     Vector<CompletionHandler<void()>> m_closeCompletionHandlers;
     WeakHashSet<VideoInPictureInPictureDidChangeObserver> m_pipChangeObservers;
+    Ref<const Logger> m_logger;
+    const void* m_logIdentifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -339,6 +339,7 @@ Ref<VideoFullscreenManagerProxy> VideoFullscreenManagerProxy::create(WebPageProx
 VideoFullscreenManagerProxy::VideoFullscreenManagerProxy(WebPageProxy& page, PlaybackSessionManagerProxy& playbackSessionManagerProxy)
     : m_page(&page)
     , m_playbackSessionManagerProxy(playbackSessionManagerProxy)
+    , m_logger(page.logger())
 {
     m_page->process().addMessageReceiver(Messages::VideoFullscreenManagerProxy::messageReceiverName(), m_page->webPageID(), *this);
 }
@@ -914,7 +915,6 @@ void VideoFullscreenManagerProxy::fullscreenMayReturnToInline(PlaybackSessionCon
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-
 AVPlayerViewController *VideoFullscreenManagerProxy::playerViewController(PlaybackSessionContextIdentifier identifier) const
 {
 #if HAVE(PIP_CONTROLLER)
@@ -924,8 +924,12 @@ AVPlayerViewController *VideoFullscreenManagerProxy::playerViewController(Playba
     return interface ? interface->avPlayerViewController() : nil;
 #endif
 }
-
 #endif // PLATFORM(IOS_FAMILY)
+
+WTFLogChannel& VideoFullscreenManagerProxy::logChannel() const
+{
+    return WebKit2LogMedia;
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -55,7 +55,7 @@ class WebPage;
 
 class WebFullScreenManager final : public WebCore::EventListener {
 public:
-    static Ref<WebFullScreenManager> create(WebPage*);
+    static Ref<WebFullScreenManager> create(WebPage&);
     virtual ~WebFullScreenManager();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
@@ -76,7 +76,7 @@ public:
     bool operator==(const WebCore::EventListener& listener) const final { return this == &listener; }
 
 protected:
-    WebFullScreenManager(WebPage*);
+    WebFullScreenManager(WebPage&);
 
     void setPIPStandbyElement(WebCore::HTMLVideoElement*);
 
@@ -95,7 +95,7 @@ protected:
     WebCore::IntRect m_finalFrame;
     WebCore::IntPoint m_scrollPosition;
     float m_topContentInset { 0 };
-    RefPtr<WebPage> m_page;
+    Ref<WebPage> m_page;
     RefPtr<WebCore::Element> m_element;
     WeakPtr<WebCore::Element, WebCore::WeakPtrImplWithEventTargetData> m_elementToRestore;
 #if ENABLE(VIDEO)
@@ -110,6 +110,13 @@ private:
     void setElement(WebCore::Element&);
     void clearElement();
 
+#if !RELEASE_LOG_DISABLED
+    const Logger& logger() const;
+    const void* logIdentifier() const { return m_logIdentifier; }
+    const char* logClassName() const { return "WebFullScreenManager"; }
+    WTFLogChannel& logChannel() const;
+#endif
+
 #if ENABLE(VIDEO)
     void scheduleTextRecognitionForMainVideo();
     void endTextRecognitionForMainVideoIfNeeded();
@@ -121,6 +128,10 @@ private:
     RunLoop::Timer<WebFullScreenManager> m_mainVideoElementTextRecognitionTimer;
     bool m_isPerformingTextRecognitionInMainVideo { false };
 #endif // ENABLE(VIDEO)
+
+#if !RELEASE_LOG_DISABLED
+    const void* m_logIdentifier;
+#endif
 
     bool m_closing { false };
 };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4615,7 +4615,7 @@ void WebPage::setAllowsMediaDocumentInlinePlayback(bool allows)
 WebFullScreenManager* WebPage::fullScreenManager()
 {
     if (!m_fullScreenManager)
-        m_fullScreenManager = WebFullScreenManager::create(this);
+        m_fullScreenManager = WebFullScreenManager::create(*this);
     return m_fullScreenManager.get();
 }
 #endif
@@ -8355,6 +8355,15 @@ bool WebPage::isUsingUISideCompositing() const
 #else
     return false;
 #endif
+}
+
+const Logger& WebPage::logger() const
+{
+    if (!m_logger) {
+        m_logger = Logger::create(this);
+        m_logger->setEnabled(this, m_page && m_page->sessionID().isAlwaysOnLoggingAllowed());
+    }
+    return *m_logger;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1593,6 +1593,8 @@ public:
     void updateImageAnimationEnabled();
 #endif
 
+    const Logger& logger() const;
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 
@@ -2555,6 +2557,8 @@ private:
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
     WeakHashSet<WebCore::HTMLImageElement, WebCore::WeakPtrImplWithEventTargetData> m_elementsToExcludeFromRemoveBackground;
 #endif
+
+    mutable RefPtr<Logger> m_logger;
 };
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
@@ -93,6 +93,8 @@ public:
     bool isFullscreen() const { return m_isFullscreen; }
     void setIsFullscreen(bool flag) { m_isFullscreen = flag; }
 
+    PlaybackSessionContextIdentifier contextId() const { return m_contextId; }
+
 private:
     // VideoFullscreenModelClient
     void hasVideoChanged(bool) override;
@@ -170,6 +172,11 @@ protected:
 
     void setCurrentlyInFullscreen(VideoFullscreenInterfaceContext&, bool);
 
+    const Logger& logger() const { return m_logger.get(); }
+    const void* logIdentifier() const { return m_logIdentifier; }
+    const char* logClassName() const { return "VideoFullscreenManager"; }
+    WTFLogChannel& logChannel() const;
+
     WebPage* m_page;
     Ref<PlaybackSessionManager> m_playbackSessionManager;
     HashMap<WebCore::HTMLVideoElement*, PlaybackSessionContextIdentifier> m_videoElements;
@@ -177,6 +184,8 @@ protected:
     PlaybackSessionContextIdentifier m_controlsManagerContextId;
     HashMap<PlaybackSessionContextIdentifier, int> m_clientCounts;
     WeakPtr<WebCore::HTMLVideoElement, WebCore::WeakPtrImplWithEventTargetData> m_videoElementInPictureInPicture;
+    Ref<const Logger> m_logger;
+    const void* m_logIdentifier;
     bool m_currentlyInFullscreen { false };
 };
 


### PR DESCRIPTION
#### 8a0e957a9528df9746ab47feb92ae9c840d48b54
<pre>
Add more fullscreen release logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=249053">https://bugs.webkit.org/show_bug.cgi?id=249053</a>
rdar://103199644

Reviewed by NOBODY (OOPS!).

Convert debug-only fullscreen logging to release logging to make future investigations
easier.

* Source/WebCore/platform/graphics/FloatRect.h:
(WTF::LogArgument&lt;WebCore::FloatRect&gt;::toString):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/graphics/MediaPlayerEnums.h:
(WTF::LogArgument&lt;WebCore::MediaPlayerEnums::VideoFullscreenMode&gt;::toString):
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm:
(WebCore::PlaybackSessionInterfaceAVKit::setLogger):
(WebCore::PlaybackSessionInterfaceAVKit::logChannel const):
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h:
(WTF::LogArgument&lt;WebCore::VideoFullscreenInterfaceAVKit::NextActions&gt;::toString):
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
(VideoFullscreenInterfaceAVKit::loggerPtr):
(VideoFullscreenInterfaceAVKit::logIdentifier):
(VideoFullscreenInterfaceAVKit::logChannel const):
(VideoFullscreenInterfaceAVKit::applicationDidBecomeActive):
(VideoFullscreenInterfaceAVKit::setupFullscreen):
(VideoFullscreenInterfaceAVKit::enterFullscreen):
(VideoFullscreenInterfaceAVKit::exitFullscreen):
(VideoFullscreenInterfaceAVKit::cleanupFullscreen):
(VideoFullscreenInterfaceAVKit::requestHideAndExitFullscreen):
(VideoFullscreenInterfaceAVKit::preparedToReturnToInline):
(VideoFullscreenInterfaceAVKit::willStartPictureInPicture):
(VideoFullscreenInterfaceAVKit::didStartPictureInPicture):
(VideoFullscreenInterfaceAVKit::failedToStartPictureInPicture):
(VideoFullscreenInterfaceAVKit::willStopPictureInPicture):
(VideoFullscreenInterfaceAVKit::didStopPictureInPicture):
(VideoFullscreenInterfaceAVKit::prepareForPictureInPictureStopWithCompletionHandler):
(VideoFullscreenInterfaceAVKit::doSetup):
(VideoFullscreenInterfaceAVKit::doEnterFullscreen):
(VideoFullscreenInterfaceAVKit::doExitFullscreen):
(VideoFullscreenInterfaceAVKit::exitFullscreenHandler):
(VideoFullscreenInterfaceAVKit::enterFullscreenHandler):
(VideoFullscreenInterfaceAVKit::watchdogTimerFired):
(VideoFullscreenInterfaceAVKit::nextActionToString):
(boolString): Deleted.
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
(WebKit::PlaybackSessionManagerProxy::logger const):
(WebKit::PlaybackSessionManagerProxy::logIdentifier const):
(WebKit::PlaybackSessionManagerProxy::logClassName const):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::PlaybackSessionManagerProxy):
(WebKit::PlaybackSessionManagerProxy::createModelAndInterface):
(WebKit::PlaybackSessionManagerProxy::logChannel const):
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h:
(WebKit::VideoFullscreenManagerProxy::logger const):
(WebKit::VideoFullscreenManagerProxy::logIdentifier const):
(WebKit::VideoFullscreenManagerProxy::logClassName const):
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenManagerProxy::VideoFullscreenManagerProxy):
(WebKit::VideoFullscreenManagerProxy::playerViewController const):
(WebKit::VideoFullscreenManagerProxy::logChannel const):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::create):
(WebKit::WebFullScreenManager::WebFullScreenManager):
(WebKit::WebFullScreenManager::setPIPStandbyElement):
(WebKit::WebFullScreenManager::supportsFullScreen):
(WebKit::WebFullScreenManager::enterFullScreenForElement):
(WebKit::WebFullScreenManager::exitFullScreenForElement):
(WebKit::WebFullScreenManager::willEnterFullScreen):
(WebKit::WebFullScreenManager::didEnterFullScreen):
(WebKit::WebFullScreenManager::willExitFullScreen):
(WebKit::WebFullScreenManager::didExitFullScreen):
(WebKit::WebFullScreenManager::close):
(WebKit::WebFullScreenManager::logger const):
(WebKit::WebFullScreenManager::logChannel const):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::fullScreenManager):
(WebKit::WebPage::logger const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h:
(WebKit::VideoFullscreenInterfaceContext::contextId const):
(WebKit::VideoFullscreenManager::logger const):
(WebKit::VideoFullscreenManager::logIdentifier const):
(WebKit::VideoFullscreenManager::logClassName const):
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::VideoFullscreenManager):
(WebKit::VideoFullscreenManager::enterVideoFullscreenForVideoElement):
(WebKit::VideoFullscreenManager::exitVideoFullscreenForVideoElement):
(WebKit::VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation):
(WebKit::VideoFullscreenManager::didSetupFullscreen):
(WebKit::VideoFullscreenManager::willExitFullscreen):
(WebKit::VideoFullscreenManager::didEnterFullscreen):
(WebKit::VideoFullscreenManager::failedToEnterFullscreen):
(WebKit::VideoFullscreenManager::didExitFullscreen):
(WebKit::VideoFullscreenManager::didCleanupFullscreen):
(WebKit::VideoFullscreenManager::setCurrentlyInFullscreen):
(WebKit::VideoFullscreenManager::setVideoLayerFrameFenced):
(WebKit::VideoFullscreenManager::logChannel const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a0e957a9528df9746ab47feb92ae9c840d48b54

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 🧪 win ](https://ews-build.webkit.org/#/builders/Windows-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-9-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5365 "Hash 8a0e957a for PR 7422 does not build (failure)") | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-9-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | | | | 
<!--EWS-Status-Bubble-End-->