### PR TITLE
REGRESSION(257606@main): WebProcess::didClose override broke GLib ports

### DIFF
--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -159,7 +159,10 @@ protected:
 #if HAVE(AUDIO_COMPONENT_SERVER_REGISTRATIONS)
     void consumeAudioComponentRegistrations(const IPC::SharedBufferReference&);
 #endif
-    
+
+    // IPC::Connection::Client.
+    void didClose(IPC::Connection&) override;
+
 private:
     virtual bool shouldOverrideQuarantine() { return true; }
 
@@ -169,7 +172,6 @@ private:
 
     // IPC::Connection::Client.
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) final;
-    void didClose(IPC::Connection&) override;
 
     void shutDown();
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -944,7 +944,7 @@ void WebProcess::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& de
     LOG_ERROR("Unhandled web process message '%s' (destination: %" PRIu64 " pid: %d)", description(decoder.messageName()), decoder.destinationID(), static_cast<int>(getCurrentProcessID()));
 }
 
-void WebProcess::didClose(IPC::Connection&)
+void WebProcess::didClose(IPC::Connection& connection)
 {
     FileSystem::markPurgeable(WebCore::HTMLMediaElement::mediaCacheDirectory());
     if (m_applicationCacheStorage)
@@ -952,6 +952,7 @@ void WebProcess::didClose(IPC::Connection&)
 #if ENABLE(ARKIT_INLINE_PREVIEW_MAC)
     FileSystem::markPurgeable(ARKitInlinePreviewModelPlayerMac::modelElementCacheDirectory());
 #endif
+    AuxiliaryProcess::didClose(connection);
 }
 
 WebFrame* WebProcess::webFrame(FrameIdentifier frameID) const


### PR DESCRIPTION
#### ab0bcd358b5081f5b138e51b620a46d06b0169d1
<pre>
REGRESSION(257606@main): WebProcess::didClose override broke GLib ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=249101">https://bugs.webkit.org/show_bug.cgi?id=249101</a>

Reviewed by Carlos Garcia Campos.

Chain WebProcess::didClose() to parent class in order to let the AuxiliaryProcess clean-up properly.

* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::didClose):

Canonical link: <a href="https://commits.webkit.org/257721@main">https://commits.webkit.org/257721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f008aeeb0b4fca3402d4e57b6f27e4ec6f15c12d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109186 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86290 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92285 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107095 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105587 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34192 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2815 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2761 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/46015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5302 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43107 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->