### PR TITLE
Further porting of high frequency IPC types to the new serialization format

### DIFF
--- a/Source/WebCore/Modules/applepay/ApplePayErrorCode.h
+++ b/Source/WebCore/Modules/applepay/ApplePayErrorCode.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-enum class ApplePayErrorCode {
+enum class ApplePayErrorCode : uint8_t {
     Unknown,
     ShippingContactInvalid,
     BillingContactInvalid,
@@ -43,23 +43,5 @@ enum class ApplePayErrorCode {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ApplePayErrorCode> {
-    using values = EnumValues<
-        WebCore::ApplePayErrorCode,
-        WebCore::ApplePayErrorCode::Unknown,
-        WebCore::ApplePayErrorCode::ShippingContactInvalid,
-        WebCore::ApplePayErrorCode::BillingContactInvalid,
-        WebCore::ApplePayErrorCode::AddressUnserviceable
-#if ENABLE(APPLE_PAY_COUPON_CODE)
-        , WebCore::ApplePayErrorCode::CouponCodeInvalid
-        , WebCore::ApplePayErrorCode::CouponCodeExpired
-#endif
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(APPLE_PAY)

--- a/Source/WebCore/Modules/applepay/ApplePayErrorContactField.h
+++ b/Source/WebCore/Modules/applepay/ApplePayErrorContactField.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-enum class ApplePayErrorContactField {
+enum class ApplePayErrorContactField : uint8_t {
     PhoneNumber,
     EmailAddress,
     Name,
@@ -48,28 +48,5 @@ enum class ApplePayErrorContactField {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ApplePayErrorContactField> {
-    using values = EnumValues<
-        WebCore::ApplePayErrorContactField,
-        WebCore::ApplePayErrorContactField::PhoneNumber,
-        WebCore::ApplePayErrorContactField::EmailAddress,
-        WebCore::ApplePayErrorContactField::Name,
-        WebCore::ApplePayErrorContactField::PhoneticName,
-        WebCore::ApplePayErrorContactField::PostalAddress,
-        WebCore::ApplePayErrorContactField::AddressLines,
-        WebCore::ApplePayErrorContactField::SubLocality,
-        WebCore::ApplePayErrorContactField::Locality,
-        WebCore::ApplePayErrorContactField::PostalCode,
-        WebCore::ApplePayErrorContactField::SubAdministrativeArea,
-        WebCore::ApplePayErrorContactField::AdministrativeArea,
-        WebCore::ApplePayErrorContactField::Country,
-        WebCore::ApplePayErrorContactField::CountryCode
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(APPLE_PAY)

--- a/Source/WebCore/Modules/webauthn/UserVerificationRequirement.h
+++ b/Source/WebCore/Modules/webauthn/UserVerificationRequirement.h
@@ -31,25 +31,12 @@
 
 namespace WebCore {
 
-enum class UserVerificationRequirement {
+enum class UserVerificationRequirement : uint8_t {
     Required,
     Preferred,
     Discouraged
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::UserVerificationRequirement> {
-    using values = EnumValues<
-        WebCore::UserVerificationRequirement,
-        WebCore::UserVerificationRequirement::Required,
-        WebCore::UserVerificationRequirement::Preferred,
-        WebCore::UserVerificationRequirement::Discouraged
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/platform/encryptedmedia/CDMKeySystemConfiguration.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMKeySystemConfiguration.h
@@ -48,67 +48,6 @@ struct CDMKeySystemConfiguration {
     CDMRequirement distinctiveIdentifier { CDMRequirement::Optional };
     CDMRequirement persistentState { CDMRequirement::Optional };
     Vector<CDMSessionType> sessionTypes;
-
-    template<class Encoder>
-    void encode(Encoder& encoder) const
-    {
-        encoder << label;
-        encoder << initDataTypes;
-        encoder << audioCapabilities;
-        encoder << videoCapabilities;
-        encoder << distinctiveIdentifier;
-        encoder << persistentState;
-        encoder << sessionTypes;
-    }
-
-    template <class Decoder>
-    static std::optional<CDMKeySystemConfiguration> decode(Decoder& decoder)
-    {
-        std::optional<String> label;
-        decoder >> label;
-        if (!label)
-            return std::nullopt;
-
-        std::optional<Vector<AtomString>> initDataTypes;
-        decoder >> initDataTypes;
-        if (!initDataTypes)
-            return std::nullopt;
-
-        std::optional<Vector<CDMMediaCapability>> audioCapabilities;
-        decoder >> audioCapabilities;
-        if (!audioCapabilities)
-            return std::nullopt;
-
-        std::optional<Vector<CDMMediaCapability>> videoCapabilities;
-        decoder >> videoCapabilities;
-        if (!videoCapabilities)
-            return std::nullopt;
-
-        std::optional<CDMRequirement> distinctiveIdentifier;
-        decoder >> distinctiveIdentifier;
-        if (!distinctiveIdentifier)
-            return std::nullopt;
-        
-        std::optional<CDMRequirement> persistentState;
-        decoder >> persistentState;
-        if (!persistentState)
-            return std::nullopt;
-
-        std::optional<Vector<CDMSessionType>> sessionTypes;
-        decoder >> sessionTypes;
-        if (!sessionTypes)
-            return std::nullopt;
-
-        return {{
-            WTFMove(*label),
-            WTFMove(*initDataTypes),
-            WTFMove(*audioCapabilities),
-            WTFMove(*videoCapabilities),
-            *distinctiveIdentifier,
-            *persistentState,
-            WTFMove(*sessionTypes),
-        }};
-    }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FloatQuad.h
+++ b/Source/WebCore/platform/graphics/FloatQuad.h
@@ -150,48 +150,12 @@ public:
     // Note that output is undefined when all points are colinear.
     bool isCounterclockwise() const;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<FloatQuad> decode(Decoder&);
-
 private:
     FloatPoint m_p1;
     FloatPoint m_p2;
     FloatPoint m_p3;
     FloatPoint m_p4;
 };
-
-template<class Encoder> void FloatQuad::encode(Encoder& encoder) const
-{
-    encoder << m_p1;
-    encoder << m_p2;
-    encoder << m_p3;
-    encoder << m_p4;
-}
-
-template<class Decoder> std::optional<FloatQuad> FloatQuad::decode(Decoder& decoder)
-{
-    std::optional<FloatPoint> p1;
-    decoder >> p1;
-    if (!p1)
-        return std::nullopt;
-
-    std::optional<FloatPoint> p2;
-    decoder >> p2;
-    if (!p2)
-        return std::nullopt;
-
-    std::optional<FloatPoint> p3;
-    decoder >> p3;
-    if (!p3)
-        return std::nullopt;
-
-    std::optional<FloatPoint> p4;
-    decoder >> p4;
-    if (!p4)
-        return std::nullopt;
-
-    return {{ *p1, *p2, *p3, *p4 }};
-}
 
 inline FloatQuad& operator+=(FloatQuad& a, const FloatSize& b)
 {

--- a/Source/WebCore/platform/mediacapabilities/MediaConfiguration.h
+++ b/Source/WebCore/platform/mediacapabilities/MediaConfiguration.h
@@ -40,9 +40,6 @@ struct MediaConfiguration {
 
     MediaConfiguration isolatedCopy() const &;
     MediaConfiguration isolatedCopy() &&;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<MediaConfiguration> decode(Decoder&);
 };
 
 inline MediaConfiguration MediaConfiguration::isolatedCopy() const &
@@ -53,46 +50,6 @@ inline MediaConfiguration MediaConfiguration::isolatedCopy() const &
 inline MediaConfiguration MediaConfiguration::isolatedCopy() &&
 {
     return { crossThreadCopy(WTFMove(video)),  crossThreadCopy(WTFMove(audio)), crossThreadCopy(WTFMove(allowedMediaContainerTypes)), crossThreadCopy(WTFMove(allowedMediaCodecTypes)) };
-}
-
-template<class Encoder>
-void MediaConfiguration::encode(Encoder& encoder) const
-{
-    encoder << video;
-    encoder << audio;
-    encoder << allowedMediaContainerTypes;
-    encoder << allowedMediaCodecTypes;
-}
-
-template<class Decoder>
-std::optional<MediaConfiguration> MediaConfiguration::decode(Decoder& decoder)
-{
-    std::optional<std::optional<VideoConfiguration>> video;
-    decoder >> video;
-    if (!video)
-        return std::nullopt;
-
-    std::optional<std::optional<AudioConfiguration>> audio;
-    decoder >> audio;
-    if (!audio)
-        return std::nullopt;
-
-    std::optional<std::optional<Vector<String>>> allowedMediaContainerTypes;
-    decoder >> allowedMediaContainerTypes;
-    if (!allowedMediaContainerTypes)
-        return std::nullopt;
-
-    std::optional<std::optional<Vector<String>>> allowedMediaCodecTypes;
-    decoder >> allowedMediaCodecTypes;
-    if (!allowedMediaCodecTypes)
-        return std::nullopt;
-
-    return {{
-        *video,
-        *audio,
-        *allowedMediaContainerTypes,
-        *allowedMediaCodecTypes,
-    }};
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediacapabilities/MediaDecodingConfiguration.h
+++ b/Source/WebCore/platform/mediacapabilities/MediaDecodingConfiguration.h
@@ -36,45 +36,11 @@ struct MediaDecodingConfiguration : MediaConfiguration {
     bool canExposeVP9 { true };
 
     MediaDecodingConfiguration isolatedCopy() const;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<MediaDecodingConfiguration> decode(Decoder&);
 };
 
 inline MediaDecodingConfiguration MediaDecodingConfiguration::isolatedCopy() const
 {
     return { MediaConfiguration::isolatedCopy(), type, canExposeVP9 };
-}
-
-template<class Encoder>
-void MediaDecodingConfiguration::encode(Encoder& encoder) const
-{
-    MediaConfiguration::encode(encoder);
-    encoder << type << canExposeVP9;
-}
-
-template<class Decoder>
-std::optional<MediaDecodingConfiguration> MediaDecodingConfiguration::decode(Decoder& decoder)
-{
-    auto mediaConfiguration = MediaConfiguration::decode(decoder);
-    if (!mediaConfiguration)
-        return std::nullopt;
-
-    std::optional<MediaDecodingType> type;
-    decoder >> type;
-    if (!type)
-        return std::nullopt;
-
-    std::optional<bool> canExposeVP9;
-    decoder >> canExposeVP9;
-    if (!canExposeVP9)
-        return std::nullopt;
-
-    return {{
-        *mediaConfiguration,
-        *type,
-        *canExposeVP9
-    }};
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediacapabilities/MediaEncodingConfiguration.h
+++ b/Source/WebCore/platform/mediacapabilities/MediaEncodingConfiguration.h
@@ -34,39 +34,11 @@ struct MediaEncodingConfiguration : MediaConfiguration {
     MediaEncodingType type;
 
     MediaEncodingConfiguration isolatedCopy() const;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<MediaEncodingConfiguration> decode(Decoder&);
 };
 
 inline MediaEncodingConfiguration MediaEncodingConfiguration::isolatedCopy() const
 {
     return { MediaConfiguration::isolatedCopy(), type };
-}
-
-template<class Encoder>
-void MediaEncodingConfiguration::encode(Encoder& encoder) const
-{
-    MediaConfiguration::encode(encoder);
-    encoder << type;
-}
-
-template<class Decoder>
-std::optional<MediaEncodingConfiguration> MediaEncodingConfiguration::decode(Decoder& decoder)
-{
-    auto mediaConfiguration = MediaConfiguration::decode(decoder);
-    if (!mediaConfiguration)
-        return std::nullopt;
-
-    std::optional<MediaEncodingType> type;
-    decoder >> type;
-    if (!type)
-        return std::nullopt;
-
-    return {{
-        *mediaConfiguration,
-        *type,
-    }};
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateOptions.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateOptions.h
@@ -35,44 +35,7 @@ struct MediaRecorderPrivateOptions {
     std::optional<unsigned> audioBitsPerSecond;
     std::optional<unsigned> videoBitsPerSecond;
     std::optional<unsigned> bitsPerSecond;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<MediaRecorderPrivateOptions> decode(Decoder&);
 };
-
-template<class Encoder>
-inline void MediaRecorderPrivateOptions::encode(Encoder& encoder) const
-{
-    encoder << mimeType;
-    encoder << audioBitsPerSecond;
-    encoder << videoBitsPerSecond;
-    encoder << bitsPerSecond;
-}
-
-template<class Decoder>
-inline std::optional<MediaRecorderPrivateOptions> MediaRecorderPrivateOptions::decode(Decoder& decoder)
-{
-    String mimeType;
-    if (!decoder.decode(mimeType))
-        return std::nullopt;
-
-    std::optional<std::optional<unsigned>> audioBitsPerSecond;
-    decoder >> audioBitsPerSecond;
-    if (!audioBitsPerSecond)
-        return std::nullopt;
-
-    std::optional<std::optional<unsigned>> videoBitsPerSecond;
-    decoder >> videoBitsPerSecond;
-    if (!videoBitsPerSecond)
-        return std::nullopt;
-
-    std::optional<std::optional<unsigned>> bitsPerSecond;
-    decoder >> bitsPerSecond;
-    if (!bitsPerSecond)
-        return std::nullopt;
-
-    return MediaRecorderPrivateOptions { WTFMove(mimeType), *audioBitsPerSecond, *videoBitsPerSecond, *bitsPerSecond };
-}
 
 } // namespace WebCore
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -252,6 +252,7 @@ def serialized_identifiers():
         'WebKit::GraphicsContextGLIdentifier',
         'WebKit::IPCConnectionTesterIdentifier',
         'WebKit::IPCStreamTesterIdentifier',
+        'WebKit::LegacyCustomProtocolID',
         'WebKit::LibWebRTCResolverIdentifier',
         'WebKit::MDNSRegisterIdentifier',
         'WebKit::MarkSurfacesAsVolatileRequestIdentifier',

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -36,6 +36,7 @@
 #include "IPCStreamTesterIdentifier.h"
 #include "IdentifierTypes.h"
 #include "JSIPCBinding.h"
+#include "LegacyCustomProtocolID.h"
 #include "LibWebRTCResolverIdentifier.h"
 #include "MDNSRegisterIdentifier.h"
 #include "MarkSurfacesAsVolatileRequestIdentifier.h"
@@ -416,6 +417,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
     static_assert(sizeof(uint64_t) == sizeof(WebKit::GraphicsContextGLIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::IPCConnectionTesterIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::IPCStreamTesterIdentifier));
+    static_assert(sizeof(uint64_t) == sizeof(WebKit::LegacyCustomProtocolID));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::LibWebRTCResolverIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::MDNSRegisterIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::MarkSurfacesAsVolatileRequestIdentifier));
@@ -493,6 +495,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
         "WebKit::GraphicsContextGLIdentifier"_s,
         "WebKit::IPCConnectionTesterIdentifier"_s,
         "WebKit::IPCStreamTesterIdentifier"_s,
+        "WebKit::LegacyCustomProtocolID"_s,
         "WebKit::LibWebRTCResolverIdentifier"_s,
         "WebKit::MDNSRegisterIdentifier"_s,
         "WebKit::MarkSurfacesAsVolatileRequestIdentifier"_s,

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -39,3 +39,13 @@ struct WebCore::AttributedString {
     RetainPtr<NSAttributedString> string;
     RetainPtr<NSDictionary> documentAttributes;
 };
+#endif
+
+#if ENABLE(MEDIA_RECORDER)
+struct WebCore::MediaRecorderPrivateOptions {
+    String mimeType;
+    std::optional<unsigned> audioBitsPerSecond;
+    std::optional<unsigned> videoBitsPerSecond;
+    std::optional<unsigned> bitsPerSecond;
+};
+#endif // ENABLE(MEDIA_RECORDER)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -86,6 +86,13 @@ struct WebCore::CharacterRange {
     float z()
 }
 
+class WebCore::FloatQuad {
+    WebCore::FloatPoint p1();
+    WebCore::FloatPoint p2();
+    WebCore::FloatPoint p3();
+    WebCore::FloatPoint p4();
+}
+
 struct WebCore::IDBCursorRecord {
     WebCore::IDBKeyData key;
     WebCore::IDBKeyData primaryKey;
@@ -674,6 +681,33 @@ struct WebCore::ApplePayPaymentAuthorizationResult {
     std::optional<WebCore::ApplePayPaymentOrderDetails> orderDetails;
 #endif
 }
+
+enum class WebCore::ApplePayErrorContactField : uint8_t {
+    PhoneNumber,
+    EmailAddress,
+    Name,
+    PhoneticName,
+    PostalAddress,
+    AddressLines,
+    SubLocality,
+    Locality,
+    PostalCode,
+    SubAdministrativeArea,
+    AdministrativeArea,
+    Country,
+    CountryCode,
+};
+
+enum class WebCore::ApplePayErrorCode : uint8_t {
+    Unknown,
+    ShippingContactInvalid,
+    BillingContactInvalid,
+    AddressUnserviceable,
+#if ENABLE(APPLE_PAY_COUPON_CODE)
+    CouponCodeInvalid,
+    CouponCodeExpired,
+#endif
+};
 #endif // ENABLE(APPLE_PAY)
 
 #if ENABLE(APPLE_PAY_COUPON_CODE)
@@ -2076,3 +2110,44 @@ header: <WebCore/PathOperation.h>
     WebCore::BoxPathOperation,
     WebCore::RayPathOperation
 }
+
+#if PLATFORM(IOS_FAMILY)
+enum class WebCore::SelectionRenderingBehavior : bool
+#endif
+
+#if ENABLE(WEB_AUTHN)
+enum class WebCore::UserVerificationRequirement : uint8_t {
+    Required,
+    Preferred,
+    Discouraged
+};
+#endif // ENABLE(WEB_AUTHN)
+
+#if ENABLE(ENCRYPTED_MEDIA)
+struct WebCore::CDMKeySystemConfiguration {
+    String label;
+    Vector<AtomString> initDataTypes;
+    Vector<WebCore::CDMMediaCapability> audioCapabilities;
+    Vector<WebCore::CDMMediaCapability> videoCapabilities;
+    WebCore::CDMRequirement distinctiveIdentifier;
+    WebCore::CDMRequirement persistentState;
+    Vector<WebCore::CDMSessionType> sessionTypes;
+}
+#endif // ENABLE(ENCRYPTED_MEDIA)
+
+struct WebCore::MediaConfiguration {
+    std::optional<WebCore::VideoConfiguration> video;
+    std::optional<WebCore::AudioConfiguration> audio;
+
+    std::optional<Vector<String>> allowedMediaContainerTypes;
+    std::optional<Vector<String>> allowedMediaCodecTypes;
+};
+
+struct WebCore::MediaEncodingConfiguration : WebCore::MediaConfiguration {
+    WebCore::MediaEncodingType type;
+};
+
+struct WebCore::MediaDecodingConfiguration : WebCore::MediaConfiguration {
+    WebCore::MediaDecodingType type;
+    bool canExposeVP9;
+};

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.h
@@ -38,7 +38,7 @@ OBJC_CLASS LAContext;
 namespace WebCore {
 class AuthenticatorAssertionResponse;
 enum class ClientDataType : bool;
-enum class UserVerificationRequirement;
+enum class UserVerificationRequirement : uint8_t;
 }
 
 namespace WebKit {


### PR DESCRIPTION
#### 83f96fe0a90a9d84cf00e00e38bc6b713666dbd6
<pre>
Further porting of high frequency IPC types to the new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=249147">https://bugs.webkit.org/show_bug.cgi?id=249147</a>
rdar://103253106

Reviewed by Alex Christensen.

This change ports more types to the new serialization format. It
includes:
    - MediaRecorderPrivateOptions
    - FloatQuad
    - ApplePayErrorContactField
    - ApplePayErrorCode
    - SelectionRenderingBehavior
    - UserVerificationRequirement
    - CDMKeySystemConfiguration
    - MediaConfiguration
    - MediaEncodingConfiguration
    - MediaDecodingConfiguration

* Source/WebCore/Modules/applepay/ApplePayErrorCode.h:
* Source/WebCore/Modules/applepay/ApplePayErrorContactField.h:
* Source/WebCore/Modules/webauthn/UserVerificationRequirement.h:
* Source/WebCore/platform/encryptedmedia/CDMKeySystemConfiguration.h:
(WebCore::CDMKeySystemConfiguration::encode const): Deleted.
(WebCore::CDMKeySystemConfiguration::decode): Deleted.
* Source/WebCore/platform/graphics/FloatQuad.h:
(WebCore::FloatQuad::encode const): Deleted.
(WebCore::FloatQuad::decode): Deleted.
* Source/WebCore/platform/mediacapabilities/MediaConfiguration.h:
(WebCore::MediaConfiguration::encode const): Deleted.
(WebCore::MediaConfiguration::decode): Deleted.
* Source/WebCore/platform/mediacapabilities/MediaDecodingConfiguration.h:
(WebCore::MediaDecodingConfiguration::encode const): Deleted.
(WebCore::MediaDecodingConfiguration::decode): Deleted.
* Source/WebCore/platform/mediacapabilities/MediaEncodingConfiguration.h:
(WebCore::MediaEncodingConfiguration::encode const): Deleted.
(WebCore::MediaEncodingConfiguration::decode): Deleted.
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateOptions.h:
(WebCore::MediaRecorderPrivateOptions::encode const): Deleted.
(WebCore::MediaRecorderPrivateOptions::decode): Deleted.
* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.h:

Canonical link: <a href="https://commits.webkit.org/257847@main">https://commits.webkit.org/257847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c04399c99a8618df4a75f3614e145d72ecb5dff4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109533 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169766 "Failed to checkout and rebase branch from PR 7489") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10274 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107422 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105982 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91045 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/103719 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3132 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23956 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3110 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43444 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5388 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4942 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->