### PR TITLE
[GStreamer][WebRTC] Report video encoder bitrate in outgoing RTP stats

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -198,15 +198,17 @@ static inline void fillOutboundRTPStreamStats(RTCStatsReport::OutboundRtpStreamS
     if (const char* remoteId = gst_structure_get_string(structure, "remote-id"))
         stats.remoteId = String::fromLatin1(remoteId);
 
-    if (additionalStats) {
-        if (gst_structure_get_uint64(additionalStats, "frames-sent", &value))
-            stats.framesSent = value;
-        if (gst_structure_get_uint64(additionalStats, "frames-encoded", &value))
-            stats.framesEncoded = value;
-    }
+    if (!additionalStats)
+        return;
 
-    // FIXME
-    // stats.targetBitrate =
+    if (gst_structure_get_uint64(additionalStats, "frames-sent", &value))
+        stats.framesSent = value;
+    if (gst_structure_get_uint64(additionalStats, "frames-encoded", &value))
+        stats.framesEncoded = value;
+
+    double bitrate;
+    if (gst_structure_get_double(additionalStats, "bitrate", &bitrate))
+        stats.targetBitrate = bitrate;
 }
 
 static inline void fillRTCPeerConnectionStats(RTCStatsReport::PeerConnectionStats& stats, const GstStructure* structure)

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
@@ -77,6 +77,13 @@ void RealtimeOutgoingVideoSourceGStreamer::updateStats(GstBuffer*)
     uint64_t framesSent = 0;
     gst_structure_get_uint64(m_stats.get(), "frames-sent", &framesSent);
     framesSent++;
+
+    if (m_encoder) {
+        uint32_t bitrate;
+        g_object_get(m_encoder.get(), "bitrate", &bitrate, nullptr);
+        gst_structure_set(m_stats.get(), "bitrate", G_TYPE_DOUBLE, static_cast<double>(bitrate * 1024), nullptr);
+    }
+
     gst_structure_set(m_stats.get(), "frames-sent", G_TYPE_UINT64, framesSent, "frames-encoded", G_TYPE_UINT64, framesSent, nullptr);
 }
 


### PR DESCRIPTION
#### a4ddc34d0b3f62cb6a02a1d7e4b81bdaa8b79035
<pre>
[GStreamer][WebRTC] Report video encoder bitrate in outgoing RTP stats
<a href="https://bugs.webkit.org/show_bug.cgi?id=249093">https://bugs.webkit.org/show_bug.cgi?id=249093</a>

Reviewed by Xabier Rodriguez-Calvar.

The bitrate in kbps is queried on the encoder and passed to the stats as a bps value.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::fillOutboundRTPStreamStats):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::updateStats):

Canonical link: <a href="https://commits.webkit.org/257719@main">https://commits.webkit.org/257719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0956519f2aed499d31764fe61ba31367d58424a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109096 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169329 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86199 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92193 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107004 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105502 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90669 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34124 "An unexpected error occured. Recent messages:Running configure-build; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22044 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2732 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23558 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45939 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5301 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43032 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->