### PR TITLE
[JSC] Fix AVX function invocation ordering in X86 MacroAssembler

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -2266,39 +2266,39 @@ public:
         switch (cond) {
         case DoubleEqualAndOrdered:
             if (simdInfo.lane == SIMDLane::f32x4)
-                m_assembler.vcmpps_rrr(PackedCompareCondition::Equal, left, right, dest);
+                m_assembler.vcmpps_rrr(PackedCompareCondition::Equal, right, left, dest);
             else
-                m_assembler.vcmppd_rrr(PackedCompareCondition::Equal, left, right, dest);
+                m_assembler.vcmppd_rrr(PackedCompareCondition::Equal, right, left, dest);
             break;
         case DoubleNotEqualOrUnordered:
             if (simdInfo.lane == SIMDLane::f32x4)
-                m_assembler.vcmpps_rrr(PackedCompareCondition::NotEqual, left, right, dest);
+                m_assembler.vcmpps_rrr(PackedCompareCondition::NotEqual, right, left, dest);
             else
-                m_assembler.vcmppd_rrr(PackedCompareCondition::NotEqual, left, right, dest);
+                m_assembler.vcmppd_rrr(PackedCompareCondition::NotEqual, right, left, dest);
             break;
         case DoubleGreaterThanAndOrdered:
             if (simdInfo.lane == SIMDLane::f32x4)
-                m_assembler.vcmpps_rrr(PackedCompareCondition::GreaterThan, left, right, dest);
+                m_assembler.vcmpps_rrr(PackedCompareCondition::GreaterThan, right, left, dest);
             else
-                m_assembler.vcmppd_rrr(PackedCompareCondition::GreaterThan, left, right, dest);
+                m_assembler.vcmppd_rrr(PackedCompareCondition::GreaterThan, right, left, dest);
             break;
         case DoubleGreaterThanOrEqualAndOrdered:
             if (simdInfo.lane == SIMDLane::f32x4)
-                m_assembler.vcmpps_rrr(PackedCompareCondition::GreaterThanOrEqual, left, right, dest);
+                m_assembler.vcmpps_rrr(PackedCompareCondition::GreaterThanOrEqual, right, left, dest);
             else
-                m_assembler.vcmppd_rrr(PackedCompareCondition::GreaterThanOrEqual, left, right, dest);
+                m_assembler.vcmppd_rrr(PackedCompareCondition::GreaterThanOrEqual, right, left, dest);
             break;
         case DoubleLessThanAndOrdered:
             if (simdInfo.lane == SIMDLane::f32x4)
-                m_assembler.vcmpps_rrr(PackedCompareCondition::LessThan, left, right, dest);
+                m_assembler.vcmpps_rrr(PackedCompareCondition::LessThan, right, left, dest);
             else
-                m_assembler.vcmppd_rrr(PackedCompareCondition::LessThan, left, right, dest);
+                m_assembler.vcmppd_rrr(PackedCompareCondition::LessThan, right, left, dest);
             break;
         case DoubleLessThanOrEqualAndOrdered:
             if (simdInfo.lane == SIMDLane::f32x4)
-                m_assembler.vcmpps_rrr(PackedCompareCondition::LessThanOrEqual, left, right, dest);
+                m_assembler.vcmpps_rrr(PackedCompareCondition::LessThanOrEqual, right, left, dest);
             else
-                m_assembler.vcmppd_rrr(PackedCompareCondition::LessThanOrEqual, left, right, dest);
+                m_assembler.vcmppd_rrr(PackedCompareCondition::LessThanOrEqual, right, left, dest);
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();
@@ -2314,16 +2314,16 @@ public:
         case Equal:
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpcmpeqb_rrr(left, right, dest);
+                m_assembler.vpcmpeqb_rrr(right, left, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpcmpeqw_rrr(left, right, dest);
+                m_assembler.vpcmpeqw_rrr(right, left, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpcmpeqd_rrr(left, right, dest);
+                m_assembler.vpcmpeqd_rrr(right, left, dest);
                 break;
             case SIMDLane::i64x2:
-                m_assembler.vpcmpeqq_rrr(left, right, dest);
+                m_assembler.vpcmpeqq_rrr(right, left, dest);
                 break;
             default:
                 RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unsupported SIMD lane for comparison");
@@ -2340,17 +2340,18 @@ public:
             RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Shouldn't emit integer vector Above comparisons directly.");
             break;
         case AboveOrEqual:
+            // FIXME: these functions need to take scratch register since left can be dest.
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpmaxub_rrr(left, right, dest);
+                m_assembler.vpmaxub_rrr(right, left, dest);
                 m_assembler.vpcmpeqb_rrr(left, dest, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpmaxuw_rrr(left, right, dest);
+                m_assembler.vpmaxuw_rrr(right, left, dest);
                 m_assembler.vpcmpeqw_rrr(left, dest, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpmaxud_rrr(left, right, dest);
+                m_assembler.vpmaxud_rrr(right, left, dest);
                 m_assembler.vpcmpeqd_rrr(left, dest, dest);
                 break;
             case SIMDLane::i64x2:
@@ -2366,17 +2367,18 @@ public:
             RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Shouldn't emit integer vector Below comparisons directly.");
             break;
         case BelowOrEqual:
+            // FIXME: these functions need to take scratch register since left can be dest.
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpminub_rrr(left, right, dest);
+                m_assembler.vpminub_rrr(right, left, dest);
                 m_assembler.vpcmpeqb_rrr(left, dest, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpminuw_rrr(left, right, dest);
+                m_assembler.vpminuw_rrr(right, left, dest);
                 m_assembler.vpcmpeqw_rrr(left, dest, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpminud_rrr(left, right, dest);
+                m_assembler.vpminud_rrr(right, left, dest);
                 m_assembler.vpcmpeqd_rrr(left, dest, dest);
                 break;
             case SIMDLane::i64x2:
@@ -2387,47 +2389,6 @@ public:
             }
             break;
         case GreaterThan:
-            switch (simdInfo.lane) {
-            case SIMDLane::i8x16:
-                m_assembler.vpcmpgtb_rrr(left, right, dest);
-                break;
-            case SIMDLane::i16x8:
-                m_assembler.vpcmpgtw_rrr(left, right, dest);
-                break;
-            case SIMDLane::i32x4:
-                m_assembler.vpcmpgtd_rrr(left, right, dest);
-                break;
-            case SIMDLane::i64x2:
-                m_assembler.vpcmpgtq_rrr(left, right, dest);
-                break;
-            default:
-                RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unsupported SIMD lane for comparison");
-            }
-            break;
-        case GreaterThanOrEqual:
-            switch (simdInfo.lane) {
-            case SIMDLane::i8x16:
-                m_assembler.vpmaxsb_rrr(left, right, dest);
-                m_assembler.vpcmpeqb_rrr(left, dest, dest);
-                break;
-            case SIMDLane::i16x8:
-                m_assembler.vpmaxsw_rrr(left, right, dest);
-                m_assembler.vpcmpeqw_rrr(left, dest, dest);
-                break;
-            case SIMDLane::i32x4:
-                m_assembler.vpmaxsd_rrr(left, right, dest);
-                m_assembler.vpcmpeqd_rrr(left, dest, dest);
-                break;
-            case SIMDLane::i64x2:
-                // Intel doesn't support 64-bit packed maximum/minimum without AVX512, so this condition should have been transformed
-                // into a negated LessThan prior to reaching the macro assembler.
-                RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Shouldn't emit integer vector GreaterThanOrEqual comparisons directly.");
-                break;
-            default:
-                RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unsupported SIMD lane for comparison");
-            }
-            break;
-        case LessThan:
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
                 m_assembler.vpcmpgtb_rrr(right, left, dest);
@@ -2445,18 +2406,61 @@ public:
                 RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unsupported SIMD lane for comparison");
             }
             break;
-        case LessThanOrEqual:
+        case GreaterThanOrEqual:
+            // FIXME: these functions need to take scratch register since left can be dest.
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpminsb_rrr(left, right, dest);
+                m_assembler.vpmaxsb_rrr(right, left, dest);
                 m_assembler.vpcmpeqb_rrr(left, dest, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpminsw_rrr(left, right, dest);
+                m_assembler.vpmaxsw_rrr(right, left, dest);
                 m_assembler.vpcmpeqw_rrr(left, dest, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpminsd_rrr(left, right, dest);
+                m_assembler.vpmaxsd_rrr(right, left, dest);
+                m_assembler.vpcmpeqd_rrr(left, dest, dest);
+                break;
+            case SIMDLane::i64x2:
+                // Intel doesn't support 64-bit packed maximum/minimum without AVX512, so this condition should have been transformed
+                // into a negated LessThan prior to reaching the macro assembler.
+                RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Shouldn't emit integer vector GreaterThanOrEqual comparisons directly.");
+                break;
+            default:
+                RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unsupported SIMD lane for comparison");
+            }
+            break;
+        case LessThan:
+            switch (simdInfo.lane) {
+            case SIMDLane::i8x16:
+                m_assembler.vpcmpgtb_rrr(left, right, dest);
+                break;
+            case SIMDLane::i16x8:
+                m_assembler.vpcmpgtw_rrr(left, right, dest);
+                break;
+            case SIMDLane::i32x4:
+                m_assembler.vpcmpgtd_rrr(left, right, dest);
+                break;
+            case SIMDLane::i64x2:
+                m_assembler.vpcmpgtq_rrr(left, right, dest);
+                break;
+            default:
+                RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unsupported SIMD lane for comparison");
+            }
+            break;
+        case LessThanOrEqual:
+            // FIXME: these functions need to take scratch register since left can be dest.
+            switch (simdInfo.lane) {
+            case SIMDLane::i8x16:
+                m_assembler.vpminsb_rrr(right, left, dest);
+                m_assembler.vpcmpeqb_rrr(left, dest, dest);
+                break;
+            case SIMDLane::i16x8:
+                m_assembler.vpminsw_rrr(right, left, dest);
+                m_assembler.vpcmpeqw_rrr(left, dest, dest);
+                break;
+            case SIMDLane::i32x4:
+                m_assembler.vpminsd_rrr(right, left, dest);
                 m_assembler.vpcmpeqd_rrr(left, dest, dest);
                 break;
             case SIMDLane::i64x2:
@@ -2490,22 +2494,22 @@ public:
 
         switch (simdInfo.lane) {
         case SIMDLane::f32x4:
-            m_assembler.vaddps_rrr(left, right, dest);
+            m_assembler.vaddps_rrr(right, left, dest);
             break;
         case SIMDLane::f64x2:
-            m_assembler.vaddpd_rrr(left, right, dest);
+            m_assembler.vaddpd_rrr(right, left, dest);
             break;
         case SIMDLane::i8x16:
-            m_assembler.vpaddb_rrr(left, right, dest);
+            m_assembler.vpaddb_rrr(right, left, dest);
             break;
         case SIMDLane::i16x8:
-            m_assembler.vpaddw_rrr(left, right, dest);
+            m_assembler.vpaddw_rrr(right, left, dest);
             break;
         case SIMDLane::i32x4:
-            m_assembler.vpaddd_rrr(left, right, dest);
+            m_assembler.vpaddd_rrr(right, left, dest);
             break;
         case SIMDLane::i64x2:
-            m_assembler.vpaddq_rrr(left, right, dest);
+            m_assembler.vpaddq_rrr(right, left, dest);
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Invalid SIMD lane for vector add.");
@@ -2518,22 +2522,22 @@ public:
 
         switch (simdInfo.lane) {
         case SIMDLane::f32x4:
-            m_assembler.vsubps_rrr(left, right, dest);
+            m_assembler.vsubps_rrr(right, left, dest);
             break;
         case SIMDLane::f64x2:
-            m_assembler.vsubpd_rrr(left, right, dest);
+            m_assembler.vsubpd_rrr(right, left, dest);
             break;
         case SIMDLane::i8x16:
-            m_assembler.vpsubb_rrr(left, right, dest);
+            m_assembler.vpsubb_rrr(right, left, dest);
             break;
         case SIMDLane::i16x8:
-            m_assembler.vpsubw_rrr(left, right, dest);
+            m_assembler.vpsubw_rrr(right, left, dest);
             break;
         case SIMDLane::i32x4:
-            m_assembler.vpsubd_rrr(left, right, dest);
+            m_assembler.vpsubd_rrr(right, left, dest);
             break;
         case SIMDLane::i64x2:
-            m_assembler.vpsubq_rrr(left, right, dest);
+            m_assembler.vpsubq_rrr(right, left, dest);
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Invalid SIMD lane for vector subtract.");
@@ -2546,16 +2550,16 @@ public:
 
         switch (simdInfo.lane) {
         case SIMDLane::f32x4:
-            m_assembler.vmulps_rrr(left, right, dest);
+            m_assembler.vmulps_rrr(right, left, dest);
             break;
         case SIMDLane::f64x2:
-            m_assembler.vmulpd_rrr(left, right, dest);
+            m_assembler.vmulpd_rrr(right, left, dest);
             break;
         case SIMDLane::i16x8:
-            m_assembler.vpmullw_rrr(left, right, dest);
+            m_assembler.vpmullw_rrr(right, left, dest);
             break;
         case SIMDLane::i32x4:
-            m_assembler.vpmulld_rrr(left, right, dest);
+            m_assembler.vpmulld_rrr(right, left, dest);
             break;
         case SIMDLane::i64x2:
             RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("i64x2 multiply is not supported on Intel without AVX-512. This instruction should have been lowered before reaching the assembler.");
@@ -2571,10 +2575,10 @@ public:
         ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));
         switch (simdInfo.lane) {
         case SIMDLane::f32x4:
-            m_assembler.vdivps_rrr(left, right, dest);
+            m_assembler.vdivps_rrr(right, left, dest);
             break;
         case SIMDLane::f64x2:
-            m_assembler.vdivpd_rrr(left, right, dest);
+            m_assembler.vdivpd_rrr(right, left, dest);
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Invalid SIMD lane for vector divide.");
@@ -2734,28 +2738,28 @@ public:
     {
         RELEASE_ASSERT(supportsAVXForSIMD());
         RELEASE_ASSERT(simdInfo.lane == SIMDLane::v128);
-        m_assembler.vandps_rrr(left, right, dest);
+        m_assembler.vandps_rrr(right, left, dest);
     }
 
     void vectorAndnot(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         RELEASE_ASSERT(supportsAVXForSIMD());
         RELEASE_ASSERT(simdInfo.lane == SIMDLane::v128);
-        m_assembler.vandnps_rrr(left, right, dest);
+        m_assembler.vandnps_rrr(right, left, dest);
     }
 
     void vectorOr(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         RELEASE_ASSERT(supportsAVXForSIMD());
         RELEASE_ASSERT(simdInfo.lane == SIMDLane::v128);
-        m_assembler.vorps_rrr(left, right, dest);
+        m_assembler.vorps_rrr(right, left, dest);
     }
 
     void vectorXor(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         RELEASE_ASSERT(supportsAVXForSIMD());
         RELEASE_ASSERT(simdInfo.lane == SIMDLane::v128);
-        m_assembler.vxorps_rrr(left, right, dest);
+        m_assembler.vxorps_rrr(right, left, dest);
     }
 
     void moveZeroToVector(FPRegisterID dest)
@@ -2916,14 +2920,14 @@ public:
         case SIMDLane::i16x8:
             if (simdInfo.signMode == SIMDSignMode::Signed) {
                 if (supportsAVXForSIMD())
-                    m_assembler.vpmovsxbw(input, dest);
+                    m_assembler.vpmovsxbw_rr(input, dest);
                 else if (supportsSSE4_1())
                     m_assembler.pmovsxbw(input, dest);
                 else
                     RELEASE_ASSERT_NOT_REACHED();
             } else {
                 if (supportsAVXForSIMD())
-                    m_assembler.vpmovzxbw(input, dest);
+                    m_assembler.vpmovzxbw_rr(input, dest);
                 else if (supportsSSE4_1())
                     m_assembler.pmovzxbw(input, dest);
                 else
@@ -2933,14 +2937,14 @@ public:
         case SIMDLane::i32x4:
             if (simdInfo.signMode == SIMDSignMode::Signed) {
                 if (supportsAVXForSIMD())
-                    m_assembler.vpmovsxwd(input, dest);
+                    m_assembler.vpmovsxwd_rr(input, dest);
                 else if (supportsSSE4_1())
                     m_assembler.pmovsxwd(input, dest);
                 else
                     RELEASE_ASSERT_NOT_REACHED();
             } else {
                 if (supportsAVXForSIMD())
-                    m_assembler.vpmovzxwd(input, dest);
+                    m_assembler.vpmovzxwd_rr(input, dest);
                 else if (supportsSSE4_1())
                     m_assembler.pmovzxwd(input, dest);
                 else
@@ -2950,14 +2954,14 @@ public:
         case SIMDLane::i64x2:
             if (simdInfo.signMode == SIMDSignMode::Signed) {
                 if (supportsAVXForSIMD())
-                    m_assembler.vpmovsxdq(input, dest);
+                    m_assembler.vpmovsxdq_rr(input, dest);
                 else if (supportsSSE4_1())
                     m_assembler.pmovsxdq(input, dest);
                 else
                     RELEASE_ASSERT_NOT_REACHED();
             } else {
                 if (supportsAVXForSIMD())
-                    m_assembler.vpmovzxdq(input, dest);
+                    m_assembler.vpmovzxdq_rr(input, dest);
                 else if (supportsSSE4_1())
                     m_assembler.pmovzxdq(input, dest);
                 else
@@ -2972,7 +2976,7 @@ public:
     void vectorExtendHigh(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
     {
         if (supportsAVXForSIMD())
-            m_assembler.vupckhpd(dest, input, dest);
+            m_assembler.vupckhpd_rrr(dest, input, dest);
         else {
             if (input != dest)
                 m_assembler.movapd_rr(input, dest);
@@ -2984,19 +2988,15 @@ public:
     void vectorPromote(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
     {
         ASSERT_UNUSED(simdInfo, simdInfo.lane == SIMDLane::f32x4);
-        if (supportsAVXForSIMD())
-            m_assembler.vcvtps2pd_rr(input, dest);
-        else
-            RELEASE_ASSERT_NOT_REACHED();
+        ASSERT(supportsAVXForSIMD());
+        m_assembler.vcvtps2pd_rr(input, dest);
     }
 
     void vectorDemote(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
     {
         ASSERT_UNUSED(simdInfo, simdInfo.lane == SIMDLane::f64x2);
-        if (supportsAVXForSIMD())
-            m_assembler.vcvtpd2ps_rr(input, dest);
-        else
-            RELEASE_ASSERT_NOT_REACHED();
+        ASSERT(supportsAVXForSIMD());
+        m_assembler.vcvtpd2ps_rr(input, dest);
     }
 
     void vectorNarrow(SIMDInfo simdInfo, FPRegisterID lower, FPRegisterID upper, FPRegisterID dest, FPRegisterID)
@@ -3461,7 +3461,7 @@ public:
     void vectorDotProductInt32(FPRegisterID a, FPRegisterID b, FPRegisterID dest)
     {
         RELEASE_ASSERT(supportsAVXForSIMD());
-        m_assembler.vpmaddwd_rrr(a, b, dest);
+        m_assembler.vpmaddwd_rrr(b, a, dest);
     }
 
     void vectorShuffle(TrustedImm64 immLow, TrustedImm64 immHigh, FPRegisterID a, FPRegisterID b, FPRegisterID dest) { (void) immLow; (void) immHigh; (void) a; (void) b; (void) dest; }

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -4998,7 +4998,7 @@ public:
         m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PACKUSDW, (RegisterID)xmm1, (RegisterID)xmm2, (RegisterID)xmm3);
     }
 
-    void vpmovsxbw(XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vpmovsxbw_rr(XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/pmovsx
         // VEX.128.66.0F38.WIG 20 /r VPMOVSXBW xmm1, xmm2/m64
@@ -5006,7 +5006,7 @@ public:
         m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PMOVSXBW, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
     }
 
-    void vpmovzxbw(XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vpmovzxbw_rr(XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/pmovzx
         // VEX.128.66.0F38.WIG 30 /r VPMOVZXBW xmm1, xmm2/m64
@@ -5014,7 +5014,7 @@ public:
         m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PMOVZXBW, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
     }
 
-    void vpmovsxwd(XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vpmovsxwd_rr(XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/pmovsx
         // VEX.128.66.0F38.WIG 23 /r VPMOVSXWD xmm1, xmm2/m64
@@ -5022,7 +5022,7 @@ public:
         m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PMOVSXWD, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
     }
 
-    void vpmovzxwd(XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vpmovzxwd_rr(XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/pmovzx
         // VEX.128.66.0F38.WIG 33 /r VPMOVZXWD xmm1, xmm2/m64
@@ -5030,7 +5030,7 @@ public:
         m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PMOVZXWD, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
     }
 
-    void vpmovsxdq(XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vpmovsxdq_rr(XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/pmovsx
         // VEX.128.66.0F38.WIG 25 /r VPMOVSXDQ xmm1, xmm2/m64
@@ -5038,7 +5038,7 @@ public:
         m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PMOVSXDQ, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
     }
 
-    void vpmovzxdq(XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vpmovzxdq_rr(XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/pmovzx
         // VEX.128.66.0F38.WIG 35 /r VPMOVZXDQ xmm1, xmm2/m64
@@ -5046,7 +5046,7 @@ public:
         m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_PMOVZXDQ, (RegisterID)xmm1, (RegisterID)0, (RegisterID)xmm2);
     }
 
-    void vupckhpd(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
+    void vupckhpd_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
     {
         // https://www.felixcloutier.com/x86/unpckhpd
         // VEX.128.66.0F.WIG 15 /r VUNPCKHPD xmm1,xmm2, xmm3/m128


### PR DESCRIPTION
#### 7668d7732987e4bd98d2598c4b49f88a64788acc
<pre>
[JSC] Fix AVX function invocation ordering in X86 MacroAssembler
<a href="https://bugs.webkit.org/show_bug.cgi?id=249126">https://bugs.webkit.org/show_bug.cgi?id=249126</a>
rdar://103244554

Reviewed by Justin Michaud.

We now applied strict consistent rule to X86Assembler for all AVX methods: using AT&amp;T ordering,
and fixing all randomly ordered functions. This patch fixes MacroAssembler&apos;s invocation with wrong
ordering based on this new rule.

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::compareFloatingPointVector):
(JSC::MacroAssemblerX86_64::compareIntegerVector):
(JSC::MacroAssemblerX86_64::vectorAdd):
(JSC::MacroAssemblerX86_64::vectorSub):
(JSC::MacroAssemblerX86_64::vectorMul):
(JSC::MacroAssemblerX86_64::vectorDiv):
(JSC::MacroAssemblerX86_64::vectorAnd):
(JSC::MacroAssemblerX86_64::vectorAndnot):
(JSC::MacroAssemblerX86_64::vectorOr):
(JSC::MacroAssemblerX86_64::vectorXor):
(JSC::MacroAssemblerX86_64::vectorExtendLow):
(JSC::MacroAssemblerX86_64::vectorExtendHigh):
(JSC::MacroAssemblerX86_64::vectorDotProductInt32):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::vpmovsxbw_rr):
(JSC::X86Assembler::vpmovzxbw_rr):
(JSC::X86Assembler::vpmovsxwd_rr):
(JSC::X86Assembler::vpmovzxwd_rr):
(JSC::X86Assembler::vpmovsxdq_rr):
(JSC::X86Assembler::vpmovzxdq_rr):
(JSC::X86Assembler::vupckhpd_rrr):
(JSC::X86Assembler::vpmovsxbw): Deleted.
(JSC::X86Assembler::vpmovzxbw): Deleted.
(JSC::X86Assembler::vpmovsxwd): Deleted.
(JSC::X86Assembler::vpmovzxwd): Deleted.
(JSC::X86Assembler::vpmovsxdq): Deleted.
(JSC::X86Assembler::vpmovzxdq): Deleted.
(JSC::X86Assembler::vupckhpd): Deleted.

Canonical link: <a href="https://commits.webkit.org/257747@main">https://commits.webkit.org/257747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7869711b40938de8b1fbf6f68a680115cf24daea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109189 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169427 "Built successfully and passed tests") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/9924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86295 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92288 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107099 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105593 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7455 "Build was cancelled. Recent messages:") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34194 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/9924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22126 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90470 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2818 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23636 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86359 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46012 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28970 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43109 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89240 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2728 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4626 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19942 "Passed tests") | 
<!--EWS-Status-Bubble-End-->