### PR TITLE
[GPU Process] [FormControls] Rename ControlPart to ControlPartType and make it enum class

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -151,6 +151,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/platform/graphics/displaylists"
     "${WEBCORE_DIR}/platform/graphics/filters"
     "${WEBCORE_DIR}/platform/graphics/filters/software"
+    "${WEBCORE_DIR}/platform/graphics/formcontrols"
     "${WEBCORE_DIR}/platform/graphics/iso"
     "${WEBCORE_DIR}/platform/graphics/opentype"
     "${WEBCORE_DIR}/platform/graphics/transforms"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1777,6 +1777,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/filters/SourceGraphic.h
     platform/graphics/filters/SpotLightSource.h
 
+    platform/graphics/formcontrols/ControlPartType.h
+
     platform/graphics/iso/ISOBox.h
     platform/graphics/iso/ISOOriginalFormatBox.h
     platform/graphics/iso/ISOProtectionSchemeInfoBox.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2257,6 +2257,7 @@ platform/graphics/filters/software/FETileSoftwareApplier.cpp
 platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
 platform/graphics/filters/software/SourceAlphaSoftwareApplier.cpp
 platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
+platform/graphics/formcontrols/ControlPartType.cpp
 platform/graphics/iso/ISOBox.cpp
 platform/graphics/iso/ISOOriginalFormatBox.cpp
 platform/graphics/iso/ISOProtectionSchemeInfoBox.cpp

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -3392,7 +3392,7 @@ bool AccessibilityRenderObject::isApplePayButton() const
 {
     if (!m_renderer)
         return false;
-    return m_renderer->style().effectiveAppearance() == ApplePayButtonPart;
+    return m_renderer->style().effectiveAppearance() == ControlPartType::ApplePayButton;
 }
 
 ApplePayButtonType AccessibilityRenderObject::applePayButtonType() const

--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -66,14 +66,14 @@ AccessibilityOrientation AccessibilitySlider::orientation() const
     
     const RenderStyle& style = m_renderer->style();
 
-    ControlPart styleAppearance = style.effectiveAppearance();
+    auto styleAppearance = style.effectiveAppearance();
     switch (styleAppearance) {
-    case SliderThumbHorizontalPart:
-    case SliderHorizontalPart:
+    case ControlPartType::SliderThumbHorizontal:
+    case ControlPartType::SliderHorizontal:
         return AccessibilityOrientation::Horizontal;
     
-    case SliderThumbVerticalPart: 
-    case SliderVerticalPart:
+    case ControlPartType::SliderThumbVertical:
+    case ControlPartType::SliderVertical:
         return AccessibilityOrientation::Vertical;
         
     default:

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -440,112 +440,112 @@ template<> inline CSSPrimitiveValue::operator CompositeOperator() const
     return CompositeOperator::Clear;
 }
 
-template<> inline CSSPrimitiveValue::CSSPrimitiveValue(ControlPart e)
+template<> inline CSSPrimitiveValue::CSSPrimitiveValue(ControlPartType e)
     : CSSValue(PrimitiveClass)
 {
     setPrimitiveUnitType(CSSUnitType::CSS_VALUE_ID);
     switch (e) {
-    case NoControlPart:
+    case ControlPartType::NoControl:
         m_value.valueID = CSSValueNone;
         break;
-    case AutoPart:
+    case ControlPartType::Auto:
         m_value.valueID = CSSValueAuto;
         break;
-    case CheckboxPart:
+    case ControlPartType::Checkbox:
         m_value.valueID = CSSValueCheckbox;
         break;
-    case RadioPart:
+    case ControlPartType::Radio:
         m_value.valueID = CSSValueRadio;
         break;
-    case PushButtonPart:
+    case ControlPartType::PushButton:
         m_value.valueID = CSSValuePushButton;
         break;
-    case SquareButtonPart:
+    case ControlPartType::SquareButton:
         m_value.valueID = CSSValueSquareButton;
         break;
-    case ButtonPart:
+    case ControlPartType::Button:
         m_value.valueID = CSSValueButton;
         break;
-    case DefaultButtonPart:
+    case ControlPartType::DefaultButton:
         m_value.valueID = CSSValueDefaultButton;
         break;
-    case ListboxPart:
+    case ControlPartType::Listbox:
         m_value.valueID = CSSValueListbox;
         break;
-    case MenulistPart:
+    case ControlPartType::Menulist:
         m_value.valueID = CSSValueMenulist;
         break;
-    case MenulistButtonPart:
+    case ControlPartType::MenulistButton:
         m_value.valueID = CSSValueMenulistButton;
         break;
-    case MeterPart:
+    case ControlPartType::Meter:
         m_value.valueID = CSSValueMeter;
         break;
-    case ProgressBarPart:
+    case ControlPartType::ProgressBar:
         m_value.valueID = CSSValueProgressBar;
         break;
-    case SliderHorizontalPart:
+    case ControlPartType::SliderHorizontal:
         m_value.valueID = CSSValueSliderHorizontal;
         break;
-    case SliderVerticalPart:
+    case ControlPartType::SliderVertical:
         m_value.valueID = CSSValueSliderVertical;
         break;
-    case SearchFieldPart:
+    case ControlPartType::SearchField:
         m_value.valueID = CSSValueSearchfield;
         break;
-    case TextFieldPart:
+    case ControlPartType::TextField:
         m_value.valueID = CSSValueTextfield;
         break;
-    case TextAreaPart:
+    case ControlPartType::TextArea:
         m_value.valueID = CSSValueTextarea;
         break;
 #if ENABLE(ATTACHMENT_ELEMENT)
-    case AttachmentPart:
+    case ControlPartType::Attachment:
         m_value.valueID = CSSValueAttachment;
         break;
-    case BorderlessAttachmentPart:
+    case ControlPartType::BorderlessAttachment:
         m_value.valueID = CSSValueBorderlessAttachment;
         break;
 #endif
 #if ENABLE(APPLE_PAY)
-    case ApplePayButtonPart:
+    case ControlPartType::ApplePayButton:
         m_value.valueID = CSSValueApplePayButton;
         break;
 #endif
-    case CapsLockIndicatorPart:
+    case ControlPartType::CapsLockIndicator:
 #if ENABLE(INPUT_TYPE_COLOR)
-    case ColorWellPart:
+    case ControlPartType::ColorWell:
 #endif
 #if ENABLE(SERVICE_CONTROLS)
-    case ImageControlsButtonPart:
+    case ControlPartType::ImageControlsButton:
 #endif
-    case InnerSpinButtonPart:
+    case ControlPartType::InnerSpinButton:
 #if ENABLE(DATALIST_ELEMENT)
-    case ListButtonPart:
+    case ControlPartType::ListButton:
 #endif
-    case SearchFieldDecorationPart:
-    case SearchFieldResultsDecorationPart:
-    case SearchFieldResultsButtonPart:
-    case SearchFieldCancelButtonPart:
-    case SliderThumbHorizontalPart:
-    case SliderThumbVerticalPart:
+    case ControlPartType::SearchFieldDecoration:
+    case ControlPartType::SearchFieldResultsDecoration:
+    case ControlPartType::SearchFieldResultsButton:
+    case ControlPartType::SearchFieldCancelButton:
+    case ControlPartType::SliderThumbHorizontal:
+    case ControlPartType::SliderThumbVertical:
         ASSERT_NOT_REACHED();
         m_value.valueID = CSSValueNone;
         break;
     }
 }
 
-template<> inline CSSPrimitiveValue::operator ControlPart() const
+template<> inline CSSPrimitiveValue::operator ControlPartType() const
 {
     ASSERT(isValueID());
 
     if (m_value.valueID == CSSValueNone)
-        return NoControlPart;
+        return ControlPartType::NoControl;
 
     if (m_value.valueID == CSSValueAuto)
-        return AutoPart;
+        return ControlPartType::Auto;
 
-    return ControlPart(m_value.valueID - CSSValueCheckbox + CheckboxPart);
+    return ControlPartType(m_value.valueID - CSSValueCheckbox + static_cast<unsigned>(ControlPartType::Checkbox));
 }
 
 template<> inline CSSPrimitiveValue::CSSPrimitiveValue(BackfaceVisibility e)

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -849,7 +849,7 @@ after-white-space
 anywhere
 
 // -webkit-appearance
-// The order here must match the order in the ControlPart enum in ThemeTypes.h.
+// The order here must match the order in the ControlPartType enum in ThemeTypes.h.
 // All appearance values that should be accepted by the parser should be listed between 'checkbox' and 'textarea':
 checkbox
 radio

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -220,7 +220,7 @@ auto RangeInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseE
 
     bool isVertical = false;
     if (auto* renderer = element()->renderer())
-        isVertical = renderer->style().effectiveAppearance() == SliderVerticalPart;
+        isVertical = renderer->style().effectiveAppearance() == ControlPartType::SliderVertical;
 
     Decimal newValue;
     if (key == "Up"_s)

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -75,7 +75,7 @@ inline static Decimal sliderPosition(HTMLInputElement& element)
 inline static bool hasVerticalAppearance(HTMLInputElement& input)
 {
     ASSERT(input.renderer());
-    return !input.renderer()->isHorizontalWritingMode() || input.renderer()->style().effectiveAppearance() == SliderVerticalPart;
+    return !input.renderer()->isHorizontalWritingMode() || input.renderer()->style().effectiveAppearance() == ControlPartType::SliderVertical;
 }
 
 // --------------------------------
@@ -561,11 +561,11 @@ std::optional<Style::ElementStyle> SliderThumbElement::resolveCustomStyle(const 
 
     auto elementStyle = resolveStyle(resolutionContext);
     switch (hostStyle->effectiveAppearance()) {
-    case SliderVerticalPart:
-        elementStyle.renderStyle->setEffectiveAppearance(SliderThumbVerticalPart);
+    case ControlPartType::SliderVertical:
+        elementStyle.renderStyle->setEffectiveAppearance(ControlPartType::SliderThumbVertical);
         break;
-    case SliderHorizontalPart:
-        elementStyle.renderStyle->setEffectiveAppearance(SliderThumbHorizontalPart);
+    case ControlPartType::SliderHorizontal:
+        elementStyle.renderStyle->setEffectiveAppearance(ControlPartType::SliderThumbHorizontal);
         break;
     default:
         break;

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -259,12 +259,12 @@ std::optional<Style::ElementStyle> SearchFieldResultsButtonElement::resolveCusto
         return std::nullopt;
 
     auto appearance = shadowHostStyle->effectiveAppearance();
-    if (appearance == TextFieldPart) {
+    if (appearance == ControlPartType::TextField) {
         auto elementStyle = resolveStyle(resolutionContext);
         elementStyle.renderStyle->setDisplay(DisplayType::None);
         return elementStyle;
     }
-    if (appearance != SearchFieldPart) {
+    if (appearance != ControlPartType::SearchField) {
         SetForScope canAdjustStyleForAppearance(m_canAdjustStyleForAppearance, false);
         return resolveStyle(resolutionContext);
     }
@@ -331,7 +331,7 @@ std::optional<Style::ElementStyle> SearchFieldCancelButtonElement::resolveCustom
     auto& inputElement = downcast<HTMLInputElement>(*shadowHost());
     elementStyle.renderStyle->setVisibility(elementStyle.renderStyle->visibility() == Visibility::Hidden || inputElement.value().isEmpty() ? Visibility::Hidden : Visibility::Visible);
 
-    if (shadowHostStyle && shadowHostStyle->effectiveAppearance() == TextFieldPart)
+    if (shadowHostStyle && shadowHostStyle->effectiveAppearance() == ControlPartType::TextField)
         elementStyle.renderStyle->setDisplay(DisplayType::None);
 
     return elementStyle;

--- a/Source/WebCore/platform/Theme.cpp
+++ b/Source/WebCore/platform/Theme.cpp
@@ -33,25 +33,25 @@
 
 namespace WebCore {
 
-int Theme::baselinePositionAdjustment(ControlPart) const
+int Theme::baselinePositionAdjustment(ControlPartType) const
 {
     return 0;
 }
 
-std::optional<FontCascadeDescription> Theme::controlFont(ControlPart, const FontCascade&, float) const
+std::optional<FontCascadeDescription> Theme::controlFont(ControlPartType, const FontCascade&, float) const
 {
     return std::nullopt;
 }
 
-LengthSize Theme::controlSize(ControlPart, const FontCascade&, const LengthSize& zoomedSize, float) const
+LengthSize Theme::controlSize(ControlPartType, const FontCascade&, const LengthSize& zoomedSize, float) const
 {
     return zoomedSize;
 }
 
-LengthSize Theme::minimumControlSize(ControlPart part, const FontCascade& fontCascade, const LengthSize& zoomedSize, const LengthSize& nonShrinkableZoomedSize, float zoom) const
+LengthSize Theme::minimumControlSize(ControlPartType type, const FontCascade& fontCascade, const LengthSize& zoomedSize, const LengthSize& nonShrinkableZoomedSize, float zoom) const
 {
-    auto minSize = minimumControlSize(part, fontCascade, zoomedSize, zoom);
-    if (part == ControlPart::RadioPart) {
+    auto minSize = minimumControlSize(type, fontCascade, zoomedSize, zoom);
+    if (type == ControlPartType::Radio) {
         if (zoomedSize.width.isIntrinsicOrAuto())
             minSize.width = nonShrinkableZoomedSize.width;
         if (zoomedSize.height.isIntrinsicOrAuto())
@@ -60,21 +60,21 @@ LengthSize Theme::minimumControlSize(ControlPart part, const FontCascade& fontCa
     return minSize;
 }
 
-LengthSize Theme::minimumControlSize(ControlPart, const FontCascade&, const LengthSize&, float) const
+LengthSize Theme::minimumControlSize(ControlPartType, const FontCascade&, const LengthSize&, float) const
 {
     return { { 0, LengthType::Fixed }, { 0, LengthType::Fixed } };
 }
 
-bool Theme::controlRequiresPreWhiteSpace(ControlPart) const
+bool Theme::controlRequiresPreWhiteSpace(ControlPartType) const
 {
     return false;
 }
 
-void Theme::paint(ControlPart, ControlStates&, GraphicsContext&, const FloatRect&, float, ScrollView*, float, float, bool, bool, const Color&)
+void Theme::paint(ControlPartType, ControlStates&, GraphicsContext&, const FloatRect&, float, ScrollView*, float, float, bool, bool, const Color&)
 {
 }
 
-void Theme::inflateControlPaintRect(ControlPart, const ControlStates&, FloatRect&, float) const
+void Theme::inflateControlPaintRect(ControlPartType, const ControlStates&, FloatRect&, float) const
 {
 }
 
@@ -89,27 +89,27 @@ bool Theme::userPrefersContrast() const
 }
 
 
-LengthBox Theme::controlBorder(ControlPart part, const FontCascade&, const LengthBox& zoomedBox, float) const
+LengthBox Theme::controlBorder(ControlPartType type, const FontCascade&, const LengthBox& zoomedBox, float) const
 {
-    switch (part) {
-    case PushButtonPart:
-    case MenulistPart:
-    case SearchFieldPart:
-    case CheckboxPart:
-    case RadioPart:
+    switch (type) {
+    case ControlPartType::PushButton:
+    case ControlPartType::Menulist:
+    case ControlPartType::SearchField:
+    case ControlPartType::Checkbox:
+    case ControlPartType::Radio:
         return LengthBox(0);
     default:
         return zoomedBox;
     }
 }
 
-LengthBox Theme::controlPadding(ControlPart part, const FontCascade&, const LengthBox& zoomedBox, float) const
+LengthBox Theme::controlPadding(ControlPartType type, const FontCascade&, const LengthBox& zoomedBox, float) const
 {
-    switch (part) {
-    case MenulistPart:
-    case MenulistButtonPart:
-    case CheckboxPart:
-    case RadioPart:
+    switch (type) {
+    case ControlPartType::Menulist:
+    case ControlPartType::MenulistButton:
+    case ControlPartType::Checkbox:
+    case ControlPartType::Radio:
         return LengthBox(0);
     default:
         return zoomedBox;

--- a/Source/WebCore/platform/Theme.h
+++ b/Source/WebCore/platform/Theme.h
@@ -51,33 +51,33 @@ public:
     // position cannot be determined by examining child content. Checkboxes and radio buttons are examples of
     // controls that need to do this. The adjustment is an offset that adds to the baseline, e.g., marginTop() + height() + |offset|.
     // The offset is not zoomed.
-    virtual int baselinePositionAdjustment(ControlPart) const;
+    virtual int baselinePositionAdjustment(ControlPartType) const;
 
     // The font description result should have a zoomed font size.
-    virtual std::optional<FontCascadeDescription> controlFont(ControlPart, const FontCascade&, float zoomFactor) const;
+    virtual std::optional<FontCascadeDescription> controlFont(ControlPartType, const FontCascade&, float zoomFactor) const;
 
     // The size here is in zoomed coordinates already. If a new size is returned, it also needs to be in zoomed coordinates.
-    virtual LengthSize controlSize(ControlPart, const FontCascade&, const LengthSize& zoomedSize, float zoomFactor) const;
+    virtual LengthSize controlSize(ControlPartType, const FontCascade&, const LengthSize& zoomedSize, float zoomFactor) const;
 
     // Returns the minimum size for a control in zoomed coordinates.
-    LengthSize minimumControlSize(ControlPart, const FontCascade&, const LengthSize& zoomedSize, const LengthSize& nonShrinkableZoomedSize, float zoomFactor) const;
+    LengthSize minimumControlSize(ControlPartType, const FontCascade&, const LengthSize& zoomedSize, const LengthSize& nonShrinkableZoomedSize, float zoomFactor) const;
     
     // Allows the theme to modify the existing padding/border.
-    virtual LengthBox controlPadding(ControlPart, const FontCascade&, const LengthBox& zoomedBox, float zoomFactor) const;
-    virtual LengthBox controlBorder(ControlPart, const FontCascade&, const LengthBox& zoomedBox, float zoomFactor) const;
+    virtual LengthBox controlPadding(ControlPartType, const FontCascade&, const LengthBox& zoomedBox, float zoomFactor) const;
+    virtual LengthBox controlBorder(ControlPartType, const FontCascade&, const LengthBox& zoomedBox, float zoomFactor) const;
 
     // Whether or not whitespace: pre should be forced on always.
-    virtual bool controlRequiresPreWhiteSpace(ControlPart) const;
+    virtual bool controlRequiresPreWhiteSpace(ControlPartType) const;
 
     // Method for painting a control. The rect is in zoomed coordinates.
     // FIXME: <https://webkit.org/b/231637> Move parameters to a struct.
-    virtual void paint(ControlPart, ControlStates&, GraphicsContext&, const FloatRect& zoomedRect, float zoomFactor, ScrollView*, float deviceScaleFactor, float pageScaleFactor, bool useSystemAppearance, bool useDarkAppearance, const Color& tintColor);
+    virtual void paint(ControlPartType, ControlStates&, GraphicsContext&, const FloatRect& zoomedRect, float zoomFactor, ScrollView*, float deviceScaleFactor, float pageScaleFactor, bool useSystemAppearance, bool useDarkAppearance, const Color& tintColor);
 
     // Some controls may spill out of their containers (e.g., the check on an OS X checkbox).  When these controls repaint,
     // the theme needs to communicate this inflated rect to the engine so that it can invalidate the whole control.
     // The rect passed in is in zoomed coordinates, so the inflation should take that into account and make sure the inflation
     // amount is also scaled by the zoomFactor.
-    virtual void inflateControlPaintRect(ControlPart, const ControlStates&, FloatRect& zoomedRect, float zoomFactor) const;
+    virtual void inflateControlPaintRect(ControlPartType, const ControlStates&, FloatRect& zoomedRect, float zoomFactor) const;
 
     virtual void drawNamedImage(const String&, GraphicsContext&, const FloatSize&) const;
 
@@ -88,7 +88,7 @@ protected:
     Theme() = default;
     virtual ~Theme() = default;
 
-    virtual LengthSize minimumControlSize(ControlPart, const FontCascade&, const LengthSize& zoomedSize, float zoomFactor) const;
+    virtual LengthSize minimumControlSize(ControlPartType, const FontCascade&, const LengthSize& zoomedSize, float zoomFactor) const;
 
 private:
     Theme(const Theme&) = delete;

--- a/Source/WebCore/platform/ThemeTypes.cpp
+++ b/Source/WebCore/platform/ThemeTypes.cpp
@@ -30,56 +30,6 @@
 
 namespace WebCore {
 
-TextStream& operator<<(TextStream& ts, ControlPart controlPart)
-{
-    switch (controlPart) {
-    case NoControlPart: ts << "no-control-part"; break;
-    case AutoPart: ts << "auto-part"; break;
-    case CheckboxPart: ts << "checkbox-part"; break;
-    case RadioPart: ts << "radio-part"; break;
-    case PushButtonPart: ts << "push-button-part"; break;
-    case SquareButtonPart: ts << "square-button-part"; break;
-    case ButtonPart: ts << "button-part"; break;
-    case DefaultButtonPart: ts << "default-button-part"; break;
-    case InnerSpinButtonPart: ts << "inner-spin-button-part"; break;
-    case ListboxPart: ts << "listbox-part"; break;
-    case MenulistPart: ts << "menulist-part"; break;
-    case MenulistButtonPart: ts << "menulist-button-part"; break;
-    case MeterPart: ts << "meter-part"; break;
-    case ProgressBarPart: ts << "progress-bar-part"; break;
-    case SliderHorizontalPart: ts << "slider-horizontal-part"; break;
-    case SliderVerticalPart: ts << "slider-vertical-part"; break;
-    case SliderThumbHorizontalPart: ts << "slider-thumb-horizontal-part"; break;
-    case SliderThumbVerticalPart: ts << "slider-thumb-vertical-part"; break;
-    case SearchFieldPart: ts << "search-field-part"; break;
-    case SearchFieldDecorationPart: ts << "search-field-decoration-part"; break;
-    case SearchFieldResultsDecorationPart: ts << "search-field-results-decoration-part"; break;
-    case SearchFieldResultsButtonPart: ts << "search-field-results-button-part"; break;
-    case SearchFieldCancelButtonPart: ts << "search-field-cancel-button-part"; break;
-    case TextFieldPart: ts << "text-field-part"; break;
-#if ENABLE(SERVICE_CONTROLS)
-    case ImageControlsButtonPart: ts << "image-controls-button-part"; break;
-#endif
-#if ENABLE(APPLE_PAY)
-    case ApplePayButtonPart: ts << "apple-pay-button-part"; break;
-#endif
-#if ENABLE(INPUT_TYPE_COLOR)
-    case ColorWellPart: ts << "color-well-part"; break;
-#endif
-#if ENABLE(DATALIST_ELEMENT)
-    case ListButtonPart: ts << "list-button-part"; break;
-#endif
-    case TextAreaPart: ts << "text-area-part"; break;
-#if ENABLE(ATTACHMENT_ELEMENT)
-    case AttachmentPart: ts << "attachment-part"; break;
-    case BorderlessAttachmentPart: ts << "borderless-attachment-part"; break;
-#endif
-    case CapsLockIndicatorPart: ts << "caps-lock-indicator-part"; break;
-    }
-
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, SelectionPart selectionPart)
 {
     switch (selectionPart) {

--- a/Source/WebCore/platform/ThemeTypes.h
+++ b/Source/WebCore/platform/ThemeTypes.h
@@ -25,65 +25,13 @@
 
 #pragma once
 
+#include "ControlPartType.h"
+
 namespace WTF {
 class TextStream;
 }
 
 namespace WebCore {
-
-// Must follow CSSValueKeywords.in order
-enum ControlPart {
-    NoControlPart,
-    AutoPart,
-    CheckboxPart,
-    RadioPart,
-    PushButtonPart,
-    SquareButtonPart,
-    ButtonPart,
-    DefaultButtonPart,
-    ListboxPart,
-    MenulistPart,
-    MenulistButtonPart,
-    MeterPart,
-    ProgressBarPart,
-    SliderHorizontalPart,
-    SliderVerticalPart,
-    SearchFieldPart,
-#if ENABLE(APPLE_PAY)
-    ApplePayButtonPart,
-#endif
-#if ENABLE(ATTACHMENT_ELEMENT)
-    AttachmentPart,
-    BorderlessAttachmentPart,
-#endif
-    TextAreaPart,
-    TextFieldPart,
-    // Internal-only Values
-    CapsLockIndicatorPart,
-#if ENABLE(INPUT_TYPE_COLOR)
-    ColorWellPart,
-#endif
-#if ENABLE(SERVICE_CONTROLS)
-    ImageControlsButtonPart,
-#endif
-    InnerSpinButtonPart,
-#if ENABLE(DATALIST_ELEMENT)
-    ListButtonPart,
-#endif
-    SearchFieldDecorationPart,
-    SearchFieldResultsDecorationPart,
-    SearchFieldResultsButtonPart,
-    SearchFieldCancelButtonPart,
-    SliderThumbHorizontalPart,
-    SliderThumbVerticalPart
-};
-
-#if ENABLE(SERVICE_CONTROLS)
-constexpr ControlPart largestControlPart = ImageControlsButtonPart;
-#else
-constexpr ControlPart largestControlPart = CapsLockIndicatorPart;
-#endif
-
 
 enum SelectionPart {
     SelectionBackground,
@@ -141,7 +89,6 @@ enum ThemeColor {
     FocusRingColor
 };
 
-WTF::TextStream& operator<<(WTF::TextStream&, ControlPart);
 WTF::TextStream& operator<<(WTF::TextStream&, SelectionPart);
 WTF::TextStream& operator<<(WTF::TextStream&, ThemeFont);
 WTF::TextStream& operator<<(WTF::TextStream&, ThemeColor);

--- a/Source/WebCore/platform/adwaita/ThemeAdwaita.cpp
+++ b/Source/WebCore/platform/adwaita/ThemeAdwaita.cpp
@@ -168,14 +168,14 @@ void ThemeAdwaita::paintArrow(GraphicsContext& graphicsContext, const FloatRect&
     graphicsContext.fillPath(path);
 }
 
-LengthSize ThemeAdwaita::controlSize(ControlPart part, const FontCascade& fontCascade, const LengthSize& zoomedSize, float zoomFactor) const
+LengthSize ThemeAdwaita::controlSize(ControlPartType type, const FontCascade& fontCascade, const LengthSize& zoomedSize, float zoomFactor) const
 {
     if (!zoomedSize.width.isIntrinsicOrAuto() && !zoomedSize.height.isIntrinsicOrAuto())
-        return Theme::controlSize(part, fontCascade, zoomedSize, zoomFactor);
+        return Theme::controlSize(type, fontCascade, zoomedSize, zoomFactor);
 
-    switch (part) {
-    case CheckboxPart:
-    case RadioPart: {
+    switch (type) {
+    case ControlPartType::Checkbox:
+    case ControlPartType::Radio: {
         LengthSize buttonSize = zoomedSize;
         if (buttonSize.width.isIntrinsicOrAuto())
             buttonSize.width = Length(12 * zoomFactor, LengthType::Fixed);
@@ -183,7 +183,7 @@ LengthSize ThemeAdwaita::controlSize(ControlPart part, const FontCascade& fontCa
             buttonSize.height = Length(12 * zoomFactor, LengthType::Fixed);
         return buttonSize;
     }
-    case InnerSpinButtonPart: {
+    case ControlPartType::InnerSpinButton: {
         LengthSize spinButtonSize = zoomedSize;
         if (spinButtonSize.width.isIntrinsicOrAuto())
             spinButtonSize.width = Length(static_cast<int>(arrowSize * zoomFactor), LengthType::Fixed);
@@ -195,10 +195,10 @@ LengthSize ThemeAdwaita::controlSize(ControlPart part, const FontCascade& fontCa
         break;
     }
 
-    return Theme::controlSize(part, fontCascade, zoomedSize, zoomFactor);
+    return Theme::controlSize(type, fontCascade, zoomedSize, zoomFactor);
 }
 
-LengthSize ThemeAdwaita::minimumControlSize(ControlPart, const FontCascade&, const LengthSize& zoomedSize, float) const
+LengthSize ThemeAdwaita::minimumControlSize(ControlPartType, const FontCascade&, const LengthSize& zoomedSize, float) const
 {
     if (!zoomedSize.width.isIntrinsicOrAuto() && !zoomedSize.height.isIntrinsicOrAuto())
         return zoomedSize;
@@ -211,37 +211,37 @@ LengthSize ThemeAdwaita::minimumControlSize(ControlPart, const FontCascade&, con
     return minSize;
 }
 
-LengthBox ThemeAdwaita::controlBorder(ControlPart part, const FontCascade& font, const LengthBox& zoomedBox, float zoomFactor) const
+LengthBox ThemeAdwaita::controlBorder(ControlPartType type, const FontCascade& font, const LengthBox& zoomedBox, float zoomFactor) const
 {
-    switch (part) {
-    case PushButtonPart:
-    case DefaultButtonPart:
-    case ButtonPart:
-    case SquareButtonPart:
+    switch (type) {
+    case ControlPartType::PushButton:
+    case ControlPartType::DefaultButton:
+    case ControlPartType::Button:
+    case ControlPartType::SquareButton:
         return zoomedBox;
     default:
         break;
     }
 
-    return Theme::controlBorder(part, font, zoomedBox, zoomFactor);
+    return Theme::controlBorder(type, font, zoomedBox, zoomFactor);
 }
 
-void ThemeAdwaita::paint(ControlPart part, ControlStates& states, GraphicsContext& context, const FloatRect& zoomedRect, float, ScrollView*, float, float, bool, bool useDarkAppearance, const Color& effectiveAccentColor)
+void ThemeAdwaita::paint(ControlPartType type, ControlStates& states, GraphicsContext& context, const FloatRect& zoomedRect, float, ScrollView*, float, float, bool, bool useDarkAppearance, const Color& effectiveAccentColor)
 {
-    switch (part) {
-    case CheckboxPart:
+    switch (type) {
+    case ControlPartType::Checkbox:
         paintCheckbox(states, context, zoomedRect, useDarkAppearance, effectiveAccentColor);
         break;
-    case RadioPart:
+    case ControlPartType::Radio:
         paintRadio(states, context, zoomedRect, useDarkAppearance, effectiveAccentColor);
         break;
-    case PushButtonPart:
-    case DefaultButtonPart:
-    case ButtonPart:
-    case SquareButtonPart:
+    case ControlPartType::PushButton:
+    case ControlPartType::DefaultButton:
+    case ControlPartType::Button:
+    case ControlPartType::SquareButton:
         paintButton(states, context, zoomedRect, useDarkAppearance);
         break;
-    case InnerSpinButtonPart:
+    case ControlPartType::InnerSpinButton:
         paintSpinButton(states, context, zoomedRect, useDarkAppearance);
         break;
     default:

--- a/Source/WebCore/platform/adwaita/ThemeAdwaita.h
+++ b/Source/WebCore/platform/adwaita/ThemeAdwaita.h
@@ -48,10 +48,10 @@ public:
     void setAccentColor(const Color&);
     Color accentColor();
 private:
-    LengthSize controlSize(ControlPart, const FontCascade&, const LengthSize&, float) const final;
-    LengthSize minimumControlSize(ControlPart, const FontCascade&, const LengthSize&, float) const final;
-    LengthBox controlBorder(ControlPart, const FontCascade&, const LengthBox&, float) const final;
-    void paint(ControlPart, ControlStates&, GraphicsContext&, const FloatRect&, float, ScrollView*, float, float, bool, bool, const Color&) final;
+    LengthSize controlSize(ControlPartType, const FontCascade&, const LengthSize&, float) const final;
+    LengthSize minimumControlSize(ControlPartType, const FontCascade&, const LengthSize&, float) const final;
+    LengthBox controlBorder(ControlPartType, const FontCascade&, const LengthBox&, float) const final;
+    void paint(ControlPartType, ControlStates&, GraphicsContext&, const FloatRect&, float, ScrollView*, float, float, bool, bool, const Color&) final;
 
     void paintCheckbox(ControlStates&, GraphicsContext&, const FloatRect&, bool, const Color&);
     void paintRadio(ControlStates&, GraphicsContext&, const FloatRect&, bool, const Color&);

--- a/Source/WebCore/platform/graphics/formcontrols/ControlPartType.cpp
+++ b/Source/WebCore/platform/graphics/formcontrols/ControlPartType.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2019-2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ControlPartType.h"
+
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+TextStream& operator<<(TextStream& ts, ControlPartType type)
+{
+    switch (type) {
+    case ControlPartType::NoControl:
+        ts << "no-control-part";
+        break;
+    case ControlPartType::Auto:
+        ts << "auto-part";
+        break;
+    case ControlPartType::Checkbox:
+        ts << "checkbox-part";
+        break;
+    case ControlPartType::Radio:
+        ts << "radio-part";
+        break;
+    case ControlPartType::PushButton:
+        ts << "push-button-part";
+        break;
+    case ControlPartType::SquareButton:
+        ts << "square-button-part";
+        break;
+    case ControlPartType::Button:
+        ts << "button-part";
+        break;
+    case ControlPartType::DefaultButton:
+        ts << "default-button-part";
+        break;
+    case ControlPartType::Listbox:
+        ts << "listbox-part";
+        break;
+    case ControlPartType::Menulist:
+        ts << "menulist-part";
+        break;
+    case ControlPartType::MenulistButton:
+        ts << "menulist-button-part";
+        break;
+    case ControlPartType::Meter:
+        ts << "meter-part";
+        break;
+    case ControlPartType::ProgressBar:
+        ts << "progress-bar-part";
+        break;
+    case ControlPartType::SliderHorizontal:
+        ts << "slider-horizontal-part";
+        break;
+    case ControlPartType::SliderVertical:
+        ts << "slider-vertical-part";
+        break;
+    case ControlPartType::SearchField:
+        ts << "search-field-part";
+        break;
+#if ENABLE(APPLE_PAY)
+    case ControlPartType::ApplePayButton:
+        ts << "apple-pay-button-part";
+        break;
+#endif
+#if ENABLE(ATTACHMENT_ELEMENT)
+    case ControlPartType::Attachment:
+        ts << "attachment-part";
+        break;
+    case ControlPartType::BorderlessAttachment:
+        ts << "borderless-attachment-part";
+        break;
+#endif
+    case ControlPartType::TextArea:
+        ts << "text-area-part";
+        break;
+    case ControlPartType::TextField:
+        ts << "text-field-part";
+        break;
+    case ControlPartType::CapsLockIndicator:
+        ts << "caps-lock-indicator-part";
+        break;
+#if ENABLE(INPUT_TYPE_COLOR)
+    case ControlPartType::ColorWell:
+        ts << "color-well-part";
+        break;
+#endif
+#if ENABLE(SERVICE_CONTROLS)
+    case ControlPartType::ImageControlsButton:
+        ts << "image-controls-button-part";
+        break;
+#endif
+    case ControlPartType::InnerSpinButton:
+        ts << "inner-spin-button-part";
+        break;
+#if ENABLE(DATALIST_ELEMENT)
+    case ControlPartType::ListButton:
+        ts << "list-button-part";
+        break;
+#endif
+    case ControlPartType::SearchFieldDecoration:
+        ts << "search-field-decoration-part";
+        break;
+    case ControlPartType::SearchFieldResultsDecoration:
+        ts << "search-field-results-decoration-part";
+        break;
+    case ControlPartType::SearchFieldResultsButton:
+        ts << "search-field-results-button-part";
+        break;
+    case ControlPartType::SearchFieldCancelButton:
+        ts << "search-field-cancel-button-part";
+        break;
+    case ControlPartType::SliderThumbHorizontal:
+        ts << "slider-thumb-horizontal-part";
+        break;
+    case ControlPartType::SliderThumbVertical:
+        ts << "slider-thumb-vertical-part";
+        break;
+    }
+    return ts;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/formcontrols/ControlPartType.h
+++ b/Source/WebCore/platform/graphics/formcontrols/ControlPartType.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2008-2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/EnumTraits.h>
+
+namespace WTF {
+class TextStream;
+}
+
+namespace WebCore {
+
+// Must follow CSSValueKeywords.in order
+enum class ControlPartType : uint8_t {
+    NoControl,
+    Auto,
+    Checkbox,
+    Radio,
+    PushButton,
+    SquareButton,
+    Button,
+    DefaultButton,
+    Listbox,
+    Menulist,
+    MenulistButton,
+    Meter,
+    ProgressBar,
+    SliderHorizontal,
+    SliderVertical,
+    SearchField,
+#if ENABLE(APPLE_PAY)
+    ApplePayButton,
+#endif
+#if ENABLE(ATTACHMENT_ELEMENT)
+    Attachment,
+    BorderlessAttachment,
+#endif
+    TextArea,
+    TextField,
+    // Internal-only Values
+    CapsLockIndicator,
+#if ENABLE(INPUT_TYPE_COLOR)
+    ColorWell,
+#endif
+#if ENABLE(SERVICE_CONTROLS)
+    ImageControlsButton,
+#endif
+    InnerSpinButton,
+#if ENABLE(DATALIST_ELEMENT)
+    ListButton,
+#endif
+    SearchFieldDecoration,
+    SearchFieldResultsDecoration,
+    SearchFieldResultsButton,
+    SearchFieldCancelButton,
+    SliderThumbHorizontal,
+    SliderThumbVertical
+};
+
+WTF::TextStream& operator<<(WTF::TextStream&, ControlPartType);
+
+} // namespace WebCore
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::ControlPartType> {
+    using values = EnumValues<
+        WebCore::ControlPartType,
+
+        WebCore::ControlPartType::NoControl,
+        WebCore::ControlPartType::Auto,
+        WebCore::ControlPartType::Checkbox,
+        WebCore::ControlPartType::Radio,
+        WebCore::ControlPartType::PushButton,
+        WebCore::ControlPartType::SquareButton,
+        WebCore::ControlPartType::Button,
+        WebCore::ControlPartType::DefaultButton,
+        WebCore::ControlPartType::Listbox,
+        WebCore::ControlPartType::Menulist,
+        WebCore::ControlPartType::MenulistButton,
+        WebCore::ControlPartType::Meter,
+        WebCore::ControlPartType::ProgressBar,
+        WebCore::ControlPartType::SliderHorizontal,
+        WebCore::ControlPartType::SliderVertical,
+        WebCore::ControlPartType::SearchField,
+#if ENABLE(APPLE_PAY)
+        WebCore::ControlPartType::ApplePayButton,
+#endif
+#if ENABLE(ATTACHMENT_ELEMENT)
+        WebCore::ControlPartType::Attachment,
+        WebCore::ControlPartType::BorderlessAttachment,
+#endif
+        WebCore::ControlPartType::TextArea,
+        WebCore::ControlPartType::TextField,
+        WebCore::ControlPartType::CapsLockIndicator,
+#if ENABLE(INPUT_TYPE_COLOR)
+        WebCore::ControlPartType::ColorWell,
+#endif
+#if ENABLE(SERVICE_CONTROLS)
+        WebCore::ControlPartType::ImageControlsButton,
+#endif
+        WebCore::ControlPartType::InnerSpinButton,
+#if ENABLE(DATALIST_ELEMENT)
+        WebCore::ControlPartType::ListButton,
+#endif
+        WebCore::ControlPartType::SearchFieldDecoration,
+        WebCore::ControlPartType::SearchFieldResultsDecoration,
+        WebCore::ControlPartType::SearchFieldResultsButton,
+        WebCore::ControlPartType::SearchFieldCancelButton,
+        WebCore::ControlPartType::SliderThumbHorizontal,
+        WebCore::ControlPartType::SliderThumbVertical
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebCore/platform/mac/ThemeMac.h
+++ b/Source/WebCore/platform/mac/ThemeMac.h
@@ -45,20 +45,20 @@ private:
     friend NeverDestroyed<ThemeMac>;
     ThemeMac() = default;
 
-    int baselinePositionAdjustment(ControlPart) const final;
+    int baselinePositionAdjustment(ControlPartType) const final;
 
-    std::optional<FontCascadeDescription> controlFont(ControlPart, const FontCascade&, float zoomFactor) const final;
+    std::optional<FontCascadeDescription> controlFont(ControlPartType, const FontCascade&, float zoomFactor) const final;
 
-    LengthSize controlSize(ControlPart, const FontCascade&, const LengthSize&, float zoomFactor) const final;
-    LengthSize minimumControlSize(ControlPart, const FontCascade&, const LengthSize&, float zoomFactor) const final;
+    LengthSize controlSize(ControlPartType, const FontCascade&, const LengthSize&, float zoomFactor) const final;
+    LengthSize minimumControlSize(ControlPartType, const FontCascade&, const LengthSize&, float zoomFactor) const final;
 
-    LengthBox controlPadding(ControlPart, const FontCascade&, const LengthBox& zoomedBox, float zoomFactor) const final;
-    LengthBox controlBorder(ControlPart, const FontCascade&, const LengthBox& zoomedBox, float zoomFactor) const final;
+    LengthBox controlPadding(ControlPartType, const FontCascade&, const LengthBox& zoomedBox, float zoomFactor) const final;
+    LengthBox controlBorder(ControlPartType, const FontCascade&, const LengthBox& zoomedBox, float zoomFactor) const final;
 
-    bool controlRequiresPreWhiteSpace(ControlPart part) const final { return part == PushButtonPart; }
+    bool controlRequiresPreWhiteSpace(ControlPartType type) const final { return type == ControlPartType::PushButton; }
 
-    void paint(ControlPart, ControlStates&, GraphicsContext&, const FloatRect&, float zoomFactor, ScrollView*, float deviceScaleFactor, float pageScaleFactor, bool useSystemAppearance, bool useDarkAppearance, const Color& tintColor) final;
-    void inflateControlPaintRect(ControlPart, const ControlStates&, FloatRect&, float zoomFactor) const final;
+    void paint(ControlPartType, ControlStates&, GraphicsContext&, const FloatRect&, float zoomFactor, ScrollView*, float deviceScaleFactor, float pageScaleFactor, bool useSystemAppearance, bool useDarkAppearance, const Color& tintColor) final;
+    void inflateControlPaintRect(ControlPartType, const ControlStates&, FloatRect&, float zoomFactor) const final;
 
     bool userPrefersReducedMotion() const final;
     bool userPrefersContrast() const final;

--- a/Source/WebCore/rendering/RenderAttachment.cpp
+++ b/Source/WebCore/rendering/RenderAttachment.cpp
@@ -86,7 +86,7 @@ LayoutUnit RenderAttachment::baselinePosition(FontBaseline, bool, LineDirectionM
 
 bool RenderAttachment::shouldDrawBorder() const
 {
-    if (style().effectiveAppearance() == BorderlessAttachmentPart)
+    if (style().effectiveAppearance() == ControlPartType::BorderlessAttachment)
         return false;
     return m_shouldDrawBorder;
 }

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1186,7 +1186,7 @@ void RenderLayerScrollableArea::updateScrollbarsAfterStyleChange(const RenderSty
         return;
 
     // List box parts handle the scrollbars by themselves so we have nothing to do.
-    if (box->style().effectiveAppearance() == ListboxPart)
+    if (box->style().effectiveAppearance() == ControlPartType::Listbox)
         return;
 
     bool hadVerticalScrollbar = hasVerticalScrollbar();
@@ -1206,7 +1206,7 @@ void RenderLayerScrollableArea::updateScrollbarsAfterLayout()
     ASSERT(box);
 
     // List box parts handle the scrollbars by themselves so we have nothing to do.
-    if (box->style().effectiveAppearance() == ListboxPart)
+    if (box->style().effectiveAppearance() == ControlPartType::Listbox)
         return;
 
     bool hadHorizontalScrollbar = hasHorizontalScrollbar();

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -981,7 +981,7 @@ Ref<Scrollbar> RenderListBox::createScrollbar()
     if (hasCustomScrollbarStyle)
         widget = RenderScrollbar::createCustomScrollbar(*this, ScrollbarOrientation::Vertical, &selectElement());
     else {
-        widget = Scrollbar::createNativeScrollbar(*this, ScrollbarOrientation::Vertical, theme().scrollbarControlSizeForPart(ListboxPart));
+        widget = Scrollbar::createNativeScrollbar(*this, ScrollbarOrientation::Vertical, theme().scrollbarControlSizeForPart(ControlPartType::Listbox));
         didAddScrollbar(widget.get(), ScrollbarOrientation::Vertical);
         if (page().isMonitoringWheelEvents())
             scrollAnimator().setWheelEventTestMonitor(page().wheelEventTestMonitor());

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -546,7 +546,7 @@ PopupMenuStyle RenderMenuList::menuStyle() const
     IntRect absBounds = absoluteBoundingBoxRectIgnoringTransforms();
     return PopupMenuStyle(styleToUse.visitedDependentColorWithColorFilter(CSSPropertyColor), styleToUse.visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor),
         styleToUse.fontCascade(), styleToUse.visibility() == Visibility::Visible, styleToUse.display() == DisplayType::None,
-        style().hasEffectiveAppearance() && style().effectiveAppearance() == MenulistPart, styleToUse.textIndent(),
+        style().hasEffectiveAppearance() && style().effectiveAppearance() == ControlPartType::Menulist, styleToUse.textIndent(),
         style().direction(), isOverride(style().unicodeBidi()), PopupMenuStyle::DefaultBackgroundColor,
         PopupMenuStyle::SelectPopup, theme().popupMenuSize(styleToUse, absBounds));
 }
@@ -578,7 +578,7 @@ const int endOfLinePadding = 2;
 
 LayoutUnit RenderMenuList::clientPaddingLeft() const
 {
-    if ((style().effectiveAppearance() == MenulistPart || style().effectiveAppearance() == MenulistButtonPart) && style().direction() == TextDirection::RTL) {
+    if ((style().effectiveAppearance() == ControlPartType::Menulist || style().effectiveAppearance() == ControlPartType::MenulistButton) && style().direction() == TextDirection::RTL) {
         // For these appearance values, the theme applies padding to leave room for the
         // drop-down button. But leaving room for the button inside the popup menu itself
         // looks strange, so we return a small default padding to avoid having a large empty
@@ -592,7 +592,7 @@ LayoutUnit RenderMenuList::clientPaddingLeft() const
 
 LayoutUnit RenderMenuList::clientPaddingRight() const
 {
-    if ((style().effectiveAppearance() == MenulistPart || style().effectiveAppearance() == MenulistButtonPart) && style().direction() == TextDirection::LTR)
+    if ((style().effectiveAppearance() == ControlPartType::Menulist || style().effectiveAppearance() == ControlPartType::MenulistButton) && style().direction() == TextDirection::LTR)
         return endOfLinePadding;
 
     return paddingRight() + m_innerBlock->paddingRight();

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -112,7 +112,7 @@ public:
 
     // A method for asking if a control is a container or not.  Leaf controls have to have some special behavior (like
     // the baseline position API above).
-    bool isControlContainer(ControlPart) const;
+    bool isControlContainer(ControlPartType) const;
 
     // A method asking if the control changes its tint when the window has focus or not.
     virtual bool controlSupportsTints(const RenderObject&) const { return false; }
@@ -195,7 +195,7 @@ public:
     virtual bool popupOptionSupportsTextIndent() const { return false; }
     virtual PopupMenuStyle::PopupMenuSize popupMenuSize(const RenderStyle&, IntRect&) const { return PopupMenuStyle::PopupMenuSizeNormal; }
 
-    virtual ScrollbarControlSize scrollbarControlSizeForPart(ControlPart) { return ScrollbarControlSize::Regular; }
+    virtual ScrollbarControlSize scrollbarControlSizeForPart(ControlPartType) { return ScrollbarControlSize::Regular; }
 
     // Returns the repeat interval of the animation for the progress bar.
     virtual Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const;
@@ -204,7 +204,7 @@ public:
     virtual IntRect progressBarRectForBounds(const RenderObject&, const IntRect&) const;
 
     virtual IntSize meterSizeForBounds(const RenderMeter&, const IntRect&) const;
-    virtual bool supportsMeter(ControlPart, const HTMLMeterElement&) const;
+    virtual bool supportsMeter(ControlPartType, const HTMLMeterElement&) const;
 
 #if ENABLE(DATALIST_ELEMENT)
     // Returns the threshold distance for snapping to a slider tick mark.
@@ -249,7 +249,7 @@ public:
 #endif
 
 protected:
-    virtual bool canPaint(const PaintInfo&, const Settings&, ControlPart) const { return true; }
+    virtual bool canPaint(const PaintInfo&, const Settings&, ControlPartType) const { return true; }
 
     // The platform selection color.
     virtual Color platformActiveSelectionBackgroundColor(OptionSet<StyleColorOptions>) const;
@@ -415,8 +415,8 @@ protected:
     virtual ColorCache& colorCache(OptionSet<StyleColorOptions>) const;
 
 private:
-    ControlPart autoAppearanceForElement(RenderStyle&, const Element*) const;
-    ControlPart adjustAppearanceForElement(RenderStyle&, const Element*, ControlPart) const;
+    ControlPartType autoAppearanceForElement(RenderStyle&, const Element*) const;
+    ControlPartType adjustAppearanceForElement(RenderStyle&, const Element*, ControlPartType) const;
 
     mutable HashMap<uint8_t, ColorCache, DefaultHash<uint8_t>, WTF::UnsignedWithZeroKeyHashTraits<uint8_t>> m_colorCacheMap;
 };

--- a/Source/WebCore/rendering/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/RenderThemeAdwaita.cpp
@@ -124,16 +124,16 @@ RenderTheme& RenderTheme::singleton()
 bool RenderThemeAdwaita::supportsFocusRing(const RenderStyle& style) const
 {
     switch (style.effectiveAppearance()) {
-    case PushButtonPart:
-    case ButtonPart:
-    case TextFieldPart:
-    case TextAreaPart:
-    case SearchFieldPart:
-    case MenulistPart:
-    case RadioPart:
-    case CheckboxPart:
-    case SliderHorizontalPart:
-    case SliderVerticalPart:
+    case ControlPartType::PushButton:
+    case ControlPartType::Button:
+    case ControlPartType::TextField:
+    case ControlPartType::TextArea:
+    case ControlPartType::SearchField:
+    case ControlPartType::Menulist:
+    case ControlPartType::Radio:
+    case ControlPartType::Checkbox:
+    case ControlPartType::SliderHorizontal:
+    case ControlPartType::SliderVertical:
         return true;
     default:
         break;
@@ -410,7 +410,7 @@ void RenderThemeAdwaita::adjustMenuListButtonStyle(RenderStyle& style, const Ele
 
 LengthBox RenderThemeAdwaita::popupInternalPaddingBox(const RenderStyle& style, const Settings&) const
 {
-    if (style.effectiveAppearance() == NoControlPart)
+    if (style.effectiveAppearance() == ControlPartType::NoControl)
         return { };
 
     auto zoomedArrowSize = menuListButtonArrowSize * style.effectiveZoom();
@@ -433,7 +433,7 @@ bool RenderThemeAdwaita::paintMenuList(const RenderObject& renderObject, const P
     if (isHovered(renderObject))
         states.add(ControlStates::States::Hovered);
     ControlStates controlStates(states);
-    Theme::singleton().paint(ButtonPart, controlStates, graphicsContext, rect, 1., nullptr, 1., 1., false, renderObject.useDarkAppearance(), renderObject.style().effectiveAccentColor());
+    Theme::singleton().paint(ControlPartType::Button, controlStates, graphicsContext, rect, 1., nullptr, 1., 1., false, renderObject.useDarkAppearance(), renderObject.style().effectiveAccentColor());
 
     auto zoomedArrowSize = menuListButtonArrowSize * renderObject.style().effectiveZoom();
     FloatRect fieldRect = rect;
@@ -534,11 +534,11 @@ bool RenderThemeAdwaita::paintSliderTrack(const RenderObject& renderObject, cons
     auto& graphicsContext = paintInfo.context();
     GraphicsContextStateSaver stateSaver(graphicsContext);
 
-    ControlPart part = renderObject.style().effectiveAppearance();
-    ASSERT(part == SliderHorizontalPart || part == SliderVerticalPart);
+    auto type = renderObject.style().effectiveAppearance();
+    ASSERT(type == ControlPartType::SliderHorizontal || type == ControlPartType::SliderVertical);
 
     FloatRect fieldRect = rect;
-    if (part == SliderHorizontalPart) {
+    if (type == ControlPartType::SliderHorizontal) {
         fieldRect.move(0, rect.height() / 2 - (sliderTrackSize / 2));
         fieldRect.setHeight(6);
     } else {
@@ -573,7 +573,7 @@ bool RenderThemeAdwaita::paintSliderTrack(const RenderObject& renderObject, cons
     }
     FloatRect rangeRect = fieldRect;
     FloatRoundedRect::Radii corners;
-    if (part == SliderHorizontalPart) {
+    if (type == ControlPartType::SliderHorizontal) {
         if (renderObject.style().direction() == TextDirection::RTL) {
             rangeRect.move(thumbLocation.x(), 0);
             rangeRect.setWidth(rangeRect.width() - thumbLocation.x());
@@ -613,8 +613,8 @@ bool RenderThemeAdwaita::paintSliderTrack(const RenderObject& renderObject, cons
 
 void RenderThemeAdwaita::adjustSliderThumbSize(RenderStyle& style, const Element*) const
 {
-    ControlPart part = style.effectiveAppearance();
-    if (part != SliderThumbHorizontalPart && part != SliderThumbVerticalPart)
+    auto type = style.effectiveAppearance();
+    if (type != ControlPartType::SliderThumbHorizontal && type != ControlPartType::SliderThumbVertical)
         return;
 
     style.setWidth(Length(sliderThumbSize, LengthType::Fixed));
@@ -626,7 +626,7 @@ bool RenderThemeAdwaita::paintSliderThumb(const RenderObject& renderObject, cons
     auto& graphicsContext = paintInfo.context();
     GraphicsContextStateSaver stateSaver(graphicsContext);
 
-    ASSERT(renderObject.style().effectiveAppearance() == SliderThumbHorizontalPart || renderObject.style().effectiveAppearance() == SliderThumbVerticalPart);
+    ASSERT(renderObject.style().effectiveAppearance() == ControlPartType::SliderThumbHorizontal || renderObject.style().effectiveAppearance() == ControlPartType::SliderThumbVertical);
 
     SRGBA<uint8_t> sliderThumbBackgroundColor;
     SRGBA<uint8_t> sliderThumbBackgroundHoveredColor;

--- a/Source/WebCore/rendering/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/RenderThemeIOS.h
@@ -66,7 +66,7 @@ public:
     WEBCORE_EXPORT static IconAndSize iconForAttachment(const String& fileName, const String& attachmentType, const String& title);
 
 private:
-    bool canPaint(const PaintInfo&, const Settings&, ControlPart) const final;
+    bool canPaint(const PaintInfo&, const Settings&, ControlPartType) const final;
 
     LengthBox popupInternalPaddingBox(const RenderStyle&, const Settings&) const override;
 
@@ -126,7 +126,7 @@ private:
 
     Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const final;
 
-    bool supportsMeter(ControlPart, const HTMLMeterElement&) const final;
+    bool supportsMeter(ControlPartType, const HTMLMeterElement&) const final;
     bool paintMeter(const RenderObject&, const PaintInfo&, const IntRect&) final;
 
 #if ENABLE(DATALIST_ELEMENT)

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -362,7 +362,7 @@ static void drawJoinedLines(CGContextRef context, const Vector<CGPoint>& points,
     CGContextStrokePath(context);
 }
 
-bool RenderThemeIOS::canPaint(const PaintInfo& paintInfo, const Settings& settings, ControlPart) const
+bool RenderThemeIOS::canPaint(const PaintInfo& paintInfo, const Settings& settings, ControlPartType) const
 {
 #if ENABLE(IOS_FORM_CONTROL_REFRESH)
     if (settings.iOSFormControlRefreshEnabled())
@@ -441,7 +441,7 @@ void RenderThemeIOS::paintCheckboxDecorations(const RenderObject& box, const Pai
 LayoutRect RenderThemeIOS::adjustedPaintRect(const RenderBox& box, const LayoutRect& paintRect) const
 {
     // Workaround for <rdar://problem/6209763>. Force the painting bounds of checkboxes and radio controls to be square.
-    if (box.style().effectiveAppearance() == CheckboxPart || box.style().effectiveAppearance() == RadioPart) {
+    if (box.style().effectiveAppearance() == ControlPartType::Checkbox || box.style().effectiveAppearance() == ControlPartType::Radio) {
         float width = std::min(paintRect.width(), paintRect.height());
         float height = width;
         return enclosingLayoutRect(FloatRect(paintRect.x(), paintRect.y() + (box.height() - height) / 2, width, height)); // Vertically center the checkbox, like on desktop
@@ -452,9 +452,9 @@ LayoutRect RenderThemeIOS::adjustedPaintRect(const RenderBox& box, const LayoutR
 
 int RenderThemeIOS::baselinePosition(const RenderBox& box) const
 {
-    if (box.style().effectiveAppearance() == CheckboxPart || box.style().effectiveAppearance() == RadioPart)
+    if (box.style().effectiveAppearance() == ControlPartType::Checkbox || box.style().effectiveAppearance() == ControlPartType::Radio)
         return box.marginTop() + box.height() - 2; // The baseline is 2px up from the bottom of the checkbox/radio in AppKit.
-    if (box.style().effectiveAppearance() == MenulistPart)
+    if (box.style().effectiveAppearance() == ControlPartType::Menulist)
         return box.marginTop() + box.height() - 5; // This is to match AppKit. There might be a better way to calculate this though.
     return RenderTheme::baselinePosition(box);
 }
@@ -462,14 +462,14 @@ int RenderThemeIOS::baselinePosition(const RenderBox& box) const
 bool RenderThemeIOS::isControlStyled(const RenderStyle& style, const RenderStyle& userAgentStyle) const
 {
     // Buttons and MenulistButtons are styled if they contain a background image.
-    if (style.effectiveAppearance() == PushButtonPart || style.effectiveAppearance() == MenulistButtonPart)
+    if (style.effectiveAppearance() == ControlPartType::PushButton || style.effectiveAppearance() == ControlPartType::MenulistButton)
         return !style.visitedDependentColor(CSSPropertyBackgroundColor).isVisible() || style.backgroundLayers().hasImage();
 
-    if (style.effectiveAppearance() == TextFieldPart || style.effectiveAppearance() == TextAreaPart)
+    if (style.effectiveAppearance() == ControlPartType::TextField || style.effectiveAppearance() == ControlPartType::TextArea)
         return style.backgroundLayers() != userAgentStyle.backgroundLayers();
 
 #if ENABLE(DATALIST_ELEMENT)
-    if (style.effectiveAppearance() == ListButtonPart)
+    if (style.effectiveAppearance() == ControlPartType::ListButton)
         return style.hasContent() || style.hasEffectiveContentNone();
 #endif
 
@@ -678,7 +678,7 @@ LengthBox RenderThemeIOS::popupInternalPaddingBox(const RenderStyle& style, cons
         padding = emSize->computeLength<float>({ style, nullptr, nullptr, nullptr });
     }
 
-    if (style.effectiveAppearance() == MenulistButtonPart) {
+    if (style.effectiveAppearance() == ControlPartType::MenulistButton) {
         if (style.direction() == TextDirection::RTL)
             return { 0, 0, 0, static_cast<int>(padding + style.borderTopWidth()) };
         return { 0, static_cast<int>(padding + style.borderTopWidth()), 0, 0 };
@@ -686,18 +686,18 @@ LengthBox RenderThemeIOS::popupInternalPaddingBox(const RenderStyle& style, cons
     return { 0, 0, 0, 0 };
 }
 
-static inline bool canAdjustBorderRadiusForAppearance(ControlPart appearance, const RenderBox& box)
+static inline bool canAdjustBorderRadiusForAppearance(ControlPartType appearance, const RenderBox& box)
 {
     switch (appearance) {
-    case NoControlPart:
+    case ControlPartType::NoControl:
 #if ENABLE(APPLE_PAY)
-    case ApplePayButtonPart:
+    case ControlPartType::ApplePayButton:
 #endif
         return false;
 #if ENABLE(IOS_FORM_CONTROL_REFRESH)
-    case SearchFieldPart:
+    case ControlPartType::SearchField:
         return !box.settings().iOSFormControlRefreshEnabled();
-    case MenulistButtonPart:
+    case ControlPartType::MenulistButton:
         return !box.style().hasExplicitlySetBorderRadius() && box.settings().iOSFormControlRefreshEnabled();
 #endif
     default:
@@ -962,7 +962,7 @@ bool RenderThemeIOS::paintSliderTrack(const RenderObject& box, const PaintInfo& 
 
     bool isHorizontal = true;
     switch (style.effectiveAppearance()) {
-    case SliderHorizontalPart:
+    case ControlPartType::SliderHorizontal:
         isHorizontal = true;
         // Inset slightly so the thumb covers the edge.
         if (trackClip.width() > 2) {
@@ -972,7 +972,7 @@ bool RenderThemeIOS::paintSliderTrack(const RenderObject& box, const PaintInfo& 
         trackClip.setHeight(static_cast<int>(kTrackThickness));
         trackClip.setY(rect.y() + rect.height() / 2 - kTrackThickness / 2);
         break;
-    case SliderVerticalPart:
+    case ControlPartType::SliderVertical:
         isHorizontal = false;
         // Inset slightly so the thumb covers the edge.
         if (trackClip.height() > 2) {
@@ -1035,7 +1035,7 @@ bool RenderThemeIOS::paintSliderTrack(const RenderObject& box, const PaintInfo& 
 
 void RenderThemeIOS::adjustSliderThumbSize(RenderStyle& style, const Element*) const
 {
-    if (style.effectiveAppearance() != SliderThumbHorizontalPart && style.effectiveAppearance() != SliderThumbVerticalPart)
+    if (style.effectiveAppearance() != ControlPartType::SliderThumbHorizontal && style.effectiveAppearance() != ControlPartType::SliderThumbVertical)
         return;
 
     // Enforce "border-radius: 50%".
@@ -1249,7 +1249,7 @@ void RenderThemeIOS::adjustButtonStyle(RenderStyle& style, const Element* elemen
         style.setMinHeight(Length(ControlBaseHeight / ControlBaseFontSize * style.fontDescription().computedSize(), LengthType::Fixed));
 
 #if ENABLE(INPUT_TYPE_COLOR)
-    if (style.effectiveAppearance() == ColorWellPart)
+    if (style.effectiveAppearance() == ControlPartType::ColorWell)
         return;
 #endif
 
@@ -1355,8 +1355,8 @@ bool RenderThemeIOS::supportsBoxShadow(const RenderStyle& style) const
 {
     // FIXME: See if additional native controls can support box shadows.
     switch (style.effectiveAppearance()) {
-    case SliderThumbHorizontalPart:
-    case SliderThumbVerticalPart:
+    case ControlPartType::SliderThumbHorizontal:
+    case ControlPartType::SliderThumbVertical:
         return true;
     default:
         return false;
@@ -2033,9 +2033,9 @@ bool RenderThemeIOS::paintProgressBarWithFormControlRefresh(const RenderObject& 
     return false;
 }
 
-bool RenderThemeIOS::supportsMeter(ControlPart part, const HTMLMeterElement& element) const
+bool RenderThemeIOS::supportsMeter(ControlPartType type, const HTMLMeterElement& element) const
 {
-    if (part == MeterPart)
+    if (type == ControlPartType::Meter)
         return element.document().settings().iOSFormControlRefreshEnabled();
 
     return false;
@@ -2162,7 +2162,7 @@ void RenderThemeIOS::paintSliderTicks(const RenderObject& box, const PaintInfo& 
     FloatRect tickRect;
     FloatRoundedRect::Radii tickCornerRadii(tickCornerRadius);
 
-    bool isHorizontal = box.style().effectiveAppearance() == SliderHorizontalPart;
+    bool isHorizontal = box.style().effectiveAppearance() == ControlPartType::SliderHorizontal;
     if (isHorizontal) {
         tickRect.setWidth(tickWidth);
         tickRect.setHeight(tickHeight);
@@ -2211,7 +2211,7 @@ bool RenderThemeIOS::paintSliderTrackWithFormControlRefresh(const RenderObject& 
     FloatRect trackClip = rect;
 
     switch (box.style().effectiveAppearance()) {
-    case SliderHorizontalPart:
+    case ControlPartType::SliderHorizontal:
         // Inset slightly so the thumb covers the edge.
         if (trackClip.width() > 2) {
             trackClip.setWidth(trackClip.width() - 2);
@@ -2220,7 +2220,7 @@ bool RenderThemeIOS::paintSliderTrackWithFormControlRefresh(const RenderObject& 
         trackClip.setHeight(kTrackThickness);
         trackClip.setY(rect.y() + rect.height() / 2 - kTrackThickness / 2);
         break;
-    case SliderVerticalPart:
+    case ControlPartType::SliderVertical:
         isHorizontal = false;
         // Inset slightly so the thumb covers the edge.
         if (trackClip.height() > 2) {

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -67,7 +67,7 @@ public:
     Color platformAnnotationHighlightColor(OptionSet<StyleColorOptions>) const final;
     Color platformDefaultButtonTextColor(OptionSet<StyleColorOptions>) const final;
 
-    ScrollbarControlSize scrollbarControlSizeForPart(ControlPart) final { return ScrollbarControlSize::Small; }
+    ScrollbarControlSize scrollbarControlSizeForPart(ControlPartType) final { return ScrollbarControlSize::Small; }
 
     int minimumMenuListSize(const RenderStyle&) const final;
 
@@ -85,7 +85,7 @@ public:
 
     IntSize meterSizeForBounds(const RenderMeter&, const IntRect&) const final;
     bool paintMeter(const RenderObject&, const PaintInfo&, const IntRect&) final;
-    bool supportsMeter(ControlPart, const HTMLMeterElement&) const final;
+    bool supportsMeter(ControlPartType, const HTMLMeterElement&) const final;
 
     // Returns the repeat interval of the animation for the progress bar.
     Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const final;
@@ -101,7 +101,7 @@ public:
 private:
     RenderThemeMac();
 
-    bool canPaint(const PaintInfo&, const Settings&, ControlPart) const final;
+    bool canPaint(const PaintInfo&, const Settings&, ControlPartType) const final;
 
     bool paintTextField(const RenderObject&, const PaintInfo&, const FloatRect&) final;
     void adjustTextFieldStyle(RenderStyle&, const Element*) const final;

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -256,16 +256,16 @@ RenderTheme& RenderTheme::singleton()
     return theme;
 }
 
-bool RenderThemeMac::canPaint(const PaintInfo& paintInfo, const Settings&, ControlPart part) const
+bool RenderThemeMac::canPaint(const PaintInfo& paintInfo, const Settings&, ControlPartType type) const
 {
-    switch (part) {
+    switch (type) {
 #if ENABLE(ATTACHMENT_ELEMENT)
-    case AttachmentPart:
-    case BorderlessAttachmentPart:
+    case ControlPartType::Attachment:
+    case ControlPartType::BorderlessAttachment:
         return true;
 #endif
 #if ENABLE(APPLE_PAY)
-    case ApplePayButtonPart:
+    case ControlPartType::ApplePayButton:
         return true;
 #endif
     default:
@@ -750,14 +750,14 @@ bool RenderThemeMac::usesTestModeFocusRingColor() const
 bool RenderThemeMac::isControlStyled(const RenderStyle& style, const RenderStyle& userAgentStyle) const
 {
     auto appearance = style.effectiveAppearance();
-    if (appearance == TextFieldPart || appearance == TextAreaPart || appearance == SearchFieldPart || appearance == ListboxPart)
+    if (appearance == ControlPartType::TextField || appearance == ControlPartType::TextArea || appearance == ControlPartType::SearchField || appearance == ControlPartType::Listbox)
         return style.border() != userAgentStyle.border();
 
     // FIXME: This is horrible, but there is not much else that can be done.  Menu lists cannot draw properly when
     // scaled.  They can't really draw properly when transformed either.  We can't detect the transform case at style
     // adjustment time so that will just have to stay broken.  We can however detect that we're zooming.  If zooming
     // is in effect we treat it like the control is styled.
-    if (appearance == MenulistPart && style.effectiveZoom() != 1.0f)
+    if (appearance == ControlPartType::Menulist && style.effectiveZoom() != 1.0f)
         return true;
 
     return RenderTheme::isControlStyled(style, userAgentStyle);
@@ -783,29 +783,29 @@ static FloatRect inflateRect(const FloatRect& rect, const IntSize& size, const i
 
 void RenderThemeMac::adjustRepaintRect(const RenderObject& renderer, FloatRect& rect)
 {
-    ControlPart part = renderer.style().effectiveAppearance();
+    auto type = renderer.style().effectiveAppearance();
 
 #if USE(NEW_THEME)
-    switch (part) {
-        case CheckboxPart:
-        case RadioPart:
-        case PushButtonPart:
-        case SquareButtonPart:
+    switch (type) {
+    case ControlPartType::Checkbox:
+    case ControlPartType::Radio:
+    case ControlPartType::PushButton:
+    case ControlPartType::SquareButton:
 #if ENABLE(INPUT_TYPE_COLOR)
-        case ColorWellPart:
+    case ControlPartType::ColorWell:
 #endif
-        case DefaultButtonPart:
-        case ButtonPart:
-        case InnerSpinButtonPart:
+    case ControlPartType::DefaultButton:
+    case ControlPartType::Button:
+    case ControlPartType::InnerSpinButton:
             return RenderTheme::adjustRepaintRect(renderer, rect);
-        default:
+    default:
             break;
     }
 #endif
 
     float zoomLevel = renderer.style().effectiveZoom();
 
-    if (part == MenulistPart) {
+    if (type == ControlPartType::Menulist) {
         setPopupButtonCellState(renderer, IntSize(rect.size()));
         IntSize size = popupButtonSizes()[[popupButton() controlSize]];
         size.setHeight(size.height() * zoomLevel);
@@ -875,7 +875,7 @@ bool RenderThemeMac::controlSupportsTints(const RenderObject& o) const
         return false;
 
     // Checkboxes only have tint when checked.
-    if (o.style().effectiveAppearance() == CheckboxPart)
+    if (o.style().effectiveAppearance() == ControlPartType::Checkbox)
         return isChecked(o);
 
     // For now assume other controls have tint if enabled.
@@ -1247,7 +1247,7 @@ bool RenderThemeMac::paintMenuList(const RenderObject& renderer, const PaintInfo
 
 IntSize RenderThemeMac::meterSizeForBounds(const RenderMeter& renderMeter, const IntRect& bounds) const
 {
-    if (NoControlPart == renderMeter.style().effectiveAppearance())
+    if (ControlPartType::NoControl == renderMeter.style().effectiveAppearance())
         return bounds.size();
 
     NSLevelIndicatorCell* cell = levelIndicatorFor(renderMeter);
@@ -1272,15 +1272,15 @@ bool RenderThemeMac::paintMeter(const RenderObject& renderObject, const PaintInf
     return false;
 }
 
-bool RenderThemeMac::supportsMeter(ControlPart part, const HTMLMeterElement&) const
+bool RenderThemeMac::supportsMeter(ControlPartType type, const HTMLMeterElement&) const
 {
-    return part == MeterPart;
+    return type == ControlPartType::Meter;
 }
 
 NSLevelIndicatorCell* RenderThemeMac::levelIndicatorFor(const RenderMeter& renderMeter) const
 {
     const RenderStyle& style = renderMeter.style();
-    ASSERT(style.effectiveAppearance() != NoControlPart);
+    ASSERT(style.effectiveAppearance() != ControlPartType::NoControl);
 
     if (!m_levelIndicator)
         m_levelIndicator = adoptNS([[NSLevelIndicatorCell alloc] initWithLevelIndicatorStyle:NSLevelIndicatorStyleContinuousCapacity]);
@@ -1341,7 +1341,7 @@ IntRect RenderThemeMac::progressBarRectForBounds(const RenderObject& renderObjec
     // Workaround until <rdar://problem/15855086> is fixed.
     int maxDimension = static_cast<int>(std::numeric_limits<ushort>::max());
     IntRect progressBarBounds(bounds.x(), bounds.y(), std::min(bounds.width(), maxDimension), std::min(bounds.height(), maxDimension));
-    if (NoControlPart == renderObject.style().effectiveAppearance())
+    if (ControlPartType::NoControl == renderObject.style().effectiveAppearance())
         return progressBarBounds;
 
     float zoomLevel = renderObject.style().effectiveZoom();
@@ -1651,7 +1651,7 @@ void RenderThemeMac::adjustMenuListStyle(RenderStyle& style, const Element* e) c
 
 LengthBox RenderThemeMac::popupInternalPaddingBox(const RenderStyle& style, const Settings&) const
 {
-    if (style.effectiveAppearance() == MenulistPart) {
+    if (style.effectiveAppearance() == ControlPartType::Menulist) {
         const int* padding = popupButtonPadding(controlSizeForFont(style), style.direction() == TextDirection::RTL);
         return { static_cast<int>(padding[topPadding] * style.effectiveZoom()),
             static_cast<int>(padding[rightPadding] * style.effectiveZoom()),
@@ -1659,7 +1659,7 @@ LengthBox RenderThemeMac::popupInternalPaddingBox(const RenderStyle& style, cons
             static_cast<int>(padding[leftPadding] * style.effectiveZoom()) };
     }
 
-    if (style.effectiveAppearance() == MenulistButtonPart) {
+    if (style.effectiveAppearance() == ControlPartType::MenulistButton) {
         float arrowWidth = baseArrowWidth * (style.computedFontPixelSize() / baseFontSize);
         float rightPadding = ceilf(arrowWidth + (arrowPaddingBefore + arrowPaddingAfter + paddingBeforeSeparator) * style.effectiveZoom());
         float leftPadding = styledPopupPaddingLeft * style.effectiveZoom();
@@ -1756,10 +1756,10 @@ bool RenderThemeMac::paintSliderTrack(const RenderObject& o, const PaintInfo& pa
     float zoomLevel = o.style().effectiveZoom();
     float zoomedTrackWidth = trackWidth * zoomLevel;
 
-    if (o.style().effectiveAppearance() ==  SliderHorizontalPart) {
+    if (o.style().effectiveAppearance() ==  ControlPartType::SliderHorizontal) {
         bounds.setHeight(zoomedTrackWidth);
         bounds.setY(r.y() + r.height() / 2 - zoomedTrackWidth / 2);
-    } else if (o.style().effectiveAppearance() == SliderVerticalPart) {
+    } else if (o.style().effectiveAppearance() == ControlPartType::SliderVertical) {
         bounds.setWidth(zoomedTrackWidth);
         bounds.setX(r.x() + r.width() / 2 - zoomedTrackWidth / 2);
     }
@@ -1778,7 +1778,7 @@ bool RenderThemeMac::paintSliderTrack(const RenderObject& o, const PaintInfo& pa
     struct CGFunctionCallbacks mainCallbacks = { 0, TrackGradientInterpolate, NULL };
     RetainPtr<CGFunctionRef> mainFunction = adoptCF(CGFunctionCreate(NULL, 1, NULL, 4, NULL, &mainCallbacks));
     RetainPtr<CGShadingRef> mainShading;
-    if (o.style().effectiveAppearance() == SliderVerticalPart)
+    if (o.style().effectiveAppearance() == ControlPartType::SliderVertical)
         mainShading = adoptCF(CGShadingCreateAxial(cspace, CGPointMake(bounds.x(),  bounds.maxY()), CGPointMake(bounds.maxX(), bounds.maxY()), mainFunction.get(), false, false));
     else
         mainShading = adoptCF(CGShadingCreateAxial(cspace, CGPointMake(bounds.x(),  bounds.y()), CGPointMake(bounds.x(), bounds.maxY()), mainFunction.get(), false, false));
@@ -1801,7 +1801,7 @@ const float verticalSliderHeightPadding = 0.1f;
 
 bool RenderThemeMac::paintSliderThumb(const RenderObject& o, const PaintInfo& paintInfo, const IntRect& r)
 {
-    NSSliderCell* sliderThumbCell = o.style().effectiveAppearance() == SliderThumbVerticalPart
+    NSSliderCell* sliderThumbCell = o.style().effectiveAppearance() == ControlPartType::SliderThumbVertical
         ? sliderThumbVertical()
         : sliderThumbHorizontal();
 
@@ -1819,14 +1819,14 @@ bool RenderThemeMac::paintSliderThumb(const RenderObject& o, const PaintInfo& pa
 
     // Update the pressed state using the NSCell tracking methods, since that's how NSSliderCell keeps track of it.
     bool oldPressed;
-    if (o.style().effectiveAppearance() == SliderThumbVerticalPart)
+    if (o.style().effectiveAppearance() == ControlPartType::SliderThumbVertical)
         oldPressed = m_isSliderThumbVerticalPressed;
     else
         oldPressed = m_isSliderThumbHorizontalPressed;
 
     bool pressed = isPressed(o);
 
-    if (o.style().effectiveAppearance() == SliderThumbVerticalPart)
+    if (o.style().effectiveAppearance() == ControlPartType::SliderThumbVertical)
         m_isSliderThumbVerticalPressed = pressed;
     else
         m_isSliderThumbHorizontalPressed = pressed;
@@ -1842,7 +1842,7 @@ bool RenderThemeMac::paintSliderThumb(const RenderObject& o, const PaintInfo& pa
 
     FloatRect bounds = r;
     // Make the height of the vertical slider slightly larger so NSSliderCell will draw a vertical slider.
-    if (o.style().effectiveAppearance() == SliderThumbVerticalPart)
+    if (o.style().effectiveAppearance() == ControlPartType::SliderThumbVertical)
         bounds.setHeight(bounds.height() + verticalSliderHeightPadding * o.style().effectiveZoom());
 
     GraphicsContextStateSaver stateSaver(paintInfo.context());
@@ -2179,7 +2179,7 @@ constexpr int sliderThumbThickness = 15;
 void RenderThemeMac::adjustSliderThumbSize(RenderStyle& style, const Element*) const
 {
     float zoomLevel = style.effectiveZoom();
-    if (style.effectiveAppearance() == SliderThumbHorizontalPart || style.effectiveAppearance() == SliderThumbVerticalPart) {
+    if (style.effectiveAppearance() == ControlPartType::SliderThumbHorizontal || style.effectiveAppearance() == ControlPartType::SliderThumbVertical) {
         style.setWidth(Length(static_cast<int>(sliderThumbThickness * zoomLevel), LengthType::Fixed));
         style.setHeight(Length(static_cast<int>(sliderThumbThickness * zoomLevel), LengthType::Fixed));
     }

--- a/Source/WebCore/rendering/RenderThemeWin.cpp
+++ b/Source/WebCore/rendering/RenderThemeWin.cpp
@@ -308,15 +308,15 @@ Color RenderThemeWin::platformInactiveSelectionForegroundColor(OptionSet<StyleCo
     return platformActiveSelectionForegroundColor(options);
 }
 
-bool RenderThemeWin::supportsFocus(ControlPart appearance) const
+bool RenderThemeWin::supportsFocus(ControlPartType appearance) const
 {
     switch (appearance) {
-        case PushButtonPart:
-        case ButtonPart:
-        case DefaultButtonPart:
-            return true;
-        default:
-            return false;
+    case ControlPartType::PushButton:
+    case ControlPartType::Button:
+    case ControlPartType::DefaultButton:
+        return true;
+    default:
+        return false;
     }
 }
 
@@ -329,45 +329,45 @@ unsigned RenderThemeWin::determineClassicState(const RenderObject& o, ControlSub
 {
     unsigned state = 0;
     switch (o.style().effectiveAppearance()) {
-        case PushButtonPart:
-        case ButtonPart:
-        case DefaultButtonPart:
-            state = DFCS_BUTTONPUSH;
-            if (!isEnabled(o))
-                state |= DFCS_INACTIVE;
-            else if (isPressed(o))
-                state |= DFCS_PUSHED;
-            break;
-        case RadioPart:
-        case CheckboxPart:
-            state = (o.style().effectiveAppearance() == RadioPart) ? DFCS_BUTTONRADIO : DFCS_BUTTONCHECK;
-            if (isChecked(o))
-                state |= DFCS_CHECKED;
-            if (!isEnabled(o))
-                state |= DFCS_INACTIVE;
-            else if (isPressed(o))
-                state |= DFCS_PUSHED;
-            break;
-        case MenulistPart:
-            state = DFCS_SCROLLCOMBOBOX;
-            if (!isEnabled(o))
-                state |= DFCS_INACTIVE;
-            else if (isPressed(o))
-                state |= DFCS_PUSHED;
-            break;
-        case InnerSpinButtonPart: {
-            bool isUpButton = subPart == SpinButtonUp;
-            state = isUpButton ? DFCS_SCROLLUP : DFCS_SCROLLDOWN;
-            if (!isEnabled(o) || isReadOnlyControl(o))
-                state |= DFCS_INACTIVE;
-            else if (isPressed(o) && isUpButton == isSpinUpButtonPartPressed(o))
-                state |= DFCS_PUSHED;
-            else if (isHovered(o) && isUpButton == isSpinUpButtonPartHovered(o))
-                state |= DFCS_HOT;
-            break;
-        }
-        default:
-            break;
+    case ControlPartType::PushButton:
+    case ControlPartType::Button:
+    case ControlPartType::DefaultButton:
+        state = DFCS_BUTTONPUSH;
+        if (!isEnabled(o))
+            state |= DFCS_INACTIVE;
+        else if (isPressed(o))
+            state |= DFCS_PUSHED;
+        break;
+    case ControlPartType::Radio:
+    case ControlPartType::Checkbox:
+        state = (o.style().effectiveAppearance() == ControlPartType::Radio) ? DFCS_BUTTONRADIO : DFCS_BUTTONCHECK;
+        if (isChecked(o))
+            state |= DFCS_CHECKED;
+        if (!isEnabled(o))
+            state |= DFCS_INACTIVE;
+        else if (isPressed(o))
+            state |= DFCS_PUSHED;
+        break;
+    case ControlPartType::Menulist:
+        state = DFCS_SCROLLCOMBOBOX;
+        if (!isEnabled(o))
+            state |= DFCS_INACTIVE;
+        else if (isPressed(o))
+            state |= DFCS_PUSHED;
+        break;
+    case ControlPartType::InnerSpinButton: {
+        bool isUpButton = subPart == SpinButtonUp;
+        state = isUpButton ? DFCS_SCROLLUP : DFCS_SCROLLDOWN;
+        if (!isEnabled(o) || isReadOnlyControl(o))
+            state |= DFCS_INACTIVE;
+        else if (isPressed(o) && isUpButton == isSpinUpButtonPartPressed(o))
+            state |= DFCS_PUSHED;
+        else if (isHovered(o) && isUpButton == isSpinUpButtonPartHovered(o))
+            state |= DFCS_HOT;
+        break;
+    }
+    default:
+        break;
     }
     return state;
 }
@@ -375,10 +375,10 @@ unsigned RenderThemeWin::determineClassicState(const RenderObject& o, ControlSub
 unsigned RenderThemeWin::determineState(const RenderObject& o)
 {
     unsigned result = TS_NORMAL;
-    ControlPart appearance = o.style().effectiveAppearance();
+    auto appearance = o.style().effectiveAppearance();
     if (!isEnabled(o))
         result = TS_DISABLED;
-    else if (isReadOnlyControl(o) && (TextFieldPart == appearance || TextAreaPart == appearance || SearchFieldPart == appearance))
+    else if (isReadOnlyControl(o) && (ControlPartType::TextField == appearance || ControlPartType::TextArea == appearance || ControlPartType::SearchField == appearance))
         result = TFS_READONLY; // Readonly is supported on textfields.
     else if (isPressed(o)) // Active overrides hover and focused.
         result = TS_ACTIVE;
@@ -386,7 +386,7 @@ unsigned RenderThemeWin::determineState(const RenderObject& o)
         result = TS_FOCUSED;
     else if (isHovered(o))
         result = TS_HOVER;
-    if (isIndeterminate(o) && appearance == CheckboxPart)
+    if (isIndeterminate(o) && appearance == ControlPartType::Checkbox)
         result += 8;
     else if (isChecked(o))
         result += 4; // 4 unchecked states, 4 checked states.
@@ -440,50 +440,50 @@ ThemeData RenderThemeWin::getClassicThemeData(const RenderObject& o, ControlSubP
 {
     ThemeData result;
     switch (o.style().effectiveAppearance()) {
-        case PushButtonPart:
-        case ButtonPart:
-        case DefaultButtonPart:
-        case CheckboxPart:
-        case RadioPart:
-            result.m_part = DFC_BUTTON;
-            result.m_state = determineClassicState(o);
-            break;
-        case MenulistPart:
-            result.m_part = DFC_SCROLL;
-            result.m_state = determineClassicState(o);
-            break;
-        case MeterPart:
-            result.m_part = PP_BAR;
-            result.m_state = determineState(o);
-            break;
-        case SearchFieldPart:
-        case TextFieldPart:
-        case TextAreaPart:
-            result.m_part = TFP_TEXTFIELD;
-            result.m_state = determineState(o);
-            break;
-        case SliderHorizontalPart:
-            result.m_part = TKP_TRACK;
-            result.m_state = TS_NORMAL;
-            break;
-        case SliderVerticalPart:
-            result.m_part = TKP_TRACKVERT;
-            result.m_state = TS_NORMAL;
-            break;
-        case SliderThumbHorizontalPart:
-            result.m_part = TKP_THUMBBOTTOM;
-            result.m_state = determineSliderThumbState(o);
-            break;
-        case SliderThumbVerticalPart:
-            result.m_part = TKP_THUMBRIGHT;
-            result.m_state = determineSliderThumbState(o);
-            break;
-        case InnerSpinButtonPart:
-            result.m_part = DFC_SCROLL;
-            result.m_state = determineClassicState(o, subPart);
-            break;
-        default:
-            break;
+    case ControlPartType::PushButton:
+    case ControlPartType::Button:
+    case ControlPartType::DefaultButton:
+    case ControlPartType::Checkbox:
+    case ControlPartType::Radio:
+        result.m_part = DFC_BUTTON;
+        result.m_state = determineClassicState(o);
+        break;
+    case ControlPartType::Menulist:
+        result.m_part = DFC_SCROLL;
+        result.m_state = determineClassicState(o);
+        break;
+    case ControlPartType::Meter:
+        result.m_part = PP_BAR;
+        result.m_state = determineState(o);
+        break;
+    case ControlPartType::SearchField:
+    case ControlPartType::TextField:
+    case ControlPartType::TextArea:
+        result.m_part = TFP_TEXTFIELD;
+        result.m_state = determineState(o);
+        break;
+    case ControlPartType::SliderHorizontal:
+        result.m_part = TKP_TRACK;
+        result.m_state = TS_NORMAL;
+        break;
+    case ControlPartType::SliderVertical:
+        result.m_part = TKP_TRACKVERT;
+        result.m_state = TS_NORMAL;
+        break;
+    case ControlPartType::SliderThumbHorizontal:
+        result.m_part = TKP_THUMBBOTTOM;
+        result.m_state = determineSliderThumbState(o);
+        break;
+    case ControlPartType::SliderThumbVertical:
+        result.m_part = TKP_THUMBRIGHT;
+        result.m_state = determineSliderThumbState(o);
+        break;
+    case ControlPartType::InnerSpinButton:
+        result.m_part = DFC_SCROLL;
+        result.m_state = determineClassicState(o, subPart);
+        break;
+    default:
+        break;
     }
     return result;
 }
@@ -495,62 +495,62 @@ ThemeData RenderThemeWin::getThemeData(const RenderObject& o, ControlSubPart sub
 
     ThemeData result;
     switch (o.style().effectiveAppearance()) {
-        case PushButtonPart:
-        case ButtonPart:
-        case DefaultButtonPart:
-            result.m_part = BP_BUTTON;
-            result.m_state = determineButtonState(o);
-            break;
-        case CheckboxPart:
-            result.m_part = BP_CHECKBOX;
-            result.m_state = determineState(o);
-            break;
-        case MenulistPart:
-        case MenulistButtonPart: {
-            const bool isVistaOrLater = (windowsVersion() >= WindowsVista);
-            result.m_part = isVistaOrLater ? CP_DROPDOWNBUTTONRIGHT : CP_DROPDOWNBUTTON;
-            if (isVistaOrLater) {
-                result.m_state = TS_NORMAL;
-            } else
-                result.m_state = determineState(o);
-            break;
-        }
-        case MeterPart:
-            result.m_part = PP_BAR;
-            result.m_state = determineState(o);
-            break;
-        case RadioPart:
-            result.m_part = BP_RADIO;
-            result.m_state = determineState(o);
-            break;
-        case SearchFieldPart:
-        case TextFieldPart:
-        case TextAreaPart:
-            result.m_part = (windowsVersion() >= WindowsVista) ? EP_EDITBORDER_NOSCROLL : TFP_TEXTFIELD;
-            result.m_state = determineState(o);
-            break;
-        case SliderHorizontalPart:
-            result.m_part = TKP_TRACK;
+    case ControlPartType::PushButton:
+    case ControlPartType::Button:
+    case ControlPartType::DefaultButton:
+        result.m_part = BP_BUTTON;
+        result.m_state = determineButtonState(o);
+        break;
+    case ControlPartType::Checkbox:
+        result.m_part = BP_CHECKBOX;
+        result.m_state = determineState(o);
+        break;
+    case ControlPartType::Menulist:
+    case ControlPartType::MenulistButton: {
+        const bool isVistaOrLater = (windowsVersion() >= WindowsVista);
+        result.m_part = isVistaOrLater ? CP_DROPDOWNBUTTONRIGHT : CP_DROPDOWNBUTTON;
+        if (isVistaOrLater)
             result.m_state = TS_NORMAL;
-            break;
-        case SliderVerticalPart:
-            result.m_part = TKP_TRACKVERT;
-            result.m_state = TS_NORMAL;
-            break;
-        case SliderThumbHorizontalPart:
-            result.m_part = TKP_THUMBBOTTOM;
-            result.m_state = determineSliderThumbState(o);
-            break;
-        case SliderThumbVerticalPart:
-            result.m_part = TKP_THUMBRIGHT;
-            result.m_state = determineSliderThumbState(o);
-            break;
-        case InnerSpinButtonPart:
-            result.m_part = subPart == SpinButtonUp ? SPNP_UP : SPNP_DOWN;
-            result.m_state = determineSpinButtonState(o, subPart);
-            break;
-        default:
-            break;
+        else
+            result.m_state = determineState(o);
+        break;
+    }
+    case ControlPartType::Meter:
+        result.m_part = PP_BAR;
+        result.m_state = determineState(o);
+        break;
+    case ControlPartType::Radio:
+        result.m_part = BP_RADIO;
+        result.m_state = determineState(o);
+        break;
+    case ControlPartType::SearchField:
+    case ControlPartType::TextField:
+    case ControlPartType::TextArea:
+        result.m_part = (windowsVersion() >= WindowsVista) ? EP_EDITBORDER_NOSCROLL : TFP_TEXTFIELD;
+        result.m_state = determineState(o);
+        break;
+    case ControlPartType::SliderHorizontal:
+        result.m_part = TKP_TRACK;
+        result.m_state = TS_NORMAL;
+        break;
+    case ControlPartType::SliderVertical:
+        result.m_part = TKP_TRACKVERT;
+        result.m_state = TS_NORMAL;
+        break;
+    case ControlPartType::SliderThumbHorizontal:
+        result.m_part = TKP_THUMBBOTTOM;
+        result.m_state = determineSliderThumbState(o);
+        break;
+    case ControlPartType::SliderThumbVertical:
+        result.m_part = TKP_THUMBRIGHT;
+        result.m_state = determineSliderThumbState(o);
+        break;
+    case ControlPartType::InnerSpinButton:
+        result.m_part = subPart == SpinButtonUp ? SPNP_UP : SPNP_DOWN;
+        result.m_state = determineSpinButtonState(o, subPart);
+        break;
+    default:
+        break;
     }
 
     return result;
@@ -576,8 +576,8 @@ static void drawControl(GraphicsContext& context, const RenderObject& o, HANDLE 
         } else if (themeData.m_part == TKP_TRACK || themeData.m_part == TKP_TRACKVERT) {
             ::DrawEdge(hdc, &widgetRect, EDGE_SUNKEN, BF_RECT | BF_ADJUST);
             ::FillRect(hdc, &widgetRect, (HBRUSH)GetStockObject(GRAY_BRUSH));
-        } else if ((o.style().effectiveAppearance() == SliderThumbHorizontalPart
-        || o.style().effectiveAppearance() == SliderThumbVerticalPart)
+        } else if ((o.style().effectiveAppearance() == ControlPartType::SliderThumbHorizontal
+        || o.style().effectiveAppearance() == ControlPartType::SliderThumbVertical)
         && (themeData.m_part == TKP_THUMBBOTTOM || themeData.m_part == TKP_THUMBTOP
         || themeData.m_part == TKP_THUMBLEFT || themeData.m_part == TKP_THUMBRIGHT)) {
             ::DrawEdge(hdc, &widgetRect, EDGE_RAISED, BF_RECT | BF_SOFT | BF_MIDDLE | BF_ADJUST);
@@ -601,7 +601,7 @@ static void drawControl(GraphicsContext& context, const RenderObject& o, HANDLE 
             }
         } else {
             // Push buttons, buttons, checkboxes and radios, and the dropdown arrow in menulists.
-            if (o.style().effectiveAppearance() == DefaultButtonPart) {
+            if (o.style().effectiveAppearance() == ControlPartType::DefaultButton) {
                 HBRUSH brush = ::GetSysColorBrush(COLOR_3DDKSHADOW);
                 ::FrameRect(hdc, &widgetRect, brush);
                 ::InflateRect(&widgetRect, -1, -1);
@@ -754,10 +754,10 @@ bool RenderThemeWin::paintSliderTrack(const RenderObject& o, const PaintInfo& i,
 {
     IntRect bounds = r;
     
-    if (o.style().effectiveAppearance() ==  SliderHorizontalPart) {
+    if (o.style().effectiveAppearance() ==  ControlPartType::SliderHorizontal) {
         bounds.setHeight(trackWidth);
         bounds.setY(r.y() + r.height() / 2 - trackWidth / 2);
-    } else if (o.style().effectiveAppearance() == SliderVerticalPart) {
+    } else if (o.style().effectiveAppearance() == ControlPartType::SliderVertical) {
         bounds.setWidth(trackWidth);
         bounds.setX(r.x() + r.width() / 2 - trackWidth / 2);
     }
@@ -777,11 +777,11 @@ const int sliderThumbHeight = 15;
 
 void RenderThemeWin::adjustSliderThumbSize(RenderStyle& style, const Element*) const
 {
-    ControlPart part = style.effectiveAppearance();
-    if (part == SliderThumbVerticalPart) {
+    auto type = style.effectiveAppearance();
+    if (type == ControlPartType::SliderThumbVertical) {
         style.setWidth(Length(sliderThumbHeight, LengthType::Fixed));
         style.setHeight(Length(sliderThumbWidth, LengthType::Fixed));
-    } else if (part == SliderThumbHorizontalPart) {
+    } else if (type == ControlPartType::SliderThumbHorizontal) {
         style.setWidth(Length(sliderThumbWidth, LengthType::Fixed));
         style.setHeight(Length(sliderThumbHeight, LengthType::Fixed));
     }
@@ -1006,10 +1006,10 @@ void RenderThemeWin::adjustMeterStyle(RenderStyle& style, const Element*) const
     style.setBoxShadow(nullptr);
 }
 
-bool RenderThemeWin::supportsMeter(ControlPart part, const HTMLMeterElement&) const
+bool RenderThemeWin::supportsMeter(ControlPartType type, const HTMLMeterElement&) const
 {
-    switch (part) {
-    case MeterPart:
+    switch (type) {
+    case ControlPartType::Meter:
         return true;
     default:
         return false;

--- a/Source/WebCore/rendering/RenderThemeWin.h
+++ b/Source/WebCore/rendering/RenderThemeWin.h
@@ -125,7 +125,7 @@ public:
 #endif
 
     IntSize meterSizeForBounds(const RenderMeter&, const IntRect&) const override;
-    bool supportsMeter(ControlPart, const HTMLMeterElement&) const override;
+    bool supportsMeter(ControlPartType, const HTMLMeterElement&) const override;
     void adjustMeterStyle(RenderStyle&, const Element*) const override;
     bool paintMeter(const RenderObject&, const PaintInfo&, const IntRect&) override;
 
@@ -148,7 +148,7 @@ private:
     unsigned determineButtonState(const RenderObject&);
     unsigned determineSpinButtonState(const RenderObject&, ControlSubPart = None);
 
-    bool supportsFocus(ControlPart) const;
+    bool supportsFocus(ControlPartType) const;
 
     ThemeData getThemeData(const RenderObject&, ControlSubPart = None);
     ThemeData getClassicThemeData(const RenderObject&, ControlSubPart = None);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -223,8 +223,8 @@ public:
     bool hasEntirelyFixedBackground() const;
     bool hasAnyLocalBackground() const { return backgroundLayers().hasImageWithAttachment(FillAttachment::LocalBackground); }
 
-    bool hasAppearance() const { return appearance() != NoControlPart; }
-    bool hasEffectiveAppearance() const { return effectiveAppearance() != NoControlPart; }
+    bool hasAppearance() const { return appearance() != ControlPartType::NoControl; }
+    bool hasEffectiveAppearance() const { return effectiveAppearance() != ControlPartType::NoControl; }
 
     bool hasBackground() const;
     
@@ -522,8 +522,8 @@ public:
     float textStrokeWidth() const { return m_rareInheritedData->textStrokeWidth; }
     float opacity() const { return m_rareNonInheritedData->opacity; }
     bool hasOpacity() const { return m_rareNonInheritedData->opacity < 1; }
-    ControlPart appearance() const { return static_cast<ControlPart>(m_rareNonInheritedData->appearance); }
-    ControlPart effectiveAppearance() const { return static_cast<ControlPart>(m_rareNonInheritedData->effectiveAppearance); }
+    ControlPartType appearance() const { return static_cast<ControlPartType>(m_rareNonInheritedData->appearance); }
+    ControlPartType effectiveAppearance() const { return static_cast<ControlPartType>(m_rareNonInheritedData->effectiveAppearance); }
     AspectRatioType aspectRatioType() const { return static_cast<AspectRatioType>(m_rareNonInheritedData->aspectRatioType); }
     double aspectRatioWidth() const { return m_rareNonInheritedData->aspectRatioWidth; }
     double aspectRatioHeight() const { return m_rareNonInheritedData->aspectRatioHeight; }
@@ -1217,9 +1217,8 @@ public:
     void setAccentColor(const StyleColor& c) { SET_VAR(m_rareInheritedData, accentColor, c); SET_VAR(m_rareInheritedData, hasAutoAccentColor, false);  }
     void setHasAutoAccentColor() { SET_VAR(m_rareInheritedData, hasAutoAccentColor, true); SET_VAR(m_rareInheritedData, accentColor, currentColor()); }
     void setOpacity(float f) { float v = clampTo<float>(f, 0.f, 1.f); SET_VAR(m_rareNonInheritedData, opacity, v); }
-    static_assert(largestControlPart < 1 << appearanceBitWidth, "Control part must fit in storage bits");
-    void setAppearance(ControlPart a) { SET_VAR(m_rareNonInheritedData, appearance, a); SET_VAR(m_rareNonInheritedData, effectiveAppearance, a); }
-    void setEffectiveAppearance(ControlPart a) { SET_VAR(m_rareNonInheritedData, effectiveAppearance, a); }
+    void setAppearance(ControlPartType a) { SET_VAR(m_rareNonInheritedData, appearance, static_cast<unsigned>(a)); SET_VAR(m_rareNonInheritedData, effectiveAppearance, static_cast<unsigned>(a)); }
+    void setEffectiveAppearance(ControlPartType a) { SET_VAR(m_rareNonInheritedData, effectiveAppearance, static_cast<unsigned>(a)); }
     // For valid values of box-align see http://www.w3.org/TR/2009/WD-css3-flexbox-20090723/#alignment
     void setBoxAlign(BoxAlignment a) { SET_NESTED_VAR(m_rareNonInheritedData, deprecatedFlexibleBox, align, static_cast<unsigned>(a)); }
     void setBoxDirection(BoxDirection d) { m_inheritedFlags.boxDirection = static_cast<unsigned>(d); }
@@ -1748,7 +1747,7 @@ public:
     static short initialHyphenationLimitLines() { return -1; }
     static const AtomString& initialHyphenationString() { return nullAtom(); }
     static Resize initialResize() { return Resize::None; }
-    static ControlPart initialAppearance() { return NoControlPart; }
+    static ControlPartType initialAppearance() { return ControlPartType::NoControl; }
     static AspectRatioType initialAspectRatioType() { return AspectRatioType::Auto; }
     static OptionSet<Containment> initialContainment() { return OptionSet<Containment> { }; }
     static OptionSet<Containment> strictContainment() { return OptionSet<Containment> { Containment::Size, Containment::Layout, Containment::Paint, Containment::Style }; }


### PR DESCRIPTION
#### c9a83d0bf5725764c9064eb91af724c3df4a3495
<pre>
[GPU Process] [FormControls] Rename ControlPart to ControlPartType and make it enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=249167">https://bugs.webkit.org/show_bug.cgi?id=249167</a>
rdar://103266751

Reviewed by Aditya Keerthi.

The plan is to add a new class called ControlPart in which arguments from the DOM
elements and the render elements will be passed to GraphicsContext. GraphicsContext
will be responsible of drawing the ControlPart so we can delegate the drawing as
a DisplayList item to GPUP.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::isApplePayButton const):
* Source/WebCore/accessibility/AccessibilitySlider.cpp:
(WebCore::AccessibilitySlider::orientation const):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::CSSPrimitiveValue::CSSPrimitiveValue):
(WebCore::CSSPrimitiveValue::operator ControlPartType const):
(WebCore::CSSPrimitiveValue::operator ControlPart const): Deleted.
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::handleKeydownEvent):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::hasVerticalAppearance):
(WebCore::SliderThumbElement::resolveCustomStyle):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::SearchFieldResultsButtonElement::resolveCustomStyle):
(WebCore::SearchFieldCancelButtonElement::resolveCustomStyle):
* Source/WebCore/platform/Theme.cpp:
(WebCore::Theme::baselinePositionAdjustment const):
(WebCore::Theme::controlFont const):
(WebCore::Theme::controlSize const):
(WebCore::Theme::minimumControlSize const):
(WebCore::Theme::controlRequiresPreWhiteSpace const):
(WebCore::Theme::paint):
(WebCore::Theme::inflateControlPaintRect const):
(WebCore::Theme::controlBorder const):
(WebCore::Theme::controlPadding const):
* Source/WebCore/platform/Theme.h:
* Source/WebCore/platform/ThemeTypes.cpp:
* Source/WebCore/platform/ThemeTypes.h:
* Source/WebCore/platform/adwaita/ThemeAdwaita.cpp:
(WebCore::ThemeAdwaita::controlSize const):
(WebCore::ThemeAdwaita::minimumControlSize const):
(WebCore::ThemeAdwaita::controlBorder const):
(WebCore::ThemeAdwaita::paint):
* Source/WebCore/platform/adwaita/ThemeAdwaita.h:
* Source/WebCore/platform/graphics/formcontrols/ControlPartType.cpp: Added.
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/formcontrols/ControlPartType.h: Added.
* Source/WebCore/platform/mac/ThemeMac.h:
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::configureToggleButton):
(WebCore::createToggleButtonCell):
(WebCore::sharedRadioCell):
(WebCore::sharedCheckboxCell):
(WebCore::paintToggleButton):
(WebCore::setUpButtonCell):
(WebCore::button):
(WebCore::paintButton):
(WebCore::paintColorWell):
(WebCore::ThemeMac::baselinePositionAdjustment const):
(WebCore::ThemeMac::controlFont const):
(WebCore::ThemeMac::controlSize const):
(WebCore::ThemeMac::minimumControlSize const):
(WebCore::ThemeMac::controlBorder const):
(WebCore::ThemeMac::controlPadding const):
(WebCore::ThemeMac::inflateControlPaintRect const):
(WebCore::ThemeMac::paint):
* Source/WebCore/rendering/RenderAttachment.cpp:
(WebCore::RenderAttachment::shouldDrawBorder const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::updateScrollbarsAfterStyleChange):
(WebCore::RenderLayerScrollableArea::updateScrollbarsAfterLayout):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::createScrollbar):
* Source/WebCore/rendering/RenderMenuList.cpp:
(RenderMenuList::menuStyle const):
(RenderMenuList::clientPaddingLeft const):
(RenderMenuList::clientPaddingRight const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustAppearanceForElement const):
(WebCore::isAppearanceAllowedForAllElements):
(WebCore::RenderTheme::adjustStyle):
(WebCore::RenderTheme::autoAppearanceForElement const):
(WebCore::RenderTheme::paint):
(WebCore::RenderTheme::paintBorderOnly):
(WebCore::RenderTheme::paintDecorations):
(WebCore::RenderTheme::isControlContainer const):
(WebCore::RenderTheme::isControlStyled const):
(WebCore::RenderTheme::supportsFocusRing const):
(WebCore::RenderTheme::isDefault const):
(WebCore::RenderTheme::supportsMeter const):
(WebCore::RenderTheme::paintSliderTicks):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::scrollbarControlSizeForPart):
(WebCore::RenderTheme::canPaint const):
* Source/WebCore/rendering/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::supportsFocusRing const):
(WebCore::RenderThemeAdwaita::popupInternalPaddingBox const):
(WebCore::RenderThemeAdwaita::paintMenuList):
(WebCore::RenderThemeAdwaita::paintSliderTrack):
(WebCore::RenderThemeAdwaita::adjustSliderThumbSize const):
(WebCore::RenderThemeAdwaita::paintSliderThumb):
* Source/WebCore/rendering/RenderThemeIOS.h:
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::canPaint const):
(WebCore::RenderThemeIOS::adjustedPaintRect const):
(WebCore::RenderThemeIOS::baselinePosition const):
(WebCore::RenderThemeIOS::isControlStyled const):
(WebCore::RenderThemeIOS::popupInternalPaddingBox const):
(WebCore::canAdjustBorderRadiusForAppearance):
(WebCore::RenderThemeIOS::paintSliderTrack):
(WebCore::RenderThemeIOS::adjustSliderThumbSize const):
(WebCore::RenderThemeIOS::adjustButtonStyle const):
(WebCore::RenderThemeIOS::supportsBoxShadow const):
(WebCore::RenderThemeIOS::supportsMeter const):
(WebCore::RenderThemeIOS::paintSliderTicks):
(WebCore::RenderThemeIOS::paintSliderTrackWithFormControlRefresh):
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::isControlStyled const):
(WebCore::RenderThemeMac::adjustRepaintRect):
(WebCore::RenderThemeMac::controlSupportsTints const):
(WebCore::RenderThemeMac::meterSizeForBounds const):
(WebCore::RenderThemeMac::supportsMeter const):
(WebCore::RenderThemeMac::levelIndicatorFor const):
(WebCore::RenderThemeMac::progressBarRectForBounds const):
(WebCore::RenderThemeMac::popupInternalPaddingBox const):
(WebCore::RenderThemeMac::paintSliderTrack):
(WebCore::RenderThemeMac::paintSliderThumb):
(WebCore::RenderThemeMac::adjustSliderThumbSize const):
* Source/WebCore/rendering/RenderThemeWin.cpp:
(WebCore::RenderThemeWin::supportsFocus const):
(WebCore::RenderThemeWin::determineClassicState):
(WebCore::RenderThemeWin::determineState):
(WebCore::RenderThemeWin::getClassicThemeData):
(WebCore::RenderThemeWin::getThemeData):
(WebCore::drawControl):
(WebCore::RenderThemeWin::paintSliderTrack):
(WebCore::RenderThemeWin::adjustSliderThumbSize const):
(WebCore::RenderThemeWin::supportsMeter const):
* Source/WebCore/rendering/RenderThemeWin.h:
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::hasAppearance const):
(WebCore::RenderStyle::hasEffectiveAppearance const):
(WebCore::RenderStyle::appearance const):
(WebCore::RenderStyle::effectiveAppearance const):
(WebCore::RenderStyle::setAppearance):
(WebCore::RenderStyle::setEffectiveAppearance):
(WebCore::RenderStyle::initialAppearance):

Canonical link: <a href="https://commits.webkit.org/257791@main">https://commits.webkit.org/257791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7b65ecb810d67efa43dc1a0cc2cae1acec63d36

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109334 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169567 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103986 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86457 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92436 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107234 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105755 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34305 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22259 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2951 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23772 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46145 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43250 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5349 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4759 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->