### PR TITLE
HTMLImageElement width/height should update renderer first

### DIFF
--- a/LayoutTests/fast/images/img-dimensions-styled-expected.txt
+++ b/LayoutTests/fast/images/img-dimensions-styled-expected.txt
@@ -1,0 +1,13 @@
+Should used styled image dimensions if available.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS image.width is 200
+PASS image.height is 200
+PASS rect.width is 200
+PASS rect.height is 200
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/images/img-dimensions-styled.html
+++ b/LayoutTests/fast/images/img-dimensions-styled.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>HTMLImageElement.width/height returns styled dimensions.</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+    img {
+        width: 200px;
+        height: 200px;
+    }
+</style>
+<img src="resources/test-load.jpg" width="100" height="100">
+<script>
+test(function() {
+    var image = document.querySelector("img");
+    assert_equals(image.width, 200);
+    assert_equals(image.height, 200);
+    var rect = image.getBoundingClientRect();
+    assert_equals(rect.width, 200);
+    assert_equals(rect.height, 200);
+});
+</script>

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -1,8 +1,8 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2004-2016 Apple Inc. All rights reserved.
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -501,8 +501,11 @@ void HTMLImageElement::setPictureElement(HTMLPictureElement* pictureElement)
     m_pictureElement = pictureElement;
 }
     
-unsigned HTMLImageElement::width(bool ignorePendingStylesheets)
+unsigned HTMLImageElement::width()
 {
+    if (inRenderedDocument())
+        document().updateLayoutIgnorePendingStylesheets();
+
     if (!renderer()) {
         // check the attribute first for an explicit pixel value
         auto optionalWidth = parseHTMLNonNegativeInteger(attributeWithoutSynchronization(widthAttr));
@@ -514,11 +517,6 @@ unsigned HTMLImageElement::width(bool ignorePendingStylesheets)
             return m_imageLoader->image()->imageSizeForRenderer(renderer(), 1.0f).width().toUnsigned();
     }
 
-    if (ignorePendingStylesheets)
-        document().updateLayoutIgnorePendingStylesheets();
-    else
-        document().updateLayout();
-
     RenderBox* box = renderBox();
     if (!box)
         return 0;
@@ -526,8 +524,11 @@ unsigned HTMLImageElement::width(bool ignorePendingStylesheets)
     return adjustForAbsoluteZoom(snappedIntRect(contentRect).width(), *box);
 }
 
-unsigned HTMLImageElement::height(bool ignorePendingStylesheets)
+unsigned HTMLImageElement::height()
 {
+    if (inRenderedDocument())
+        document().updateLayoutIgnorePendingStylesheets();
+
     if (!renderer()) {
         // check the attribute first for an explicit pixel value
         auto optionalHeight = parseHTMLNonNegativeInteger(attributeWithoutSynchronization(heightAttr));
@@ -538,11 +539,6 @@ unsigned HTMLImageElement::height(bool ignorePendingStylesheets)
         if (m_imageLoader->image())
             return m_imageLoader->image()->imageSizeForRenderer(renderer(), 1.0f).height().toUnsigned();
     }
-
-    if (ignorePendingStylesheets)
-        document().updateLayoutIgnorePendingStylesheets();
-    else
-        document().updateLayout();
 
     RenderBox* box = renderBox();
     if (!box)

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -1,8 +1,8 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2004, 2008, 2010 Apple Inc. All rights reserved.
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -60,8 +60,8 @@ public:
 
     void formOwnerRemovedFromTree(const Node& formRoot);
 
-    WEBCORE_EXPORT unsigned width(bool ignorePendingStylesheets = false);
-    WEBCORE_EXPORT unsigned height(bool ignorePendingStylesheets = false);
+    WEBCORE_EXPORT unsigned width();
+    WEBCORE_EXPORT unsigned height();
 
     WEBCORE_EXPORT int naturalWidth() const;
     WEBCORE_EXPORT int naturalHeight() const;


### PR DESCRIPTION
<pre>
HTMLImageElement width/height should update renderer first
<a href="https://bugs.webkit.org/show_bug.cgi?id=249056">https://bugs.webkit.org/show_bug.cgi?id=249056</a>

Reviewed by NOBODY (OOPS!).

This patch is to align Webkit with Gecko / Firefox and Blink / Chromium.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/d3adbd3a3f1bcbebdf515ac15a8c250873a2a1d9">https://chromium.googlesource.com/chromium/blink/+/d3adbd3a3f1bcbebdf515ac15a8c250873a2a1d9</a>

HTMLImageElement::width/height were not updating layout first before checking for the
renderer, which means that we fall back to the attribute when we shouldn't. We're also
using the renderer method instead of updateLayoutIgnorePendingStylesheets which should be
used for all JS APIs. It also enabled us to remove unused bool.

We also make sure to check if we're in the document before causing a layout so checking
for a disconnected image's width/height before drawing to a canvas doesn't cause a sync layout.

* Source/WebCore/HTMLImageElement.h: Remove unused 'boolean'
* Source/WebCore/HTMLImageElement.cpp:
(HTMLImageElement::width): Update to account for renderer
(HTMLImageElement::height): Ditto
* LayoutTests/fast/image/img-dimensions-styled.html: Add Test Case
* LayoutTests/fast/image/img-dimensions-styled-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c92a7c0fe3b4ddfea261d2c0e5aa8894d5ec57b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109071 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169303 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Deleted stale build files; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); layout-tests (exception)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86174 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92169 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106979 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105479 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90651 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34105 "An unexpected error occured. Recent messages:Failed to print configuration; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception); Running set-build-summary") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22020 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2707 "Built successfully") | [💥 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23534 "An unexpected error occured. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2653 "Built successfully") | [💥 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45916 "An unexpected error occured. Recent messages:Cleaned up git repository; Running apply-patch; Checked out pull request; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43008 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4514 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->