### PR TITLE
[LBSE] Do not relayout on dynamic transform changes, if necessary.

### DIFF
--- a/LayoutTests/platform/mac-ventura-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-ventura-wk2-lbse-text/TestExpectations
@@ -563,6 +563,9 @@ svg/animations/animated-string-href.svg                   [ ImageOnlyFailure ]
 svg/animations/smil-multiple-animate-list.svg             [ ImageOnlyFailure ]
 svg/stroke/animated-non-scaling-stroke.html               [ ImageOnlyFailure ]
 
+# SMIL <animateTransform> reset to baseVal partly broken
+svg/animations/list-wrapper-assertion.svg [ ImageOnlyFailure ]
+
 # SVGViewSpec / svgView() support broken
 svg/custom/linking-a-03-b-all.svg               [ ImageOnlyFailure ]
 svg/custom/linking-a-03-b-transform.svg         [ Failure ]

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -90,6 +90,8 @@ public:
     void updateHasSVGTransformFlags();
     virtual bool needsHasSVGTransformFlags() const { ASSERT_NOT_REACHED(); return false; }
 
+    void repaintOrRelayoutAfterSVGTransformChange();
+
     LayoutPoint nominalSVGLayoutLocation() const { return flooredLayoutPoint(objectBoundingBoxWithoutTransformations().minXMinYCorner()); }
     virtual LayoutPoint currentSVGLayoutLocation() const { ASSERT_NOT_REACHED(); return { }; }
     virtual void setCurrentSVGLayoutLocation(const LayoutPoint&) { ASSERT_NOT_REACHED(); }

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -149,12 +149,11 @@ void SVGGraphicsElement::svgAttributeChanged(const QualifiedName& attrName)
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
         if (document().settings().layerBasedSVGEngineEnabled()) {
             if (auto* layerRenderer = dynamicDowncast<RenderLayerModelObject>(renderer()))
-                layerRenderer->updateHasSVGTransformFlags();
-            // TODO: [LBSE] Avoid relayout upon transform changes (not possible in legacy, but should be in LBSE).
-            updateSVGRendererForElementChange();
+                layerRenderer->repaintOrRelayoutAfterSVGTransformChange();
             return;
         }
 #endif
+
         if (auto* renderer = this->renderer())
             renderer->setNeedsTransformUpdate();
         updateSVGRendererForElementChange();


### PR DESCRIPTION
#### b348ce7635b6efa824493df9ac2b67716a4c95c6
<pre>
[LBSE] Do not relayout on dynamic transform changes, if necessary.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249141">https://bugs.webkit.org/show_bug.cgi?id=249141</a>

Reviewed by Rob Buis.

The legacy SVG engine always had to perform relayouts when the transform
of an element changed (up to the containing block, stopping at RenderSVGRoot
boundary in case of mixed SVG/HTML documents). Container position and sizes
were affected by the transformations of the descendants. That&apos;s no longer the
case in LBSE, which follows CSS/HTML style of making transformations a paint
effect, not inducing costly relayouts.

However this only works if SVG &lt;text&gt; elements are not involved: SVG text
always needs a relayout, as the &quot;screen font size scaling factor&quot; depends on
the CTM of the transformed element (all transformations from target element
up to RenderSVGRoot enter the calculation).

Therefore add the necessary code to figure out if a relayout is unavoidable
(&apos;xScale()&apos; / &apos;yScale()&apos; of involved matrices changed --&gt; relayout text).
For translations, etc. a relayout is unncessary, as the scaling factor cannot
change. That&apos;s the only optimization we can apply for text at present.

For all other shapes, images, etc. this is an important optimization.

Covered by existing tests, introduces one regression, marked in TestExpectations.
Currently this change Breaks svg/animations/list-wrapper-assertion.svg in LBSE,
webkit.org/b/249140 will fix it in a follow-up patch.

* LayoutTests/platform/mac-ventura-wk2-lbse-text/TestExpectations:
 Mark svg/animations/list-wrapper-assertion.svg as failing for the moment.
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::repaintOrRelayoutAfterSVGTransformChange):
Introduce helper function for SVG either update transform and repaint or relayout
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::svgAttributeChanged):
Use new repaintOrRelayoutAfterSVGTransformChange() method, when LBSE is activated.

Canonical link: <a href="https://commits.webkit.org/259158@main">https://commits.webkit.org/259158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb2cfc9d2988cf6d9a02c1d783e331e20d4ef8be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/37045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113333 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173633 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4131 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96353 "Failed to checkout and rebase branch from PR 7482") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112400 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109895 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/11005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94063 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/96353 "Failed to checkout and rebase branch from PR 7482") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25675 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/96353 "Failed to checkout and rebase branch from PR 7482") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6582 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/27049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6719 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/3592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46587 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6307 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8500 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->