### PR TITLE
[ews-build.webkit.org] Use twisted defer when communicating with results.webkit.org (Follow-up)

### DIFF
--- a/Tools/CISupport/ews-build/results_db.py
+++ b/Tools/CISupport/ews-build/results_db.py
@@ -97,7 +97,7 @@ class ResultsDatabase(object):
                 data = yield finished
                 defer.returnValue(json.loads(data))
             else:
-                logger(f'Failed to query results summary with status code {response.status_code}\n')
+                logger(f'Failed to query results summary with status code {response.code}\n')
                 defer.returnValue({})
         except error.ConnectError as e:
             logger(f'Failed to connect to {cls.HOSTNAME}: {e}\n')


### PR DESCRIPTION
#### 0504683ee79c985c82ae7bb6641ff930221ae40a
<pre>
[ews-build.webkit.org] Use twisted defer when communicating with results.webkit.org (Follow-up)
<a href="https://bugs.webkit.org/show_bug.cgi?id=249026">https://bugs.webkit.org/show_bug.cgi?id=249026</a>
rdar://103184263

Unreviewed follow-up fix.

* Tools/CISupport/ews-build/results_db.py:
(ResultsDatabase.get_results_summary): Log response.code instead of response.status_code.

Canonical link: <a href="https://commits.webkit.org/257674@main">https://commits.webkit.org/257674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/194064a506dfaefbd84daf3a368c279656388db8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109021 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169252 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86125 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92120 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106929 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105431 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2659 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/98590 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2604 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8741 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/42962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2704 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4466 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->