### PR TITLE
Implement fullscreen rendering update step

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6312,17 +6312,7 @@ imported/w3c/web-platform-tests/fetch/sec-metadata/redirect/multiple-redirect-sa
 imported/w3c/web-platform-tests/fetch/sec-metadata/redirect/same-origin-redirect.tentative.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/sec-metadata/track.tentative.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/sec-metadata/window-open.tentative.https.sub.html [ Skip ]
-imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-svg-rect.html [ Skip ]
-imported/w3c/web-platform-tests/fullscreen/model/move-to-inactive-document.html [ Skip ]
-imported/w3c/web-platform-tests/fullscreen/model/move-to-fullscreen-iframe.html [ Skip ]
-imported/w3c/web-platform-tests/fullscreen/model/move-to-iframe.html [ Skip ]
-imported/w3c/web-platform-tests/fullscreen/model/remove-last.html [ Skip ]
-imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-size.html [ Skip ]
-imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-scroll.html [ Skip ]
-imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html [ Skip ]
-imported/w3c/web-platform-tests/fullscreen/rendering/ua-style-iframe.html [ Skip ]
 imported/w3c/web-platform-tests/fullscreen/api/element-ready-check-not-allowed-cross-origin.sub.html [ Skip ]
-imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-and-move-to-iframe.html [ Skip ]
 imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-cross-origin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-timing.html [ Skip ]
 imported/w3c/web-platform-tests/geolocation/non-fully-active.https.html [ Skip ]
@@ -6440,6 +6430,10 @@ imported/w3c/web-platform-tests/workers/modules/shared-worker-import-data-url-cr
 imported/w3c/web-platform-tests/workers/modules/shared-worker-import-data-url.window.html [ Skip ]
 imported/w3c/web-platform-tests/workers/modules/shared-worker-options-credentials.html [ Skip ]
 imported/w3c/web-platform-tests/xhr/send-after-setting-document-domain.htm [ Skip ]
+
+# This test needs proper promise handling in fullscreen to avoid the flaky console message:
+imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-subframe-same-origin.https.tentative.html [ Pass Failure ]
+imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-and-move-to-iframe.html [ Pass Failure ]
 
 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h264_annexb [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h264_avc [ DumpJSConsoleLogInStdErr ]

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-ready-allowed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-ready-allowed-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Element ready check with enabled flag not set assert_unreached: document fullscreenchange event Reached unreachable code
+PASS Element ready check with enabled flag not set
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-and-move-to-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-and-move-to-iframe-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Element#requestFullscreen() followed by moving the element into an iframe Test timed out
+PASS Element#requestFullscreen() followed by moving the element into an iframe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-namespaces-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-namespaces-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL requestFullscreen() fails for an element in null namespace assert_unreached: fullscreenchange event Reached unreachable code
+FAIL requestFullscreen() fails for an element in null namespace assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL requestFullscreen() fails for an element in https://unknown.namespace namespace promise_rejects_js: function "function() { throw e }" threw object "Error: element click intercepted error" ("Error") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-svg-rect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-svg-rect-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Element#requestFullscreen() for SVG rect element assert_unreached: Should have rejected: undefined Reached unreachable code
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/move-to-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/move-to-iframe-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Move the fullscreen element to another document Test timed out
+PASS Move the fullscreen element to another document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/move-to-inactive-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/move-to-inactive-document-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Move the fullscreen element to an inactive document Test timed out
+PASS Move the fullscreen element to an inactive document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/remove-first-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/remove-first-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Remove the first element on the fullscreen element stack assert_equals: expected Document node with 2 children but got Element node <html><head><title>Remove the first element on the fullsc...
+PASS Remove the first element on the fullscreen element stack
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/remove-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/remove-last-expected.txt
@@ -1,0 +1,5 @@
+
+FAIL Remove the last element on the fullscreen element stack assert_equals: expected Document node with 2 children but got Element node <div id="first">
+
+</div>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/remove-parent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/remove-parent-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Remove the parent of the fullscreen element assert_equals: expected Document node with 2 children but got Element node <html><head><title>Remove the parent of the fullscreen el...
+PASS Remove the parent of the fullscreen element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT :fullscreen pseudo-class Test timed out
+PASS :fullscreen pseudo-class
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-scroll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-scroll-expected.txt
@@ -1,6 +1,4 @@
 This page tests that entering fullscreen doesn't adjust the scroll offset
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT fullscreen root block scrolling Test timed out
+PASS fullscreen root block scrolling
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-size-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT fullscreen root block sizing Test timed out
+PASS fullscreen root block sizing
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/ua-style-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/ua-style-iframe-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT User-agent levels style sheet defaults for iframe Test timed out
+PASS User-agent levels style sheet defaults for iframe
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-and-move-to-iframe-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-and-move-to-iframe-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Cannot request fullscreen because the associated document has changed.
+
+PASS Element#requestFullscreen() followed by moving the element into an iframe
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-timing-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-timing-expected.txt
@@ -1,4 +1,0 @@
-
-FAIL Timing of fullscreenchange and resize events promise_test: Unhandled rejection with value: object "TypeError: Type error"
-PASS Timing of fullscreenerror event
-

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2151,7 +2151,7 @@ void Page::updateRendering()
     });
 
     runProcessingStep(RenderingUpdateStep::MediaQueryEvaluation, [] (Document& document) {
-        document.evaluateMediaQueriesAndReportChanges();        
+        document.evaluateMediaQueriesAndReportChanges();
     });
 
     // FIXME: This suppression shouldn't be needed.
@@ -2163,8 +2163,13 @@ void Page::updateRendering()
         document.updateAnimationsAndSendEvents();
     });
 
-    // FIXME: Run the fullscreen steps.
+#if ENABLE(FULLSCREEN_API)
+    runProcessingStep(RenderingUpdateStep::Fullscreen, [] (Document& document) {
+        document.fullscreenManager().dispatchPendingEvents();
+    });
+#else
     m_renderingUpdateRemainingSteps.last().remove(RenderingUpdateStep::Fullscreen);
+#endif
 
     runProcessingStep(RenderingUpdateStep::VideoFrameCallbacks, [] (Document& document) {
         document.serviceRequestVideoFrameCallbacks();

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1199,18 +1199,6 @@ bool Quirks::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFull
 #endif
 }
 
-// bbc.com: rdar://108304377
-bool Quirks::shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk() const
-{
-#if ENABLE(VIDEO_PRESENTATION_MODE)
-    // This quirk delay the "webkitstartfullscreen" and "fullscreenchange" event when a video exits picture-in-picture
-    // to fullscreen.
-    return needsQuirks() && m_quirksData.shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk;
-#else
-    return false;
-#endif
-}
-
 // teams.live.com rdar://88678598
 // teams.microsoft.com rdar://90434296
 bool Quirks::shouldAllowNavigationToCustomProtocolWithoutUserGesture(StringView protocol, const SecurityOriginData& requesterOrigin)
@@ -2242,13 +2230,6 @@ static void handleBBCQuirks(QuirksData& quirksData, const URL& quirksURL, const 
         // bbc.co.uk rdar://126494734
         quirksData.returnNullPictureInPictureElementDuringFullscreenChangeQuirk = true;
     }
-
-#if ENABLE(VIDEO_PRESENTATION_MODE)
-    if (quirksDomainString == "bbc.com"_s) {
-        // bbc.com rdar://108304377
-        quirksData.shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk = true;
-    }
-#endif
 }
 
 static void handleBankOfAmericaQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -160,7 +160,6 @@ public:
     WEBCORE_EXPORT bool blocksReturnToFullscreenFromPictureInPictureQuirk() const;
     WEBCORE_EXPORT bool blocksEnteringStandardFullscreenFromPictureInPictureQuirk() const;
     bool shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk() const;
-    bool shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk() const;
 
     static bool isMicrosoftTeamsRedirectURL(const URL&);
     static bool hasStorageAccessForAllLoginDomains(const HashSet<RegistrableDomain>&, const RegistrableDomain&);

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -174,7 +174,6 @@ struct WEBCORE_EXPORT QuirksData {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     bool requiresUserGestureToLoadInPictureInPictureQuirk { false };
     bool requiresUserGestureToPauseInPictureInPictureQuirk { false };
-    bool shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk { false };
     bool shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk { false };
 #endif
 };


### PR DESCRIPTION
#### cba51d14a79420eea435792f37f3e379bc523bb9
<pre>
Implement fullscreen rendering update step
<a href="https://bugs.webkit.org/show_bug.cgi?id=249069">https://bugs.webkit.org/show_bug.cgi?id=249069</a>
<a href="https://rdar.apple.com/103209495">rdar://103209495</a>

Reviewed by Alex Christensen.

Event dispatching should be done by the rendering update steps.

<a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a>
<a href="https://fullscreen.spec.whatwg.org/#run-the-fullscreen-steps">https://fullscreen.spec.whatwg.org/#run-the-fullscreen-steps</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-ready-allowed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-namespaces-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/move-to-iframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/model/move-to-inactive-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-scroll-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/ua-style-iframe-expected.txt:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-and-move-to-iframe-expected.txt: Added.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-timing-expected.txt: Removed.
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):
(WebCore::FullscreenManager::willEnterFullscreen):
(WebCore::FullscreenManager::didExitFullscreen):
(WebCore::FullscreenManager::resolvePendingPromise):
(WebCore::FullscreenManager::rejectPendingPromise):
(WebCore::FullscreenManager::dispatchPendingEvents):
(WebCore::FullscreenManager::notifyAboutFullscreenChangeOrError): Deleted.
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):
* Source/WebCore/page/Quirks.cpp:
(WebCore::handleBBCQuirks):
(WebCore::Quirks::shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk const): Deleted.
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/289984@main">https://commits.webkit.org/289984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d8a74aee590c903beb1ead43db553e26d44efc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93566 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39360 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16309 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68316 "Found 2 new test failures: fullscreen/full-screen-enter-while-exiting.html media/media-fullscreen-not-in-document.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26026 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48680 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6278 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38468 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76647 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95406 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15781 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77186 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76458 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18825 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20845 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19272 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8820 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15797 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15538 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17320 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->