### PR TITLE
[SIMD] Intel support for load and store operations and fix operation shuffle

### DIFF
--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -306,6 +306,7 @@ private:
         OP2_PACKSSDW_VdqWdq             = 0x6B,
         OP2_PUNPCKLQDQ_VdqWdq           = 0x6C,
         OP2_MOVD_VdEd                   = 0x6E,
+        OP2_MOVQ_PqQq                   = 0x6E,
         OP2_MOVDQA_VdqWdq               = 0x6F,
         OP2_PSHUFD_VdqWdqIb             = 0x70,
         OP2_PSHUFLW_VdqWdqIb            = 0x70,
@@ -407,24 +408,27 @@ private:
         OP3_ROUNDPD_MbVdqIb     = 0x09,
         OP3_ROUNDSS_VssWssIb    = 0x0A,
         OP3_ROUNDSD_VsdWsdIb    = 0x0B,
-        OP3_PBLENDW             = 0x0E,
+        OP3_VPBLENDW_VxHxWxIb   = 0x0E,
         OP3_PEXTRB_MbVdqIb      = 0x14,
         OP3_PEXTRW_MwVdqIb      = 0x15,
-        OP3_PEXTRD_EdVdqIb      = 0x16,
-        OP3_EXTRACTPS           = 0x17,
-        OP3_PMOVSXBW            = 0x20,
+        OP3_PEXTRD_EyVdqIb      = 0x16,
+        OP3_PEXTRQ_EyVdqIb      = 0x16,
+        OP3_EXTRACTPS_EdVdqIb   = 0x17,
+        OP3_VBROADCASTSS_VxWd   = 0x18,
+        OP3_VPMOVSXBW_VxUx      = 0x20,
         OP3_PABSB_VdqWdq        = 0x1C,
         OP3_PABSW_VdqWdq        = 0x1D,
         OP3_PABSD_VdqWdq        = 0x1E,
         OP3_INSERTPS_VpsUpsIb   = 0x21,
-        OP3_PINSRB              = 0x20,
-        OP3_PINSRD              = 0x22,
-        OP3_PMOVSXWD            = 0x23,
-        OP3_PMOVSXDQ            = 0x25,
-        OP3_PACKUSDW            = 0x2B,
-        OP3_PMOVZXBW            = 0x30,
-        OP3_PMOVZXWD            = 0x33,
-        OP3_PMOVZXDQ            = 0x35,
+        OP3_PINSRB_VdqRdqpIb    = 0x20,
+        OP3_PINSRD_VdqEdIb      = 0x22,
+        OP3_PINSRQ_VdqEqbIb     = 0x22,
+        OP3_VPMOVSXWD_VxUx      = 0x23,
+        OP3_VPMOVSXDQ_VxUx      = 0x25,
+        OP3_VPACKUSDW_VxHxWx    = 0x2B,
+        OP3_VPMOVZXBW_VxUx      = 0x30,
+        OP3_VPMOVZXWD_VxUx      = 0x33,
+        OP3_VPMOVZXDQ_VxUx      = 0x35,
         OP3_BLENDVPD_VpdWpdXMM0 = 0x4B,
         OP3_LFENCE              = 0xE8,
         OP3_MFENCE              = 0xF0,
@@ -2491,17 +2495,17 @@ public:
     }
 #endif
     
-    void pinsrb_rr(uint8_t laneIndex, RegisterID rn, XMMRegisterID vd)
+    void pinsrb_i8rr(uint8_t laneIndex, RegisterID rn, XMMRegisterID vd)
     {
         ASSERT(laneIndex < 16);
         // https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
         // 66 0F 3A 20 /r ib PINSRB xmm1, r32/m8, imm8
         m_formatter.prefix(PRE_SSE_66);
-        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_3A, OP3_PINSRB, (RegisterID)vd, rn);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_3A, OP3_PINSRB_VdqRdqpIb, (RegisterID)vd, rn);
         m_formatter.immediate8((uint8_t)laneIndex);
     }
 
-    void pinsrw_rr(uint8_t laneIndex, RegisterID rn, XMMRegisterID vd)
+    void pinsrw_i8rr(uint8_t laneIndex, RegisterID rn, XMMRegisterID vd)
     {
         ASSERT(laneIndex < 8);
         // https://www.felixcloutier.com/x86/pinsrw
@@ -2511,31 +2515,31 @@ public:
         m_formatter.immediate8((uint8_t)laneIndex);
     }
 
-    void pinsrd_rr(uint8_t laneIndex, RegisterID rn, XMMRegisterID vd)
+    void pinsrd_i8rr(uint8_t laneIndex, RegisterID rn, XMMRegisterID vd)
     {
         ASSERT(laneIndex < 4);
         // https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
         // 66 0F 3A 22 /r ib PINSRD xmm1, r/m32, imm8
         m_formatter.prefix(PRE_SSE_66);
-        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_3A, OP3_PINSRD, (RegisterID)vd, rn);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_3A, OP3_PINSRD_VdqEdIb, (RegisterID)vd, rn);
         m_formatter.immediate8((uint8_t)laneIndex);
     }
 
-    void pinsrq_rr(uint8_t laneIndex, RegisterID rn, XMMRegisterID vd)
+    void pinsrq_i8rr(uint8_t laneIndex, RegisterID rn, XMMRegisterID vd)
     {
         ASSERT(laneIndex < 2);
         // https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
         // 66 REX.W 0F 3A 22 /r ib PINSRQ xmm1, r/m64, imm8
         m_formatter.prefix(PRE_SSE_66);
-        m_formatter.threeByteOp64(OP2_3BYTE_ESCAPE_3A, OP3_PINSRD, (RegisterID)vd, rn);
+        m_formatter.threeByteOp64(OP2_3BYTE_ESCAPE_3A, OP3_PINSRQ_VdqEqbIb, (RegisterID)vd, rn);
         m_formatter.immediate8((uint8_t)laneIndex);
     }
 
-    void insertps_rr(uint8_t laneIndex, XMMRegisterID rn, XMMRegisterID vd)
+    void insertps_i8rr(uint8_t laneIndex, XMMRegisterID rn, XMMRegisterID vd)
     {
         ASSERT(laneIndex < 4);
         // https://www.felixcloutier.com/x86/insertps
-        // 66 0F 3A 21 /r ib INSERTPS xmm1, xmm2/m32, imm8
+        // 66 0F 3A 21 /r ib INSERTPS xmm1, xmm2/m32, imm8 | SSE4_1
         m_formatter.prefix(PRE_SSE_66);
         m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_3A, OP3_INSERTPS_VpsUpsIb, (RegisterID)vd, (RegisterID)rn);
         m_formatter.immediate8(laneIndex << 4);
@@ -2549,7 +2553,7 @@ public:
         m_formatter.twoByteOp(OP2_UNPCKLPD_VpdWpd, (RegisterID)vd, (RegisterID)rn);
     }
 
-    void pextrb_rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
+    void pextrb_i8rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
     {
         ASSERT(laneIndex < 16);
         // https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
@@ -2559,7 +2563,7 @@ public:
         m_formatter.immediate8(laneIndex);
     }
 
-    void pextrw_rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
+    void pextrw_i8rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
     {
         ASSERT(laneIndex < 8);
         // https://www.felixcloutier.com/x86/pextrw
@@ -2569,27 +2573,27 @@ public:
         m_formatter.immediate8(laneIndex);
     }
 
-    void pextrd_rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
+    void pextrd_i8rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
     {
         ASSERT(laneIndex < 4);
         // https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
         // 66 0F 3A 16 /r ib PEXTRD r/m32, xmm2, imm8 | SSE4_1
         m_formatter.prefix(PRE_SSE_66);
-        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_3A, OP3_PEXTRD_EdVdqIb, (RegisterID)vn, rd);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_3A, OP3_PEXTRD_EyVdqIb, (RegisterID)vn, rd);
         m_formatter.immediate8(laneIndex);
     }
 
-    void pextrq_rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
+    void pextrq_i8rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
     {
         ASSERT(laneIndex < 2);
         // https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
         // 66 REX.W 0F 3A 16 /r ib PEXTRQ r/m64, xmm2, imm8 | SSE4_1
         m_formatter.prefix(PRE_SSE_66);
-        m_formatter.threeByteOp64(OP2_3BYTE_ESCAPE_3A, OP3_PEXTRD_EdVdqIb, (RegisterID)vn, rd);
+        m_formatter.threeByteOp64(OP2_3BYTE_ESCAPE_3A, OP3_PEXTRQ_EyVdqIb, (RegisterID)vn, rd);
         m_formatter.immediate8(laneIndex);
     }
 
-    void pshufd_rr(uint8_t controlBits, XMMRegisterID vn, XMMRegisterID vd)
+    void pshufd_i8rr(uint8_t controlBits, XMMRegisterID vn, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pshufd
         // 66 0F 70 /r ib PSHUFD xmm1, xmm2/m128, imm8
@@ -2606,7 +2610,7 @@ public:
         m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PSHUFB_VdqWdq, (RegisterID)vd, (RegisterID)vn);
     }
 
-    void pshuflw_rr(uint8_t controlBits, XMMRegisterID vn, XMMRegisterID vd)
+    void pshuflw_i8rr(uint8_t controlBits, XMMRegisterID vn, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/pshuflw
         // F2 0F 70 /r ib PSHUFLW xmm1, xmm2/m128, imm8
@@ -2632,7 +2636,7 @@ public:
         m_formatter.twoByteOp(OP2_PUNPCKLQDQ_VdqWdq, (RegisterID)vd, (RegisterID)vn);
     }
 
-    void shufps_rr(uint8_t controlBits, XMMRegisterID vn, XMMRegisterID vd)
+    void shufps_i8rr(uint8_t controlBits, XMMRegisterID vn, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/shufps
         // NP 0F C6 /r ib SHUFPS xmm1, xmm3/m128, imm8
@@ -2640,7 +2644,7 @@ public:
         m_formatter.immediate8((uint8_t)controlBits);
     }
 
-    void shufpd_rr(uint8_t controlBits, XMMRegisterID vn, XMMRegisterID vd)
+    void shufpd_i8rr(uint8_t controlBits, XMMRegisterID vn, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/shufpd
         // 66 0F C6 /r ib SHUFPD xmm1, xmm2/m128, imm8
@@ -2862,7 +2866,7 @@ public:
         // https://www.felixcloutier.com/x86/pblendw
         // 66 0F 3A 0E /r ib PBLENDW xmm1, xmm2/m128, imm8 | SSE4_1
         m_formatter.prefix(PRE_SSE_66);
-        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_3A, OP3_PBLENDW, (RegisterID)vd, (RegisterID)vn);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_3A, OP3_VPBLENDW_VxHxWxIb, (RegisterID)vd, (RegisterID)vn);
         m_formatter.immediate8((uint8_t)imm8);
     }
 
@@ -2943,7 +2947,7 @@ public:
         // https://www.felixcloutier.com/x86/packusdw
         // 66 0F 38 2B /r PACKUSDW xmm1, xmm2/m128 | SSE4_1
         m_formatter.prefix(PRE_SSE_66);
-        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PACKUSDW, (RegisterID)xmm1, (RegisterID)xmm2);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_VPACKUSDW_VxHxWx, (RegisterID)xmm1, (RegisterID)xmm2);
     }
 
     void pmovsxbw(XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -2951,7 +2955,7 @@ public:
         // https://www.felixcloutier.com/x86/pmovsx
         // 66 0f 38 20 /r PMOVSXBW xmm1, xmm2/m64 | SSE4_1
         m_formatter.prefix(PRE_SSE_66);
-        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMOVSXBW, (RegisterID)xmm1, (RegisterID)xmm2);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_VPMOVSXBW_VxUx, (RegisterID)xmm1, (RegisterID)xmm2);
     }
 
     void pmovzxbw(XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -2959,7 +2963,7 @@ public:
         // https://www.felixcloutier.com/x86/pmovzx
         // 66 0f 38 30 /r PMOVZXBW xmm1, xmm2/m64 | SSE4_1
         m_formatter.prefix(PRE_SSE_66);
-        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMOVZXBW, (RegisterID)xmm1, (RegisterID)xmm2);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_VPMOVZXBW_VxUx, (RegisterID)xmm1, (RegisterID)xmm2);
     }
 
     void pmovsxwd(XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -2967,7 +2971,7 @@ public:
         // https://www.felixcloutier.com/x86/pmovsx
         // 66 0f 38 23 /r PMOVSXWD xmm1, xmm2/m64 | SSE4_1
         m_formatter.prefix(PRE_SSE_66);
-        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMOVSXWD, (RegisterID)xmm1, (RegisterID)xmm2);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_VPMOVSXWD_VxUx, (RegisterID)xmm1, (RegisterID)xmm2);
     }
 
     void pmovzxwd(XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -2975,7 +2979,7 @@ public:
         // https://www.felixcloutier.com/x86/pmovzx
         // 66 0f 38 33 /r PMOVZXWD xmm1, xmm2/m64 | SSE4_1
         m_formatter.prefix(PRE_SSE_66);
-        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMOVZXWD, (RegisterID)xmm1, (RegisterID)xmm2);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_VPMOVZXWD_VxUx, (RegisterID)xmm1, (RegisterID)xmm2);
     }
 
     void pmovsxdq(XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -2983,7 +2987,7 @@ public:
         // https://www.felixcloutier.com/x86/pmovsx
         // 66 0f 38 25 /r PMOVSXDQ xmm1, xmm2/m64
         m_formatter.prefix(PRE_SSE_66);
-        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMOVSXDQ, (RegisterID)xmm1, (RegisterID)xmm2);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_VPMOVSXDQ_VxUx, (RegisterID)xmm1, (RegisterID)xmm2);
     }
 
     void pmovzxdq(XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -2991,7 +2995,7 @@ public:
         // https://www.felixcloutier.com/x86/pmovzx
         // 66 0f 38 35 /r PMOVZXDQ xmm1, xmm2/m64
         m_formatter.prefix(PRE_SSE_66);
-        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_PMOVZXDQ, (RegisterID)xmm1, (RegisterID)xmm2);
+        m_formatter.threeByteOp(OP2_3BYTE_ESCAPE_38, OP3_VPMOVZXDQ_VxUx, (RegisterID)xmm1, (RegisterID)xmm2);
     }
 
     void movl_rr(RegisterID src, RegisterID dst)
@@ -4330,6 +4334,144 @@ public:
     //  Prefixes are typically empty (LOCK etc. and they are invalid).
     //  How operand is mapped to these fields are defined per instruction.
 
+    void vpinsrb_i8mrr(uint8_t laneIndex, int offset, RegisterID base, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        ASSERT(laneIndex < 16);
+        // https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
+        // VEX.128.66.0F3A.W0 20 /r ib VPINSRB xmm1, xmm2, r32/m8, imm8
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    imm8
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, OP3_PINSRB_VdqRdqpIb, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)base, offset);
+        m_formatter.immediate8(laneIndex);
+    }
+
+    void vpinsrb_i8rrr(uint8_t laneIndex,  RegisterID rm, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        ASSERT(laneIndex < 16);
+        // https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
+        // VEX.128.66.0F3A.W0 20 /r ib VPINSRB xmm1, xmm2, r32/m8, imm8
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    imm8
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, OP3_PINSRB_VdqRdqpIb, (RegisterID)xmm1, (RegisterID)xmm2, rm);
+        m_formatter.immediate8(laneIndex);
+    }
+
+    void vpinsrw_i8mrr(uint8_t laneIndex, int offset, RegisterID base, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        ASSERT(laneIndex < 8);
+        // https://www.felixcloutier.com/x86/pinsrw
+        // VEX.128.66.0F.W0 C4 /r ib VPINSRW xmm1, xmm2, r32/m16, imm8
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    imm8
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_PINSRW_VdqRdqp, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)base, offset);
+        m_formatter.immediate8(laneIndex);
+    }
+
+    void vpinsrw_i8rrr(uint8_t laneIndex, RegisterID rm, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        ASSERT(laneIndex < 8);
+        // https://www.felixcloutier.com/x86/pinsrw
+        // VEX.128.66.0F.W0 C4 /r ib VPINSRW xmm1, xmm2, r32/m16, imm8
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    imm8
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_PINSRW_VdqRdqp, (RegisterID)xmm1, (RegisterID)xmm2, rm);
+        m_formatter.immediate8(laneIndex);
+    }
+
+    void vpinsrd_i8mrr(uint8_t laneIndex, int offset, RegisterID base, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        ASSERT(laneIndex < 4);
+        // https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
+        // VEX.128.66.0F3A.W0 22 /r ib VPINSRD xmm1, xmm2, r/m32, imm8
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    imm8
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, OP3_PINSRD_VdqEdIb, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)base, offset);
+        m_formatter.immediate8(laneIndex);
+    }
+
+    void vpinsrd_i8rrr(uint8_t laneIndex, RegisterID rm, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        ASSERT(laneIndex < 4);
+        // https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
+        // VEX.128.66.0F3A.W0 22 /r ib VPINSRD xmm1, xmm2, r/m32, imm8
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    imm8
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, OP3_PINSRD_VdqEdIb, (RegisterID)xmm1, (RegisterID)xmm2, rm);
+        m_formatter.immediate8(laneIndex);
+    }
+
+    void vpinsrq_i8mrr(uint8_t laneIndex, int offset, RegisterID base, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        ASSERT(laneIndex < 2);
+        // https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
+        // VEX.128.66.0F3A.W1 22 /r ib VPINSRQ xmm1, xmm2, r/m64, imm8
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    imm8
+        m_formatter.vexNdsLigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, VexW::W1, OP3_PINSRQ_VdqEqbIb, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)base, offset);
+        m_formatter.immediate8(laneIndex);
+    }
+
+    void vpinsrq_i8rrr(uint8_t laneIndex, RegisterID rm, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        ASSERT(laneIndex < 2);
+        // https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
+        // VEX.128.66.0F3A.W1 22 /r ib VPINSRQ xmm1, xmm2, r/m64, imm8
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    imm8
+        m_formatter.vexNdsLigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, VexW::W1, OP3_PINSRQ_VdqEqbIb, (RegisterID)xmm1, (RegisterID)xmm2, rm);
+        m_formatter.immediate8(laneIndex);
+    }
+
+    void vinsertps_i8rrr(uint8_t laneIndex, XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        ASSERT(laneIndex < 4);
+        // https://www.felixcloutier.com/x86/insertps
+        // VEX.128.66.0F3A.WIG 21 /r ib VINSERTPS xmm1, xmm2, xmm3/m32, imm8
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    Imm8
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, OP3_INSERTPS_VpsUpsIb, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)xmm3);
+        m_formatter.immediate8(laneIndex << 4);
+    }
+
+    void vmovddup_rr(XMMRegisterID src, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/movddup
+        // VEX.128.F2.0F.WIG 12 /r VMOVDDUP xmm1, xmm2/m64
+        // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_MOVDDUP_VqWq, (RegisterID)dst, (RegisterID)0, (RegisterID)src);
+    }
+
+    void vmovddup_mr(int offset, RegisterID base, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/movddup
+        // VEX.128.F2.0F.WIG 12 /r VMOVDDUP xmm1, xmm2/m64
+        // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_MOVDDUP_VqWq, (RegisterID)dst, (RegisterID)0, base, offset);
+    }
+
+    void vmovapd_rr(XMMRegisterID src, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/movapd
+        // VEX.128.66.0F.WIG 28 /r VMOVAPD xmm1, xmm2/m128
+        // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_MOVAPD_VpdWpd, (RegisterID)dst, (RegisterID)0, (RegisterID)src);
+    }
+
+    void vbroadcastss_mr(int offset, RegisterID base, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/vbroadcast
+        // VEX.128.66.0F38.W0 18 /r VBROADCASTSS xmm1, m32
+        // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_VBROADCASTSS_VxWd, (RegisterID)dst, (RegisterID)0, base, offset);
+    }
+
+    void vmovq_rr(RegisterID src, FPRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/movd:movq
+        // VEX.128.66.0F.W1 6E /r VMOVQ xmm1, r64/m64
+        // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, VexW::W1, OP2_MOVQ_PqQq, (RegisterID)dest, (RegisterID)0, (RegisterID)src);
+    }
+
+    void vpunpcklqdq_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        // https://www.felixcloutier.com/x86/punpcklbw:punpcklwd:punpckldq:punpcklqdq
+        // VEX.128.66.0F.WIG 6C /r VPUNPCKLQDQ xmm1, xmm2, xmm3/m128
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_PUNPCKLQDQ_VdqWdq, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)xmm3);
+    }
+
     void vunpcklps_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/unpcklps
@@ -4338,7 +4480,15 @@ public:
         m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_UNPCKLPD_VpdWpd, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)xmm3);
     }
 
-    void vpextrb_rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
+    void vunpcklpd_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        // https://www.felixcloutier.com/x86/unpcklpd
+        // VEX.128.66.0F.WIG 14 /r VUNPCKLPD xmm1,xmm2, xmm3/m128
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_UNPCKLPD_VpdWpd, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)xmm3);
+    }
+
+    void vpextrb_i8rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
     {
         // https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
         // VEX.128.66.0F3A.W0 14 /r ib VPEXTRB reg/m8, xmm2, imm8
@@ -4348,7 +4498,17 @@ public:
         m_formatter.immediate8(laneIndex);
     }
 
-    void vpextrw_rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
+    void vpextrb_i8rm(uint8_t laneIndex, XMMRegisterID src, RegisterID base, int offset)
+    {
+        // https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
+        // VEX.128.66.0F3A.W0 14 /r ib VPEXTRB reg/m8, xmm2, imm8
+        // A    NA    ModRM:r/m (w)    ModRM:reg (r)    imm8    NA
+        ASSERT(laneIndex < 16);
+        m_formatter.vexNdsLigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, VexW::W0, OP3_PEXTRB_MbVdqIb, (RegisterID)src, (RegisterID)0, base, offset);
+        m_formatter.immediate8(laneIndex);
+    }
+
+    void vpextrw_i8rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
     {
         // https://www.felixcloutier.com/x86/pextrw
         // VEX.128.66.0F3A.W0 15 /r ib VPEXTRW reg/m16, xmm2, imm8
@@ -4358,23 +4518,53 @@ public:
         m_formatter.immediate8(laneIndex);
     }
 
-    void vpextrd_rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
+    void vpextrw_i8rm(uint8_t laneIndex, XMMRegisterID src, RegisterID base, int offset)
+    {
+        // https://www.felixcloutier.com/x86/pextrw
+        // VEX.128.66.0F3A.W0 15 /r ib VPEXTRW reg/m16, xmm2, imm8
+        // B    NA    ModRM:r/m (w)    ModRM:reg (r)    imm8    NA
+        ASSERT(laneIndex < 8);
+        m_formatter.vexNdsLigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, VexW::W0, OP3_PEXTRW_MwVdqIb, (RegisterID)src, (RegisterID)0, base, offset);
+        m_formatter.immediate8(laneIndex);
+    }
+
+    void vpextrd_i8rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
     {
         // https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
         // VEX.128.66.0F3A.W0 16 /r ib VPEXTRD r32/m32, xmm2, imm8
         // A    NA    ModRM:r/m (w)    ModRM:reg (r)    imm8    NA
         ASSERT(laneIndex < 4);
-        m_formatter.vexNdsLigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, VexW::W0, OP3_PEXTRD_EdVdqIb, (RegisterID)vn, (RegisterID)0, rd);
+        m_formatter.vexNdsLigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, VexW::W0, OP3_PEXTRD_EyVdqIb, (RegisterID)vn, (RegisterID)0, rd);
         m_formatter.immediate8(laneIndex);
     }
 
-    void vpextrq_rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
+    void vpextrd_i8rm(uint8_t laneIndex, XMMRegisterID src, RegisterID base, int offset)
+    {
+        // https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
+        // VEX.128.66.0F3A.W0 16 /r ib VPEXTRD r32/m32, xmm2, imm8
+        // A    NA    ModRM:r/m (w)    ModRM:reg (r)    imm8    NA
+        ASSERT(laneIndex < 4);
+        m_formatter.vexNdsLigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, VexW::W0, OP3_PEXTRD_EyVdqIb, (RegisterID)src, (RegisterID)0, base, offset);
+        m_formatter.immediate8(laneIndex);
+    }
+
+    void vpextrq_i8rr(uint8_t laneIndex, XMMRegisterID vn, RegisterID rd)
     {
         // https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
         // VEX.128.66.0F3A.W1 16 /r ib VPEXTRQ r64/m64, xmm2, imm8
         // A    NA    ModRM:r/m (w)    ModRM:reg (r)    imm8    NA
         ASSERT(laneIndex < 2);
-        m_formatter.vexNdsLigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, VexW::W1, OP3_PEXTRD_EdVdqIb, (RegisterID)vn, (RegisterID)0, rd);
+        m_formatter.vexNdsLigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, VexW::W1, OP3_PEXTRQ_EyVdqIb, (RegisterID)vn, (RegisterID)0, rd);
+        m_formatter.immediate8(laneIndex);
+    }
+
+    void vpextrq_i8rm(uint8_t laneIndex, XMMRegisterID src, RegisterID base, int offset)
+    {
+        // https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
+        // VEX.128.66.0F3A.W1 16 /r ib VPEXTRQ r64/m64, xmm2, imm8
+        // A    NA    ModRM:r/m (w)    ModRM:reg (r)    imm8    NA
+        ASSERT(laneIndex < 2);
+        m_formatter.vexNdsLigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, VexW::W1, OP3_PEXTRQ_EyVdqIb, (RegisterID)src, (RegisterID)0, base, offset);
         m_formatter.immediate8(laneIndex);
     }
 
@@ -4386,12 +4576,39 @@ public:
         m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PSHUFB_VdqWdq, (RegisterID)vd, (RegisterID)vn, (RegisterID)vm);
     }
 
-    void vshufps_rrr(uint8_t controlBits, XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vshufps_i8rrr(uint8_t controlBits, XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/shufps
         // VEX.128.0F.WIG C6 /r ib VSHUFPS xmm1, xmm2, xmm3/m128, imm8
         // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    Imm8
         m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_SHUFPS_VpdWpdIb, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)xmm3);
+        m_formatter.immediate8(controlBits);
+    }
+
+    void vshufpd_i8rrr(uint8_t controlBits, XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        // https://www.felixcloutier.com/x86/shufpd
+        // VEX.128.66.0F.WIG C6 /r ib VSHUFPD xmm1, xmm2, xmm3/m128, imm8
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    Imm8
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_SHUFPD_VpdWpdIb, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)xmm3);
+        m_formatter.immediate8(controlBits);
+    }
+
+    void vpshuflw_i8rr(uint8_t controlBits, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        // https://www.felixcloutier.com/x86/pshuflw
+        // VEX.128.F2.0F.WIG 70 /r ib VPSHUFLW xmm1, xmm2/m128, imm8
+        // A    NA    ModRM:reg (w)    ModRM:r/m (r)    imm8    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_PSHUFLW_VdqWdqIb, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
+        m_formatter.immediate8(controlBits);
+    }
+
+    void vpshufd_i8rr(uint8_t controlBits, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        // https://www.felixcloutier.com/x86/pshufd
+        // VEX.128.66.0F.WIG 70 /r ib VPSHUFD xmm1, xmm2/m128, imm8
+        // A    NA    ModRM:reg (w)    ModRM:r/m (r)    imm8    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_PSHUFD_VdqWdqIb, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
         m_formatter.immediate8(controlBits);
     }
 
@@ -4995,7 +5212,7 @@ public:
         // https://www.felixcloutier.com/x86/packusdw
         // VEX.128.66.0F38 2B /r VPACKUSDW xmm1,xmm2, xmm3/m128
         // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    NA
-        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PACKUSDW, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)xmm3);
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_VPACKUSDW_VxHxWx, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)xmm3);
     }
 
     void vpmovsxbw_rr(XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -5003,7 +5220,7 @@ public:
         // https://www.felixcloutier.com/x86/pmovsx
         // VEX.128.66.0F38.WIG 20 /r VPMOVSXBW xmm1, xmm2/m64
         // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
-        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PMOVSXBW, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_VPMOVSXBW_VxUx, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
     }
 
     void vpmovzxbw_rr(XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -5011,7 +5228,7 @@ public:
         // https://www.felixcloutier.com/x86/pmovzx
         // VEX.128.66.0F38.WIG 30 /r VPMOVZXBW xmm1, xmm2/m64
         // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
-        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PMOVZXBW, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_VPMOVZXBW_VxUx, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
     }
 
     void vpmovsxwd_rr(XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -5019,7 +5236,7 @@ public:
         // https://www.felixcloutier.com/x86/pmovsx
         // VEX.128.66.0F38.WIG 23 /r VPMOVSXWD xmm1, xmm2/m64
         // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
-        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PMOVSXWD, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_VPMOVSXWD_VxUx, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
     }
 
     void vpmovzxwd_rr(XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -5027,7 +5244,7 @@ public:
         // https://www.felixcloutier.com/x86/pmovzx
         // VEX.128.66.0F38.WIG 33 /r VPMOVZXWD xmm1, xmm2/m64
         // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
-        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PMOVZXWD, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_VPMOVZXWD_VxUx, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
     }
 
     void vpmovsxdq_rr(XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -5035,7 +5252,7 @@ public:
         // https://www.felixcloutier.com/x86/pmovsx
         // VEX.128.66.0F38.WIG 25 /r VPMOVSXDQ xmm1, xmm2/m64
         // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
-        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PMOVSXDQ, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_VPMOVSXDQ_VxUx, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
     }
 
     void vpmovzxdq_rr(XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -5043,7 +5260,7 @@ public:
         // https://www.felixcloutier.com/x86/pmovzx
         // VEX.128.66.0F38.WIG 35 /r VPMOVZXDQ xmm1, xmm2/m64
         // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
-        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PMOVZXDQ, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_VPMOVZXDQ_VxUx, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
     }
 
     void vupckhpd_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -5132,6 +5349,38 @@ public:
         // VEX.128.66.0F.WIG D7 /r VPMOVMSKB reg, xmm1
         // RM    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
         m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_PMOVMSKB_EqWdq, (RegisterID)dest, (RegisterID)0, (RegisterID)input);
+    }
+
+    void vmovaps_rr(XMMRegisterID input, XMMRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/movaps
+        // VEX.128.0F.WIG 28 /r VMOVAPS xmm1, xmm2/m128
+        // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVAPS_VpdWpd, (RegisterID)dest, (RegisterID)0, (RegisterID)input);
+    }
+
+    void vmovshdup_rr(XMMRegisterID input, XMMRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/movshdup
+        // VEX.128.F3.0F.WIG 16 /r VMOVSHDUP xmm1, xmm2/m128
+        // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_MOVSHDUP_VqWq, (RegisterID)dest, (RegisterID)0, (RegisterID)input);
+    }
+
+    void vmovhlps_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        // https://www.felixcloutier.com/x86/movhlps
+        // VEX.128.0F.WIG 12 /r VMOVHLPS xmm1, xmm2, xmm3
+        // RVM    ModRM:reg (w)    vvvv (r)    ModRM:r/m (r)    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVHLPS_VqUq, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)xmm3);
+    }
+
+    void vmovsd_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    {
+        // https://www.felixcloutier.com/x86/movsd
+        // VEX.LIG.F2.0F.WIG 10 /r VMOVSD xmm1, xmm2, xmm3
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_MOVSD_VsdWsd, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)xmm3);
     }
 
     void vmovmskps_rr(XMMRegisterID input, RegisterID dest)
@@ -5262,7 +5511,7 @@ public:
         // https://www.felixcloutier.com/x86/pblendw
         // VEX.128.66.0F3A.WIG 0E /r ib VPBLENDW xmm1, xmm2, xmm3/m128, imm8
         // RVMI    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    imm8
-        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, OP3_PBLENDW, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)xmm3);
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, OP3_VPBLENDW_VxHxWxIb, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)xmm3);
         m_formatter.immediate8(imm8);
     }
 
@@ -6086,6 +6335,12 @@ private:
                 threeBytesVex(isVEX256, simdPrefix, impliedBytes, isW1, r, (RegisterID)0, b, inOpReg);
             }
 
+            ALWAYS_INLINE void threeBytesVexNds(OneByteOpcodeID simdPrefix, VexImpliedBytes impliedBytes, VexW vexW, RegisterID r, RegisterID inOpReg, RegisterID b)
+            {
+                constexpr bool isVEX256 = false;
+                threeBytesVex(isVEX256, simdPrefix, impliedBytes, vexW == VexW::W1, r, (RegisterID)0, b, inOpReg);
+            }
+
         private:
             uint8_t vexEncodeSIMDPrefix(OneByteOpcodeID simdPrefix)
             {
@@ -6249,6 +6504,19 @@ private:
             writer.registerModRM(dest, b);
         }
 
+        void vexNdsLigWigTwoByteOp(OneByteOpcodeID simdPrefix, VexW vexW, TwoByteOpcodeID opcode, RegisterID dest, RegisterID a, RegisterID b)
+        {
+            SingleInstructionBufferWriter writer(m_buffer);
+            // Section 3.1.1.2 from Intel SDM volume 2:
+            // The presence of W1 in the opcode column implies the opcode must be encoded using the 3-byte form of the VEX prefix.
+            if (regRequiresRex(b) || vexW == VexW::W1)
+                writer.threeBytesVexNds(simdPrefix, VexImpliedBytes::TwoBytesOp, vexW, dest, a, b);
+            else
+                writer.twoBytesVex(simdPrefix, a, dest);
+            writer.putByteUnchecked(opcode);
+            writer.registerModRM(dest, b);
+        }
+
         void vexNdsLigWigCommutativeTwoByteOp(OneByteOpcodeID simdPrefix, TwoByteOpcodeID opcode, RegisterID dest, RegisterID a, RegisterID b)
         {
             // Since this is a commutative operation, we can try switching the arguments.
@@ -6286,6 +6554,11 @@ private:
             vexNdsLigThreeByteOp(simdPrefix, impliedBytes, VexW::W0, opcode, dest, a, b);
         }
 
+        void vexNdsLigWigThreeByteOp(OneByteOpcodeID simdPrefix, VexImpliedBytes impliedBytes, ThreeByteOpcodeID opcode, RegisterID dest, RegisterID a, RegisterID base, int offset)
+        {
+            vexNdsLigThreeByteOp(simdPrefix, impliedBytes, VexW::W0, opcode, dest, a, base, offset);
+        }
+
         // Typically, xmm1 = dest, xmm2 = a, xmm3 = b, but it depends.
         // dest = reg, a = vvvv, b = r/m
         void vexNdsLigThreeByteOp(OneByteOpcodeID simdPrefix, VexImpliedBytes impliedBytes, VexW vexW, ThreeByteOpcodeID opcode, RegisterID dest, RegisterID a, RegisterID b)
@@ -6295,6 +6568,15 @@ private:
             writer.threeBytesVex(/* isVEX256 */ false, simdPrefix, impliedBytes, vexW == VexW::W1, dest, (RegisterID)0, b, a);
             writer.putByteUnchecked(opcode);
             writer.registerModRM(dest, b);
+        }
+
+        void vexNdsLigThreeByteOp(OneByteOpcodeID simdPrefix, VexImpliedBytes impliedBytes, VexW vexW, ThreeByteOpcodeID opcode, RegisterID dest, RegisterID a, RegisterID base, int offset)
+        {
+            SingleInstructionBufferWriter writer(m_buffer);
+            ASSERT(impliedBytes != VexImpliedBytes::TwoBytesOp);
+            writer.threeBytesVex(/* isVEX256 */ false, simdPrefix, impliedBytes, vexW == VexW::W1, dest, (RegisterID)0, base, a);
+            writer.putByteUnchecked(opcode);
+            writer.memoryModRM(dest, base, offset);
         }
 
         void threeByteOp(TwoByteOpcodeID twoBytePrefix, ThreeByteOpcodeID opcode)

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1869,32 +1869,35 @@ x86_64: VectorConvertLowUnsignedInt32 U:F:64, D:F:128, S:G:64, S:F:128
 64: VectorDemote U:G:Ptr, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp
 
-64: VectorLoad8Splat U:G:8, D:F:128
-    arm64: SimpleAddr, Tmp
+arm64: VectorLoad8Splat U:G:8, D:F:128
+    SimpleAddr, Tmp
+x86_64: VectorLoad8Splat U:G:8, D:F:128, S:F:128
+    SimpleAddr, Tmp, Tmp
+
 64: VectorLoad16Splat U:G:16, D:F:128
-    arm64: SimpleAddr, Tmp
+    SimpleAddr, Tmp
 64: VectorLoad32Splat U:G:32, D:F:128
-    arm64: SimpleAddr, Tmp
+    SimpleAddr, Tmp
 64: VectorLoad64Splat U:G:64, D:F:128
-    arm64: SimpleAddr, Tmp
+    SimpleAddr, Tmp
 
 64: VectorLoad8Lane U:G:8, U:G:8, UD:F:128
-    arm64: SimpleAddr, Imm, Tmp
+    SimpleAddr, Imm, Tmp
 64: VectorLoad16Lane U:G:16, U:G:8, UD:F:128
-    arm64: SimpleAddr, Imm, Tmp
+    SimpleAddr, Imm, Tmp
 64: VectorLoad32Lane U:G:32, U:G:8, UD:F:128
-    arm64: SimpleAddr, Imm, Tmp
+    SimpleAddr, Imm, Tmp
 64: VectorLoad64Lane U:G:64, U:G:8, UD:F:128
-    arm64: SimpleAddr, Imm, Tmp
+    SimpleAddr, Imm, Tmp
 
 64: VectorStore8Lane U:F:128, U:G:8, U:G:8
-    arm64: Tmp, SimpleAddr, Imm
+    Tmp, SimpleAddr, Imm
 64: VectorStore16Lane U:F:128, U:G:16, U:G:8
-    arm64: Tmp, SimpleAddr, Imm
+    Tmp, SimpleAddr, Imm
 64: VectorStore32Lane U:F:128, U:G:32, U:G:8
-    arm64: Tmp, SimpleAddr, Imm
+    Tmp, SimpleAddr, Imm
 64: VectorStore64Lane U:F:128, U:G:64, U:G:8
-    arm64: Tmp, SimpleAddr, Imm
+    Tmp, SimpleAddr, Imm
 
 64: VectorAnyTrue U:F:128, ZD:G:32
     Tmp, Tmp


### PR DESCRIPTION
#### 0def43da76cfb0f0fce99e5ff7a3e2b57f8e7dce
<pre>
[SIMD] Intel support for load and store operations and fix operation shuffle
<a href="https://bugs.webkit.org/show_bug.cgi?id=249073">https://bugs.webkit.org/show_bug.cgi?id=249073</a>
rdar://103214919

Reviewed by Yusuke Suzuki.

This patch achieves four tasks:
1. Add load and store operations for WASM SIMD on Intel.
   <a href="https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md#load-and-store">https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md#load-and-store</a>
2. And fix WASM SIMD operation i8x16.shuffle.
3. Fix instruction encoding in X86Assember.h according to the new conventions.
4. Define and use AVX functions for operations replace_lane, extract_lane, and splat.

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::vectorReplaceLaneAVX):
(JSC::MacroAssemblerX86_64::vectorReplaceLane):
(JSC::MacroAssemblerX86_64::vectorExtractLane):
(JSC::MacroAssemblerX86_64::vectorExtractLaneAVX):
(JSC::MacroAssemblerX86_64::vectorAbs):
(JSC::MacroAssemblerX86_64::vectorTruncSatUnsignedFloat64):
(JSC::MacroAssemblerX86_64::vectorExtendHigh):
(JSC::MacroAssemblerX86_64::vectorSplatAVX):
(JSC::MacroAssemblerX86_64::vectorSplat):
(JSC::MacroAssemblerX86_64::vectorLoad8Splat):
(JSC::MacroAssemblerX86_64::vectorLoad16Splat):
(JSC::MacroAssemblerX86_64::vectorLoad32Splat):
(JSC::MacroAssemblerX86_64::vectorLoad64Splat):
(JSC::MacroAssemblerX86_64::vectorLoad8Lane):
(JSC::MacroAssemblerX86_64::vectorLoad16Lane):
(JSC::MacroAssemblerX86_64::vectorLoad32Lane):
(JSC::MacroAssemblerX86_64::vectorLoad64Lane):
(JSC::MacroAssemblerX86_64::vectorStore8Lane):
(JSC::MacroAssemblerX86_64::vectorStore16Lane):
(JSC::MacroAssemblerX86_64::vectorStore32Lane):
(JSC::MacroAssemblerX86_64::vectorStore64Lane):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::pinsrb_i8rr):
(JSC::X86Assembler::pinsrw_i8rr):
(JSC::X86Assembler::pinsrd_i8rr):
(JSC::X86Assembler::pinsrq_i8rr):
(JSC::X86Assembler::insertps_i8rr):
(JSC::X86Assembler::pextrb_i8rr):
(JSC::X86Assembler::pextrw_i8rr):
(JSC::X86Assembler::pextrd_i8rr):
(JSC::X86Assembler::pextrq_i8rr):
(JSC::X86Assembler::pshufd_i8rr):
(JSC::X86Assembler::pshuflw_i8rr):
(JSC::X86Assembler::shufps_i8rr):
(JSC::X86Assembler::shufpd_i8rr):
(JSC::X86Assembler::pblendw_rr):
(JSC::X86Assembler::packusdw_rr):
(JSC::X86Assembler::pmovsxbw):
(JSC::X86Assembler::pmovzxbw):
(JSC::X86Assembler::pmovsxwd):
(JSC::X86Assembler::pmovzxwd):
(JSC::X86Assembler::pmovsxdq):
(JSC::X86Assembler::pmovzxdq):
(JSC::X86Assembler::vpinsrb_i8mrr):
(JSC::X86Assembler::vpinsrb_i8rrr):
(JSC::X86Assembler::vpinsrw_i8mrr):
(JSC::X86Assembler::vpinsrw_i8rrr):
(JSC::X86Assembler::vpinsrd_i8mrr):
(JSC::X86Assembler::vpinsrd_i8rrr):
(JSC::X86Assembler::vpinsrq_i8mrr):
(JSC::X86Assembler::vpinsrq_i8rrr):
(JSC::X86Assembler::vinsertps_i8rrr):
(JSC::X86Assembler::vmovddup_rr):
(JSC::X86Assembler::vmovddup_mr):
(JSC::X86Assembler::vmovapd_rr):
(JSC::X86Assembler::vbroadcastss_mr):
(JSC::X86Assembler::vmovq_rr):
(JSC::X86Assembler::vpunpcklqdq_rrr):
(JSC::X86Assembler::vunpcklpd_rrr):
(JSC::X86Assembler::vpextrb_i8rr):
(JSC::X86Assembler::vpextrb_i8rm):
(JSC::X86Assembler::vpextrw_i8rr):
(JSC::X86Assembler::vpextrw_i8rm):
(JSC::X86Assembler::vpextrd_i8rr):
(JSC::X86Assembler::vpextrd_i8rm):
(JSC::X86Assembler::vpextrq_i8rr):
(JSC::X86Assembler::vpextrq_i8rm):
(JSC::X86Assembler::vshufps_i8rrr):
(JSC::X86Assembler::vshufpd_i8rrr):
(JSC::X86Assembler::vpshuflw_i8rr):
(JSC::X86Assembler::vpshufd_i8rr):
(JSC::X86Assembler::vpackusdw_rrr):
(JSC::X86Assembler::vpmovsxbw_rr):
(JSC::X86Assembler::vpmovzxbw_rr):
(JSC::X86Assembler::vpmovsxwd_rr):
(JSC::X86Assembler::vpmovzxwd_rr):
(JSC::X86Assembler::vpmovsxdq_rr):
(JSC::X86Assembler::vpmovzxdq_rr):
(JSC::X86Assembler::vmovaps_rr):
(JSC::X86Assembler::vmovshdup_rr):
(JSC::X86Assembler::vmovhlps_rrr):
(JSC::X86Assembler::vmovsd_rrr):
(JSC::X86Assembler::vpblendw_i8rrr):
(JSC::X86Assembler::X86InstructionFormatter::SingleInstructionBufferWriter::memoryModRM):
(JSC::X86Assembler::pinsrb_rr): Deleted.
(JSC::X86Assembler::pinsrw_rr): Deleted.
(JSC::X86Assembler::pinsrd_rr): Deleted.
(JSC::X86Assembler::pinsrq_rr): Deleted.
(JSC::X86Assembler::insertps_rr): Deleted.
(JSC::X86Assembler::pextrb_rr): Deleted.
(JSC::X86Assembler::pextrw_rr): Deleted.
(JSC::X86Assembler::pextrd_rr): Deleted.
(JSC::X86Assembler::pextrq_rr): Deleted.
(JSC::X86Assembler::pshufd_rr): Deleted.
(JSC::X86Assembler::pshuflw_rr): Deleted.
(JSC::X86Assembler::shufps_rr): Deleted.
(JSC::X86Assembler::shufpd_rr): Deleted.
(JSC::X86Assembler::vpextrb_rr): Deleted.
(JSC::X86Assembler::vpextrw_rr): Deleted.
(JSC::X86Assembler::vpextrd_rr): Deleted.
(JSC::X86Assembler::vpextrq_rr): Deleted.
(JSC::X86Assembler::vshufps_rrr): Deleted.
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::addSIMDSwizzleHelperX86):
(JSC::Wasm::AirIRGenerator::addSIMDV_VV):
(JSC::Wasm::AirIRGenerator::addSIMDShuffle):
(JSC::Wasm::AirIRGenerator::addSIMDLoadSplat):
(JSC::Wasm::AirIRGenerator::addSIMDSwizzle): Deleted.

Canonical link: <a href="https://commits.webkit.org/257818@main">https://commits.webkit.org/257818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c5a1522fc26fb879a3817325e52b03509d31222

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109458 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169693 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10175 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92555 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107348 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105892 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90706 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3062 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86668 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/491 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3032 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29048 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43365 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89549 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5370 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20021 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->