### PR TITLE
[JSC] Should not assume content in scratch register

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1794,10 +1794,10 @@ VectorTrunc U:G:Ptr, U:F:128, D:F:128
 arm64: VectorTruncSat U:G:Ptr, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp
 
-x86_64: VectorSignedTruncSatF64 U:F:128, D:F:128, S:F:128, S:F:128
-    Tmp, Tmp, Tmp, Tmp
+x86_64: VectorTruncSatSignedFloat64 U:F:128, D:F:128, S:G:64, S:F:128, S:F:128
+    Tmp, Tmp, Tmp, Tmp, Tmp
 
-x86_64: VectorUnsignedTruncSatF64 U:F:128, D:F:128, S:F:128, S:F:128, S:F:128
+x86_64: VectorTruncSatUnsignedFloat64 U:F:128, D:F:128, S:G:64, S:F:128, S:F:128
     Tmp, Tmp, Tmp, Tmp, Tmp
 
 VectorConvert U:G:Ptr, U:F:128, D:F:128
@@ -1809,8 +1809,11 @@ x86_64: VectorConvertUnsigned U:F:128, D:F:128, S:F:128
 arm64: VectorConvertLow U:G:Ptr, U:F:64, D:F:128
     SIMDInfo, Tmp, Tmp
 
-x86_64: VectorConvertLow U:G:Ptr, U:F:64, D:F:128, S:F:128, S:F:128
-    SIMDInfo, Tmp, Tmp, Tmp, Tmp
+x86_64: VectorConvertLowSignedInt32 U:F:64, D:F:128
+    Tmp, Tmp
+
+x86_64: VectorConvertLowUnsignedInt32 U:F:64, D:F:128, S:G:64, S:F:128
+    Tmp, Tmp, Tmp, Tmp
 
 VectorNearest U:G:Ptr, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
@@ -578,48 +578,35 @@ public:
 
         result = tmpForType(Types::V128);
 
-        if (isX86() && airOp == B3::Air::VectorExtaddPairwise) {
-            if (info.lane == SIMDLane::i16x8 && info.signMode == SIMDSignMode::Unsigned)
-                append(VectorExtaddPairwiseUnsignedInt16, v, result, tmpForType(Types::V128), tmpForType(Types::V128));
-            else
-                append(airOp, Arg::simdInfo(info), v, result, tmpForType(Types::I64), tmpForType(Types::V128));
-            return { };
-        }
+        if (isX86()) {
+            if (airOp == B3::Air::VectorExtaddPairwise) {
+                if (info.lane == SIMDLane::i16x8 && info.signMode == SIMDSignMode::Unsigned)
+                    append(VectorExtaddPairwiseUnsignedInt16, v, result, tmpForType(Types::V128), tmpForType(Types::V128));
+                else
+                    append(airOp, Arg::simdInfo(info), v, result, tmpForType(Types::I64), tmpForType(Types::V128));
+                return { };
+            }
 
-        if (isX86() && airOp == B3::Air::VectorConvert && info.signMode == SIMDSignMode::Unsigned) {
-            append(VectorConvertUnsigned, v, result, tmpForType(Types::V128));
-            return { };
-        }
 
-        if (isX86() && airOp == B3::Air::VectorConvertLow) {
-            // https://github.com/WebAssembly/simd/pull/383
-            auto scratch1 = tmpForType(Types::V128);
-            uint64_t mask = bitwise_cast<uint64_t>(0x1.0p+52);
-            // Note: 0x43300000 is the high 32 bits of 0x1.0p+52.
-            uint64_t high32Bits = 0x43300000;
-            append(VectorSplat32, addConstant(Types::I32, high32Bits), scratch1);
-            auto scratch2 = tmpForType(Types::V128);
-            append(VectorSplatFloat64, addConstant(Types::F64, mask), scratch2);
-            append(airOp, Arg::simdInfo(info), v, result, scratch1, scratch2);
-            return { };
-        }
+            if (airOp == B3::Air::VectorConvert && info.signMode == SIMDSignMode::Unsigned) {
+                append(VectorConvertUnsigned, v, result, tmpForType(Types::V128));
+                return { };
+            }
 
-        if (isX86() && airOp == B3::Air::VectorTruncSat) {
-            if (info.lane == SIMDLane::f64x2) {
-                // https://github.com/WebAssembly/simd/pull/383
-                if (info.signMode == SIMDSignMode::Signed) {
-                    auto tmp = tmpForType(Types::V128);
-                    uint64_t mask = bitwise_cast<uint64_t>(2147483647.0);
-                    append(VectorSplatFloat64, addConstant(Types::F64, mask), tmp);
-                    append(VectorSignedTruncSatF64, v, result, tmp, tmpForType(Types::V128));
-                } else {
-                    auto tmp1 = tmpForType(Types::V128);
-                    uint64_t mask1 = bitwise_cast<uint64_t>(4294967295.0);
-                    append(VectorSplatFloat64, addConstant(Types::F64, mask1), tmp1);
-                    auto tmp2 = tmpForType(Types::V128);
-                    uint64_t mask2 = bitwise_cast<uint64_t>(0x1.0p+52);
-                    append(VectorSplatFloat64, addConstant(Types::F64, mask2), tmp2);
-                    append(VectorUnsignedTruncSatF64, v, result, tmp1, tmp2, tmpForType(Types::V128));
+            if (airOp == B3::Air::VectorConvertLow) {
+                if (info.signMode == SIMDSignMode::Signed)
+                    append(VectorConvertLowSignedInt32, v, result);
+                else
+                    append(VectorConvertLowUnsignedInt32, v, result, tmpForType(Types::I64), tmpForType(Types::V128));
+                return { };
+            }
+
+            if (airOp == B3::Air::VectorTruncSat) {
+                if (info.lane == SIMDLane::f64x2) {
+                    if (info.signMode == SIMDSignMode::Signed)
+                        append(VectorTruncSatSignedFloat64, v, result, tmpForType(Types::I64), tmpForType(Types::V128), tmpForType(Types::V128));
+                    else
+                        append(VectorTruncSatUnsignedFloat64, v, result, tmpForType(Types::I64), tmpForType(Types::V128), tmpForType(Types::V128));
                 }
                 return { };
             }


### PR DESCRIPTION
#### 4ced12722d5dbafd2245d6c624d539312dbc8969
<pre>
[JSC] Should not assume content in scratch register
<a href="https://bugs.webkit.org/show_bug.cgi?id=249059">https://bugs.webkit.org/show_bug.cgi?id=249059</a>
rdar://problem/103201987

Reviewed by Justin Michaud.

We should not assume content in scratch register in MacroAssembler.
This patch fixes it so that X86 MacroAssembler functions correctly
set up content inside it.
We also fix naming of some X86 MacroAssembler functions since they
are not aligned to MacroAssembler&apos;s DEFINE_SIGNED_SIMD_FUNCS rules.

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::vectorTruncSatSignedFloat64):
(JSC::MacroAssemblerX86_64::vectorTruncSatUnsignedFloat64):
(JSC::MacroAssemblerX86_64::vectorConvertLowUnsignedInt32):
(JSC::MacroAssemblerX86_64::vectorConvertLowSignedInt32):
(JSC::MacroAssemblerX86_64::vectorSignedTruncSatF64): Deleted.
(JSC::MacroAssemblerX86_64::vectorUnsignedTruncSatF64): Deleted.
(JSC::MacroAssemblerX86_64::vectorConvertLow): Deleted.
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::addSIMDV_V):

Canonical link: <a href="https://commits.webkit.org/257663@main">https://commits.webkit.org/257663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84cf490f3df3362fa420844b6b8e0708d3c19670

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8822 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/32725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109007 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9407 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/86110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105417 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/32725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/32725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90291 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/32725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86183 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2589 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/86110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28938 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/8727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/32725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89055 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2697 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4452 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19908 "Passed tests") | 
<!--EWS-Status-Bubble-End-->