### PR TITLE
Turn -webkit-mask-box-image into a shorthand

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
@@ -238,7 +238,6 @@ zoom: 1;
 -webkit-line-grid: none;
 -webkit-line-snap: none;
 -webkit-locale: auto;
--webkit-mask-box-image: none;
 -webkit-mask-box-image-outset: 0;
 -webkit-mask-box-image-repeat: stretch;
 -webkit-mask-box-image-slice: 0 fill;

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
@@ -237,7 +237,6 @@ zoom: 1
 -webkit-line-grid: none
 -webkit-line-snap: none
 -webkit-locale: auto
--webkit-mask-box-image: none
 -webkit-mask-box-image-outset: 0
 -webkit-mask-box-image-repeat: stretch
 -webkit-mask-box-image-slice: 0 fill

--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-webkit-mask-box-image.html
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-webkit-mask-box-image.html
@@ -43,6 +43,7 @@ const testCases = [
     [ '-webkit-mask-box-image: 1% // 2', {
         ...initialValues,
         '-webkit-mask-box-image-slice': '1% fill',
+        '-webkit-mask-box-image-outset': '2',
     }],
     [ '-webkit-mask-box-image: 1% / 2px / 3', {
         ...initialValues,

--- a/LayoutTests/fast/css/image-set-parsing-expected.txt
+++ b/LayoutTests/fast/css/image-set-parsing-expected.txt
@@ -98,7 +98,7 @@ PASS subRule.cssText is '1x'
 PASS subRule is 'b'
 PASS subRule.cssText is '2x'
 
-Single value for -webkit-mask-box-image : url('#a') 1x
+Single value for -webkit-mask-box-image-source : url('#a') 1x
 PASS jsWrapperClass(imageSetRule) is 'CSSValueList'
 PASS jsWrapperClass(imageSetRule.__proto__) is 'CSSValueList'
 PASS jsWrapperClass(imageSetRule.constructor) is 'Function'
@@ -106,7 +106,7 @@ PASS imageSetRule.length is 2
 PASS subRule is 'a'
 PASS subRule.cssText is '1x'
 
-Multiple values for -webkit-mask-box-image : url('#a') 1x, url('#b') 2x
+Multiple values for -webkit-mask-box-image-source : url('#a') 1x, url('#b') 2x
 PASS jsWrapperClass(imageSetRule) is 'CSSValueList'
 PASS jsWrapperClass(imageSetRule.__proto__) is 'CSSValueList'
 PASS jsWrapperClass(imageSetRule.constructor) is 'Function'

--- a/LayoutTests/fast/css/image-set-parsing.html
+++ b/LayoutTests/fast/css/image-set-parsing.html
@@ -117,13 +117,13 @@ testImageSetRule("Multiple values for border-image-source",
                 "url('#a') 1x, url('#b') 2x", 4,
                 ["a", "1x", "b", "2x"]);
 
-testImageSetRule("Single value for -webkit-mask-box-image",
-                "-webkit-mask-box-image",
+testImageSetRule("Single value for -webkit-mask-box-image-source",
+                "-webkit-mask-box-image-source",
                 "url('#a') 1x", 2,
                 ["a", "1x"]);
 
-testImageSetRule("Multiple values for -webkit-mask-box-image",
-                "-webkit-mask-box-image",
+testImageSetRule("Multiple values for -webkit-mask-box-image-source",
+                "-webkit-mask-box-image-source",
                 "url('#a') 1x, url('#b') 2x", 4,
                 ["a", "1x", "b", "2x"]);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -376,7 +376,6 @@ PASS -webkit-line-clamp
 PASS -webkit-line-grid
 PASS -webkit-line-snap
 PASS -webkit-locale
-PASS -webkit-mask-box-image
 PASS -webkit-mask-box-image-outset
 PASS -webkit-mask-box-image-repeat
 PASS -webkit-mask-box-image-slice

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -373,7 +373,6 @@ PASS -webkit-line-clamp
 PASS -webkit-line-grid
 PASS -webkit-line-snap
 PASS -webkit-locale
-PASS -webkit-mask-box-image
 PASS -webkit-mask-box-image-outset
 PASS -webkit-mask-box-image-repeat
 PASS -webkit-mask-box-image-slice

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -376,7 +376,6 @@ PASS -webkit-line-clamp
 PASS -webkit-line-grid
 PASS -webkit-line-snap
 PASS -webkit-locale
-PASS -webkit-mask-box-image
 PASS -webkit-mask-box-image-outset
 PASS -webkit-mask-box-image-repeat
 PASS -webkit-mask-box-image-slice

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -374,7 +374,6 @@ PASS -webkit-line-clamp
 PASS -webkit-line-grid
 PASS -webkit-line-snap
 PASS -webkit-locale
-PASS -webkit-mask-box-image
 PASS -webkit-mask-box-image-outset
 PASS -webkit-mask-box-image-repeat
 PASS -webkit-mask-box-image-slice

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -376,7 +376,6 @@ PASS -webkit-line-clamp
 PASS -webkit-line-grid
 PASS -webkit-line-snap
 PASS -webkit-locale
-PASS -webkit-mask-box-image
 PASS -webkit-mask-box-image-outset
 PASS -webkit-mask-box-image-repeat
 PASS -webkit-mask-box-image-slice

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -370,7 +370,6 @@ PASS -webkit-line-clamp
 PASS -webkit-line-grid
 PASS -webkit-line-snap
 PASS -webkit-locale
-PASS -webkit-mask-box-image
 PASS -webkit-mask-box-image-outset
 PASS -webkit-mask-box-image-repeat
 PASS -webkit-mask-box-image-slice

--- a/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
+++ b/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
@@ -474,8 +474,6 @@ rect: style.getPropertyValue(-webkit-line-snap) : none
 rect: style.getPropertyCSSValue(-webkit-line-snap) : [object CSSPrimitiveValue]
 rect: style.getPropertyValue(-webkit-locale) : auto
 rect: style.getPropertyCSSValue(-webkit-locale) : [object CSSPrimitiveValue]
-rect: style.getPropertyValue(-webkit-mask-box-image) : none
-rect: style.getPropertyCSSValue(-webkit-mask-box-image) : [object CSSPrimitiveValue]
 rect: style.getPropertyValue(-webkit-mask-box-image-outset) : 0
 rect: style.getPropertyCSSValue(-webkit-mask-box-image-outset) : [object CSSPrimitiveValue]
 rect: style.getPropertyValue(-webkit-mask-box-image-repeat) : stretch
@@ -984,8 +982,6 @@ g: style.getPropertyValue(-webkit-line-snap) : none
 g: style.getPropertyCSSValue(-webkit-line-snap) : [object CSSPrimitiveValue]
 g: style.getPropertyValue(-webkit-locale) : auto
 g: style.getPropertyCSSValue(-webkit-locale) : [object CSSPrimitiveValue]
-g: style.getPropertyValue(-webkit-mask-box-image) : none
-g: style.getPropertyCSSValue(-webkit-mask-box-image) : [object CSSPrimitiveValue]
 g: style.getPropertyValue(-webkit-mask-box-image-outset) : 0
 g: style.getPropertyCSSValue(-webkit-mask-box-image-outset) : [object CSSPrimitiveValue]
 g: style.getPropertyValue(-webkit-mask-box-image-repeat) : stretch

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7315,11 +7315,14 @@
         },
         "-webkit-mask-box-image": {
             "codegen-properties": {
-                "initial": "initialNinePieceImageForMask",
-                "converter": "BorderMask<CSSPropertyWebkitMaskBoxImage>",
-                "parser-function": "consumeWebkitBorderImage",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "longhands": [
+                    "-webkit-mask-box-image-source",
+                    "-webkit-mask-box-image-slice",
+                    "-webkit-mask-box-image-width",
+                    "-webkit-mask-box-image-outset",
+                    "-webkit-mask-box-image-repeat"
+                ],
+                "custom-parser": true
             },
             "status": "non-standard",
             "specification": {

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -302,6 +302,7 @@ String StyleProperties::getPropertyValue(CSSPropertyID propertyID) const
         return borderPropertyValue(borderInlineWidthShorthand(), borderInlineStyleShorthand(), borderInlineColorShorthand());
     case CSSPropertyBorderImage:
     case CSSPropertyWebkitBorderImage:
+    case CSSPropertyWebkitMaskBoxImage:
         return borderImagePropertyValue(shorthand);
     case CSSPropertyBorderRadius:
     case CSSPropertyWebkitBorderRadius:
@@ -1106,13 +1107,13 @@ String StyleProperties::borderImagePropertyValue(const StylePropertyShorthand& s
 
         // FIXME: We should omit values based on them being equal to the initial value, not based on the implicit flag.
         if (isPropertyImplicit(longhand)) {
-            if (longhand == CSSPropertyBorderImageSlice)
+            if (longhand == CSSPropertyBorderImageSlice || longhand == CSSPropertyWebkitMaskBoxImageSlice)
                 omittedSlice = true;
-            else if (longhand == CSSPropertyBorderImageWidth)
+            else if (longhand == CSSPropertyBorderImageWidth || longhand == CSSPropertyWebkitMaskBoxImageWidth)
                 omittedWidth = true;
             continue;
         }
-        if (omittedSlice && (longhand == CSSPropertyBorderImageWidth || longhand == CSSPropertyBorderImageOutset))
+        if (omittedSlice && (longhand == CSSPropertyBorderImageWidth || longhand == CSSPropertyBorderImageOutset || longhand == CSSPropertyWebkitMaskBoxImageWidth || longhand == CSSPropertyWebkitMaskBoxImageOutset))
             return String();
 
         String valueText;
@@ -1129,9 +1130,9 @@ String StyleProperties::borderImagePropertyValue(const StylePropertyShorthand& s
             valueText = value->cssText();
 
         // Append separator and text.
-        if (longhand == CSSPropertyBorderImageWidth)
+        if (longhand == CSSPropertyBorderImageWidth || longhand == CSSPropertyWebkitMaskBoxImageWidth)
             separator = " / ";
-        else if (longhand == CSSPropertyBorderImageOutset)
+        else if (longhand == CSSPropertyBorderImageOutset || longhand == CSSPropertyWebkitMaskBoxImageOutset)
             separator = omittedWidth ? " / / " : " / ";
         result.append(separator, valueText);
         separator = " ";

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -7196,18 +7196,6 @@ bool consumeBorderImageComponents(CSSPropertyID property, CSSParserTokenRange& r
     return true;
 }
 
-RefPtr<CSSValue> consumeWebkitBorderImage(CSSPropertyID property, CSSParserTokenRange& range, const CSSParserContext& context)
-{
-    RefPtr<CSSValue> source;
-    RefPtr<CSSValue> slice;
-    RefPtr<CSSValue> width;
-    RefPtr<CSSValue> outset;
-    RefPtr<CSSValue> repeat;
-    if (consumeBorderImageComponents(property, range, context, source, slice, width, outset, repeat))
-        return createBorderImageValue(WTFMove(source), WTFMove(slice), WTFMove(width), WTFMove(outset), WTFMove(repeat));
-    return nullptr;
-}
-
 RefPtr<CSSValue> consumeReflect(CSSParserTokenRange& range, const CSSParserContext& context)
 {
     if (range.peek().id() == CSSValueNone)
@@ -7228,9 +7216,14 @@ RefPtr<CSSValue> consumeReflect(CSSParserTokenRange& range, const CSSParserConte
 
     RefPtr<CSSValue> mask;
     if (!range.atEnd()) {
-        mask = consumeWebkitBorderImage(CSSPropertyWebkitBoxReflect, range, context);
-        if (!mask)
+        RefPtr<CSSValue> source;
+        RefPtr<CSSValue> slice;
+        RefPtr<CSSValue> width;
+        RefPtr<CSSValue> outset;
+        RefPtr<CSSValue> repeat;
+        if (!consumeBorderImageComponents(CSSPropertyWebkitBoxReflect, range, context, source, slice, width, outset, repeat))
             return nullptr;
+        mask = createBorderImageValue(WTFMove(source), WTFMove(slice), WTFMove(width), WTFMove(outset), WTFMove(repeat));
     }
     return CSSReflectValue::create(direction.releaseNonNull(), offset.releaseNonNull(), WTFMove(mask));
 }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1650,7 +1650,6 @@ public:
     static BorderCollapse initialBorderCollapse() { return BorderCollapse::Separate; }
     static BorderStyle initialBorderStyle() { return BorderStyle::None; }
     static OutlineIsAuto initialOutlineStyleIsAuto() { return OutlineIsAuto::Off; }
-    static NinePieceImage initialNinePieceImageForMask() { return NinePieceImage(NinePieceImage::Type::Mask); }
     static LengthSize initialBorderRadius() { return { { 0, LengthType::Fixed }, { 0, LengthType::Fixed } }; }
     static CaptionSide initialCaptionSide() { return CaptionSide::Top; }
     static ColumnAxis initialColumnAxis() { return ColumnAxis::Auto; }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -89,7 +89,6 @@ public:
     template<typename T> static T convertNumber(BuilderState&, const CSSValue&);
     template<typename T> static T convertNumberOrAuto(BuilderState&, const CSSValue&);
     static short convertWebkitHyphenateLimitLines(BuilderState&, const CSSValue&);
-    template<CSSPropertyID> static NinePieceImage convertBorderMask(BuilderState&, CSSValue&);
     template<CSSPropertyID> static RefPtr<StyleImage> convertStyleImage(BuilderState&, CSSValue&);
     static ImageOrientation convertImageOrientation(BuilderState&, const CSSValue&);
     static TransformOperations convertTransform(BuilderState&, const CSSValue&);
@@ -469,14 +468,6 @@ inline short BuilderConverter::convertWebkitHyphenateLimitLines(BuilderState&, c
     if (primitiveValue.valueID() == CSSValueNoLimit)
         return -1;
     return primitiveValue.value<short>(CSSUnitType::CSS_NUMBER);
-}
-
-template<CSSPropertyID property>
-inline NinePieceImage BuilderConverter::convertBorderMask(BuilderState& builderState, CSSValue& value)
-{
-    NinePieceImage image(NinePieceImage::Type::Mask);
-    builderState.styleMap().mapNinePieceImage(&value, image);
-    return image;
 }
 
 template<CSSPropertyID>


### PR DESCRIPTION
#### 3bdc3f2824cf4d01a15ee402d7de99b099e8b3ec
<pre>
Turn -webkit-mask-box-image into a shorthand
<a href="https://bugs.webkit.org/show_bug.cgi?id=249115">https://bugs.webkit.org/show_bug.cgi?id=249115</a>

Reviewed by Darin Adler.

* LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt: Shorthands are not indexed in style declarations.
* LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt: Shorthands are not indexed in style declarations.
* LayoutTests/fast/css/getComputedStyle/getComputedStyle-webkit-mask-box-image.html: Fix bug with omitted values.
* LayoutTests/fast/css/image-set-parsing-expected.txt: getPropertyCSSValue doesn&apos;t work for shorthands.
* LayoutTests/fast/css/image-set-parsing.html: getPropertyCSSValue doesn&apos;t work for shorthands.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt: Shorthands are not indexed in style declarations.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt: Shorthands are not indexed in style declarations.
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt: Shorthands are not indexed in style declarations.
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt: Shorthands are not indexed in style declarations.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt: Shorthands are not indexed in style declarations.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt: Shorthands are not indexed in style declarations.
* LayoutTests/svg/css/getComputedStyle-basic-expected.txt: Shorthands are not indexed in style declarations.
* Source/WebCore/css/CSSProperties.json: Turn -webkit-mask-box-image into a shorthand.
* Source/WebCore/css/StyleProperties.cpp: Serialize -webkit-mask-box-image as a shorthand.
(WebCore::StyleProperties::getPropertyValue const):
(WebCore::StyleProperties::borderImagePropertyValue const):
* Source/WebCore/css/parser/CSSPropertyParser.cpp: Parse -webkit-mask-box-image as a shorthand.
(WebCore::CSSPropertyParser::consumeBorderImage):
(WebCore::CSSPropertyParser::parseShorthand):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp: Refactoring.
(WebCore::CSSPropertyParserHelpers::consumeReflect):
(WebCore::CSSPropertyParserHelpers::consumeWebkitBorderImage): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h: Delete dead code.
(WebCore::RenderStyle::initialOutlineStyleIsAuto):
(WebCore::RenderStyle::initialNinePieceImageForMask): Deleted.
* Source/WebCore/style/StyleBuilderConverter.h: Delete dead code.
(WebCore::Style::BuilderConverter::convertBorderMask): Deleted.

Canonical link: <a href="https://commits.webkit.org/257723@main">https://commits.webkit.org/257723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d19cda79f0a4cd65fab0358d0c65d835703b554

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109170 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169409 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86275 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92268 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107080 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105571 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34184 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22111 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2800 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23623 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2746 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46002 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5306 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43093 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4609 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->