### PR TITLE
Cleanup SVGContainerLayout::layoutSizeOfNearestViewportChanged

### DIFF
--- a/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
+++ b/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
@@ -238,14 +238,17 @@ void SVGContainerLayout::invalidateResourcesOfChildren(RenderElement& renderer)
 bool SVGContainerLayout::layoutSizeOfNearestViewportChanged() const
 {
     RenderElement* ancestor = &m_container;
-    while (ancestor && !is<RenderSVGRoot>(*ancestor) && !is<RenderSVGViewportContainer>(*ancestor))
+    while (ancestor && !is<RenderSVGRoot>(ancestor) && !is<RenderSVGViewportContainer>(ancestor))
         ancestor = ancestor->parent();
 
     ASSERT(ancestor);
-    if (is<RenderSVGViewportContainer>(*ancestor))
-        return downcast<RenderSVGViewportContainer>(*ancestor).isLayoutSizeChanged();
+    if (auto* viewportContainer = dynamicDowncast<RenderSVGViewportContainer>(ancestor))
+        return viewportContainer->isLayoutSizeChanged();
 
-    return downcast<RenderSVGRoot>(*ancestor).isLayoutSizeChanged();
+    if (auto* svgRoot = dynamicDowncast<RenderSVGRoot>(ancestor))
+        return svgRoot->isLayoutSizeChanged();
+
+    return false;
 }
 
 bool SVGContainerLayout::transformToRootChanged(const RenderObject* ancestor)


### PR DESCRIPTION
#### 9b508cf38c09ef26b0a0627a81801e42cef01fcd
<pre>
Cleanup SVGContainerLayout::layoutSizeOfNearestViewportChanged
<a href="https://bugs.webkit.org/show_bug.cgi?id=249139">https://bugs.webkit.org/show_bug.cgi?id=249139</a>

Reviewed by Rob Buis.

- Avoid pointer dereferencing when using is&lt;Foo&gt;().
- Use dynamicDowncast&lt;&gt; instead of is&lt;&gt; + downcast&lt;&gt; pairs

No change in functionality, covered by existing tests.

* Source/WebCore/rendering/svg/SVGContainerLayout.cpp:
(WebCore::SVGContainerLayout::layoutSizeOfNearestViewportChanged const):

Canonical link: <a href="https://commits.webkit.org/258133@main">https://commits.webkit.org/258133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76018ec6b147a38f24dffcdfb6d211d2b2d77067

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109207 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169444 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86315 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92307 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107116 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34207 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22141 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2836 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23651 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46032 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43124 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5584 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4644 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->