### PR TITLE
Add inspectable property to _WKWebExtensionContext.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -47,7 +47,7 @@ WK_EXTERN NSErrorDomain const _WKWebExtensionErrorDomain WK_API_AVAILABLE(macos(
  @constant WKWebExtensionErrorResourceNotFound  Indicates that a specified resource was not found on disk.
  @constant WKWebExtensionErrorInvalidResourceCodeSignature  Indicates that a resource failed the bundle's code signature checks.
  @constant WKWebExtensionErrorInvalidManifest  Indicates that an invalid `manifest.json` was encountered.
- @constant WKWebExtensionErrorUnsupportedManifestVersion  Indicates that a the manifest version is not supported.
+ @constant WKWebExtensionErrorUnsupportedManifestVersion  Indicates that the manifest version is not supported.
  @constant WKWebExtensionErrorInvalidManifestEntry  Indicates that an invalid manifest entry was encountered.
  @constant WKWebExtensionErrorInvalidDeclarativeNetRequestEntry  Indicates that an invalid declarative net request entry was encountered.
  @constant WKWebExtensionErrorInvalidBackgroundPersistence  Indicates that the extension specified background persistence that was not compatible with the platform or features requested.
@@ -123,7 +123,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @property (nonatomic, readonly, copy) NSDictionary<NSString *, id> *manifest;
 
 /*!
- @abstract The parsed manifest version, or `0` is if there is no version specified in the manifest.
+ @abstract The parsed manifest version, or `0` if there is no version specified in the manifest.
  @note An `WKWebExtensionErrorUnsupportedManifestVersion` error will be reported if the manifest version isn't specified.
  */
 @property (nonatomic, readonly) double manifestVersion;
@@ -131,7 +131,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 /*!
  @abstract Checks if a manifest version is supported by the extension.
  @param manifestVersion The version number to check.
- @result Returns `YES` if the extension specified a manifest version that is is greater than or equal to `manifestVersion`.
+ @result Returns `YES` if the extension specified a manifest version that is greater than or equal to `manifestVersion`.
  */
 - (BOOL)usesManifestVersion:(double)manifestVersion;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -171,6 +171,13 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @property (nonatomic, copy) NSString *uniqueIdentifier;
 
 /*!
+ @abstract Determines whether Web Inspector can inspect the @link WKWebView @/link instances for this context.
+ @discussion A context can control multiple `WKWebView` instances, from the background content, to the popover.
+ You should set this to `YES` when needed for debugging purposes. The default value is `NO`.
+*/
+@property (nonatomic, getter=isInspectable) BOOL inspectable;
+
+/*!
  @abstract The currently granted permissions and their expiration dates.
  @discussion Permissions that don't expire will have a distant future date. This will never include expired entries at time of access.
  Setting this property will replace all existing entries. Use this property for saving and restoring permission state in bulk.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -129,6 +129,16 @@ _WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotifi
     _webExtensionContext->setUniqueIdentifier(uniqueIdentifier);
 }
 
+- (BOOL)isInspectable
+{
+    return _webExtensionContext->isInspectable();
+}
+
+- (void)setInspectable:(BOOL)inspectable
+{
+    _webExtensionContext->setInspectable(inspectable);
+}
+
 static inline WallTime toImpl(NSDate *date)
 {
     return date ? WebKit::toImpl(date) : WebKit::toImpl(NSDate.distantFuture);
@@ -510,6 +520,15 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 }
 
 - (void)setUniqueIdentifier:(NSString *)uniqueIdentifier
+{
+}
+
+- (BOOL)isInspectable
+{
+    return NO;
+}
+
+- (void)setInspectable:(BOOL)inspectable
 {
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -321,6 +321,13 @@ void WebExtensionContext::setUniqueIdentifier(String&& uniqueIdentifier)
     m_uniqueIdentifier = uniqueIdentifier;
 }
 
+void WebExtensionContext::setInspectable(bool inspectable)
+{
+    m_inspectable = inspectable;
+
+    m_backgroundWebView.get().inspectable = inspectable;
+}
+
 const WebExtensionContext::InjectedContentVector& WebExtensionContext::injectedContents()
 {
     // FIXME: <https://webkit.org/b/248429> Support dynamic content scripts by including them here.
@@ -1171,6 +1178,7 @@ void WebExtensionContext::loadBackgroundWebView()
 
     m_backgroundWebView.get().UIDelegate = m_delegate.get();
     m_backgroundWebView.get().navigationDelegate = m_delegate.get();
+    m_backgroundWebView.get().inspectable = m_inspectable;
 
     if (extension().backgroundContentIsServiceWorker())
         m_backgroundWebView.get()._remoteInspectionNameOverride = WEB_UI_FORMAT_CFSTRING("%@ — Extension Service Worker", "Label for an inspectable Web Extension service worker", (__bridge CFStringRef)extension().displayShortName());

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -149,6 +149,9 @@ public:
     const String& uniqueIdentifier() const { return m_uniqueIdentifier; }
     void setUniqueIdentifier(String&&);
 
+    bool isInspectable() const { return m_inspectable; }
+    void setInspectable(bool);
+
     const InjectedContentVector& injectedContents();
     bool hasInjectedContentForURL(NSURL *);
 
@@ -286,6 +289,8 @@ private:
     URL m_baseURL;
     String m_uniqueIdentifier = UUID::createVersion4().toString();
     bool m_customUniqueIdentifier { false };
+
+    bool m_inspectable { false };
 
     RefPtr<API::ContentWorld> m_contentScriptWorld;
 


### PR DESCRIPTION
#### aeaa83466dee4a3fc967195a531b720f306ecd55
<pre>
Add inspectable property to _WKWebExtensionContext.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249158">https://bugs.webkit.org/show_bug.cgi?id=249158</a>

Reviewed by Brian Weinstein.

Also fix some typos in other HeadDoc comments.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext isInspectable]): Added.
(-[_WKWebExtensionContext setInspectable:]): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::setInspectable): Added.
(WebKit::WebExtensionContext::loadBackgroundWebView): Set inspectable proeprty.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::isInspectable const): Added.

Canonical link: <a href="https://commits.webkit.org/257740@main">https://commits.webkit.org/257740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8befe6275ff8a7d3ed5df8c00dd9e68f3d3a5590

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109248 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9899 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/86360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105661 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2824 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/86360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/8957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2722 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->