### PR TITLE
Debug build fixes with assertions disabled

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGCSEPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCSEPhase.cpp
@@ -193,11 +193,13 @@ public:
                 + m_abstractHeapStackMap.size()
                 + m_fallbackStackMap.size()));
 
+#if ASSERT_ENABLED
         const bool verifyClobber = false;
         if (verifyClobber) {
             for (auto& pair : m_debugImpureData)
                 ASSERT(!!get(pair.key));
         }
+#endif
 #endif
     }
 

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -96,10 +96,14 @@ void fastSetMaxSingleAllocationSize(size_t size)
     maxSingleAllocationSize = size;
 }
 
+#if ASSERT_ENABLED
 #define ASSERT_IS_WITHIN_LIMIT(size) do { \
         size_t size__ = (size); \
         ASSERT_WITH_MESSAGE((size__) <= maxSingleAllocationSize, "Requested size (%zu) exceeds max single allocation size set for testing (%zu)", (size__), maxSingleAllocationSize); \
     } while (false)
+#else
+#define ASSERT_IS_WITHIN_LIMIT(size)
+#endif // ASSERT_ENABLED
 
 #define FAIL_IF_EXCEEDS_LIMIT(size) do { \
         if (UNLIKELY((size) > maxSingleAllocationSize)) \

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp
@@ -208,7 +208,7 @@ IDBError MemoryIDBBackingStore::clearObjectStore(const IDBResourceIdentifier& tr
 
 #ifndef NDEBUG
     auto transaction = m_transactions.get(transactionIdentifier);
-    ASSERT(transaction->isWriting());
+    ASSERT_UNUSED(transaction, transaction->isWriting());
 #endif
 
     auto objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -528,7 +528,7 @@ void PeerConnectionBackend::disableICECandidateFiltering()
 
 void PeerConnectionBackend::validateSDP(const String& sdp) const
 {
-#ifndef NDEBUG
+#if ASSERT_ENABLED
     if (!m_shouldFilterICECandidates)
         return;
     sdp.split('\n', [](auto line) {

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1241,7 +1241,7 @@ void AXObjectCache::notificationPostTimerFired()
         if (note.first->isDetached() || !note.first->axObjectCache())
             continue;
 
-#ifndef NDEBUG
+#if ASSERT_ENABLED
         // Make sure none of the render views are in the process of being layed out.
         // Notifications should only be sent after the renderer has finished
         if (is<AccessibilityRenderObject>(*note.first)) {

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -575,7 +575,7 @@ static void appendAccessibilityObject(RefPtr<AXCoreObject> object, Accessibility
         results.append(object);
 }
 
-#ifndef NDEBUG
+#if ASSERT_ENABLED
 static bool isTableComponent(AXCoreObject& axObject)
 {
     return axObject.isTable() || axObject.isTableColumn() || axObject.isTableRow() || axObject.isTableCell();

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -125,7 +125,7 @@ AccessibilityRenderObject::AccessibilityRenderObject(RenderObject* renderer)
     : AccessibilityNodeObject(renderer->node())
     , m_renderer(renderer)
 {
-#ifndef NDEBUG
+#if ASSERT_ENABLED
     m_renderer->setHasAXObject(true);
 #endif
 }
@@ -146,7 +146,7 @@ void AccessibilityRenderObject::detachRemoteParts(AccessibilityDetachmentType de
     
     detachRemoteSVGRoot();
     
-#ifndef NDEBUG
+#if ASSERT_ENABLED
     if (m_renderer)
         m_renderer->setHasAXObject(false);
 #endif

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3881,7 +3881,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
             continue;
         default:
             auto resolvedProperty = CSSProperty::resolveDirectionAwareProperty(property, RenderStyle::initialDirection(), RenderStyle::initialWritingMode());
-            ASSERT(wrapperForProperty(resolvedProperty));
+            ASSERT_UNUSED(resolvedProperty, wrapperForProperty(resolvedProperty));
             break;
         }
     }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -785,14 +785,14 @@ void Document::removedLastRef()
         
         commonTeardown();
 
-#ifndef NDEBUG
+#if ASSERT_ENABLED
         // We need to do this right now since selfOnlyDeref() can delete this.
         m_inRemovedLastRefFunction = false;
 #endif
         decrementReferencingNodeCount();
     } else {
         commonTeardown();
-#ifndef NDEBUG
+#if ASSERT_ENABLED
         m_inRemovedLastRefFunction = false;
         m_deletionHasBegun = true;
 #endif

--- a/Source/WebCore/layout/formattingContexts/FormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingContext.cpp
@@ -354,6 +354,7 @@ const ElementBox& FormattingContext::formattingContextRoot(const Box& layoutBox)
 
 void FormattingContext::validateGeometryConstraintsAfterLayout() const
 {
+#if ASSERT_ENABLED
     auto& root = this->root();
     // FIXME: add a descendantsOfType<> flavor that stops at nested formatting contexts
     for (auto& layoutBox : descendantsOfType<Box>(root)) {
@@ -378,6 +379,7 @@ void FormattingContext::validateGeometryConstraintsAfterLayout() const
                 + boxGeometry.paddingAfter().value_or(0) + boxGeometry.borderAfter() + boxGeometry.marginAfter() == containingBlockHeight);
         }
     }
+#endif
 }
 #endif
 

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -154,8 +154,10 @@ CachedResource::~CachedResource()
     ASSERT(!m_deleted);
     ASSERT(url().isNull() || !allowsCaching() || MemoryCache::singleton().resourceForRequest(resourceRequest(), sessionID()) != this);
 
-#ifndef NDEBUG
+#if ASSERT_ENABLED
     m_deleted = true;
+#endif
+#ifndef NDEBUG
     cachedResourceLeakCounter.decrement();
 #endif
 }

--- a/Source/WebCore/platform/PODRedBlackTree.h
+++ b/Source/WebCore/platform/PODRedBlackTree.h
@@ -592,7 +592,7 @@ private:
 
 #endif
 
-#ifdef NDEBUG
+#ifdef ERROR_DISABLED
     void logIfVerbose(const char*) const { }
 #else
     void logIfVerbose(const char* output) const

--- a/Source/WebCore/platform/audio/FFTFrame.cpp
+++ b/Source/WebCore/platform/audio/FFTFrame.cpp
@@ -282,7 +282,7 @@ void FFTFrame::addConstantGroupDelay(double sampleFrameDelay)
     }
 }
 
-#ifndef NDEBUG
+#if !defined(NDEBUG) && !LOG_DISABLED
 void FFTFrame::print()
 {
     FFTFrame& frame = *this;
@@ -301,7 +301,7 @@ void FFTFrame::print()
     }
     LOG(WebAudio, "****\n");
 }
-#endif // NDEBUG
+#endif // NDEBUG && !LOG_DISABLED
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -257,11 +257,7 @@ CDMFactoryClearKey::~CDMFactoryClearKey() = default;
 
 std::unique_ptr<CDMPrivate> CDMFactoryClearKey::createCDM(const String& keySystem, const CDMPrivateClient&)
 {
-#ifdef NDEBUG
-    UNUSED_PARAM(keySystem);
-#else
-    ASSERT(supportsKeySystem(keySystem));
-#endif
+    ASSERT_UNUSED(keySystem, supportsKeySystem(keySystem));
     return makeUnique<CDMPrivateClearKey>();
 }
 
@@ -525,11 +521,7 @@ void CDMInstanceSessionClearKey::updateLicense(const String& sessionId, LicenseT
 
 void CDMInstanceSessionClearKey::loadSession(LicenseType, const String& sessionId, const String&, LoadSessionCallback&& callback)
 {
-#ifdef NDEBUG
-    UNUSED_PARAM(sessionId);
-#endif
-
-    ASSERT(sessionId == m_sessionID);
+    ASSERT_UNUSED(sessionId, sessionId == m_sessionID);
     KeyStatusVector keyStatusVector = m_keyStore.convertToJSKeyStatusVector();
     callOnMainThread([weakThis = WeakPtr { *this }, callback = WTFMove(callback), &keyStatusVector]() mutable {
         if (!weakThis)
@@ -552,11 +544,7 @@ void CDMInstanceSessionClearKey::closeSession(const String&, CloseSessionCallbac
 
 void CDMInstanceSessionClearKey::removeSessionData(const String& sessionId, LicenseType, RemoveSessionDataCallback&& callback)
 {
-#ifdef NDEBUG
-    UNUSED_PARAM(sessionId);
-#endif
-
-    ASSERT(sessionId == m_sessionID);
+    ASSERT_UNUSED(sessionId, sessionId == m_sessionID);
 
     auto dispatchCallback =
         [weakThis = WeakPtr { *this }, &callback](KeyStatusVector&& keyStatusVector, RefPtr<SharedBuffer>&& message, SuccessValue success) {

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -307,7 +307,7 @@ static std::optional<size_t> codePointSupportIndex(UChar32 codePoint)
             found = true;
         }
     }
-    ASSERT(found == static_cast<bool>(result));
+    ASSERT_UNUSED(found, found == static_cast<bool>(result));
 #endif
     return result;
 }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -248,7 +248,7 @@ void AppendPipeline::handleErrorConditionFromStreamingThread()
         m_sourceBufferPrivate.appendParsingFailed();
         return AbortableTaskQueue::Void();
     });
-#ifdef NDEBUG
+#if !ASSERT_ENABLED
     UNUSED_VARIABLE(response);
 #endif
     // The streaming thread has now been unblocked because we are aborting in the main thread.

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -470,7 +470,7 @@ void RenderFragmentedFlow::removeRenderBoxFragmentInfo(RenderBox& box)
 #ifndef NDEBUG
     // We have to make sure we did not leave any RenderBoxFragmentInfo attached.
     for (auto& fragment : m_fragmentList)
-        ASSERT(!fragment->renderBoxFragmentInfo(&box));
+        ASSERT_UNUSED(fragment, !fragment->renderBoxFragmentInfo(&box));
 #endif
 
     m_fragmentRangeMap.remove(&box);

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -574,7 +574,7 @@ LayoutRect RenderInline::clippedOverflowRect(const RenderLayerModelObject* repai
         }
         return false;
     };
-    ASSERT(!view().frameView().layoutContext().isPaintOffsetCacheEnabled() || style().styleType() == PseudoId::FirstLetter || insideSelfPaintingInlineBox());
+    ASSERT_UNUSED(insideSelfPaintingInlineBox, !view().frameView().layoutContext().isPaintOffsetCacheEnabled() || style().styleType() == PseudoId::FirstLetter || insideSelfPaintingInlineBox());
 #endif
 
     auto knownEmpty = [&] {

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -1274,7 +1274,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
             }
         } else {
             // The overflowing cells should be scarce to avoid adding a lot of cells to the HashSet.
-#ifndef NDEBUG
+#if ASSERT_ENABLED
             unsigned totalRows = m_grid.size();
             unsigned totalCols = table()->columns().size();
             ASSERT(m_overflowingCells.size() < totalRows * totalCols * gMaxAllowedOverflowingCellRatioForFastPaintPath);

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -192,7 +192,7 @@ static inline void checkLayoutAttributesConsistency(RenderSVGText* text, Vector<
 #ifndef NDEBUG
     Vector<SVGTextLayoutAttributes*> newLayoutAttributes;
     collectLayoutAttributes(text, newLayoutAttributes);
-    ASSERT(newLayoutAttributes == expectedLayoutAttributes);
+    ASSERT_UNUSED(expectedLayoutAttributes, newLayoutAttributes == expectedLayoutAttributes);
 #else
     UNUSED_PARAM(text);
     UNUSED_PARAM(expectedLayoutAttributes);


### PR DESCRIPTION
#### b9d802d8c6456d7cd603897751af94c900431f30
<pre>
Debug build fixes with assertions disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=249129">https://bugs.webkit.org/show_bug.cgi?id=249129</a>

Reviewed by Philippe Normand.

When disabling assertions in a Debug build there are
plenty of unused variables that break the build due
to -Werror. Most of those are due to using NDEBUG
when ASSERT_ENABLED is needed. Fix those.

* Source/JavaScriptCore/dfg/DFGCSEPhase.cpp:
* Source/WTF/wtf/FastMalloc.cpp:
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp:
(WebCore::IDBServer::MemoryIDBBackingStore::clearObjectStore):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::validateSDP const):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::notificationPostTimerFired):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::AccessibilityRenderObject):
(WebCore::AccessibilityRenderObject::detachRemoteParts):
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::removedLastRef):
* Source/WebCore/layout/formattingContexts/FormattingContext.cpp:
(WebCore::Layout::FormattingContext::validateGeometryConstraintsAfterLayout const):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::~CachedResource):
* Source/WebCore/platform/PODRedBlackTree.h:
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp:
(WebCore::CDMFactoryClearKey::createCDM):
(WebCore::CDMInstanceSessionClearKey::loadSession):
(WebCore::CDMInstanceSessionClearKey::removeSessionData):
* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::codePointSupportIndex):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::handleErrorConditionFromStreamingThread):
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::removeRenderBoxFragmentInfo):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::clippedOverflowRect const):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::paintObject):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::checkLayoutAttributesConsistency):

Canonical link: <a href="https://commits.webkit.org/257784@main">https://commits.webkit.org/257784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68f8bf663d14806089c9f9fb4966644a4c327bfb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109218 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169455 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103860 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86326 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92318 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107127 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105624 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7496 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing.html, imported/w3c/web-platform-tests/css/css-properties-values-api/typedom.html, imported/w3c/web-platform-tests/fullscreen/api/element-ready-check-allowed-cross-origin.sub.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34220 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22154 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90497 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2847 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23664 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86391 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46045 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28986 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5344 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43137 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89271 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4655 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19958 "Passed tests") | 
<!--EWS-Status-Bubble-End-->