### PR TITLE
Port ResourceResponse to the new CoreIPC serialization format.

### DIFF
--- a/Source/WebCore/platform/ReferrerPolicy.h
+++ b/Source/WebCore/platform/ReferrerPolicy.h
@@ -58,21 +58,6 @@ String referrerPolicyToString(const ReferrerPolicy&);
 
 namespace WTF {
 
-template<> struct EnumTraits<WebCore::ReferrerPolicy> {
-    using values = EnumValues<
-        WebCore::ReferrerPolicy,
-        WebCore::ReferrerPolicy::EmptyString,
-        WebCore::ReferrerPolicy::NoReferrer,
-        WebCore::ReferrerPolicy::NoReferrerWhenDowngrade,
-        WebCore::ReferrerPolicy::SameOrigin,
-        WebCore::ReferrerPolicy::Origin,
-        WebCore::ReferrerPolicy::StrictOrigin,
-        WebCore::ReferrerPolicy::OriginWhenCrossOrigin,
-        WebCore::ReferrerPolicy::StrictOriginWhenCrossOrigin,
-        WebCore::ReferrerPolicy::UnsafeUrl
-    >;
-};
-
 template<> struct EnumTraitsForPersistence<WebCore::ReferrerPolicy> {
     using values = EnumValues<
         WebCore::ReferrerPolicy,

--- a/Source/WebCore/platform/network/ResourceLoadPriority.h
+++ b/Source/WebCore/platform/network/ResourceLoadPriority.h
@@ -59,17 +59,6 @@ inline ResourceLoadPriority& operator--(ResourceLoadPriority& priority)
 
 namespace WTF {
 
-template<> struct EnumTraits<WebCore::ResourceLoadPriority> {
-    using values = EnumValues<
-        WebCore::ResourceLoadPriority,
-        WebCore::ResourceLoadPriority::VeryLow,
-        WebCore::ResourceLoadPriority::Low,
-        WebCore::ResourceLoadPriority::Medium,
-        WebCore::ResourceLoadPriority::High,
-        WebCore::ResourceLoadPriority::VeryHigh
-    >;
-};
-
 template<> struct EnumTraitsForPersistence<WebCore::ResourceLoadPriority> {
     using values = EnumValues<
         WebCore::ResourceLoadPriority,

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -322,18 +322,6 @@ WEBCORE_EXPORT void initializeHTTPConnectionSettingsOnStartup();
 
 namespace WTF {
 
-template<> struct EnumTraits<WebCore::ResourceRequestCachePolicy> {
-    using values = EnumValues<
-        WebCore::ResourceRequestCachePolicy,
-        WebCore::ResourceRequestCachePolicy::UseProtocolCachePolicy,
-        WebCore::ResourceRequestCachePolicy::ReloadIgnoringCacheData,
-        WebCore::ResourceRequestCachePolicy::ReturnCacheDataElseLoad,
-        WebCore::ResourceRequestCachePolicy::ReturnCacheDataDontLoad,
-        WebCore::ResourceRequestCachePolicy::DoNotUseAnyCache,
-        WebCore::ResourceRequestCachePolicy::RefreshAnyCacheData
-    >;
-};
-
 template<> struct EnumTraitsForPersistence<WebCore::ResourceRequestCachePolicy> {
     using values = EnumValues<
         WebCore::ResourceRequestCachePolicy,
@@ -346,36 +334,12 @@ template<> struct EnumTraitsForPersistence<WebCore::ResourceRequestCachePolicy> 
     >;
 };
 
-template<> struct EnumTraits<WebCore::ResourceRequestBase::SameSiteDisposition> {
-    using values = EnumValues<
-        WebCore::ResourceRequestBase::SameSiteDisposition,
-        WebCore::ResourceRequestBase::SameSiteDisposition::Unspecified,
-        WebCore::ResourceRequestBase::SameSiteDisposition::SameSite,
-        WebCore::ResourceRequestBase::SameSiteDisposition::CrossSite
-    >;
-};
-
 template<> struct EnumTraitsForPersistence<WebCore::ResourceRequestBase::SameSiteDisposition> {
     using values = EnumValues<
         WebCore::ResourceRequestBase::SameSiteDisposition,
         WebCore::ResourceRequestBase::SameSiteDisposition::Unspecified,
         WebCore::ResourceRequestBase::SameSiteDisposition::SameSite,
         WebCore::ResourceRequestBase::SameSiteDisposition::CrossSite
-    >;
-};
-
-template<> struct EnumTraits<WebCore::ResourceRequestRequester> {
-    using values = EnumValues<
-        WebCore::ResourceRequestRequester,
-        WebCore::ResourceRequestRequester::Unspecified,
-        WebCore::ResourceRequestRequester::Main,
-        WebCore::ResourceRequestRequester::XHR,
-        WebCore::ResourceRequestRequester::Fetch,
-        WebCore::ResourceRequestRequester::Media,
-        WebCore::ResourceRequestRequester::ImportScripts,
-        WebCore::ResourceRequestRequester::Ping,
-        WebCore::ResourceRequestRequester::Beacon,
-        WebCore::ResourceRequestRequester::EventSource
     >;
 };
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -31,6 +31,7 @@
 #include "HTTPHeaderMap.h"
 #include "NetworkLoadMetrics.h"
 #include "ParsedContentRange.h"
+#include <wtf/ArgumentCoder.h>
 #include <wtf/Box.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/Markable.h>
@@ -64,6 +65,8 @@ public:
     static constexpr unsigned bitWidthOfType = 3;
     enum class Tainting : uint8_t { Basic, Cors, Opaque, Opaqueredirect };
     static constexpr unsigned bitWidthOfTainting = 2;
+    enum class Source : uint8_t { Unknown, Network, DiskCache, DiskCacheAfterValidation, MemoryCache, MemoryCacheAfterValidation, ServiceWorker, ApplicationCache, DOMCache, InspectorOverride };
+    static constexpr unsigned bitWidthOfSource = 4;
 
     static bool isRedirectionStatusCode(int code) { return code == 301 || code == 302 || code == 303 || code == 307 || code == 308; }
 
@@ -86,6 +89,29 @@ public:
         Tainting tainting;
         bool isRedirected;
         bool isRangeRequested;
+    };
+    
+    struct ResponseData {
+        URL m_url;
+        AtomString m_mimeType;
+        long long m_expectedContentLength;
+        AtomString m_textEncodingName;
+        AtomString m_httpStatusText;
+        AtomString m_httpVersion;
+        HTTPHeaderMap m_httpHeaderFields;
+        Box<WebCore::NetworkLoadMetrics> m_networkLoadMetrics;
+
+        short m_httpStatusCode;
+        std::optional<CertificateInfo> m_certificateInfo;
+        
+        ResourceResponseBase::Source m_source;
+        ResourceResponseBase::Type m_type;
+        ResourceResponseBase::Tainting m_tainting;
+
+        bool m_isRedirected;
+        UsedLegacyTLS m_usedLegacyTLS;
+        WasPrivateRelayed m_wasPrivateRelayed;
+        bool m_isRangeRequested;
     };
 
     CrossThreadData crossThreadData() const;
@@ -168,8 +194,6 @@ public:
     WEBCORE_EXPORT std::optional<WallTime> lastModified() const;
     const ParsedContentRange& contentRange() const;
 
-    enum class Source : uint8_t { Unknown, Network, DiskCache, DiskCacheAfterValidation, MemoryCache, MemoryCacheAfterValidation, ServiceWorker, ApplicationCache, DOMCache, InspectorOverride };
-    static constexpr unsigned bitWidthOfSource = 4;
     static_assert(static_cast<unsigned>(Source::InspectorOverride) <= ((1U << bitWidthOfSource) - 1));
 
     WEBCORE_EXPORT Source source() const;
@@ -220,8 +244,10 @@ public:
 
     static bool equalForWebKitLegacyChallengeComparison(const ResourceResponse&, const ResourceResponse&);
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, ResourceResponseBase&);
+    template<class Encoder, typename = std::enable_if_t<!std::is_same_v<Encoder, IPC::Encoder>>>
+    void encode(Encoder&) const;
+    template<class Decoder, typename = std::enable_if_t<!std::is_same_v<Decoder, IPC::Decoder>>>
+    static WARN_UNUSED_RETURN bool decode(Decoder&, ResourceResponseBase&);
 
     bool isRangeRequested() const { return m_isRangeRequested; }
     void setAsRangeRequested() { m_isRangeRequested = true; }
@@ -229,6 +255,10 @@ public:
     bool containsInvalidHTTPHeaders() const;
 
     WEBCORE_EXPORT static ResourceResponse dataURLResponse(const URL&, const DataURLDecoder::Result&);
+    
+    WEBCORE_EXPORT ResourceResponseBase(std::optional<ResponseData>);
+    
+    WEBCORE_EXPORT std::optional<ResponseData> getResponseData() const;
 
 protected:
     enum InitLevel {
@@ -274,28 +304,28 @@ private:
     mutable ParsedContentRange m_contentRange;
     mutable CacheControlDirectives m_cacheControlDirectives;
 
-    mutable bool m_haveParsedCacheControlHeader : 1;
-    mutable bool m_haveParsedAgeHeader : 1;
-    mutable bool m_haveParsedDateHeader : 1;
-    mutable bool m_haveParsedExpiresHeader : 1;
-    mutable bool m_haveParsedLastModifiedHeader : 1;
-    mutable bool m_haveParsedContentRangeHeader : 1;
-    bool m_isRedirected : 1;
-    bool m_isRangeRequested : 1;
+    mutable bool m_haveParsedCacheControlHeader : 1 { false };
+    mutable bool m_haveParsedAgeHeader : 1 { false };
+    mutable bool m_haveParsedDateHeader : 1 { false };
+    mutable bool m_haveParsedExpiresHeader : 1 { false };
+    mutable bool m_haveParsedLastModifiedHeader : 1 { false };
+    mutable bool m_haveParsedContentRangeHeader : 1 { false };
+    bool m_isRedirected : 1 { false };
+    bool m_isRangeRequested : 1 { false };
 protected:
-    bool m_isNull : 1;
+    bool m_isNull : 1 { true };
     unsigned m_initLevel : 3; // Controlled by ResourceResponse.
-    mutable UsedLegacyTLS m_usedLegacyTLS : bitWidthOfUsedLegacyTLS;
-    mutable WasPrivateRelayed m_wasPrivateRelayed : bitWidthOfWasPrivateRelayed;
+    mutable UsedLegacyTLS m_usedLegacyTLS : bitWidthOfUsedLegacyTLS { UsedLegacyTLS::No };
+    mutable WasPrivateRelayed m_wasPrivateRelayed : bitWidthOfWasPrivateRelayed { WasPrivateRelayed::No };
 private:
-    Tainting m_tainting : bitWidthOfTainting;
-    Source m_source : bitWidthOfSource;
-    Type m_type : bitWidthOfType;
+    Tainting m_tainting : bitWidthOfTainting { Tainting::Basic };
+    Source m_source : bitWidthOfSource { Source::Unknown };
+    Type m_type : bitWidthOfType { Type::Default };
 protected:
     short m_httpStatusCode { 0 };
 };
 
-template<class Encoder>
+template<class Encoder, typename>
 void ResourceResponseBase::encode(Encoder& encoder) const
 {
     encoder << m_isNull;
@@ -311,11 +341,6 @@ void ResourceResponseBase::encode(Encoder& encoder) const
     encoder << m_httpVersion;
     encoder << m_httpHeaderFields;
 
-    // We don't want to put the networkLoadMetrics info
-    // into the disk cache, because we will never use the old info.
-    if constexpr (Encoder::isIPCEncoder)
-        encoder << m_networkLoadMetrics;
-
     encoder << m_httpStatusCode;
     encoder << m_certificateInfo;
     encoder << m_source;
@@ -329,7 +354,7 @@ void ResourceResponseBase::encode(Encoder& encoder) const
     encoder << m_isRangeRequested;
 }
 
-template<class Decoder>
+template<class Decoder, typename>
 bool ResourceResponseBase::decode(Decoder& decoder, ResourceResponseBase& response)
 {
     ASSERT(response.m_isNull);
@@ -383,15 +408,6 @@ bool ResourceResponseBase::decode(Decoder& decoder, ResourceResponseBase& respon
     if (!httpHeaderFields)
         return false;
     response.m_httpHeaderFields = WTFMove(*httpHeaderFields);
-
-    // The networkLoadMetrics info is only send over IPC and not stored in disk cache.
-    if constexpr (Decoder::isIPCDecoder) {
-        std::optional<Box<NetworkLoadMetrics>> networkLoadMetrics;
-        decoder >> networkLoadMetrics;
-        if (!networkLoadMetrics)
-            return false;
-        response.m_networkLoadMetrics = WTFMove(*networkLoadMetrics);
-    }
 
     std::optional<short> httpStatusCode;
     decoder >> httpStatusCode;
@@ -454,18 +470,6 @@ bool ResourceResponseBase::decode(Decoder& decoder, ResourceResponseBase& respon
 
 namespace WTF {
 
-template<> struct EnumTraits<WebCore::ResourceResponseBase::Type> {
-    using values = EnumValues<
-        WebCore::ResourceResponseBase::Type,
-        WebCore::ResourceResponseBase::Type::Basic,
-        WebCore::ResourceResponseBase::Type::Cors,
-        WebCore::ResourceResponseBase::Type::Default,
-        WebCore::ResourceResponseBase::Type::Error,
-        WebCore::ResourceResponseBase::Type::Opaque,
-        WebCore::ResourceResponseBase::Type::Opaqueredirect
-    >;
-};
-
 template<> struct EnumTraitsForPersistence<WebCore::ResourceResponseBase::Type> {
     using values = EnumValues<
         WebCore::ResourceResponseBase::Type,
@@ -478,16 +482,6 @@ template<> struct EnumTraitsForPersistence<WebCore::ResourceResponseBase::Type> 
     >;
 };
 
-template<> struct EnumTraits<WebCore::ResourceResponseBase::Tainting> {
-    using values = EnumValues<
-        WebCore::ResourceResponseBase::Tainting,
-        WebCore::ResourceResponseBase::Tainting::Basic,
-        WebCore::ResourceResponseBase::Tainting::Cors,
-        WebCore::ResourceResponseBase::Tainting::Opaque,
-        WebCore::ResourceResponseBase::Tainting::Opaqueredirect
-    >;
-};
-
 template<> struct EnumTraitsForPersistence<WebCore::ResourceResponseBase::Tainting> {
     using values = EnumValues<
         WebCore::ResourceResponseBase::Tainting,
@@ -495,22 +489,6 @@ template<> struct EnumTraitsForPersistence<WebCore::ResourceResponseBase::Tainti
         WebCore::ResourceResponseBase::Tainting::Cors,
         WebCore::ResourceResponseBase::Tainting::Opaque,
         WebCore::ResourceResponseBase::Tainting::Opaqueredirect
-    >;
-};
-
-template<> struct EnumTraits<WebCore::ResourceResponseBase::Source> {
-    using values = EnumValues<
-        WebCore::ResourceResponseBase::Source,
-        WebCore::ResourceResponseBase::Source::Unknown,
-        WebCore::ResourceResponseBase::Source::Network,
-        WebCore::ResourceResponseBase::Source::DiskCache,
-        WebCore::ResourceResponseBase::Source::DiskCacheAfterValidation,
-        WebCore::ResourceResponseBase::Source::MemoryCache,
-        WebCore::ResourceResponseBase::Source::MemoryCacheAfterValidation,
-        WebCore::ResourceResponseBase::Source::ServiceWorker,
-        WebCore::ResourceResponseBase::Source::ApplicationCache,
-        WebCore::ResourceResponseBase::Source::DOMCache,
-        WebCore::ResourceResponseBase::Source::InspectorOverride
     >;
 };
 

--- a/Source/WebCore/platform/network/cf/ResourceResponse.h
+++ b/Source/WebCore/platform/network/cf/ResourceResponse.h
@@ -42,6 +42,12 @@ public:
     {
         m_initLevel = AllFields;
     }
+    
+    ResourceResponse(ResourceResponseBase&& base)
+        : ResourceResponseBase(WTFMove(base))
+    {
+        m_initLevel = AllFields;
+    }
 
 #if USE(CFURLCONNECTION)
     ResourceResponse(CFURLResponseRef cfResponse)

--- a/Source/WebCore/platform/network/curl/ResourceResponse.h
+++ b/Source/WebCore/platform/network/curl/ResourceResponse.h
@@ -47,6 +47,11 @@ public:
     }
 
     ResourceResponse(CurlResponse&);
+    
+    ResourceResponse(ResourceResponseBase&& base)
+        : ResourceResponseBase(WTFMove(base))
+    {
+    }
 
     void appendHTTPHeaderField(const String&);
 

--- a/Source/WebCore/platform/network/soup/ResourceResponse.h
+++ b/Source/WebCore/platform/network/soup/ResourceResponse.h
@@ -42,6 +42,11 @@ public:
     {
     }
 
+    ResourceResponse(ResourceResponseBase&& base)
+        : ResourceResponseBase(WTFMove(base))
+    {
+    }
+
     ResourceResponse(SoupMessage*, const CString& sniffedContentType = CString());
 
     void updateSoupMessageHeaders(SoupMessageHeaders*) const;

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp
@@ -603,8 +603,9 @@ static std::optional<WebCore::DOMCacheEngine::Record> decodeDOMCacheRecord(WTF::
     if (!responseHeadersGuard)
         return std::nullopt;
 
-    ResourceResponse response;
-    if (!ResourceResponse::decode(decoder, response))
+    std::optional<ResourceResponse> response;
+    decoder >> response;
+    if (!response)
         return std::nullopt;
     
     std::optional<uint64_t> responseBodySize;
@@ -623,7 +624,7 @@ static std::optional<WebCore::DOMCacheEngine::Record> decodeDOMCacheRecord(WTF::
         WTFMove(options),
         WTFMove(*referrer),
         WTFMove(*responseHeadersGuard),
-        WTFMove(response),
+        WTFMove(*response),
         { },
         WTFMove(*responseBodySize)
     }};

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
@@ -116,10 +116,11 @@ std::unique_ptr<Entry> Entry::decodeStorageRecord(const Storage::Record& storage
     auto entry = makeUnique<Entry>(storageEntry);
 
     WTF::Persistence::Decoder decoder(storageEntry.header.span());
-    WebCore::ResourceResponse response;
-    if (!WebCore::ResourceResponse::decode(decoder, response))
+    std::optional<WebCore::ResourceResponse> response;
+    decoder >> response;
+    if (!response)
         return nullptr;
-    entry->m_response = WTFMove(response);
+    entry->m_response = WTFMove(*response);
     entry->m_response.setSource(WebCore::ResourceResponse::Source::DiskCache);
 
     std::optional<bool> hasVaryingRequestHeaders;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2151,3 +2151,110 @@ struct WebCore::MediaDecodingConfiguration : WebCore::MediaConfiguration {
     WebCore::MediaDecodingType type;
     bool canExposeVP9;
 };
+    
+enum class WebCore::ResourceRequestCachePolicy : uint8_t {
+    UseProtocolCachePolicy,
+    ReloadIgnoringCacheData,
+    ReturnCacheDataElseLoad,
+    ReturnCacheDataDontLoad,
+    DoNotUseAnyCache,
+    RefreshAnyCacheData,
+};
+
+[Nested] enum class WebCore::ResourceRequestBase::SameSiteDisposition : uint8_t {
+    Unspecified,
+    SameSite,
+    CrossSite
+};
+
+[Nested] enum class WebCore::ResourceRequestRequester : uint8_t {
+    Unspecified,
+    Main,
+    XHR,
+    Fetch,
+    Media,
+    Model,
+    ImportScripts,
+    Ping,
+    Beacon,
+    EventSource
+};
+
+enum class WebCore::ResourceLoadPriority : uint8_t {
+    VeryLow,
+    Low,
+    Medium,
+    High,
+    VeryHigh,
+};
+
+[Nested] enum class WebCore::ResourceResponseBase::Type : uint8_t {
+    Basic,
+    Cors,
+    Default,
+    Error,
+    Opaque,
+    Opaqueredirect
+};
+
+[Nested] enum class WebCore::ResourceResponseBase::Tainting : uint8_t {
+    Basic,
+    Cors,
+    Opaque,
+    Opaqueredirect
+};
+    
+[Nested] enum class WebCore::ResourceResponseBase::Source : uint8_t {
+    Unknown,
+    Network,
+    DiskCache,
+    DiskCacheAfterValidation,
+    MemoryCache,
+    MemoryCacheAfterValidation,
+    ServiceWorker,
+    ApplicationCache,
+    DOMCache,
+    InspectorOverride
+};
+
+[Nested] struct WebCore::ResourceResponseBase::ResponseData {
+    URL m_url;
+    AtomString m_mimeType;
+    long long m_expectedContentLength;
+    AtomString m_textEncodingName;
+    AtomString m_httpStatusText;
+    AtomString m_httpVersion;
+    WebCore::HTTPHeaderMap m_httpHeaderFields;
+    Box<WebCore::NetworkLoadMetrics> m_networkLoadMetrics;
+
+    short m_httpStatusCode;
+    std::optional<WebCore::CertificateInfo> m_certificateInfo;
+    
+    WebCore::ResourceResponseBase::Source m_source;
+    WebCore::ResourceResponseBase::Type m_type;
+    WebCore::ResourceResponseBase::Tainting m_tainting;
+
+    bool m_isRedirected;
+    WebCore::UsedLegacyTLS m_usedLegacyTLS;
+    WebCore::WasPrivateRelayed m_wasPrivateRelayed;
+    bool m_isRangeRequested;
+}
+
+class WebCore::ResourceResponseBase {
+    std::optional<WebCore::ResourceResponseBase::ResponseData> getResponseData()
+}
+
+class WebCore::ResourceResponse : WebCore::ResourceResponseBase {
+}
+
+enum class WebCore::ReferrerPolicy : uint8_t {
+    EmptyString,
+    NoReferrer,
+    NoReferrerWhenDowngrade,
+    SameOrigin,
+    Origin,
+    StrictOrigin,
+    OriginWhenCrossOrigin,
+    StrictOriginWhenCrossOrigin,
+    UnsafeUrl,
+};


### PR DESCRIPTION
#### d80ae68ecc7a4a5756a38de4a2eb3d2360375012
<pre>
Port ResourceResponse to the new CoreIPC serialization format.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249130">https://bugs.webkit.org/show_bug.cgi?id=249130</a>
&lt;rdar://problem/103247059&gt;

Reviewed by Alex Christensen.

Port ResourceResponse and related classes to the new serialization format.
The types moved are:
    - WebCore::ResourceRequestCachePolicy
    - WebCore::ResourceRequestBase::SameSiteDisposition
    - WebCore::ResourceRequestRequester
    - WebCore::ResourceLoadPriority
    - WebCore::ResourceResponseBase
    - WebCore::ResourceResponseBase::Type
    - WebCore::ResourceResponseBase::Tainting
    - WebCore::ResourceResponseBase::Source
    - WebCore::ReferrerPolicy

* Source/WebCore/platform/ReferrerPolicy.h:
* Source/WebCore/platform/network/ResourceLoadPriority.h:
* Source/WebCore/platform/network/ResourceRequestBase.h:
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::ResourceResponseBase):
(WebCore::m_mimeType):
(WebCore::m_textEncodingName):
(WebCore::m_httpStatusText):
(WebCore::m_httpVersion):
(WebCore::m_httpHeaderFields):
(WebCore::m_networkLoadMetrics):
(WebCore::m_httpStatusCode):
(WebCore::ResourceResponseBase::getResponseData const):
* Source/WebCore/platform/network/ResourceResponseBase.h:
(WebCore::ResourceResponseBase::encode const):
(WebCore::ResourceResponseBase::decode):
* Source/WebCore/platform/network/cf/ResourceResponse.h:
(WebCore::ResourceResponse::ResourceResponse):
* Source/WebCore/platform/network/curl/ResourceResponse.h:
* Source/WebCore/platform/network/soup/ResourceResponse.h:
(WebCore::ResourceResponse::ResourceResponse):
* Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp:
(WebKit::CacheStorage::decodeDOMCacheRecord):
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp:
(WebKit::NetworkCache::Entry::decodeStorageRecord):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/257908@main">https://commits.webkit.org/257908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/336e904899b65407290eda175319ef11cc7f452c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100217 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109544 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169777 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104209 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10285 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92638 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107433 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7784 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91058 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34460 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77406 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3143 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23968 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3121 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43456 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5431 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4953 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->