### PR TITLE
REGRESSION(257701@main): Broke linux clang builds

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
@@ -42,11 +42,11 @@ PASS syntax:'<integer>', initialValue:'calc(3.1415 + 3.1415)' is valid
 PASS syntax:'<angle>', initialValue:'10deg' is valid
 PASS syntax:'<angle>', initialValue:'20.5rad' is valid
 PASS syntax:'<angle>', initialValue:'calc(50grad + 3.14159rad)' is valid
-PASS syntax:'<time>', initialValue:'2s' is valid
-PASS syntax:'<time>', initialValue:'calc(2s - 9ms)' is valid
-PASS syntax:'<resolution>', initialValue:'10dpi' is valid
-PASS syntax:'<resolution>', initialValue:'3dPpX' is valid
-PASS syntax:'<resolution>', initialValue:'-5.3dpcm' is valid
+FAIL syntax:'<time>', initialValue:'2s' is valid The given initial value does not parse for the given syntax.
+FAIL syntax:'<time>', initialValue:'calc(2s - 9ms)' is valid The given initial value does not parse for the given syntax.
+FAIL syntax:'<resolution>', initialValue:'10dpi' is valid The given initial value does not parse for the given syntax.
+FAIL syntax:'<resolution>', initialValue:'3dPpX' is valid The given initial value does not parse for the given syntax.
+FAIL syntax:'<resolution>', initialValue:'-5.3dpcm' is valid The given initial value does not parse for the given syntax.
 FAIL syntax:'<transform-function>', initialValue:'translateX(2px)' is valid The given initial value does not parse for the given syntax.
 PASS syntax:'<transform-function>|<integer>', initialValue:'5' is valid
 FAIL syntax:'<transform-function>|<integer>', initialValue:'scale(2)' is valid The given initial value does not parse for the given syntax.
@@ -55,9 +55,9 @@ FAIL syntax:'<transform-list>', initialValue:'scale(2)' is valid The given initi
 FAIL syntax:'<transform-list>', initialValue:'translateX(2px) rotate(20deg)' is valid The given initial value does not parse for the given syntax.
 PASS syntax:'<color>', initialValue:'rgb(12, 34, 56)' is valid
 PASS syntax:'<color>', initialValue:'lightgoldenrodyellow' is valid
-PASS syntax:'<image>', initialValue:'url(a)' is valid
-PASS syntax:'<image>', initialValue:'linear-gradient(yellow, blue)' is valid
-PASS syntax:'<url>', initialValue:'url(a)' is valid
+FAIL syntax:'<image>', initialValue:'url(a)' is valid The given initial value does not parse for the given syntax.
+FAIL syntax:'<image>', initialValue:'linear-gradient(yellow, blue)' is valid The given initial value does not parse for the given syntax.
+FAIL syntax:'<url>', initialValue:'url(a)' is valid The given initial value does not parse for the given syntax.
 PASS syntax:'banana', initialValue:'banana' is valid
 PASS syntax:'bAnAnA', initialValue:'bAnAnA' is valid
 PASS syntax:'ba-na-nya', initialValue:'ba-na-nya' is valid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-expected.txt
@@ -53,12 +53,12 @@ PASS <angle> values are computed correctly [180deg]
 PASS <angle> values are computed correctly [400grad]
 PASS <angle> values are computed correctly [calc(360deg + 400grad)]
 PASS * values are computed correctly [50s]
-PASS <time> values are computed correctly [1s]
-PASS <time> values are computed correctly [1000ms]
-PASS <time> values are computed correctly [calc(1000ms + 1s)]
+FAIL <time> values are computed correctly [1s] The given initial value does not parse for the given syntax.
+FAIL <time> values are computed correctly [1000ms] The given initial value does not parse for the given syntax.
+FAIL <time> values are computed correctly [calc(1000ms + 1s)] The given initial value does not parse for the given syntax.
 PASS * values are computed correctly [50dpi]
-PASS <resolution> values are computed correctly [1dppx]
-PASS <resolution> values are computed correctly [96dpi]
-PASS <resolution> values are computed correctly [calc(1dppx + 96dpi)]
+FAIL <resolution> values are computed correctly [1dppx] The given initial value does not parse for the given syntax.
+FAIL <resolution> values are computed correctly [96dpi] The given initial value does not parse for the given syntax.
+FAIL <resolution> values are computed correctly [calc(1dppx + 96dpi)] The given initial value does not parse for the given syntax.
 PASS * values are computed correctly [url(why)]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-initial-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-initial-expected.txt
@@ -12,7 +12,7 @@ PASS Initial value for <color> correctly computed [purple]
 FAIL Initial value for <transform-function> correctly computed [rotate(42deg)] The given initial value does not parse for the given syntax.
 FAIL Initial value for <transform-list> correctly computed [scale(calc(2 + 2))] The given initial value does not parse for the given syntax.
 FAIL Initial value for <transform-list> correctly computed [scale(calc(2 + 1)) translateX(calc(3px + 1px))] The given initial value does not parse for the given syntax.
-PASS Initial value for <url> correctly computed [url(a)]
+FAIL Initial value for <url> correctly computed [url(a)] The given initial value does not parse for the given syntax.
 FAIL Initial value for <url>+ correctly computed [url(a) url(a)] The given initial value does not parse for the given syntax.
 PASS Initial inherited value can be substituted [purple, color]
 PASS Initial non-inherited value can be substituted [pink, background-color]
@@ -25,7 +25,7 @@ PASS Initial non-inherited value can be substituted [	calc(13% + 37px), --x]
 PASS Initial non-inherited value can be substituted [calc(10px + 15px), --x]
 PASS Initial non-inherited value can be substituted [calc(13 + 37), --x]
 PASS Initial non-inherited value can be substituted [calc(13% + 37%), --x]
-PASS Initial non-inherited value can be substituted [2000ms, --x]
+FAIL Initial non-inherited value can be substituted [2000ms, --x] The given initial value does not parse for the given syntax.
 FAIL Initial non-inherited value can be substituted [scale(calc(2 + 2)), --x] The given initial value does not parse for the given syntax.
 FAIL Initial non-inherited value can be substituted [scale(calc(2 + 2)) translateX(calc(3px + 1px)), --x] The given initial value does not parse for the given syntax.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
@@ -3,7 +3,7 @@ PASS Computed * is reified as CSSUnparsedValue
 FAIL Computed <angle> is reified as CSSUnitValue assert_false: expected false got true
 FAIL Computed <color> is reified as CSSStyleValue assert_false: expected false got true
 FAIL Computed <custom-ident> is reified as CSSKeywordValue assert_false: expected false got true
-FAIL Computed <image> [url] is reified as CSSImageValue assert_false: expected false got true
+FAIL Computed <image> [url] is reified as CSSImageValue The given initial value does not parse for the given syntax.
 FAIL Computed <integer> is reified as CSSUnitValue assert_false: expected false got true
 FAIL Computed <length-percentage> [%] is reified as CSSUnitValue assert_false: expected false got true
 FAIL Computed <length-percentage> [px] is reified as CSSUnitValue assert_false: expected false got true
@@ -11,9 +11,9 @@ FAIL Computed <length-percentage> [px + %] is reified as CSSMathSum assert_false
 FAIL Computed <length> is reified as CSSUnitValue assert_false: expected false got true
 FAIL Computed <number> is reified as CSSUnitValue assert_false: expected false got true
 FAIL Computed <percentage> is reified as CSSUnitValue assert_false: expected false got true
-FAIL Computed <resolution> is reified as CSSUnitValue assert_false: expected false got true
-FAIL Computed <time> is reified as CSSUnitValue assert_false: expected false got true
-FAIL Computed <url> is reified as CSSStyleValue assert_false: expected false got true
+FAIL Computed <resolution> is reified as CSSUnitValue The given initial value does not parse for the given syntax.
+FAIL Computed <time> is reified as CSSUnitValue The given initial value does not parse for the given syntax.
+FAIL Computed <url> is reified as CSSStyleValue The given initial value does not parse for the given syntax.
 FAIL Computed ident is reified as CSSKeywordValue assert_false: expected false got true
 FAIL First computed value correctly reified in space-separated list assert_false: expected false got true
 FAIL First computed value correctly reified in comma-separated list assert_false: expected false got true
@@ -29,8 +29,8 @@ PASS Specified <color> is reified as CSSUnparsedValue from get/getAll [attribute
 PASS Specified <color> is reified as CSSUnparsedValue from get/getAll [styleMap]
 PASS Specified <custom-ident> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
 PASS Specified <custom-ident> is reified as CSSUnparsedValue from get/getAll [styleMap]
-PASS Specified <image> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
-PASS Specified <image> is reified as CSSUnparsedValue from get/getAll [styleMap]
+FAIL Specified <image> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <image> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
 PASS Specified <integer> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
 PASS Specified <integer> is reified as CSSUnparsedValue from get/getAll [styleMap]
 PASS Specified <length-percentage> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
@@ -41,16 +41,16 @@ PASS Specified <number> is reified as CSSUnparsedValue from get/getAll [attribut
 PASS Specified <number> is reified as CSSUnparsedValue from get/getAll [styleMap]
 PASS Specified <percentage> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
 PASS Specified <percentage> is reified as CSSUnparsedValue from get/getAll [styleMap]
-PASS Specified <resolution> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
-PASS Specified <resolution> is reified as CSSUnparsedValue from get/getAll [styleMap]
-PASS Specified <time> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
-PASS Specified <time> is reified as CSSUnparsedValue from get/getAll [styleMap]
+FAIL Specified <resolution> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <resolution> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <time> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <time> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <transform-function> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <transform-function> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <transform-list> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <transform-list> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
-PASS Specified <url> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
-PASS Specified <url> is reified as CSSUnparsedValue from get/getAll [styleMap]
+FAIL Specified <url> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <url> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
 PASS Specified <length>+ is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
 PASS Specified <length>+ is reified as CSSUnparsedValue from get/getAll [styleMap]
 PASS Specified <length># is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
@@ -65,8 +65,8 @@ PASS Specified string "green" accepted by set() for syntax <color> [attributeSty
 PASS Specified string "green" accepted by set() for syntax <color> [styleMap]
 PASS Specified string "foo" accepted by set() for syntax <custom-ident> [attributeStyleMap]
 PASS Specified string "foo" accepted by set() for syntax <custom-ident> [styleMap]
-PASS Specified string "url("a")" accepted by set() for syntax <image> [attributeStyleMap]
-PASS Specified string "url("a")" accepted by set() for syntax <image> [styleMap]
+FAIL Specified string "url("a")" accepted by set() for syntax <image> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "url("a")" accepted by set() for syntax <image> [styleMap] The given initial value does not parse for the given syntax.
 PASS Specified string "1" accepted by set() for syntax <integer> [attributeStyleMap]
 PASS Specified string "1" accepted by set() for syntax <integer> [styleMap]
 PASS Specified string "calc(10% + 10px)" accepted by set() for syntax <length-percentage> [attributeStyleMap]
@@ -77,16 +77,16 @@ PASS Specified string "1" accepted by set() for syntax <number> [attributeStyleM
 PASS Specified string "1" accepted by set() for syntax <number> [styleMap]
 PASS Specified string "10%" accepted by set() for syntax <percentage> [attributeStyleMap]
 PASS Specified string "10%" accepted by set() for syntax <percentage> [styleMap]
-PASS Specified string "10dpi" accepted by set() for syntax <resolution> [attributeStyleMap]
-PASS Specified string "10dpi" accepted by set() for syntax <resolution> [styleMap]
-PASS Specified string "1s" accepted by set() for syntax <time> [attributeStyleMap]
-PASS Specified string "1s" accepted by set() for syntax <time> [styleMap]
+FAIL Specified string "10dpi" accepted by set() for syntax <resolution> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "10dpi" accepted by set() for syntax <resolution> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "1s" accepted by set() for syntax <time> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "1s" accepted by set() for syntax <time> [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-function> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-function> [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-list> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
-PASS Specified string "url("a")" accepted by set() for syntax <url> [attributeStyleMap]
-PASS Specified string "url("a")" accepted by set() for syntax <url> [styleMap]
+FAIL Specified string "url("a")" accepted by set() for syntax <url> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "url("a")" accepted by set() for syntax <url> [styleMap] The given initial value does not parse for the given syntax.
 PASS Specified string "10px 11px" accepted by set() for syntax <length>+ [attributeStyleMap]
 PASS Specified string "10px 11px" accepted by set() for syntax <length>+ [styleMap]
 PASS Specified string "10px, 11px" accepted by set() for syntax <length># [attributeStyleMap]
@@ -99,8 +99,8 @@ PASS Specified string "10px" accepted by set() for syntax <color> [attributeStyl
 PASS Specified string "10px" accepted by set() for syntax <color> [styleMap]
 PASS Specified string "10px" accepted by set() for syntax <custom-ident> [attributeStyleMap]
 PASS Specified string "10px" accepted by set() for syntax <custom-ident> [styleMap]
-PASS Specified string "a" accepted by set() for syntax <image> [attributeStyleMap]
-PASS Specified string "a" accepted by set() for syntax <image> [styleMap]
+FAIL Specified string "a" accepted by set() for syntax <image> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "a" accepted by set() for syntax <image> [styleMap] The given initial value does not parse for the given syntax.
 PASS Specified string "float" accepted by set() for syntax <integer> [attributeStyleMap]
 PASS Specified string "float" accepted by set() for syntax <integer> [styleMap]
 PASS Specified string "red" accepted by set() for syntax <length-percentage> [attributeStyleMap]
@@ -111,16 +111,16 @@ PASS Specified string "red" accepted by set() for syntax <number> [attributeStyl
 PASS Specified string "red" accepted by set() for syntax <number> [styleMap]
 PASS Specified string "var(--x)" accepted by set() for syntax <percentage> [attributeStyleMap]
 PASS Specified string "var(--x)" accepted by set() for syntax <percentage> [styleMap]
-PASS Specified string "blue" accepted by set() for syntax <resolution> [attributeStyleMap]
-PASS Specified string "blue" accepted by set() for syntax <resolution> [styleMap]
-PASS Specified string "1meter" accepted by set() for syntax <time> [attributeStyleMap]
-PASS Specified string "1meter" accepted by set() for syntax <time> [styleMap]
+FAIL Specified string "blue" accepted by set() for syntax <resolution> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "blue" accepted by set() for syntax <resolution> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "1meter" accepted by set() for syntax <time> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "1meter" accepted by set() for syntax <time> [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "foo(0)" accepted by set() for syntax <transform-function> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "foo(0)" accepted by set() for syntax <transform-function> [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "bar(1)" accepted by set() for syntax <transform-list> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "bar(1)" accepted by set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
-PASS Specified string "a" accepted by set() for syntax <url> [attributeStyleMap]
-PASS Specified string "a" accepted by set() for syntax <url> [styleMap]
+FAIL Specified string "a" accepted by set() for syntax <url> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "a" accepted by set() for syntax <url> [styleMap] The given initial value does not parse for the given syntax.
 PASS Specified string "a b" accepted by set() for syntax <length>+ [attributeStyleMap]
 PASS Specified string "a b" accepted by set() for syntax <length>+ [styleMap]
 PASS Specified string "a, b" accepted by set() for syntax <length># [attributeStyleMap]
@@ -135,8 +135,8 @@ PASS CSSUnparsedValue is accepted via set() for syntax <color> [attributeStyleMa
 PASS CSSUnparsedValue is accepted via set() for syntax <color> [styleMap]
 PASS CSSUnparsedValue is accepted via set() for syntax <custom-ident> [attributeStyleMap]
 PASS CSSUnparsedValue is accepted via set() for syntax <custom-ident> [styleMap]
-PASS CSSUnparsedValue is accepted via set() for syntax <image> [attributeStyleMap]
-PASS CSSUnparsedValue is accepted via set() for syntax <image> [styleMap]
+FAIL CSSUnparsedValue is accepted via set() for syntax <image> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <image> [styleMap] The given initial value does not parse for the given syntax.
 PASS CSSUnparsedValue is accepted via set() for syntax <integer> [attributeStyleMap]
 PASS CSSUnparsedValue is accepted via set() for syntax <integer> [styleMap]
 PASS CSSUnparsedValue is accepted via set() for syntax <length-percentage> [attributeStyleMap]
@@ -147,16 +147,16 @@ PASS CSSUnparsedValue is accepted via set() for syntax <number> [attributeStyleM
 PASS CSSUnparsedValue is accepted via set() for syntax <number> [styleMap]
 PASS CSSUnparsedValue is accepted via set() for syntax <percentage> [attributeStyleMap]
 PASS CSSUnparsedValue is accepted via set() for syntax <percentage> [styleMap]
-PASS CSSUnparsedValue is accepted via set() for syntax <resolution> [attributeStyleMap]
-PASS CSSUnparsedValue is accepted via set() for syntax <resolution> [styleMap]
-PASS CSSUnparsedValue is accepted via set() for syntax <time> [attributeStyleMap]
-PASS CSSUnparsedValue is accepted via set() for syntax <time> [styleMap]
+FAIL CSSUnparsedValue is accepted via set() for syntax <resolution> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <resolution> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <time> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <time> [styleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnparsedValue is accepted via set() for syntax <transform-function> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnparsedValue is accepted via set() for syntax <transform-function> [styleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnparsedValue is accepted via set() for syntax <transform-list> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnparsedValue is accepted via set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
-PASS CSSUnparsedValue is accepted via set() for syntax <url> [attributeStyleMap]
-PASS CSSUnparsedValue is accepted via set() for syntax <url> [styleMap]
+FAIL CSSUnparsedValue is accepted via set() for syntax <url> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <url> [styleMap] The given initial value does not parse for the given syntax.
 PASS CSSUnparsedValue is accepted via set() for syntax <length>+ [attributeStyleMap]
 PASS CSSUnparsedValue is accepted via set() for syntax <length>+ [styleMap]
 PASS CSSUnparsedValue is accepted via set() for syntax <length># [attributeStyleMap]
@@ -169,8 +169,8 @@ PASS CSSUnitValue rejected by set() for syntax <angle> [attributeStyleMap]
 PASS CSSUnitValue rejected by set() for syntax <angle> [styleMap]
 PASS CSSKeywordValue rejected by set() for syntax <custom-ident> [attributeStyleMap]
 PASS CSSKeywordValue rejected by set() for syntax <custom-ident> [styleMap]
-PASS CSSImageValue rejected by set() for syntax <image> [attributeStyleMap]
-PASS CSSImageValue rejected by set() for syntax <image> [styleMap]
+FAIL CSSImageValue rejected by set() for syntax <image> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSImageValue rejected by set() for syntax <image> [styleMap] The given initial value does not parse for the given syntax.
 PASS CSSUnitValue rejected by set() for syntax <integer> [attributeStyleMap]
 PASS CSSUnitValue rejected by set() for syntax <integer> [styleMap]
 PASS CSSUnitValue rejected by set() for syntax <length-percentage> [attributeStyleMap]
@@ -181,10 +181,10 @@ PASS CSSUnitValue rejected by set() for syntax <number> [attributeStyleMap]
 PASS CSSUnitValue rejected by set() for syntax <number> [styleMap]
 PASS CSSUnitValue rejected by set() for syntax <percentage> [attributeStyleMap]
 PASS CSSUnitValue rejected by set() for syntax <percentage> [styleMap]
-PASS CSSUnitValue rejected by set() for syntax <resolution> [attributeStyleMap]
-PASS CSSUnitValue rejected by set() for syntax <resolution> [styleMap]
-PASS CSSUnitValue rejected by set() for syntax <time> [attributeStyleMap]
-PASS CSSUnitValue rejected by set() for syntax <time> [styleMap]
+FAIL CSSUnitValue rejected by set() for syntax <resolution> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnitValue rejected by set() for syntax <resolution> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnitValue rejected by set() for syntax <time> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnitValue rejected by set() for syntax <time> [styleMap] The given initial value does not parse for the given syntax.
 FAIL CSSTransformValue rejected by set() for syntax <transform-list> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL CSSTransformValue rejected by set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
 PASS CSSUnitValue rejected by set() for syntax <length>+ [attributeStyleMap]
@@ -201,8 +201,8 @@ PASS Appending a string to <color>+ is not allowed [attributeStyleMap]
 PASS Appending a string to <color>+ is not allowed [styleMap]
 PASS Appending a string to <custom-ident>+ is not allowed [attributeStyleMap]
 PASS Appending a string to <custom-ident>+ is not allowed [styleMap]
-PASS Appending a string to <image>+ is not allowed [attributeStyleMap]
-PASS Appending a string to <image>+ is not allowed [styleMap]
+FAIL Appending a string to <image>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <image>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
 PASS Appending a string to <integer>+ is not allowed [attributeStyleMap]
 PASS Appending a string to <integer>+ is not allowed [styleMap]
 PASS Appending a string to <length-percentage>+ is not allowed [attributeStyleMap]
@@ -213,16 +213,16 @@ PASS Appending a string to <number>+ is not allowed [attributeStyleMap]
 PASS Appending a string to <number>+ is not allowed [styleMap]
 PASS Appending a string to <percentage>+ is not allowed [attributeStyleMap]
 PASS Appending a string to <percentage>+ is not allowed [styleMap]
-PASS Appending a string to <resolution>+ is not allowed [attributeStyleMap]
-PASS Appending a string to <resolution>+ is not allowed [styleMap]
-PASS Appending a string to <time>+ is not allowed [attributeStyleMap]
-PASS Appending a string to <time>+ is not allowed [styleMap]
+FAIL Appending a string to <resolution>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <resolution>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <time>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <time>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a string to <transform-function>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a string to <transform-function>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a string to <transform-list> is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a string to <transform-list> is not allowed [styleMap] The given initial value does not parse for the given syntax.
-PASS Appending a string to <url>+ is not allowed [attributeStyleMap]
-PASS Appending a string to <url>+ is not allowed [styleMap]
+FAIL Appending a string to <url>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <url>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
 PASS Appending a string to <length># is not allowed [attributeStyleMap]
 PASS Appending a string to <length># is not allowed [styleMap]
 PASS Appending a CSSKeywordValue to * is not allowed [attributeStyleMap]
@@ -233,8 +233,8 @@ PASS Appending a CSSUnitValue to <angle>+ is not allowed [attributeStyleMap]
 PASS Appending a CSSUnitValue to <angle>+ is not allowed [styleMap]
 PASS Appending a CSSKeywordValue to <custom-ident>+ is not allowed [attributeStyleMap]
 PASS Appending a CSSKeywordValue to <custom-ident>+ is not allowed [styleMap]
-PASS Appending a CSSImageValue to <image>+ is not allowed [attributeStyleMap]
-PASS Appending a CSSImageValue to <image>+ is not allowed [styleMap]
+FAIL Appending a CSSImageValue to <image>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSImageValue to <image>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
 PASS Appending a CSSUnitValue to <integer>+ is not allowed [attributeStyleMap]
 PASS Appending a CSSUnitValue to <integer>+ is not allowed [styleMap]
 PASS Appending a CSSUnitValue to <length-percentage>+ is not allowed [attributeStyleMap]
@@ -245,10 +245,10 @@ PASS Appending a CSSUnitValue to <number>+ is not allowed [attributeStyleMap]
 PASS Appending a CSSUnitValue to <number>+ is not allowed [styleMap]
 PASS Appending a CSSUnitValue to <percentage>+ is not allowed [attributeStyleMap]
 PASS Appending a CSSUnitValue to <percentage>+ is not allowed [styleMap]
-PASS Appending a CSSUnitValue to <resolution>+ is not allowed [attributeStyleMap]
-PASS Appending a CSSUnitValue to <resolution>+ is not allowed [styleMap]
-PASS Appending a CSSUnitValue to <time>+ is not allowed [attributeStyleMap]
-PASS Appending a CSSUnitValue to <time>+ is not allowed [styleMap]
+FAIL Appending a CSSUnitValue to <resolution>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSUnitValue to <resolution>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSUnitValue to <time>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSUnitValue to <time>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a CSSKeywordValue to <transform-list> is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a CSSKeywordValue to <transform-list> is not allowed [styleMap] The given initial value does not parse for the given syntax.
 PASS Appending a CSSUnitValue to <length># is not allowed [attributeStyleMap]
@@ -257,7 +257,7 @@ PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax *
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <angle>
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <color>
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <custom-ident> | <length>
-PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <image>
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <image> The given initial value does not parse for the given syntax.
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <integer>
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length-percentage> (10%)
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length-percentage> (10px)
@@ -265,11 +265,11 @@ PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length-percen
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length>
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <number>
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <percentage>
-PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <resolution>
-PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <time>
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <resolution> The given initial value does not parse for the given syntax.
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <time> The given initial value does not parse for the given syntax.
 FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <transform-function> The given initial value does not parse for the given syntax.
 FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <transform-list> The given initial value does not parse for the given syntax.
-PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <url>
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <url> The given initial value does not parse for the given syntax.
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax thing1 | THING2 | <url>
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length>+
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length>#
@@ -285,8 +285,8 @@ PASS Specified <color> is reified CSSUnparsedValue by iterator [attributeStyleMa
 PASS Specified <color> is reified CSSUnparsedValue by iterator [styleMap]
 PASS Specified <custom-ident> is reified CSSUnparsedValue by iterator [attributeStyleMap]
 PASS Specified <custom-ident> is reified CSSUnparsedValue by iterator [styleMap]
-PASS Specified <image> is reified CSSUnparsedValue by iterator [attributeStyleMap]
-PASS Specified <image> is reified CSSUnparsedValue by iterator [styleMap]
+FAIL Specified <image> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <image> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
 PASS Specified <integer> is reified CSSUnparsedValue by iterator [attributeStyleMap]
 PASS Specified <integer> is reified CSSUnparsedValue by iterator [styleMap]
 PASS Specified <length-percentage> is reified CSSUnparsedValue by iterator [attributeStyleMap]
@@ -297,16 +297,16 @@ PASS Specified <number> is reified CSSUnparsedValue by iterator [attributeStyleM
 PASS Specified <number> is reified CSSUnparsedValue by iterator [styleMap]
 PASS Specified <percentage> is reified CSSUnparsedValue by iterator [attributeStyleMap]
 PASS Specified <percentage> is reified CSSUnparsedValue by iterator [styleMap]
-PASS Specified <resolution> is reified CSSUnparsedValue by iterator [attributeStyleMap]
-PASS Specified <resolution> is reified CSSUnparsedValue by iterator [styleMap]
-PASS Specified <time> is reified CSSUnparsedValue by iterator [attributeStyleMap]
-PASS Specified <time> is reified CSSUnparsedValue by iterator [styleMap]
+FAIL Specified <resolution> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <resolution> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <time> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <time> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <transform-function> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <transform-function> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <transform-list> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <transform-list> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
-PASS Specified <url> is reified CSSUnparsedValue by iterator [attributeStyleMap]
-PASS Specified <url> is reified CSSUnparsedValue by iterator [styleMap]
+FAIL Specified <url> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <url> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
 PASS Specified <length>+ is reified CSSUnparsedValue by iterator [attributeStyleMap]
 PASS Specified <length>+ is reified CSSUnparsedValue by iterator [styleMap]
 PASS Specified <length># is reified CSSUnparsedValue by iterator [attributeStyleMap]
@@ -315,13 +315,13 @@ FAIL Registered property with initial value show up on iteration of computedStyl
 FAIL Computed * is reified as CSSUnparsedValue by iterator undefined is not an object (evaluating 'result.length')
 FAIL Computed <angle> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
 FAIL Computed <custom-ident> is reified as CSSKeywordValue by iterator undefined is not an object (evaluating 'result.length')
-FAIL Computed <image> is reified as CSSImageValue by iterator undefined is not an object (evaluating 'result.length')
+FAIL Computed <image> is reified as CSSImageValue by iterator The given initial value does not parse for the given syntax.
 FAIL Computed <integer> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
 FAIL Computed <length> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
 FAIL Computed <number> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
 FAIL Computed <percentage> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
-FAIL Computed <resolution> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
-FAIL Computed <time> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
+FAIL Computed <resolution> is reified as CSSUnitValue by iterator The given initial value does not parse for the given syntax.
+FAIL Computed <time> is reified as CSSUnitValue by iterator The given initial value does not parse for the given syntax.
 FAIL Computed none | thing | THING is reified as CSSKeywordValue by iterator undefined is not an object (evaluating 'result.length')
 FAIL Computed <angle> | <length> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/url-resolution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/url-resolution-expected.txt
@@ -1,20 +1,20 @@
 
 PASS Unregistered property resolves against document (URL token)
 PASS Unregistered property resolves against document (URL function)
-PASS Registered non-inherited <url> resolves against sheet (URL token)
-PASS Registered non-inherited <url> resolves against sheet (URL function)
-PASS Registered inherited <url> resolves against sheet (URL token)
-PASS Registered inherited <url> resolves against sheet (URL function)
-PASS Registered inherited <url> resolves against sheet (Child node, URL token)
-PASS Registered inherited <url> resolves against sheet (Child node, URL function)
-PASS Registered property with unregistered var reference resolves against sheet (URL token)
-PASS Registered property with unregistered var reference resolves against sheet. (URL function)
-PASS Registered property with registered var reference resolves against sheet of referenced property (URL token)
-PASS Registered property with registered var reference resolves against sheet of referenced property (URL function)
-PASS Unregistered property with registered var reference resolves against sheet of referenced property (URL token)
-PASS Unregistered property with registered var reference resolves against sheet of referenced property (URL function)
-PASS Multiple (registered) var reference resolve against respective sheets (URL token)
-PASS Multiple (registered) var reference resolve against respective sheets (URL function)
-PASS Registered UTF16BE-encoded var reference resolve against sheet (URL token)
-PASS Registered UTF16BE-encoded var reference resolve against sheet (URL function)
+FAIL Registered non-inherited <url> resolves against sheet (URL token) Unknown url format: none
+FAIL Registered non-inherited <url> resolves against sheet (URL function) Unknown url format: none
+FAIL Registered inherited <url> resolves against sheet (URL token) Unknown url format: none
+FAIL Registered inherited <url> resolves against sheet (URL function) Unknown url format: none
+FAIL Registered inherited <url> resolves against sheet (Child node, URL token) Unknown url format: none
+FAIL Registered inherited <url> resolves against sheet (Child node, URL function) Unknown url format: none
+FAIL Registered property with unregistered var reference resolves against sheet (URL token) Unknown url format: none
+FAIL Registered property with unregistered var reference resolves against sheet. (URL function) Unknown url format: none
+FAIL Registered property with registered var reference resolves against sheet of referenced property (URL token) Unknown url format: none
+FAIL Registered property with registered var reference resolves against sheet of referenced property (URL function) Unknown url format: none
+FAIL Unregistered property with registered var reference resolves against sheet of referenced property (URL token) Unknown url format: none
+FAIL Unregistered property with registered var reference resolves against sheet of referenced property (URL function) Unknown url format: none
+FAIL Multiple (registered) var reference resolve against respective sheets (URL token) Unknown url format: none
+FAIL Multiple (registered) var reference resolve against respective sheets (URL function) Unknown url format: none
+FAIL Registered UTF16BE-encoded var reference resolve against sheet (URL token) Unknown url format: none
+FAIL Registered UTF16BE-encoded var reference resolve against sheet (URL function) Unknown url format: none
 

--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -70,11 +70,6 @@ String CSSCustomPropertyValue::customCSSText() const
             return CSSPrimitiveValue::create(value.value, value.unitType)->cssText();
         }, [&](const StyleColor& value) {
             return serializationForCSS(value);
-        }, [&](const RefPtr<StyleImage>& value) {
-            // FIXME: This is not right for gradients that use `currentcolor`. There should be a way preserve it.
-            return value->computedStyleValue(RenderStyle::defaultStyle())->cssText();
-        }, [&](const String& value) {
-            return serializeURL(value);
         });
     };
 

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -30,7 +30,7 @@
 #include "CSSVariableReferenceValue.h"
 #include "Length.h"
 #include "StyleColor.h"
-#include "StyleImage.h"
+#include <variant>
 
 namespace WebCore {
 
@@ -44,7 +44,7 @@ public:
 
         bool operator==(const NumericSyntaxValue&) const = default;
     };
-    using SyntaxValue = std::variant<Length, NumericSyntaxValue, StyleColor, RefPtr<StyleImage>, String>;
+    using SyntaxValue = std::variant<Length, NumericSyntaxValue, StyleColor>;
 
     using VariantValue = std::variant<std::monostate, Ref<CSSVariableReferenceValue>, CSSValueID, Ref<CSSVariableData>, SyntaxValue>;
 
@@ -81,16 +81,6 @@ public:
     static Ref<CSSCustomPropertyValue> createForColorSyntax(const AtomString& name, StyleColor color)
     {
         return adoptRef(*new CSSCustomPropertyValue(name, { SyntaxValue { WTFMove(color) } }));
-    }
-
-    static Ref<CSSCustomPropertyValue> createForImageSyntax(const AtomString& name, RefPtr<StyleImage> image)
-    {
-        return adoptRef(*new CSSCustomPropertyValue(name, { SyntaxValue { WTFMove(image) } }));
-    }
-
-    static Ref<CSSCustomPropertyValue> createForURLSyntax(const AtomString& name, String url)
-    {
-        return adoptRef(*new CSSCustomPropertyValue(name, { SyntaxValue { WTFMove(url) } }));
     }
 
     static Ref<CSSCustomPropertyValue> create(const CSSCustomPropertyValue& other)

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -280,7 +280,6 @@ CSSUnitType CSSPrimitiveValue::primitiveType() const
     case CalculationCategory::Angle:
     case CalculationCategory::Time:
     case CalculationCategory::Frequency:
-    case CalculationCategory::Resolution:
         return m_value.calc->primitiveType();
     case CalculationCategory::Other:
         return CSSUnitType::CSS_UNKNOWN;
@@ -1147,9 +1146,6 @@ std::optional<double> CSSPrimitiveValue::doubleValueInternal(CSSUnitType request
         return std::nullopt;
 
     if (targetCategory == CSSUnitCategory::Number) {
-        // Cannot convert between numbers and percent.
-        if (sourceCategory == CSSUnitCategory::Percent)
-            return std::nullopt;
         // We interpret conversion to CSSUnitType::CSS_NUMBER as conversion to a canonical unit in this value's category.
         targetUnitType = canonicalUnitTypeForCategory(sourceCategory);
         if (targetUnitType == CSSUnitType::CSS_UNKNOWN)
@@ -1157,9 +1153,6 @@ std::optional<double> CSSPrimitiveValue::doubleValueInternal(CSSUnitType request
     }
 
     if (sourceUnitType == CSSUnitType::CSS_NUMBER || sourceUnitType == CSSUnitType::CSS_INTEGER) {
-        // Cannot convert between numbers and percent.
-        if (targetCategory == CSSUnitCategory::Percent)
-            return std::nullopt;
         // We interpret conversion from CSSUnitType::CSS_NUMBER in the same way as CSSParser::validUnit() while using non-strict mode.
         sourceUnitType = canonicalUnitTypeForCategory(targetCategory);
         if (sourceUnitType == CSSUnitType::CSS_UNKNOWN)

--- a/Source/WebCore/css/CSSUnits.cpp
+++ b/Source/WebCore/css/CSSUnits.cpp
@@ -141,7 +141,7 @@ CSSUnitType canonicalUnitTypeForCategory(CSSUnitCategory category)
     case CSSUnitCategory::AbsoluteLength:
         return CSSUnitType::CSS_PX;
     case CSSUnitCategory::Percent:
-        return CSSUnitType::CSS_PERCENTAGE;
+        return CSSUnitType::CSS_UNKNOWN; // Cannot convert between numbers and percent.
     case CSSUnitCategory::Time:
         return CSSUnitType::CSS_S;
     case CSSUnitCategory::Angle:
@@ -159,11 +159,6 @@ CSSUnitType canonicalUnitTypeForCategory(CSSUnitCategory category)
     }
     ASSERT_NOT_REACHED();
     return CSSUnitType::CSS_UNKNOWN;
-}
-
-CSSUnitType canonicalUnitTypeForUnitType(CSSUnitType unitType)
-{
-    return canonicalUnitTypeForCategory(unitCategory(unitType));
 }
 
 TextStream& operator<<(TextStream& ts, CSSUnitCategory category)

--- a/Source/WebCore/css/CSSUnits.h
+++ b/Source/WebCore/css/CSSUnits.h
@@ -149,7 +149,6 @@ enum class CSSUnitCategory : uint8_t {
 
 CSSUnitCategory unitCategory(CSSUnitType);
 CSSUnitType canonicalUnitTypeForCategory(CSSUnitCategory);
-CSSUnitType canonicalUnitTypeForUnitType(CSSUnitType);
 
 WTF::TextStream& operator<<(WTF::TextStream&, CSSUnitCategory);
 WTF::TextStream& operator<<(WTF::TextStream&, CSSUnitType);

--- a/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
+++ b/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
@@ -67,7 +67,7 @@ ExceptionOr<void> DOMCSSRegisterCustomProperty::registerProperty(Document& docum
         auto parentStyle = RenderStyle::clone(*style);
         Style::Builder dummyBuilder(*style, { document, parentStyle }, matchResult, { });
 
-        initialValue = CSSPropertyParser::parseTypedCustomPropertyValue(descriptor.name, descriptor.syntax, tokenizer.tokenRange(), dummyBuilder.state(), { document });
+        initialValue = CSSPropertyParser::parseTypedCustomPropertyValue(descriptor.name, descriptor.syntax, tokenizer.tokenRange(), dummyBuilder.state(), strictCSSParserContext());
 
         if (!initialValue || !initialValue->isResolved())
             return Exception { SyntaxError, "The given initial value does not parse for the given syntax."_s };

--- a/Source/WebCore/css/calc/CSSCalcCategoryMapping.cpp
+++ b/Source/WebCore/css/calc/CSSCalcCategoryMapping.cpp
@@ -95,10 +95,6 @@ CalculationCategory calcUnitCategory(CSSUnitType type)
     case CSSUnitType::CSS_HZ:
     case CSSUnitType::CSS_KHZ:
         return CalculationCategory::Frequency;
-    case CSSUnitType::CSS_DPPX:
-    case CSSUnitType::CSS_DPI:
-    case CSSUnitType::CSS_DPCM:
-        return CalculationCategory::Resolution;
     default:
         return CalculationCategory::Other;
     }
@@ -131,10 +127,6 @@ CalculationCategory calculationCategoryForCombination(CSSUnitType type)
     case CSSUnitType::CSS_HZ:
     case CSSUnitType::CSS_KHZ:
         return CalculationCategory::Frequency;
-    case CSSUnitType::CSS_DPPX:
-    case CSSUnitType::CSS_DPI:
-    case CSSUnitType::CSS_DPCM:
-        return CalculationCategory::Resolution;
     case CSSUnitType::CSS_EMS:
     case CSSUnitType::CSS_EXS:
     case CSSUnitType::CSS_LHS:
@@ -186,7 +178,6 @@ CSSUnitType canonicalUnitTypeForCalculationCategory(CalculationCategory category
     case CalculationCategory::Angle: return CSSUnitType::CSS_DEG;
     case CalculationCategory::Time: return CSSUnitType::CSS_S;
     case CalculationCategory::Frequency: return CSSUnitType::CSS_HZ;
-    case CalculationCategory::Resolution: return CSSUnitType::CSS_DPPX;
     case CalculationCategory::Other:
     case CalculationCategory::PercentNumber:
     case CalculationCategory::PercentLength:

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -164,7 +164,6 @@ static CalculationCategory resolvedTypeForMinOrMaxOrClamp(CalculationCategory ca
     case CalculationCategory::Angle:
     case CalculationCategory::Time:
     case CalculationCategory::Frequency:
-    case CalculationCategory::Resolution:
     case CalculationCategory::Other:
         return category;
 
@@ -202,7 +201,6 @@ static SortingCategory sortingCategoryForType(CSSUnitType unitType)
         SortingCategory::Dimension,     // CalculationCategory::Angle,
         SortingCategory::Dimension,     // CalculationCategory::Time,
         SortingCategory::Dimension,     // CalculationCategory::Frequency,
-        SortingCategory::Dimension,     // CalculationCategory::Resolution,
         SortingCategory::Other,         // UOther
     };
 
@@ -1008,7 +1006,6 @@ CSSUnitType CSSCalcOperationNode::primitiveType() const
     case CalculationCategory::Angle:
     case CalculationCategory::Time:
     case CalculationCategory::Frequency:
-    case CalculationCategory::Resolution:
         if (m_children.size() == 1 && !isInverseTrigNode())
             return m_children.first()->primitiveType();
         return canonicalUnitTypeForCalculationCategory(unitCategory);

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
@@ -101,7 +101,9 @@ void CSSCalcPrimitiveValueNode::add(const CSSCalcPrimitiveValueNode& node, UnitC
         m_value = CSSPrimitiveValue::create(m_value->doubleValue() + node.doubleValue(valueType), valueType);
         break;
     case UnitConversion::Canonicalize: {
-        auto canonicalType = canonicalUnitTypeForUnitType(valueType);
+        auto valueCategory = unitCategory(valueType);
+        // FIXME: It's awkward that canonicalUnitTypeForCategory() has special handling for CSSUnitCategory::Percent.
+        auto canonicalType = valueCategory == CSSUnitCategory::Percent ? CSSUnitType::CSS_PERCENTAGE : canonicalUnitTypeForCategory(valueCategory);
         ASSERT(canonicalType != CSSUnitType::CSS_UNKNOWN);
         double leftValue = m_value->doubleValue(canonicalType);
         double rightValue = node.doubleValue(canonicalType);
@@ -156,7 +158,6 @@ std::unique_ptr<CalcExpressionNode> CSSCalcPrimitiveValueNode::createCalcExpress
     case CalculationCategory::Angle:
     case CalculationCategory::Time:
     case CalculationCategory::Frequency:
-    case CalculationCategory::Resolution:
     case CalculationCategory::Other:
         ASSERT_NOT_REACHED();
     }
@@ -192,7 +193,6 @@ double CSSCalcPrimitiveValueNode::computeLengthPx(const CSSToLengthConversionDat
     case CalculationCategory::Angle:
     case CalculationCategory::Time:
     case CalculationCategory::Frequency:
-    case CalculationCategory::Resolution:
     case CalculationCategory::Other:
         ASSERT_NOT_REACHED();
         break;

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -256,7 +256,7 @@ bool CSSPropertyParser::canParseTypedCustomPropertyValue(const String& syntax, c
     return parser.canParseTypedCustomPropertyValue(syntax);
 }
 
-RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(const AtomString& name, const String& syntax, const CSSParserTokenRange& tokens, Style::BuilderState& builderState, const CSSParserContext& context)
+RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(const AtomString& name, const String& syntax, const CSSParserTokenRange& tokens, const Style::BuilderState& builderState, const CSSParserContext& context)
 {
     CSSPropertyParser parser(tokens, context, nullptr, false);
     RefPtr<CSSCustomPropertyValue> value = parser.parseTypedCustomPropertyValue(name, syntax, builderState);
@@ -358,16 +358,8 @@ std::pair<RefPtr<CSSValue>, CSSPropertySyntax::Type> CSSPropertyParser::parseCus
             return consumeNumber(m_range, ValueRange::All);
         case CSSPropertySyntax::Type::Angle:
             return consumeAngle(m_range, m_context.mode);
-        case CSSPropertySyntax::Type::Time:
-            return consumeTime(m_range, m_context.mode, ValueRange::All);
-        case CSSPropertySyntax::Type::Resolution:
-            return consumeResolution(m_range);
         case CSSPropertySyntax::Type::Color:
             return consumeColor(m_range, m_context);
-        case CSSPropertySyntax::Type::Image:
-            return consumeImage(m_range, m_context, { AllowedImageType::URLFunction, AllowedImageType::GeneratedImage });
-        case CSSPropertySyntax::Type::URL:
-            return consumeURL(m_range);
         case CSSPropertySyntax::Type::Unknown:
             return nullptr;
         }
@@ -416,7 +408,7 @@ void CSSPropertyParser::collectParsedCustomPropertyValueDependencies(const Strin
     }
 }
 
-RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(const AtomString& name, const String& syntax, Style::BuilderState& builderState)
+RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(const AtomString& name, const String& syntax, const Style::BuilderState& builderState)
 {
     auto syntaxDefinition = CSSPropertySyntax::parse(syntax);
     if (syntaxDefinition.isEmpty())
@@ -433,7 +425,10 @@ RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(
     if (!value)
         return nullptr;
 
-    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value.get());
+    if (!is<CSSPrimitiveValue>(*value))
+        return nullptr;
+
+    auto& primitiveValue = downcast<CSSPrimitiveValue>(*value);
 
     switch (syntaxType) {
     case CSSPropertySyntax::Type::Universal:
@@ -441,31 +436,20 @@ RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(
         return nullptr;
     case CSSPropertySyntax::Type::LengthPercentage:
     case CSSPropertySyntax::Type::Length: {
-        auto length = Style::BuilderConverter::convertLength(builderState, *primitiveValue);
+        auto length = Style::BuilderConverter::convertLength(builderState, primitiveValue);
         return CSSCustomPropertyValue::createForLengthSyntax(name, WTFMove(length));
     }
     case CSSPropertySyntax::Type::Percentage:
+        return CSSCustomPropertyValue::createForNumericSyntax(name, primitiveValue.doubleValue(), CSSUnitType::CSS_PERCENTAGE);
     case CSSPropertySyntax::Type::Integer:
+        return CSSCustomPropertyValue::createForNumericSyntax(name, primitiveValue.intValue(), CSSUnitType::CSS_INTEGER);
     case CSSPropertySyntax::Type::Number:
+        return CSSCustomPropertyValue::createForNumericSyntax(name, primitiveValue.doubleValue(), CSSUnitType::CSS_NUMBER);
     case CSSPropertySyntax::Type::Angle:
-    case CSSPropertySyntax::Type::Time:
-    case CSSPropertySyntax::Type::Resolution: {
-        auto canonicalUnit = canonicalUnitTypeForUnitType(primitiveValue->primitiveType());
-        return CSSCustomPropertyValue::createForNumericSyntax(name, primitiveValue->doubleValue(canonicalUnit), canonicalUnit);
-    }
+        return CSSCustomPropertyValue::createForNumericSyntax(name, primitiveValue.computeDegrees(), CSSUnitType::CSS_DEG);
     case CSSPropertySyntax::Type::Color: {
-        auto color = builderState.colorFromPrimitiveValue(*primitiveValue, Style::ForVisitedLink::No);
+        auto color = builderState.colorFromPrimitiveValue(primitiveValue, Style::ForVisitedLink::No);
         return CSSCustomPropertyValue::createForColorSyntax(name, color);
-    }
-    case CSSPropertySyntax::Type::Image: {
-        auto styleImage = builderState.createStyleImage(*value);
-        if (!styleImage)
-            return nullptr;
-        return CSSCustomPropertyValue::createForImageSyntax(name, WTFMove(styleImage));
-    }
-    case CSSPropertySyntax::Type::URL: {
-        auto url = m_context.completeURL(primitiveValue->stringValue());
-        return CSSCustomPropertyValue::createForURLSyntax(name, url.resolvedURL.string());
     }
     case CSSPropertySyntax::Type::CustomIdent: {
         auto tokenizer = CSSTokenizer::tryCreate(value->cssText());

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -52,7 +52,7 @@ public:
     // Parses a non-shorthand CSS property
     static RefPtr<CSSValue> parseSingleValue(CSSPropertyID, const CSSParserTokenRange&, const CSSParserContext&);
     static bool canParseTypedCustomPropertyValue(const String& syntax, const CSSParserTokenRange&, const CSSParserContext&);
-    static RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const String& syntax, const CSSParserTokenRange&, Style::BuilderState&, const CSSParserContext&);
+    static RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const String& syntax, const CSSParserTokenRange&, const Style::BuilderState&, const CSSParserContext&);
     static void collectParsedCustomPropertyValueDependencies(const String& syntax, bool isRoot, HashSet<CSSPropertyID>& dependencies, const CSSParserTokenRange&, const CSSParserContext&);
 
     static RefPtr<CSSValue> parseCounterStyleDescriptor(CSSPropertyID, CSSParserTokenRange&, const CSSParserContext&);
@@ -66,7 +66,7 @@ private:
     RefPtr<CSSValue> parseSingleValue(CSSPropertyID, CSSPropertyID = CSSPropertyInvalid);
     std::pair<RefPtr<CSSValue>, CSSPropertySyntax::Type> parseCustomPropertyValueWithSyntaxDefinition(const CSSPropertySyntax::Definition&);
     bool canParseTypedCustomPropertyValue(const String& syntax);
-    RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const String& syntax, Style::BuilderState&);
+    RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const String& syntax, const Style::BuilderState&);
     void collectParsedCustomPropertyValueDependencies(const String& syntax, bool isRoot, HashSet<CSSPropertyID>& dependencies);
 
     bool inQuirksMode() const { return m_context.mode == HTMLQuirksMode; }

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -785,20 +785,9 @@ struct TimeCSSPrimitiveValueWithCalcWithKnownTokenTypeNumberConsumer {
     }
 };
 
-// MARK: Resolution (CSSPrimitiveValue - maintaining calc)
+// MARK: Resolution (CSSPrimitiveValue - no calc)
 
-struct ResolutionCSSPrimitiveValueWithCalcWithKnownTokenTypeFunctionConsumer {
-    static constexpr CSSParserTokenType tokenType = FunctionToken;
-    static RefPtr<CSSPrimitiveValue> consume(CSSParserTokenRange& range, const CSSCalcSymbolTable& symbolTable, ValueRange valueRange, CSSParserMode, UnitlessQuirk, UnitlessZeroQuirk, CSSValuePool& pool)
-    {
-        ASSERT(range.peek().type() == FunctionToken);
-
-        CalcParser parser(range, CalculationCategory::Resolution, valueRange, symbolTable, pool);
-        return parser.consumeValueIfCategory(CalculationCategory::Resolution);
-    }
-};
-
-struct ResolutionCSSPrimitiveValueWithCalcWithKnownTokenTypeDimensionConsumer {
+struct ResolutionCSSPrimitiveValueWithKnownTokenTypeDimensionConsumer {
     static constexpr CSSParserTokenType tokenType = DimensionToken;
     static RefPtr<CSSPrimitiveValue> consume(CSSParserTokenRange& range, const CSSCalcSymbolTable&, ValueRange, CSSParserMode, UnitlessQuirk, UnitlessZeroQuirk, CSSValuePool& pool)
     {
@@ -1215,8 +1204,8 @@ struct TimeConsumer {
 struct ResolutionConsumer {
     using Result = RefPtr<CSSPrimitiveValue>;
 
-    using FunctionToken = ResolutionCSSPrimitiveValueWithCalcWithKnownTokenTypeFunctionConsumer;
-    using DimensionToken = ResolutionCSSPrimitiveValueWithCalcWithKnownTokenTypeDimensionConsumer;
+    // NOTE: Unlike the other types, calc() does not work with <resolution>.
+    using DimensionToken = ResolutionCSSPrimitiveValueWithKnownTokenTypeDimensionConsumer;
 };
 
 // MARK: - Combination consumer definitions.

--- a/Source/WebCore/css/parser/CSSPropertySyntax.cpp
+++ b/Source/WebCore/css/parser/CSSPropertySyntax.cpp
@@ -70,16 +70,8 @@ auto CSSPropertySyntax::parseComponent(StringParsingBuffer<CharacterType> buffer
             return Component { Type::Number, multiplier };
         if (dataTypeName == "angle"_s)
             return Component { Type::Angle, multiplier };
-        if (dataTypeName == "time"_s)
-            return Component { Type::Time, multiplier };
-        if (dataTypeName == "resolution"_s)
-            return Component { Type::Resolution, multiplier };
         if (dataTypeName == "color"_s)
             return Component { Type::Color, multiplier };
-        if (dataTypeName == "image"_s)
-            return Component { Type::Image, multiplier };
-        if (dataTypeName == "url"_s)
-            return Component { Type::URL, multiplier };
 
         return Component { Type::Unknown, multiplier };
     }

--- a/Source/WebCore/css/parser/CSSPropertySyntax.h
+++ b/Source/WebCore/css/parser/CSSPropertySyntax.h
@@ -39,11 +39,7 @@ public:
         Integer,
         Number,
         Angle,
-        Time,
-        Resolution,
         Color,
-        Image,
-        URL,
         CustomIdent,
         Unknown
     };

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -155,10 +155,20 @@ RefPtr<CSSUnitValue> CSSUnitValue::convertTo(CSSUnitType unit) const
 auto CSSUnitValue::toSumValue() const -> std::optional<SumValue>
 {
     // https://drafts.css-houdini.org/css-typed-om/#create-a-sum-value
-    auto canonicalUnit = canonicalUnitTypeForUnitType(m_unit);
-    if (canonicalUnit == CSSUnitType::CSS_UNKNOWN)
-        canonicalUnit = m_unit;
-    
+    auto canonicalUnit = [] (CSSUnitType unit) {
+        // FIXME: We probably want to change the definition of canonicalUnitTypeForCategory so this lambda isn't necessary.
+        auto category = unitCategory(unit);
+        switch (category) {
+        case CSSUnitCategory::Percent:
+            return CSSUnitType::CSS_PERCENTAGE;
+        case CSSUnitCategory::Flex:
+            return CSSUnitType::CSS_FR;
+        default:
+            break;
+        }
+        auto result = canonicalUnitTypeForCategory(category);
+        return result == CSSUnitType::CSS_UNKNOWN ? unit : result;
+    } (m_unit);
     auto convertedValue = m_value * conversionToCanonicalUnitsScaleFactor(unitEnum()) / conversionToCanonicalUnitsScaleFactor(canonicalUnit);
 
     if (m_unit == CSSUnitType::CSS_NUMBER)

--- a/Source/WebCore/platform/calc/CalculationCategory.cpp
+++ b/Source/WebCore/platform/calc/CalculationCategory.cpp
@@ -41,7 +41,6 @@ TextStream& operator<<(TextStream& ts, CalculationCategory category)
     case CalculationCategory::Angle: ts << "angle"; break;
     case CalculationCategory::Time: ts << "time"; break;
     case CalculationCategory::Frequency: ts << "frequency"; break;
-    case CalculationCategory::Resolution: ts << "resolution"; break;
     case CalculationCategory::Other: ts << "other"; break;
     }
 

--- a/Source/WebCore/platform/calc/CalculationCategory.h
+++ b/Source/WebCore/platform/calc/CalculationCategory.h
@@ -39,7 +39,6 @@ enum class CalculationCategory : uint8_t {
     Angle,
     Time,
     Frequency,
-    Resolution,
     Other
 };
 


### PR DESCRIPTION
#### 89b63835cb026d8d4244ed47afa663ed3a0f60ab
<pre>
REGRESSION(257701@main): Broke linux clang builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=249133">https://bugs.webkit.org/show_bug.cgi?id=249133</a>

Unreviewed, manual revert of 257716@main 257706@main 257701@main.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-initial-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/url-resolution-expected.txt:
* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::customCSSText const):
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::primitiveType const):
(WebCore::CSSPrimitiveValue::doubleValueInternal const):
* Source/WebCore/css/CSSUnits.cpp:
(WebCore::canonicalUnitTypeForCategory):
(WebCore::canonicalUnitTypeForUnitType): Deleted.
* Source/WebCore/css/CSSUnits.h:
* Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp:
(WebCore::DOMCSSRegisterCustomProperty::registerProperty):
* Source/WebCore/css/calc/CSSCalcCategoryMapping.cpp:
(WebCore::calcUnitCategory):
(WebCore::calculationCategoryForCombination):
(WebCore::canonicalUnitTypeForCalculationCategory):
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::resolvedTypeForMinOrMaxOrClamp):
(WebCore::sortingCategoryForType):
(WebCore::CSSCalcOperationNode::primitiveType const):
* Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp:
(WebCore::CSSCalcPrimitiveValueNode::add):
(WebCore::CSSCalcPrimitiveValueNode::createCalcExpression const):
(WebCore::CSSCalcPrimitiveValueNode::computeLengthPx const):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue):
(WebCore::CSSPropertyParser::parseCustomPropertyValueWithSyntaxDefinition):
* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::ResolutionCSSPrimitiveValueWithCalcWithKnownTokenTypeFunctionConsumer::consume): Deleted.
(WebCore::CSSPropertyParserHelpers::ResolutionCSSPrimitiveValueWithCalcWithKnownTokenTypeDimensionConsumer::consume): Deleted.
* Source/WebCore/css/parser/CSSPropertySyntax.cpp:
(WebCore::CSSPropertySyntax::parseComponent):
* Source/WebCore/css/parser/CSSPropertySyntax.h:
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::CSSUnitValue::toSumValue const):
* Source/WebCore/platform/calc/CalculationCategory.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/calc/CalculationCategory.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89b63835cb026d8d4244ed47afa663ed3a0f60ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109197 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169435 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86306 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105604 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23642 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2774 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/46022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5304 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43115 "Passed tests") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->