### PR TITLE
perspective calc() values aren't clipped to 0

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt
@@ -6,7 +6,7 @@ PASS Can set 'perspective' to CSS-wide keywords: revert
 FAIL Can set 'perspective' to var() references:  var(--A) assert_equals: expected 2 but got 1
 PASS Can set 'perspective' to the 'none' keyword: none
 PASS Can set 'perspective' to a length: 0px
-FAIL Can set 'perspective' to a length: -3.14em assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSKeywordValue]"
+PASS Can set 'perspective' to a length: -3.14em
 PASS Can set 'perspective' to a length: 3.14cm
 FAIL Can set 'perspective' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'perspective' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/perspective-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/perspective-expected.txt
@@ -1,5 +1,5 @@
 
 PASS perspective responsive to style changes
-FAIL perspective clamped to 0px assert_equals: expected "0px" but got "100px"
+FAIL perspective clamped to 0px assert_equals: expected "0px" but got "20px"
 FAIL perspective responsive to inherited changes assert_equals: expected "80px" but got "none"
 

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -6569,13 +6569,7 @@ RefPtr<CSSValue> consumePerspective(CSSParserTokenRange& range, CSSParserMode cs
 {
     if (range.peek().id() == CSSValueNone)
         return consumeIdent(range);
-
-    if (auto parsedValue = consumeLength(range, cssParserMode, ValueRange::All)) {
-        if (!parsedValue->isNegative().value_or(false))
-            return parsedValue;
-    }
-
-    return nullptr;
+    return consumeLength(range, cssParserMode, ValueRange::NonNegative);
 }
 
 RefPtr<CSSValue> consumeScrollSnapAlign(CSSParserTokenRange& range)


### PR DESCRIPTION
#### c1c0e7fbede03d23c5191147fbd385498a289301
<pre>
perspective calc() values aren&apos;t clipped to 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=249151">https://bugs.webkit.org/show_bug.cgi?id=249151</a>

Reviewed by Simon Fraser and Dean Jackson.

The &quot;perspective&quot; property is specified to only allow non-negative values,
see <a href="https://www.w3.org/TR/css-transforms-2/#perspective-property.">https://www.w3.org/TR/css-transforms-2/#perspective-property.</a> However,
we don&apos;t clip values that are computed to less than 0, for instance using a
calc() expression. Instead, we deem them invalid internally and thus consider
as if &quot;none&quot; was provided, which has implications when blending. Indeed, when
interpolating between a valid value and &quot;none&quot;, we use discrete interpolation.

We now correctly clip values below 0.

Note that the relevant WPT test still fails, because the test itself is not
valid. It is being addressed in a dedicated WPT PR and will be imported back
into WebKit yielding a PASS result. See <a href="https://github.com/web-platform-tests/wpt/pull/37457.">https://github.com/web-platform-tests/wpt/pull/37457.</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/perspective-expected.txt:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumePerspective):

Canonical link: <a href="https://commits.webkit.org/257779@main">https://commits.webkit.org/257779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f66226d5bb59d2385e2c68b669d40848878430fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109344 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169577 "Failed to checkout and rebase branch from PR 7493") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86480 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92444 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107244 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105765 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2921 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/46155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4769 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2746 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->