### PR TITLE
Make RenderText::absoluteQuadsForRange to consider leading/trailing whitespaces

### DIFF
--- a/LayoutTests/fast/dom/Range/getClientRects-leading-trailing-whitespaces-expected.txt
+++ b/LayoutTests/fast/dom/Range/getClientRects-leading-trailing-whitespaces-expected.txt
@@ -1,0 +1,5 @@
+abc
+
+PASS leading whitespaces
+PASS trailing whitespaces
+

--- a/LayoutTests/fast/dom/Range/getClientRects-leading-trailing-whitespaces.html
+++ b/LayoutTests/fast/dom/Range/getClientRects-leading-trailing-whitespaces.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<div id="target">   abc   </div>
+<div id="log"></div>
+<script>
+var target = document.getElementById('target').firstChild;
+function clientRectLeftOfNodeOffsetAt(offset) {
+    var range = document.createRange();
+    range.setStart(target, offset);
+    var rects = range.getClientRects();
+    return rects.length ? rects[0].left : 'no rects';
+}
+test(function() {
+    assert_equals(clientRectLeftOfNodeOffsetAt(0), clientRectLeftOfNodeOffsetAt(3), '0');
+    assert_equals(clientRectLeftOfNodeOffsetAt(1), clientRectLeftOfNodeOffsetAt(3), '1');
+    assert_equals(clientRectLeftOfNodeOffsetAt(2), clientRectLeftOfNodeOffsetAt(3), '2');
+}, 'leading whitespaces');
+
+test(function() {
+    assert_greater_than(clientRectLeftOfNodeOffsetAt(6), clientRectLeftOfNodeOffsetAt(5), '6');
+    assert_equals(clientRectLeftOfNodeOffsetAt(7), clientRectLeftOfNodeOffsetAt(6), '7');
+    assert_equals(clientRectLeftOfNodeOffsetAt(8), clientRectLeftOfNodeOffsetAt(6), '8');
+}, 'trailing whitespaces');
+</script>

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1,7 +1,8 @@
 /*
  * (C) 1999 Lars Knoll (knoll@kde.org)
  * (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  * Copyright (C) 2006 Andrew Wellington (proton@wiretapped.net)
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
  *
@@ -487,6 +488,14 @@ Vector<FloatQuad> RenderText::absoluteQuadsForRange(unsigned start, unsigned end
     ASSERT(start <= INT_MAX);
     start = std::min(start, static_cast<unsigned>(INT_MAX));
     end = std::min(end, static_cast<unsigned>(INT_MAX));
+
+    const unsigned caretMinOffset = static_cast<unsigned>(this->caretMinOffset());
+    const unsigned caretMaxOffset = static_cast<unsigned>(this->caretMaxOffset());
+
+    // Narrows |start| and |end| into |caretMinOffset| and |caretMaxOffset| to ignore unrendered leading 
+    // and trailing whitespaces.
+    start = std::min(std::max(caretMinOffset, start), caretMaxOffset);
+    end = std::min(std::max(caretMinOffset, end), caretMaxOffset);
 
     Vector<FloatQuad> quads;
     for (auto& run : InlineIterator::textBoxesFor(*this)) {


### PR DESCRIPTION
#### 8cf3b62f57cc63daf35783bd81cf13ca3cc42e0c
<pre>
Make RenderText::absoluteQuadsForRange to consider leading/trailing whitespaces

Make RenderText::absoluteQuadsForRange to consider leading/trailing whitespaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=249048">https://bugs.webkit.org/show_bug.cgi?id=249048</a>

Reviewed by Ryosuke Niwa.

This patch is to align Webkit with Gecko / Firefox and Blink / Chromium.

Merge - <a href="https://src.chromium.org/viewvc/blink?revision=200828&amp">https://src.chromium.org/viewvc/blink?revision=200828&amp</a>;view=revision

This patch makes |RenderText::absoluteQuadsForRange| to consider leading and
trailing whitespaces by adjusting specified offsets by rendered portion of characters.

Before this patch, the function returned empty rectangle
for character offsets not in |InlineTextBox| objects.

* Source/WebCore/rendering/RenderText.cpp:
(RenderText::absoluteQuadsForRange): Add logic to account for whitepsaces
* LayoutTests/fast/dom/Range/getClientRects-leading-trailing-whitespaces.html: Add Test Case
* LayoutTests/fast/dom/Range/getClientRects-leading-trailing-whitespaces-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/257692@main">https://commits.webkit.org/257692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f23356314879c0e51166b2b2f5792bbd77970985

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109042 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169273 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86146 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106950 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105451 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90629 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34079 "An unexpected error occured. Recent messages:Failed to print configuration; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21992 "Found 1 new test failure: media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2679 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23508 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45891 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5287 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8761 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42982 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4486 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->