### PR TITLE
Mitigate crashes when removing KVO from NSWindow in -[WKWindowVisibilityObserver stopObserving:]

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -332,6 +332,10 @@ static void* keyValueObservingContext = &keyValueObservingContext;
     if (_shouldObserveFontPanel)
         [self startObservingFontPanel];
 
+    if (objc_getAssociatedObject(window, _impl))
+        return;
+
+    objc_setAssociatedObject(window, _impl, @YES, OBJC_ASSOCIATION_COPY_NONATOMIC);
     [window addObserver:self forKeyPath:@"contentLayoutRect" options:NSKeyValueObservingOptionInitial context:keyValueObservingContext];
     [window addObserver:self forKeyPath:@"titlebarAppearsTransparent" options:NSKeyValueObservingOptionInitial context:keyValueObservingContext];
 }
@@ -362,6 +366,10 @@ static void* keyValueObservingContext = &keyValueObservingContext;
     if (_shouldObserveFontPanel)
         [[NSFontPanel sharedFontPanel] removeObserver:self forKeyPath:@"visible" context:keyValueObservingContext];
 
+    if (!objc_getAssociatedObject(window, _impl))
+        return;
+
+    objc_setAssociatedObject(window, _impl, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
     [window removeObserver:self forKeyPath:@"contentLayoutRect" context:keyValueObservingContext];
     [window removeObserver:self forKeyPath:@"titlebarAppearsTransparent" context:keyValueObservingContext];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrepareForMoveToWindow.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrepareForMoveToWindow.mm
@@ -70,6 +70,23 @@ TEST(WKWebView, PrepareToUnparentView)
     TestWebKitAPI::Util::run(&done);
 }
 
+TEST(WKWebView, PrepareForMoveToWindowShouldNotCrashWhenRemovingWindowObservers)
+{
+    auto window = adoptNS([NSWindow new]);
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView synchronouslyLoadTestPageNamed:@"simple"];
+
+    [[window contentView] addSubview:webView.get()];
+    [webView _prepareForMoveToWindow:nil completionHandler:^{ }];
+    [webView _prepareForMoveToWindow:window.get() completionHandler:^{ }];
+
+    __block bool done = false;
+    [webView _prepareForMoveToWindow:nil completionHandler:^{
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
 TEST(WKWebView, PrepareForMoveToWindowThenClose)
 {
     auto webView = adoptNS([[WKWebView alloc] init]);


### PR DESCRIPTION
#### a9b66fad8de2f2a774d86bfd78afa01b77f6df8a
<pre>
Mitigate crashes when removing KVO from NSWindow in -[WKWindowVisibilityObserver stopObserving:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=249103">https://bugs.webkit.org/show_bug.cgi?id=249103</a>
rdar://102360839

Reviewed by Patrick Angle.

After the fix in 256334@main, Music sometimes crashes when destroying `NSWindow`, when
`WKWindowVisibilityObserver` attempts to remove key-value observers for &quot;contentLayoutRect&quot; and
&quot;titlebarAppearsTransparent&quot; from the window that were not added in the first place.

While I haven&apos;t been able to reproduce the crash locally or come up with a test case that (exactly)
replicates the crashing stack during `NSWindow` destruction, it should be possible to avoid it
altogether by guarding KVO registration and unregistration by using an associated object on the
`NSWindow` to indicate when `WKWindowVisibilityObserver` has key-value observers to the window. If
this flag is not set, then we avoid attempting to unregister KVO; similarly, if this flag is set,
then we avoid attempting to re-register KVO.

Test: WKWebView.PrepareForMoveToWindowShouldNotCrashWhenRemovingWindowObservers

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKWindowVisibilityObserver startObserving:]):
(-[WKWindowVisibilityObserver stopObserving:]):

Use the `_impl` pointer as the context key.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/PrepareForMoveToWindow.mm:

Add a (somewhat contrived) API test that exercises the mitigation.

Canonical link: <a href="https://commits.webkit.org/257736@main">https://commits.webkit.org/257736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/543f0efffcdad2960f90ddea24c9f19b629a5964

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109131 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169369 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103768 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/9940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86235 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92229 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107041 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105533 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7426 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34151 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/9940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22073 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2761 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23585 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45967 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5316 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43055 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->