### PR TITLE
Fix ordering when calling requestFullscreen inside a frame

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-ready-allowed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-ready-allowed-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Element ready check with enabled flag not set assert_unreached: iframe fullscreenchange event Reached unreachable code
+FAIL Element ready check with enabled flag not set assert_unreached: document fullscreenchange event Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-and-exit-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-and-exit-iframe-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Checks that the fullscreenchange events fire in right order when entering fullscreen assert_equals: expected Element node <iframe allowfullscreen="" src="about:blank"></iframe> but got Element node <body></body>
+PASS Checks that the fullscreenchange events fire in right order when entering fullscreen
 PASS Checks that the fullscreenchange events fire in right order when exiting fullscreen
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-timing-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-timing-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL Timing of fullscreenchange and resize events promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Timing of fullscreenerror event assert_unreached: timer callback Reached unreachable code
+PASS Timing of fullscreenerror event
 


### PR DESCRIPTION
#### 1e45867f3dc4e1b81a17ef2fe037c531106507e2
<pre>
Fix ordering when calling requestFullscreen inside a frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=249067">https://bugs.webkit.org/show_bug.cgi?id=249067</a>
rdar://103206507

Reviewed by Ryosuke Niwa.

- Queue events in tree order when entering fullscreen
- Add to top layer should always add at the end of the top layer

* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-ready-allowed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-and-exit-iframe-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-timing-expected.txt:
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::willEnterFullscreen):

Canonical link: <a href="https://commits.webkit.org/257673@main">https://commits.webkit.org/257673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a29c44051dc923ea56d6dfe8bb1f1d18aee3ae9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99662 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/8839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109024 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169255 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/103666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9425 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/86128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105434 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/2607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/8744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/42965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2703 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->