### PR TITLE
Fix reset to baseVal after animation end for SVGTransformList

### DIFF
--- a/LayoutTests/platform/mac-ventura-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-ventura-wk2-lbse-text/TestExpectations
@@ -560,9 +560,6 @@ svg/animations/animated-string-href.svg                   [ ImageOnlyFailure ]
 svg/animations/smil-multiple-animate-list.svg             [ ImageOnlyFailure ]
 svg/stroke/animated-non-scaling-stroke.html               [ ImageOnlyFailure ]
 
-# SMIL <animateTransform> reset to baseVal partly broken
-svg/animations/list-wrapper-assertion.svg [ ImageOnlyFailure ]
-
 # SVGViewSpec / svgView() support broken
 svg/custom/linking-a-03-b-all.svg               [ ImageOnlyFailure ]
 svg/custom/linking-a-03-b-transform.svg         [ Failure ]

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimator.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimator.h
@@ -85,13 +85,13 @@ public:
         if (!m_animated->isAnimating())
             return;
 
-        applyAnimatedPropertyChange(targetElement);
-        if (isAnimatedStylePropertyAnimator(targetElement))
-            removeAnimatedStyleProperty(targetElement);
-
         m_animated->stopAnimation(*this);
         for (auto& instance : m_animatedInstances)
             instance->instanceStopAnimation(*this);
+
+        applyAnimatedPropertyChange(targetElement);
+        if (isAnimatedStylePropertyAnimator(targetElement))
+            removeAnimatedStyleProperty(targetElement);
     }
 
     std::optional<float> calculateDistance(SVGElement& targetElement, const String& from, const String& to) const override


### PR DESCRIPTION
#### 5a8f69dc67ce414cca0c9575080c73d858a603bc
<pre>
Fix reset to baseVal after animation end for SVGTransformList
<a href="https://bugs.webkit.org/show_bug.cgi?id=249140">https://bugs.webkit.org/show_bug.cgi?id=249140</a>

Reviewed by Rob Buis.

Partly revert the fix from webkit.org/b/198576 (REGRESSION (r243121): Load event
should not be fired while animating the &apos;externalResourcesRequired&apos; attribute),
that landed in <a href="https://commits.webkit.org/212621@main.">https://commits.webkit.org/212621@main.</a>

First of all, externalResourcesRequired support is gone from WebKit, therefore
SMIL animations of that property are no longer possible: the workaround is obsolete.

More importantly, the applied workaround is harmful for SVGTransformList animations,
which go through the same SVGAnimatedPropertyAnimator code paths to apply changes,
when &lt;animateTransform&gt; animations are active.

The now-reverted patch changed the order of two calls, when applying property
animations. Before the patch, stopAnimation() was called first, then
applyAnimatedPropertyChange() (which calls svgAttributeChanged()).

SVGAnimatedPropertyList::stopAnimation() first calls SVGAnimatedProperty::stopAnimation(),
and then resets m_animVal to m_baseVal (#). The SVGAnimatedProperty::stopAnimation() code
removes the &apos;SVGAttributeAnimator&apos; object from the m_animators hash set. If there was
only one animation running, isAnimating() would now return false. Thus when calling
stopAnimation() first and applyAnimatedPropertyChanged() afterwards, one cannot query
anymore if the svgAttributeChanged() origin is a SMIL animation or not (that kind of
information was needed by SVGExternalResourcesRequired support, and nowhere else).

However it is guaranteed that the &quot;m_animVal&quot; is reset to the &quot;m_baseVal&quot; _BEFORE_
calling svgAttributeChanged(), which potentially triggers repaints / relayouts etc.

For the legacy SVG engine this imposes no problem: svgAttributeChanged() _marks_
the renderer for a transform update (renderer()-&gt;setNeedsTransformUpdate()) and triggers
an async relayout. Next time layout is updated, the correct values are used to update
and render the scene (property now reflect &apos;baseVal&apos; visually, animVal was reset).

For LBSE we only want to update the layer transform and repaint, avoiding any relayout.
Therefore the current behaviour in ToT, first calling applyAnimatedPropertyChange()
(which calls svgAttributeChanged()) and then stopAnimation() is harmful.
When svgAttributeChanged() is called, the SVGTransformList state reflects the _LAST_
animation progress value that was calculated. That state is used to update the layer
transform and trigger a repaint. Just afterwards stopAnimation() reset the animVal
to the baseVal (e.g. back to identity matrix, ...) -- but since we no longer trigger
any async relayout from svgAttributeChanged(), nobody is going to pick up that change
and redraw the scene.

The fix is simple: revert the order again, and things are fine.
Solves the recently induced regression in svg/animations/list-wrapper-assertion.svg.

* LayoutTests/platform/mac-ventura-wk2-lbse-text/TestExpectations: Remove svg/animations/list-wrapper-assertion.svg failure expectation.
* Source/WebCore/svg/properties/SVGAnimatedPropertyAnimator.h: Call stopAnimation() before applyAnimatedPropertyChange().

Canonical link: <a href="https://commits.webkit.org/268987@main">https://commits.webkit.org/268987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f38a05ea1a9f84709aa3d2b3656ad455c59a195

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23118 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19722 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21801 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23971 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18314 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19259 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23442 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/20634 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16992 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/24655 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19269 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5087 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23534 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25923 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19857 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->