### PR TITLE
[JSC] Make X86Assembler AVX functions consistent

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -1570,7 +1570,7 @@ public:
     void addDouble(Address op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vaddsd_mr(op1.offset, op1.base, op2, dest);
+            m_assembler.vaddsd_mrr(op1.offset, op1.base, op2, dest);
         else {
             if (op2 == dest) {
                 m_assembler.addsd_mr(op1.offset, op1.base, dest);
@@ -1590,7 +1590,7 @@ public:
     void addDouble(BaseIndex op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vaddsd_mr(op1.offset, op1.base, op1.index, op1.scale, op2, dest);
+            m_assembler.vaddsd_mrr(op1.offset, op1.base, op1.index, op1.scale, op2, dest);
         else {
             if (op2 == dest) {
                 m_assembler.addsd_mr(op1.offset, op1.base, op1.index, op1.scale, dest);
@@ -1628,7 +1628,7 @@ public:
     void addFloat(Address op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vaddss_mr(op1.offset, op1.base, op2, dest);
+            m_assembler.vaddss_mrr(op1.offset, op1.base, op2, dest);
         else {
             if (op2 == dest) {
                 m_assembler.addss_mr(op1.offset, op1.base, dest);
@@ -1648,7 +1648,7 @@ public:
     void addFloat(BaseIndex op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vaddss_mr(op1.offset, op1.base, op1.index, op1.scale, op2, dest);
+            m_assembler.vaddss_mrr(op1.offset, op1.base, op1.index, op1.scale, op2, dest);
         else {
             if (op2 == dest) {
                 m_assembler.addss_mr(op1.offset, op1.base, op1.index, op1.scale, dest);
@@ -1696,7 +1696,7 @@ public:
     void subDouble(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vsubsd_rrr(op1, op2, dest);
+            m_assembler.vsubsd_rrr(op2, op1, dest);
         else {
             // B := A - B is invalid.
             ASSERT(op1 == dest || op2 != dest);
@@ -1708,7 +1708,7 @@ public:
     void subDouble(FPRegisterID op1, Address op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vsubsd_mr(op1, op2.offset, op2.base, dest);
+            m_assembler.vsubsd_mrr(op2.offset, op2.base, op1, dest);
         else {
             moveDouble(op1, dest);
             m_assembler.subsd_mr(op2.offset, op2.base, dest);
@@ -1718,7 +1718,7 @@ public:
     void subDouble(FPRegisterID op1, BaseIndex op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vsubsd_mr(op1, op2.offset, op2.base, op2.index, op2.scale, dest);
+            m_assembler.vsubsd_mrr(op2.offset, op2.base, op2.index, op2.scale, op1, dest);
         else {
             moveDouble(op1, dest);
             m_assembler.subsd_mr(op2.offset, op2.base, op2.index, op2.scale, dest);
@@ -1738,7 +1738,7 @@ public:
     void subFloat(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vsubss_rrr(op1, op2, dest);
+            m_assembler.vsubss_rrr(op2, op1, dest);
         else {
             // B := A - B is invalid.
             ASSERT(op1 == dest || op2 != dest);
@@ -1750,7 +1750,7 @@ public:
     void subFloat(FPRegisterID op1, Address op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vsubss_mr(op1, op2.offset, op2.base, dest);
+            m_assembler.vsubss_mrr(op2.offset, op2.base, op1, dest);
         else {
             moveDouble(op1, dest);
             m_assembler.subss_mr(op2.offset, op2.base, dest);
@@ -1760,7 +1760,7 @@ public:
     void subFloat(FPRegisterID op1, BaseIndex op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vsubss_mr(op1, op2.offset, op2.base, op2.index, op2.scale, dest);
+            m_assembler.vsubss_mrr(op2.offset, op2.base, op2.index, op2.scale, op1, dest);
         else {
             moveDouble(op1, dest);
             m_assembler.subss_mr(op2.offset, op2.base, op2.index, op2.scale, dest);
@@ -1799,7 +1799,7 @@ public:
     void mulDouble(Address op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vmulsd_mr(op1.offset, op1.base, op2, dest);
+            m_assembler.vmulsd_mrr(op1.offset, op1.base, op2, dest);
         else {
             if (op2 == dest) {
                 m_assembler.mulsd_mr(op1.offset, op1.base, dest);
@@ -1818,7 +1818,7 @@ public:
     void mulDouble(BaseIndex op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vmulsd_mr(op1.offset, op1.base, op1.index, op1.scale, op2, dest);
+            m_assembler.vmulsd_mrr(op1.offset, op1.base, op1.index, op1.scale, op2, dest);
         else {
             if (op2 == dest) {
                 m_assembler.mulsd_mr(op1.offset, op1.base, op1.index, op1.scale, dest);
@@ -1856,7 +1856,7 @@ public:
     void mulFloat(Address op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vmulss_mr(op1.offset, op1.base, op2, dest);
+            m_assembler.vmulss_mrr(op1.offset, op1.base, op2, dest);
         else {
             if (op2 == dest) {
                 m_assembler.mulss_mr(op1.offset, op1.base, dest);
@@ -1875,7 +1875,7 @@ public:
     void mulFloat(BaseIndex op1, FPRegisterID op2, FPRegisterID dest)
     {
         if (supportsAVX())
-            m_assembler.vmulss_mr(op1.offset, op1.base, op1.index, op1.scale, op2, dest);
+            m_assembler.vmulss_mrr(op1.offset, op1.base, op1.index, op1.scale, op2, dest);
         else {
             if (op2 == dest) {
                 m_assembler.mulss_mr(op1.offset, op1.base, op1.index, op1.scale, dest);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -2891,7 +2891,7 @@ public:
         m_assembler.vmaxpd_rrr(scratch1FPR, src, dest);
         loadVector(Address(scratchGPR), scratch2FPR);
         m_assembler.vminpd_rrr(scratch2FPR, dest, dest);
-        m_assembler.vroundpd_rr(0x0B, dest, dest);
+        m_assembler.vroundpd_rr(dest, dest, RoundingType::TowardZero);
         loadVector(Address(scratchGPR, sizeof(double) * 2), scratch2FPR);
         m_assembler.vaddpd_rrr(scratch2FPR, dest, dest);
         m_assembler.vshufps_rrr(0x88, scratch1FPR, dest, dest);
@@ -3153,6 +3153,7 @@ public:
             m_assembler.vpsrad_rrr(shift, input, dest);
             break;
         case SIMDLane::i64x2:
+            // FIXME: This is AVX-512, and not implemented correctly right now.
             m_assembler.vpsraq_rrr(shift, input, dest);
             break;
         default:


### PR DESCRIPTION
#### 24087b31f152b74021e14e012d494ce2d855e0fd
<pre>
[JSC] Make X86Assembler AVX functions consistent
<a href="https://bugs.webkit.org/show_bug.cgi?id=249070">https://bugs.webkit.org/show_bug.cgi?id=249070</a>
rdar://103211117

Reviewed by Mark Lam.

This patch makes all AVX functions in X86Assembler consistent and clean.

1. It should be AT&amp;T style.
2. Not use raw method. Always use high-level method for defining code.
3. Add appropriate information of enconding.
4. Add comment about AVX instruction encoding.
5. AVX functions are consolidated into one place.
6. Fixed many arithmetic operations wrongly using commutative version of AVX generation function.

* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h:
(JSC::MacroAssemblerX86Common::subDouble):
(JSC::MacroAssemblerX86Common::subFloat):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::vectorTruncSatUnsignedFloat64):
(JSC::MacroAssemblerX86_64::vectorSshr):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::psubd_rr):
(JSC::X86Assembler::movl_rr):
(JSC::X86Assembler::movl_rm):
(JSC::X86Assembler::movl_rm_disp32):
(JSC::X86Assembler::movl_mEAX):
(JSC::X86Assembler::addss_rr):
(JSC::X86Assembler::addss_mr):
(JSC::X86Assembler::addsd_mr):
(JSC::X86Assembler::cvtsi2sd_rr):
(JSC::X86Assembler::cvtsi2ss_rr):
(JSC::X86Assembler::cvtsi2sdq_rr):
(JSC::X86Assembler::cvtsi2ssq_rr):
(JSC::X86Assembler::cvtsi2sdq_mr):
(JSC::X86Assembler::cvtsi2ssq_mr):
(JSC::X86Assembler::cvtsi2sd_mr):
(JSC::X86Assembler::cvtsi2ss_mr):
(JSC::X86Assembler::cvttsd2si_rr):
(JSC::X86Assembler::cvttss2si_rr):
(JSC::X86Assembler::cvttss2siq_rr):
(JSC::X86Assembler::cvtsd2ss_rr):
(JSC::X86Assembler::cvtsd2ss_mr):
(JSC::X86Assembler::cvtss2sd_rr):
(JSC::X86Assembler::cvtss2sd_mr):
(JSC::X86Assembler::cvttsd2siq_rr):
(JSC::X86Assembler::movd_rr):
(JSC::X86Assembler::movddup_rr):
(JSC::X86Assembler::movmskpd_rr):
(JSC::X86Assembler::movq_rr):
(JSC::X86Assembler::movapd_rr):
(JSC::X86Assembler::movaps_rr):
(JSC::X86Assembler::movhlps_rr):
(JSC::X86Assembler::movsd_rr):
(JSC::X86Assembler::movsd_rm):
(JSC::X86Assembler::movss_rm):
(JSC::X86Assembler::movsd_mr):
(JSC::X86Assembler::movss_mr):
(JSC::X86Assembler::movshdup_rr):
(JSC::X86Assembler::movsldup_rr):
(JSC::X86Assembler::mulsd_rr):
(JSC::X86Assembler::mulsd_mr):
(JSC::X86Assembler::mulss_rr):
(JSC::X86Assembler::mulss_mr):
(JSC::X86Assembler::pextrw_irr):
(JSC::X86Assembler::psllq_i8r):
(JSC::X86Assembler::psrld_i8r):
(JSC::X86Assembler::psrlq_i8r):
(JSC::X86Assembler::por_rr):
(JSC::X86Assembler::subsd_rr):
(JSC::X86Assembler::subsd_mr):
(JSC::X86Assembler::subss_rr):
(JSC::X86Assembler::subss_mr):
(JSC::X86Assembler::ucomisd_rr):
(JSC::X86Assembler::ucomisd_mr):
(JSC::X86Assembler::ucomiss_rr):
(JSC::X86Assembler::ucomiss_mr):
(JSC::X86Assembler::divsd_rr):
(JSC::X86Assembler::divsd_mr):
(JSC::X86Assembler::divss_rr):
(JSC::X86Assembler::divss_mr):
(JSC::X86Assembler::andps_rr):
(JSC::X86Assembler::orps_rr):
(JSC::X86Assembler::xorps_rr):
(JSC::X86Assembler::xorpd_rr):
(JSC::X86Assembler::andnpd_rr):
(JSC::X86Assembler::sqrtsd_rr):
(JSC::X86Assembler::sqrtsd_mr):
(JSC::X86Assembler::sqrtss_rr):
(JSC::X86Assembler::sqrtss_mr):
(JSC::X86Assembler::roundss_rr):
(JSC::X86Assembler::roundss_mr):
(JSC::X86Assembler::roundsd_rr):
(JSC::X86Assembler::roundsd_mr):
(JSC::X86Assembler::int3):
(JSC::X86Assembler::isInt3):
(JSC::X86Assembler::ret):
(JSC::X86Assembler::predictNotTaken):
(JSC::X86Assembler::lock):
(JSC::X86Assembler::gs):
(JSC::X86Assembler::cmpxchgb_rm):
(JSC::X86Assembler::cmpxchgw_rm):
(JSC::X86Assembler::cmpxchgl_rm):
(JSC::X86Assembler::cmpxchgq_rm):
(JSC::X86Assembler::xaddb_rm):
(JSC::X86Assembler::xaddw_rm):
(JSC::X86Assembler::xaddl_rm):
(JSC::X86Assembler::xaddq_rm):
(JSC::X86Assembler::lfence):
(JSC::X86Assembler::mfence):
(JSC::X86Assembler::sfence):
(JSC::X86Assembler::rdtsc):
(JSC::X86Assembler::pause):
(JSC::X86Assembler::cpuid):
(JSC::X86Assembler::vunpcklps_rrr):
(JSC::X86Assembler::vpextrb_rr):
(JSC::X86Assembler::vpextrw_rr):
(JSC::X86Assembler::vpextrd_rr):
(JSC::X86Assembler::vpextrq_rr):
(JSC::X86Assembler::vpshufb_rrr):
(JSC::X86Assembler::vshufps_rrr):
(JSC::X86Assembler::vpaddsb_rrr):
(JSC::X86Assembler::vpaddusb_rrr):
(JSC::X86Assembler::vpaddsw_rrr):
(JSC::X86Assembler::vpaddusw_rrr):
(JSC::X86Assembler::vpsubsb_rrr):
(JSC::X86Assembler::vpsubusb_rrr):
(JSC::X86Assembler::vpsubsw_rrr):
(JSC::X86Assembler::vpsubusw_rrr):
(JSC::X86Assembler::vpmaxsb_rrr):
(JSC::X86Assembler::vpmaxsw_rrr):
(JSC::X86Assembler::vpmaxsd_rrr):
(JSC::X86Assembler::vpmaxub_rrr):
(JSC::X86Assembler::vpmaxuw_rrr):
(JSC::X86Assembler::vpmaxud_rrr):
(JSC::X86Assembler::vpminsb_rrr):
(JSC::X86Assembler::vpminsw_rrr):
(JSC::X86Assembler::vpminsd_rrr):
(JSC::X86Assembler::vpminub_rrr):
(JSC::X86Assembler::vpminuw_rrr):
(JSC::X86Assembler::vpminud_rrr):
(JSC::X86Assembler::vpavgb_rrr):
(JSC::X86Assembler::vpavgw_rrr):
(JSC::X86Assembler::vpabsb_rr):
(JSC::X86Assembler::vpabsw_rr):
(JSC::X86Assembler::vpabsd_rr):
(JSC::X86Assembler::vpxor_rrr):
(JSC::X86Assembler::vpsubq_rrr):
(JSC::X86Assembler::vblendvpd_rrrr):
(JSC::X86Assembler::vpmulhrsw_rrr):
(JSC::X86Assembler::vaddps_rrr):
(JSC::X86Assembler::vaddpd_rrr):
(JSC::X86Assembler::vpaddb_rrr):
(JSC::X86Assembler::vpaddw_rrr):
(JSC::X86Assembler::vpaddd_rrr):
(JSC::X86Assembler::vpaddq_rrr):
(JSC::X86Assembler::vsubps_rrr):
(JSC::X86Assembler::vsubpd_rrr):
(JSC::X86Assembler::vpsubb_rrr):
(JSC::X86Assembler::vpsubw_rrr):
(JSC::X86Assembler::vpsubd_rrr):
(JSC::X86Assembler::vmulps_rrr):
(JSC::X86Assembler::vmulpd_rrr):
(JSC::X86Assembler::vpmullw_rrr):
(JSC::X86Assembler::vpmulld_rrr):
(JSC::X86Assembler::vdivps_rrr):
(JSC::X86Assembler::vdivpd_rrr):
(JSC::X86Assembler::vroundps_rr):
(JSC::X86Assembler::vroundpd_rr):
(JSC::X86Assembler::vpmaddwd_rrr):
(JSC::X86Assembler::vpcmpeqb_rrr):
(JSC::X86Assembler::vpcmpeqw_rrr):
(JSC::X86Assembler::vpcmpeqd_rrr):
(JSC::X86Assembler::vpcmpeqq_rrr):
(JSC::X86Assembler::vpcmpgtb_rrr):
(JSC::X86Assembler::vpcmpgtw_rrr):
(JSC::X86Assembler::vpcmpgtd_rrr):
(JSC::X86Assembler::vpcmpgtq_rrr):
(JSC::X86Assembler::vcmpps_rrr):
(JSC::X86Assembler::vcmppd_rrr):
(JSC::X86Assembler::vcvtdq2ps_rr):
(JSC::X86Assembler::vcvtdq2pd_rr):
(JSC::X86Assembler::vmaxpd_rrr):
(JSC::X86Assembler::vminpd_rrr):
(JSC::X86Assembler::vcmpeqpd_rrr):
(JSC::X86Assembler::vcvttpd2dq_rr):
(JSC::X86Assembler::vcvtpd2ps_rr):
(JSC::X86Assembler::vcvtps2pd_rr):
(JSC::X86Assembler::vpacksswb_rrr):
(JSC::X86Assembler::vpackuswb_rrr):
(JSC::X86Assembler::vpackssdw_rrr):
(JSC::X86Assembler::vpackusdw_rrr):
(JSC::X86Assembler::vpmovsxbw):
(JSC::X86Assembler::vpmovzxbw):
(JSC::X86Assembler::vpmovsxwd):
(JSC::X86Assembler::vpmovzxwd):
(JSC::X86Assembler::vpmovsxdq):
(JSC::X86Assembler::vpmovzxdq):
(JSC::X86Assembler::vupckhpd):
(JSC::X86Assembler::vandps_rrr):
(JSC::X86Assembler::vandpd_rrr):
(JSC::X86Assembler::vorps_rrr):
(JSC::X86Assembler::vorpd_rrr):
(JSC::X86Assembler::vxorps_rrr):
(JSC::X86Assembler::vxorpd_rrr):
(JSC::X86Assembler::vandnps_rrr):
(JSC::X86Assembler::vandnpd_rrr):
(JSC::X86Assembler::vpmovmskb_rr):
(JSC::X86Assembler::vmovmskps_rr):
(JSC::X86Assembler::vmovmskpd_rr):
(JSC::X86Assembler::vptest_rr):
(JSC::X86Assembler::vpsllw_rrr):
(JSC::X86Assembler::vpslld_rrr):
(JSC::X86Assembler::vpsllq_rrr):
(JSC::X86Assembler::vpsrlw_rrr):
(JSC::X86Assembler::vpsrld_rrr):
(JSC::X86Assembler::vpsrlq_rrr):
(JSC::X86Assembler::vpsraw_rrr):
(JSC::X86Assembler::vpsrad_rrr):
(JSC::X86Assembler::vpsraq_rrr):
(JSC::X86Assembler::vmovdqa_rr):
(JSC::X86Assembler::vpmaddubsw_rrr):
(JSC::X86Assembler::vpsrld_i8rr):
(JSC::X86Assembler::vpblendw_i8rrr):
(JSC::X86Assembler::vaddsd_rrr):
(JSC::X86Assembler::vaddsd_mr):
(JSC::X86Assembler::vaddss_rrr):
(JSC::X86Assembler::vaddss_mr):
(JSC::X86Assembler::vmovups_mr):
(JSC::X86Assembler::vmovups_rm):
(JSC::X86Assembler::vmulsd_rrr):
(JSC::X86Assembler::vmulsd_mr):
(JSC::X86Assembler::vmulss_rrr):
(JSC::X86Assembler::vmulss_mr):
(JSC::X86Assembler::vsubsd_rrr):
(JSC::X86Assembler::vsubsd_mrr):
(JSC::X86Assembler::vsubss_rrr):
(JSC::X86Assembler::vsubss_mrr):
(JSC::X86Assembler::X86InstructionFormatter::SingleInstructionBufferWriter::memoryModRM):
(JSC::X86Assembler::vsubsd_mr): Deleted.
(JSC::X86Assembler::vsubss_mr): Deleted.

Canonical link: <a href="https://commits.webkit.org/257718@main">https://commits.webkit.org/257718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f954edca375fbb512974452af2ab83f3dbbe7c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/99815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/8995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32903 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/109181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/9772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/86285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/105582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/9772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/9772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90460 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86349 "Failed to checkout and rebase branch from PR 7436") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/2756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/86285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/38/builds/86349 "Failed to checkout and rebase branch from PR 7436") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/8891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89229 "Failed to checkout and rebase branch from PR 7436") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2716 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/37/builds/89229 "Failed to checkout and rebase branch from PR 7436") | 
<!--EWS-Status-Bubble-End-->