### PR TITLE
getComputedStyle() returns the right values for invalid pseudoElement

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/computed-style-properties-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-properties-expected.txt
@@ -11,7 +11,9 @@ Heading B
 
 PASS computedStyleFor('outline', null, 'outline-offset') is '5px'
 PASS computedStyleFor('content', ':before', 'content') is "\"text\""
+PASS computedStyleFor('content', '::before', 'content') is "\"text\""
 PASS computedStyleFor('content', ':after', 'content') is "\"test \" url(\"data:image/gif;base64,R0lGODlhAQABAJAAAP8AAAAAACwAAAAAAQABAAACAgQBADs=\")"
+PASS computedStyleFor('content', '::after', 'content') is "\"test \" url(\"data:image/gif;base64,R0lGODlhAQABAJAAAP8AAAAAACwAAAAAAQABAAACAgQBADs=\")"
 PASS computedStyleFor('counter', null, 'counter-reset') is "section 0"
 PASS str.indexOf('subsection 0') != -1 is true
 PASS str.indexOf('anothercounter 5') != -1 is true

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-properties.html
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-properties.html
@@ -66,7 +66,9 @@ function computedStyleFor(id, pseudo, property)
 shouldBe("computedStyleFor('outline', null, 'outline-offset')", "'5px'");
 
 shouldBeEqualToString("computedStyleFor('content', ':before', 'content')", '"text"');
+shouldBeEqualToString("computedStyleFor('content', '::before', 'content')", '"text"');
 shouldBeEqualToString("computedStyleFor('content', ':after', 'content')", `"test " url(\"data:image/gif;base64,R0lGODlhAQABAJAAAP8AAAAAACwAAAAAAQABAAACAgQBADs=\")`);
+shouldBeEqualToString("computedStyleFor('content', '::after', 'content')", `"test " url(\"data:image/gif;base64,R0lGODlhAQABAJAAAP8AAAAAACwAAAAAAQABAAACAgQBADs=\")`);
 shouldBeEqualToString("computedStyleFor('counter', null, 'counter-reset')", "section 0");
 var str = computedStyleFor('subcounter', null, 'counter-reset');
 shouldBe("str.indexOf('subsection 0') != -1", "true");

--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element-expected.txt
@@ -60,7 +60,7 @@ PASS Expected 'rgb(165, 42, 42)' for color in the computed style for element wit
 PASS Expected 'rgb(165, 42, 42)' for color in the computed style for element with id testNoPseudoElement and pseudo-element :first-letter and got 'rgb(165, 42, 42)'
 PASS Expected 'rgb(165, 42, 42)' for color in the computed style for element with id testNoPseudoElement and pseudo-element :before and got 'rgb(165, 42, 42)'
 PASS Expected 'rgb(165, 42, 42)' for color in the computed style for element with id testNoPseudoElement and pseudo-element :after and got 'rgb(165, 42, 42)'
-PASS Expected 'rgb(165, 42, 42)' for color in the computed style for element with id testNoPseudoElement and pseudo-element :garbage and got 'rgb(165, 42, 42)'
+PASS Expected '' for color in the computed style for element with id testNoPseudoElement and pseudo-element :garbage and got ''
 PASS Expected '100px' for height in the computed style for element with id testNoPseudoElement and pseudo-element null and got '100px'
 PASS Expected '100px' for width in the computed style for element with id testNoPseudoElement and pseudo-element null and got '100px'
 PASS Expected 'auto' for height in the computed style for element with id testNoPseudoElement and pseudo-element :after and got 'auto'

--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html
@@ -177,7 +177,7 @@
         { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : ':first-letter', 'property' : 'color', 'expectedValue' : 'rgb(165, 42, 42)' },
         { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : ':before', 'property' : 'color', 'expectedValue' : 'rgb(165, 42, 42)' },
         { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : ':after', 'property' : 'color', 'expectedValue' : 'rgb(165, 42, 42)' },
-        { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : ':garbage', 'property' : 'color', 'expectedValue' : 'rgb(165, 42, 42)' },
+        { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : ':garbage', 'property' : 'color', 'expectedValue' : '' },
         { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : null, 'property' : 'height', 'expectedValue' : '100px' },
         { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : null, 'property' : 'width', 'expectedValue' : '100px' },
         { 'elementId' : 'testNoPseudoElement', 'pseudoElement' : ':after', 'property' : 'height', 'expectedValue' : 'auto' },

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -51,7 +51,8 @@ CSSComputedStyleDeclaration::CSSComputedStyleDeclaration(Element& element, bool 
     : m_element(element)
     , m_allowVisitedStyle(allowVisitedStyle)
 {
-    // FIXME: This should return a style with initial values if the pseudo-element is invalid (webkit.org/b/243539).
+    // FIXME: Return the element style values if the pseudo-element is "unknown" (webkit.org/b/243539).
+    // FIXME: Return a list style properties with empty values if the pseudo-element is ":marker" or "::unknown" (webkit.org/b/243539).
     auto pseudoId = CSSSelector::parseStandalonePseudoElement(pseudoElementName, CSSSelectorParserContext { element.document() });
     m_pseudoElementSpecifier = pseudoId ? *pseudoId : PseudoId::None;
 }

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -359,7 +359,7 @@ std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElement(String
 
 std::optional<PseudoId> CSSSelector::parseStandalonePseudoElement(StringView input, const CSSSelectorParserContext& context)
 {
-    // FIXME: Tokenize input.
+    // FIXME: Tokenize input to handle cases like "::\000041fter" instead of "::after" or "::highlight(name)"
     if (input.startsWith("::"_s)) {
         auto pseudoElement = parsePseudoElement(input.substring(2), context);
         if (!pseudoElement)

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2657,6 +2657,8 @@ RenderElement* ComputedStyleExtractor::styledRenderer() const
 {
     if (!m_element)
         return nullptr;
+    if (m_pseudoElementSpecifier == PseudoId::Invalid)
+        return nullptr;
     if (m_pseudoElementSpecifier != PseudoId::None)
         return Styleable(*m_element, m_pseudoElementSpecifier).renderer();
     if (m_element->hasDisplayContents())

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4163,6 +4163,9 @@ const RenderStyle* Element::computedStyle(PseudoId pseudoElementSpecifier)
     if (!isConnected())
         return nullptr;
 
+    if (pseudoElementSpecifier == PseudoId::Invalid)
+        return nullptr;
+
     if (RefPtr pseudoElement = beforeOrAfterPseudoElement(*this, pseudoElementSpecifier))
         return pseudoElement->computedStyle();
 

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -109,6 +109,7 @@ enum class PseudoId : uint32_t {
     ScrollbarTrackPiece,
     ScrollbarCorner,
     Resizer,
+    Invalid,
 
     AfterLastInternalPseudoId,
 


### PR DESCRIPTION
#### c7fe66d121e6466441ec0d8d15b8c5258462fa11
<pre>
getComputedStyle() returns the right values for invalid pseudoElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=243539">https://bugs.webkit.org/show_bug.cgi?id=243539</a>
<a href="https://rdar.apple.com/98504661">rdar://98504661</a>

Reviewed by NOBODY (OOPS!).

FIXME: Needs to change the description and list of files as
<a href="https://github.com/WebKit/WebKit/pull/22231">https://github.com/WebKit/WebKit/pull/22231</a>
fixed some of the issues in a more general way than the way this
patch was trying to do. Or maybe I should just closed this PR and
starts fresh.

parseStandalonePseudoElement() should probably be moved in
CSSComputedStyleDeclaration.cpp

The getComputedStyle(elt, pseudoElt) method must run these steps:

1. Let doc be elt&apos;s node document.
2. Let obj be elt.
3. If pseudoElt is provided, is not the empty string, and starts with a colon, then:
   3.1 Parse pseudoElt as a &lt;pseudo-element-selector&gt;, and let type be the result.
   3.2 If type is failure, or is an ::slotted() or ::part() pseudo-element, let obj be null.
   3.3 Otherwise let obj be the given pseudo-element of elt.
       Note: CSS2 pseudo-elements should match both the double
       and single-colon versions. That is, both :before
       and ::before should match above.
4. Let decls be an empty list of CSS declarations.
5. If obj is not null, and elt is connected, part of the flat tree, and its shadow-including root has a browsing context which either doesn’t have a browsing context container, or whose browsing context container is being rendered, set decls to a list of all longhand properties that are supported CSS properties, in lexicographical order, with the value being the resolved value computed for obj using the style rules associated with doc. Additionally, append to decls all the custom properties whose computed value for obj is not the guaranteed-invalid value.

* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::CSSComputedStyleDeclaration):
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::pseudoId):
(WebCore::CSSSelector::parsePseudoElement):
(WebCore::CSSSelector::parseStandalonePseudoElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7fe66d121e6466441ec0d8d15b8c5258462fa11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/10632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/33687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/34448 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28931 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7870 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28526 "Found 1 new test failure: fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32304 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8991 "Found 1 new test failure: fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/28536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7776 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7957 "Exiting early after 10 failures. 20 tests run. 1 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28449 "Found 1 new test failure: fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35792 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29053 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28903 "Found 2 new test failures: fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html, tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical-then-horizontal.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34055 "Found 1 new test failure: fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8041 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6027 "Found 29 new test failures: fast/css/getComputedStyle/getComputedStyle-with-pseudo-element.html, fast/media/media-query-dynamic-with-font-face.html, inspector/css/add-css-property.html, inspector/css/css-property.html, inspector/css/forcePseudoState.html, inspector/css/generateFormattedText.html, inspector/css/getComputedPrimaryFontForNode.html, inspector/css/getMatchedStylesForNode.html, inspector/css/getMatchedStylesForNodeBackdropPseudoId.html, inspector/css/getMatchedStylesForNodeContainerGrouping.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31914 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9687 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28256 "Exiting early after 10 failures. 20 tests run. 1 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8704 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/8564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->