### PR TITLE
Use dump-as-markup.js in fast/dom/delete-contents.html

### DIFF
--- a/LayoutTests/fast/dom/delete-contents-expected.txt
+++ b/LayoutTests/fast/dom/delete-contents-expected.txt
@@ -1,8 +1,3 @@
-layer at (0,0) size 800x600
-  RenderView at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderBlock {HTML} at (0,0) size 800x600
-    RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DIV} at (0,0) size 784x0
-        RenderBlock {DIV} at (0,0) size 784x0
-caret: position 0 of child 0 {#text} of child 0 {DIV} of body
+| "<#selection-caret>"
+| <div>
+| ""

--- a/LayoutTests/fast/dom/delete-contents.html
+++ b/LayoutTests/fast/dom/delete-contents.html
@@ -1,7 +1,7 @@
 <!-- This test was derived from a real case inside the Mail application, bug 4598149-->
 
 <div id="mydiv">01234</div>
-
+<script src="../../resources/dump-as-markup.js"></script>
 <script>
 
 var txt = document.getElementById("mydiv").firstChild;
@@ -9,5 +9,7 @@ window.getSelection().setBaseAndExtent(txt, 0, txt, 5)
 var r = window.getSelection().getRangeAt(0);
 r.deleteContents();
 r.insertNode(document.createElement("div"));
+
+Markup.dump(mydiv);
 
 </script>


### PR DESCRIPTION
#### 2ba33980b4a4a8b632a4f66df0ce5f68c6c351a2
<pre>
Use dump-as-markup.js in fast/dom/delete-contents.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=249172">https://bugs.webkit.org/show_bug.cgi?id=249172</a>

Reviewed by Wenson Hsieh.

Use dump-as-markup.js in this test for clarity.

* LayoutTests/fast/dom/delete-contents-expected.txt:
* LayoutTests/fast/dom/delete-contents.html:

Canonical link: <a href="https://commits.webkit.org/257774@main">https://commits.webkit.org/257774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e5e401086c4577fc55043e682f71b9771ca1c32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109273 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169510 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86386 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92371 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107176 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105690 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34251 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22204 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2893 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23717 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46089 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8982 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43191 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2744 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4701 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->