### PR TITLE
[GCC] Unreviewed, build fix for Ubuntu 20.04 after 257678@main

### DIFF
--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -42,7 +42,11 @@ public:
         double value;
         CSSUnitType unitType;
 
-        bool operator==(const NumericSyntaxValue&) const = default;
+        bool operator==(const NumericSyntaxValue& other) const
+        {
+            return value == other.value && unitType == other.unitType;
+        }
+
     };
     using SyntaxValue = std::variant<Length, NumericSyntaxValue, StyleColor, RefPtr<StyleImage>, String>;
 


### PR DESCRIPTION
#### 93e78bed20d3690720f3bfc0fd00ce6c305b6655
<pre>
[GCC] Unreviewed, build fix for Ubuntu 20.04 after 257678@main

Constructors cannot be defaulted in GCC9.3.

* Source/WebCore/css/CSSCustomPropertyValue.h: Define explicit
  constructor for NumericSyntaxValue.

Canonical link: <a href="https://commits.webkit.org/257724@main">https://commits.webkit.org/257724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6435cd144f6cebb028526f6d752469e28a322067

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109191 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169429 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86297 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92290 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107101 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105595 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34195 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22127 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2820 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23637 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46016 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5305 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43110 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4628 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->