### PR TITLE
Fix use-after-free in WebCore::StyleGradientImage constructor

### DIFF
--- a/Source/WebCore/rendering/style/StyleGradientImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGradientImage.cpp
@@ -113,7 +113,7 @@ StyleGradientImage::StyleGradientImage(Data&& data, CSSGradientColorInterpolatio
     , m_data { WTFMove(data) }
     , m_colorInterpolationMethod { colorInterpolationMethod }
     , m_stops { WTFMove(stops) }
-    , m_knownCacheableBarringFilter { stopsAreCacheable(stops) }
+    , m_knownCacheableBarringFilter { stopsAreCacheable(m_stops) }
 {
 }
 


### PR DESCRIPTION
#### 40f4e5e1facea60ca8d6e709d3c5d9d97a33e105
<pre>
Fix use-after-free in WebCore::StyleGradientImage constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=249061">https://bugs.webkit.org/show_bug.cgi?id=249061</a>
&lt;rdar://103202572&gt;

Reviewed by Sam Weinig.

Fix use-after-move by replacing `stops` with `m_stops` when
calling stopsAreCacheable() to initialize
`m_knownCacheableBarringFilter`.

* Source/WebCore/rendering/style/StyleGradientImage.cpp:
(WebCore::StyleGradientImage::StyleGradientImage):

Canonical link: <a href="https://commits.webkit.org/257686@main">https://commits.webkit.org/257686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/203eb78b0d5c9383d8817f915bc109025de679c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109008 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169240 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86111 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92110 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106916 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90606 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34051 "An unexpected error occured. Recent messages:Failed to print configuration; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88904 "Passed tests") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21963 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2646 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23477 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45865 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42951 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4453 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2710 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->