### PR TITLE
HTMLImageElement width/height should update renderer first

### DIFF
--- a/LayoutTests/fast/images/img-dimensions-styled-expected.txt
+++ b/LayoutTests/fast/images/img-dimensions-styled-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS HTMLImageElement.width/height returns styled dimensions.
+

--- a/LayoutTests/fast/images/img-dimensions-styled.html
+++ b/LayoutTests/fast/images/img-dimensions-styled.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>HTMLImageElement.width/height returns styled dimensions.</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+    img {
+        width: 200px;
+        height: 200px;
+    }
+</style>
+<img src="resources/test-load.jpg" width="100" height="100">
+<script>
+test(function() {
+    var image = document.querySelector("img");
+    assert_equals(image.width, 200);
+    assert_equals(image.height, 200);
+    var rect = image.getBoundingClientRect();
+    assert_equals(rect.width, 200);
+    assert_equals(rect.height, 200);
+});
+</script>

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -1,8 +1,8 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2004-2016 Apple Inc. All rights reserved.
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -501,8 +501,11 @@ void HTMLImageElement::setPictureElement(HTMLPictureElement* pictureElement)
     m_pictureElement = pictureElement;
 }
     
-unsigned HTMLImageElement::width(bool ignorePendingStylesheets)
+unsigned HTMLImageElement::width()
 {
+    if (inRenderedDocument())
+        document().updateLayoutIgnorePendingStylesheets();
+
     if (!renderer()) {
         // check the attribute first for an explicit pixel value
         auto optionalWidth = parseHTMLNonNegativeInteger(attributeWithoutSynchronization(widthAttr));
@@ -514,11 +517,6 @@ unsigned HTMLImageElement::width(bool ignorePendingStylesheets)
             return m_imageLoader->image()->imageSizeForRenderer(renderer(), 1.0f).width().toUnsigned();
     }
 
-    if (ignorePendingStylesheets)
-        document().updateLayoutIgnorePendingStylesheets();
-    else
-        document().updateLayout();
-
     RenderBox* box = renderBox();
     if (!box)
         return 0;
@@ -526,8 +524,11 @@ unsigned HTMLImageElement::width(bool ignorePendingStylesheets)
     return adjustForAbsoluteZoom(snappedIntRect(contentRect).width(), *box);
 }
 
-unsigned HTMLImageElement::height(bool ignorePendingStylesheets)
+unsigned HTMLImageElement::height()
 {
+    if (inRenderedDocument())
+        document().updateLayoutIgnorePendingStylesheets();
+
     if (!renderer()) {
         // check the attribute first for an explicit pixel value
         auto optionalHeight = parseHTMLNonNegativeInteger(attributeWithoutSynchronization(heightAttr));
@@ -538,11 +539,6 @@ unsigned HTMLImageElement::height(bool ignorePendingStylesheets)
         if (m_imageLoader->image())
             return m_imageLoader->image()->imageSizeForRenderer(renderer(), 1.0f).height().toUnsigned();
     }
-
-    if (ignorePendingStylesheets)
-        document().updateLayoutIgnorePendingStylesheets();
-    else
-        document().updateLayout();
 
     RenderBox* box = renderBox();
     if (!box)

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -1,8 +1,8 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2004, 2008, 2010 Apple Inc. All rights reserved.
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -60,8 +60,8 @@ public:
 
     void formOwnerRemovedFromTree(const Node& formRoot);
 
-    WEBCORE_EXPORT unsigned width(bool ignorePendingStylesheets = false);
-    WEBCORE_EXPORT unsigned height(bool ignorePendingStylesheets = false);
+    WEBCORE_EXPORT unsigned width();
+    WEBCORE_EXPORT unsigned height();
 
     WEBCORE_EXPORT int naturalWidth() const;
     WEBCORE_EXPORT int naturalHeight() const;


### PR DESCRIPTION
#### 4db09a03542040dba6c022e7d217d3eb526654d7
<pre>
HTMLImageElement width/height should update renderer first

HTMLImageElement width/height should update renderer first
<a href="https://bugs.webkit.org/show_bug.cgi?id=249056">https://bugs.webkit.org/show_bug.cgi?id=249056</a>

Reviewed by Simon Fraser.

This patch is to align Webkit with Gecko / Firefox and Blink / Chromium.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/d3adbd3a3f1bcbebdf515ac15a8c250873a2a1d9">https://chromium.googlesource.com/chromium/blink/+/d3adbd3a3f1bcbebdf515ac15a8c250873a2a1d9</a>

HTMLImageElement::width/height were not updating layout first before checking for the
renderer, which means that we fall back to the attribute when we shouldn&apos;t. We&apos;re also
using the renderer method instead of updateLayoutIgnorePendingStylesheets which should be
used for all JS APIs. It also enabled us to remove unused bool.

We also make sure to check if we&apos;re in the document before causing a layout so checking
for a disconnected image&apos;s width/height before drawing to a canvas doesn&apos;t cause a sync layout.

* Source/WebCore/HTMLImageElement.h: Remove unused &apos;boolean&apos;
* Source/WebCore/HTMLImageElement.cpp:
(HTMLImageElement::width): Update to account for renderer
(HTMLImageElement::height): Ditto
* LayoutTests/fast/image/img-dimensions-styled.html: Add Test Case
* LayoutTests/fast/image/img-dimensions-styled-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/257961@main">https://commits.webkit.org/257961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73a440f3e261b86ae41c7342c0a2e9002aecffca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109238 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169475 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86350 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92338 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107146 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90783 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34232 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22197 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2863 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23684 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2815 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46061 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43157 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5455 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4671 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->