### PR TITLE
Let '-webkit-mask-box-image:initial' use the initial value

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-webkit-mask-box-image-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-webkit-mask-box-image-expected.txt
@@ -1,0 +1,12 @@
+
+PASS ""
+PASS "-webkit-mask-box-image: initial"
+PASS "-webkit-mask-box-image: none"
+PASS "-webkit-mask-box-image-source: initial; -webkit-mask-box-image-slice: initial; -webkit-mask-box-image-width: initial; -webkit-mask-box-image-outset: initial; -webkit-mask-box-image-repeat: initial;"
+PASS "-webkit-mask-box-image: url(#)"
+PASS "-webkit-mask-box-image: 1"
+PASS "-webkit-mask-box-image: 1% / 2"
+PASS "-webkit-mask-box-image: 1% // 2"
+PASS "-webkit-mask-box-image: 1% / 2px / 3"
+PASS "-webkit-mask-box-image: round"
+

--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-webkit-mask-box-image.html
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-webkit-mask-box-image.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test computed style on the -webkit-mask-box-image property</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<div id="target"></div>
+<script>
+const target = document.getElementById('target');
+const computedStyle = getComputedStyle(target);
+
+const initialValues = {
+    '-webkit-mask-box-image': 'none',
+    '-webkit-mask-box-image-slice': '0 fill',
+    '-webkit-mask-box-image-width': 'auto',
+    '-webkit-mask-box-image-outset': '0',
+    '-webkit-mask-box-image-repeat': 'stretch',
+};
+
+const testCases = [
+    // value, expected
+    [ '', initialValues ],
+    [ '-webkit-mask-box-image: initial', initialValues ],
+    [ '-webkit-mask-box-image: none', initialValues ],
+    [
+        '-webkit-mask-box-image-source: initial; -webkit-mask-box-image-slice: initial; -webkit-mask-box-image-width: initial; -webkit-mask-box-image-outset: initial; -webkit-mask-box-image-repeat: initial;',
+        initialValues
+    ],
+    [ '-webkit-mask-box-image: url(#)', {
+        ...initialValues,
+        '-webkit-mask-box-image': 'url("#") 0 fill / auto / 0 stretch',
+        '-webkit-mask-box-image-source': 'url("#")',
+    }],
+    [ '-webkit-mask-box-image: 1', {
+        ...initialValues,
+        '-webkit-mask-box-image-slice': '1 fill',
+    }],
+    [ '-webkit-mask-box-image: 1% / 2', {
+        ...initialValues,
+        '-webkit-mask-box-image-slice': '1% fill',
+        '-webkit-mask-box-image-width': '2',
+    }],
+    [ '-webkit-mask-box-image: 1% // 2', {
+        ...initialValues,
+        '-webkit-mask-box-image-slice': '1% fill',
+    }],
+    [ '-webkit-mask-box-image: 1% / 2px / 3', {
+        ...initialValues,
+        '-webkit-mask-box-image-slice': '1% fill',
+        '-webkit-mask-box-image-width': '2px',
+        '-webkit-mask-box-image-outset': '3',
+    }],
+    [ '-webkit-mask-box-image: round', {
+        ...initialValues,
+        '-webkit-mask-box-image-repeat': 'round',
+    }],
+];
+
+for (let testCase of testCases) {
+    target.style.cssText = testCase[0];
+    test(function() {
+        for (let [prop, expected] of Object.entries(testCase[1])) {
+            assert_equals(computedStyle.getPropertyValue(prop), expected, prop);
+        }
+    }, JSON.stringify(testCase[0]));
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7335,7 +7335,7 @@
         },
         "-webkit-mask-box-image": {
             "codegen-properties": {
-                "initial": "initialNinePieceImage",
+                "initial": "initialNinePieceImageForMask",
                 "converter": "BorderMask<CSSPropertyWebkitMaskBoxImage>",
                 "parser-function": "consumeWebkitBorderImage",
                 "parser-requires-current-property": true,

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1650,7 +1650,7 @@ public:
     static BorderCollapse initialBorderCollapse() { return BorderCollapse::Separate; }
     static BorderStyle initialBorderStyle() { return BorderStyle::None; }
     static OutlineIsAuto initialOutlineStyleIsAuto() { return OutlineIsAuto::Off; }
-    static NinePieceImage initialNinePieceImage() { return NinePieceImage(); }
+    static NinePieceImage initialNinePieceImageForMask() { return NinePieceImage(NinePieceImage::Type::Mask); }
     static LengthSize initialBorderRadius() { return { { 0, LengthType::Fixed }, { 0, LengthType::Fixed } }; }
     static CaptionSide initialCaptionSide() { return CaptionSide::Top; }
     static ColumnAxis initialColumnAxis() { return ColumnAxis::Auto; }


### PR DESCRIPTION
#### 20eb361ea0990e511cbdeb418f3a5c819a70afc4
<pre>
Let '-webkit-mask-box-image:initial' use the initial value
https://bugs.webkit.org/show_bug.cgi?id=249079

Reviewed by Tim Nguyen.

-webkit-mask-box-image:initial was setting it to is NinePieceImage(),
but the initial value is NinePieceImage(NinePieceImage::Type::Mask).

* LayoutTests/fast/css/getComputedStyle/getComputedStyle-webkit-mask-box-image-expected.txt: Added.
* LayoutTests/fast/css/getComputedStyle/getComputedStyle-webkit-mask-box-image.html: Added.
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::initialNinePieceImageForMask):
(WebCore::RenderStyle::initialNinePieceImage): Deleted.

Canonical link: https://commits.webkit.org/257707@main
</pre>

[WebKit/WebKit@`5c0a579`](https://github.com/WebKit/WebKit/commit/5c0a579bd955ef857e5cf552962e0f850baff3b6)