### PR TITLE
Check for promise before resolving in FullscreenManager::exitFullscreen()

### DIFF
--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -334,14 +334,16 @@ void FullscreenManager::exitFullscreen(RefPtr<DeferredPromise>&& promise)
     // Return promise, and run the remaining steps in parallel.
     m_document.eventLoop().queueTask(TaskSource::MediaElement, [this, promise = WTFMove(promise), weakThis = WeakPtr { *this }, mode, identifier = LOGIDENTIFIER] () mutable {
         if (!weakThis) {
-            promise->resolve();
+            if (promise)
+                promise->resolve();
             return;
         }
 
         auto* page = this->page();
         if (!page) {
             m_pendingExitFullscreen = false;
-            promise->resolve();
+            if (promise)
+                promise->resolve();
             ERROR_LOG(identifier, "task - Document not in page; bailing.");
             return;
         }
@@ -353,7 +355,8 @@ void FullscreenManager::exitFullscreen(RefPtr<DeferredPromise>&& promise)
             INFO_LOG(identifier, "task - Cancelling pending fullscreen request.");
             m_pendingFullscreenElement = nullptr;
             m_pendingExitFullscreen = false;
-            promise->resolve();
+            if (promise)
+                promise->resolve();
             return;
         }
 


### PR DESCRIPTION
#### 91d9d701a8cd80a5e55650b583b66c4c0f78fa6d
<pre>
Check for promise before resolving in FullscreenManager::exitFullscreen()
<a href="https://bugs.webkit.org/show_bug.cgi?id=249075">https://bugs.webkit.org/show_bug.cgi?id=249075</a>
rdar://103215492

Reviewed by Simon Fraser.

The promise can be nullptr if called from the legacy fullscreen API (see DocumentFullscreen::webkitExitFullScreen), so we should check it&apos;s existence before trying to resolve.

* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::exitFullscreen):

Canonical link: <a href="https://commits.webkit.org/257689@main">https://commits.webkit.org/257689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/539a4f559e9f638dc4b1053b4c0890af0f90322e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109056 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169287 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103697 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86160 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92155 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106964 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105465 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34093 "An unexpected error occured. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22005 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2693 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23520 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-rows-item-placement-auto-flow-next-001.html, imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-timing.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45902 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42994 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2712 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4500 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->