### PR TITLE
[JSC] B3ConstrainedValue: fix compile error when WASM is not enabled

### DIFF
--- a/Source/JavaScriptCore/b3/B3ConstrainedValue.h
+++ b/Source/JavaScriptCore/b3/B3ConstrainedValue.h
@@ -35,6 +35,7 @@ namespace JSC { namespace B3 {
 
 class Value;
 
+#if ENABLE(WEBASSEMBLY)
 struct ArgumentLocation {
     ArgumentLocation(Wasm::ValueLocation loc, Width width)
         : location(loc)
@@ -47,6 +48,7 @@ struct ArgumentLocation {
     Wasm::ValueLocation location;
     Width width;
 };
+#endif
 
 class ConstrainedValue {
 public:
@@ -66,11 +68,13 @@ public:
     {
     }
 
+#if ENABLE(WEBASSEMBLY)
     ConstrainedValue(Value* value, const Wasm::ArgumentLocation& loc)
         : m_value(value)
         , m_rep(loc.location)
     {
     }
+#endif
 
     explicit operator bool() const { return m_value || m_rep; }
 


### PR DESCRIPTION
#### 2d2f8ac6371b7d83a9f125aa74fdfd15f5817faf
<pre>
[JSC] B3ConstrainedValue: fix compile error when WASM is not enabled

<a href="https://bugs.webkit.org/show_bug.cgi?id=246487">https://bugs.webkit.org/show_bug.cgi?id=246487</a>

Reviewed by Justin Michaud.

Fix WEBASSEMBLY=OFF build error,
introduced by <a href="https://commits.webkit.org/255736@main.">https://commits.webkit.org/255736@main.</a>

Signed-off-by: Thomas Devoogdt &lt;thomas.devoogdt@barco.com&gt;

Canonical link: <a href="https://commits.webkit.org/257737@main">https://commits.webkit.org/257737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/129973fafaf5f142a5485392ca62aeea2c26fdd6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109225 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169462 "Built successfully and passed tests") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/9923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86333 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92325 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107133 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105633 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/9923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34222 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/9923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22158 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90502 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2853 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23668 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86400 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2801 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46048 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28989 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5317 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8935 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43141 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89280 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4661 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19961 "Passed tests") | 
<!--EWS-Status-Bubble-End-->