### PR TITLE
[WK2] Decoding in ArgumentCoder<Vector<T>> should reserve initial capacity, avoid shrink-to-fit

### DIFF
--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -462,13 +462,13 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
             return std::nullopt;
 
         Vector<T, inlineCapacity, OverflowHandler, minCapacity> vector;
+        vector.reserveInitialCapacity(*size);
         for (size_t i = 0; i < *size; ++i) {
             auto element = decoder.template decode<T>();
             if (!element)
                 return std::nullopt;
-            vector.append(WTFMove(*element));
+            vector.uncheckedAppend(WTFMove(*element));
         }
-        vector.shrinkToFit();
         return vector;
     }
 };

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -414,14 +414,14 @@ TEST_F(ArgumentCoderDecodingMoveCounterTest, DecodeVector)
         ASSERT_TRUE(!!vector);
         ASSERT_EQ(vector->size(), 2u);
         for (auto&& entry : *vector)
-            ASSERT_EQ(entry.moveCounter, 2u);
+            ASSERT_EQ(entry.moveCounter, 1u);
     }
     {
         auto vector = decoder->decode<Vector<DecodingMoveCounter>>();
         ASSERT_TRUE(!!vector);
         ASSERT_EQ(vector->size(), 2u);
         for (auto&& entry : *vector)
-            ASSERT_EQ(entry.moveCounter, 2u);
+            ASSERT_EQ(entry.moveCounter, 1u);
     }
 }
 


### PR DESCRIPTION
#### 0c0b2027ab6bc02c2c08fbde469af8d2e28da9d6
<pre>
[WK2] Decoding in ArgumentCoder&lt;Vector&lt;T&gt;&gt; should reserve initial capacity, avoid shrink-to-fit
<a href="https://bugs.webkit.org/show_bug.cgi?id=249077">https://bugs.webkit.org/show_bug.cgi?id=249077</a>

Reviewed by Kimmo Kinnunen.

When decoding a Vector of non-trivial elements, use the decoded size to
reserve initial capacity and then perform unchecked appends of each
decoded element. This replaces the incremental grow-as-you-go appending
and the final shrink-to-fit operation which possibly ends up moving over
all the elements into the newly-allocated smaller buffer.

The decoding-moves-counter test is updated, with the only remaining and
unavoidable move of each element contained in the Vector happening when
that element is moved into the resulting Vector.

* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/257725@main">https://commits.webkit.org/257725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fae0c38c35f99f6b4626d484a0ddec891d007fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109059 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169290 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86163 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92158 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106967 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105468 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90644 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34097 "An unexpected error occured. Recent messages:Failed to print configuration; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89293 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22011 "Found 3 new test failures: media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html, media/modern-media-controls/skip-back-button/skip-back-button.html, platform/mac/media/encrypted-media/fps-generateRequest.html (failure)") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2696 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23526 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45906 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5307 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43000 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->