### PR TITLE
Remove unnecessary nullptr check from GridMasonryLayout::addItemsToFirstTrack.

### DIFF
--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -103,12 +103,8 @@ void GridMasonryLayout::resizeAndResetRunningPositions()
 
 void GridMasonryLayout::addItemsToFirstTrack(const HashMap<RenderBox*, GridArea>& firstTrackItems)
 {
-    for (auto& [item, gridArea] : firstTrackItems) {
-        ASSERT(item);
-        if (!item)
-            continue;
+    for (auto& [item, gridArea] : firstTrackItems)
         insertIntoGridAndLayoutItem(*item, gridArea);
-    }
 }
 
 void GridMasonryLayout::placeItemsUsingOrderModifiedDocumentOrder()


### PR DESCRIPTION
#### 3f50a04024ebe84af4be47752fb4ee3d1a501889
<pre>
Remove unnecessary nullptr check from GridMasonryLayout::addItemsToFirstTrack.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249104">https://bugs.webkit.org/show_bug.cgi?id=249104</a>
rdar://103230303

Reviewed by Alan Baradlay.

The HashMap implementation would not allow a nullptr to get inserted
into the HashMap when a raw C++ pointer is being used as the key,
so the code that iterates over all of the keys and values should not
need to check for nullptr.

The HashMap implementation would not allow a nullptr to get inserted
into the HashMap when a raw C++ pointer is being used as the key,
so the code that iterates over all of the keys and values should not
need to check for nullptr.

* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::addItemsToFirstTrack):

Canonical link: <a href="https://commits.webkit.org/257714@main">https://commits.webkit.org/257714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f55913bc9b88cc51871dfa919782641fe11bd22

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109129 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169367 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86233 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92227 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107039 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105530 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34152 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22071 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2759 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23583 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45966 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5298 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43053 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->