### PR TITLE
Enable first party for cookies check on Linux

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -550,11 +550,7 @@ std::unique_ptr<ServiceWorkerFetchTask> NetworkConnectionToWebProcess::createFet
 
 void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadParameters&& loadParameters, std::optional<NetworkResourceLoadIdentifier> existingLoaderToResume)
 {
-    // FIXME: This shouldn't be different on different platforms.
-    // It may be related to the difference in networkProcessForSession.
-#if !PLATFORM(GTK) && !PLATFORM(WPE)
     NETWORK_PROCESS_MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, loadParameters.request.firstPartyForCookies()));
-#endif
 
     CONNECTION_RELEASE_LOG(Loading, "scheduleResourceLoad: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ", existingLoaderToResume=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID.toUInt64(), loadParameters.webPageID.toUInt64(), loadParameters.webFrameID.object().toUInt64(), loadParameters.identifier.toUInt64(), valueOrDefault(existingLoaderToResume).toUInt64());
 


### PR DESCRIPTION
#### 3fbd169622ae4d641d3f3c30e25dd8c1a67e8680
<pre>
Enable first party for cookies check on Linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=247693">https://bugs.webkit.org/show_bug.cgi?id=247693</a>
rdar://102154645

Reviewed by NOBODY (OOPS!).

I think 256488@main resolved the problem and now the check can be done on all platforms.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::scheduleResourceLoad):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fbd169622ae4d641d3f3c30e25dd8c1a67e8680

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109046 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86150 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92145 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106954 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105455 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7157 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Pull request contains relevant changes; Skipped layout-tests; layout-tests (failure); layout-tests (failure); Reverted pull request changes; Running compile-webkit-without-change") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90631 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; 3 api tests failed or timed out; 3 api tests failed or timed out; Reverted pull request changes; Running compile-webkit-without-change") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34084 "An unexpected error occured. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21996 "Found 1 new test failure: media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2683 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23511 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2628 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42985 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->