### PR TITLE
Content with -webkit-user-select: none should be skipped during copy

### DIFF
--- a/LayoutTests/editing/pasteboard/copy-content-with-user-select-none-expected.txt
+++ b/LayoutTests/editing/pasteboard/copy-content-with-user-select-none-expected.txt
@@ -1,0 +1,24 @@
+This tests copying excludes content with user-select: none.
+To manually test, copy "hello world foo bar" below then paste.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getSelection().toString().includes("hello") is true
+PASS getSelection().toString().includes("world") is false
+PASS getSelection().toString().includes("foo") is false
+PASS getSelection().toString().includes("bar") is true
+PASS event.clipboardData.getData("text/plain").includes("hello") is true
+PASS event.clipboardData.getData("text/plain").includes("world") is false
+PASS event.clipboardData.getData("text/plain").includes("foo") is false
+PASS event.clipboardData.getData("text/plain").includes("bar") is true
+PASS event.clipboardData.getData("text/html").includes("hello") is true
+PASS event.clipboardData.getData("text/html").includes("world") is false
+PASS event.clipboardData.getData("text/html").includes("foo") is false
+PASS event.clipboardData.getData("text/html").includes("bar") is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+hello world foo bar
+hello bar
+

--- a/LayoutTests/editing/pasteboard/copy-content-with-user-select-none.html
+++ b/LayoutTests/editing/pasteboard/copy-content-with-user-select-none.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="source">hello <span style="-webkit-user-select: none; user-select: none;">world </span><span inert>foo </span>bar</div>
+<div id="destination" contenteditable></div>
+<pre id="output"></pre>
+</body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description(`This tests copying excludes content with user-select: none.<br>
+To manually test, copy "hello world foo bar" below then paste.`);
+
+jsTestIsAsync = true;
+getSelection().setBaseAndExtent(source, 0, source, source.childNodes.length);
+
+source.addEventListener("copy", () => {
+    shouldBeTrue('getSelection().toString().includes("hello")');
+    shouldBeFalse('getSelection().toString().includes("world")');
+    shouldBeFalse('getSelection().toString().includes("foo")');
+    shouldBeTrue('getSelection().toString().includes("bar")');
+});
+
+destination.addEventListener("paste", () => {
+    shouldBeTrue('event.clipboardData.getData("text/plain").includes("hello")');
+    shouldBeFalse('event.clipboardData.getData("text/plain").includes("world")');
+    shouldBeFalse('event.clipboardData.getData("text/plain").includes("foo")');
+    shouldBeTrue('event.clipboardData.getData("text/plain").includes("bar")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("hello")');
+    shouldBeFalse('event.clipboardData.getData("text/html").includes("world")');
+    shouldBeFalse('event.clipboardData.getData("text/html").includes("foo")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("bar")');
+    finishJSTest();
+});
+
+if (window.testRunner && window.internals) {
+    testRunner.dumpAsText();
+    testRunner.execCommand("Copy");
+    destination.focus();
+    testRunner.execCommand("Paste");
+} else {
+    source.addEventListener("copy", () => {
+        setTimeout(() => destination.focus(), 0);
+    });
+}
+
+</script>
+</html>

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -3367,12 +3367,12 @@ void Editor::changeSelectionAfterCommand(const VisibleSelection& newSelection, O
 
 String Editor::selectedText() const
 {
-    return selectedText(TextIteratorBehavior::TraversesFlatTree);
+    return selectedText({ TextIteratorBehavior::TraversesFlatTree, TextIteratorBehavior::IgnoresUserSelectNone });
 }
 
 String Editor::selectedTextForDataTransfer() const
 {
-    return selectedText(OptionSet { TextIteratorBehavior::EmitsImageAltText, TextIteratorBehavior::TraversesFlatTree });
+    return selectedText(OptionSet { TextIteratorBehavior::EmitsImageAltText, TextIteratorBehavior::TraversesFlatTree, TextIteratorBehavior::IgnoresUserSelectNone });
 }
 
 String Editor::selectedText(TextIteratorBehaviors behaviors) const

--- a/Source/WebCore/editing/TextIteratorBehavior.h
+++ b/Source/WebCore/editing/TextIteratorBehavior.h
@@ -63,6 +63,8 @@ enum class TextIteratorBehavior : uint16_t {
     EntersImageOverlays = 1 << 10,
 
     IgnoresWhiteSpaceAtEndOfRun = 1 << 11,
+
+    IgnoresUserSelectNone = 1 << 12,
 };
 
 using TextIteratorBehaviors = OptionSet<TextIteratorBehavior>;

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -80,7 +80,7 @@ String Editor::selectionInHTMLFormat()
 {
     if (ImageOverlay::isInsideOverlay(m_document.selection().selection()))
         return { };
-    return serializePreservingVisualAppearance(m_document.selection().selection(), ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes);
+    return serializePreservingVisualAppearance(m_document.selection().selection(), ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes, IgnoreUserSelectNone::Yes);
 }
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -1608,10 +1608,11 @@ void HTMLConverter::_processHeadElement(Element& element)
 BOOL HTMLConverter::_enterElement(Element& element, BOOL embedded)
 {
     String displayValue = _caches->propertyValueForNode(element, CSSPropertyDisplay);
+    bool hasUserSelectNone = element.renderer() && element.renderer()->style().effectiveUserSelect() == UserSelect::None;
 
     if (element.hasTagName(headTag) && !embedded)
         _processHeadElement(element);
-    else if (!displayValue.length() || !(displayValue == noneAtom() || displayValue == "table-column"_s || displayValue == "table-column-group"_s)) {
+    else if (!hasUserSelectNone && (!displayValue.length() || !(displayValue == noneAtom() || displayValue == "table-column"_s || displayValue == "table-column-group"_s))) {
         if (_caches->isBlockElement(element) && !element.hasTagName(brTag) && !(displayValue == "table-cell"_s && ![_textTables count])
             && !([_textLists count] > 0 && displayValue == "block"_s && !element.hasTagName(liTag) && !element.hasTagName(ulTag) && !element.hasTagName(olTag)))
             _newParagraphForElement(element, element.tagName(), NO, YES);

--- a/Source/WebCore/editing/gtk/EditorGtk.cpp
+++ b/Source/WebCore/editing/gtk/EditorGtk.cpp
@@ -117,7 +117,7 @@ void Editor::writeSelectionToPasteboard(Pasteboard& pasteboard)
     PasteboardWebContent pasteboardContent;
     pasteboardContent.canSmartCopyOrDelete = canSmartCopyOrDelete();
     pasteboardContent.text = selectedTextForDataTransfer();
-    pasteboardContent.markup = serializePreservingVisualAppearance(m_document.selection().selection(), ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes);
+    pasteboardContent.markup = serializePreservingVisualAppearance(m_document.selection().selection(), ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes, IgnoreUserSelectNone::Yes);
     pasteboardContent.contentOrigin = m_document.originIdentifierForPasteboard();
     pasteboard.write(pasteboardContent);
 }

--- a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
+++ b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
@@ -66,7 +66,7 @@ void Editor::writeSelectionToPasteboard(Pasteboard& pasteboard)
 {
     PasteboardWebContent pasteboardContent;
     pasteboardContent.text = selectedTextForDataTransfer();
-    pasteboardContent.markup = serializePreservingVisualAppearance(m_document.selection().selection(), ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes);
+    pasteboardContent.markup = serializePreservingVisualAppearance(m_document.selection().selection(), ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes, IgnoreUserSelectNone::Yes);
     pasteboard.write(pasteboardContent);
 }
 

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -250,7 +250,7 @@ void Editor::writeImageToPasteboard(Pasteboard& pasteboard, Element& imageElemen
         pasteboardImage.dataInWebArchiveFormat = imageInWebArchiveFormat(imageElement);
 
     if (auto imageRange = makeRangeSelectingNode(imageElement))
-        pasteboardImage.dataInHTMLFormat = serializePreservingVisualAppearance(VisibleSelection { *imageRange }, ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes);
+        pasteboardImage.dataInHTMLFormat = serializePreservingVisualAppearance(VisibleSelection { *imageRange }, ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes, IgnoreUserSelectNone::Yes);
 
     pasteboardImage.url.url = url;
     pasteboardImage.url.title = title;

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -73,8 +73,10 @@ ExceptionOr<void> replaceChildrenWithFragment(ContainerNode&, Ref<DocumentFragme
 
 enum class ConvertBlocksToInlines : uint8_t { No, Yes };
 enum class SerializeComposedTree : uint8_t { No, Yes };
+enum class IgnoreUserSelectNone: uint8_t { No, Yes };
 WEBCORE_EXPORT String serializePreservingVisualAppearance(const SimpleRange&, Vector<Node*>* = nullptr, AnnotateForInterchange = AnnotateForInterchange::No, ConvertBlocksToInlines = ConvertBlocksToInlines::No, ResolveURLs = ResolveURLs::No);
-String serializePreservingVisualAppearance(const VisibleSelection&, ResolveURLs = ResolveURLs::No, SerializeComposedTree = SerializeComposedTree::No, Vector<Node*>* = nullptr);
+String serializePreservingVisualAppearance(const VisibleSelection&, ResolveURLs = ResolveURLs::No, SerializeComposedTree = SerializeComposedTree::No,
+    IgnoreUserSelectNone = IgnoreUserSelectNone::Yes, Vector<Node*>* = nullptr);
 
 enum class SerializedNodes : uint8_t { SubtreeIncludingNode, SubtreesOfChildren };
 enum class SerializationSyntax : uint8_t { HTML, XML };

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -599,7 +599,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::createFromSelection(Frame* frame)
     builder.append(documentTypeString(*document));
 
     Vector<Node*> nodeList;
-    builder.append(serializePreservingVisualAppearance(frame->selection().selection(), ResolveURLs::No, SerializeComposedTree::Yes, &nodeList));
+    builder.append(serializePreservingVisualAppearance(frame->selection().selection(), ResolveURLs::No, SerializeComposedTree::Yes, IgnoreUserSelectNone::Yes, &nodeList));
 
     auto archive = create(builder.toString(), *frame, nodeList, nullptr);
     if (!archive)

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -452,10 +452,10 @@ String DOMSelection::toString() const
         return String();
     if (frame->settings().liveRangeSelectionEnabled()) {
         auto range = this->range();
-        return range ? plainText(*range) : emptyString();
+        return range ? plainText(*range, TextIteratorBehavior::IgnoresUserSelectNone) : emptyString();
     }
     auto range = frame->selection().selection().firstRange();
-    return range ? plainText(*range) : emptyString();
+    return range ? plainText(*range, TextIteratorBehavior::IgnoresUserSelectNone) : emptyString();
 }
 
 RefPtr<Node> DOMSelection::shadowAdjustedNode(const Position& position) const

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm
@@ -163,4 +163,11 @@ TEST(CopyRTF, StripsDataDetectorsLinks)
 
 #endif // ENABLE(DATA_DETECTION)
 
+TEST(CopyRTF, StripsUserSelectNone)
+{
+    auto attributedString = copyAttributedStringFromHTML(@"hello <span style='-webkit-user-select: none'>world </span><span inert>foo </span>bar", false);
+
+    EXPECT_WK_STREQ([attributedString string].UTF8String, "hello bar");
+}
+
 #endif // PLATFORM(COCOA)


### PR DESCRIPTION
#### 166aef8967703338451b376ce492edc0fa79d86a
<pre>
Content with -webkit-user-select: none should be skipped during copy
<a href="https://bugs.webkit.org/show_bug.cgi?id=80159">https://bugs.webkit.org/show_bug.cgi?id=80159</a>

Reviewed by Darin Adler.

Exclude content with -webkit-user-select: none when copying. This patch introduces
TextIteratorBehavior::IgnoresUserSelectNone to exclude such content from plain text,
and adds IgnoreUserSelectNone as an argument to serializePreservingVisualAppearance
to exclude such content from HTML. It also updates HTMLConverter::_enterElement to
exclude such content from RTFD.

Finally, this patch also updates DOMSelection::toString to have the same treatment.

* LayoutTests/editing/pasteboard/copy-content-with-user-select-none-expected.txt: Added.
* LayoutTests/editing/pasteboard/copy-content-with-user-select-none.html: Added.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::selectedText const):
(WebCore::Editor::selectedTextForDataTransfer const):

* Source/WebCore/editing/TextIterator.cpp:
(WebCore::isRendererVisible): Added.
(WebCore::TextIterator::advance):
(WebCore::hasVisibleTextNode):
(WebCore::TextIterator::handleTextNodeFirstLetter):

* Source/WebCore/editing/TextIteratorBehavior.h:

* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::selectionInHTMLFormat):

* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::_enterElement):

* Source/WebCore/editing/gtk/EditorGtk.cpp:
(WebCore::Editor::writeSelectionToPasteboard):

* Source/WebCore/editing/libwpe/EditorLibWPE.cpp:
(WebCore::Editor::writeSelectionToPasteboard):

* Source/WebCore/editing/mac/EditorMac.mm:
(WebCore::Editor::writeImageToPasteboard):

* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::StyledMarkupAccumulator):
(WebCore::StyledMarkupAccumulator::renderedTextRespectingRange):
(WebCore::StyledMarkupAccumulator::traverseNodesForSerialization):
(WebCore::serializePreservingVisualAppearanceInternal):
(WebCore::serializePreservingVisualAppearance):
(WebCore::sanitizedMarkupForFragmentInDocument):

* Source/WebCore/editing/markup.h:

* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::createFromSelection):

* Source/WebCore/page/DOMSelection.cpp:
(WebCore::DOMSelection::toString const):

* Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm:
(CopyRTF.StripsUserSelectNone):

Canonical link: <a href="https://commits.webkit.org/257749@main">https://commits.webkit.org/257749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0694fc8efabaf436f47ce043db7e49bd2ad2a5b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99817 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32905 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109183 "Updated wpe dependencies (failure)") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169420 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86287 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92296 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107092 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105584 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34198 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22120 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2812 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23630 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46009 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43103 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2729 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->