### PR TITLE
[CSS-Typed-OM] Create more subtests for StylePropertyMap tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/accent-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/accent-color-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'accent-color' to CSS-wide keywords
-FAIL Can set 'accent-color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'accent-color' to the 'currentcolor' keyword
-FAIL Can set 'accent-color' to the 'auto' keyword assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Can set 'accent-color' to CSS-wide keywords: initial
+PASS Can set 'accent-color' to CSS-wide keywords: inherit
+PASS Can set 'accent-color' to CSS-wide keywords: unset
+PASS Can set 'accent-color' to CSS-wide keywords: revert
+FAIL Can set 'accent-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'accent-color' to the 'currentcolor' keyword: currentcolor
+FAIL Can set 'accent-color' to the 'auto' keyword: auto assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 PASS Setting 'accent-color' to a length throws TypeError
 PASS Setting 'accent-color' to a percent throws TypeError
 PASS Setting 'accent-color' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline-expected.txt
@@ -1,17 +1,20 @@
 
-PASS Can set 'alignment-baseline' to CSS-wide keywords
-FAIL Can set 'alignment-baseline' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'alignment-baseline' to the 'baseline' keyword
-FAIL Can set 'alignment-baseline' to the 'text-bottom' keyword Invalid values
-PASS Can set 'alignment-baseline' to the 'alphabetic' keyword
-PASS Can set 'alignment-baseline' to the 'ideographic' keyword
-PASS Can set 'alignment-baseline' to the 'middle' keyword
-PASS Can set 'alignment-baseline' to the 'central' keyword
-PASS Can set 'alignment-baseline' to the 'mathematical' keyword
-FAIL Can set 'alignment-baseline' to the 'text-top' keyword Invalid values
-FAIL Can set 'alignment-baseline' to the 'bottom' keyword Invalid values
-FAIL Can set 'alignment-baseline' to the 'center' keyword Invalid values
-FAIL Can set 'alignment-baseline' to the 'top' keyword Invalid values
+PASS Can set 'alignment-baseline' to CSS-wide keywords: initial
+PASS Can set 'alignment-baseline' to CSS-wide keywords: inherit
+PASS Can set 'alignment-baseline' to CSS-wide keywords: unset
+PASS Can set 'alignment-baseline' to CSS-wide keywords: revert
+FAIL Can set 'alignment-baseline' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'alignment-baseline' to the 'baseline' keyword: baseline
+FAIL Can set 'alignment-baseline' to the 'text-bottom' keyword: text-bottom Invalid values
+PASS Can set 'alignment-baseline' to the 'alphabetic' keyword: alphabetic
+PASS Can set 'alignment-baseline' to the 'ideographic' keyword: ideographic
+PASS Can set 'alignment-baseline' to the 'middle' keyword: middle
+PASS Can set 'alignment-baseline' to the 'central' keyword: central
+PASS Can set 'alignment-baseline' to the 'mathematical' keyword: mathematical
+FAIL Can set 'alignment-baseline' to the 'text-top' keyword: text-top Invalid values
+FAIL Can set 'alignment-baseline' to the 'bottom' keyword: bottom Invalid values
+FAIL Can set 'alignment-baseline' to the 'center' keyword: center Invalid values
+FAIL Can set 'alignment-baseline' to the 'top' keyword: top Invalid values
 PASS Setting 'alignment-baseline' to a length throws TypeError
 PASS Setting 'alignment-baseline' to a percent throws TypeError
 PASS Setting 'alignment-baseline' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/all-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/all-expected.txt
@@ -1,6 +1,9 @@
 
-FAIL Can set 'all' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'all' to var() references assert_equals: expected 2 but got 1
+FAIL Can set 'all' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'all' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'all' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'all' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'all' to var() references:  var(--A) assert_equals: expected 2 but got 1
 PASS Setting 'all' to a length throws TypeError
 PASS Setting 'all' to a percent throws TypeError
 PASS Setting 'all' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-end.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-end.tentative-expected.txt
@@ -1,7 +1,13 @@
 
-FAIL Can set 'animation-delay-end' to CSS-wide keywords Invalid property animation-delay-end
-FAIL Can set 'animation-delay-end' to var() references Invalid property animation-delay-end
-FAIL Can set 'animation-delay-end' to a time Invalid property animation-delay-end
+FAIL Can set 'animation-delay-end' to CSS-wide keywords: initial Invalid property animation-delay-end
+FAIL Can set 'animation-delay-end' to CSS-wide keywords: inherit Invalid property animation-delay-end
+FAIL Can set 'animation-delay-end' to CSS-wide keywords: unset Invalid property animation-delay-end
+FAIL Can set 'animation-delay-end' to CSS-wide keywords: revert Invalid property animation-delay-end
+FAIL Can set 'animation-delay-end' to var() references:  var(--A) Invalid property animation-delay-end
+FAIL Can set 'animation-delay-end' to a time: 0s Invalid property animation-delay-end
+FAIL Can set 'animation-delay-end' to a time: -3.14ms Invalid property animation-delay-end
+FAIL Can set 'animation-delay-end' to a time: 3.14s Invalid property animation-delay-end
+FAIL Can set 'animation-delay-end' to a time: calc(0s + 0ms) Invalid property animation-delay-end
 PASS Setting 'animation-delay-end' to a length throws TypeError
 PASS Setting 'animation-delay-end' to a percent throws TypeError
 PASS Setting 'animation-delay-end' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'animation-delay' to CSS-wide keywords
-FAIL Can set 'animation-delay' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'animation-delay' to a time
+PASS Can set 'animation-delay' to CSS-wide keywords: initial
+PASS Can set 'animation-delay' to CSS-wide keywords: inherit
+PASS Can set 'animation-delay' to CSS-wide keywords: unset
+PASS Can set 'animation-delay' to CSS-wide keywords: revert
+FAIL Can set 'animation-delay' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-delay' to a time: 0s
+PASS Can set 'animation-delay' to a time: -3.14ms
+PASS Can set 'animation-delay' to a time: 3.14s
+PASS Can set 'animation-delay' to a time: calc(0s + 0ms)
 PASS Setting 'animation-delay' to a length throws TypeError
 PASS Setting 'animation-delay' to a percent throws TypeError
 PASS Setting 'animation-delay' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-start.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-start.tentative-expected.txt
@@ -1,7 +1,13 @@
 
-FAIL Can set 'animation-delay-start' to CSS-wide keywords Invalid property animation-delay-start
-FAIL Can set 'animation-delay-start' to var() references Invalid property animation-delay-start
-FAIL Can set 'animation-delay-start' to a time Invalid property animation-delay-start
+FAIL Can set 'animation-delay-start' to CSS-wide keywords: initial Invalid property animation-delay-start
+FAIL Can set 'animation-delay-start' to CSS-wide keywords: inherit Invalid property animation-delay-start
+FAIL Can set 'animation-delay-start' to CSS-wide keywords: unset Invalid property animation-delay-start
+FAIL Can set 'animation-delay-start' to CSS-wide keywords: revert Invalid property animation-delay-start
+FAIL Can set 'animation-delay-start' to var() references:  var(--A) Invalid property animation-delay-start
+FAIL Can set 'animation-delay-start' to a time: 0s Invalid property animation-delay-start
+FAIL Can set 'animation-delay-start' to a time: -3.14ms Invalid property animation-delay-start
+FAIL Can set 'animation-delay-start' to a time: 3.14s Invalid property animation-delay-start
+FAIL Can set 'animation-delay-start' to a time: calc(0s + 0ms) Invalid property animation-delay-start
 PASS Setting 'animation-delay-start' to a length throws TypeError
 PASS Setting 'animation-delay-start' to a percent throws TypeError
 PASS Setting 'animation-delay-start' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction-expected.txt
@@ -1,10 +1,13 @@
 
-PASS Can set 'animation-direction' to CSS-wide keywords
-FAIL Can set 'animation-direction' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'animation-direction' to the 'normal' keyword
-PASS Can set 'animation-direction' to the 'reverse' keyword
-PASS Can set 'animation-direction' to the 'alternate-reverse' keyword
-PASS Can set 'animation-direction' to the 'alternate' keyword
+PASS Can set 'animation-direction' to CSS-wide keywords: initial
+PASS Can set 'animation-direction' to CSS-wide keywords: inherit
+PASS Can set 'animation-direction' to CSS-wide keywords: unset
+PASS Can set 'animation-direction' to CSS-wide keywords: revert
+FAIL Can set 'animation-direction' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-direction' to the 'normal' keyword: normal
+PASS Can set 'animation-direction' to the 'reverse' keyword: reverse
+PASS Can set 'animation-direction' to the 'alternate-reverse' keyword: alternate-reverse
+PASS Can set 'animation-direction' to the 'alternate' keyword: alternate
 PASS Setting 'animation-direction' to a length throws TypeError
 PASS Setting 'animation-direction' to a percent throws TypeError
 PASS Setting 'animation-direction' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'animation-duration' to CSS-wide keywords
-FAIL Can set 'animation-duration' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'animation-duration' to a time assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'animation-duration' to CSS-wide keywords: initial
+PASS Can set 'animation-duration' to CSS-wide keywords: inherit
+PASS Can set 'animation-duration' to CSS-wide keywords: unset
+PASS Can set 'animation-duration' to CSS-wide keywords: revert
+FAIL Can set 'animation-duration' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-duration' to a time: 0s
+FAIL Can set 'animation-duration' to a time: -3.14ms assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'animation-duration' to a time: 3.14s
+PASS Can set 'animation-duration' to a time: calc(0s + 0ms)
 PASS Setting 'animation-duration' to a length throws TypeError
 PASS Setting 'animation-duration' to a percent throws TypeError
 PASS Setting 'animation-duration' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode-expected.txt
@@ -1,10 +1,13 @@
 
-PASS Can set 'animation-fill-mode' to CSS-wide keywords
-FAIL Can set 'animation-fill-mode' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'animation-fill-mode' to the 'none' keyword
-PASS Can set 'animation-fill-mode' to the 'forwards' keyword
-PASS Can set 'animation-fill-mode' to the 'backwards' keyword
-PASS Can set 'animation-fill-mode' to the 'both' keyword
+PASS Can set 'animation-fill-mode' to CSS-wide keywords: initial
+PASS Can set 'animation-fill-mode' to CSS-wide keywords: inherit
+PASS Can set 'animation-fill-mode' to CSS-wide keywords: unset
+PASS Can set 'animation-fill-mode' to CSS-wide keywords: revert
+FAIL Can set 'animation-fill-mode' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-fill-mode' to the 'none' keyword: none
+PASS Can set 'animation-fill-mode' to the 'forwards' keyword: forwards
+PASS Can set 'animation-fill-mode' to the 'backwards' keyword: backwards
+PASS Can set 'animation-fill-mode' to the 'both' keyword: both
 PASS Setting 'animation-fill-mode' to a length throws TypeError
 PASS Setting 'animation-fill-mode' to a percent throws TypeError
 PASS Setting 'animation-fill-mode' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt
@@ -1,8 +1,14 @@
 
-PASS Can set 'animation-iteration-count' to CSS-wide keywords
-FAIL Can set 'animation-iteration-count' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'animation-iteration-count' to the 'infinite' keyword
-FAIL Can set 'animation-iteration-count' to a number assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'animation-iteration-count' to CSS-wide keywords: initial
+PASS Can set 'animation-iteration-count' to CSS-wide keywords: inherit
+PASS Can set 'animation-iteration-count' to CSS-wide keywords: unset
+PASS Can set 'animation-iteration-count' to CSS-wide keywords: revert
+FAIL Can set 'animation-iteration-count' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-iteration-count' to the 'infinite' keyword: infinite
+PASS Can set 'animation-iteration-count' to a number: 0
+FAIL Can set 'animation-iteration-count' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'animation-iteration-count' to a number: 3.14
+PASS Can set 'animation-iteration-count' to a number: calc(2 + 3)
 PASS Setting 'animation-iteration-count' to a length throws TypeError
 PASS Setting 'animation-iteration-count' to a percent throws TypeError
 PASS Setting 'animation-iteration-count' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'animation-name' to CSS-wide keywords
-FAIL Can set 'animation-name' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'animation-name' to the 'none' keyword
-FAIL Can set 'animation-name' to the 'custom-ident' keyword Invalid values
+PASS Can set 'animation-name' to CSS-wide keywords: initial
+PASS Can set 'animation-name' to CSS-wide keywords: inherit
+PASS Can set 'animation-name' to CSS-wide keywords: unset
+PASS Can set 'animation-name' to CSS-wide keywords: revert
+FAIL Can set 'animation-name' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-name' to the 'none' keyword: none
+FAIL Can set 'animation-name' to the 'custom-ident' keyword: custom-ident Invalid values
 PASS Setting 'animation-name' to a length throws TypeError
 PASS Setting 'animation-name' to a percent throws TypeError
 PASS Setting 'animation-name' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-play-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-play-state-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'animation-play-state' to CSS-wide keywords
-FAIL Can set 'animation-play-state' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'animation-play-state' to the 'running' keyword
-PASS Can set 'animation-play-state' to the 'paused' keyword
+PASS Can set 'animation-play-state' to CSS-wide keywords: initial
+PASS Can set 'animation-play-state' to CSS-wide keywords: inherit
+PASS Can set 'animation-play-state' to CSS-wide keywords: unset
+PASS Can set 'animation-play-state' to CSS-wide keywords: revert
+FAIL Can set 'animation-play-state' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-play-state' to the 'running' keyword: running
+PASS Can set 'animation-play-state' to the 'paused' keyword: paused
 PASS Setting 'animation-play-state' to a length throws TypeError
 PASS Setting 'animation-play-state' to a percent throws TypeError
 PASS Setting 'animation-play-state' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-timing-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-timing-function-expected.txt
@@ -1,13 +1,16 @@
 
-PASS Can set 'animation-timing-function' to CSS-wide keywords
-FAIL Can set 'animation-timing-function' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'animation-timing-function' to the 'linear' keyword
-PASS Can set 'animation-timing-function' to the 'ease' keyword
-PASS Can set 'animation-timing-function' to the 'ease-in' keyword
-PASS Can set 'animation-timing-function' to the 'ease-out' keyword
-PASS Can set 'animation-timing-function' to the 'ease-in-out' keyword
-FAIL Can set 'animation-timing-function' to the 'step-start' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'animation-timing-function' to the 'step-end' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'animation-timing-function' to CSS-wide keywords: initial
+PASS Can set 'animation-timing-function' to CSS-wide keywords: inherit
+PASS Can set 'animation-timing-function' to CSS-wide keywords: unset
+PASS Can set 'animation-timing-function' to CSS-wide keywords: revert
+FAIL Can set 'animation-timing-function' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-timing-function' to the 'linear' keyword: linear
+PASS Can set 'animation-timing-function' to the 'ease' keyword: ease
+PASS Can set 'animation-timing-function' to the 'ease-in' keyword: ease-in
+PASS Can set 'animation-timing-function' to the 'ease-out' keyword: ease-out
+PASS Can set 'animation-timing-function' to the 'ease-in-out' keyword: ease-in-out
+FAIL Can set 'animation-timing-function' to the 'step-start' keyword: step-start assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'animation-timing-function' to the 'step-end' keyword: step-end assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'animation-timing-function' to a length throws TypeError
 PASS Setting 'animation-timing-function' to a percent throws TypeError
 PASS Setting 'animation-timing-function' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backdrop-filter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backdrop-filter-expected.txt
@@ -1,7 +1,10 @@
 
-FAIL Can set 'backdrop-filter' to CSS-wide keywords Invalid property backdrop-filter
-FAIL Can set 'backdrop-filter' to var() references Invalid property backdrop-filter
-FAIL Can set 'backdrop-filter' to the 'none' keyword Invalid property backdrop-filter
+FAIL Can set 'backdrop-filter' to CSS-wide keywords: initial Invalid property backdrop-filter
+FAIL Can set 'backdrop-filter' to CSS-wide keywords: inherit Invalid property backdrop-filter
+FAIL Can set 'backdrop-filter' to CSS-wide keywords: unset Invalid property backdrop-filter
+FAIL Can set 'backdrop-filter' to CSS-wide keywords: revert Invalid property backdrop-filter
+FAIL Can set 'backdrop-filter' to var() references:  var(--A) Invalid property backdrop-filter
+FAIL Can set 'backdrop-filter' to the 'none' keyword: none Invalid property backdrop-filter
 PASS Setting 'backdrop-filter' to a length throws TypeError
 PASS Setting 'backdrop-filter' to a percent throws TypeError
 PASS Setting 'backdrop-filter' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backface-visibility-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backface-visibility-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'backface-visibility' to CSS-wide keywords
-FAIL Can set 'backface-visibility' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'backface-visibility' to the 'visible' keyword
-PASS Can set 'backface-visibility' to the 'hidden' keyword
+PASS Can set 'backface-visibility' to CSS-wide keywords: initial
+PASS Can set 'backface-visibility' to CSS-wide keywords: inherit
+PASS Can set 'backface-visibility' to CSS-wide keywords: unset
+PASS Can set 'backface-visibility' to CSS-wide keywords: revert
+FAIL Can set 'backface-visibility' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'backface-visibility' to the 'visible' keyword: visible
+PASS Can set 'backface-visibility' to the 'hidden' keyword: hidden
 PASS Setting 'backface-visibility' to a length throws TypeError
 PASS Setting 'backface-visibility' to a percent throws TypeError
 PASS Setting 'backface-visibility' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-attachment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-attachment-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'background-attachment' to CSS-wide keywords
-FAIL Can set 'background-attachment' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'background-attachment' to the 'scroll' keyword
-PASS Can set 'background-attachment' to the 'fixed' keyword
-PASS Can set 'background-attachment' to the 'local' keyword
+PASS Can set 'background-attachment' to CSS-wide keywords: initial
+PASS Can set 'background-attachment' to CSS-wide keywords: inherit
+PASS Can set 'background-attachment' to CSS-wide keywords: unset
+PASS Can set 'background-attachment' to CSS-wide keywords: revert
+FAIL Can set 'background-attachment' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'background-attachment' to the 'scroll' keyword: scroll
+PASS Can set 'background-attachment' to the 'fixed' keyword: fixed
+PASS Can set 'background-attachment' to the 'local' keyword: local
 PASS Setting 'background-attachment' to a length throws TypeError
 PASS Setting 'background-attachment' to a percent throws TypeError
 PASS Setting 'background-attachment' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-blend-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-blend-mode-expected.txt
@@ -1,22 +1,25 @@
 
-PASS Can set 'background-blend-mode' to CSS-wide keywords
-FAIL Can set 'background-blend-mode' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'background-blend-mode' to the 'normal' keyword
-PASS Can set 'background-blend-mode' to the 'multiply' keyword
-PASS Can set 'background-blend-mode' to the 'screen' keyword
-PASS Can set 'background-blend-mode' to the 'overlay' keyword
-PASS Can set 'background-blend-mode' to the 'darken' keyword
-PASS Can set 'background-blend-mode' to the 'lighten' keyword
-PASS Can set 'background-blend-mode' to the 'color-dodge' keyword
-PASS Can set 'background-blend-mode' to the 'color-burn' keyword
-PASS Can set 'background-blend-mode' to the 'hard-light' keyword
-PASS Can set 'background-blend-mode' to the 'soft-light' keyword
-PASS Can set 'background-blend-mode' to the 'difference' keyword
-PASS Can set 'background-blend-mode' to the 'exclusion' keyword
-PASS Can set 'background-blend-mode' to the 'hue' keyword
-PASS Can set 'background-blend-mode' to the 'saturation' keyword
-PASS Can set 'background-blend-mode' to the 'color' keyword
-PASS Can set 'background-blend-mode' to the 'luminosity' keyword
+PASS Can set 'background-blend-mode' to CSS-wide keywords: initial
+PASS Can set 'background-blend-mode' to CSS-wide keywords: inherit
+PASS Can set 'background-blend-mode' to CSS-wide keywords: unset
+PASS Can set 'background-blend-mode' to CSS-wide keywords: revert
+FAIL Can set 'background-blend-mode' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'background-blend-mode' to the 'normal' keyword: normal
+PASS Can set 'background-blend-mode' to the 'multiply' keyword: multiply
+PASS Can set 'background-blend-mode' to the 'screen' keyword: screen
+PASS Can set 'background-blend-mode' to the 'overlay' keyword: overlay
+PASS Can set 'background-blend-mode' to the 'darken' keyword: darken
+PASS Can set 'background-blend-mode' to the 'lighten' keyword: lighten
+PASS Can set 'background-blend-mode' to the 'color-dodge' keyword: color-dodge
+PASS Can set 'background-blend-mode' to the 'color-burn' keyword: color-burn
+PASS Can set 'background-blend-mode' to the 'hard-light' keyword: hard-light
+PASS Can set 'background-blend-mode' to the 'soft-light' keyword: soft-light
+PASS Can set 'background-blend-mode' to the 'difference' keyword: difference
+PASS Can set 'background-blend-mode' to the 'exclusion' keyword: exclusion
+PASS Can set 'background-blend-mode' to the 'hue' keyword: hue
+PASS Can set 'background-blend-mode' to the 'saturation' keyword: saturation
+PASS Can set 'background-blend-mode' to the 'color' keyword: color
+PASS Can set 'background-blend-mode' to the 'luminosity' keyword: luminosity
 PASS Setting 'background-blend-mode' to a length throws TypeError
 PASS Setting 'background-blend-mode' to a percent throws TypeError
 PASS Setting 'background-blend-mode' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-clip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-clip-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'background-clip' to CSS-wide keywords
-FAIL Can set 'background-clip' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'background-clip' to the 'border-box' keyword
-PASS Can set 'background-clip' to the 'padding-box' keyword
-PASS Can set 'background-clip' to the 'content-box' keyword
+PASS Can set 'background-clip' to CSS-wide keywords: initial
+PASS Can set 'background-clip' to CSS-wide keywords: inherit
+PASS Can set 'background-clip' to CSS-wide keywords: unset
+PASS Can set 'background-clip' to CSS-wide keywords: revert
+FAIL Can set 'background-clip' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'background-clip' to the 'border-box' keyword: border-box
+PASS Can set 'background-clip' to the 'padding-box' keyword: padding-box
+PASS Can set 'background-clip' to the 'content-box' keyword: content-box
 PASS Setting 'background-clip' to a length throws TypeError
 PASS Setting 'background-clip' to a percent throws TypeError
 PASS Setting 'background-clip' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-color-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'background-color' to CSS-wide keywords
-FAIL Can set 'background-color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'background-color' to the 'currentcolor' keyword
+PASS Can set 'background-color' to CSS-wide keywords: initial
+PASS Can set 'background-color' to CSS-wide keywords: inherit
+PASS Can set 'background-color' to CSS-wide keywords: unset
+PASS Can set 'background-color' to CSS-wide keywords: revert
+FAIL Can set 'background-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'background-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'background-color' to a length throws TypeError
 PASS Setting 'background-color' to a percent throws TypeError
 PASS Setting 'background-color' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-expected.txt
@@ -1,6 +1,9 @@
 
-FAIL Can set 'background' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'background' to var() references assert_equals: expected 2 but got 1
+FAIL Can set 'background' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'background' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'background' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'background' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'background' to var() references:  var(--A) assert_equals: expected 2 but got 1
 FAIL Setting 'background' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 FAIL Setting 'background' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'background' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-image-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'background-image' to CSS-wide keywords
-FAIL Can set 'background-image' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'background-image' to the 'none' keyword
+PASS Can set 'background-image' to CSS-wide keywords: initial
+PASS Can set 'background-image' to CSS-wide keywords: inherit
+PASS Can set 'background-image' to CSS-wide keywords: unset
+PASS Can set 'background-image' to CSS-wide keywords: revert
+FAIL Can set 'background-image' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'background-image' to the 'none' keyword: none
 PASS Can set 'background-image' to an image
 PASS Setting 'background-image' to a length throws TypeError
 PASS Setting 'background-image' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-origin-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'background-origin' to CSS-wide keywords
-FAIL Can set 'background-origin' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'background-origin' to the 'border-box' keyword
-PASS Can set 'background-origin' to the 'padding-box' keyword
-PASS Can set 'background-origin' to the 'content-box' keyword
+PASS Can set 'background-origin' to CSS-wide keywords: initial
+PASS Can set 'background-origin' to CSS-wide keywords: inherit
+PASS Can set 'background-origin' to CSS-wide keywords: unset
+PASS Can set 'background-origin' to CSS-wide keywords: revert
+FAIL Can set 'background-origin' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'background-origin' to the 'border-box' keyword: border-box
+PASS Can set 'background-origin' to the 'padding-box' keyword: padding-box
+PASS Can set 'background-origin' to the 'content-box' keyword: content-box
 PASS Setting 'background-origin' to a length throws TypeError
 PASS Setting 'background-origin' to a percent throws TypeError
 PASS Setting 'background-origin' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-position-expected.txt
@@ -2,6 +2,9 @@ CONSOLE MESSAGE: Error: '<position>' is not a valid CSS component
 
 Harness Error (FAIL), message = Error: '<position>' is not a valid CSS component
 
-FAIL Can set 'background-position' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'background-position' to var() references assert_equals: expected 2 but got 1
+FAIL Can set 'background-position' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'background-position' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'background-position' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'background-position' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'background-position' to var() references:  var(--A) assert_equals: expected 2 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat-expected.txt
@@ -1,12 +1,15 @@
 
-FAIL Can set 'background-position' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'background-position' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'background-position' to the 'repeat-x' keyword Bad value for shorthand CSS property
-FAIL Can set 'background-position' to the 'repeat-y' keyword Bad value for shorthand CSS property
-FAIL Can set 'background-position' to the 'repeat' keyword Bad value for shorthand CSS property
-FAIL Can set 'background-position' to the 'space' keyword Bad value for shorthand CSS property
-FAIL Can set 'background-position' to the 'round' keyword Bad value for shorthand CSS property
-FAIL Can set 'background-position' to the 'no-repeat' keyword Bad value for shorthand CSS property
+FAIL Can set 'background-position' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'background-position' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'background-position' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'background-position' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'background-position' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'background-position' to the 'repeat-x' keyword: repeat-x Bad value for shorthand CSS property
+FAIL Can set 'background-position' to the 'repeat-y' keyword: repeat-y Bad value for shorthand CSS property
+FAIL Can set 'background-position' to the 'repeat' keyword: repeat Bad value for shorthand CSS property
+FAIL Can set 'background-position' to the 'space' keyword: space Bad value for shorthand CSS property
+FAIL Can set 'background-position' to the 'round' keyword: round Bad value for shorthand CSS property
+FAIL Can set 'background-position' to the 'no-repeat' keyword: no-repeat Bad value for shorthand CSS property
 FAIL Setting 'background-position' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 FAIL Setting 'background-position' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'background-position' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt
@@ -1,11 +1,20 @@
 
-PASS Can set 'background-size' to CSS-wide keywords
-FAIL Can set 'background-size' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'background-size' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'background-size' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'background-size' to the 'auto' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-PASS Can set 'background-size' to the 'cover' keyword
-PASS Can set 'background-size' to the 'contain' keyword
+PASS Can set 'background-size' to CSS-wide keywords: initial
+PASS Can set 'background-size' to CSS-wide keywords: inherit
+PASS Can set 'background-size' to CSS-wide keywords: unset
+PASS Can set 'background-size' to CSS-wide keywords: revert
+FAIL Can set 'background-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'background-size' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'background-size' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'background-size' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'background-size' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'background-size' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'background-size' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'background-size' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'background-size' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'background-size' to the 'auto' keyword: auto assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'background-size' to the 'cover' keyword: cover
+PASS Can set 'background-size' to the 'contain' keyword: contain
 PASS Setting 'background-size' to a time throws TypeError
 PASS Setting 'background-size' to an angle throws TypeError
 PASS Setting 'background-size' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt
@@ -1,10 +1,19 @@
 
-PASS Can set 'baseline-shift' to CSS-wide keywords
-FAIL Can set 'baseline-shift' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'baseline-shift' to the 'sub' keyword
-PASS Can set 'baseline-shift' to the 'super' keyword
-PASS Can set 'baseline-shift' to a percent
-FAIL Can set 'baseline-shift' to a length assert_equals: unit expected "px" but got "em"
+PASS Can set 'baseline-shift' to CSS-wide keywords: initial
+PASS Can set 'baseline-shift' to CSS-wide keywords: inherit
+PASS Can set 'baseline-shift' to CSS-wide keywords: unset
+PASS Can set 'baseline-shift' to CSS-wide keywords: revert
+FAIL Can set 'baseline-shift' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'baseline-shift' to the 'sub' keyword: sub
+PASS Can set 'baseline-shift' to the 'super' keyword: super
+PASS Can set 'baseline-shift' to a percent: 0%
+PASS Can set 'baseline-shift' to a percent: -3.14%
+PASS Can set 'baseline-shift' to a percent: 3.14%
+PASS Can set 'baseline-shift' to a percent: calc(0% + 0%)
+PASS Can set 'baseline-shift' to a length: 0px
+FAIL Can set 'baseline-shift' to a length: -3.14em assert_equals: unit expected "px" but got "em"
+FAIL Can set 'baseline-shift' to a length: 3.14cm assert_equals: unit expected "px" but got "cm"
+PASS Can set 'baseline-shift' to a length: calc(0px + 0em)
 PASS Setting 'baseline-shift' to a time throws TypeError
 PASS Setting 'baseline-shift' to an angle throws TypeError
 PASS Setting 'baseline-shift' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt
@@ -1,30 +1,57 @@
 
-PASS Can set 'block-size' to CSS-wide keywords
-FAIL Can set 'block-size' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'block-size' to the 'auto' keyword
-FAIL Can set 'block-size' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'block-size' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'block-size' to CSS-wide keywords: initial
+PASS Can set 'block-size' to CSS-wide keywords: inherit
+PASS Can set 'block-size' to CSS-wide keywords: unset
+PASS Can set 'block-size' to CSS-wide keywords: revert
+FAIL Can set 'block-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'block-size' to the 'auto' keyword: auto
+PASS Can set 'block-size' to a percent: 0%
+FAIL Can set 'block-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'block-size' to a percent: 3.14%
+FAIL Can set 'block-size' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'block-size' to a length: 0px
+PASS Can set 'block-size' to a length: -3.14em
+PASS Can set 'block-size' to a length: 3.14cm
+FAIL Can set 'block-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'block-size' to a time throws TypeError
 PASS Setting 'block-size' to an angle throws TypeError
 PASS Setting 'block-size' to a flexible length throws TypeError
 FAIL Setting 'block-size' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'block-size' to a URL throws TypeError
 PASS Setting 'block-size' to a transform throws TypeError
-PASS Can set 'min-block-size' to CSS-wide keywords
-FAIL Can set 'min-block-size' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'min-block-size' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'min-block-size' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'min-block-size' to CSS-wide keywords: initial
+PASS Can set 'min-block-size' to CSS-wide keywords: inherit
+PASS Can set 'min-block-size' to CSS-wide keywords: unset
+PASS Can set 'min-block-size' to CSS-wide keywords: revert
+FAIL Can set 'min-block-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'min-block-size' to a percent: 0%
+FAIL Can set 'min-block-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'min-block-size' to a percent: 3.14%
+FAIL Can set 'min-block-size' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'min-block-size' to a length: 0px
+PASS Can set 'min-block-size' to a length: -3.14em
+PASS Can set 'min-block-size' to a length: 3.14cm
+FAIL Can set 'min-block-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'min-block-size' to a time throws TypeError
 PASS Setting 'min-block-size' to an angle throws TypeError
 PASS Setting 'min-block-size' to a flexible length throws TypeError
 FAIL Setting 'min-block-size' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'min-block-size' to a URL throws TypeError
 PASS Setting 'min-block-size' to a transform throws TypeError
-PASS Can set 'max-block-size' to CSS-wide keywords
-FAIL Can set 'max-block-size' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'max-block-size' to the 'none' keyword
-FAIL Can set 'max-block-size' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'max-block-size' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'max-block-size' to CSS-wide keywords: initial
+PASS Can set 'max-block-size' to CSS-wide keywords: inherit
+PASS Can set 'max-block-size' to CSS-wide keywords: unset
+PASS Can set 'max-block-size' to CSS-wide keywords: revert
+FAIL Can set 'max-block-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'max-block-size' to the 'none' keyword: none
+PASS Can set 'max-block-size' to a percent: 0%
+FAIL Can set 'max-block-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'max-block-size' to a percent: 3.14%
+FAIL Can set 'max-block-size' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'max-block-size' to a length: 0px
+PASS Can set 'max-block-size' to a length: -3.14em
+PASS Can set 'max-block-size' to a length: 3.14cm
+FAIL Can set 'max-block-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'max-block-size' to a time throws TypeError
 PASS Setting 'max-block-size' to an angle throws TypeError
 PASS Setting 'max-block-size' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-collapse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-collapse-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'border-collapse' to CSS-wide keywords
-FAIL Can set 'border-collapse' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-collapse' to the 'separate' keyword
-PASS Can set 'border-collapse' to the 'collapse' keyword
+PASS Can set 'border-collapse' to CSS-wide keywords: initial
+PASS Can set 'border-collapse' to CSS-wide keywords: inherit
+PASS Can set 'border-collapse' to CSS-wide keywords: unset
+PASS Can set 'border-collapse' to CSS-wide keywords: revert
+FAIL Can set 'border-collapse' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-collapse' to the 'separate' keyword: separate
+PASS Can set 'border-collapse' to the 'collapse' keyword: collapse
 PASS Setting 'border-collapse' to a length throws TypeError
 PASS Setting 'border-collapse' to a percent throws TypeError
 PASS Setting 'border-collapse' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-color-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'border-top-color' to CSS-wide keywords
-FAIL Can set 'border-top-color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-top-color' to the 'currentcolor' keyword
+PASS Can set 'border-top-color' to CSS-wide keywords: initial
+PASS Can set 'border-top-color' to CSS-wide keywords: inherit
+PASS Can set 'border-top-color' to CSS-wide keywords: unset
+PASS Can set 'border-top-color' to CSS-wide keywords: revert
+FAIL Can set 'border-top-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-top-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'border-top-color' to a length throws TypeError
 PASS Setting 'border-top-color' to a percent throws TypeError
 PASS Setting 'border-top-color' to a time throws TypeError
@@ -15,9 +18,12 @@ PASS 'border-top-color' does not supported '#bbff00'
 PASS 'border-top-color' does not supported 'rgb(255, 255, 128)'
 PASS 'border-top-color' does not supported 'hsl(50, 33%, 25%)'
 FAIL 'border-top-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS Can set 'border-left-color' to CSS-wide keywords
-FAIL Can set 'border-left-color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-left-color' to the 'currentcolor' keyword
+PASS Can set 'border-left-color' to CSS-wide keywords: initial
+PASS Can set 'border-left-color' to CSS-wide keywords: inherit
+PASS Can set 'border-left-color' to CSS-wide keywords: unset
+PASS Can set 'border-left-color' to CSS-wide keywords: revert
+FAIL Can set 'border-left-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-left-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'border-left-color' to a length throws TypeError
 PASS Setting 'border-left-color' to a percent throws TypeError
 PASS Setting 'border-left-color' to a time throws TypeError
@@ -31,9 +37,12 @@ PASS 'border-left-color' does not supported '#bbff00'
 PASS 'border-left-color' does not supported 'rgb(255, 255, 128)'
 PASS 'border-left-color' does not supported 'hsl(50, 33%, 25%)'
 FAIL 'border-left-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS Can set 'border-right-color' to CSS-wide keywords
-FAIL Can set 'border-right-color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-right-color' to the 'currentcolor' keyword
+PASS Can set 'border-right-color' to CSS-wide keywords: initial
+PASS Can set 'border-right-color' to CSS-wide keywords: inherit
+PASS Can set 'border-right-color' to CSS-wide keywords: unset
+PASS Can set 'border-right-color' to CSS-wide keywords: revert
+FAIL Can set 'border-right-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-right-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'border-right-color' to a length throws TypeError
 PASS Setting 'border-right-color' to a percent throws TypeError
 PASS Setting 'border-right-color' to a time throws TypeError
@@ -47,9 +56,12 @@ PASS 'border-right-color' does not supported '#bbff00'
 PASS 'border-right-color' does not supported 'rgb(255, 255, 128)'
 PASS 'border-right-color' does not supported 'hsl(50, 33%, 25%)'
 FAIL 'border-right-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS Can set 'border-bottom-color' to CSS-wide keywords
-FAIL Can set 'border-bottom-color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-bottom-color' to the 'currentcolor' keyword
+PASS Can set 'border-bottom-color' to CSS-wide keywords: initial
+PASS Can set 'border-bottom-color' to CSS-wide keywords: inherit
+PASS Can set 'border-bottom-color' to CSS-wide keywords: unset
+PASS Can set 'border-bottom-color' to CSS-wide keywords: revert
+FAIL Can set 'border-bottom-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-bottom-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'border-bottom-color' to a length throws TypeError
 PASS Setting 'border-bottom-color' to a percent throws TypeError
 PASS Setting 'border-bottom-color' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset-expected.txt
@@ -1,8 +1,17 @@
 
-PASS Can set 'border-image-outset' to CSS-wide keywords
-FAIL Can set 'border-image-outset' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-image-outset' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-outset' to a number assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-image-outset' to CSS-wide keywords: initial
+PASS Can set 'border-image-outset' to CSS-wide keywords: inherit
+PASS Can set 'border-image-outset' to CSS-wide keywords: unset
+PASS Can set 'border-image-outset' to CSS-wide keywords: revert
+FAIL Can set 'border-image-outset' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-image-outset' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-outset' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-outset' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-outset' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-image-outset' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-outset' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-outset' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-outset' to a number: calc(2 + 3) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'border-image-outset' to a percent throws TypeError
 PASS Setting 'border-image-outset' to a time throws TypeError
 PASS Setting 'border-image-outset' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat-expected.txt
@@ -1,10 +1,13 @@
 
-PASS Can set 'border-image-repeat' to CSS-wide keywords
-FAIL Can set 'border-image-repeat' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-image-repeat' to the 'stretch' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-repeat' to the 'repeat' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-repeat' to the 'round' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-repeat' to the 'space' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'border-image-repeat' to CSS-wide keywords: initial
+PASS Can set 'border-image-repeat' to CSS-wide keywords: inherit
+PASS Can set 'border-image-repeat' to CSS-wide keywords: unset
+PASS Can set 'border-image-repeat' to CSS-wide keywords: revert
+FAIL Can set 'border-image-repeat' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-image-repeat' to the 'stretch' keyword: stretch assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-repeat' to the 'repeat' keyword: repeat assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-repeat' to the 'round' keyword: round assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-repeat' to the 'space' keyword: space assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'border-image-repeat' to a length throws TypeError
 PASS Setting 'border-image-repeat' to a percent throws TypeError
 PASS Setting 'border-image-repeat' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice-expected.txt
@@ -1,8 +1,17 @@
 
-PASS Can set 'border-image-slice' to CSS-wide keywords
-FAIL Can set 'border-image-slice' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-image-slice' to a number assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-slice' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-image-slice' to CSS-wide keywords: initial
+PASS Can set 'border-image-slice' to CSS-wide keywords: inherit
+PASS Can set 'border-image-slice' to CSS-wide keywords: unset
+PASS Can set 'border-image-slice' to CSS-wide keywords: revert
+FAIL Can set 'border-image-slice' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-image-slice' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-slice' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-slice' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-slice' to a number: calc(2 + 3) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-image-slice' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-slice' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-slice' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-slice' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'border-image-slice' to a length throws TypeError
 PASS Setting 'border-image-slice' to a time throws TypeError
 PASS Setting 'border-image-slice' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-source-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-source-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'border-image-source' to CSS-wide keywords
-FAIL Can set 'border-image-source' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-image-source' to the 'none' keyword
+PASS Can set 'border-image-source' to CSS-wide keywords: initial
+PASS Can set 'border-image-source' to CSS-wide keywords: inherit
+PASS Can set 'border-image-source' to CSS-wide keywords: unset
+PASS Can set 'border-image-source' to CSS-wide keywords: revert
+FAIL Can set 'border-image-source' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-image-source' to the 'none' keyword: none
 PASS Can set 'border-image-source' to an image
 PASS Setting 'border-image-source' to a length throws TypeError
 PASS Setting 'border-image-source' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width-expected.txt
@@ -1,10 +1,22 @@
 
-PASS Can set 'border-image-width' to CSS-wide keywords
-FAIL Can set 'border-image-width' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-image-width' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-width' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-width' to a number assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-width' to the 'auto' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'border-image-width' to CSS-wide keywords: initial
+PASS Can set 'border-image-width' to CSS-wide keywords: inherit
+PASS Can set 'border-image-width' to CSS-wide keywords: unset
+PASS Can set 'border-image-width' to CSS-wide keywords: revert
+FAIL Can set 'border-image-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-image-width' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-width' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-width' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-image-width' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-width' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-width' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-width' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-image-width' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-width' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-width' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-image-width' to a number: calc(2 + 3) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-image-width' to the 'auto' keyword: auto assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'border-image-width' to a time throws TypeError
 PASS Setting 'border-image-width' to an angle throws TypeError
 PASS Setting 'border-image-width' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt
@@ -1,38 +1,74 @@
 
-PASS Can set 'border-top-left-radius' to CSS-wide keywords
-FAIL Can set 'border-top-left-radius' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-top-left-radius' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-top-left-radius' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-top-left-radius' to CSS-wide keywords: initial
+PASS Can set 'border-top-left-radius' to CSS-wide keywords: inherit
+PASS Can set 'border-top-left-radius' to CSS-wide keywords: unset
+PASS Can set 'border-top-left-radius' to CSS-wide keywords: revert
+FAIL Can set 'border-top-left-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-top-left-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-top-left-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-top-left-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-top-left-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-top-left-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-top-left-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-top-left-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-top-left-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'border-top-left-radius' to a time throws TypeError
 PASS Setting 'border-top-left-radius' to an angle throws TypeError
 PASS Setting 'border-top-left-radius' to a flexible length throws TypeError
 FAIL Setting 'border-top-left-radius' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-top-left-radius' to a URL throws TypeError
 PASS Setting 'border-top-left-radius' to a transform throws TypeError
-PASS Can set 'border-top-right-radius' to CSS-wide keywords
-FAIL Can set 'border-top-right-radius' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-top-right-radius' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-top-right-radius' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-top-right-radius' to CSS-wide keywords: initial
+PASS Can set 'border-top-right-radius' to CSS-wide keywords: inherit
+PASS Can set 'border-top-right-radius' to CSS-wide keywords: unset
+PASS Can set 'border-top-right-radius' to CSS-wide keywords: revert
+FAIL Can set 'border-top-right-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-top-right-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-top-right-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-top-right-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-top-right-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-top-right-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-top-right-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-top-right-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-top-right-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'border-top-right-radius' to a time throws TypeError
 PASS Setting 'border-top-right-radius' to an angle throws TypeError
 PASS Setting 'border-top-right-radius' to a flexible length throws TypeError
 FAIL Setting 'border-top-right-radius' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-top-right-radius' to a URL throws TypeError
 PASS Setting 'border-top-right-radius' to a transform throws TypeError
-PASS Can set 'border-bottom-left-radius' to CSS-wide keywords
-FAIL Can set 'border-bottom-left-radius' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-bottom-left-radius' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-bottom-left-radius' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-bottom-left-radius' to CSS-wide keywords: initial
+PASS Can set 'border-bottom-left-radius' to CSS-wide keywords: inherit
+PASS Can set 'border-bottom-left-radius' to CSS-wide keywords: unset
+PASS Can set 'border-bottom-left-radius' to CSS-wide keywords: revert
+FAIL Can set 'border-bottom-left-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-bottom-left-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-bottom-left-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-bottom-left-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-bottom-left-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-bottom-left-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-bottom-left-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-bottom-left-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-bottom-left-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'border-bottom-left-radius' to a time throws TypeError
 PASS Setting 'border-bottom-left-radius' to an angle throws TypeError
 PASS Setting 'border-bottom-left-radius' to a flexible length throws TypeError
 FAIL Setting 'border-bottom-left-radius' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-bottom-left-radius' to a URL throws TypeError
 PASS Setting 'border-bottom-left-radius' to a transform throws TypeError
-PASS Can set 'border-bottom-right-radius' to CSS-wide keywords
-FAIL Can set 'border-bottom-right-radius' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-bottom-right-radius' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-bottom-right-radius' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-bottom-right-radius' to CSS-wide keywords: initial
+PASS Can set 'border-bottom-right-radius' to CSS-wide keywords: inherit
+PASS Can set 'border-bottom-right-radius' to CSS-wide keywords: unset
+PASS Can set 'border-bottom-right-radius' to CSS-wide keywords: revert
+FAIL Can set 'border-bottom-right-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-bottom-right-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-bottom-right-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-bottom-right-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-bottom-right-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-bottom-right-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-bottom-right-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-bottom-right-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-bottom-right-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'border-bottom-right-radius' to a time throws TypeError
 PASS Setting 'border-bottom-right-radius' to an angle throws TypeError
 PASS Setting 'border-bottom-right-radius' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-style-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'border-top-style' to CSS-wide keywords
-FAIL Can set 'border-top-style' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-top-style' to the 'none' keyword
-PASS Can set 'border-top-style' to the 'solid' keyword
+PASS Can set 'border-top-style' to CSS-wide keywords: initial
+PASS Can set 'border-top-style' to CSS-wide keywords: inherit
+PASS Can set 'border-top-style' to CSS-wide keywords: unset
+PASS Can set 'border-top-style' to CSS-wide keywords: revert
+FAIL Can set 'border-top-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-top-style' to the 'none' keyword: none
+PASS Can set 'border-top-style' to the 'solid' keyword: solid
 PASS Setting 'border-top-style' to a length throws TypeError
 PASS Setting 'border-top-style' to a percent throws TypeError
 PASS Setting 'border-top-style' to a time throws TypeError
@@ -11,10 +14,13 @@ PASS Setting 'border-top-style' to a flexible length throws TypeError
 PASS Setting 'border-top-style' to a number throws TypeError
 PASS Setting 'border-top-style' to a URL throws TypeError
 PASS Setting 'border-top-style' to a transform throws TypeError
-PASS Can set 'border-left-style' to CSS-wide keywords
-FAIL Can set 'border-left-style' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-left-style' to the 'none' keyword
-PASS Can set 'border-left-style' to the 'solid' keyword
+PASS Can set 'border-left-style' to CSS-wide keywords: initial
+PASS Can set 'border-left-style' to CSS-wide keywords: inherit
+PASS Can set 'border-left-style' to CSS-wide keywords: unset
+PASS Can set 'border-left-style' to CSS-wide keywords: revert
+FAIL Can set 'border-left-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-left-style' to the 'none' keyword: none
+PASS Can set 'border-left-style' to the 'solid' keyword: solid
 PASS Setting 'border-left-style' to a length throws TypeError
 PASS Setting 'border-left-style' to a percent throws TypeError
 PASS Setting 'border-left-style' to a time throws TypeError
@@ -23,10 +29,13 @@ PASS Setting 'border-left-style' to a flexible length throws TypeError
 PASS Setting 'border-left-style' to a number throws TypeError
 PASS Setting 'border-left-style' to a URL throws TypeError
 PASS Setting 'border-left-style' to a transform throws TypeError
-PASS Can set 'border-right-style' to CSS-wide keywords
-FAIL Can set 'border-right-style' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-right-style' to the 'none' keyword
-PASS Can set 'border-right-style' to the 'solid' keyword
+PASS Can set 'border-right-style' to CSS-wide keywords: initial
+PASS Can set 'border-right-style' to CSS-wide keywords: inherit
+PASS Can set 'border-right-style' to CSS-wide keywords: unset
+PASS Can set 'border-right-style' to CSS-wide keywords: revert
+FAIL Can set 'border-right-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-right-style' to the 'none' keyword: none
+PASS Can set 'border-right-style' to the 'solid' keyword: solid
 PASS Setting 'border-right-style' to a length throws TypeError
 PASS Setting 'border-right-style' to a percent throws TypeError
 PASS Setting 'border-right-style' to a time throws TypeError
@@ -35,10 +44,13 @@ PASS Setting 'border-right-style' to a flexible length throws TypeError
 PASS Setting 'border-right-style' to a number throws TypeError
 PASS Setting 'border-right-style' to a URL throws TypeError
 PASS Setting 'border-right-style' to a transform throws TypeError
-PASS Can set 'border-bottom-style' to CSS-wide keywords
-FAIL Can set 'border-bottom-style' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-bottom-style' to the 'none' keyword
-PASS Can set 'border-bottom-style' to the 'solid' keyword
+PASS Can set 'border-bottom-style' to CSS-wide keywords: initial
+PASS Can set 'border-bottom-style' to CSS-wide keywords: inherit
+PASS Can set 'border-bottom-style' to CSS-wide keywords: unset
+PASS Can set 'border-bottom-style' to CSS-wide keywords: revert
+FAIL Can set 'border-bottom-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-bottom-style' to the 'none' keyword: none
+PASS Can set 'border-bottom-style' to the 'solid' keyword: solid
 PASS Setting 'border-bottom-style' to a length throws TypeError
 PASS Setting 'border-bottom-style' to a percent throws TypeError
 PASS Setting 'border-bottom-style' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt
@@ -1,10 +1,16 @@
 
-PASS Can set 'border-top-width' to CSS-wide keywords
-FAIL Can set 'border-top-width' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-top-width' to the 'thin' keyword
-PASS Can set 'border-top-width' to the 'medium' keyword
-PASS Can set 'border-top-width' to the 'thick' keyword
-FAIL Can set 'border-top-width' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'border-top-width' to CSS-wide keywords: initial
+PASS Can set 'border-top-width' to CSS-wide keywords: inherit
+PASS Can set 'border-top-width' to CSS-wide keywords: unset
+PASS Can set 'border-top-width' to CSS-wide keywords: revert
+FAIL Can set 'border-top-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-top-width' to the 'thin' keyword: thin
+PASS Can set 'border-top-width' to the 'medium' keyword: medium
+PASS Can set 'border-top-width' to the 'thick' keyword: thick
+PASS Can set 'border-top-width' to a length: 0px
+PASS Can set 'border-top-width' to a length: -3.14em
+PASS Can set 'border-top-width' to a length: 3.14cm
+FAIL Can set 'border-top-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'border-top-width' to a percent throws TypeError
 PASS Setting 'border-top-width' to a time throws TypeError
 PASS Setting 'border-top-width' to an angle throws TypeError
@@ -12,12 +18,18 @@ PASS Setting 'border-top-width' to a flexible length throws TypeError
 FAIL Setting 'border-top-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-top-width' to a URL throws TypeError
 PASS Setting 'border-top-width' to a transform throws TypeError
-PASS Can set 'border-left-width' to CSS-wide keywords
-FAIL Can set 'border-left-width' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-left-width' to the 'thin' keyword
-PASS Can set 'border-left-width' to the 'medium' keyword
-PASS Can set 'border-left-width' to the 'thick' keyword
-FAIL Can set 'border-left-width' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'border-left-width' to CSS-wide keywords: initial
+PASS Can set 'border-left-width' to CSS-wide keywords: inherit
+PASS Can set 'border-left-width' to CSS-wide keywords: unset
+PASS Can set 'border-left-width' to CSS-wide keywords: revert
+FAIL Can set 'border-left-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-left-width' to the 'thin' keyword: thin
+PASS Can set 'border-left-width' to the 'medium' keyword: medium
+PASS Can set 'border-left-width' to the 'thick' keyword: thick
+PASS Can set 'border-left-width' to a length: 0px
+PASS Can set 'border-left-width' to a length: -3.14em
+PASS Can set 'border-left-width' to a length: 3.14cm
+FAIL Can set 'border-left-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'border-left-width' to a percent throws TypeError
 PASS Setting 'border-left-width' to a time throws TypeError
 PASS Setting 'border-left-width' to an angle throws TypeError
@@ -25,12 +37,18 @@ PASS Setting 'border-left-width' to a flexible length throws TypeError
 FAIL Setting 'border-left-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-left-width' to a URL throws TypeError
 PASS Setting 'border-left-width' to a transform throws TypeError
-PASS Can set 'border-right-width' to CSS-wide keywords
-FAIL Can set 'border-right-width' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-right-width' to the 'thin' keyword
-PASS Can set 'border-right-width' to the 'medium' keyword
-PASS Can set 'border-right-width' to the 'thick' keyword
-FAIL Can set 'border-right-width' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'border-right-width' to CSS-wide keywords: initial
+PASS Can set 'border-right-width' to CSS-wide keywords: inherit
+PASS Can set 'border-right-width' to CSS-wide keywords: unset
+PASS Can set 'border-right-width' to CSS-wide keywords: revert
+FAIL Can set 'border-right-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-right-width' to the 'thin' keyword: thin
+PASS Can set 'border-right-width' to the 'medium' keyword: medium
+PASS Can set 'border-right-width' to the 'thick' keyword: thick
+PASS Can set 'border-right-width' to a length: 0px
+PASS Can set 'border-right-width' to a length: -3.14em
+PASS Can set 'border-right-width' to a length: 3.14cm
+FAIL Can set 'border-right-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'border-right-width' to a percent throws TypeError
 PASS Setting 'border-right-width' to a time throws TypeError
 PASS Setting 'border-right-width' to an angle throws TypeError
@@ -38,12 +56,18 @@ PASS Setting 'border-right-width' to a flexible length throws TypeError
 FAIL Setting 'border-right-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-right-width' to a URL throws TypeError
 PASS Setting 'border-right-width' to a transform throws TypeError
-PASS Can set 'border-bottom-width' to CSS-wide keywords
-FAIL Can set 'border-bottom-width' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-bottom-width' to the 'thin' keyword
-PASS Can set 'border-bottom-width' to the 'medium' keyword
-PASS Can set 'border-bottom-width' to the 'thick' keyword
-FAIL Can set 'border-bottom-width' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'border-bottom-width' to CSS-wide keywords: initial
+PASS Can set 'border-bottom-width' to CSS-wide keywords: inherit
+PASS Can set 'border-bottom-width' to CSS-wide keywords: unset
+PASS Can set 'border-bottom-width' to CSS-wide keywords: revert
+FAIL Can set 'border-bottom-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-bottom-width' to the 'thin' keyword: thin
+PASS Can set 'border-bottom-width' to the 'medium' keyword: medium
+PASS Can set 'border-bottom-width' to the 'thick' keyword: thick
+PASS Can set 'border-bottom-width' to a length: 0px
+PASS Can set 'border-bottom-width' to a length: -3.14em
+PASS Can set 'border-bottom-width' to a length: 3.14cm
+FAIL Can set 'border-bottom-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'border-bottom-width' to a percent throws TypeError
 PASS Setting 'border-bottom-width' to a time throws TypeError
 PASS Setting 'border-bottom-width' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/bottom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/bottom-expected.txt
@@ -1,9 +1,18 @@
 
-PASS Can set 'bottom' to CSS-wide keywords
-FAIL Can set 'bottom' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'bottom' to the 'auto' keyword
-PASS Can set 'bottom' to a percent
-PASS Can set 'bottom' to a length
+PASS Can set 'bottom' to CSS-wide keywords: initial
+PASS Can set 'bottom' to CSS-wide keywords: inherit
+PASS Can set 'bottom' to CSS-wide keywords: unset
+PASS Can set 'bottom' to CSS-wide keywords: revert
+FAIL Can set 'bottom' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'bottom' to the 'auto' keyword: auto
+PASS Can set 'bottom' to a percent: 0%
+PASS Can set 'bottom' to a percent: -3.14%
+PASS Can set 'bottom' to a percent: 3.14%
+PASS Can set 'bottom' to a percent: calc(0% + 0%)
+PASS Can set 'bottom' to a length: 0px
+PASS Can set 'bottom' to a length: -3.14em
+PASS Can set 'bottom' to a length: 3.14cm
+PASS Can set 'bottom' to a length: calc(0px + 0em)
 PASS Setting 'bottom' to a time throws TypeError
 PASS Setting 'bottom' to an angle throws TypeError
 PASS Setting 'bottom' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-shadow-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'box-shadow' to CSS-wide keywords
-FAIL Can set 'box-shadow' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'box-shadow' to the 'none' keyword
+PASS Can set 'box-shadow' to CSS-wide keywords: initial
+PASS Can set 'box-shadow' to CSS-wide keywords: inherit
+PASS Can set 'box-shadow' to CSS-wide keywords: unset
+PASS Can set 'box-shadow' to CSS-wide keywords: revert
+FAIL Can set 'box-shadow' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'box-shadow' to the 'none' keyword: none
 PASS Setting 'box-shadow' to a length throws TypeError
 PASS Setting 'box-shadow' to a percent throws TypeError
 PASS Setting 'box-shadow' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-sizing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-sizing-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'box-sizing' to CSS-wide keywords
-FAIL Can set 'box-sizing' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'box-sizing' to the 'content-box' keyword
-PASS Can set 'box-sizing' to the 'border-box' keyword
+PASS Can set 'box-sizing' to CSS-wide keywords: initial
+PASS Can set 'box-sizing' to CSS-wide keywords: inherit
+PASS Can set 'box-sizing' to CSS-wide keywords: unset
+PASS Can set 'box-sizing' to CSS-wide keywords: revert
+FAIL Can set 'box-sizing' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'box-sizing' to the 'content-box' keyword: content-box
+PASS Can set 'box-sizing' to the 'border-box' keyword: border-box
 PASS Setting 'box-sizing' to a length throws TypeError
 PASS Setting 'box-sizing' to a percent throws TypeError
 PASS Setting 'box-sizing' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/break-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/break-expected.txt
@@ -1,18 +1,21 @@
 
-PASS Can set 'break-after' to CSS-wide keywords
-FAIL Can set 'break-after' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'break-after' to the 'auto' keyword
-PASS Can set 'break-after' to the 'avoid' keyword
-PASS Can set 'break-after' to the 'avoid-column' keyword
-PASS Can set 'break-after' to the 'avoid-page' keyword
-FAIL Can set 'break-after' to the 'avoid-region' keyword Invalid values
-PASS Can set 'break-after' to the 'column' keyword
-PASS Can set 'break-after' to the 'left' keyword
-PASS Can set 'break-after' to the 'page' keyword
-PASS Can set 'break-after' to the 'recto' keyword
-FAIL Can set 'break-after' to the 'region' keyword Invalid values
-PASS Can set 'break-after' to the 'right' keyword
-PASS Can set 'break-after' to the 'verso' keyword
+PASS Can set 'break-after' to CSS-wide keywords: initial
+PASS Can set 'break-after' to CSS-wide keywords: inherit
+PASS Can set 'break-after' to CSS-wide keywords: unset
+PASS Can set 'break-after' to CSS-wide keywords: revert
+FAIL Can set 'break-after' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'break-after' to the 'auto' keyword: auto
+PASS Can set 'break-after' to the 'avoid' keyword: avoid
+PASS Can set 'break-after' to the 'avoid-column' keyword: avoid-column
+PASS Can set 'break-after' to the 'avoid-page' keyword: avoid-page
+FAIL Can set 'break-after' to the 'avoid-region' keyword: avoid-region Invalid values
+PASS Can set 'break-after' to the 'column' keyword: column
+PASS Can set 'break-after' to the 'left' keyword: left
+PASS Can set 'break-after' to the 'page' keyword: page
+PASS Can set 'break-after' to the 'recto' keyword: recto
+FAIL Can set 'break-after' to the 'region' keyword: region Invalid values
+PASS Can set 'break-after' to the 'right' keyword: right
+PASS Can set 'break-after' to the 'verso' keyword: verso
 PASS Setting 'break-after' to a length throws TypeError
 PASS Setting 'break-after' to a percent throws TypeError
 PASS Setting 'break-after' to a time throws TypeError
@@ -21,20 +24,23 @@ PASS Setting 'break-after' to a flexible length throws TypeError
 PASS Setting 'break-after' to a number throws TypeError
 PASS Setting 'break-after' to a URL throws TypeError
 PASS Setting 'break-after' to a transform throws TypeError
-PASS Can set 'break-before' to CSS-wide keywords
-FAIL Can set 'break-before' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'break-before' to the 'auto' keyword
-PASS Can set 'break-before' to the 'avoid' keyword
-PASS Can set 'break-before' to the 'avoid-column' keyword
-PASS Can set 'break-before' to the 'avoid-page' keyword
-FAIL Can set 'break-before' to the 'avoid-region' keyword Invalid values
-PASS Can set 'break-before' to the 'column' keyword
-PASS Can set 'break-before' to the 'left' keyword
-PASS Can set 'break-before' to the 'page' keyword
-PASS Can set 'break-before' to the 'recto' keyword
-FAIL Can set 'break-before' to the 'region' keyword Invalid values
-PASS Can set 'break-before' to the 'right' keyword
-PASS Can set 'break-before' to the 'verso' keyword
+PASS Can set 'break-before' to CSS-wide keywords: initial
+PASS Can set 'break-before' to CSS-wide keywords: inherit
+PASS Can set 'break-before' to CSS-wide keywords: unset
+PASS Can set 'break-before' to CSS-wide keywords: revert
+FAIL Can set 'break-before' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'break-before' to the 'auto' keyword: auto
+PASS Can set 'break-before' to the 'avoid' keyword: avoid
+PASS Can set 'break-before' to the 'avoid-column' keyword: avoid-column
+PASS Can set 'break-before' to the 'avoid-page' keyword: avoid-page
+FAIL Can set 'break-before' to the 'avoid-region' keyword: avoid-region Invalid values
+PASS Can set 'break-before' to the 'column' keyword: column
+PASS Can set 'break-before' to the 'left' keyword: left
+PASS Can set 'break-before' to the 'page' keyword: page
+PASS Can set 'break-before' to the 'recto' keyword: recto
+FAIL Can set 'break-before' to the 'region' keyword: region Invalid values
+PASS Can set 'break-before' to the 'right' keyword: right
+PASS Can set 'break-before' to the 'verso' keyword: verso
 PASS Setting 'break-before' to a length throws TypeError
 PASS Setting 'break-before' to a percent throws TypeError
 PASS Setting 'break-before' to a time throws TypeError
@@ -43,13 +49,16 @@ PASS Setting 'break-before' to a flexible length throws TypeError
 PASS Setting 'break-before' to a number throws TypeError
 PASS Setting 'break-before' to a URL throws TypeError
 PASS Setting 'break-before' to a transform throws TypeError
-PASS Can set 'break-inside' to CSS-wide keywords
-FAIL Can set 'break-inside' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'break-inside' to the 'auto' keyword
-PASS Can set 'break-inside' to the 'avoid' keyword
-PASS Can set 'break-inside' to the 'avoid-column' keyword
-PASS Can set 'break-inside' to the 'avoid-page' keyword
-FAIL Can set 'break-inside' to the 'avoid-region' keyword Invalid values
+PASS Can set 'break-inside' to CSS-wide keywords: initial
+PASS Can set 'break-inside' to CSS-wide keywords: inherit
+PASS Can set 'break-inside' to CSS-wide keywords: unset
+PASS Can set 'break-inside' to CSS-wide keywords: revert
+FAIL Can set 'break-inside' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'break-inside' to the 'auto' keyword: auto
+PASS Can set 'break-inside' to the 'avoid' keyword: avoid
+PASS Can set 'break-inside' to the 'avoid-column' keyword: avoid-column
+PASS Can set 'break-inside' to the 'avoid-page' keyword: avoid-page
+FAIL Can set 'break-inside' to the 'avoid-region' keyword: avoid-region Invalid values
 PASS Setting 'break-inside' to a length throws TypeError
 PASS Setting 'break-inside' to a percent throws TypeError
 PASS Setting 'break-inside' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caption-side-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caption-side-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'caption-side' to CSS-wide keywords
-FAIL Can set 'caption-side' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'caption-side' to the 'top' keyword
-PASS Can set 'caption-side' to the 'bottom' keyword
+PASS Can set 'caption-side' to CSS-wide keywords: initial
+PASS Can set 'caption-side' to CSS-wide keywords: inherit
+PASS Can set 'caption-side' to CSS-wide keywords: unset
+PASS Can set 'caption-side' to CSS-wide keywords: revert
+FAIL Can set 'caption-side' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'caption-side' to the 'top' keyword: top
+PASS Can set 'caption-side' to the 'bottom' keyword: bottom
 PASS Setting 'caption-side' to a length throws TypeError
 PASS Setting 'caption-side' to a percent throws TypeError
 PASS Setting 'caption-side' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caret-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caret-color-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'caret-color' to CSS-wide keywords
-FAIL Can set 'caret-color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'caret-color' to the 'currentcolor' keyword
-PASS Can set 'caret-color' to the 'auto' keyword
+PASS Can set 'caret-color' to CSS-wide keywords: initial
+PASS Can set 'caret-color' to CSS-wide keywords: inherit
+PASS Can set 'caret-color' to CSS-wide keywords: unset
+PASS Can set 'caret-color' to CSS-wide keywords: revert
+FAIL Can set 'caret-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'caret-color' to the 'currentcolor' keyword: currentcolor
+PASS Can set 'caret-color' to the 'auto' keyword: auto
 PASS Setting 'caret-color' to a length throws TypeError
 PASS Setting 'caret-color' to a percent throws TypeError
 PASS Setting 'caret-color' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt
@@ -1,18 +1,36 @@
 
-PASS Can set 'cx' to CSS-wide keywords
-FAIL Can set 'cx' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'cx' to a percent
-PASS Can set 'cx' to a length
+PASS Can set 'cx' to CSS-wide keywords: initial
+PASS Can set 'cx' to CSS-wide keywords: inherit
+PASS Can set 'cx' to CSS-wide keywords: unset
+PASS Can set 'cx' to CSS-wide keywords: revert
+FAIL Can set 'cx' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'cx' to a percent: 0%
+PASS Can set 'cx' to a percent: -3.14%
+PASS Can set 'cx' to a percent: 3.14%
+PASS Can set 'cx' to a percent: calc(0% + 0%)
+PASS Can set 'cx' to a length: 0px
+PASS Can set 'cx' to a length: -3.14em
+PASS Can set 'cx' to a length: 3.14cm
+PASS Can set 'cx' to a length: calc(0px + 0em)
 PASS Setting 'cx' to a time throws TypeError
 PASS Setting 'cx' to an angle throws TypeError
 PASS Setting 'cx' to a flexible length throws TypeError
 FAIL Setting 'cx' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'cx' to a URL throws TypeError
 PASS Setting 'cx' to a transform throws TypeError
-PASS Can set 'cy' to CSS-wide keywords
-FAIL Can set 'cy' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'cy' to a percent
-PASS Can set 'cy' to a length
+PASS Can set 'cy' to CSS-wide keywords: initial
+PASS Can set 'cy' to CSS-wide keywords: inherit
+PASS Can set 'cy' to CSS-wide keywords: unset
+PASS Can set 'cy' to CSS-wide keywords: revert
+FAIL Can set 'cy' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'cy' to a percent: 0%
+PASS Can set 'cy' to a percent: -3.14%
+PASS Can set 'cy' to a percent: 3.14%
+PASS Can set 'cy' to a percent: calc(0% + 0%)
+PASS Can set 'cy' to a length: 0px
+PASS Can set 'cy' to a length: -3.14em
+PASS Can set 'cy' to a length: 3.14cm
+PASS Can set 'cy' to a length: calc(0px + 0em)
 PASS Setting 'cy' to a time throws TypeError
 PASS Setting 'cy' to an angle throws TypeError
 PASS Setting 'cy' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clear-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clear-expected.txt
@@ -1,10 +1,13 @@
 
-PASS Can set 'clear' to CSS-wide keywords
-FAIL Can set 'clear' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'clear' to the 'none' keyword
-PASS Can set 'clear' to the 'left' keyword
-PASS Can set 'clear' to the 'right' keyword
-PASS Can set 'clear' to the 'both' keyword
+PASS Can set 'clear' to CSS-wide keywords: initial
+PASS Can set 'clear' to CSS-wide keywords: inherit
+PASS Can set 'clear' to CSS-wide keywords: unset
+PASS Can set 'clear' to CSS-wide keywords: revert
+FAIL Can set 'clear' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'clear' to the 'none' keyword: none
+PASS Can set 'clear' to the 'left' keyword: left
+PASS Can set 'clear' to the 'right' keyword: right
+PASS Can set 'clear' to the 'both' keyword: both
 PASS Setting 'clear' to a length throws TypeError
 PASS Setting 'clear' to a percent throws TypeError
 PASS Setting 'clear' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'clip' to CSS-wide keywords
-FAIL Can set 'clip' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'clip' to the 'auto' keyword
+PASS Can set 'clip' to CSS-wide keywords: initial
+PASS Can set 'clip' to CSS-wide keywords: inherit
+PASS Can set 'clip' to CSS-wide keywords: unset
+PASS Can set 'clip' to CSS-wide keywords: revert
+FAIL Can set 'clip' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'clip' to the 'auto' keyword: auto
 PASS Setting 'clip' to a length throws TypeError
 PASS Setting 'clip' to a percent throws TypeError
 PASS Setting 'clip' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-path-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-path-expected.txt
@@ -1,15 +1,17 @@
 
-PASS Can set 'clip-path' to CSS-wide keywords
-FAIL Can set 'clip-path' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'clip-path' to the 'none' keyword
-PASS Can set 'clip-path' to the 'fill-box' keyword
-PASS Can set 'clip-path' to the 'stroke-box' keyword
-PASS Can set 'clip-path' to the 'view-box' keyword
-PASS Can set 'clip-path' to the 'margin-box' keyword
-PASS Can set 'clip-path' to the 'border-box' keyword
-PASS Can set 'clip-path' to the 'padding-box' keyword
-PASS Can set 'clip-path' to the 'content-box' keyword
-PASS Can set 'clip-path' to a URL
+PASS Can set 'clip-path' to CSS-wide keywords: initial
+PASS Can set 'clip-path' to CSS-wide keywords: inherit
+PASS Can set 'clip-path' to CSS-wide keywords: unset
+PASS Can set 'clip-path' to CSS-wide keywords: revert
+FAIL Can set 'clip-path' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'clip-path' to the 'none' keyword: none
+PASS Can set 'clip-path' to the 'fill-box' keyword: fill-box
+PASS Can set 'clip-path' to the 'stroke-box' keyword: stroke-box
+PASS Can set 'clip-path' to the 'view-box' keyword: view-box
+PASS Can set 'clip-path' to the 'margin-box' keyword: margin-box
+PASS Can set 'clip-path' to the 'border-box' keyword: border-box
+PASS Can set 'clip-path' to the 'padding-box' keyword: padding-box
+PASS Can set 'clip-path' to the 'content-box' keyword: content-box
 PASS Setting 'clip-path' to a length throws TypeError
 PASS Setting 'clip-path' to a percent throws TypeError
 PASS Setting 'clip-path' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-rule-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'clip-rule' to CSS-wide keywords
-FAIL Can set 'clip-rule' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'clip-rule' to the 'nonzero' keyword
-PASS Can set 'clip-rule' to the 'evenodd' keyword
+PASS Can set 'clip-rule' to CSS-wide keywords: initial
+PASS Can set 'clip-rule' to CSS-wide keywords: inherit
+PASS Can set 'clip-rule' to CSS-wide keywords: unset
+PASS Can set 'clip-rule' to CSS-wide keywords: revert
+FAIL Can set 'clip-rule' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'clip-rule' to the 'nonzero' keyword: nonzero
+PASS Can set 'clip-rule' to the 'evenodd' keyword: evenodd
 PASS Setting 'clip-rule' to a length throws TypeError
 PASS Setting 'clip-rule' to a percent throws TypeError
 PASS Setting 'clip-rule' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'color' to CSS-wide keywords
-FAIL Can set 'color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'color' to the 'currentcolor' keyword
+PASS Can set 'color' to CSS-wide keywords: initial
+PASS Can set 'color' to CSS-wide keywords: inherit
+PASS Can set 'color' to CSS-wide keywords: unset
+PASS Can set 'color' to CSS-wide keywords: revert
+FAIL Can set 'color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'color' to a length throws TypeError
 PASS Setting 'color' to a percent throws TypeError
 PASS Setting 'color' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-interpolation-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'color-interpolation' to CSS-wide keywords
-FAIL Can set 'color-interpolation' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'color-interpolation' to the 'auto' keyword
-FAIL Can set 'color-interpolation' to the 'srgb' keyword assert_equals: expected "srgb" but got "sRGB"
-FAIL Can set 'color-interpolation' to the 'linearrgb' keyword assert_equals: expected "linearrgb" but got "linearRGB"
+PASS Can set 'color-interpolation' to CSS-wide keywords: initial
+PASS Can set 'color-interpolation' to CSS-wide keywords: inherit
+PASS Can set 'color-interpolation' to CSS-wide keywords: unset
+PASS Can set 'color-interpolation' to CSS-wide keywords: revert
+FAIL Can set 'color-interpolation' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'color-interpolation' to the 'auto' keyword: auto
+FAIL Can set 'color-interpolation' to the 'srgb' keyword: srgb assert_equals: expected "srgb" but got "sRGB"
+FAIL Can set 'color-interpolation' to the 'linearrgb' keyword: linearrgb assert_equals: expected "linearrgb" but got "linearRGB"
 PASS Setting 'color-interpolation' to a length throws TypeError
 PASS Setting 'color-interpolation' to a percent throws TypeError
 PASS Setting 'color-interpolation' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-count-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-count-expected.txt
@@ -1,8 +1,14 @@
 
-PASS Can set 'column-count' to CSS-wide keywords
-FAIL Can set 'column-count' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'column-count' to the 'auto' keyword
-FAIL Can set 'column-count' to a number assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+PASS Can set 'column-count' to CSS-wide keywords: initial
+PASS Can set 'column-count' to CSS-wide keywords: inherit
+PASS Can set 'column-count' to CSS-wide keywords: unset
+PASS Can set 'column-count' to CSS-wide keywords: revert
+FAIL Can set 'column-count' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'column-count' to the 'auto' keyword: auto
+FAIL Can set 'column-count' to a number: 0 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'column-count' to a number: -3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'column-count' to a number: 3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'column-count' to a number: calc(2 + 3) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
 PASS Setting 'column-count' to a length throws TypeError
 PASS Setting 'column-count' to a percent throws TypeError
 PASS Setting 'column-count' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-color-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'column-rule-color' to CSS-wide keywords
-FAIL Can set 'column-rule-color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'column-rule-color' to the 'currentcolor' keyword
+PASS Can set 'column-rule-color' to CSS-wide keywords: initial
+PASS Can set 'column-rule-color' to CSS-wide keywords: inherit
+PASS Can set 'column-rule-color' to CSS-wide keywords: unset
+PASS Can set 'column-rule-color' to CSS-wide keywords: revert
+FAIL Can set 'column-rule-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'column-rule-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'column-rule-color' to a length throws TypeError
 PASS Setting 'column-rule-color' to a percent throws TypeError
 PASS Setting 'column-rule-color' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-style-expected.txt
@@ -1,16 +1,19 @@
 
-PASS Can set 'column-rule-style' to CSS-wide keywords
-FAIL Can set 'column-rule-style' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'column-rule-style' to the 'none' keyword
-PASS Can set 'column-rule-style' to the 'hidden' keyword
-PASS Can set 'column-rule-style' to the 'dotted' keyword
-PASS Can set 'column-rule-style' to the 'dashed' keyword
-PASS Can set 'column-rule-style' to the 'solid' keyword
-PASS Can set 'column-rule-style' to the 'double' keyword
-PASS Can set 'column-rule-style' to the 'groove' keyword
-PASS Can set 'column-rule-style' to the 'ridge' keyword
-PASS Can set 'column-rule-style' to the 'inset' keyword
-PASS Can set 'column-rule-style' to the 'outset' keyword
+PASS Can set 'column-rule-style' to CSS-wide keywords: initial
+PASS Can set 'column-rule-style' to CSS-wide keywords: inherit
+PASS Can set 'column-rule-style' to CSS-wide keywords: unset
+PASS Can set 'column-rule-style' to CSS-wide keywords: revert
+FAIL Can set 'column-rule-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'column-rule-style' to the 'none' keyword: none
+PASS Can set 'column-rule-style' to the 'hidden' keyword: hidden
+PASS Can set 'column-rule-style' to the 'dotted' keyword: dotted
+PASS Can set 'column-rule-style' to the 'dashed' keyword: dashed
+PASS Can set 'column-rule-style' to the 'solid' keyword: solid
+PASS Can set 'column-rule-style' to the 'double' keyword: double
+PASS Can set 'column-rule-style' to the 'groove' keyword: groove
+PASS Can set 'column-rule-style' to the 'ridge' keyword: ridge
+PASS Can set 'column-rule-style' to the 'inset' keyword: inset
+PASS Can set 'column-rule-style' to the 'outset' keyword: outset
 PASS Setting 'column-rule-style' to a length throws TypeError
 PASS Setting 'column-rule-style' to a percent throws TypeError
 PASS Setting 'column-rule-style' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt
@@ -1,10 +1,16 @@
 
-PASS Can set 'column-rule-width' to CSS-wide keywords
-FAIL Can set 'column-rule-width' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'column-rule-width' to the 'thin' keyword
-PASS Can set 'column-rule-width' to the 'medium' keyword
-PASS Can set 'column-rule-width' to the 'thick' keyword
-FAIL Can set 'column-rule-width' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'column-rule-width' to CSS-wide keywords: initial
+PASS Can set 'column-rule-width' to CSS-wide keywords: inherit
+PASS Can set 'column-rule-width' to CSS-wide keywords: unset
+PASS Can set 'column-rule-width' to CSS-wide keywords: revert
+FAIL Can set 'column-rule-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'column-rule-width' to the 'thin' keyword: thin
+PASS Can set 'column-rule-width' to the 'medium' keyword: medium
+PASS Can set 'column-rule-width' to the 'thick' keyword: thick
+PASS Can set 'column-rule-width' to a length: 0px
+PASS Can set 'column-rule-width' to a length: -3.14em
+PASS Can set 'column-rule-width' to a length: 3.14cm
+FAIL Can set 'column-rule-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'column-rule-width' to a percent throws TypeError
 PASS Setting 'column-rule-width' to a time throws TypeError
 PASS Setting 'column-rule-width' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-span-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-span-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'column-span' to CSS-wide keywords
-FAIL Can set 'column-span' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'column-span' to the 'none' keyword
-PASS Can set 'column-span' to the 'all' keyword
+PASS Can set 'column-span' to CSS-wide keywords: initial
+PASS Can set 'column-span' to CSS-wide keywords: inherit
+PASS Can set 'column-span' to CSS-wide keywords: unset
+PASS Can set 'column-span' to CSS-wide keywords: revert
+FAIL Can set 'column-span' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'column-span' to the 'none' keyword: none
+PASS Can set 'column-span' to the 'all' keyword: all
 PASS Setting 'column-span' to a length throws TypeError
 PASS Setting 'column-span' to a percent throws TypeError
 PASS Setting 'column-span' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt
@@ -1,8 +1,14 @@
 
-PASS Can set 'column-width' to CSS-wide keywords
-FAIL Can set 'column-width' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'column-width' to the 'auto' keyword
-FAIL Can set 'column-width' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'column-width' to CSS-wide keywords: initial
+PASS Can set 'column-width' to CSS-wide keywords: inherit
+PASS Can set 'column-width' to CSS-wide keywords: unset
+PASS Can set 'column-width' to CSS-wide keywords: revert
+FAIL Can set 'column-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'column-width' to the 'auto' keyword: auto
+PASS Can set 'column-width' to a length: 0px
+PASS Can set 'column-width' to a length: -3.14em
+PASS Can set 'column-width' to a length: 3.14cm
+FAIL Can set 'column-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'column-width' to a percent throws TypeError
 PASS Setting 'column-width' to a time throws TypeError
 PASS Setting 'column-width' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/contain-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/contain-expected.txt
@@ -1,14 +1,17 @@
 
-PASS Can set 'contain' to CSS-wide keywords
-FAIL Can set 'contain' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'contain' to the 'none' keyword
-PASS Can set 'contain' to the 'strict' keyword
-PASS Can set 'contain' to the 'content' keyword
-PASS Can set 'contain' to the 'size' keyword
-PASS Can set 'contain' to the 'layout' keyword
-PASS Can set 'contain' to the 'style' keyword
-PASS Can set 'contain' to the 'paint' keyword
-PASS Can set 'contain' to the 'inline-size' keyword
+PASS Can set 'contain' to CSS-wide keywords: initial
+PASS Can set 'contain' to CSS-wide keywords: inherit
+PASS Can set 'contain' to CSS-wide keywords: unset
+PASS Can set 'contain' to CSS-wide keywords: revert
+FAIL Can set 'contain' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'contain' to the 'none' keyword: none
+PASS Can set 'contain' to the 'strict' keyword: strict
+PASS Can set 'contain' to the 'content' keyword: content
+PASS Can set 'contain' to the 'size' keyword: size
+PASS Can set 'contain' to the 'layout' keyword: layout
+PASS Can set 'contain' to the 'style' keyword: style
+PASS Can set 'contain' to the 'paint' keyword: paint
+PASS Can set 'contain' to the 'inline-size' keyword: inline-size
 PASS Setting 'contain' to a length throws TypeError
 PASS Setting 'contain' to a percent throws TypeError
 PASS Setting 'contain' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'container-name' to CSS-wide keywords
-FAIL Can set 'container-name' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'container-name' to the 'none' keyword
-FAIL Can set 'container-name' to the 'my-container' keyword Invalid values
+PASS Can set 'container-name' to CSS-wide keywords: initial
+PASS Can set 'container-name' to CSS-wide keywords: inherit
+PASS Can set 'container-name' to CSS-wide keywords: unset
+PASS Can set 'container-name' to CSS-wide keywords: revert
+FAIL Can set 'container-name' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'container-name' to the 'none' keyword: none
+FAIL Can set 'container-name' to the 'my-container' keyword: my-container Invalid values
 PASS Setting 'container-name' to a length throws TypeError
 PASS Setting 'container-name' to a percent throws TypeError
 PASS Setting 'container-name' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-type-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'container-type' to CSS-wide keywords
-FAIL Can set 'container-type' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'container-type' to the 'normal' keyword
-PASS Can set 'container-type' to the 'size' keyword
-PASS Can set 'container-type' to the 'inline-size' keyword
+PASS Can set 'container-type' to CSS-wide keywords: initial
+PASS Can set 'container-type' to CSS-wide keywords: inherit
+PASS Can set 'container-type' to CSS-wide keywords: unset
+PASS Can set 'container-type' to CSS-wide keywords: revert
+FAIL Can set 'container-type' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'container-type' to the 'normal' keyword: normal
+PASS Can set 'container-type' to the 'size' keyword: size
+PASS Can set 'container-type' to the 'inline-size' keyword: inline-size
 PASS Setting 'container-type' to a length throws TypeError
 PASS Setting 'container-type' to a percent throws TypeError
 PASS Setting 'container-type' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt
@@ -1,18 +1,36 @@
 
-PASS Can set 'x' to CSS-wide keywords
-FAIL Can set 'x' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'x' to a percent
-PASS Can set 'x' to a length
+PASS Can set 'x' to CSS-wide keywords: initial
+PASS Can set 'x' to CSS-wide keywords: inherit
+PASS Can set 'x' to CSS-wide keywords: unset
+PASS Can set 'x' to CSS-wide keywords: revert
+FAIL Can set 'x' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'x' to a percent: 0%
+PASS Can set 'x' to a percent: -3.14%
+PASS Can set 'x' to a percent: 3.14%
+PASS Can set 'x' to a percent: calc(0% + 0%)
+PASS Can set 'x' to a length: 0px
+PASS Can set 'x' to a length: -3.14em
+PASS Can set 'x' to a length: 3.14cm
+PASS Can set 'x' to a length: calc(0px + 0em)
 PASS Setting 'x' to a time throws TypeError
 PASS Setting 'x' to an angle throws TypeError
 PASS Setting 'x' to a flexible length throws TypeError
 FAIL Setting 'x' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'x' to a URL throws TypeError
 PASS Setting 'x' to a transform throws TypeError
-PASS Can set 'y' to CSS-wide keywords
-FAIL Can set 'y' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'y' to a percent
-PASS Can set 'y' to a length
+PASS Can set 'y' to CSS-wide keywords: initial
+PASS Can set 'y' to CSS-wide keywords: inherit
+PASS Can set 'y' to CSS-wide keywords: unset
+PASS Can set 'y' to CSS-wide keywords: revert
+FAIL Can set 'y' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'y' to a percent: 0%
+PASS Can set 'y' to a percent: -3.14%
+PASS Can set 'y' to a percent: 3.14%
+PASS Can set 'y' to a percent: calc(0% + 0%)
+PASS Can set 'y' to a length: 0px
+PASS Can set 'y' to a length: -3.14em
+PASS Can set 'y' to a length: 3.14cm
+PASS Can set 'y' to a length: calc(0px + 0em)
 PASS Setting 'y' to a time throws TypeError
 PASS Setting 'y' to an angle throws TypeError
 PASS Setting 'y' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-increment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-increment-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'counter-increment' to CSS-wide keywords
-FAIL Can set 'counter-increment' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'counter-increment' to the 'none' keyword
+PASS Can set 'counter-increment' to CSS-wide keywords: initial
+PASS Can set 'counter-increment' to CSS-wide keywords: inherit
+PASS Can set 'counter-increment' to CSS-wide keywords: unset
+PASS Can set 'counter-increment' to CSS-wide keywords: revert
+FAIL Can set 'counter-increment' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'counter-increment' to the 'none' keyword: none
 PASS Setting 'counter-increment' to a length throws TypeError
 PASS Setting 'counter-increment' to a percent throws TypeError
 PASS Setting 'counter-increment' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-reset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-reset-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'counter-reset' to CSS-wide keywords
-FAIL Can set 'counter-reset' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'counter-reset' to the 'none' keyword
+PASS Can set 'counter-reset' to CSS-wide keywords: initial
+PASS Can set 'counter-reset' to CSS-wide keywords: inherit
+PASS Can set 'counter-reset' to CSS-wide keywords: unset
+PASS Can set 'counter-reset' to CSS-wide keywords: revert
+FAIL Can set 'counter-reset' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'counter-reset' to the 'none' keyword: none
 PASS Setting 'counter-reset' to a length throws TypeError
 PASS Setting 'counter-reset' to a percent throws TypeError
 PASS Setting 'counter-reset' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-set-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-set-expected.txt
@@ -1,7 +1,10 @@
 
-FAIL Can set 'counter-set' to CSS-wide keywords Invalid property counter-set
-FAIL Can set 'counter-set' to var() references Invalid property counter-set
-FAIL Can set 'counter-set' to the 'none' keyword Invalid property counter-set
+FAIL Can set 'counter-set' to CSS-wide keywords: initial Invalid property counter-set
+FAIL Can set 'counter-set' to CSS-wide keywords: inherit Invalid property counter-set
+FAIL Can set 'counter-set' to CSS-wide keywords: unset Invalid property counter-set
+FAIL Can set 'counter-set' to CSS-wide keywords: revert Invalid property counter-set
+FAIL Can set 'counter-set' to var() references:  var(--A) Invalid property counter-set
+FAIL Can set 'counter-set' to the 'none' keyword: none Invalid property counter-set
 PASS Setting 'counter-set' to a length throws TypeError
 PASS Setting 'counter-set' to a percent throws TypeError
 PASS Setting 'counter-set' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/cursor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/cursor-expected.txt
@@ -1,42 +1,45 @@
 
-PASS Can set 'cursor' to CSS-wide keywords
-FAIL Can set 'cursor' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'cursor' to the 'auto' keyword
-PASS Can set 'cursor' to the 'default' keyword
-PASS Can set 'cursor' to the 'none' keyword
-PASS Can set 'cursor' to the 'context-menu' keyword
-PASS Can set 'cursor' to the 'help' keyword
-PASS Can set 'cursor' to the 'pointer' keyword
-PASS Can set 'cursor' to the 'progress' keyword
-PASS Can set 'cursor' to the 'wait' keyword
-PASS Can set 'cursor' to the 'cell' keyword
-PASS Can set 'cursor' to the 'crosshair' keyword
-PASS Can set 'cursor' to the 'text' keyword
-PASS Can set 'cursor' to the 'vertical-text' keyword
-PASS Can set 'cursor' to the 'alias' keyword
-PASS Can set 'cursor' to the 'copy' keyword
-PASS Can set 'cursor' to the 'move' keyword
-PASS Can set 'cursor' to the 'no-drop' keyword
-PASS Can set 'cursor' to the 'not-allowed' keyword
-PASS Can set 'cursor' to the 'grab' keyword
-PASS Can set 'cursor' to the 'grabbing' keyword
-PASS Can set 'cursor' to the 'e-resize' keyword
-PASS Can set 'cursor' to the 'n-resize' keyword
-PASS Can set 'cursor' to the 'ne-resize' keyword
-PASS Can set 'cursor' to the 'nw-resize' keyword
-PASS Can set 'cursor' to the 's-resize' keyword
-PASS Can set 'cursor' to the 'se-resize' keyword
-PASS Can set 'cursor' to the 'sw-resize' keyword
-PASS Can set 'cursor' to the 'w-resize' keyword
-PASS Can set 'cursor' to the 'ew-resize' keyword
-PASS Can set 'cursor' to the 'ns-resize' keyword
-PASS Can set 'cursor' to the 'nesw-resize' keyword
-PASS Can set 'cursor' to the 'nwse-resize' keyword
-PASS Can set 'cursor' to the 'col-resize' keyword
-PASS Can set 'cursor' to the 'row-resize' keyword
-PASS Can set 'cursor' to the 'all-scroll' keyword
-PASS Can set 'cursor' to the 'zoom-in' keyword
-PASS Can set 'cursor' to the 'zoom-out' keyword
+PASS Can set 'cursor' to CSS-wide keywords: initial
+PASS Can set 'cursor' to CSS-wide keywords: inherit
+PASS Can set 'cursor' to CSS-wide keywords: unset
+PASS Can set 'cursor' to CSS-wide keywords: revert
+FAIL Can set 'cursor' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'cursor' to the 'auto' keyword: auto
+PASS Can set 'cursor' to the 'default' keyword: default
+PASS Can set 'cursor' to the 'none' keyword: none
+PASS Can set 'cursor' to the 'context-menu' keyword: context-menu
+PASS Can set 'cursor' to the 'help' keyword: help
+PASS Can set 'cursor' to the 'pointer' keyword: pointer
+PASS Can set 'cursor' to the 'progress' keyword: progress
+PASS Can set 'cursor' to the 'wait' keyword: wait
+PASS Can set 'cursor' to the 'cell' keyword: cell
+PASS Can set 'cursor' to the 'crosshair' keyword: crosshair
+PASS Can set 'cursor' to the 'text' keyword: text
+PASS Can set 'cursor' to the 'vertical-text' keyword: vertical-text
+PASS Can set 'cursor' to the 'alias' keyword: alias
+PASS Can set 'cursor' to the 'copy' keyword: copy
+PASS Can set 'cursor' to the 'move' keyword: move
+PASS Can set 'cursor' to the 'no-drop' keyword: no-drop
+PASS Can set 'cursor' to the 'not-allowed' keyword: not-allowed
+PASS Can set 'cursor' to the 'grab' keyword: grab
+PASS Can set 'cursor' to the 'grabbing' keyword: grabbing
+PASS Can set 'cursor' to the 'e-resize' keyword: e-resize
+PASS Can set 'cursor' to the 'n-resize' keyword: n-resize
+PASS Can set 'cursor' to the 'ne-resize' keyword: ne-resize
+PASS Can set 'cursor' to the 'nw-resize' keyword: nw-resize
+PASS Can set 'cursor' to the 's-resize' keyword: s-resize
+PASS Can set 'cursor' to the 'se-resize' keyword: se-resize
+PASS Can set 'cursor' to the 'sw-resize' keyword: sw-resize
+PASS Can set 'cursor' to the 'w-resize' keyword: w-resize
+PASS Can set 'cursor' to the 'ew-resize' keyword: ew-resize
+PASS Can set 'cursor' to the 'ns-resize' keyword: ns-resize
+PASS Can set 'cursor' to the 'nesw-resize' keyword: nesw-resize
+PASS Can set 'cursor' to the 'nwse-resize' keyword: nwse-resize
+PASS Can set 'cursor' to the 'col-resize' keyword: col-resize
+PASS Can set 'cursor' to the 'row-resize' keyword: row-resize
+PASS Can set 'cursor' to the 'all-scroll' keyword: all-scroll
+PASS Can set 'cursor' to the 'zoom-in' keyword: zoom-in
+PASS Can set 'cursor' to the 'zoom-out' keyword: zoom-out
 PASS Setting 'cursor' to a length throws TypeError
 PASS Setting 'cursor' to a percent throws TypeError
 PASS Setting 'cursor' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/d-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/d-expected.txt
@@ -1,7 +1,10 @@
 
-FAIL Can set 'd' to CSS-wide keywords Invalid property d
-FAIL Can set 'd' to var() references Invalid property d
-FAIL Can set 'd' to the 'none' keyword Invalid property d
+FAIL Can set 'd' to CSS-wide keywords: initial Invalid property d
+FAIL Can set 'd' to CSS-wide keywords: inherit Invalid property d
+FAIL Can set 'd' to CSS-wide keywords: unset Invalid property d
+FAIL Can set 'd' to CSS-wide keywords: revert Invalid property d
+FAIL Can set 'd' to var() references:  var(--A) Invalid property d
+FAIL Can set 'd' to the 'none' keyword: none Invalid property d
 PASS Setting 'd' to a length throws TypeError
 PASS Setting 'd' to a percent throws TypeError
 PASS Setting 'd' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/direction-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'direction' to CSS-wide keywords
-FAIL Can set 'direction' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'direction' to the 'ltr' keyword
-PASS Can set 'direction' to the 'rtl' keyword
+PASS Can set 'direction' to CSS-wide keywords: initial
+PASS Can set 'direction' to CSS-wide keywords: inherit
+PASS Can set 'direction' to CSS-wide keywords: unset
+PASS Can set 'direction' to CSS-wide keywords: revert
+FAIL Can set 'direction' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'direction' to the 'ltr' keyword: ltr
+PASS Can set 'direction' to the 'rtl' keyword: rtl
 PASS Setting 'direction' to a length throws TypeError
 PASS Setting 'direction' to a percent throws TypeError
 PASS Setting 'direction' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/display-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/display-expected.txt
@@ -1,27 +1,30 @@
 
-PASS Can set 'display' to CSS-wide keywords
-FAIL Can set 'display' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'display' to the 'none' keyword
-PASS Can set 'display' to the 'block' keyword
-PASS Can set 'display' to the 'inline' keyword
-PASS Can set 'display' to the 'flow-root' keyword
-PASS Can set 'display' to the 'table' keyword
-PASS Can set 'display' to the 'flex' keyword
-PASS Can set 'display' to the 'grid' keyword
-PASS Can set 'display' to the 'list-item' keyword
-PASS Can set 'display' to the 'table-row-group' keyword
-PASS Can set 'display' to the 'table-header-group' keyword
-PASS Can set 'display' to the 'table-footer-group' keyword
-PASS Can set 'display' to the 'table-row' keyword
-PASS Can set 'display' to the 'table-cell' keyword
-PASS Can set 'display' to the 'table-column-group' keyword
-PASS Can set 'display' to the 'table-column' keyword
-PASS Can set 'display' to the 'table-caption' keyword
-PASS Can set 'display' to the 'contents' keyword
-PASS Can set 'display' to the 'inline-block' keyword
-PASS Can set 'display' to the 'inline-table' keyword
-PASS Can set 'display' to the 'inline-flex' keyword
-PASS Can set 'display' to the 'inline-grid' keyword
+PASS Can set 'display' to CSS-wide keywords: initial
+PASS Can set 'display' to CSS-wide keywords: inherit
+PASS Can set 'display' to CSS-wide keywords: unset
+PASS Can set 'display' to CSS-wide keywords: revert
+FAIL Can set 'display' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'display' to the 'none' keyword: none
+PASS Can set 'display' to the 'block' keyword: block
+PASS Can set 'display' to the 'inline' keyword: inline
+PASS Can set 'display' to the 'flow-root' keyword: flow-root
+PASS Can set 'display' to the 'table' keyword: table
+PASS Can set 'display' to the 'flex' keyword: flex
+PASS Can set 'display' to the 'grid' keyword: grid
+PASS Can set 'display' to the 'list-item' keyword: list-item
+PASS Can set 'display' to the 'table-row-group' keyword: table-row-group
+PASS Can set 'display' to the 'table-header-group' keyword: table-header-group
+PASS Can set 'display' to the 'table-footer-group' keyword: table-footer-group
+PASS Can set 'display' to the 'table-row' keyword: table-row
+PASS Can set 'display' to the 'table-cell' keyword: table-cell
+PASS Can set 'display' to the 'table-column-group' keyword: table-column-group
+PASS Can set 'display' to the 'table-column' keyword: table-column
+PASS Can set 'display' to the 'table-caption' keyword: table-caption
+PASS Can set 'display' to the 'contents' keyword: contents
+PASS Can set 'display' to the 'inline-block' keyword: inline-block
+PASS Can set 'display' to the 'inline-table' keyword: inline-table
+PASS Can set 'display' to the 'inline-flex' keyword: inline-flex
+PASS Can set 'display' to the 'inline-grid' keyword: inline-grid
 PASS Setting 'display' to a length throws TypeError
 PASS Setting 'display' to a percent throws TypeError
 PASS Setting 'display' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/dominant-baseline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/dominant-baseline-expected.txt
@@ -1,15 +1,18 @@
 
-PASS Can set 'dominant-baseline' to CSS-wide keywords
-FAIL Can set 'dominant-baseline' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'dominant-baseline' to the 'auto' keyword
-FAIL Can set 'dominant-baseline' to the 'text-bottom' keyword Invalid values
-PASS Can set 'dominant-baseline' to the 'alphabetic' keyword
-PASS Can set 'dominant-baseline' to the 'ideographic' keyword
-PASS Can set 'dominant-baseline' to the 'middle' keyword
-PASS Can set 'dominant-baseline' to the 'central' keyword
-PASS Can set 'dominant-baseline' to the 'mathematical' keyword
-PASS Can set 'dominant-baseline' to the 'hanging' keyword
-FAIL Can set 'dominant-baseline' to the 'text-top' keyword Invalid values
+PASS Can set 'dominant-baseline' to CSS-wide keywords: initial
+PASS Can set 'dominant-baseline' to CSS-wide keywords: inherit
+PASS Can set 'dominant-baseline' to CSS-wide keywords: unset
+PASS Can set 'dominant-baseline' to CSS-wide keywords: revert
+FAIL Can set 'dominant-baseline' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'dominant-baseline' to the 'auto' keyword: auto
+FAIL Can set 'dominant-baseline' to the 'text-bottom' keyword: text-bottom Invalid values
+PASS Can set 'dominant-baseline' to the 'alphabetic' keyword: alphabetic
+PASS Can set 'dominant-baseline' to the 'ideographic' keyword: ideographic
+PASS Can set 'dominant-baseline' to the 'middle' keyword: middle
+PASS Can set 'dominant-baseline' to the 'central' keyword: central
+PASS Can set 'dominant-baseline' to the 'mathematical' keyword: mathematical
+PASS Can set 'dominant-baseline' to the 'hanging' keyword: hanging
+FAIL Can set 'dominant-baseline' to the 'text-top' keyword: text-top Invalid values
 PASS Setting 'dominant-baseline' to a length throws TypeError
 PASS Setting 'dominant-baseline' to a percent throws TypeError
 PASS Setting 'dominant-baseline' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/empty-cells-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/empty-cells-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'empty-cells' to CSS-wide keywords
-FAIL Can set 'empty-cells' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'empty-cells' to the 'show' keyword
-PASS Can set 'empty-cells' to the 'hide' keyword
+PASS Can set 'empty-cells' to CSS-wide keywords: initial
+PASS Can set 'empty-cells' to CSS-wide keywords: inherit
+PASS Can set 'empty-cells' to CSS-wide keywords: unset
+PASS Can set 'empty-cells' to CSS-wide keywords: revert
+FAIL Can set 'empty-cells' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'empty-cells' to the 'show' keyword: show
+PASS Can set 'empty-cells' to the 'hide' keyword: hide
 PASS Setting 'empty-cells' to a length throws TypeError
 PASS Setting 'empty-cells' to a percent throws TypeError
 PASS Setting 'empty-cells' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-color-expected.txt
@@ -1,7 +1,10 @@
 
-FAIL Can set 'fill-color' to CSS-wide keywords Invalid property fill-color
-FAIL Can set 'fill-color' to var() references Invalid property fill-color
-FAIL Can set 'fill-color' to the 'currentcolor' keyword Invalid property fill-color
+FAIL Can set 'fill-color' to CSS-wide keywords: initial Invalid property fill-color
+FAIL Can set 'fill-color' to CSS-wide keywords: inherit Invalid property fill-color
+FAIL Can set 'fill-color' to CSS-wide keywords: unset Invalid property fill-color
+FAIL Can set 'fill-color' to CSS-wide keywords: revert Invalid property fill-color
+FAIL Can set 'fill-color' to var() references:  var(--A) Invalid property fill-color
+FAIL Can set 'fill-color' to the 'currentcolor' keyword: currentcolor Invalid property fill-color
 PASS Setting 'fill-color' to a length throws TypeError
 PASS Setting 'fill-color' to a percent throws TypeError
 PASS Setting 'fill-color' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'fill-opacity' to CSS-wide keywords
-FAIL Can set 'fill-opacity' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'fill-opacity' to a number
+PASS Can set 'fill-opacity' to CSS-wide keywords: initial
+PASS Can set 'fill-opacity' to CSS-wide keywords: inherit
+PASS Can set 'fill-opacity' to CSS-wide keywords: unset
+PASS Can set 'fill-opacity' to CSS-wide keywords: revert
+FAIL Can set 'fill-opacity' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'fill-opacity' to a number: 0
+PASS Can set 'fill-opacity' to a number: -3.14
+PASS Can set 'fill-opacity' to a number: 3.14
+PASS Can set 'fill-opacity' to a number: calc(2 + 3)
 PASS Setting 'fill-opacity' to a length throws TypeError
 FAIL Setting 'fill-opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'fill-opacity' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-rule-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'fill-rule' to CSS-wide keywords
-FAIL Can set 'fill-rule' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'fill-rule' to the 'nonzero' keyword
-PASS Can set 'fill-rule' to the 'evenodd' keyword
+PASS Can set 'fill-rule' to CSS-wide keywords: initial
+PASS Can set 'fill-rule' to CSS-wide keywords: inherit
+PASS Can set 'fill-rule' to CSS-wide keywords: unset
+PASS Can set 'fill-rule' to CSS-wide keywords: revert
+FAIL Can set 'fill-rule' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'fill-rule' to the 'nonzero' keyword: nonzero
+PASS Can set 'fill-rule' to the 'evenodd' keyword: evenodd
 PASS Setting 'fill-rule' to a length throws TypeError
 PASS Setting 'fill-rule' to a percent throws TypeError
 PASS Setting 'fill-rule' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/filter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/filter-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'filter' to CSS-wide keywords
-FAIL Can set 'filter' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'filter' to the 'none' keyword
+PASS Can set 'filter' to CSS-wide keywords: initial
+PASS Can set 'filter' to CSS-wide keywords: inherit
+PASS Can set 'filter' to CSS-wide keywords: unset
+PASS Can set 'filter' to CSS-wide keywords: revert
+FAIL Can set 'filter' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'filter' to the 'none' keyword: none
 PASS Setting 'filter' to a length throws TypeError
 PASS Setting 'filter' to a percent throws TypeError
 PASS Setting 'filter' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt
@@ -1,13 +1,22 @@
 
-PASS Can set 'flex-basis' to CSS-wide keywords
-FAIL Can set 'flex-basis' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'flex-basis' to the 'auto' keyword
-PASS Can set 'flex-basis' to the 'content' keyword
-PASS Can set 'flex-basis' to the 'fit-content' keyword
-PASS Can set 'flex-basis' to the 'min-content' keyword
-PASS Can set 'flex-basis' to the 'max-content' keyword
-FAIL Can set 'flex-basis' to a length assert_equals: expected "px" but got "em"
-FAIL Can set 'flex-basis' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'flex-basis' to CSS-wide keywords: initial
+PASS Can set 'flex-basis' to CSS-wide keywords: inherit
+PASS Can set 'flex-basis' to CSS-wide keywords: unset
+PASS Can set 'flex-basis' to CSS-wide keywords: revert
+FAIL Can set 'flex-basis' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'flex-basis' to the 'auto' keyword: auto
+PASS Can set 'flex-basis' to the 'content' keyword: content
+PASS Can set 'flex-basis' to the 'fit-content' keyword: fit-content
+PASS Can set 'flex-basis' to the 'min-content' keyword: min-content
+PASS Can set 'flex-basis' to the 'max-content' keyword: max-content
+PASS Can set 'flex-basis' to a length: 0px
+PASS Can set 'flex-basis' to a length: -3.14em
+PASS Can set 'flex-basis' to a length: 3.14cm
+FAIL Can set 'flex-basis' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'flex-basis' to a percent: 0%
+FAIL Can set 'flex-basis' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'flex-basis' to a percent: 3.14%
+FAIL Can set 'flex-basis' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
 PASS Setting 'flex-basis' to a time throws TypeError
 PASS Setting 'flex-basis' to an angle throws TypeError
 PASS Setting 'flex-basis' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-direction-expected.txt
@@ -1,10 +1,13 @@
 
-PASS Can set 'flex-direction' to CSS-wide keywords
-FAIL Can set 'flex-direction' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'flex-direction' to the 'row' keyword
-PASS Can set 'flex-direction' to the 'row-reverse' keyword
-PASS Can set 'flex-direction' to the 'column' keyword
-PASS Can set 'flex-direction' to the 'column-reverse' keyword
+PASS Can set 'flex-direction' to CSS-wide keywords: initial
+PASS Can set 'flex-direction' to CSS-wide keywords: inherit
+PASS Can set 'flex-direction' to CSS-wide keywords: unset
+PASS Can set 'flex-direction' to CSS-wide keywords: revert
+FAIL Can set 'flex-direction' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'flex-direction' to the 'row' keyword: row
+PASS Can set 'flex-direction' to the 'row-reverse' keyword: row-reverse
+PASS Can set 'flex-direction' to the 'column' keyword: column
+PASS Can set 'flex-direction' to the 'column-reverse' keyword: column-reverse
 PASS Setting 'flex-direction' to a length throws TypeError
 PASS Setting 'flex-direction' to a percent throws TypeError
 PASS Setting 'flex-direction' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'flex-grow' to CSS-wide keywords
-FAIL Can set 'flex-grow' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'flex-grow' to a number assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'flex-grow' to CSS-wide keywords: initial
+PASS Can set 'flex-grow' to CSS-wide keywords: inherit
+PASS Can set 'flex-grow' to CSS-wide keywords: unset
+PASS Can set 'flex-grow' to CSS-wide keywords: revert
+FAIL Can set 'flex-grow' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'flex-grow' to a number: 0
+FAIL Can set 'flex-grow' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'flex-grow' to a number: 3.14
+FAIL Can set 'flex-grow' to a number: calc(2 + 3) assert_equals: expected 2 but got 1
 PASS Setting 'flex-grow' to a length throws TypeError
 PASS Setting 'flex-grow' to a percent throws TypeError
 PASS Setting 'flex-grow' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'flex-shrink' to CSS-wide keywords
-FAIL Can set 'flex-shrink' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'flex-shrink' to a number assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'flex-shrink' to CSS-wide keywords: initial
+PASS Can set 'flex-shrink' to CSS-wide keywords: inherit
+PASS Can set 'flex-shrink' to CSS-wide keywords: unset
+PASS Can set 'flex-shrink' to CSS-wide keywords: revert
+FAIL Can set 'flex-shrink' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'flex-shrink' to a number: 0
+FAIL Can set 'flex-shrink' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'flex-shrink' to a number: 3.14
+FAIL Can set 'flex-shrink' to a number: calc(2 + 3) assert_equals: expected 2 but got 1
 PASS Setting 'flex-shrink' to a length throws TypeError
 PASS Setting 'flex-shrink' to a percent throws TypeError
 PASS Setting 'flex-shrink' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-wrap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-wrap-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'flex-wrap' to CSS-wide keywords
-FAIL Can set 'flex-wrap' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'flex-wrap' to the 'nowrap' keyword
-PASS Can set 'flex-wrap' to the 'wrap' keyword
-PASS Can set 'flex-wrap' to the 'wrap-reverse' keyword
+PASS Can set 'flex-wrap' to CSS-wide keywords: initial
+PASS Can set 'flex-wrap' to CSS-wide keywords: inherit
+PASS Can set 'flex-wrap' to CSS-wide keywords: unset
+PASS Can set 'flex-wrap' to CSS-wide keywords: revert
+FAIL Can set 'flex-wrap' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'flex-wrap' to the 'nowrap' keyword: nowrap
+PASS Can set 'flex-wrap' to the 'wrap' keyword: wrap
+PASS Can set 'flex-wrap' to the 'wrap-reverse' keyword: wrap-reverse
 PASS Setting 'flex-wrap' to a length throws TypeError
 PASS Setting 'flex-wrap' to a percent throws TypeError
 PASS Setting 'flex-wrap' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/float-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/float-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'float' to CSS-wide keywords
-FAIL Can set 'float' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'float' to the 'left' keyword
-PASS Can set 'float' to the 'right' keyword
-PASS Can set 'float' to the 'none' keyword
+PASS Can set 'float' to CSS-wide keywords: initial
+PASS Can set 'float' to CSS-wide keywords: inherit
+PASS Can set 'float' to CSS-wide keywords: unset
+PASS Can set 'float' to CSS-wide keywords: revert
+FAIL Can set 'float' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'float' to the 'left' keyword: left
+PASS Can set 'float' to the 'right' keyword: right
+PASS Can set 'float' to the 'none' keyword: none
 PASS Setting 'float' to a length throws TypeError
 PASS Setting 'float' to a percent throws TypeError
 PASS Setting 'float' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-color-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'flood-color' to CSS-wide keywords
-FAIL Can set 'flood-color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'flood-color' to the 'currentcolor' keyword
+PASS Can set 'flood-color' to CSS-wide keywords: initial
+PASS Can set 'flood-color' to CSS-wide keywords: inherit
+PASS Can set 'flood-color' to CSS-wide keywords: unset
+PASS Can set 'flood-color' to CSS-wide keywords: revert
+FAIL Can set 'flood-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'flood-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'flood-color' to a length throws TypeError
 PASS Setting 'flood-color' to a percent throws TypeError
 PASS Setting 'flood-color' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'flood-opacity' to CSS-wide keywords
-FAIL Can set 'flood-opacity' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'flood-opacity' to a number
+PASS Can set 'flood-opacity' to CSS-wide keywords: initial
+PASS Can set 'flood-opacity' to CSS-wide keywords: inherit
+PASS Can set 'flood-opacity' to CSS-wide keywords: unset
+PASS Can set 'flood-opacity' to CSS-wide keywords: revert
+FAIL Can set 'flood-opacity' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'flood-opacity' to a number: 0
+PASS Can set 'flood-opacity' to a number: -3.14
+PASS Can set 'flood-opacity' to a number: 3.14
+PASS Can set 'flood-opacity' to a number: calc(2 + 3)
 PASS Setting 'flood-opacity' to a length throws TypeError
 FAIL Setting 'flood-opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'flood-opacity' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-feature-settings-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-feature-settings-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'font-feature-settings' to CSS-wide keywords
-FAIL Can set 'font-feature-settings' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-feature-settings' to the 'normal' keyword
+PASS Can set 'font-feature-settings' to CSS-wide keywords: initial
+PASS Can set 'font-feature-settings' to CSS-wide keywords: inherit
+PASS Can set 'font-feature-settings' to CSS-wide keywords: unset
+PASS Can set 'font-feature-settings' to CSS-wide keywords: revert
+FAIL Can set 'font-feature-settings' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-feature-settings' to the 'normal' keyword: normal
 PASS Setting 'font-feature-settings' to a length throws TypeError
 PASS Setting 'font-feature-settings' to a percent throws TypeError
 PASS Setting 'font-feature-settings' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-kerning-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-kerning-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'font-kerning' to CSS-wide keywords
-FAIL Can set 'font-kerning' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-kerning' to the 'auto' keyword
-PASS Can set 'font-kerning' to the 'normal' keyword
-PASS Can set 'font-kerning' to the 'none' keyword
+PASS Can set 'font-kerning' to CSS-wide keywords: initial
+PASS Can set 'font-kerning' to CSS-wide keywords: inherit
+PASS Can set 'font-kerning' to CSS-wide keywords: unset
+PASS Can set 'font-kerning' to CSS-wide keywords: revert
+FAIL Can set 'font-kerning' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-kerning' to the 'auto' keyword: auto
+PASS Can set 'font-kerning' to the 'normal' keyword: normal
+PASS Can set 'font-kerning' to the 'none' keyword: none
 PASS Setting 'font-kerning' to a length throws TypeError
 PASS Setting 'font-kerning' to a percent throws TypeError
 PASS Setting 'font-kerning' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-language-override-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-language-override-expected.txt
@@ -1,7 +1,10 @@
 
-FAIL Can set 'font-language-override' to CSS-wide keywords Invalid property font-language-override
-FAIL Can set 'font-language-override' to var() references Invalid property font-language-override
-FAIL Can set 'font-language-override' to the 'normal' keyword Invalid property font-language-override
+FAIL Can set 'font-language-override' to CSS-wide keywords: initial Invalid property font-language-override
+FAIL Can set 'font-language-override' to CSS-wide keywords: inherit Invalid property font-language-override
+FAIL Can set 'font-language-override' to CSS-wide keywords: unset Invalid property font-language-override
+FAIL Can set 'font-language-override' to CSS-wide keywords: revert Invalid property font-language-override
+FAIL Can set 'font-language-override' to var() references:  var(--A) Invalid property font-language-override
+FAIL Can set 'font-language-override' to the 'normal' keyword: normal Invalid property font-language-override
 PASS Setting 'font-language-override' to a length throws TypeError
 PASS Setting 'font-language-override' to a percent throws TypeError
 PASS Setting 'font-language-override' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-optical-sizing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-optical-sizing-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'font-optical-sizing' to CSS-wide keywords
-FAIL Can set 'font-optical-sizing' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-optical-sizing' to the 'auto' keyword
-PASS Can set 'font-optical-sizing' to the 'none' keyword
+PASS Can set 'font-optical-sizing' to CSS-wide keywords: initial
+PASS Can set 'font-optical-sizing' to CSS-wide keywords: inherit
+PASS Can set 'font-optical-sizing' to CSS-wide keywords: unset
+PASS Can set 'font-optical-sizing' to CSS-wide keywords: revert
+FAIL Can set 'font-optical-sizing' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-optical-sizing' to the 'auto' keyword: auto
+PASS Can set 'font-optical-sizing' to the 'none' keyword: none
 PASS Setting 'font-optical-sizing' to a length throws TypeError
 PASS Setting 'font-optical-sizing' to a percent throws TypeError
 PASS Setting 'font-optical-sizing' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-palette-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-palette-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'font-palette' to CSS-wide keywords
-FAIL Can set 'font-palette' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-palette' to the 'normal' keyword
-PASS Can set 'font-palette' to the 'light' keyword
-PASS Can set 'font-palette' to the 'dark' keyword
+PASS Can set 'font-palette' to CSS-wide keywords: initial
+PASS Can set 'font-palette' to CSS-wide keywords: inherit
+PASS Can set 'font-palette' to CSS-wide keywords: unset
+PASS Can set 'font-palette' to CSS-wide keywords: revert
+FAIL Can set 'font-palette' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-palette' to the 'normal' keyword: normal
+PASS Can set 'font-palette' to the 'light' keyword: light
+PASS Can set 'font-palette' to the 'dark' keyword: dark
 PASS Setting 'font-palette' to a length throws TypeError
 PASS Setting 'font-palette' to a percent throws TypeError
 PASS Setting 'font-palette' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-presentation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-presentation-expected.txt
@@ -1,9 +1,12 @@
 
-FAIL Can set 'font-presentation' to CSS-wide keywords Invalid property font-presentation
-FAIL Can set 'font-presentation' to var() references Invalid property font-presentation
-FAIL Can set 'font-presentation' to the 'auto' keyword Invalid property font-presentation
-FAIL Can set 'font-presentation' to the 'text' keyword Invalid property font-presentation
-FAIL Can set 'font-presentation' to the 'emoji' keyword Invalid property font-presentation
+FAIL Can set 'font-presentation' to CSS-wide keywords: initial Invalid property font-presentation
+FAIL Can set 'font-presentation' to CSS-wide keywords: inherit Invalid property font-presentation
+FAIL Can set 'font-presentation' to CSS-wide keywords: unset Invalid property font-presentation
+FAIL Can set 'font-presentation' to CSS-wide keywords: revert Invalid property font-presentation
+FAIL Can set 'font-presentation' to var() references:  var(--A) Invalid property font-presentation
+FAIL Can set 'font-presentation' to the 'auto' keyword: auto Invalid property font-presentation
+FAIL Can set 'font-presentation' to the 'text' keyword: text Invalid property font-presentation
+FAIL Can set 'font-presentation' to the 'emoji' keyword: emoji Invalid property font-presentation
 PASS Setting 'font-presentation' to a length throws TypeError
 PASS Setting 'font-presentation' to a percent throws TypeError
 PASS Setting 'font-presentation' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt
@@ -1,8 +1,14 @@
 
-PASS Can set 'font-size-adjust' to CSS-wide keywords
-FAIL Can set 'font-size-adjust' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-size-adjust' to the 'none' keyword
-FAIL Can set 'font-size-adjust' to a number assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'font-size-adjust' to CSS-wide keywords: initial
+PASS Can set 'font-size-adjust' to CSS-wide keywords: inherit
+PASS Can set 'font-size-adjust' to CSS-wide keywords: unset
+PASS Can set 'font-size-adjust' to CSS-wide keywords: revert
+FAIL Can set 'font-size-adjust' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-size-adjust' to the 'none' keyword: none
+PASS Can set 'font-size-adjust' to a number: 0
+FAIL Can set 'font-size-adjust' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'font-size-adjust' to a number: 3.14
+FAIL Can set 'font-size-adjust' to a number: calc(2 + 3) assert_equals: expected 2 but got 1
 PASS Setting 'font-size-adjust' to a length throws TypeError
 PASS Setting 'font-size-adjust' to a percent throws TypeError
 PASS Setting 'font-size-adjust' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt
@@ -1,56 +1,83 @@
 
-PASS Can set 'font-size' to CSS-wide keywords
-FAIL Can set 'font-size' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-size' to the 'xx-small' keyword
-PASS Can set 'font-size' to the 'x-small' keyword
-PASS Can set 'font-size' to the 'small' keyword
-PASS Can set 'font-size' to the 'medium' keyword
-PASS Can set 'font-size' to the 'large' keyword
-PASS Can set 'font-size' to the 'x-large' keyword
-PASS Can set 'font-size' to the 'xx-large' keyword
-PASS Can set 'font-size' to the 'larger' keyword
-PASS Can set 'font-size' to the 'smaller' keyword
-FAIL Can set 'font-size' to a length assert_equals: expected "px" but got "em"
-FAIL Can set 'font-size' to a percent assert_equals: expected 2 but got 1
+PASS Can set 'font-size' to CSS-wide keywords: initial
+PASS Can set 'font-size' to CSS-wide keywords: inherit
+PASS Can set 'font-size' to CSS-wide keywords: unset
+PASS Can set 'font-size' to CSS-wide keywords: revert
+FAIL Can set 'font-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-size' to the 'xx-small' keyword: xx-small
+PASS Can set 'font-size' to the 'x-small' keyword: x-small
+PASS Can set 'font-size' to the 'small' keyword: small
+PASS Can set 'font-size' to the 'medium' keyword: medium
+PASS Can set 'font-size' to the 'large' keyword: large
+PASS Can set 'font-size' to the 'x-large' keyword: x-large
+PASS Can set 'font-size' to the 'xx-large' keyword: xx-large
+PASS Can set 'font-size' to the 'larger' keyword: larger
+PASS Can set 'font-size' to the 'smaller' keyword: smaller
+PASS Can set 'font-size' to a length: 0px
+PASS Can set 'font-size' to a length: -3.14em
+PASS Can set 'font-size' to a length: 3.14cm
+FAIL Can set 'font-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'font-size' to a percent: 0%
+PASS Can set 'font-size' to a percent: -3.14%
+PASS Can set 'font-size' to a percent: 3.14%
+FAIL Can set 'font-size' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
 PASS Setting 'font-size' to a time throws TypeError
 PASS Setting 'font-size' to an angle throws TypeError
 PASS Setting 'font-size' to a flexible length throws TypeError
 FAIL Setting 'font-size' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'font-size' to a URL throws TypeError
 PASS Setting 'font-size' to a transform throws TypeError
-FAIL Can set 'font-min-size' to CSS-wide keywords Invalid property font-min-size
-FAIL Can set 'font-min-size' to var() references Invalid property font-min-size
-FAIL Can set 'font-min-size' to the 'xx-small' keyword Invalid property font-min-size
-FAIL Can set 'font-min-size' to the 'x-small' keyword Invalid property font-min-size
-FAIL Can set 'font-min-size' to the 'small' keyword Invalid property font-min-size
-FAIL Can set 'font-min-size' to the 'medium' keyword Invalid property font-min-size
-FAIL Can set 'font-min-size' to the 'large' keyword Invalid property font-min-size
-FAIL Can set 'font-min-size' to the 'x-large' keyword Invalid property font-min-size
-FAIL Can set 'font-min-size' to the 'xx-large' keyword Invalid property font-min-size
-FAIL Can set 'font-min-size' to the 'larger' keyword Invalid property font-min-size
-FAIL Can set 'font-min-size' to the 'smaller' keyword Invalid property font-min-size
-FAIL Can set 'font-min-size' to a length Invalid property font-min-size
-FAIL Can set 'font-min-size' to a percent Invalid property font-min-size
+FAIL Can set 'font-min-size' to CSS-wide keywords: initial Invalid property font-min-size
+FAIL Can set 'font-min-size' to CSS-wide keywords: inherit Invalid property font-min-size
+FAIL Can set 'font-min-size' to CSS-wide keywords: unset Invalid property font-min-size
+FAIL Can set 'font-min-size' to CSS-wide keywords: revert Invalid property font-min-size
+FAIL Can set 'font-min-size' to var() references:  var(--A) Invalid property font-min-size
+FAIL Can set 'font-min-size' to the 'xx-small' keyword: xx-small Invalid property font-min-size
+FAIL Can set 'font-min-size' to the 'x-small' keyword: x-small Invalid property font-min-size
+FAIL Can set 'font-min-size' to the 'small' keyword: small Invalid property font-min-size
+FAIL Can set 'font-min-size' to the 'medium' keyword: medium Invalid property font-min-size
+FAIL Can set 'font-min-size' to the 'large' keyword: large Invalid property font-min-size
+FAIL Can set 'font-min-size' to the 'x-large' keyword: x-large Invalid property font-min-size
+FAIL Can set 'font-min-size' to the 'xx-large' keyword: xx-large Invalid property font-min-size
+FAIL Can set 'font-min-size' to the 'larger' keyword: larger Invalid property font-min-size
+FAIL Can set 'font-min-size' to the 'smaller' keyword: smaller Invalid property font-min-size
+FAIL Can set 'font-min-size' to a length: 0px Invalid property font-min-size
+FAIL Can set 'font-min-size' to a length: -3.14em Invalid property font-min-size
+FAIL Can set 'font-min-size' to a length: 3.14cm Invalid property font-min-size
+FAIL Can set 'font-min-size' to a length: calc(0px + 0em) Invalid property font-min-size
+FAIL Can set 'font-min-size' to a percent: 0% Invalid property font-min-size
+FAIL Can set 'font-min-size' to a percent: -3.14% Invalid property font-min-size
+FAIL Can set 'font-min-size' to a percent: 3.14% Invalid property font-min-size
+FAIL Can set 'font-min-size' to a percent: calc(0% + 0%) Invalid property font-min-size
 PASS Setting 'font-min-size' to a time throws TypeError
 PASS Setting 'font-min-size' to an angle throws TypeError
 PASS Setting 'font-min-size' to a flexible length throws TypeError
 PASS Setting 'font-min-size' to a number throws TypeError
 PASS Setting 'font-min-size' to a URL throws TypeError
 PASS Setting 'font-min-size' to a transform throws TypeError
-FAIL Can set 'font-max-size' to CSS-wide keywords Invalid property font-max-size
-FAIL Can set 'font-max-size' to var() references Invalid property font-max-size
-FAIL Can set 'font-max-size' to the 'infinity' keyword Invalid property font-max-size
-FAIL Can set 'font-max-size' to the 'xx-small' keyword Invalid property font-max-size
-FAIL Can set 'font-max-size' to the 'x-small' keyword Invalid property font-max-size
-FAIL Can set 'font-max-size' to the 'small' keyword Invalid property font-max-size
-FAIL Can set 'font-max-size' to the 'medium' keyword Invalid property font-max-size
-FAIL Can set 'font-max-size' to the 'large' keyword Invalid property font-max-size
-FAIL Can set 'font-max-size' to the 'x-large' keyword Invalid property font-max-size
-FAIL Can set 'font-max-size' to the 'xx-large' keyword Invalid property font-max-size
-FAIL Can set 'font-max-size' to the 'larger' keyword Invalid property font-max-size
-FAIL Can set 'font-max-size' to the 'smaller' keyword Invalid property font-max-size
-FAIL Can set 'font-max-size' to a length Invalid property font-max-size
-FAIL Can set 'font-max-size' to a percent Invalid property font-max-size
+FAIL Can set 'font-max-size' to CSS-wide keywords: initial Invalid property font-max-size
+FAIL Can set 'font-max-size' to CSS-wide keywords: inherit Invalid property font-max-size
+FAIL Can set 'font-max-size' to CSS-wide keywords: unset Invalid property font-max-size
+FAIL Can set 'font-max-size' to CSS-wide keywords: revert Invalid property font-max-size
+FAIL Can set 'font-max-size' to var() references:  var(--A) Invalid property font-max-size
+FAIL Can set 'font-max-size' to the 'infinity' keyword: infinity Invalid property font-max-size
+FAIL Can set 'font-max-size' to the 'xx-small' keyword: xx-small Invalid property font-max-size
+FAIL Can set 'font-max-size' to the 'x-small' keyword: x-small Invalid property font-max-size
+FAIL Can set 'font-max-size' to the 'small' keyword: small Invalid property font-max-size
+FAIL Can set 'font-max-size' to the 'medium' keyword: medium Invalid property font-max-size
+FAIL Can set 'font-max-size' to the 'large' keyword: large Invalid property font-max-size
+FAIL Can set 'font-max-size' to the 'x-large' keyword: x-large Invalid property font-max-size
+FAIL Can set 'font-max-size' to the 'xx-large' keyword: xx-large Invalid property font-max-size
+FAIL Can set 'font-max-size' to the 'larger' keyword: larger Invalid property font-max-size
+FAIL Can set 'font-max-size' to the 'smaller' keyword: smaller Invalid property font-max-size
+FAIL Can set 'font-max-size' to a length: 0px Invalid property font-max-size
+FAIL Can set 'font-max-size' to a length: -3.14em Invalid property font-max-size
+FAIL Can set 'font-max-size' to a length: 3.14cm Invalid property font-max-size
+FAIL Can set 'font-max-size' to a length: calc(0px + 0em) Invalid property font-max-size
+FAIL Can set 'font-max-size' to a percent: 0% Invalid property font-max-size
+FAIL Can set 'font-max-size' to a percent: -3.14% Invalid property font-max-size
+FAIL Can set 'font-max-size' to a percent: 3.14% Invalid property font-max-size
+FAIL Can set 'font-max-size' to a percent: calc(0% + 0%) Invalid property font-max-size
 PASS Setting 'font-max-size' to a time throws TypeError
 PASS Setting 'font-max-size' to an angle throws TypeError
 PASS Setting 'font-max-size' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt
@@ -1,16 +1,22 @@
 
-PASS Can set 'font-stretch' to CSS-wide keywords
-FAIL Can set 'font-stretch' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'font-stretch' to the 'normal' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'font-stretch' to the 'ultra-condensed' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'font-stretch' to the 'extra-condensed' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'font-stretch' to the 'condensed' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'font-stretch' to the 'semi-condensed' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'font-stretch' to the 'semi-expanded' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'font-stretch' to the 'expanded' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'font-stretch' to the 'extra-expanded' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'font-stretch' to the 'ultra-expanded' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'font-stretch' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'font-stretch' to CSS-wide keywords: initial
+PASS Can set 'font-stretch' to CSS-wide keywords: inherit
+PASS Can set 'font-stretch' to CSS-wide keywords: unset
+PASS Can set 'font-stretch' to CSS-wide keywords: revert
+FAIL Can set 'font-stretch' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'font-stretch' to the 'normal' keyword: normal assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'font-stretch' to the 'ultra-condensed' keyword: ultra-condensed assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'font-stretch' to the 'extra-condensed' keyword: extra-condensed assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'font-stretch' to the 'condensed' keyword: condensed assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'font-stretch' to the 'semi-condensed' keyword: semi-condensed assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'font-stretch' to the 'semi-expanded' keyword: semi-expanded assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'font-stretch' to the 'expanded' keyword: expanded assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'font-stretch' to the 'extra-expanded' keyword: extra-expanded assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'font-stretch' to the 'ultra-expanded' keyword: ultra-expanded assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+PASS Can set 'font-stretch' to a percent: 0%
+FAIL Can set 'font-stretch' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'font-stretch' to a percent: 3.14% assert_approx_equals: expected 3.14 +/- 0.000001 but got 3
+FAIL Can set 'font-stretch' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
 PASS Setting 'font-stretch' to a length throws TypeError
 PASS Setting 'font-stretch' to a time throws TypeError
 PASS Setting 'font-stretch' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-style-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'font-style' to CSS-wide keywords
-FAIL Can set 'font-style' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-style' to the 'normal' keyword
-PASS Can set 'font-style' to the 'italic' keyword
-PASS Can set 'font-style' to the 'oblique' keyword
+PASS Can set 'font-style' to CSS-wide keywords: initial
+PASS Can set 'font-style' to CSS-wide keywords: inherit
+PASS Can set 'font-style' to CSS-wide keywords: unset
+PASS Can set 'font-style' to CSS-wide keywords: revert
+FAIL Can set 'font-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-style' to the 'normal' keyword: normal
+PASS Can set 'font-style' to the 'italic' keyword: italic
+PASS Can set 'font-style' to the 'oblique' keyword: oblique
 PASS Setting 'font-style' to a length throws TypeError
 PASS Setting 'font-style' to a percent throws TypeError
 PASS Setting 'font-style' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-synthesis-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-synthesis-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'font-synthesis-weight' to CSS-wide keywords
-FAIL Can set 'font-synthesis-weight' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-synthesis-weight' to the 'auto' keyword
-PASS Can set 'font-synthesis-weight' to the 'none' keyword
+PASS Can set 'font-synthesis-weight' to CSS-wide keywords: initial
+PASS Can set 'font-synthesis-weight' to CSS-wide keywords: inherit
+PASS Can set 'font-synthesis-weight' to CSS-wide keywords: unset
+PASS Can set 'font-synthesis-weight' to CSS-wide keywords: revert
+FAIL Can set 'font-synthesis-weight' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-synthesis-weight' to the 'auto' keyword: auto
+PASS Can set 'font-synthesis-weight' to the 'none' keyword: none
 PASS Setting 'font-synthesis-weight' to a length throws TypeError
 PASS Setting 'font-synthesis-weight' to a percent throws TypeError
 PASS Setting 'font-synthesis-weight' to a time throws TypeError
@@ -11,10 +14,13 @@ PASS Setting 'font-synthesis-weight' to a flexible length throws TypeError
 PASS Setting 'font-synthesis-weight' to a number throws TypeError
 PASS Setting 'font-synthesis-weight' to a URL throws TypeError
 PASS Setting 'font-synthesis-weight' to a transform throws TypeError
-PASS Can set 'font-synthesis-style' to CSS-wide keywords
-FAIL Can set 'font-synthesis-style' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-synthesis-style' to the 'auto' keyword
-PASS Can set 'font-synthesis-style' to the 'none' keyword
+PASS Can set 'font-synthesis-style' to CSS-wide keywords: initial
+PASS Can set 'font-synthesis-style' to CSS-wide keywords: inherit
+PASS Can set 'font-synthesis-style' to CSS-wide keywords: unset
+PASS Can set 'font-synthesis-style' to CSS-wide keywords: revert
+FAIL Can set 'font-synthesis-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-synthesis-style' to the 'auto' keyword: auto
+PASS Can set 'font-synthesis-style' to the 'none' keyword: none
 PASS Setting 'font-synthesis-style' to a length throws TypeError
 PASS Setting 'font-synthesis-style' to a percent throws TypeError
 PASS Setting 'font-synthesis-style' to a time throws TypeError
@@ -23,10 +29,13 @@ PASS Setting 'font-synthesis-style' to a flexible length throws TypeError
 PASS Setting 'font-synthesis-style' to a number throws TypeError
 PASS Setting 'font-synthesis-style' to a URL throws TypeError
 PASS Setting 'font-synthesis-style' to a transform throws TypeError
-PASS Can set 'font-synthesis-small-caps' to CSS-wide keywords
-FAIL Can set 'font-synthesis-small-caps' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-synthesis-small-caps' to the 'auto' keyword
-PASS Can set 'font-synthesis-small-caps' to the 'none' keyword
+PASS Can set 'font-synthesis-small-caps' to CSS-wide keywords: initial
+PASS Can set 'font-synthesis-small-caps' to CSS-wide keywords: inherit
+PASS Can set 'font-synthesis-small-caps' to CSS-wide keywords: unset
+PASS Can set 'font-synthesis-small-caps' to CSS-wide keywords: revert
+FAIL Can set 'font-synthesis-small-caps' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-synthesis-small-caps' to the 'auto' keyword: auto
+PASS Can set 'font-synthesis-small-caps' to the 'none' keyword: none
 PASS Setting 'font-synthesis-small-caps' to a length throws TypeError
 PASS Setting 'font-synthesis-small-caps' to a percent throws TypeError
 PASS Setting 'font-synthesis-small-caps' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-alternates-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-alternates-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'font-variant-alternates' to CSS-wide keywords
-FAIL Can set 'font-variant-alternates' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-variant-alternates' to the 'normal' keyword
-FAIL Can set 'font-variant-alternates' to the 'historical-forms' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'font-variant-alternates' to CSS-wide keywords: initial
+PASS Can set 'font-variant-alternates' to CSS-wide keywords: inherit
+PASS Can set 'font-variant-alternates' to CSS-wide keywords: unset
+PASS Can set 'font-variant-alternates' to CSS-wide keywords: revert
+FAIL Can set 'font-variant-alternates' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-variant-alternates' to the 'normal' keyword: normal
+FAIL Can set 'font-variant-alternates' to the 'historical-forms' keyword: historical-forms assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'font-variant-alternates' to a length throws TypeError
 PASS Setting 'font-variant-alternates' to a percent throws TypeError
 PASS Setting 'font-variant-alternates' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-caps-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-caps-expected.txt
@@ -1,13 +1,16 @@
 
-PASS Can set 'font-variant-caps' to CSS-wide keywords
-FAIL Can set 'font-variant-caps' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-variant-caps' to the 'normal' keyword
-PASS Can set 'font-variant-caps' to the 'small-caps' keyword
-PASS Can set 'font-variant-caps' to the 'all-small-caps' keyword
-PASS Can set 'font-variant-caps' to the 'petite-caps' keyword
-PASS Can set 'font-variant-caps' to the 'all-petite-caps' keyword
-PASS Can set 'font-variant-caps' to the 'unicase' keyword
-PASS Can set 'font-variant-caps' to the 'titling-caps' keyword
+PASS Can set 'font-variant-caps' to CSS-wide keywords: initial
+PASS Can set 'font-variant-caps' to CSS-wide keywords: inherit
+PASS Can set 'font-variant-caps' to CSS-wide keywords: unset
+PASS Can set 'font-variant-caps' to CSS-wide keywords: revert
+FAIL Can set 'font-variant-caps' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-variant-caps' to the 'normal' keyword: normal
+PASS Can set 'font-variant-caps' to the 'small-caps' keyword: small-caps
+PASS Can set 'font-variant-caps' to the 'all-small-caps' keyword: all-small-caps
+PASS Can set 'font-variant-caps' to the 'petite-caps' keyword: petite-caps
+PASS Can set 'font-variant-caps' to the 'all-petite-caps' keyword: all-petite-caps
+PASS Can set 'font-variant-caps' to the 'unicase' keyword: unicase
+PASS Can set 'font-variant-caps' to the 'titling-caps' keyword: titling-caps
 PASS Setting 'font-variant-caps' to a length throws TypeError
 PASS Setting 'font-variant-caps' to a percent throws TypeError
 PASS Setting 'font-variant-caps' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-east-asian-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-east-asian-expected.txt
@@ -1,16 +1,19 @@
 
-PASS Can set 'font-variant-east-asian' to CSS-wide keywords
-FAIL Can set 'font-variant-east-asian' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-variant-east-asian' to the 'normal' keyword
-PASS Can set 'font-variant-east-asian' to the 'jis78' keyword
-PASS Can set 'font-variant-east-asian' to the 'jis83' keyword
-PASS Can set 'font-variant-east-asian' to the 'jis90' keyword
-PASS Can set 'font-variant-east-asian' to the 'jis04' keyword
-PASS Can set 'font-variant-east-asian' to the 'simplified' keyword
-PASS Can set 'font-variant-east-asian' to the 'traditional' keyword
-PASS Can set 'font-variant-east-asian' to the 'full-width' keyword
-PASS Can set 'font-variant-east-asian' to the 'proportional-width' keyword
-PASS Can set 'font-variant-east-asian' to the 'ruby' keyword
+PASS Can set 'font-variant-east-asian' to CSS-wide keywords: initial
+PASS Can set 'font-variant-east-asian' to CSS-wide keywords: inherit
+PASS Can set 'font-variant-east-asian' to CSS-wide keywords: unset
+PASS Can set 'font-variant-east-asian' to CSS-wide keywords: revert
+FAIL Can set 'font-variant-east-asian' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-variant-east-asian' to the 'normal' keyword: normal
+PASS Can set 'font-variant-east-asian' to the 'jis78' keyword: jis78
+PASS Can set 'font-variant-east-asian' to the 'jis83' keyword: jis83
+PASS Can set 'font-variant-east-asian' to the 'jis90' keyword: jis90
+PASS Can set 'font-variant-east-asian' to the 'jis04' keyword: jis04
+PASS Can set 'font-variant-east-asian' to the 'simplified' keyword: simplified
+PASS Can set 'font-variant-east-asian' to the 'traditional' keyword: traditional
+PASS Can set 'font-variant-east-asian' to the 'full-width' keyword: full-width
+PASS Can set 'font-variant-east-asian' to the 'proportional-width' keyword: proportional-width
+PASS Can set 'font-variant-east-asian' to the 'ruby' keyword: ruby
 PASS Setting 'font-variant-east-asian' to a length throws TypeError
 PASS Setting 'font-variant-east-asian' to a percent throws TypeError
 PASS Setting 'font-variant-east-asian' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-emoji-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-emoji-expected.txt
@@ -1,9 +1,12 @@
 
-FAIL Can set 'font-variant-emoji' to CSS-wide keywords Invalid property font-variant-emoji
-FAIL Can set 'font-variant-emoji' to var() references Invalid property font-variant-emoji
-FAIL Can set 'font-variant-emoji' to the 'auto' keyword Invalid property font-variant-emoji
-FAIL Can set 'font-variant-emoji' to the 'text' keyword Invalid property font-variant-emoji
-FAIL Can set 'font-variant-emoji' to the 'emoji' keyword Invalid property font-variant-emoji
+FAIL Can set 'font-variant-emoji' to CSS-wide keywords: initial Invalid property font-variant-emoji
+FAIL Can set 'font-variant-emoji' to CSS-wide keywords: inherit Invalid property font-variant-emoji
+FAIL Can set 'font-variant-emoji' to CSS-wide keywords: unset Invalid property font-variant-emoji
+FAIL Can set 'font-variant-emoji' to CSS-wide keywords: revert Invalid property font-variant-emoji
+FAIL Can set 'font-variant-emoji' to var() references:  var(--A) Invalid property font-variant-emoji
+FAIL Can set 'font-variant-emoji' to the 'auto' keyword: auto Invalid property font-variant-emoji
+FAIL Can set 'font-variant-emoji' to the 'text' keyword: text Invalid property font-variant-emoji
+FAIL Can set 'font-variant-emoji' to the 'emoji' keyword: emoji Invalid property font-variant-emoji
 PASS Setting 'font-variant-emoji' to a length throws TypeError
 PASS Setting 'font-variant-emoji' to a percent throws TypeError
 PASS Setting 'font-variant-emoji' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-ligatures-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-ligatures-expected.txt
@@ -1,16 +1,19 @@
 
-PASS Can set 'font-variant-ligatures' to CSS-wide keywords
-FAIL Can set 'font-variant-ligatures' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-variant-ligatures' to the 'normal' keyword
-PASS Can set 'font-variant-ligatures' to the 'none' keyword
-PASS Can set 'font-variant-ligatures' to the 'common-ligatures' keyword
-PASS Can set 'font-variant-ligatures' to the 'no-common-ligatures' keyword
-PASS Can set 'font-variant-ligatures' to the 'discretionary-ligatures' keyword
-PASS Can set 'font-variant-ligatures' to the 'no-discretionary-ligatures' keyword
-PASS Can set 'font-variant-ligatures' to the 'historical-ligatures' keyword
-PASS Can set 'font-variant-ligatures' to the 'no-historical-ligatures' keyword
-PASS Can set 'font-variant-ligatures' to the 'contextual' keyword
-PASS Can set 'font-variant-ligatures' to the 'no-contextual' keyword
+PASS Can set 'font-variant-ligatures' to CSS-wide keywords: initial
+PASS Can set 'font-variant-ligatures' to CSS-wide keywords: inherit
+PASS Can set 'font-variant-ligatures' to CSS-wide keywords: unset
+PASS Can set 'font-variant-ligatures' to CSS-wide keywords: revert
+FAIL Can set 'font-variant-ligatures' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-variant-ligatures' to the 'normal' keyword: normal
+PASS Can set 'font-variant-ligatures' to the 'none' keyword: none
+PASS Can set 'font-variant-ligatures' to the 'common-ligatures' keyword: common-ligatures
+PASS Can set 'font-variant-ligatures' to the 'no-common-ligatures' keyword: no-common-ligatures
+PASS Can set 'font-variant-ligatures' to the 'discretionary-ligatures' keyword: discretionary-ligatures
+PASS Can set 'font-variant-ligatures' to the 'no-discretionary-ligatures' keyword: no-discretionary-ligatures
+PASS Can set 'font-variant-ligatures' to the 'historical-ligatures' keyword: historical-ligatures
+PASS Can set 'font-variant-ligatures' to the 'no-historical-ligatures' keyword: no-historical-ligatures
+PASS Can set 'font-variant-ligatures' to the 'contextual' keyword: contextual
+PASS Can set 'font-variant-ligatures' to the 'no-contextual' keyword: no-contextual
 PASS Setting 'font-variant-ligatures' to a length throws TypeError
 PASS Setting 'font-variant-ligatures' to a percent throws TypeError
 PASS Setting 'font-variant-ligatures' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-numeric-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-numeric-expected.txt
@@ -1,15 +1,18 @@
 
-PASS Can set 'font-variant-numeric' to CSS-wide keywords
-FAIL Can set 'font-variant-numeric' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-variant-numeric' to the 'normal' keyword
-PASS Can set 'font-variant-numeric' to the 'lining-nums' keyword
-PASS Can set 'font-variant-numeric' to the 'oldstyle-nums' keyword
-PASS Can set 'font-variant-numeric' to the 'proportional-nums' keyword
-PASS Can set 'font-variant-numeric' to the 'tabular-nums' keyword
-PASS Can set 'font-variant-numeric' to the 'diagonal-fractions' keyword
-PASS Can set 'font-variant-numeric' to the 'stacked-fractions' keyword
-PASS Can set 'font-variant-numeric' to the 'ordinal' keyword
-PASS Can set 'font-variant-numeric' to the 'slashed-zero' keyword
+PASS Can set 'font-variant-numeric' to CSS-wide keywords: initial
+PASS Can set 'font-variant-numeric' to CSS-wide keywords: inherit
+PASS Can set 'font-variant-numeric' to CSS-wide keywords: unset
+PASS Can set 'font-variant-numeric' to CSS-wide keywords: revert
+FAIL Can set 'font-variant-numeric' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-variant-numeric' to the 'normal' keyword: normal
+PASS Can set 'font-variant-numeric' to the 'lining-nums' keyword: lining-nums
+PASS Can set 'font-variant-numeric' to the 'oldstyle-nums' keyword: oldstyle-nums
+PASS Can set 'font-variant-numeric' to the 'proportional-nums' keyword: proportional-nums
+PASS Can set 'font-variant-numeric' to the 'tabular-nums' keyword: tabular-nums
+PASS Can set 'font-variant-numeric' to the 'diagonal-fractions' keyword: diagonal-fractions
+PASS Can set 'font-variant-numeric' to the 'stacked-fractions' keyword: stacked-fractions
+PASS Can set 'font-variant-numeric' to the 'ordinal' keyword: ordinal
+PASS Can set 'font-variant-numeric' to the 'slashed-zero' keyword: slashed-zero
 PASS Setting 'font-variant-numeric' to a length throws TypeError
 PASS Setting 'font-variant-numeric' to a percent throws TypeError
 PASS Setting 'font-variant-numeric' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variation-settings-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variation-settings-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'font-variation-settings' to CSS-wide keywords
-FAIL Can set 'font-variation-settings' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-variation-settings' to the 'normal' keyword
+PASS Can set 'font-variation-settings' to CSS-wide keywords: initial
+PASS Can set 'font-variation-settings' to CSS-wide keywords: inherit
+PASS Can set 'font-variation-settings' to CSS-wide keywords: unset
+PASS Can set 'font-variation-settings' to CSS-wide keywords: revert
+FAIL Can set 'font-variation-settings' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-variation-settings' to the 'normal' keyword: normal
 PASS Setting 'font-variation-settings' to a length throws TypeError
 PASS Setting 'font-variation-settings' to a percent throws TypeError
 PASS Setting 'font-variation-settings' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt
@@ -1,11 +1,17 @@
 
-PASS Can set 'font-weight' to CSS-wide keywords
-FAIL Can set 'font-weight' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'font-weight' to the 'normal' keyword
-PASS Can set 'font-weight' to the 'bold' keyword
-PASS Can set 'font-weight' to the 'bolder' keyword
-PASS Can set 'font-weight' to the 'lighter' keyword
-FAIL Can set 'font-weight' to a number assert_approx_equals: expected 0 +/- 0.000001 but got 1
+PASS Can set 'font-weight' to CSS-wide keywords: initial
+PASS Can set 'font-weight' to CSS-wide keywords: inherit
+PASS Can set 'font-weight' to CSS-wide keywords: unset
+PASS Can set 'font-weight' to CSS-wide keywords: revert
+FAIL Can set 'font-weight' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-weight' to the 'normal' keyword: normal
+PASS Can set 'font-weight' to the 'bold' keyword: bold
+PASS Can set 'font-weight' to the 'bolder' keyword: bolder
+PASS Can set 'font-weight' to the 'lighter' keyword: lighter
+FAIL Can set 'font-weight' to a number: 0 assert_approx_equals: expected 0 +/- 0.000001 but got 1
+FAIL Can set 'font-weight' to a number: -3.14 assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
+FAIL Can set 'font-weight' to a number: 3.14 assert_approx_equals: expected 3.14 +/- 0.000001 but got 3
+FAIL Can set 'font-weight' to a number: calc(2 + 3) assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
 PASS Setting 'font-weight' to a length throws TypeError
 PASS Setting 'font-weight' to a percent throws TypeError
 PASS Setting 'font-weight' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt
@@ -1,20 +1,38 @@
 
-PASS Can set 'column-gap' to CSS-wide keywords
-FAIL Can set 'column-gap' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'column-gap' to the 'normal' keyword
-FAIL Can set 'column-gap' to a length assert_equals: expected "px" but got "em"
-FAIL Can set 'column-gap' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'column-gap' to CSS-wide keywords: initial
+PASS Can set 'column-gap' to CSS-wide keywords: inherit
+PASS Can set 'column-gap' to CSS-wide keywords: unset
+PASS Can set 'column-gap' to CSS-wide keywords: revert
+FAIL Can set 'column-gap' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'column-gap' to the 'normal' keyword: normal
+PASS Can set 'column-gap' to a length: 0px
+PASS Can set 'column-gap' to a length: -3.14em
+PASS Can set 'column-gap' to a length: 3.14cm
+FAIL Can set 'column-gap' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'column-gap' to a percent: 0%
+FAIL Can set 'column-gap' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'column-gap' to a percent: 3.14%
+FAIL Can set 'column-gap' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
 PASS Setting 'column-gap' to a time throws TypeError
 PASS Setting 'column-gap' to an angle throws TypeError
 PASS Setting 'column-gap' to a flexible length throws TypeError
 FAIL Setting 'column-gap' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'column-gap' to a URL throws TypeError
 PASS Setting 'column-gap' to a transform throws TypeError
-PASS Can set 'row-gap' to CSS-wide keywords
-FAIL Can set 'row-gap' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'row-gap' to the 'normal' keyword
-FAIL Can set 'row-gap' to a length assert_equals: expected "px" but got "em"
-FAIL Can set 'row-gap' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'row-gap' to CSS-wide keywords: initial
+PASS Can set 'row-gap' to CSS-wide keywords: inherit
+PASS Can set 'row-gap' to CSS-wide keywords: unset
+PASS Can set 'row-gap' to CSS-wide keywords: revert
+FAIL Can set 'row-gap' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'row-gap' to the 'normal' keyword: normal
+PASS Can set 'row-gap' to a length: 0px
+PASS Can set 'row-gap' to a length: -3.14em
+PASS Can set 'row-gap' to a length: 3.14cm
+FAIL Can set 'row-gap' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'row-gap' to a percent: 0%
+FAIL Can set 'row-gap' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'row-gap' to a percent: 3.14%
+FAIL Can set 'row-gap' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
 PASS Setting 'row-gap' to a time throws TypeError
 PASS Setting 'row-gap' to an angle throws TypeError
 PASS Setting 'row-gap' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
@@ -1,12 +1,25 @@
 
-PASS Can set 'grid-auto-columns' to CSS-wide keywords
-FAIL Can set 'grid-auto-columns' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'grid-auto-columns' to the 'min-content' keyword
-PASS Can set 'grid-auto-columns' to the 'max-content' keyword
-PASS Can set 'grid-auto-columns' to the 'auto' keyword
-FAIL Can set 'grid-auto-columns' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'grid-auto-columns' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'grid-auto-columns' to a flexible length Invalid values
+Harness Error (FAIL), message = 2 duplicate test names: "Can set 'grid-auto-columns' to a flexible length: 0fr", "Can set 'grid-auto-rows' to a flexible length: 0fr"
+
+PASS Can set 'grid-auto-columns' to CSS-wide keywords: initial
+PASS Can set 'grid-auto-columns' to CSS-wide keywords: inherit
+PASS Can set 'grid-auto-columns' to CSS-wide keywords: unset
+PASS Can set 'grid-auto-columns' to CSS-wide keywords: revert
+FAIL Can set 'grid-auto-columns' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-auto-columns' to the 'min-content' keyword: min-content
+PASS Can set 'grid-auto-columns' to the 'max-content' keyword: max-content
+PASS Can set 'grid-auto-columns' to the 'auto' keyword: auto
+PASS Can set 'grid-auto-columns' to a length: 0px
+FAIL Can set 'grid-auto-columns' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'grid-auto-columns' to a length: 3.14cm
+PASS Can set 'grid-auto-columns' to a length: calc(0px + 0em)
+PASS Can set 'grid-auto-columns' to a percent: 0%
+FAIL Can set 'grid-auto-columns' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'grid-auto-columns' to a percent: 3.14%
+PASS Can set 'grid-auto-columns' to a percent: calc(0% + 0%)
+PASS Can set 'grid-auto-columns' to a flexible length: 0fr
+PASS Can set 'grid-auto-columns' to a flexible length: 0fr
+FAIL Can set 'grid-auto-columns' to a flexible length: -3.14fr Invalid values
 PASS Setting 'grid-auto-columns' to a time throws TypeError
 PASS Setting 'grid-auto-columns' to an angle throws TypeError
 FAIL Setting 'grid-auto-columns' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
@@ -14,14 +27,25 @@ PASS Setting 'grid-auto-columns' to a URL throws TypeError
 PASS Setting 'grid-auto-columns' to a transform throws TypeError
 PASS 'grid-auto-columns' does not supported 'minmax(100px, auto)'
 PASS 'grid-auto-columns' does not supported 'fit-content(400px)'
-PASS Can set 'grid-auto-rows' to CSS-wide keywords
-FAIL Can set 'grid-auto-rows' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'grid-auto-rows' to the 'min-content' keyword
-PASS Can set 'grid-auto-rows' to the 'max-content' keyword
-PASS Can set 'grid-auto-rows' to the 'auto' keyword
-FAIL Can set 'grid-auto-rows' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'grid-auto-rows' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'grid-auto-rows' to a flexible length Invalid values
+PASS Can set 'grid-auto-rows' to CSS-wide keywords: initial
+PASS Can set 'grid-auto-rows' to CSS-wide keywords: inherit
+PASS Can set 'grid-auto-rows' to CSS-wide keywords: unset
+PASS Can set 'grid-auto-rows' to CSS-wide keywords: revert
+FAIL Can set 'grid-auto-rows' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-auto-rows' to the 'min-content' keyword: min-content
+PASS Can set 'grid-auto-rows' to the 'max-content' keyword: max-content
+PASS Can set 'grid-auto-rows' to the 'auto' keyword: auto
+PASS Can set 'grid-auto-rows' to a length: 0px
+FAIL Can set 'grid-auto-rows' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'grid-auto-rows' to a length: 3.14cm
+PASS Can set 'grid-auto-rows' to a length: calc(0px + 0em)
+PASS Can set 'grid-auto-rows' to a percent: 0%
+FAIL Can set 'grid-auto-rows' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'grid-auto-rows' to a percent: 3.14%
+PASS Can set 'grid-auto-rows' to a percent: calc(0% + 0%)
+PASS Can set 'grid-auto-rows' to a flexible length: 0fr
+PASS Can set 'grid-auto-rows' to a flexible length: 0fr
+FAIL Can set 'grid-auto-rows' to a flexible length: -3.14fr Invalid values
 PASS Setting 'grid-auto-rows' to a time throws TypeError
 PASS Setting 'grid-auto-rows' to an angle throws TypeError
 FAIL Setting 'grid-auto-rows' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-flow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-flow-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'grid-auto-flow' to CSS-wide keywords
-FAIL Can set 'grid-auto-flow' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'grid-auto-flow' to the 'row' keyword
-PASS Can set 'grid-auto-flow' to the 'column' keyword
+PASS Can set 'grid-auto-flow' to CSS-wide keywords: initial
+PASS Can set 'grid-auto-flow' to CSS-wide keywords: inherit
+PASS Can set 'grid-auto-flow' to CSS-wide keywords: unset
+PASS Can set 'grid-auto-flow' to CSS-wide keywords: revert
+FAIL Can set 'grid-auto-flow' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-auto-flow' to the 'row' keyword: row
+PASS Can set 'grid-auto-flow' to the 'column' keyword: column
 PASS Setting 'grid-auto-flow' to a length throws TypeError
 PASS Setting 'grid-auto-flow' to a percent throws TypeError
 PASS Setting 'grid-auto-flow' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'grid-row-start' to CSS-wide keywords
-FAIL Can set 'grid-row-start' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'grid-row-start' to the 'auto' keyword
+PASS Can set 'grid-row-start' to CSS-wide keywords: initial
+PASS Can set 'grid-row-start' to CSS-wide keywords: inherit
+PASS Can set 'grid-row-start' to CSS-wide keywords: unset
+PASS Can set 'grid-row-start' to CSS-wide keywords: revert
+FAIL Can set 'grid-row-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-row-start' to the 'auto' keyword: auto
 PASS Setting 'grid-row-start' to a length throws TypeError
 PASS Setting 'grid-row-start' to a percent throws TypeError
 PASS Setting 'grid-row-start' to a time throws TypeError
@@ -13,9 +16,12 @@ PASS Setting 'grid-row-start' to a transform throws TypeError
 PASS 'grid-row-start' does not supported '3'
 FAIL 'grid-row-start' does not supported 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 FAIL 'grid-row-start' does not supported '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS Can set 'grid-row-end' to CSS-wide keywords
-FAIL Can set 'grid-row-end' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'grid-row-end' to the 'auto' keyword
+PASS Can set 'grid-row-end' to CSS-wide keywords: initial
+PASS Can set 'grid-row-end' to CSS-wide keywords: inherit
+PASS Can set 'grid-row-end' to CSS-wide keywords: unset
+PASS Can set 'grid-row-end' to CSS-wide keywords: revert
+FAIL Can set 'grid-row-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-row-end' to the 'auto' keyword: auto
 PASS Setting 'grid-row-end' to a length throws TypeError
 PASS Setting 'grid-row-end' to a percent throws TypeError
 PASS Setting 'grid-row-end' to a time throws TypeError
@@ -27,9 +33,12 @@ PASS Setting 'grid-row-end' to a transform throws TypeError
 PASS 'grid-row-end' does not supported '3'
 FAIL 'grid-row-end' does not supported 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 FAIL 'grid-row-end' does not supported '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS Can set 'grid-column-start' to CSS-wide keywords
-FAIL Can set 'grid-column-start' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'grid-column-start' to the 'auto' keyword
+PASS Can set 'grid-column-start' to CSS-wide keywords: initial
+PASS Can set 'grid-column-start' to CSS-wide keywords: inherit
+PASS Can set 'grid-column-start' to CSS-wide keywords: unset
+PASS Can set 'grid-column-start' to CSS-wide keywords: revert
+FAIL Can set 'grid-column-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-column-start' to the 'auto' keyword: auto
 PASS Setting 'grid-column-start' to a length throws TypeError
 PASS Setting 'grid-column-start' to a percent throws TypeError
 PASS Setting 'grid-column-start' to a time throws TypeError
@@ -41,9 +50,12 @@ PASS Setting 'grid-column-start' to a transform throws TypeError
 PASS 'grid-column-start' does not supported '3'
 FAIL 'grid-column-start' does not supported 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 FAIL 'grid-column-start' does not supported '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS Can set 'grid-column-end' to CSS-wide keywords
-FAIL Can set 'grid-column-end' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'grid-column-end' to the 'auto' keyword
+PASS Can set 'grid-column-end' to CSS-wide keywords: initial
+PASS Can set 'grid-column-end' to CSS-wide keywords: inherit
+PASS Can set 'grid-column-end' to CSS-wide keywords: unset
+PASS Can set 'grid-column-end' to CSS-wide keywords: revert
+FAIL Can set 'grid-column-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-column-end' to the 'auto' keyword: auto
 PASS Setting 'grid-column-end' to a length throws TypeError
 PASS Setting 'grid-column-end' to a percent throws TypeError
 PASS Setting 'grid-column-end' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-areas-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-areas-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'grid-template-areas' to CSS-wide keywords
-FAIL Can set 'grid-template-areas' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'grid-template-areas' to the 'none' keyword
+PASS Can set 'grid-template-areas' to CSS-wide keywords: initial
+PASS Can set 'grid-template-areas' to CSS-wide keywords: inherit
+PASS Can set 'grid-template-areas' to CSS-wide keywords: unset
+PASS Can set 'grid-template-areas' to CSS-wide keywords: revert
+FAIL Can set 'grid-template-areas' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-template-areas' to the 'none' keyword: none
 PASS Setting 'grid-template-areas' to a length throws TypeError
 PASS Setting 'grid-template-areas' to a percent throws TypeError
 PASS Setting 'grid-template-areas' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'grid-template-columns' to CSS-wide keywords
-FAIL Can set 'grid-template-columns' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'grid-template-columns' to the 'none' keyword
+PASS Can set 'grid-template-columns' to CSS-wide keywords: initial
+PASS Can set 'grid-template-columns' to CSS-wide keywords: inherit
+PASS Can set 'grid-template-columns' to CSS-wide keywords: unset
+PASS Can set 'grid-template-columns' to CSS-wide keywords: revert
+FAIL Can set 'grid-template-columns' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-template-columns' to the 'none' keyword: none
 FAIL Setting 'grid-template-columns' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 FAIL Setting 'grid-template-columns' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'grid-template-columns' to a time throws TypeError
@@ -12,9 +15,12 @@ PASS Setting 'grid-template-columns' to a URL throws TypeError
 PASS Setting 'grid-template-columns' to a transform throws TypeError
 FAIL 'grid-template-columns' does not supported '[linename1] 100px [linename2 linename3]' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 FAIL 'grid-template-columns' does not supported '200px repeat(auto-fill, 100px) 300px' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
-PASS Can set 'grid-template-rows' to CSS-wide keywords
-FAIL Can set 'grid-template-rows' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'grid-template-rows' to the 'none' keyword
+PASS Can set 'grid-template-rows' to CSS-wide keywords: initial
+PASS Can set 'grid-template-rows' to CSS-wide keywords: inherit
+PASS Can set 'grid-template-rows' to CSS-wide keywords: unset
+PASS Can set 'grid-template-rows' to CSS-wide keywords: revert
+FAIL Can set 'grid-template-rows' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-template-rows' to the 'none' keyword: none
 FAIL Setting 'grid-template-rows' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 FAIL Setting 'grid-template-rows' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'grid-template-rows' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt
@@ -1,30 +1,57 @@
 
-PASS Can set 'height' to CSS-wide keywords
-FAIL Can set 'height' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'height' to the 'auto' keyword
-FAIL Can set 'height' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'height' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'height' to CSS-wide keywords: initial
+PASS Can set 'height' to CSS-wide keywords: inherit
+PASS Can set 'height' to CSS-wide keywords: unset
+PASS Can set 'height' to CSS-wide keywords: revert
+FAIL Can set 'height' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'height' to the 'auto' keyword: auto
+PASS Can set 'height' to a percent: 0%
+FAIL Can set 'height' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'height' to a percent: 3.14%
+FAIL Can set 'height' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'height' to a length: 0px
+PASS Can set 'height' to a length: -3.14em
+PASS Can set 'height' to a length: 3.14cm
+FAIL Can set 'height' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'height' to a time throws TypeError
 PASS Setting 'height' to an angle throws TypeError
 PASS Setting 'height' to a flexible length throws TypeError
 FAIL Setting 'height' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'height' to a URL throws TypeError
 PASS Setting 'height' to a transform throws TypeError
-PASS Can set 'min-height' to CSS-wide keywords
-FAIL Can set 'min-height' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'min-height' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'min-height' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'min-height' to CSS-wide keywords: initial
+PASS Can set 'min-height' to CSS-wide keywords: inherit
+PASS Can set 'min-height' to CSS-wide keywords: unset
+PASS Can set 'min-height' to CSS-wide keywords: revert
+FAIL Can set 'min-height' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'min-height' to a percent: 0%
+FAIL Can set 'min-height' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'min-height' to a percent: 3.14%
+FAIL Can set 'min-height' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'min-height' to a length: 0px
+PASS Can set 'min-height' to a length: -3.14em
+PASS Can set 'min-height' to a length: 3.14cm
+FAIL Can set 'min-height' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'min-height' to a time throws TypeError
 PASS Setting 'min-height' to an angle throws TypeError
 PASS Setting 'min-height' to a flexible length throws TypeError
 FAIL Setting 'min-height' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'min-height' to a URL throws TypeError
 PASS Setting 'min-height' to a transform throws TypeError
-PASS Can set 'max-height' to CSS-wide keywords
-FAIL Can set 'max-height' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'max-height' to the 'none' keyword
-FAIL Can set 'max-height' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'max-height' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'max-height' to CSS-wide keywords: initial
+PASS Can set 'max-height' to CSS-wide keywords: inherit
+PASS Can set 'max-height' to CSS-wide keywords: unset
+PASS Can set 'max-height' to CSS-wide keywords: revert
+FAIL Can set 'max-height' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'max-height' to the 'none' keyword: none
+PASS Can set 'max-height' to a percent: 0%
+FAIL Can set 'max-height' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'max-height' to a percent: 3.14%
+FAIL Can set 'max-height' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'max-height' to a length: 0px
+PASS Can set 'max-height' to a length: -3.14em
+PASS Can set 'max-height' to a length: 3.14cm
+FAIL Can set 'max-height' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'max-height' to a time throws TypeError
 PASS Setting 'max-height' to an angle throws TypeError
 PASS Setting 'max-height' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/hyphens-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/hyphens-expected.txt
@@ -1,9 +1,12 @@
 
-FAIL Can set 'hyphens' to CSS-wide keywords Invalid property hyphens
-FAIL Can set 'hyphens' to var() references Invalid property hyphens
-FAIL Can set 'hyphens' to the 'none' keyword Invalid property hyphens
-FAIL Can set 'hyphens' to the 'manual' keyword Invalid property hyphens
-FAIL Can set 'hyphens' to the 'auto' keyword Invalid property hyphens
+FAIL Can set 'hyphens' to CSS-wide keywords: initial Invalid property hyphens
+FAIL Can set 'hyphens' to CSS-wide keywords: inherit Invalid property hyphens
+FAIL Can set 'hyphens' to CSS-wide keywords: unset Invalid property hyphens
+FAIL Can set 'hyphens' to CSS-wide keywords: revert Invalid property hyphens
+FAIL Can set 'hyphens' to var() references:  var(--A) Invalid property hyphens
+FAIL Can set 'hyphens' to the 'none' keyword: none Invalid property hyphens
+FAIL Can set 'hyphens' to the 'manual' keyword: manual Invalid property hyphens
+FAIL Can set 'hyphens' to the 'auto' keyword: auto Invalid property hyphens
 PASS Setting 'hyphens' to a length throws TypeError
 PASS Setting 'hyphens' to a percent throws TypeError
 PASS Setting 'hyphens' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering-expected.txt
@@ -1,11 +1,14 @@
 
-PASS Can set 'image-rendering' to CSS-wide keywords
-FAIL Can set 'image-rendering' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'image-rendering' to the 'auto' keyword
-FAIL Can set 'image-rendering' to the 'smooth' keyword Invalid values
-FAIL Can set 'image-rendering' to the 'high-quality' keyword Invalid values
-PASS Can set 'image-rendering' to the 'crisp-edges' keyword
-PASS Can set 'image-rendering' to the 'pixelated' keyword
+PASS Can set 'image-rendering' to CSS-wide keywords: initial
+PASS Can set 'image-rendering' to CSS-wide keywords: inherit
+PASS Can set 'image-rendering' to CSS-wide keywords: unset
+PASS Can set 'image-rendering' to CSS-wide keywords: revert
+FAIL Can set 'image-rendering' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'image-rendering' to the 'auto' keyword: auto
+FAIL Can set 'image-rendering' to the 'smooth' keyword: smooth Invalid values
+FAIL Can set 'image-rendering' to the 'high-quality' keyword: high-quality Invalid values
+PASS Can set 'image-rendering' to the 'crisp-edges' keyword: crisp-edges
+PASS Can set 'image-rendering' to the 'pixelated' keyword: pixelated
 PASS Setting 'image-rendering' to a length throws TypeError
 PASS Setting 'image-rendering' to a percent throws TypeError
 PASS Setting 'image-rendering' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt
@@ -1,30 +1,57 @@
 
-PASS Can set 'inline-size' to CSS-wide keywords
-FAIL Can set 'inline-size' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'inline-size' to the 'auto' keyword
-FAIL Can set 'inline-size' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'inline-size' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'inline-size' to CSS-wide keywords: initial
+PASS Can set 'inline-size' to CSS-wide keywords: inherit
+PASS Can set 'inline-size' to CSS-wide keywords: unset
+PASS Can set 'inline-size' to CSS-wide keywords: revert
+FAIL Can set 'inline-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'inline-size' to the 'auto' keyword: auto
+PASS Can set 'inline-size' to a percent: 0%
+FAIL Can set 'inline-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'inline-size' to a percent: 3.14%
+FAIL Can set 'inline-size' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'inline-size' to a length: 0px
+PASS Can set 'inline-size' to a length: -3.14em
+PASS Can set 'inline-size' to a length: 3.14cm
+FAIL Can set 'inline-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'inline-size' to a time throws TypeError
 PASS Setting 'inline-size' to an angle throws TypeError
 PASS Setting 'inline-size' to a flexible length throws TypeError
 FAIL Setting 'inline-size' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'inline-size' to a URL throws TypeError
 PASS Setting 'inline-size' to a transform throws TypeError
-PASS Can set 'min-inline-size' to CSS-wide keywords
-FAIL Can set 'min-inline-size' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'min-inline-size' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'min-inline-size' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'min-inline-size' to CSS-wide keywords: initial
+PASS Can set 'min-inline-size' to CSS-wide keywords: inherit
+PASS Can set 'min-inline-size' to CSS-wide keywords: unset
+PASS Can set 'min-inline-size' to CSS-wide keywords: revert
+FAIL Can set 'min-inline-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'min-inline-size' to a percent: 0%
+FAIL Can set 'min-inline-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'min-inline-size' to a percent: 3.14%
+FAIL Can set 'min-inline-size' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'min-inline-size' to a length: 0px
+PASS Can set 'min-inline-size' to a length: -3.14em
+PASS Can set 'min-inline-size' to a length: 3.14cm
+FAIL Can set 'min-inline-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'min-inline-size' to a time throws TypeError
 PASS Setting 'min-inline-size' to an angle throws TypeError
 PASS Setting 'min-inline-size' to a flexible length throws TypeError
 FAIL Setting 'min-inline-size' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'min-inline-size' to a URL throws TypeError
 PASS Setting 'min-inline-size' to a transform throws TypeError
-PASS Can set 'max-inline-size' to CSS-wide keywords
-FAIL Can set 'max-inline-size' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'max-inline-size' to the 'none' keyword
-FAIL Can set 'max-inline-size' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'max-inline-size' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'max-inline-size' to CSS-wide keywords: initial
+PASS Can set 'max-inline-size' to CSS-wide keywords: inherit
+PASS Can set 'max-inline-size' to CSS-wide keywords: unset
+PASS Can set 'max-inline-size' to CSS-wide keywords: revert
+FAIL Can set 'max-inline-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'max-inline-size' to the 'none' keyword: none
+PASS Can set 'max-inline-size' to a percent: 0%
+FAIL Can set 'max-inline-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'max-inline-size' to a percent: 3.14%
+FAIL Can set 'max-inline-size' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'max-inline-size' to a length: 0px
+PASS Can set 'max-inline-size' to a length: -3.14em
+PASS Can set 'max-inline-size' to a length: 3.14cm
+FAIL Can set 'max-inline-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'max-inline-size' to a time throws TypeError
 PASS Setting 'max-inline-size' to an angle throws TypeError
 PASS Setting 'max-inline-size' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/isolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/isolation-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'isolation' to CSS-wide keywords
-FAIL Can set 'isolation' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'isolation' to the 'auto' keyword
-PASS Can set 'isolation' to the 'isolate' keyword
+PASS Can set 'isolation' to CSS-wide keywords: initial
+PASS Can set 'isolation' to CSS-wide keywords: inherit
+PASS Can set 'isolation' to CSS-wide keywords: unset
+PASS Can set 'isolation' to CSS-wide keywords: revert
+FAIL Can set 'isolation' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'isolation' to the 'auto' keyword: auto
+PASS Can set 'isolation' to the 'isolate' keyword: isolate
 PASS Setting 'isolation' to a length throws TypeError
 PASS Setting 'isolation' to a percent throws TypeError
 PASS Setting 'isolation' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/left-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/left-expected.txt
@@ -1,9 +1,18 @@
 
-PASS Can set 'left' to CSS-wide keywords
-FAIL Can set 'left' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'left' to the 'auto' keyword
-PASS Can set 'left' to a percent
-PASS Can set 'left' to a length
+PASS Can set 'left' to CSS-wide keywords: initial
+PASS Can set 'left' to CSS-wide keywords: inherit
+PASS Can set 'left' to CSS-wide keywords: unset
+PASS Can set 'left' to CSS-wide keywords: revert
+FAIL Can set 'left' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'left' to the 'auto' keyword: auto
+PASS Can set 'left' to a percent: 0%
+PASS Can set 'left' to a percent: -3.14%
+PASS Can set 'left' to a percent: 3.14%
+PASS Can set 'left' to a percent: calc(0% + 0%)
+PASS Can set 'left' to a length: 0px
+PASS Can set 'left' to a length: -3.14em
+PASS Can set 'left' to a length: 3.14cm
+PASS Can set 'left' to a length: calc(0px + 0em)
 PASS Setting 'left' to a time throws TypeError
 PASS Setting 'left' to an angle throws TypeError
 PASS Setting 'left' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt
@@ -1,8 +1,14 @@
 
-PASS Can set 'letter-spacing' to CSS-wide keywords
-FAIL Can set 'letter-spacing' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'letter-spacing' to the 'normal' keyword
-FAIL Can set 'letter-spacing' to a length assert_equals: expected "CSSUnitValue" but got "CSSKeywordValue"
+PASS Can set 'letter-spacing' to CSS-wide keywords: initial
+PASS Can set 'letter-spacing' to CSS-wide keywords: inherit
+PASS Can set 'letter-spacing' to CSS-wide keywords: unset
+PASS Can set 'letter-spacing' to CSS-wide keywords: revert
+FAIL Can set 'letter-spacing' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'letter-spacing' to the 'normal' keyword: normal
+FAIL Can set 'letter-spacing' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSKeywordValue"
+PASS Can set 'letter-spacing' to a length: -3.14em
+PASS Can set 'letter-spacing' to a length: 3.14cm
+FAIL Can set 'letter-spacing' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSKeywordValue]"
 PASS Setting 'letter-spacing' to a percent throws TypeError
 PASS Setting 'letter-spacing' to a time throws TypeError
 PASS Setting 'letter-spacing' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/lighting-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/lighting-color-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'lighting-color' to CSS-wide keywords
-FAIL Can set 'lighting-color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'lighting-color' to the 'currentcolor' keyword
+PASS Can set 'lighting-color' to CSS-wide keywords: initial
+PASS Can set 'lighting-color' to CSS-wide keywords: inherit
+PASS Can set 'lighting-color' to CSS-wide keywords: unset
+PASS Can set 'lighting-color' to CSS-wide keywords: revert
+FAIL Can set 'lighting-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'lighting-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'lighting-color' to a length throws TypeError
 PASS Setting 'lighting-color' to a percent throws TypeError
 PASS Setting 'lighting-color' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-break-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-break-expected.txt
@@ -1,11 +1,14 @@
 
-PASS Can set 'line-break' to CSS-wide keywords
-FAIL Can set 'line-break' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'line-break' to the 'auto' keyword
-PASS Can set 'line-break' to the 'loose' keyword
-PASS Can set 'line-break' to the 'normal' keyword
-PASS Can set 'line-break' to the 'strict' keyword
-PASS Can set 'line-break' to the 'anywhere' keyword
+PASS Can set 'line-break' to CSS-wide keywords: initial
+PASS Can set 'line-break' to CSS-wide keywords: inherit
+PASS Can set 'line-break' to CSS-wide keywords: unset
+PASS Can set 'line-break' to CSS-wide keywords: revert
+FAIL Can set 'line-break' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'line-break' to the 'auto' keyword: auto
+PASS Can set 'line-break' to the 'loose' keyword: loose
+PASS Can set 'line-break' to the 'normal' keyword: normal
+PASS Can set 'line-break' to the 'strict' keyword: strict
+PASS Can set 'line-break' to the 'anywhere' keyword: anywhere
 PASS Setting 'line-break' to a length throws TypeError
 PASS Setting 'line-break' to a percent throws TypeError
 PASS Setting 'line-break' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-expected.txt
@@ -1,10 +1,22 @@
 
-PASS Can set 'line-height' to CSS-wide keywords
-FAIL Can set 'line-height' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'line-height' to the 'normal' keyword
-FAIL Can set 'line-height' to a length assert_equals: expected "px" but got "em"
-FAIL Can set 'line-height' to a number assert_equals: expected 2 but got 1
-FAIL Can set 'line-height' to a percent assert_equals: expected 2 but got 1
+PASS Can set 'line-height' to CSS-wide keywords: initial
+PASS Can set 'line-height' to CSS-wide keywords: inherit
+PASS Can set 'line-height' to CSS-wide keywords: unset
+PASS Can set 'line-height' to CSS-wide keywords: revert
+FAIL Can set 'line-height' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'line-height' to the 'normal' keyword: normal
+PASS Can set 'line-height' to a length: 0px
+PASS Can set 'line-height' to a length: -3.14em
+PASS Can set 'line-height' to a length: 3.14cm
+FAIL Can set 'line-height' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'line-height' to a number: 0
+PASS Can set 'line-height' to a number: -3.14
+PASS Can set 'line-height' to a number: 3.14
+FAIL Can set 'line-height' to a number: calc(2 + 3) assert_equals: expected 2 but got 1
+PASS Can set 'line-height' to a percent: 0%
+PASS Can set 'line-height' to a percent: -3.14%
+PASS Can set 'line-height' to a percent: 3.14%
+FAIL Can set 'line-height' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
 PASS Setting 'line-height' to a time throws TypeError
 PASS Setting 'line-height' to an angle throws TypeError
 PASS Setting 'line-height' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-step-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-step-expected.txt
@@ -1,7 +1,13 @@
 
-FAIL Can set 'line-height-step' to CSS-wide keywords Invalid property line-height-step
-FAIL Can set 'line-height-step' to var() references Invalid property line-height-step
-FAIL Can set 'line-height-step' to a length Invalid property line-height-step
+FAIL Can set 'line-height-step' to CSS-wide keywords: initial Invalid property line-height-step
+FAIL Can set 'line-height-step' to CSS-wide keywords: inherit Invalid property line-height-step
+FAIL Can set 'line-height-step' to CSS-wide keywords: unset Invalid property line-height-step
+FAIL Can set 'line-height-step' to CSS-wide keywords: revert Invalid property line-height-step
+FAIL Can set 'line-height-step' to var() references:  var(--A) Invalid property line-height-step
+FAIL Can set 'line-height-step' to a length: 0px Invalid property line-height-step
+FAIL Can set 'line-height-step' to a length: -3.14em Invalid property line-height-step
+FAIL Can set 'line-height-step' to a length: 3.14cm Invalid property line-height-step
+FAIL Can set 'line-height-step' to a length: calc(0px + 0em) Invalid property line-height-step
 PASS Setting 'line-height-step' to a percent throws TypeError
 PASS Setting 'line-height-step' to a time throws TypeError
 PASS Setting 'line-height-step' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-image-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'list-style-image' to CSS-wide keywords
-FAIL Can set 'list-style-image' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'list-style-image' to the 'none' keyword
+PASS Can set 'list-style-image' to CSS-wide keywords: initial
+PASS Can set 'list-style-image' to CSS-wide keywords: inherit
+PASS Can set 'list-style-image' to CSS-wide keywords: unset
+PASS Can set 'list-style-image' to CSS-wide keywords: revert
+FAIL Can set 'list-style-image' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'list-style-image' to the 'none' keyword: none
 PASS Can set 'list-style-image' to an image
 PASS Setting 'list-style-image' to a length throws TypeError
 PASS Setting 'list-style-image' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-position-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'list-style-position' to CSS-wide keywords
-FAIL Can set 'list-style-position' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'list-style-position' to the 'inside' keyword
-PASS Can set 'list-style-position' to the 'outside' keyword
+PASS Can set 'list-style-position' to CSS-wide keywords: initial
+PASS Can set 'list-style-position' to CSS-wide keywords: inherit
+PASS Can set 'list-style-position' to CSS-wide keywords: unset
+PASS Can set 'list-style-position' to CSS-wide keywords: revert
+FAIL Can set 'list-style-position' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'list-style-position' to the 'inside' keyword: inside
+PASS Can set 'list-style-position' to the 'outside' keyword: outside
 PASS Setting 'list-style-position' to a length throws TypeError
 PASS Setting 'list-style-position' to a percent throws TypeError
 PASS Setting 'list-style-position' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-type-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'list-style-type' to CSS-wide keywords
-FAIL Can set 'list-style-type' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'list-style-type' to the 'none' keyword
-FAIL Can set 'list-style-type' to the 'custom-ident' keyword Invalid values
+PASS Can set 'list-style-type' to CSS-wide keywords: initial
+PASS Can set 'list-style-type' to CSS-wide keywords: inherit
+PASS Can set 'list-style-type' to CSS-wide keywords: unset
+PASS Can set 'list-style-type' to CSS-wide keywords: revert
+FAIL Can set 'list-style-type' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'list-style-type' to the 'none' keyword: none
+FAIL Can set 'list-style-type' to the 'custom-ident' keyword: custom-ident Invalid values
 PASS Setting 'list-style-type' to a length throws TypeError
 PASS Setting 'list-style-type' to a percent throws TypeError
 PASS Setting 'list-style-type' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
@@ -1,187 +1,352 @@
 
-PASS Can set 'margin-block-start' to CSS-wide keywords
-FAIL Can set 'margin-block-start' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'margin-block-start' to a percent
-PASS Can set 'margin-block-start' to a length
+PASS Can set 'margin-block-start' to CSS-wide keywords: initial
+PASS Can set 'margin-block-start' to CSS-wide keywords: inherit
+PASS Can set 'margin-block-start' to CSS-wide keywords: unset
+PASS Can set 'margin-block-start' to CSS-wide keywords: revert
+FAIL Can set 'margin-block-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-block-start' to a percent: 0%
+PASS Can set 'margin-block-start' to a percent: -3.14%
+PASS Can set 'margin-block-start' to a percent: 3.14%
+PASS Can set 'margin-block-start' to a percent: calc(0% + 0%)
+PASS Can set 'margin-block-start' to a length: 0px
+PASS Can set 'margin-block-start' to a length: -3.14em
+PASS Can set 'margin-block-start' to a length: 3.14cm
+PASS Can set 'margin-block-start' to a length: calc(0px + 0em)
 PASS Setting 'margin-block-start' to a time throws TypeError
 PASS Setting 'margin-block-start' to an angle throws TypeError
 PASS Setting 'margin-block-start' to a flexible length throws TypeError
 FAIL Setting 'margin-block-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'margin-block-start' to a URL throws TypeError
 PASS Setting 'margin-block-start' to a transform throws TypeError
-PASS Can set 'margin-block-end' to CSS-wide keywords
-FAIL Can set 'margin-block-end' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'margin-block-end' to a percent
-PASS Can set 'margin-block-end' to a length
+PASS Can set 'margin-block-end' to CSS-wide keywords: initial
+PASS Can set 'margin-block-end' to CSS-wide keywords: inherit
+PASS Can set 'margin-block-end' to CSS-wide keywords: unset
+PASS Can set 'margin-block-end' to CSS-wide keywords: revert
+FAIL Can set 'margin-block-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-block-end' to a percent: 0%
+PASS Can set 'margin-block-end' to a percent: -3.14%
+PASS Can set 'margin-block-end' to a percent: 3.14%
+PASS Can set 'margin-block-end' to a percent: calc(0% + 0%)
+PASS Can set 'margin-block-end' to a length: 0px
+PASS Can set 'margin-block-end' to a length: -3.14em
+PASS Can set 'margin-block-end' to a length: 3.14cm
+PASS Can set 'margin-block-end' to a length: calc(0px + 0em)
 PASS Setting 'margin-block-end' to a time throws TypeError
 PASS Setting 'margin-block-end' to an angle throws TypeError
 PASS Setting 'margin-block-end' to a flexible length throws TypeError
 FAIL Setting 'margin-block-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'margin-block-end' to a URL throws TypeError
 PASS Setting 'margin-block-end' to a transform throws TypeError
-PASS Can set 'margin-inline-start' to CSS-wide keywords
-FAIL Can set 'margin-inline-start' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'margin-inline-start' to a percent
-PASS Can set 'margin-inline-start' to a length
+PASS Can set 'margin-inline-start' to CSS-wide keywords: initial
+PASS Can set 'margin-inline-start' to CSS-wide keywords: inherit
+PASS Can set 'margin-inline-start' to CSS-wide keywords: unset
+PASS Can set 'margin-inline-start' to CSS-wide keywords: revert
+FAIL Can set 'margin-inline-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-inline-start' to a percent: 0%
+PASS Can set 'margin-inline-start' to a percent: -3.14%
+PASS Can set 'margin-inline-start' to a percent: 3.14%
+PASS Can set 'margin-inline-start' to a percent: calc(0% + 0%)
+PASS Can set 'margin-inline-start' to a length: 0px
+PASS Can set 'margin-inline-start' to a length: -3.14em
+PASS Can set 'margin-inline-start' to a length: 3.14cm
+PASS Can set 'margin-inline-start' to a length: calc(0px + 0em)
 PASS Setting 'margin-inline-start' to a time throws TypeError
 PASS Setting 'margin-inline-start' to an angle throws TypeError
 PASS Setting 'margin-inline-start' to a flexible length throws TypeError
 FAIL Setting 'margin-inline-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'margin-inline-start' to a URL throws TypeError
 PASS Setting 'margin-inline-start' to a transform throws TypeError
-PASS Can set 'margin-inline-end' to CSS-wide keywords
-FAIL Can set 'margin-inline-end' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'margin-inline-end' to a percent
-PASS Can set 'margin-inline-end' to a length
+PASS Can set 'margin-inline-end' to CSS-wide keywords: initial
+PASS Can set 'margin-inline-end' to CSS-wide keywords: inherit
+PASS Can set 'margin-inline-end' to CSS-wide keywords: unset
+PASS Can set 'margin-inline-end' to CSS-wide keywords: revert
+FAIL Can set 'margin-inline-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-inline-end' to a percent: 0%
+PASS Can set 'margin-inline-end' to a percent: -3.14%
+PASS Can set 'margin-inline-end' to a percent: 3.14%
+PASS Can set 'margin-inline-end' to a percent: calc(0% + 0%)
+PASS Can set 'margin-inline-end' to a length: 0px
+PASS Can set 'margin-inline-end' to a length: -3.14em
+PASS Can set 'margin-inline-end' to a length: 3.14cm
+PASS Can set 'margin-inline-end' to a length: calc(0px + 0em)
 PASS Setting 'margin-inline-end' to a time throws TypeError
 PASS Setting 'margin-inline-end' to an angle throws TypeError
 PASS Setting 'margin-inline-end' to a flexible length throws TypeError
 FAIL Setting 'margin-inline-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'margin-inline-end' to a URL throws TypeError
 PASS Setting 'margin-inline-end' to a transform throws TypeError
-FAIL Can set 'margin-block' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'margin-block' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'margin-block' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'margin-block' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'margin-block' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'margin-block' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'margin-block' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'margin-block' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'margin-block' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'margin-block' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'margin-block' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'margin-block' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'margin-block' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'margin-block' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'margin-block' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'margin-block' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'margin-block' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'margin-block' to a time throws TypeError
 PASS Setting 'margin-block' to an angle throws TypeError
 PASS Setting 'margin-block' to a flexible length throws TypeError
 FAIL Setting 'margin-block' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'margin-block' to a URL throws TypeError
 PASS Setting 'margin-block' to a transform throws TypeError
-FAIL Can set 'margin-inline' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'margin-inline' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'margin-inline' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'margin-inline' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'margin-inline' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'margin-inline' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'margin-inline' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'margin-inline' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'margin-inline' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'margin-inline' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'margin-inline' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'margin-inline' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'margin-inline' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'margin-inline' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'margin-inline' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'margin-inline' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'margin-inline' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'margin-inline' to a time throws TypeError
 PASS Setting 'margin-inline' to an angle throws TypeError
 PASS Setting 'margin-inline' to a flexible length throws TypeError
 FAIL Setting 'margin-inline' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'margin-inline' to a URL throws TypeError
 PASS Setting 'margin-inline' to a transform throws TypeError
-PASS Can set 'inset-block-start' to CSS-wide keywords
-FAIL Can set 'inset-block-start' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'inset-block-start' to a percent
-PASS Can set 'inset-block-start' to a length
+PASS Can set 'inset-block-start' to CSS-wide keywords: initial
+PASS Can set 'inset-block-start' to CSS-wide keywords: inherit
+PASS Can set 'inset-block-start' to CSS-wide keywords: unset
+PASS Can set 'inset-block-start' to CSS-wide keywords: revert
+FAIL Can set 'inset-block-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'inset-block-start' to a percent: 0%
+PASS Can set 'inset-block-start' to a percent: -3.14%
+PASS Can set 'inset-block-start' to a percent: 3.14%
+PASS Can set 'inset-block-start' to a percent: calc(0% + 0%)
+PASS Can set 'inset-block-start' to a length: 0px
+PASS Can set 'inset-block-start' to a length: -3.14em
+PASS Can set 'inset-block-start' to a length: 3.14cm
+PASS Can set 'inset-block-start' to a length: calc(0px + 0em)
 PASS Setting 'inset-block-start' to a time throws TypeError
 PASS Setting 'inset-block-start' to an angle throws TypeError
 PASS Setting 'inset-block-start' to a flexible length throws TypeError
 FAIL Setting 'inset-block-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'inset-block-start' to a URL throws TypeError
 PASS Setting 'inset-block-start' to a transform throws TypeError
-PASS Can set 'inset-block-end' to CSS-wide keywords
-FAIL Can set 'inset-block-end' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'inset-block-end' to a percent
-PASS Can set 'inset-block-end' to a length
+PASS Can set 'inset-block-end' to CSS-wide keywords: initial
+PASS Can set 'inset-block-end' to CSS-wide keywords: inherit
+PASS Can set 'inset-block-end' to CSS-wide keywords: unset
+PASS Can set 'inset-block-end' to CSS-wide keywords: revert
+FAIL Can set 'inset-block-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'inset-block-end' to a percent: 0%
+PASS Can set 'inset-block-end' to a percent: -3.14%
+PASS Can set 'inset-block-end' to a percent: 3.14%
+PASS Can set 'inset-block-end' to a percent: calc(0% + 0%)
+PASS Can set 'inset-block-end' to a length: 0px
+PASS Can set 'inset-block-end' to a length: -3.14em
+PASS Can set 'inset-block-end' to a length: 3.14cm
+PASS Can set 'inset-block-end' to a length: calc(0px + 0em)
 PASS Setting 'inset-block-end' to a time throws TypeError
 PASS Setting 'inset-block-end' to an angle throws TypeError
 PASS Setting 'inset-block-end' to a flexible length throws TypeError
 FAIL Setting 'inset-block-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'inset-block-end' to a URL throws TypeError
 PASS Setting 'inset-block-end' to a transform throws TypeError
-PASS Can set 'inset-inline-start' to CSS-wide keywords
-FAIL Can set 'inset-inline-start' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'inset-inline-start' to a percent
-PASS Can set 'inset-inline-start' to a length
+PASS Can set 'inset-inline-start' to CSS-wide keywords: initial
+PASS Can set 'inset-inline-start' to CSS-wide keywords: inherit
+PASS Can set 'inset-inline-start' to CSS-wide keywords: unset
+PASS Can set 'inset-inline-start' to CSS-wide keywords: revert
+FAIL Can set 'inset-inline-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'inset-inline-start' to a percent: 0%
+PASS Can set 'inset-inline-start' to a percent: -3.14%
+PASS Can set 'inset-inline-start' to a percent: 3.14%
+PASS Can set 'inset-inline-start' to a percent: calc(0% + 0%)
+PASS Can set 'inset-inline-start' to a length: 0px
+PASS Can set 'inset-inline-start' to a length: -3.14em
+PASS Can set 'inset-inline-start' to a length: 3.14cm
+PASS Can set 'inset-inline-start' to a length: calc(0px + 0em)
 PASS Setting 'inset-inline-start' to a time throws TypeError
 PASS Setting 'inset-inline-start' to an angle throws TypeError
 PASS Setting 'inset-inline-start' to a flexible length throws TypeError
 FAIL Setting 'inset-inline-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'inset-inline-start' to a URL throws TypeError
 PASS Setting 'inset-inline-start' to a transform throws TypeError
-PASS Can set 'inset-inline-end' to CSS-wide keywords
-FAIL Can set 'inset-inline-end' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'inset-inline-end' to a percent
-PASS Can set 'inset-inline-end' to a length
+PASS Can set 'inset-inline-end' to CSS-wide keywords: initial
+PASS Can set 'inset-inline-end' to CSS-wide keywords: inherit
+PASS Can set 'inset-inline-end' to CSS-wide keywords: unset
+PASS Can set 'inset-inline-end' to CSS-wide keywords: revert
+FAIL Can set 'inset-inline-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'inset-inline-end' to a percent: 0%
+PASS Can set 'inset-inline-end' to a percent: -3.14%
+PASS Can set 'inset-inline-end' to a percent: 3.14%
+PASS Can set 'inset-inline-end' to a percent: calc(0% + 0%)
+PASS Can set 'inset-inline-end' to a length: 0px
+PASS Can set 'inset-inline-end' to a length: -3.14em
+PASS Can set 'inset-inline-end' to a length: 3.14cm
+PASS Can set 'inset-inline-end' to a length: calc(0px + 0em)
 PASS Setting 'inset-inline-end' to a time throws TypeError
 PASS Setting 'inset-inline-end' to an angle throws TypeError
 PASS Setting 'inset-inline-end' to a flexible length throws TypeError
 FAIL Setting 'inset-inline-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'inset-inline-end' to a URL throws TypeError
 PASS Setting 'inset-inline-end' to a transform throws TypeError
-FAIL Can set 'inset-block' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'inset-block' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'inset-block' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'inset-block' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'inset-block' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'inset-block' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'inset-block' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'inset-block' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'inset-block' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'inset-block' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'inset-block' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'inset-block' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'inset-block' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'inset-block' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'inset-block' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'inset-block' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'inset-block' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'inset-block' to a time throws TypeError
 PASS Setting 'inset-block' to an angle throws TypeError
 PASS Setting 'inset-block' to a flexible length throws TypeError
 FAIL Setting 'inset-block' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'inset-block' to a URL throws TypeError
 PASS Setting 'inset-block' to a transform throws TypeError
-FAIL Can set 'inset-inline' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'inset-inline' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'inset-inline' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'inset-inline' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'inset-inline' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'inset-inline' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'inset-inline' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'inset-inline' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'inset-inline' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'inset-inline' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'inset-inline' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'inset-inline' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'inset-inline' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'inset-inline' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'inset-inline' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'inset-inline' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'inset-inline' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'inset-inline' to a time throws TypeError
 PASS Setting 'inset-inline' to an angle throws TypeError
 PASS Setting 'inset-inline' to a flexible length throws TypeError
 FAIL Setting 'inset-inline' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'inset-inline' to a URL throws TypeError
 PASS Setting 'inset-inline' to a transform throws TypeError
-PASS Can set 'padding-block-start' to CSS-wide keywords
-FAIL Can set 'padding-block-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-block-start' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'padding-block-start' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'padding-block-start' to CSS-wide keywords: initial
+PASS Can set 'padding-block-start' to CSS-wide keywords: inherit
+PASS Can set 'padding-block-start' to CSS-wide keywords: unset
+PASS Can set 'padding-block-start' to CSS-wide keywords: revert
+FAIL Can set 'padding-block-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-block-start' to a percent: 0%
+FAIL Can set 'padding-block-start' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'padding-block-start' to a percent: 3.14%
+PASS Can set 'padding-block-start' to a percent: calc(0% + 0%)
+PASS Can set 'padding-block-start' to a length: 0px
+FAIL Can set 'padding-block-start' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'padding-block-start' to a length: 3.14cm
+PASS Can set 'padding-block-start' to a length: calc(0px + 0em)
 PASS Setting 'padding-block-start' to a time throws TypeError
 PASS Setting 'padding-block-start' to an angle throws TypeError
 PASS Setting 'padding-block-start' to a flexible length throws TypeError
 FAIL Setting 'padding-block-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'padding-block-start' to a URL throws TypeError
 PASS Setting 'padding-block-start' to a transform throws TypeError
-PASS Can set 'padding-block-end' to CSS-wide keywords
-FAIL Can set 'padding-block-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-block-end' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'padding-block-end' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'padding-block-end' to CSS-wide keywords: initial
+PASS Can set 'padding-block-end' to CSS-wide keywords: inherit
+PASS Can set 'padding-block-end' to CSS-wide keywords: unset
+PASS Can set 'padding-block-end' to CSS-wide keywords: revert
+FAIL Can set 'padding-block-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-block-end' to a percent: 0%
+FAIL Can set 'padding-block-end' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'padding-block-end' to a percent: 3.14%
+PASS Can set 'padding-block-end' to a percent: calc(0% + 0%)
+PASS Can set 'padding-block-end' to a length: 0px
+FAIL Can set 'padding-block-end' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'padding-block-end' to a length: 3.14cm
+PASS Can set 'padding-block-end' to a length: calc(0px + 0em)
 PASS Setting 'padding-block-end' to a time throws TypeError
 PASS Setting 'padding-block-end' to an angle throws TypeError
 PASS Setting 'padding-block-end' to a flexible length throws TypeError
 FAIL Setting 'padding-block-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'padding-block-end' to a URL throws TypeError
 PASS Setting 'padding-block-end' to a transform throws TypeError
-PASS Can set 'padding-inline-start' to CSS-wide keywords
-FAIL Can set 'padding-inline-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-inline-start' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'padding-inline-start' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'padding-inline-start' to CSS-wide keywords: initial
+PASS Can set 'padding-inline-start' to CSS-wide keywords: inherit
+PASS Can set 'padding-inline-start' to CSS-wide keywords: unset
+PASS Can set 'padding-inline-start' to CSS-wide keywords: revert
+FAIL Can set 'padding-inline-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-inline-start' to a percent: 0%
+FAIL Can set 'padding-inline-start' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'padding-inline-start' to a percent: 3.14%
+PASS Can set 'padding-inline-start' to a percent: calc(0% + 0%)
+PASS Can set 'padding-inline-start' to a length: 0px
+FAIL Can set 'padding-inline-start' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'padding-inline-start' to a length: 3.14cm
+PASS Can set 'padding-inline-start' to a length: calc(0px + 0em)
 PASS Setting 'padding-inline-start' to a time throws TypeError
 PASS Setting 'padding-inline-start' to an angle throws TypeError
 PASS Setting 'padding-inline-start' to a flexible length throws TypeError
 FAIL Setting 'padding-inline-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'padding-inline-start' to a URL throws TypeError
 PASS Setting 'padding-inline-start' to a transform throws TypeError
-PASS Can set 'padding-inline-end' to CSS-wide keywords
-FAIL Can set 'padding-inline-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-inline-end' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'padding-inline-end' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'padding-inline-end' to CSS-wide keywords: initial
+PASS Can set 'padding-inline-end' to CSS-wide keywords: inherit
+PASS Can set 'padding-inline-end' to CSS-wide keywords: unset
+PASS Can set 'padding-inline-end' to CSS-wide keywords: revert
+FAIL Can set 'padding-inline-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-inline-end' to a percent: 0%
+FAIL Can set 'padding-inline-end' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'padding-inline-end' to a percent: 3.14%
+PASS Can set 'padding-inline-end' to a percent: calc(0% + 0%)
+PASS Can set 'padding-inline-end' to a length: 0px
+FAIL Can set 'padding-inline-end' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'padding-inline-end' to a length: 3.14cm
+PASS Can set 'padding-inline-end' to a length: calc(0px + 0em)
 PASS Setting 'padding-inline-end' to a time throws TypeError
 PASS Setting 'padding-inline-end' to an angle throws TypeError
 PASS Setting 'padding-inline-end' to a flexible length throws TypeError
 FAIL Setting 'padding-inline-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'padding-inline-end' to a URL throws TypeError
 PASS Setting 'padding-inline-end' to a transform throws TypeError
-FAIL Can set 'padding-block' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'padding-block' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-block' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'padding-block' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'padding-block' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to a percent: -3.14% Bad value for shorthand CSS property
+FAIL Can set 'padding-block' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'padding-block' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to a length: -3.14em Bad value for shorthand CSS property
+FAIL Can set 'padding-block' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'padding-block' to a time throws TypeError
 PASS Setting 'padding-block' to an angle throws TypeError
 PASS Setting 'padding-block' to a flexible length throws TypeError
 FAIL Setting 'padding-block' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'padding-block' to a URL throws TypeError
 PASS Setting 'padding-block' to a transform throws TypeError
-FAIL Can set 'padding-inline' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'padding-inline' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-inline' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'padding-inline' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'padding-inline' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to a percent: -3.14% Bad value for shorthand CSS property
+FAIL Can set 'padding-inline' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'padding-inline' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to a length: -3.14em Bad value for shorthand CSS property
+FAIL Can set 'padding-inline' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'padding-inline' to a time throws TypeError
 PASS Setting 'padding-inline' to an angle throws TypeError
 PASS Setting 'padding-inline' to a flexible length throws TypeError
 FAIL Setting 'padding-inline' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'padding-inline' to a URL throws TypeError
 PASS Setting 'padding-inline' to a transform throws TypeError
-FAIL Can set 'border-block-start' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-block-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-block-start' to the 'none' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-start' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-start' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-start' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-start' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-block-start' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Setting 'border-block-start' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-block-start' to a percent throws TypeError
 PASS Setting 'border-block-start' to a time throws TypeError
@@ -190,12 +355,18 @@ PASS Setting 'border-block-start' to a flexible length throws TypeError
 FAIL Setting 'border-block-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-block-start' to a URL throws TypeError
 PASS Setting 'border-block-start' to a transform throws TypeError
-PASS Can set 'border-block-start-width' to CSS-wide keywords
-FAIL Can set 'border-block-start-width' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-block-start-width' to the 'thin' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-block-start-width' to the 'medium' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-block-start-width' to the 'thick' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-block-start-width' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-block-start-width' to CSS-wide keywords: initial
+PASS Can set 'border-block-start-width' to CSS-wide keywords: inherit
+PASS Can set 'border-block-start-width' to CSS-wide keywords: unset
+PASS Can set 'border-block-start-width' to CSS-wide keywords: revert
+FAIL Can set 'border-block-start-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-block-start-width' to the 'thin' keyword: thin assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'border-block-start-width' to the 'medium' keyword: medium assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'border-block-start-width' to the 'thick' keyword: thick assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+PASS Can set 'border-block-start-width' to a length: 0px
+FAIL Can set 'border-block-start-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-block-start-width' to a length: 3.14cm
+PASS Can set 'border-block-start-width' to a length: calc(0px + 0em)
 PASS Setting 'border-block-start-width' to a percent throws TypeError
 PASS Setting 'border-block-start-width' to a time throws TypeError
 PASS Setting 'border-block-start-width' to an angle throws TypeError
@@ -203,9 +374,12 @@ PASS Setting 'border-block-start-width' to a flexible length throws TypeError
 FAIL Setting 'border-block-start-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-block-start-width' to a URL throws TypeError
 PASS Setting 'border-block-start-width' to a transform throws TypeError
-PASS Can set 'border-block-start-color' to CSS-wide keywords
-FAIL Can set 'border-block-start-color' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-block-start-color' to the 'currentcolor' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'border-block-start-color' to CSS-wide keywords: initial
+PASS Can set 'border-block-start-color' to CSS-wide keywords: inherit
+PASS Can set 'border-block-start-color' to CSS-wide keywords: unset
+PASS Can set 'border-block-start-color' to CSS-wide keywords: revert
+FAIL Can set 'border-block-start-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-block-start-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'border-block-start-color' to a length throws TypeError
 PASS Setting 'border-block-start-color' to a percent throws TypeError
 PASS Setting 'border-block-start-color' to a time throws TypeError
@@ -214,10 +388,13 @@ PASS Setting 'border-block-start-color' to a flexible length throws TypeError
 PASS Setting 'border-block-start-color' to a number throws TypeError
 PASS Setting 'border-block-start-color' to a URL throws TypeError
 PASS Setting 'border-block-start-color' to a transform throws TypeError
-PASS Can set 'border-block-start-style' to CSS-wide keywords
-FAIL Can set 'border-block-start-style' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-block-start-style' to the 'none' keyword
-PASS Can set 'border-block-start-style' to the 'solid' keyword
+PASS Can set 'border-block-start-style' to CSS-wide keywords: initial
+PASS Can set 'border-block-start-style' to CSS-wide keywords: inherit
+PASS Can set 'border-block-start-style' to CSS-wide keywords: unset
+PASS Can set 'border-block-start-style' to CSS-wide keywords: revert
+FAIL Can set 'border-block-start-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-block-start-style' to the 'none' keyword: none
+PASS Can set 'border-block-start-style' to the 'solid' keyword: solid
 PASS Setting 'border-block-start-style' to a length throws TypeError
 PASS Setting 'border-block-start-style' to a percent throws TypeError
 PASS Setting 'border-block-start-style' to a time throws TypeError
@@ -226,9 +403,12 @@ PASS Setting 'border-block-start-style' to a flexible length throws TypeError
 PASS Setting 'border-block-start-style' to a number throws TypeError
 PASS Setting 'border-block-start-style' to a URL throws TypeError
 PASS Setting 'border-block-start-style' to a transform throws TypeError
-FAIL Can set 'border-block-end' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-block-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-block-end' to the 'none' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-end' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-end' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-end' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-end' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-block-end' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Setting 'border-block-end' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-block-end' to a percent throws TypeError
 PASS Setting 'border-block-end' to a time throws TypeError
@@ -237,12 +417,18 @@ PASS Setting 'border-block-end' to a flexible length throws TypeError
 FAIL Setting 'border-block-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-block-end' to a URL throws TypeError
 PASS Setting 'border-block-end' to a transform throws TypeError
-PASS Can set 'border-block-end-width' to CSS-wide keywords
-FAIL Can set 'border-block-end-width' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-block-end-width' to the 'thin' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-block-end-width' to the 'medium' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-block-end-width' to the 'thick' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-block-end-width' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-block-end-width' to CSS-wide keywords: initial
+PASS Can set 'border-block-end-width' to CSS-wide keywords: inherit
+PASS Can set 'border-block-end-width' to CSS-wide keywords: unset
+PASS Can set 'border-block-end-width' to CSS-wide keywords: revert
+FAIL Can set 'border-block-end-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-block-end-width' to the 'thin' keyword: thin assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'border-block-end-width' to the 'medium' keyword: medium assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'border-block-end-width' to the 'thick' keyword: thick assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+PASS Can set 'border-block-end-width' to a length: 0px
+FAIL Can set 'border-block-end-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-block-end-width' to a length: 3.14cm
+PASS Can set 'border-block-end-width' to a length: calc(0px + 0em)
 PASS Setting 'border-block-end-width' to a percent throws TypeError
 PASS Setting 'border-block-end-width' to a time throws TypeError
 PASS Setting 'border-block-end-width' to an angle throws TypeError
@@ -250,9 +436,12 @@ PASS Setting 'border-block-end-width' to a flexible length throws TypeError
 FAIL Setting 'border-block-end-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-block-end-width' to a URL throws TypeError
 PASS Setting 'border-block-end-width' to a transform throws TypeError
-PASS Can set 'border-block-end-color' to CSS-wide keywords
-FAIL Can set 'border-block-end-color' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-block-end-color' to the 'currentcolor' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'border-block-end-color' to CSS-wide keywords: initial
+PASS Can set 'border-block-end-color' to CSS-wide keywords: inherit
+PASS Can set 'border-block-end-color' to CSS-wide keywords: unset
+PASS Can set 'border-block-end-color' to CSS-wide keywords: revert
+FAIL Can set 'border-block-end-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-block-end-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'border-block-end-color' to a length throws TypeError
 PASS Setting 'border-block-end-color' to a percent throws TypeError
 PASS Setting 'border-block-end-color' to a time throws TypeError
@@ -261,10 +450,13 @@ PASS Setting 'border-block-end-color' to a flexible length throws TypeError
 PASS Setting 'border-block-end-color' to a number throws TypeError
 PASS Setting 'border-block-end-color' to a URL throws TypeError
 PASS Setting 'border-block-end-color' to a transform throws TypeError
-PASS Can set 'border-block-end-style' to CSS-wide keywords
-FAIL Can set 'border-block-end-style' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-block-end-style' to the 'none' keyword
-PASS Can set 'border-block-end-style' to the 'solid' keyword
+PASS Can set 'border-block-end-style' to CSS-wide keywords: initial
+PASS Can set 'border-block-end-style' to CSS-wide keywords: inherit
+PASS Can set 'border-block-end-style' to CSS-wide keywords: unset
+PASS Can set 'border-block-end-style' to CSS-wide keywords: revert
+FAIL Can set 'border-block-end-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-block-end-style' to the 'none' keyword: none
+PASS Can set 'border-block-end-style' to the 'solid' keyword: solid
 PASS Setting 'border-block-end-style' to a length throws TypeError
 PASS Setting 'border-block-end-style' to a percent throws TypeError
 PASS Setting 'border-block-end-style' to a time throws TypeError
@@ -273,9 +465,12 @@ PASS Setting 'border-block-end-style' to a flexible length throws TypeError
 PASS Setting 'border-block-end-style' to a number throws TypeError
 PASS Setting 'border-block-end-style' to a URL throws TypeError
 PASS Setting 'border-block-end-style' to a transform throws TypeError
-FAIL Can set 'border-inline-start' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-inline-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-inline-start' to the 'none' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-start' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-start' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-start' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-start' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-inline-start' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Setting 'border-inline-start' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-inline-start' to a percent throws TypeError
 PASS Setting 'border-inline-start' to a time throws TypeError
@@ -284,12 +479,18 @@ PASS Setting 'border-inline-start' to a flexible length throws TypeError
 FAIL Setting 'border-inline-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-inline-start' to a URL throws TypeError
 PASS Setting 'border-inline-start' to a transform throws TypeError
-PASS Can set 'border-inline-start-width' to CSS-wide keywords
-FAIL Can set 'border-inline-start-width' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-inline-start-width' to the 'thin' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-inline-start-width' to the 'medium' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-inline-start-width' to the 'thick' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-inline-start-width' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-inline-start-width' to CSS-wide keywords: initial
+PASS Can set 'border-inline-start-width' to CSS-wide keywords: inherit
+PASS Can set 'border-inline-start-width' to CSS-wide keywords: unset
+PASS Can set 'border-inline-start-width' to CSS-wide keywords: revert
+FAIL Can set 'border-inline-start-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-inline-start-width' to the 'thin' keyword: thin assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'border-inline-start-width' to the 'medium' keyword: medium assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'border-inline-start-width' to the 'thick' keyword: thick assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+PASS Can set 'border-inline-start-width' to a length: 0px
+FAIL Can set 'border-inline-start-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-inline-start-width' to a length: 3.14cm
+PASS Can set 'border-inline-start-width' to a length: calc(0px + 0em)
 PASS Setting 'border-inline-start-width' to a percent throws TypeError
 PASS Setting 'border-inline-start-width' to a time throws TypeError
 PASS Setting 'border-inline-start-width' to an angle throws TypeError
@@ -297,9 +498,12 @@ PASS Setting 'border-inline-start-width' to a flexible length throws TypeError
 FAIL Setting 'border-inline-start-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-inline-start-width' to a URL throws TypeError
 PASS Setting 'border-inline-start-width' to a transform throws TypeError
-PASS Can set 'border-inline-start-color' to CSS-wide keywords
-FAIL Can set 'border-inline-start-color' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-inline-start-color' to the 'currentcolor' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'border-inline-start-color' to CSS-wide keywords: initial
+PASS Can set 'border-inline-start-color' to CSS-wide keywords: inherit
+PASS Can set 'border-inline-start-color' to CSS-wide keywords: unset
+PASS Can set 'border-inline-start-color' to CSS-wide keywords: revert
+FAIL Can set 'border-inline-start-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-inline-start-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'border-inline-start-color' to a length throws TypeError
 PASS Setting 'border-inline-start-color' to a percent throws TypeError
 PASS Setting 'border-inline-start-color' to a time throws TypeError
@@ -308,10 +512,13 @@ PASS Setting 'border-inline-start-color' to a flexible length throws TypeError
 PASS Setting 'border-inline-start-color' to a number throws TypeError
 PASS Setting 'border-inline-start-color' to a URL throws TypeError
 PASS Setting 'border-inline-start-color' to a transform throws TypeError
-PASS Can set 'border-inline-start-style' to CSS-wide keywords
-FAIL Can set 'border-inline-start-style' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-inline-start-style' to the 'none' keyword
-PASS Can set 'border-inline-start-style' to the 'solid' keyword
+PASS Can set 'border-inline-start-style' to CSS-wide keywords: initial
+PASS Can set 'border-inline-start-style' to CSS-wide keywords: inherit
+PASS Can set 'border-inline-start-style' to CSS-wide keywords: unset
+PASS Can set 'border-inline-start-style' to CSS-wide keywords: revert
+FAIL Can set 'border-inline-start-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-inline-start-style' to the 'none' keyword: none
+PASS Can set 'border-inline-start-style' to the 'solid' keyword: solid
 PASS Setting 'border-inline-start-style' to a length throws TypeError
 PASS Setting 'border-inline-start-style' to a percent throws TypeError
 PASS Setting 'border-inline-start-style' to a time throws TypeError
@@ -320,9 +527,12 @@ PASS Setting 'border-inline-start-style' to a flexible length throws TypeError
 PASS Setting 'border-inline-start-style' to a number throws TypeError
 PASS Setting 'border-inline-start-style' to a URL throws TypeError
 PASS Setting 'border-inline-start-style' to a transform throws TypeError
-FAIL Can set 'border-inline-end' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-inline-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-inline-end' to the 'none' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-end' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-end' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-end' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-end' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-inline-end' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Setting 'border-inline-end' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-inline-end' to a percent throws TypeError
 PASS Setting 'border-inline-end' to a time throws TypeError
@@ -331,12 +541,18 @@ PASS Setting 'border-inline-end' to a flexible length throws TypeError
 FAIL Setting 'border-inline-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-inline-end' to a URL throws TypeError
 PASS Setting 'border-inline-end' to a transform throws TypeError
-PASS Can set 'border-inline-end-width' to CSS-wide keywords
-FAIL Can set 'border-inline-end-width' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-inline-end-width' to the 'thin' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-inline-end-width' to the 'medium' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-inline-end-width' to the 'thick' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-FAIL Can set 'border-inline-end-width' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-inline-end-width' to CSS-wide keywords: initial
+PASS Can set 'border-inline-end-width' to CSS-wide keywords: inherit
+PASS Can set 'border-inline-end-width' to CSS-wide keywords: unset
+PASS Can set 'border-inline-end-width' to CSS-wide keywords: revert
+FAIL Can set 'border-inline-end-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-inline-end-width' to the 'thin' keyword: thin assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'border-inline-end-width' to the 'medium' keyword: medium assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+FAIL Can set 'border-inline-end-width' to the 'thick' keyword: thick assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+PASS Can set 'border-inline-end-width' to a length: 0px
+FAIL Can set 'border-inline-end-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-inline-end-width' to a length: 3.14cm
+PASS Can set 'border-inline-end-width' to a length: calc(0px + 0em)
 PASS Setting 'border-inline-end-width' to a percent throws TypeError
 PASS Setting 'border-inline-end-width' to a time throws TypeError
 PASS Setting 'border-inline-end-width' to an angle throws TypeError
@@ -344,9 +560,12 @@ PASS Setting 'border-inline-end-width' to a flexible length throws TypeError
 FAIL Setting 'border-inline-end-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-inline-end-width' to a URL throws TypeError
 PASS Setting 'border-inline-end-width' to a transform throws TypeError
-PASS Can set 'border-inline-end-color' to CSS-wide keywords
-FAIL Can set 'border-inline-end-color' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-inline-end-color' to the 'currentcolor' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'border-inline-end-color' to CSS-wide keywords: initial
+PASS Can set 'border-inline-end-color' to CSS-wide keywords: inherit
+PASS Can set 'border-inline-end-color' to CSS-wide keywords: unset
+PASS Can set 'border-inline-end-color' to CSS-wide keywords: revert
+FAIL Can set 'border-inline-end-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-inline-end-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'border-inline-end-color' to a length throws TypeError
 PASS Setting 'border-inline-end-color' to a percent throws TypeError
 PASS Setting 'border-inline-end-color' to a time throws TypeError
@@ -355,10 +574,13 @@ PASS Setting 'border-inline-end-color' to a flexible length throws TypeError
 PASS Setting 'border-inline-end-color' to a number throws TypeError
 PASS Setting 'border-inline-end-color' to a URL throws TypeError
 PASS Setting 'border-inline-end-color' to a transform throws TypeError
-PASS Can set 'border-inline-end-style' to CSS-wide keywords
-FAIL Can set 'border-inline-end-style' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'border-inline-end-style' to the 'none' keyword
-PASS Can set 'border-inline-end-style' to the 'solid' keyword
+PASS Can set 'border-inline-end-style' to CSS-wide keywords: initial
+PASS Can set 'border-inline-end-style' to CSS-wide keywords: inherit
+PASS Can set 'border-inline-end-style' to CSS-wide keywords: unset
+PASS Can set 'border-inline-end-style' to CSS-wide keywords: revert
+FAIL Can set 'border-inline-end-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-inline-end-style' to the 'none' keyword: none
+PASS Can set 'border-inline-end-style' to the 'solid' keyword: solid
 PASS Setting 'border-inline-end-style' to a length throws TypeError
 PASS Setting 'border-inline-end-style' to a percent throws TypeError
 PASS Setting 'border-inline-end-style' to a time throws TypeError
@@ -367,9 +589,12 @@ PASS Setting 'border-inline-end-style' to a flexible length throws TypeError
 PASS Setting 'border-inline-end-style' to a number throws TypeError
 PASS Setting 'border-inline-end-style' to a URL throws TypeError
 PASS Setting 'border-inline-end-style' to a transform throws TypeError
-FAIL Can set 'border-block' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-block' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-block' to the 'none' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-block' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Setting 'border-block' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-block' to a percent throws TypeError
 PASS Setting 'border-block' to a time throws TypeError
@@ -378,12 +603,18 @@ PASS Setting 'border-block' to a flexible length throws TypeError
 FAIL Setting 'border-block' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-block' to a URL throws TypeError
 PASS Setting 'border-block' to a transform throws TypeError
-FAIL Can set 'border-block-width' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-block-width' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-block-width' to the 'thin' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-block-width' to the 'medium' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-block-width' to the 'thick' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-block-width' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-width' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-width' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-width' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-width' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-block-width' to the 'thin' keyword: thin assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-width' to the 'medium' keyword: medium assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-width' to the 'thick' keyword: thick assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-width' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-width' to a length: -3.14em Bad value for shorthand CSS property
+FAIL Can set 'border-block-width' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-width' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'border-block-width' to a percent throws TypeError
 PASS Setting 'border-block-width' to a time throws TypeError
 PASS Setting 'border-block-width' to an angle throws TypeError
@@ -391,9 +622,12 @@ PASS Setting 'border-block-width' to a flexible length throws TypeError
 FAIL Setting 'border-block-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-block-width' to a URL throws TypeError
 PASS Setting 'border-block-width' to a transform throws TypeError
-FAIL Can set 'border-block-color' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-block-color' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-block-color' to the 'currentcolor' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-color' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-color' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-color' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-color' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-block-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'border-block-color' to a length throws TypeError
 PASS Setting 'border-block-color' to a percent throws TypeError
 PASS Setting 'border-block-color' to a time throws TypeError
@@ -402,10 +636,13 @@ PASS Setting 'border-block-color' to a flexible length throws TypeError
 PASS Setting 'border-block-color' to a number throws TypeError
 PASS Setting 'border-block-color' to a URL throws TypeError
 PASS Setting 'border-block-color' to a transform throws TypeError
-FAIL Can set 'border-block-style' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-block-style' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-block-style' to the 'none' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-block-style' to the 'solid' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-style' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-style' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-style' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-style' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-block-style' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-block-style' to the 'solid' keyword: solid assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'border-block-style' to a length throws TypeError
 PASS Setting 'border-block-style' to a percent throws TypeError
 PASS Setting 'border-block-style' to a time throws TypeError
@@ -414,9 +651,12 @@ PASS Setting 'border-block-style' to a flexible length throws TypeError
 PASS Setting 'border-block-style' to a number throws TypeError
 PASS Setting 'border-block-style' to a URL throws TypeError
 PASS Setting 'border-block-style' to a transform throws TypeError
-FAIL Can set 'border-inline' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-inline' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-inline' to the 'none' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-inline' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Setting 'border-inline' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-inline' to a percent throws TypeError
 PASS Setting 'border-inline' to a time throws TypeError
@@ -425,12 +665,18 @@ PASS Setting 'border-inline' to a flexible length throws TypeError
 FAIL Setting 'border-inline' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-inline' to a URL throws TypeError
 PASS Setting 'border-inline' to a transform throws TypeError
-FAIL Can set 'border-inline-width' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-inline-width' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-inline-width' to the 'thin' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-inline-width' to the 'medium' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-inline-width' to the 'thick' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-inline-width' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-width' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-width' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-width' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-width' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-inline-width' to the 'thin' keyword: thin assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-width' to the 'medium' keyword: medium assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-width' to the 'thick' keyword: thick assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-width' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-width' to a length: -3.14em Bad value for shorthand CSS property
+FAIL Can set 'border-inline-width' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-width' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'border-inline-width' to a percent throws TypeError
 PASS Setting 'border-inline-width' to a time throws TypeError
 PASS Setting 'border-inline-width' to an angle throws TypeError
@@ -438,9 +684,12 @@ PASS Setting 'border-inline-width' to a flexible length throws TypeError
 FAIL Setting 'border-inline-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-inline-width' to a URL throws TypeError
 PASS Setting 'border-inline-width' to a transform throws TypeError
-FAIL Can set 'border-inline-color' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-inline-color' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-inline-color' to the 'currentcolor' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-color' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-color' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-color' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-color' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-inline-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'border-inline-color' to a length throws TypeError
 PASS Setting 'border-inline-color' to a percent throws TypeError
 PASS Setting 'border-inline-color' to a time throws TypeError
@@ -449,10 +698,13 @@ PASS Setting 'border-inline-color' to a flexible length throws TypeError
 PASS Setting 'border-inline-color' to a number throws TypeError
 PASS Setting 'border-inline-color' to a URL throws TypeError
 PASS Setting 'border-inline-color' to a transform throws TypeError
-FAIL Can set 'border-inline-style' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-inline-style' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-inline-style' to the 'none' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-inline-style' to the 'solid' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-style' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-style' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-style' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-style' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-inline-style' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'border-inline-style' to the 'solid' keyword: solid assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'border-inline-style' to a length throws TypeError
 PASS Setting 'border-inline-style' to a percent throws TypeError
 PASS Setting 'border-inline-style' to a time throws TypeError
@@ -461,40 +713,76 @@ PASS Setting 'border-inline-style' to a flexible length throws TypeError
 PASS Setting 'border-inline-style' to a number throws TypeError
 PASS Setting 'border-inline-style' to a URL throws TypeError
 PASS Setting 'border-inline-style' to a transform throws TypeError
-PASS Can set 'border-start-start-radius' to CSS-wide keywords
-FAIL Can set 'border-start-start-radius' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-start-start-radius' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-start-start-radius' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-start-start-radius' to CSS-wide keywords: initial
+PASS Can set 'border-start-start-radius' to CSS-wide keywords: inherit
+PASS Can set 'border-start-start-radius' to CSS-wide keywords: unset
+PASS Can set 'border-start-start-radius' to CSS-wide keywords: revert
+FAIL Can set 'border-start-start-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-start-start-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-start-start-radius' to a percent: -3.14% Invalid values
+FAIL Can set 'border-start-start-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-start-start-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-start-start-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-start-start-radius' to a length: -3.14em Invalid values
+FAIL Can set 'border-start-start-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-start-start-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'border-start-start-radius' to a time throws TypeError
 PASS Setting 'border-start-start-radius' to an angle throws TypeError
 PASS Setting 'border-start-start-radius' to a flexible length throws TypeError
 FAIL Setting 'border-start-start-radius' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-start-start-radius' to a URL throws TypeError
 PASS Setting 'border-start-start-radius' to a transform throws TypeError
-PASS Can set 'border-start-end-radius' to CSS-wide keywords
-FAIL Can set 'border-start-end-radius' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-start-end-radius' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-start-end-radius' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-start-end-radius' to CSS-wide keywords: initial
+PASS Can set 'border-start-end-radius' to CSS-wide keywords: inherit
+PASS Can set 'border-start-end-radius' to CSS-wide keywords: unset
+PASS Can set 'border-start-end-radius' to CSS-wide keywords: revert
+FAIL Can set 'border-start-end-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-start-end-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-start-end-radius' to a percent: -3.14% Invalid values
+FAIL Can set 'border-start-end-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-start-end-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-start-end-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-start-end-radius' to a length: -3.14em Invalid values
+FAIL Can set 'border-start-end-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-start-end-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'border-start-end-radius' to a time throws TypeError
 PASS Setting 'border-start-end-radius' to an angle throws TypeError
 PASS Setting 'border-start-end-radius' to a flexible length throws TypeError
 FAIL Setting 'border-start-end-radius' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-start-end-radius' to a URL throws TypeError
 PASS Setting 'border-start-end-radius' to a transform throws TypeError
-PASS Can set 'border-end-start-radius' to CSS-wide keywords
-FAIL Can set 'border-end-start-radius' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-end-start-radius' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-end-start-radius' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-end-start-radius' to CSS-wide keywords: initial
+PASS Can set 'border-end-start-radius' to CSS-wide keywords: inherit
+PASS Can set 'border-end-start-radius' to CSS-wide keywords: unset
+PASS Can set 'border-end-start-radius' to CSS-wide keywords: revert
+FAIL Can set 'border-end-start-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-end-start-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-end-start-radius' to a percent: -3.14% Invalid values
+FAIL Can set 'border-end-start-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-end-start-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-end-start-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-end-start-radius' to a length: -3.14em Invalid values
+FAIL Can set 'border-end-start-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-end-start-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'border-end-start-radius' to a time throws TypeError
 PASS Setting 'border-end-start-radius' to an angle throws TypeError
 PASS Setting 'border-end-start-radius' to a flexible length throws TypeError
 FAIL Setting 'border-end-start-radius' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'border-end-start-radius' to a URL throws TypeError
 PASS Setting 'border-end-start-radius' to a transform throws TypeError
-PASS Can set 'border-end-end-radius' to CSS-wide keywords
-FAIL Can set 'border-end-end-radius' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'border-end-end-radius' to a percent assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-end-end-radius' to a length assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-end-end-radius' to CSS-wide keywords: initial
+PASS Can set 'border-end-end-radius' to CSS-wide keywords: inherit
+PASS Can set 'border-end-end-radius' to CSS-wide keywords: unset
+PASS Can set 'border-end-end-radius' to CSS-wide keywords: revert
+FAIL Can set 'border-end-end-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'border-end-end-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-end-end-radius' to a percent: -3.14% Invalid values
+FAIL Can set 'border-end-end-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-end-end-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-end-end-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-end-end-radius' to a length: -3.14em Invalid values
+FAIL Can set 'border-end-end-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'border-end-end-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'border-end-end-radius' to a time throws TypeError
 PASS Setting 'border-end-end-radius' to an angle throws TypeError
 PASS Setting 'border-end-end-radius' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/margin-expected.txt
@@ -1,50 +1,89 @@
 
-PASS Can set 'margin-top' to CSS-wide keywords
-FAIL Can set 'margin-top' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'margin-top' to the 'auto' keyword
-PASS Can set 'margin-top' to a percent
-PASS Can set 'margin-top' to a length
+PASS Can set 'margin-top' to CSS-wide keywords: initial
+PASS Can set 'margin-top' to CSS-wide keywords: inherit
+PASS Can set 'margin-top' to CSS-wide keywords: unset
+PASS Can set 'margin-top' to CSS-wide keywords: revert
+FAIL Can set 'margin-top' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-top' to the 'auto' keyword: auto
+PASS Can set 'margin-top' to a percent: 0%
+PASS Can set 'margin-top' to a percent: -3.14%
+PASS Can set 'margin-top' to a percent: 3.14%
+PASS Can set 'margin-top' to a percent: calc(0% + 0%)
+PASS Can set 'margin-top' to a length: 0px
+PASS Can set 'margin-top' to a length: -3.14em
+PASS Can set 'margin-top' to a length: 3.14cm
+PASS Can set 'margin-top' to a length: calc(0px + 0em)
 PASS Setting 'margin-top' to a time throws TypeError
 PASS Setting 'margin-top' to an angle throws TypeError
 PASS Setting 'margin-top' to a flexible length throws TypeError
 FAIL Setting 'margin-top' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'margin-top' to a URL throws TypeError
 PASS Setting 'margin-top' to a transform throws TypeError
-PASS Can set 'margin-left' to CSS-wide keywords
-FAIL Can set 'margin-left' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'margin-left' to the 'auto' keyword
-PASS Can set 'margin-left' to a percent
-PASS Can set 'margin-left' to a length
+PASS Can set 'margin-left' to CSS-wide keywords: initial
+PASS Can set 'margin-left' to CSS-wide keywords: inherit
+PASS Can set 'margin-left' to CSS-wide keywords: unset
+PASS Can set 'margin-left' to CSS-wide keywords: revert
+FAIL Can set 'margin-left' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-left' to the 'auto' keyword: auto
+PASS Can set 'margin-left' to a percent: 0%
+PASS Can set 'margin-left' to a percent: -3.14%
+PASS Can set 'margin-left' to a percent: 3.14%
+PASS Can set 'margin-left' to a percent: calc(0% + 0%)
+PASS Can set 'margin-left' to a length: 0px
+PASS Can set 'margin-left' to a length: -3.14em
+PASS Can set 'margin-left' to a length: 3.14cm
+PASS Can set 'margin-left' to a length: calc(0px + 0em)
 PASS Setting 'margin-left' to a time throws TypeError
 PASS Setting 'margin-left' to an angle throws TypeError
 PASS Setting 'margin-left' to a flexible length throws TypeError
 FAIL Setting 'margin-left' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'margin-left' to a URL throws TypeError
 PASS Setting 'margin-left' to a transform throws TypeError
-PASS Can set 'margin-right' to CSS-wide keywords
-FAIL Can set 'margin-right' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'margin-right' to the 'auto' keyword
-PASS Can set 'margin-right' to a percent
-PASS Can set 'margin-right' to a length
+PASS Can set 'margin-right' to CSS-wide keywords: initial
+PASS Can set 'margin-right' to CSS-wide keywords: inherit
+PASS Can set 'margin-right' to CSS-wide keywords: unset
+PASS Can set 'margin-right' to CSS-wide keywords: revert
+FAIL Can set 'margin-right' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-right' to the 'auto' keyword: auto
+PASS Can set 'margin-right' to a percent: 0%
+PASS Can set 'margin-right' to a percent: -3.14%
+PASS Can set 'margin-right' to a percent: 3.14%
+PASS Can set 'margin-right' to a percent: calc(0% + 0%)
+PASS Can set 'margin-right' to a length: 0px
+PASS Can set 'margin-right' to a length: -3.14em
+PASS Can set 'margin-right' to a length: 3.14cm
+PASS Can set 'margin-right' to a length: calc(0px + 0em)
 PASS Setting 'margin-right' to a time throws TypeError
 PASS Setting 'margin-right' to an angle throws TypeError
 PASS Setting 'margin-right' to a flexible length throws TypeError
 FAIL Setting 'margin-right' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'margin-right' to a URL throws TypeError
 PASS Setting 'margin-right' to a transform throws TypeError
-PASS Can set 'margin-bottom' to CSS-wide keywords
-FAIL Can set 'margin-bottom' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'margin-bottom' to the 'auto' keyword
-PASS Can set 'margin-bottom' to a percent
-PASS Can set 'margin-bottom' to a length
+PASS Can set 'margin-bottom' to CSS-wide keywords: initial
+PASS Can set 'margin-bottom' to CSS-wide keywords: inherit
+PASS Can set 'margin-bottom' to CSS-wide keywords: unset
+PASS Can set 'margin-bottom' to CSS-wide keywords: revert
+FAIL Can set 'margin-bottom' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-bottom' to the 'auto' keyword: auto
+PASS Can set 'margin-bottom' to a percent: 0%
+PASS Can set 'margin-bottom' to a percent: -3.14%
+PASS Can set 'margin-bottom' to a percent: 3.14%
+PASS Can set 'margin-bottom' to a percent: calc(0% + 0%)
+PASS Can set 'margin-bottom' to a length: 0px
+PASS Can set 'margin-bottom' to a length: -3.14em
+PASS Can set 'margin-bottom' to a length: 3.14cm
+PASS Can set 'margin-bottom' to a length: calc(0px + 0em)
 PASS Setting 'margin-bottom' to a time throws TypeError
 PASS Setting 'margin-bottom' to an angle throws TypeError
 PASS Setting 'margin-bottom' to a flexible length throws TypeError
 FAIL Setting 'margin-bottom' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'margin-bottom' to a URL throws TypeError
 PASS Setting 'margin-bottom' to a transform throws TypeError
-FAIL Can set 'margin' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'margin' to var() references assert_equals: expected 2 but got 1
+FAIL Can set 'margin' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'margin' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'margin' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'margin' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'margin' to var() references:  var(--A) assert_equals: expected 2 but got 1
 FAIL Setting 'margin' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 FAIL Setting 'margin' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'margin' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/marker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/marker-expected.txt
@@ -1,10 +1,12 @@
 
 PASS 'marker' does not supported 'none'
 PASS 'marker' does not supported 'url(#m1)'
-PASS Can set 'marker-start' to CSS-wide keywords
-FAIL Can set 'marker-start' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'marker-start' to the 'none' keyword
-PASS Can set 'marker-start' to a URL
+PASS Can set 'marker-start' to CSS-wide keywords: initial
+PASS Can set 'marker-start' to CSS-wide keywords: inherit
+PASS Can set 'marker-start' to CSS-wide keywords: unset
+PASS Can set 'marker-start' to CSS-wide keywords: revert
+FAIL Can set 'marker-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'marker-start' to the 'none' keyword: none
 PASS Setting 'marker-start' to a length throws TypeError
 PASS Setting 'marker-start' to a percent throws TypeError
 PASS Setting 'marker-start' to a time throws TypeError
@@ -12,10 +14,12 @@ PASS Setting 'marker-start' to an angle throws TypeError
 PASS Setting 'marker-start' to a flexible length throws TypeError
 PASS Setting 'marker-start' to a number throws TypeError
 PASS Setting 'marker-start' to a transform throws TypeError
-PASS Can set 'marker-mid' to CSS-wide keywords
-FAIL Can set 'marker-mid' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'marker-mid' to the 'none' keyword
-PASS Can set 'marker-mid' to a URL
+PASS Can set 'marker-mid' to CSS-wide keywords: initial
+PASS Can set 'marker-mid' to CSS-wide keywords: inherit
+PASS Can set 'marker-mid' to CSS-wide keywords: unset
+PASS Can set 'marker-mid' to CSS-wide keywords: revert
+FAIL Can set 'marker-mid' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'marker-mid' to the 'none' keyword: none
 PASS Setting 'marker-mid' to a length throws TypeError
 PASS Setting 'marker-mid' to a percent throws TypeError
 PASS Setting 'marker-mid' to a time throws TypeError
@@ -23,10 +27,12 @@ PASS Setting 'marker-mid' to an angle throws TypeError
 PASS Setting 'marker-mid' to a flexible length throws TypeError
 PASS Setting 'marker-mid' to a number throws TypeError
 PASS Setting 'marker-mid' to a transform throws TypeError
-PASS Can set 'marker-end' to CSS-wide keywords
-FAIL Can set 'marker-end' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'marker-end' to the 'none' keyword
-PASS Can set 'marker-end' to a URL
+PASS Can set 'marker-end' to CSS-wide keywords: initial
+PASS Can set 'marker-end' to CSS-wide keywords: inherit
+PASS Can set 'marker-end' to CSS-wide keywords: unset
+PASS Can set 'marker-end' to CSS-wide keywords: revert
+FAIL Can set 'marker-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'marker-end' to the 'none' keyword: none
 PASS Setting 'marker-end' to a length throws TypeError
 PASS Setting 'marker-end' to a percent throws TypeError
 PASS Setting 'marker-end' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-image-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'mask-image' to CSS-wide keywords
-FAIL Can set 'mask-image' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'mask-image' to the 'none' keyword
+PASS Can set 'mask-image' to CSS-wide keywords: initial
+PASS Can set 'mask-image' to CSS-wide keywords: inherit
+PASS Can set 'mask-image' to CSS-wide keywords: unset
+PASS Can set 'mask-image' to CSS-wide keywords: revert
+FAIL Can set 'mask-image' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'mask-image' to the 'none' keyword: none
 PASS Can set 'mask-image' to an image
 PASS Setting 'mask-image' to a length throws TypeError
 PASS Setting 'mask-image' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-type-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'mask-type' to CSS-wide keywords
-FAIL Can set 'mask-type' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'mask-type' to the 'luminance' keyword
-PASS Can set 'mask-type' to the 'alpha' keyword
+PASS Can set 'mask-type' to CSS-wide keywords: initial
+PASS Can set 'mask-type' to CSS-wide keywords: inherit
+PASS Can set 'mask-type' to CSS-wide keywords: unset
+PASS Can set 'mask-type' to CSS-wide keywords: revert
+FAIL Can set 'mask-type' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'mask-type' to the 'luminance' keyword: luminance
+PASS Can set 'mask-type' to the 'alpha' keyword: alpha
 PASS Setting 'mask-type' to a length throws TypeError
 PASS Setting 'mask-type' to a percent throws TypeError
 PASS Setting 'mask-type' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mix-blend-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mix-blend-mode-expected.txt
@@ -1,22 +1,25 @@
 
-PASS Can set 'mix-blend-mode' to CSS-wide keywords
-FAIL Can set 'mix-blend-mode' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'mix-blend-mode' to the 'normal' keyword
-PASS Can set 'mix-blend-mode' to the 'multiply' keyword
-PASS Can set 'mix-blend-mode' to the 'screen' keyword
-PASS Can set 'mix-blend-mode' to the 'overlay' keyword
-PASS Can set 'mix-blend-mode' to the 'darken' keyword
-PASS Can set 'mix-blend-mode' to the 'lighten' keyword
-PASS Can set 'mix-blend-mode' to the 'color-dodge' keyword
-PASS Can set 'mix-blend-mode' to the 'color-burn' keyword
-PASS Can set 'mix-blend-mode' to the 'hard-light' keyword
-PASS Can set 'mix-blend-mode' to the 'soft-light' keyword
-PASS Can set 'mix-blend-mode' to the 'difference' keyword
-PASS Can set 'mix-blend-mode' to the 'exclusion' keyword
-PASS Can set 'mix-blend-mode' to the 'hue' keyword
-PASS Can set 'mix-blend-mode' to the 'saturation' keyword
-PASS Can set 'mix-blend-mode' to the 'color' keyword
-PASS Can set 'mix-blend-mode' to the 'luminosity' keyword
+PASS Can set 'mix-blend-mode' to CSS-wide keywords: initial
+PASS Can set 'mix-blend-mode' to CSS-wide keywords: inherit
+PASS Can set 'mix-blend-mode' to CSS-wide keywords: unset
+PASS Can set 'mix-blend-mode' to CSS-wide keywords: revert
+FAIL Can set 'mix-blend-mode' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'mix-blend-mode' to the 'normal' keyword: normal
+PASS Can set 'mix-blend-mode' to the 'multiply' keyword: multiply
+PASS Can set 'mix-blend-mode' to the 'screen' keyword: screen
+PASS Can set 'mix-blend-mode' to the 'overlay' keyword: overlay
+PASS Can set 'mix-blend-mode' to the 'darken' keyword: darken
+PASS Can set 'mix-blend-mode' to the 'lighten' keyword: lighten
+PASS Can set 'mix-blend-mode' to the 'color-dodge' keyword: color-dodge
+PASS Can set 'mix-blend-mode' to the 'color-burn' keyword: color-burn
+PASS Can set 'mix-blend-mode' to the 'hard-light' keyword: hard-light
+PASS Can set 'mix-blend-mode' to the 'soft-light' keyword: soft-light
+PASS Can set 'mix-blend-mode' to the 'difference' keyword: difference
+PASS Can set 'mix-blend-mode' to the 'exclusion' keyword: exclusion
+PASS Can set 'mix-blend-mode' to the 'hue' keyword: hue
+PASS Can set 'mix-blend-mode' to the 'saturation' keyword: saturation
+PASS Can set 'mix-blend-mode' to the 'color' keyword: color
+PASS Can set 'mix-blend-mode' to the 'luminosity' keyword: luminosity
 PASS Setting 'mix-blend-mode' to a length throws TypeError
 PASS Setting 'mix-blend-mode' to a percent throws TypeError
 PASS Setting 'mix-blend-mode' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-fit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-fit-expected.txt
@@ -1,11 +1,14 @@
 
-PASS Can set 'object-fit' to CSS-wide keywords
-FAIL Can set 'object-fit' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'object-fit' to the 'fill' keyword
-PASS Can set 'object-fit' to the 'contain' keyword
-PASS Can set 'object-fit' to the 'cover' keyword
-PASS Can set 'object-fit' to the 'none' keyword
-PASS Can set 'object-fit' to the 'scale-down' keyword
+PASS Can set 'object-fit' to CSS-wide keywords: initial
+PASS Can set 'object-fit' to CSS-wide keywords: inherit
+PASS Can set 'object-fit' to CSS-wide keywords: unset
+PASS Can set 'object-fit' to CSS-wide keywords: revert
+FAIL Can set 'object-fit' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'object-fit' to the 'fill' keyword: fill
+PASS Can set 'object-fit' to the 'contain' keyword: contain
+PASS Can set 'object-fit' to the 'cover' keyword: cover
+PASS Can set 'object-fit' to the 'none' keyword: none
+PASS Can set 'object-fit' to the 'scale-down' keyword: scale-down
 PASS Setting 'object-fit' to a length throws TypeError
 PASS Setting 'object-fit' to a percent throws TypeError
 PASS Setting 'object-fit' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-position-expected.txt
@@ -2,6 +2,9 @@ CONSOLE MESSAGE: Error: '<position>' is not a valid CSS component
 
 Harness Error (FAIL), message = Error: '<position>' is not a valid CSS component
 
-PASS Can set 'object-position' to CSS-wide keywords
-FAIL Can set 'object-position' to var() references assert_equals: expected 2 but got 1
+PASS Can set 'object-position' to CSS-wide keywords: initial
+PASS Can set 'object-position' to CSS-wide keywords: inherit
+PASS Can set 'object-position' to CSS-wide keywords: unset
+PASS Can set 'object-position' to CSS-wide keywords: revert
+FAIL Can set 'object-position' to var() references:  var(--A) assert_equals: expected 2 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-anchor-expected.txt
@@ -2,7 +2,10 @@ CONSOLE MESSAGE: Error: '<position>' is not a valid CSS component
 
 Harness Error (FAIL), message = Error: '<position>' is not a valid CSS component
 
-PASS Can set 'offset-anchor' to CSS-wide keywords
-FAIL Can set 'offset-anchor' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'offset-anchor' to the 'auto' keyword
+PASS Can set 'offset-anchor' to CSS-wide keywords: initial
+PASS Can set 'offset-anchor' to CSS-wide keywords: inherit
+PASS Can set 'offset-anchor' to CSS-wide keywords: unset
+PASS Can set 'offset-anchor' to CSS-wide keywords: revert
+FAIL Can set 'offset-anchor' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'offset-anchor' to the 'auto' keyword: auto
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-distance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-distance-expected.txt
@@ -1,8 +1,17 @@
 
-PASS Can set 'offset-distance' to CSS-wide keywords
-FAIL Can set 'offset-distance' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'offset-distance' to a length
-PASS Can set 'offset-distance' to a percent
+PASS Can set 'offset-distance' to CSS-wide keywords: initial
+PASS Can set 'offset-distance' to CSS-wide keywords: inherit
+PASS Can set 'offset-distance' to CSS-wide keywords: unset
+PASS Can set 'offset-distance' to CSS-wide keywords: revert
+FAIL Can set 'offset-distance' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'offset-distance' to a length: 0px
+PASS Can set 'offset-distance' to a length: -3.14em
+PASS Can set 'offset-distance' to a length: 3.14cm
+PASS Can set 'offset-distance' to a length: calc(0px + 0em)
+PASS Can set 'offset-distance' to a percent: 0%
+PASS Can set 'offset-distance' to a percent: -3.14%
+PASS Can set 'offset-distance' to a percent: 3.14%
+PASS Can set 'offset-distance' to a percent: calc(0% + 0%)
 PASS Setting 'offset-distance' to a time throws TypeError
 PASS Setting 'offset-distance' to an angle throws TypeError
 PASS Setting 'offset-distance' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-path-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-path-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'offset-path' to CSS-wide keywords
-FAIL Can set 'offset-path' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'offset-path' to the 'none' keyword
+PASS Can set 'offset-path' to CSS-wide keywords: initial
+PASS Can set 'offset-path' to CSS-wide keywords: inherit
+PASS Can set 'offset-path' to CSS-wide keywords: unset
+PASS Can set 'offset-path' to CSS-wide keywords: revert
+FAIL Can set 'offset-path' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'offset-path' to the 'none' keyword: none
 PASS Setting 'offset-path' to a length throws TypeError
 PASS Setting 'offset-path' to a percent throws TypeError
 PASS Setting 'offset-path' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-position-expected.txt
@@ -2,7 +2,10 @@ CONSOLE MESSAGE: Error: '<position>' is not a valid CSS component
 
 Harness Error (FAIL), message = Error: '<position>' is not a valid CSS component
 
-PASS Can set 'offset-position' to CSS-wide keywords
-FAIL Can set 'offset-position' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'offset-position' to the 'auto' keyword
+PASS Can set 'offset-position' to CSS-wide keywords: initial
+PASS Can set 'offset-position' to CSS-wide keywords: inherit
+PASS Can set 'offset-position' to CSS-wide keywords: unset
+PASS Can set 'offset-position' to CSS-wide keywords: revert
+FAIL Can set 'offset-position' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'offset-position' to the 'auto' keyword: auto
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-rotate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-rotate-expected.txt
@@ -1,9 +1,15 @@
 
-PASS Can set 'offset-rotate' to CSS-wide keywords
-FAIL Can set 'offset-rotate' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'offset-rotate' to the 'auto' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'offset-rotate' to the 'reverse' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'offset-rotate' to an angle assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'offset-rotate' to CSS-wide keywords: initial
+PASS Can set 'offset-rotate' to CSS-wide keywords: inherit
+PASS Can set 'offset-rotate' to CSS-wide keywords: unset
+PASS Can set 'offset-rotate' to CSS-wide keywords: revert
+FAIL Can set 'offset-rotate' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'offset-rotate' to the 'auto' keyword: auto assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'offset-rotate' to the 'reverse' keyword: reverse assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'offset-rotate' to an angle: 0deg assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'offset-rotate' to an angle: 3.14rad assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'offset-rotate' to an angle: -3.14deg assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'offset-rotate' to an angle: calc(0rad + 0deg) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
 PASS Setting 'offset-rotate' to a length throws TypeError
 PASS Setting 'offset-rotate' to a percent throws TypeError
 PASS Setting 'offset-rotate' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'opacity' to CSS-wide keywords
-FAIL Can set 'opacity' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'opacity' to a number
+PASS Can set 'opacity' to CSS-wide keywords: initial
+PASS Can set 'opacity' to CSS-wide keywords: inherit
+PASS Can set 'opacity' to CSS-wide keywords: unset
+PASS Can set 'opacity' to CSS-wide keywords: revert
+FAIL Can set 'opacity' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'opacity' to a number: 0
+PASS Can set 'opacity' to a number: -3.14
+PASS Can set 'opacity' to a number: 3.14
+PASS Can set 'opacity' to a number: calc(2 + 3)
 PASS Setting 'opacity' to a length throws TypeError
 FAIL Setting 'opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'opacity' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'order' to CSS-wide keywords
-FAIL Can set 'order' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'order' to a number assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'order' to CSS-wide keywords: initial
+PASS Can set 'order' to CSS-wide keywords: inherit
+PASS Can set 'order' to CSS-wide keywords: unset
+PASS Can set 'order' to CSS-wide keywords: revert
+FAIL Can set 'order' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'order' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'order' to a number: -3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'order' to a number: 3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'order' to a number: calc(2 + 3) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
 PASS Setting 'order' to a length throws TypeError
 PASS Setting 'order' to a percent throws TypeError
 PASS Setting 'order' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'orphans' to CSS-wide keywords
-FAIL Can set 'orphans' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'orphans' to a number assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+PASS Can set 'orphans' to CSS-wide keywords: initial
+PASS Can set 'orphans' to CSS-wide keywords: inherit
+PASS Can set 'orphans' to CSS-wide keywords: unset
+PASS Can set 'orphans' to CSS-wide keywords: revert
+FAIL Can set 'orphans' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'orphans' to a number: 0 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'orphans' to a number: -3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'orphans' to a number: 3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'orphans' to a number: calc(2 + 3) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
 PASS Setting 'orphans' to a length throws TypeError
 PASS Setting 'orphans' to a percent throws TypeError
 PASS Setting 'orphans' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-color-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'outline-color' to CSS-wide keywords
-FAIL Can set 'outline-color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'outline-color' to the 'currentcolor' keyword
+PASS Can set 'outline-color' to CSS-wide keywords: initial
+PASS Can set 'outline-color' to CSS-wide keywords: inherit
+PASS Can set 'outline-color' to CSS-wide keywords: unset
+PASS Can set 'outline-color' to CSS-wide keywords: revert
+FAIL Can set 'outline-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'outline-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'outline-color' to a length throws TypeError
 PASS Setting 'outline-color' to a percent throws TypeError
 PASS Setting 'outline-color' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-offset-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'outline-offset' to CSS-wide keywords
-FAIL Can set 'outline-offset' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'outline-offset' to a length
+PASS Can set 'outline-offset' to CSS-wide keywords: initial
+PASS Can set 'outline-offset' to CSS-wide keywords: inherit
+PASS Can set 'outline-offset' to CSS-wide keywords: unset
+PASS Can set 'outline-offset' to CSS-wide keywords: revert
+FAIL Can set 'outline-offset' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'outline-offset' to a length: 0px
+PASS Can set 'outline-offset' to a length: -3.14em
+PASS Can set 'outline-offset' to a length: 3.14cm
+PASS Can set 'outline-offset' to a length: calc(0px + 0em)
 PASS Setting 'outline-offset' to a percent throws TypeError
 PASS Setting 'outline-offset' to a time throws TypeError
 PASS Setting 'outline-offset' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-style-expected.txt
@@ -1,16 +1,19 @@
 
-PASS Can set 'outline-style' to CSS-wide keywords
-FAIL Can set 'outline-style' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'outline-style' to the 'auto' keyword
-PASS Can set 'outline-style' to the 'none' keyword
-PASS Can set 'outline-style' to the 'dotted' keyword
-PASS Can set 'outline-style' to the 'dashed' keyword
-PASS Can set 'outline-style' to the 'solid' keyword
-PASS Can set 'outline-style' to the 'double' keyword
-PASS Can set 'outline-style' to the 'groove' keyword
-PASS Can set 'outline-style' to the 'ridge' keyword
-PASS Can set 'outline-style' to the 'inset' keyword
-PASS Can set 'outline-style' to the 'outset' keyword
+PASS Can set 'outline-style' to CSS-wide keywords: initial
+PASS Can set 'outline-style' to CSS-wide keywords: inherit
+PASS Can set 'outline-style' to CSS-wide keywords: unset
+PASS Can set 'outline-style' to CSS-wide keywords: revert
+FAIL Can set 'outline-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'outline-style' to the 'auto' keyword: auto
+PASS Can set 'outline-style' to the 'none' keyword: none
+PASS Can set 'outline-style' to the 'dotted' keyword: dotted
+PASS Can set 'outline-style' to the 'dashed' keyword: dashed
+PASS Can set 'outline-style' to the 'solid' keyword: solid
+PASS Can set 'outline-style' to the 'double' keyword: double
+PASS Can set 'outline-style' to the 'groove' keyword: groove
+PASS Can set 'outline-style' to the 'ridge' keyword: ridge
+PASS Can set 'outline-style' to the 'inset' keyword: inset
+PASS Can set 'outline-style' to the 'outset' keyword: outset
 PASS Setting 'outline-style' to a length throws TypeError
 PASS Setting 'outline-style' to a percent throws TypeError
 PASS Setting 'outline-style' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt
@@ -1,10 +1,16 @@
 
-PASS Can set 'outline-width' to CSS-wide keywords
-FAIL Can set 'outline-width' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'outline-width' to the 'thin' keyword
-PASS Can set 'outline-width' to the 'medium' keyword
-PASS Can set 'outline-width' to the 'thick' keyword
-FAIL Can set 'outline-width' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'outline-width' to CSS-wide keywords: initial
+PASS Can set 'outline-width' to CSS-wide keywords: inherit
+PASS Can set 'outline-width' to CSS-wide keywords: unset
+PASS Can set 'outline-width' to CSS-wide keywords: revert
+FAIL Can set 'outline-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'outline-width' to the 'thin' keyword: thin
+PASS Can set 'outline-width' to the 'medium' keyword: medium
+PASS Can set 'outline-width' to the 'thick' keyword: thick
+PASS Can set 'outline-width' to a length: 0px
+PASS Can set 'outline-width' to a length: -3.14em
+PASS Can set 'outline-width' to a length: 3.14cm
+FAIL Can set 'outline-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'outline-width' to a percent throws TypeError
 PASS Setting 'outline-width' to a time throws TypeError
 PASS Setting 'outline-width' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-anchor-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'overflow-anchor' to CSS-wide keywords
-FAIL Can set 'overflow-anchor' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'overflow-anchor' to the 'auto' keyword
-PASS Can set 'overflow-anchor' to the 'none' keyword
+PASS Can set 'overflow-anchor' to CSS-wide keywords: initial
+PASS Can set 'overflow-anchor' to CSS-wide keywords: inherit
+PASS Can set 'overflow-anchor' to CSS-wide keywords: unset
+PASS Can set 'overflow-anchor' to CSS-wide keywords: revert
+FAIL Can set 'overflow-anchor' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'overflow-anchor' to the 'auto' keyword: auto
+PASS Can set 'overflow-anchor' to the 'none' keyword: none
 PASS Setting 'overflow-anchor' to a length throws TypeError
 PASS Setting 'overflow-anchor' to a percent throws TypeError
 PASS Setting 'overflow-anchor' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-expected.txt
@@ -1,11 +1,14 @@
 
-PASS Can set 'overflow-x' to CSS-wide keywords
-FAIL Can set 'overflow-x' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'overflow-x' to the 'visible' keyword
-PASS Can set 'overflow-x' to the 'hidden' keyword
-PASS Can set 'overflow-x' to the 'clip' keyword
-PASS Can set 'overflow-x' to the 'scroll' keyword
-PASS Can set 'overflow-x' to the 'auto' keyword
+PASS Can set 'overflow-x' to CSS-wide keywords: initial
+PASS Can set 'overflow-x' to CSS-wide keywords: inherit
+PASS Can set 'overflow-x' to CSS-wide keywords: unset
+PASS Can set 'overflow-x' to CSS-wide keywords: revert
+FAIL Can set 'overflow-x' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'overflow-x' to the 'visible' keyword: visible
+PASS Can set 'overflow-x' to the 'hidden' keyword: hidden
+PASS Can set 'overflow-x' to the 'clip' keyword: clip
+PASS Can set 'overflow-x' to the 'scroll' keyword: scroll
+PASS Can set 'overflow-x' to the 'auto' keyword: auto
 PASS Setting 'overflow-x' to a length throws TypeError
 PASS Setting 'overflow-x' to a percent throws TypeError
 PASS Setting 'overflow-x' to a time throws TypeError
@@ -14,13 +17,16 @@ PASS Setting 'overflow-x' to a flexible length throws TypeError
 PASS Setting 'overflow-x' to a number throws TypeError
 PASS Setting 'overflow-x' to a URL throws TypeError
 PASS Setting 'overflow-x' to a transform throws TypeError
-PASS Can set 'overflow-y' to CSS-wide keywords
-FAIL Can set 'overflow-y' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'overflow-y' to the 'visible' keyword
-PASS Can set 'overflow-y' to the 'hidden' keyword
-PASS Can set 'overflow-y' to the 'clip' keyword
-PASS Can set 'overflow-y' to the 'scroll' keyword
-PASS Can set 'overflow-y' to the 'auto' keyword
+PASS Can set 'overflow-y' to CSS-wide keywords: initial
+PASS Can set 'overflow-y' to CSS-wide keywords: inherit
+PASS Can set 'overflow-y' to CSS-wide keywords: unset
+PASS Can set 'overflow-y' to CSS-wide keywords: revert
+FAIL Can set 'overflow-y' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'overflow-y' to the 'visible' keyword: visible
+PASS Can set 'overflow-y' to the 'hidden' keyword: hidden
+PASS Can set 'overflow-y' to the 'clip' keyword: clip
+PASS Can set 'overflow-y' to the 'scroll' keyword: scroll
+PASS Can set 'overflow-y' to the 'auto' keyword: auto
 PASS Setting 'overflow-y' to a length throws TypeError
 PASS Setting 'overflow-y' to a percent throws TypeError
 PASS Setting 'overflow-y' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-wrap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-wrap-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'overflow-wrap' to CSS-wide keywords
-FAIL Can set 'overflow-wrap' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'overflow-wrap' to the 'normal' keyword
-PASS Can set 'overflow-wrap' to the 'break-word' keyword
-FAIL Can set 'overflow-wrap' to the 'break-spaces' keyword Invalid values
+PASS Can set 'overflow-wrap' to CSS-wide keywords: initial
+PASS Can set 'overflow-wrap' to CSS-wide keywords: inherit
+PASS Can set 'overflow-wrap' to CSS-wide keywords: unset
+PASS Can set 'overflow-wrap' to CSS-wide keywords: revert
+FAIL Can set 'overflow-wrap' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'overflow-wrap' to the 'normal' keyword: normal
+PASS Can set 'overflow-wrap' to the 'break-word' keyword: break-word
+FAIL Can set 'overflow-wrap' to the 'break-spaces' keyword: break-spaces Invalid values
 PASS Setting 'overflow-wrap' to a length throws TypeError
 PASS Setting 'overflow-wrap' to a percent throws TypeError
 PASS Setting 'overflow-wrap' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overscroll-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overscroll-behavior-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'overscroll-behavior-x' to CSS-wide keywords
-FAIL Can set 'overscroll-behavior-x' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'overscroll-behavior-x' to the 'contain' keyword
-PASS Can set 'overscroll-behavior-x' to the 'none' keyword
-PASS Can set 'overscroll-behavior-x' to the 'auto' keyword
+PASS Can set 'overscroll-behavior-x' to CSS-wide keywords: initial
+PASS Can set 'overscroll-behavior-x' to CSS-wide keywords: inherit
+PASS Can set 'overscroll-behavior-x' to CSS-wide keywords: unset
+PASS Can set 'overscroll-behavior-x' to CSS-wide keywords: revert
+FAIL Can set 'overscroll-behavior-x' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'overscroll-behavior-x' to the 'contain' keyword: contain
+PASS Can set 'overscroll-behavior-x' to the 'none' keyword: none
+PASS Can set 'overscroll-behavior-x' to the 'auto' keyword: auto
 PASS Setting 'overscroll-behavior-x' to a length throws TypeError
 PASS Setting 'overscroll-behavior-x' to a percent throws TypeError
 PASS Setting 'overscroll-behavior-x' to a time throws TypeError
@@ -12,11 +15,14 @@ PASS Setting 'overscroll-behavior-x' to a flexible length throws TypeError
 PASS Setting 'overscroll-behavior-x' to a number throws TypeError
 PASS Setting 'overscroll-behavior-x' to a URL throws TypeError
 PASS Setting 'overscroll-behavior-x' to a transform throws TypeError
-PASS Can set 'overscroll-behavior-y' to CSS-wide keywords
-FAIL Can set 'overscroll-behavior-y' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'overscroll-behavior-y' to the 'contain' keyword
-PASS Can set 'overscroll-behavior-y' to the 'none' keyword
-PASS Can set 'overscroll-behavior-y' to the 'auto' keyword
+PASS Can set 'overscroll-behavior-y' to CSS-wide keywords: initial
+PASS Can set 'overscroll-behavior-y' to CSS-wide keywords: inherit
+PASS Can set 'overscroll-behavior-y' to CSS-wide keywords: unset
+PASS Can set 'overscroll-behavior-y' to CSS-wide keywords: revert
+FAIL Can set 'overscroll-behavior-y' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'overscroll-behavior-y' to the 'contain' keyword: contain
+PASS Can set 'overscroll-behavior-y' to the 'none' keyword: none
+PASS Can set 'overscroll-behavior-y' to the 'auto' keyword: auto
 PASS Setting 'overscroll-behavior-y' to a length throws TypeError
 PASS Setting 'overscroll-behavior-y' to a percent throws TypeError
 PASS Setting 'overscroll-behavior-y' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt
@@ -1,38 +1,74 @@
 
-PASS Can set 'padding-top' to CSS-wide keywords
-FAIL Can set 'padding-top' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-top' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'padding-top' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'padding-top' to CSS-wide keywords: initial
+PASS Can set 'padding-top' to CSS-wide keywords: inherit
+PASS Can set 'padding-top' to CSS-wide keywords: unset
+PASS Can set 'padding-top' to CSS-wide keywords: revert
+FAIL Can set 'padding-top' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-top' to a percent: 0%
+FAIL Can set 'padding-top' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-top' to a percent: 3.14%
+FAIL Can set 'padding-top' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'padding-top' to a length: 0px
+PASS Can set 'padding-top' to a length: -3.14em
+PASS Can set 'padding-top' to a length: 3.14cm
+FAIL Can set 'padding-top' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'padding-top' to a time throws TypeError
 PASS Setting 'padding-top' to an angle throws TypeError
 PASS Setting 'padding-top' to a flexible length throws TypeError
 FAIL Setting 'padding-top' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'padding-top' to a URL throws TypeError
 PASS Setting 'padding-top' to a transform throws TypeError
-PASS Can set 'padding-left' to CSS-wide keywords
-FAIL Can set 'padding-left' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-left' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'padding-left' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'padding-left' to CSS-wide keywords: initial
+PASS Can set 'padding-left' to CSS-wide keywords: inherit
+PASS Can set 'padding-left' to CSS-wide keywords: unset
+PASS Can set 'padding-left' to CSS-wide keywords: revert
+FAIL Can set 'padding-left' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-left' to a percent: 0%
+FAIL Can set 'padding-left' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-left' to a percent: 3.14%
+FAIL Can set 'padding-left' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'padding-left' to a length: 0px
+PASS Can set 'padding-left' to a length: -3.14em
+PASS Can set 'padding-left' to a length: 3.14cm
+FAIL Can set 'padding-left' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'padding-left' to a time throws TypeError
 PASS Setting 'padding-left' to an angle throws TypeError
 PASS Setting 'padding-left' to a flexible length throws TypeError
 FAIL Setting 'padding-left' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'padding-left' to a URL throws TypeError
 PASS Setting 'padding-left' to a transform throws TypeError
-PASS Can set 'padding-right' to CSS-wide keywords
-FAIL Can set 'padding-right' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-right' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'padding-right' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'padding-right' to CSS-wide keywords: initial
+PASS Can set 'padding-right' to CSS-wide keywords: inherit
+PASS Can set 'padding-right' to CSS-wide keywords: unset
+PASS Can set 'padding-right' to CSS-wide keywords: revert
+FAIL Can set 'padding-right' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-right' to a percent: 0%
+FAIL Can set 'padding-right' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-right' to a percent: 3.14%
+FAIL Can set 'padding-right' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'padding-right' to a length: 0px
+PASS Can set 'padding-right' to a length: -3.14em
+PASS Can set 'padding-right' to a length: 3.14cm
+FAIL Can set 'padding-right' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'padding-right' to a time throws TypeError
 PASS Setting 'padding-right' to an angle throws TypeError
 PASS Setting 'padding-right' to a flexible length throws TypeError
 FAIL Setting 'padding-right' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'padding-right' to a URL throws TypeError
 PASS Setting 'padding-right' to a transform throws TypeError
-PASS Can set 'padding-bottom' to CSS-wide keywords
-FAIL Can set 'padding-bottom' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'padding-bottom' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'padding-bottom' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'padding-bottom' to CSS-wide keywords: initial
+PASS Can set 'padding-bottom' to CSS-wide keywords: inherit
+PASS Can set 'padding-bottom' to CSS-wide keywords: unset
+PASS Can set 'padding-bottom' to CSS-wide keywords: revert
+FAIL Can set 'padding-bottom' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-bottom' to a percent: 0%
+FAIL Can set 'padding-bottom' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-bottom' to a percent: 3.14%
+FAIL Can set 'padding-bottom' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'padding-bottom' to a length: 0px
+PASS Can set 'padding-bottom' to a length: -3.14em
+PASS Can set 'padding-bottom' to a length: 3.14cm
+FAIL Can set 'padding-bottom' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'padding-bottom' to a time throws TypeError
 PASS Setting 'padding-bottom' to an angle throws TypeError
 PASS Setting 'padding-bottom' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt
@@ -1,8 +1,11 @@
 
-FAIL Can set 'page' to CSS-wide keywords assert_not_equals: Computed value must not be null got disallowed value null
-FAIL Can set 'page' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'page' to the 'auto' keyword assert_not_equals: Computed value must not be null got disallowed value null
-FAIL Can set 'page' to the 'custom-ident' keyword Invalid values
+FAIL Can set 'page' to CSS-wide keywords: initial assert_not_equals: Computed value must not be null got disallowed value null
+FAIL Can set 'page' to CSS-wide keywords: inherit assert_not_equals: Computed value must not be null got disallowed value null
+FAIL Can set 'page' to CSS-wide keywords: unset assert_not_equals: Computed value must not be null got disallowed value null
+FAIL Can set 'page' to CSS-wide keywords: revert assert_not_equals: Computed value must not be null got disallowed value null
+FAIL Can set 'page' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'page' to the 'auto' keyword: auto assert_not_equals: Computed value must not be null got disallowed value null
+FAIL Can set 'page' to the 'custom-ident' keyword: custom-ident Invalid values
 PASS Setting 'page' to a length throws TypeError
 PASS Setting 'page' to a percent throws TypeError
 PASS Setting 'page' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/paint-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/paint-order-expected.txt
@@ -1,10 +1,13 @@
 
-PASS Can set 'paint-order' to CSS-wide keywords
-FAIL Can set 'paint-order' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'paint-order' to the 'normal' keyword
-PASS Can set 'paint-order' to the 'fill' keyword
-PASS Can set 'paint-order' to the 'stroke' keyword
-PASS Can set 'paint-order' to the 'markers' keyword
+PASS Can set 'paint-order' to CSS-wide keywords: initial
+PASS Can set 'paint-order' to CSS-wide keywords: inherit
+PASS Can set 'paint-order' to CSS-wide keywords: unset
+PASS Can set 'paint-order' to CSS-wide keywords: revert
+FAIL Can set 'paint-order' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'paint-order' to the 'normal' keyword: normal
+PASS Can set 'paint-order' to the 'fill' keyword: fill
+PASS Can set 'paint-order' to the 'stroke' keyword: stroke
+PASS Can set 'paint-order' to the 'markers' keyword: markers
 PASS Setting 'paint-order' to a length throws TypeError
 PASS Setting 'paint-order' to a percent throws TypeError
 PASS Setting 'paint-order' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt
@@ -1,8 +1,14 @@
 
-PASS Can set 'perspective' to CSS-wide keywords
-FAIL Can set 'perspective' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'perspective' to the 'none' keyword
-FAIL Can set 'perspective' to a length assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSKeywordValue]"
+PASS Can set 'perspective' to CSS-wide keywords: initial
+PASS Can set 'perspective' to CSS-wide keywords: inherit
+PASS Can set 'perspective' to CSS-wide keywords: unset
+PASS Can set 'perspective' to CSS-wide keywords: revert
+FAIL Can set 'perspective' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'perspective' to the 'none' keyword: none
+PASS Can set 'perspective' to a length: 0px
+FAIL Can set 'perspective' to a length: -3.14em assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSKeywordValue]"
+PASS Can set 'perspective' to a length: 3.14cm
+FAIL Can set 'perspective' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'perspective' to a percent throws TypeError
 PASS Setting 'perspective' to a time throws TypeError
 PASS Setting 'perspective' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-origin-expected.txt
@@ -2,7 +2,10 @@ CONSOLE MESSAGE: Error: '<position>' is not a valid CSS component
 
 Harness Error (FAIL), message = Error: '<position>' is not a valid CSS component
 
-FAIL Can set 'perspective-origin' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'perspective-origin' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'perspective-origin' to the 'none' keyword Bad value for shorthand CSS property
+FAIL Can set 'perspective-origin' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'perspective-origin' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'perspective-origin' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'perspective-origin' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'perspective-origin' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'perspective-origin' to the 'none' keyword: none Bad value for shorthand CSS property
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/pointer-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/pointer-events-expected.txt
@@ -1,16 +1,19 @@
 
-PASS Can set 'pointer-events' to CSS-wide keywords
-FAIL Can set 'pointer-events' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'pointer-events' to the 'bounding-box' keyword
-FAIL Can set 'pointer-events' to the 'visiblepainted' keyword assert_equals: expected "visiblepainted" but got "visiblePainted"
-FAIL Can set 'pointer-events' to the 'visiblefill' keyword assert_equals: expected "visiblefill" but got "visibleFill"
-FAIL Can set 'pointer-events' to the 'visiblestroke' keyword assert_equals: expected "visiblestroke" but got "visibleStroke"
-PASS Can set 'pointer-events' to the 'visible' keyword
-PASS Can set 'pointer-events' to the 'painted' keyword
-PASS Can set 'pointer-events' to the 'fill' keyword
-PASS Can set 'pointer-events' to the 'stroke' keyword
-PASS Can set 'pointer-events' to the 'all' keyword
-PASS Can set 'pointer-events' to the 'none' keyword
+PASS Can set 'pointer-events' to CSS-wide keywords: initial
+PASS Can set 'pointer-events' to CSS-wide keywords: inherit
+PASS Can set 'pointer-events' to CSS-wide keywords: unset
+PASS Can set 'pointer-events' to CSS-wide keywords: revert
+FAIL Can set 'pointer-events' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'pointer-events' to the 'bounding-box' keyword: bounding-box
+FAIL Can set 'pointer-events' to the 'visiblepainted' keyword: visiblepainted assert_equals: expected "visiblepainted" but got "visiblePainted"
+FAIL Can set 'pointer-events' to the 'visiblefill' keyword: visiblefill assert_equals: expected "visiblefill" but got "visibleFill"
+FAIL Can set 'pointer-events' to the 'visiblestroke' keyword: visiblestroke assert_equals: expected "visiblestroke" but got "visibleStroke"
+PASS Can set 'pointer-events' to the 'visible' keyword: visible
+PASS Can set 'pointer-events' to the 'painted' keyword: painted
+PASS Can set 'pointer-events' to the 'fill' keyword: fill
+PASS Can set 'pointer-events' to the 'stroke' keyword: stroke
+PASS Can set 'pointer-events' to the 'all' keyword: all
+PASS Can set 'pointer-events' to the 'none' keyword: none
 PASS Setting 'pointer-events' to a length throws TypeError
 PASS Setting 'pointer-events' to a percent throws TypeError
 PASS Setting 'pointer-events' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/position-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'position' to CSS-wide keywords
-FAIL Can set 'position' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'position' to the 'relative' keyword
-PASS Can set 'position' to the 'absolute' keyword
+PASS Can set 'position' to CSS-wide keywords: initial
+PASS Can set 'position' to CSS-wide keywords: inherit
+PASS Can set 'position' to CSS-wide keywords: unset
+PASS Can set 'position' to CSS-wide keywords: revert
+FAIL Can set 'position' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'position' to the 'relative' keyword: relative
+PASS Can set 'position' to the 'absolute' keyword: absolute
 PASS Setting 'position' to a length throws TypeError
 PASS Setting 'position' to a percent throws TypeError
 PASS Setting 'position' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/quotes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/quotes-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'quotes' to CSS-wide keywords
-FAIL Can set 'quotes' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'quotes' to the 'none' keyword
+PASS Can set 'quotes' to CSS-wide keywords: initial
+PASS Can set 'quotes' to CSS-wide keywords: inherit
+PASS Can set 'quotes' to CSS-wide keywords: unset
+PASS Can set 'quotes' to CSS-wide keywords: revert
+FAIL Can set 'quotes' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'quotes' to the 'none' keyword: none
 PASS Setting 'quotes' to a length throws TypeError
 PASS Setting 'quotes' to a percent throws TypeError
 PASS Setting 'quotes' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt
@@ -1,30 +1,57 @@
 
-PASS Can set 'r' to CSS-wide keywords
-FAIL Can set 'r' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'r' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'r' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'r' to CSS-wide keywords: initial
+PASS Can set 'r' to CSS-wide keywords: inherit
+PASS Can set 'r' to CSS-wide keywords: unset
+PASS Can set 'r' to CSS-wide keywords: revert
+FAIL Can set 'r' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'r' to a percent: 0%
+FAIL Can set 'r' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'r' to a percent: 3.14%
+FAIL Can set 'r' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'r' to a length: 0px
+PASS Can set 'r' to a length: -3.14em
+PASS Can set 'r' to a length: 3.14cm
+FAIL Can set 'r' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'r' to a time throws TypeError
 PASS Setting 'r' to an angle throws TypeError
 PASS Setting 'r' to a flexible length throws TypeError
 FAIL Setting 'r' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'r' to a URL throws TypeError
 PASS Setting 'r' to a transform throws TypeError
-PASS Can set 'rx' to CSS-wide keywords
-FAIL Can set 'rx' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'rx' to the 'auto' keyword
-FAIL Can set 'rx' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'rx' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'rx' to CSS-wide keywords: initial
+PASS Can set 'rx' to CSS-wide keywords: inherit
+PASS Can set 'rx' to CSS-wide keywords: unset
+PASS Can set 'rx' to CSS-wide keywords: revert
+FAIL Can set 'rx' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'rx' to the 'auto' keyword: auto
+PASS Can set 'rx' to a percent: 0%
+FAIL Can set 'rx' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'rx' to a percent: 3.14%
+FAIL Can set 'rx' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'rx' to a length: 0px
+PASS Can set 'rx' to a length: -3.14em
+PASS Can set 'rx' to a length: 3.14cm
+FAIL Can set 'rx' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'rx' to a time throws TypeError
 PASS Setting 'rx' to an angle throws TypeError
 PASS Setting 'rx' to a flexible length throws TypeError
 FAIL Setting 'rx' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'rx' to a URL throws TypeError
 PASS Setting 'rx' to a transform throws TypeError
-PASS Can set 'ry' to CSS-wide keywords
-FAIL Can set 'ry' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'ry' to the 'auto' keyword
-FAIL Can set 'ry' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'ry' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'ry' to CSS-wide keywords: initial
+PASS Can set 'ry' to CSS-wide keywords: inherit
+PASS Can set 'ry' to CSS-wide keywords: unset
+PASS Can set 'ry' to CSS-wide keywords: revert
+FAIL Can set 'ry' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'ry' to the 'auto' keyword: auto
+PASS Can set 'ry' to a percent: 0%
+FAIL Can set 'ry' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'ry' to a percent: 3.14%
+FAIL Can set 'ry' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'ry' to a length: 0px
+PASS Can set 'ry' to a length: -3.14em
+PASS Can set 'ry' to a length: 3.14cm
+FAIL Can set 'ry' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'ry' to a time throws TypeError
 PASS Setting 'ry' to an angle throws TypeError
 PASS Setting 'ry' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resize-expected.txt
@@ -1,10 +1,13 @@
 
-PASS Can set 'resize' to CSS-wide keywords
-FAIL Can set 'resize' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'resize' to the 'none' keyword
-PASS Can set 'resize' to the 'both' keyword
-PASS Can set 'resize' to the 'horizontal' keyword
-PASS Can set 'resize' to the 'vertical' keyword
+PASS Can set 'resize' to CSS-wide keywords: initial
+PASS Can set 'resize' to CSS-wide keywords: inherit
+PASS Can set 'resize' to CSS-wide keywords: unset
+PASS Can set 'resize' to CSS-wide keywords: revert
+FAIL Can set 'resize' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'resize' to the 'none' keyword: none
+PASS Can set 'resize' to the 'both' keyword: both
+PASS Can set 'resize' to the 'horizontal' keyword: horizontal
+PASS Can set 'resize' to the 'vertical' keyword: vertical
 PASS Setting 'resize' to a length throws TypeError
 PASS Setting 'resize' to a percent throws TypeError
 PASS Setting 'resize' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resources/testsuite.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resources/testsuite.js
@@ -27,11 +27,11 @@ const gCssWideKeywordsExamples = [
   },
   {
     description: 'inherit keyword',
-    input: new CSSKeywordValue('initial')
+    input: new CSSKeywordValue('inherit')
   },
   {
     description: 'unset keyword',
-    input: new CSSKeywordValue('initial')
+    input: new CSSKeywordValue('unset')
   },
   {
     description: 'revert keyword',
@@ -292,10 +292,10 @@ const gTestSyntaxExamples = {
 // Test setting a value in a style map and then getting it from the inline and
 // computed styles.
 function testPropertyValid(propertyName, examples, specified, computed, description) {
-  test(t => {
-    let element = createDivWithStyle(t);
+  for (const example of examples) {
+    test(t => {
+      let element = createDivWithStyle(t);
 
-    for (const example of examples) {
       element.attributeStyleMap.set(propertyName, example.input);
 
       // specified style
@@ -325,8 +325,8 @@ function testPropertyValid(propertyName, examples, specified, computed, descript
         assert_style_value_equals(computedResult, example.input,
           `Setting ${example.description} and getting its computed value`);
       }
-    }
-  }, `Can set '${propertyName}' to ${description}`);
+    }, `Can set '${propertyName}' to ${description}: ` + example.input);
+  }
 }
 
 // We have to special case CSSImageValue as they cannot be created with a

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/right-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/right-expected.txt
@@ -1,9 +1,18 @@
 
-PASS Can set 'right' to CSS-wide keywords
-FAIL Can set 'right' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'right' to the 'auto' keyword
-PASS Can set 'right' to a percent
-PASS Can set 'right' to a length
+PASS Can set 'right' to CSS-wide keywords: initial
+PASS Can set 'right' to CSS-wide keywords: inherit
+PASS Can set 'right' to CSS-wide keywords: unset
+PASS Can set 'right' to CSS-wide keywords: revert
+FAIL Can set 'right' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'right' to the 'auto' keyword: auto
+PASS Can set 'right' to a percent: 0%
+PASS Can set 'right' to a percent: -3.14%
+PASS Can set 'right' to a percent: 3.14%
+PASS Can set 'right' to a percent: calc(0% + 0%)
+PASS Can set 'right' to a length: 0px
+PASS Can set 'right' to a length: -3.14em
+PASS Can set 'right' to a length: 3.14cm
+PASS Can set 'right' to a length: calc(0px + 0em)
 PASS Setting 'right' to a time throws TypeError
 PASS Setting 'right' to an angle throws TypeError
 PASS Setting 'right' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-behavior-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'scroll-behavior' to CSS-wide keywords
-FAIL Can set 'scroll-behavior' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'scroll-behavior' to the 'auto' keyword
-PASS Can set 'scroll-behavior' to the 'smooth' keyword
+PASS Can set 'scroll-behavior' to CSS-wide keywords: initial
+PASS Can set 'scroll-behavior' to CSS-wide keywords: inherit
+PASS Can set 'scroll-behavior' to CSS-wide keywords: unset
+PASS Can set 'scroll-behavior' to CSS-wide keywords: revert
+FAIL Can set 'scroll-behavior' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-behavior' to the 'auto' keyword: auto
+PASS Can set 'scroll-behavior' to the 'smooth' keyword: smooth
 PASS Setting 'scroll-behavior' to a length throws TypeError
 PASS Setting 'scroll-behavior' to a percent throws TypeError
 PASS Setting 'scroll-behavior' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-margin-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'scroll-margin-top' to CSS-wide keywords
-FAIL Can set 'scroll-margin-top' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'scroll-margin-top' to a length
+PASS Can set 'scroll-margin-top' to CSS-wide keywords: initial
+PASS Can set 'scroll-margin-top' to CSS-wide keywords: inherit
+PASS Can set 'scroll-margin-top' to CSS-wide keywords: unset
+PASS Can set 'scroll-margin-top' to CSS-wide keywords: revert
+FAIL Can set 'scroll-margin-top' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-top' to a length: 0px
+PASS Can set 'scroll-margin-top' to a length: -3.14em
+PASS Can set 'scroll-margin-top' to a length: 3.14cm
+PASS Can set 'scroll-margin-top' to a length: calc(0px + 0em)
 PASS Setting 'scroll-margin-top' to a percent throws TypeError
 PASS Setting 'scroll-margin-top' to a time throws TypeError
 PASS Setting 'scroll-margin-top' to an angle throws TypeError
@@ -9,9 +15,15 @@ PASS Setting 'scroll-margin-top' to a flexible length throws TypeError
 FAIL Setting 'scroll-margin-top' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'scroll-margin-top' to a URL throws TypeError
 PASS Setting 'scroll-margin-top' to a transform throws TypeError
-PASS Can set 'scroll-margin-left' to CSS-wide keywords
-FAIL Can set 'scroll-margin-left' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'scroll-margin-left' to a length
+PASS Can set 'scroll-margin-left' to CSS-wide keywords: initial
+PASS Can set 'scroll-margin-left' to CSS-wide keywords: inherit
+PASS Can set 'scroll-margin-left' to CSS-wide keywords: unset
+PASS Can set 'scroll-margin-left' to CSS-wide keywords: revert
+FAIL Can set 'scroll-margin-left' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-left' to a length: 0px
+PASS Can set 'scroll-margin-left' to a length: -3.14em
+PASS Can set 'scroll-margin-left' to a length: 3.14cm
+PASS Can set 'scroll-margin-left' to a length: calc(0px + 0em)
 PASS Setting 'scroll-margin-left' to a percent throws TypeError
 PASS Setting 'scroll-margin-left' to a time throws TypeError
 PASS Setting 'scroll-margin-left' to an angle throws TypeError
@@ -19,9 +31,15 @@ PASS Setting 'scroll-margin-left' to a flexible length throws TypeError
 FAIL Setting 'scroll-margin-left' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'scroll-margin-left' to a URL throws TypeError
 PASS Setting 'scroll-margin-left' to a transform throws TypeError
-PASS Can set 'scroll-margin-right' to CSS-wide keywords
-FAIL Can set 'scroll-margin-right' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'scroll-margin-right' to a length
+PASS Can set 'scroll-margin-right' to CSS-wide keywords: initial
+PASS Can set 'scroll-margin-right' to CSS-wide keywords: inherit
+PASS Can set 'scroll-margin-right' to CSS-wide keywords: unset
+PASS Can set 'scroll-margin-right' to CSS-wide keywords: revert
+FAIL Can set 'scroll-margin-right' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-right' to a length: 0px
+PASS Can set 'scroll-margin-right' to a length: -3.14em
+PASS Can set 'scroll-margin-right' to a length: 3.14cm
+PASS Can set 'scroll-margin-right' to a length: calc(0px + 0em)
 PASS Setting 'scroll-margin-right' to a percent throws TypeError
 PASS Setting 'scroll-margin-right' to a time throws TypeError
 PASS Setting 'scroll-margin-right' to an angle throws TypeError
@@ -29,9 +47,15 @@ PASS Setting 'scroll-margin-right' to a flexible length throws TypeError
 FAIL Setting 'scroll-margin-right' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'scroll-margin-right' to a URL throws TypeError
 PASS Setting 'scroll-margin-right' to a transform throws TypeError
-PASS Can set 'scroll-margin-bottom' to CSS-wide keywords
-FAIL Can set 'scroll-margin-bottom' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'scroll-margin-bottom' to a length
+PASS Can set 'scroll-margin-bottom' to CSS-wide keywords: initial
+PASS Can set 'scroll-margin-bottom' to CSS-wide keywords: inherit
+PASS Can set 'scroll-margin-bottom' to CSS-wide keywords: unset
+PASS Can set 'scroll-margin-bottom' to CSS-wide keywords: revert
+FAIL Can set 'scroll-margin-bottom' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-bottom' to a length: 0px
+PASS Can set 'scroll-margin-bottom' to a length: -3.14em
+PASS Can set 'scroll-margin-bottom' to a length: 3.14cm
+PASS Can set 'scroll-margin-bottom' to a length: calc(0px + 0em)
 PASS Setting 'scroll-margin-bottom' to a percent throws TypeError
 PASS Setting 'scroll-margin-bottom' to a time throws TypeError
 PASS Setting 'scroll-margin-bottom' to an angle throws TypeError
@@ -39,9 +63,15 @@ PASS Setting 'scroll-margin-bottom' to a flexible length throws TypeError
 FAIL Setting 'scroll-margin-bottom' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'scroll-margin-bottom' to a URL throws TypeError
 PASS Setting 'scroll-margin-bottom' to a transform throws TypeError
-PASS Can set 'scroll-margin-inline-start' to CSS-wide keywords
-FAIL Can set 'scroll-margin-inline-start' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'scroll-margin-inline-start' to a length
+PASS Can set 'scroll-margin-inline-start' to CSS-wide keywords: initial
+PASS Can set 'scroll-margin-inline-start' to CSS-wide keywords: inherit
+PASS Can set 'scroll-margin-inline-start' to CSS-wide keywords: unset
+PASS Can set 'scroll-margin-inline-start' to CSS-wide keywords: revert
+FAIL Can set 'scroll-margin-inline-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-inline-start' to a length: 0px
+PASS Can set 'scroll-margin-inline-start' to a length: -3.14em
+PASS Can set 'scroll-margin-inline-start' to a length: 3.14cm
+PASS Can set 'scroll-margin-inline-start' to a length: calc(0px + 0em)
 PASS Setting 'scroll-margin-inline-start' to a percent throws TypeError
 PASS Setting 'scroll-margin-inline-start' to a time throws TypeError
 PASS Setting 'scroll-margin-inline-start' to an angle throws TypeError
@@ -49,9 +79,15 @@ PASS Setting 'scroll-margin-inline-start' to a flexible length throws TypeError
 FAIL Setting 'scroll-margin-inline-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'scroll-margin-inline-start' to a URL throws TypeError
 PASS Setting 'scroll-margin-inline-start' to a transform throws TypeError
-PASS Can set 'scroll-margin-block-start' to CSS-wide keywords
-FAIL Can set 'scroll-margin-block-start' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'scroll-margin-block-start' to a length
+PASS Can set 'scroll-margin-block-start' to CSS-wide keywords: initial
+PASS Can set 'scroll-margin-block-start' to CSS-wide keywords: inherit
+PASS Can set 'scroll-margin-block-start' to CSS-wide keywords: unset
+PASS Can set 'scroll-margin-block-start' to CSS-wide keywords: revert
+FAIL Can set 'scroll-margin-block-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-block-start' to a length: 0px
+PASS Can set 'scroll-margin-block-start' to a length: -3.14em
+PASS Can set 'scroll-margin-block-start' to a length: 3.14cm
+PASS Can set 'scroll-margin-block-start' to a length: calc(0px + 0em)
 PASS Setting 'scroll-margin-block-start' to a percent throws TypeError
 PASS Setting 'scroll-margin-block-start' to a time throws TypeError
 PASS Setting 'scroll-margin-block-start' to an angle throws TypeError
@@ -59,9 +95,15 @@ PASS Setting 'scroll-margin-block-start' to a flexible length throws TypeError
 FAIL Setting 'scroll-margin-block-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'scroll-margin-block-start' to a URL throws TypeError
 PASS Setting 'scroll-margin-block-start' to a transform throws TypeError
-PASS Can set 'scroll-margin-inline-end' to CSS-wide keywords
-FAIL Can set 'scroll-margin-inline-end' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'scroll-margin-inline-end' to a length
+PASS Can set 'scroll-margin-inline-end' to CSS-wide keywords: initial
+PASS Can set 'scroll-margin-inline-end' to CSS-wide keywords: inherit
+PASS Can set 'scroll-margin-inline-end' to CSS-wide keywords: unset
+PASS Can set 'scroll-margin-inline-end' to CSS-wide keywords: revert
+FAIL Can set 'scroll-margin-inline-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-inline-end' to a length: 0px
+PASS Can set 'scroll-margin-inline-end' to a length: -3.14em
+PASS Can set 'scroll-margin-inline-end' to a length: 3.14cm
+PASS Can set 'scroll-margin-inline-end' to a length: calc(0px + 0em)
 PASS Setting 'scroll-margin-inline-end' to a percent throws TypeError
 PASS Setting 'scroll-margin-inline-end' to a time throws TypeError
 PASS Setting 'scroll-margin-inline-end' to an angle throws TypeError
@@ -69,9 +111,15 @@ PASS Setting 'scroll-margin-inline-end' to a flexible length throws TypeError
 FAIL Setting 'scroll-margin-inline-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'scroll-margin-inline-end' to a URL throws TypeError
 PASS Setting 'scroll-margin-inline-end' to a transform throws TypeError
-PASS Can set 'scroll-margin-block-end' to CSS-wide keywords
-FAIL Can set 'scroll-margin-block-end' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'scroll-margin-block-end' to a length
+PASS Can set 'scroll-margin-block-end' to CSS-wide keywords: initial
+PASS Can set 'scroll-margin-block-end' to CSS-wide keywords: inherit
+PASS Can set 'scroll-margin-block-end' to CSS-wide keywords: unset
+PASS Can set 'scroll-margin-block-end' to CSS-wide keywords: revert
+FAIL Can set 'scroll-margin-block-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-block-end' to a length: 0px
+PASS Can set 'scroll-margin-block-end' to a length: -3.14em
+PASS Can set 'scroll-margin-block-end' to a length: 3.14cm
+PASS Can set 'scroll-margin-block-end' to a length: calc(0px + 0em)
 PASS Setting 'scroll-margin-block-end' to a percent throws TypeError
 PASS Setting 'scroll-margin-block-end' to a time throws TypeError
 PASS Setting 'scroll-margin-block-end' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt
@@ -1,78 +1,150 @@
 
-PASS Can set 'scroll-padding-top' to CSS-wide keywords
-FAIL Can set 'scroll-padding-top' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-top' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'scroll-padding-top' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-top' to CSS-wide keywords: initial
+PASS Can set 'scroll-padding-top' to CSS-wide keywords: inherit
+PASS Can set 'scroll-padding-top' to CSS-wide keywords: unset
+PASS Can set 'scroll-padding-top' to CSS-wide keywords: revert
+FAIL Can set 'scroll-padding-top' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-top' to a percent: 0%
+FAIL Can set 'scroll-padding-top' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-top' to a percent: 3.14%
+PASS Can set 'scroll-padding-top' to a percent: calc(0% + 0%)
+PASS Can set 'scroll-padding-top' to a length: 0px
+FAIL Can set 'scroll-padding-top' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-top' to a length: 3.14cm
+PASS Can set 'scroll-padding-top' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-top' to a time throws TypeError
 PASS Setting 'scroll-padding-top' to an angle throws TypeError
 PASS Setting 'scroll-padding-top' to a flexible length throws TypeError
 FAIL Setting 'scroll-padding-top' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'scroll-padding-top' to a URL throws TypeError
 PASS Setting 'scroll-padding-top' to a transform throws TypeError
-PASS Can set 'scroll-padding-left' to CSS-wide keywords
-FAIL Can set 'scroll-padding-left' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-left' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'scroll-padding-left' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-left' to CSS-wide keywords: initial
+PASS Can set 'scroll-padding-left' to CSS-wide keywords: inherit
+PASS Can set 'scroll-padding-left' to CSS-wide keywords: unset
+PASS Can set 'scroll-padding-left' to CSS-wide keywords: revert
+FAIL Can set 'scroll-padding-left' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-left' to a percent: 0%
+FAIL Can set 'scroll-padding-left' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-left' to a percent: 3.14%
+PASS Can set 'scroll-padding-left' to a percent: calc(0% + 0%)
+PASS Can set 'scroll-padding-left' to a length: 0px
+FAIL Can set 'scroll-padding-left' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-left' to a length: 3.14cm
+PASS Can set 'scroll-padding-left' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-left' to a time throws TypeError
 PASS Setting 'scroll-padding-left' to an angle throws TypeError
 PASS Setting 'scroll-padding-left' to a flexible length throws TypeError
 FAIL Setting 'scroll-padding-left' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'scroll-padding-left' to a URL throws TypeError
 PASS Setting 'scroll-padding-left' to a transform throws TypeError
-PASS Can set 'scroll-padding-right' to CSS-wide keywords
-FAIL Can set 'scroll-padding-right' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-right' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'scroll-padding-right' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-right' to CSS-wide keywords: initial
+PASS Can set 'scroll-padding-right' to CSS-wide keywords: inherit
+PASS Can set 'scroll-padding-right' to CSS-wide keywords: unset
+PASS Can set 'scroll-padding-right' to CSS-wide keywords: revert
+FAIL Can set 'scroll-padding-right' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-right' to a percent: 0%
+FAIL Can set 'scroll-padding-right' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-right' to a percent: 3.14%
+PASS Can set 'scroll-padding-right' to a percent: calc(0% + 0%)
+PASS Can set 'scroll-padding-right' to a length: 0px
+FAIL Can set 'scroll-padding-right' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-right' to a length: 3.14cm
+PASS Can set 'scroll-padding-right' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-right' to a time throws TypeError
 PASS Setting 'scroll-padding-right' to an angle throws TypeError
 PASS Setting 'scroll-padding-right' to a flexible length throws TypeError
 FAIL Setting 'scroll-padding-right' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'scroll-padding-right' to a URL throws TypeError
 PASS Setting 'scroll-padding-right' to a transform throws TypeError
-PASS Can set 'scroll-padding-bottom' to CSS-wide keywords
-FAIL Can set 'scroll-padding-bottom' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-bottom' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'scroll-padding-bottom' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: initial
+PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: inherit
+PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: unset
+PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: revert
+FAIL Can set 'scroll-padding-bottom' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-bottom' to a percent: 0%
+FAIL Can set 'scroll-padding-bottom' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-bottom' to a percent: 3.14%
+PASS Can set 'scroll-padding-bottom' to a percent: calc(0% + 0%)
+PASS Can set 'scroll-padding-bottom' to a length: 0px
+FAIL Can set 'scroll-padding-bottom' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-bottom' to a length: 3.14cm
+PASS Can set 'scroll-padding-bottom' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-bottom' to a time throws TypeError
 PASS Setting 'scroll-padding-bottom' to an angle throws TypeError
 PASS Setting 'scroll-padding-bottom' to a flexible length throws TypeError
 FAIL Setting 'scroll-padding-bottom' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'scroll-padding-bottom' to a URL throws TypeError
 PASS Setting 'scroll-padding-bottom' to a transform throws TypeError
-PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords
-FAIL Can set 'scroll-padding-inline-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-inline-start' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'scroll-padding-inline-start' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: initial
+PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: inherit
+PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: unset
+PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: revert
+FAIL Can set 'scroll-padding-inline-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-inline-start' to a percent: 0%
+FAIL Can set 'scroll-padding-inline-start' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-inline-start' to a percent: 3.14%
+PASS Can set 'scroll-padding-inline-start' to a percent: calc(0% + 0%)
+PASS Can set 'scroll-padding-inline-start' to a length: 0px
+FAIL Can set 'scroll-padding-inline-start' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-inline-start' to a length: 3.14cm
+PASS Can set 'scroll-padding-inline-start' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-inline-start' to a time throws TypeError
 PASS Setting 'scroll-padding-inline-start' to an angle throws TypeError
 PASS Setting 'scroll-padding-inline-start' to a flexible length throws TypeError
 FAIL Setting 'scroll-padding-inline-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'scroll-padding-inline-start' to a URL throws TypeError
 PASS Setting 'scroll-padding-inline-start' to a transform throws TypeError
-PASS Can set 'scroll-padding-block-start' to CSS-wide keywords
-FAIL Can set 'scroll-padding-block-start' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-block-start' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'scroll-padding-block-start' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: initial
+PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: inherit
+PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: unset
+PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: revert
+FAIL Can set 'scroll-padding-block-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-block-start' to a percent: 0%
+FAIL Can set 'scroll-padding-block-start' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-block-start' to a percent: 3.14%
+PASS Can set 'scroll-padding-block-start' to a percent: calc(0% + 0%)
+PASS Can set 'scroll-padding-block-start' to a length: 0px
+FAIL Can set 'scroll-padding-block-start' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-block-start' to a length: 3.14cm
+PASS Can set 'scroll-padding-block-start' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-block-start' to a time throws TypeError
 PASS Setting 'scroll-padding-block-start' to an angle throws TypeError
 PASS Setting 'scroll-padding-block-start' to a flexible length throws TypeError
 FAIL Setting 'scroll-padding-block-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'scroll-padding-block-start' to a URL throws TypeError
 PASS Setting 'scroll-padding-block-start' to a transform throws TypeError
-PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords
-FAIL Can set 'scroll-padding-inline-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-inline-end' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'scroll-padding-inline-end' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: initial
+PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: inherit
+PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: unset
+PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: revert
+FAIL Can set 'scroll-padding-inline-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-inline-end' to a percent: 0%
+FAIL Can set 'scroll-padding-inline-end' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-inline-end' to a percent: 3.14%
+PASS Can set 'scroll-padding-inline-end' to a percent: calc(0% + 0%)
+PASS Can set 'scroll-padding-inline-end' to a length: 0px
+FAIL Can set 'scroll-padding-inline-end' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-inline-end' to a length: 3.14cm
+PASS Can set 'scroll-padding-inline-end' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-inline-end' to a time throws TypeError
 PASS Setting 'scroll-padding-inline-end' to an angle throws TypeError
 PASS Setting 'scroll-padding-inline-end' to a flexible length throws TypeError
 FAIL Setting 'scroll-padding-inline-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'scroll-padding-inline-end' to a URL throws TypeError
 PASS Setting 'scroll-padding-inline-end' to a transform throws TypeError
-PASS Can set 'scroll-padding-block-end' to CSS-wide keywords
-FAIL Can set 'scroll-padding-block-end' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-padding-block-end' to a percent assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-FAIL Can set 'scroll-padding-block-end' to a length assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: initial
+PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: inherit
+PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: unset
+PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: revert
+FAIL Can set 'scroll-padding-block-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-block-end' to a percent: 0%
+FAIL Can set 'scroll-padding-block-end' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-block-end' to a percent: 3.14%
+PASS Can set 'scroll-padding-block-end' to a percent: calc(0% + 0%)
+PASS Can set 'scroll-padding-block-end' to a length: 0px
+FAIL Can set 'scroll-padding-block-end' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-block-end' to a length: 3.14cm
+PASS Can set 'scroll-padding-block-end' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-block-end' to a time throws TypeError
 PASS Setting 'scroll-padding-block-end' to an angle throws TypeError
 PASS Setting 'scroll-padding-block-end' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-align-expected.txt
@@ -1,10 +1,13 @@
 
-PASS Can set 'scroll-snap-align' to CSS-wide keywords
-FAIL Can set 'scroll-snap-align' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'scroll-snap-align' to the 'none' keyword assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL Can set 'scroll-snap-align' to the 'start' keyword assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL Can set 'scroll-snap-align' to the 'end' keyword assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL Can set 'scroll-snap-align' to the 'center' keyword assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Can set 'scroll-snap-align' to CSS-wide keywords: initial
+PASS Can set 'scroll-snap-align' to CSS-wide keywords: inherit
+PASS Can set 'scroll-snap-align' to CSS-wide keywords: unset
+PASS Can set 'scroll-snap-align' to CSS-wide keywords: revert
+FAIL Can set 'scroll-snap-align' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'scroll-snap-align' to the 'none' keyword: none assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL Can set 'scroll-snap-align' to the 'start' keyword: start assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL Can set 'scroll-snap-align' to the 'end' keyword: end assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL Can set 'scroll-snap-align' to the 'center' keyword: center assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 PASS Setting 'scroll-snap-align' to a length throws TypeError
 PASS Setting 'scroll-snap-align' to a percent throws TypeError
 PASS Setting 'scroll-snap-align' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-stop-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-stop-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'scroll-snap-stop' to CSS-wide keywords
-FAIL Can set 'scroll-snap-stop' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'scroll-snap-stop' to the 'normal' keyword
-PASS Can set 'scroll-snap-stop' to the 'always' keyword
+PASS Can set 'scroll-snap-stop' to CSS-wide keywords: initial
+PASS Can set 'scroll-snap-stop' to CSS-wide keywords: inherit
+PASS Can set 'scroll-snap-stop' to CSS-wide keywords: unset
+PASS Can set 'scroll-snap-stop' to CSS-wide keywords: revert
+FAIL Can set 'scroll-snap-stop' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-snap-stop' to the 'normal' keyword: normal
+PASS Can set 'scroll-snap-stop' to the 'always' keyword: always
 PASS Setting 'scroll-snap-stop' to a length throws TypeError
 PASS Setting 'scroll-snap-stop' to a percent throws TypeError
 PASS Setting 'scroll-snap-stop' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-type-expected.txt
@@ -1,12 +1,15 @@
 
-PASS Can set 'scroll-snap-type' to CSS-wide keywords
-FAIL Can set 'scroll-snap-type' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'scroll-snap-type' to the 'none' keyword
-PASS Can set 'scroll-snap-type' to the 'x' keyword
-PASS Can set 'scroll-snap-type' to the 'y' keyword
-PASS Can set 'scroll-snap-type' to the 'block' keyword
-PASS Can set 'scroll-snap-type' to the 'inline' keyword
-PASS Can set 'scroll-snap-type' to the 'both' keyword
+PASS Can set 'scroll-snap-type' to CSS-wide keywords: initial
+PASS Can set 'scroll-snap-type' to CSS-wide keywords: inherit
+PASS Can set 'scroll-snap-type' to CSS-wide keywords: unset
+PASS Can set 'scroll-snap-type' to CSS-wide keywords: revert
+FAIL Can set 'scroll-snap-type' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-snap-type' to the 'none' keyword: none
+PASS Can set 'scroll-snap-type' to the 'x' keyword: x
+PASS Can set 'scroll-snap-type' to the 'y' keyword: y
+PASS Can set 'scroll-snap-type' to the 'block' keyword: block
+PASS Can set 'scroll-snap-type' to the 'inline' keyword: inline
+PASS Can set 'scroll-snap-type' to the 'both' keyword: both
 PASS Setting 'scroll-snap-type' to a length throws TypeError
 PASS Setting 'scroll-snap-type' to a percent throws TypeError
 PASS Setting 'scroll-snap-type' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-gutter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-gutter-expected.txt
@@ -1,8 +1,11 @@
 
-FAIL Can set 'scrollbar-gutter' to CSS-wide keywords Invalid property scrollbar-gutter
-FAIL Can set 'scrollbar-gutter' to var() references Invalid property scrollbar-gutter
-FAIL Can set 'scrollbar-gutter' to the 'auto' keyword Invalid property scrollbar-gutter
-FAIL Can set 'scrollbar-gutter' to the 'stable' keyword Invalid property scrollbar-gutter
+FAIL Can set 'scrollbar-gutter' to CSS-wide keywords: initial Invalid property scrollbar-gutter
+FAIL Can set 'scrollbar-gutter' to CSS-wide keywords: inherit Invalid property scrollbar-gutter
+FAIL Can set 'scrollbar-gutter' to CSS-wide keywords: unset Invalid property scrollbar-gutter
+FAIL Can set 'scrollbar-gutter' to CSS-wide keywords: revert Invalid property scrollbar-gutter
+FAIL Can set 'scrollbar-gutter' to var() references:  var(--A) Invalid property scrollbar-gutter
+FAIL Can set 'scrollbar-gutter' to the 'auto' keyword: auto Invalid property scrollbar-gutter
+FAIL Can set 'scrollbar-gutter' to the 'stable' keyword: stable Invalid property scrollbar-gutter
 PASS Setting 'scrollbar-gutter' to a length throws TypeError
 PASS Setting 'scrollbar-gutter' to a percent throws TypeError
 PASS Setting 'scrollbar-gutter' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-width-expected.txt
@@ -1,9 +1,12 @@
 
-FAIL Can set 'scrollbar-width' to CSS-wide keywords Invalid property scrollbar-width
-FAIL Can set 'scrollbar-width' to var() references Invalid property scrollbar-width
-FAIL Can set 'scrollbar-width' to the 'auto' keyword Invalid property scrollbar-width
-FAIL Can set 'scrollbar-width' to the 'thin' keyword Invalid property scrollbar-width
-FAIL Can set 'scrollbar-width' to the 'none' keyword Invalid property scrollbar-width
+FAIL Can set 'scrollbar-width' to CSS-wide keywords: initial Invalid property scrollbar-width
+FAIL Can set 'scrollbar-width' to CSS-wide keywords: inherit Invalid property scrollbar-width
+FAIL Can set 'scrollbar-width' to CSS-wide keywords: unset Invalid property scrollbar-width
+FAIL Can set 'scrollbar-width' to CSS-wide keywords: revert Invalid property scrollbar-width
+FAIL Can set 'scrollbar-width' to var() references:  var(--A) Invalid property scrollbar-width
+FAIL Can set 'scrollbar-width' to the 'auto' keyword: auto Invalid property scrollbar-width
+FAIL Can set 'scrollbar-width' to the 'thin' keyword: thin Invalid property scrollbar-width
+FAIL Can set 'scrollbar-width' to the 'none' keyword: none Invalid property scrollbar-width
 PASS Setting 'scrollbar-width' to a length throws TypeError
 PASS Setting 'scrollbar-width' to a percent throws TypeError
 PASS Setting 'scrollbar-width' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-image-threshold-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-image-threshold-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'shape-image-threshold' to CSS-wide keywords
-FAIL Can set 'shape-image-threshold' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'shape-image-threshold' to a number
+PASS Can set 'shape-image-threshold' to CSS-wide keywords: initial
+PASS Can set 'shape-image-threshold' to CSS-wide keywords: inherit
+PASS Can set 'shape-image-threshold' to CSS-wide keywords: unset
+PASS Can set 'shape-image-threshold' to CSS-wide keywords: revert
+FAIL Can set 'shape-image-threshold' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'shape-image-threshold' to a number: 0
+PASS Can set 'shape-image-threshold' to a number: -3.14
+PASS Can set 'shape-image-threshold' to a number: 3.14
+PASS Can set 'shape-image-threshold' to a number: calc(2 + 3)
 PASS Setting 'shape-image-threshold' to a length throws TypeError
 PASS Setting 'shape-image-threshold' to a percent throws TypeError
 PASS Setting 'shape-image-threshold' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt
@@ -1,8 +1,17 @@
 
-PASS Can set 'shape-margin' to CSS-wide keywords
-FAIL Can set 'shape-margin' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'shape-margin' to a length assert_equals: expected "px" but got "em"
-FAIL Can set 'shape-margin' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'shape-margin' to CSS-wide keywords: initial
+PASS Can set 'shape-margin' to CSS-wide keywords: inherit
+PASS Can set 'shape-margin' to CSS-wide keywords: unset
+PASS Can set 'shape-margin' to CSS-wide keywords: revert
+FAIL Can set 'shape-margin' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'shape-margin' to a length: 0px
+PASS Can set 'shape-margin' to a length: -3.14em
+PASS Can set 'shape-margin' to a length: 3.14cm
+FAIL Can set 'shape-margin' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'shape-margin' to a percent: 0%
+FAIL Can set 'shape-margin' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'shape-margin' to a percent: 3.14%
+FAIL Can set 'shape-margin' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
 PASS Setting 'shape-margin' to a time throws TypeError
 PASS Setting 'shape-margin' to an angle throws TypeError
 PASS Setting 'shape-margin' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-outside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-outside-expected.txt
@@ -1,11 +1,14 @@
 
-PASS Can set 'shape-outside' to CSS-wide keywords
-FAIL Can set 'shape-outside' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'shape-outside' to the 'none' keyword
-PASS Can set 'shape-outside' to the 'margin-box' keyword
-PASS Can set 'shape-outside' to the 'border-box' keyword
-PASS Can set 'shape-outside' to the 'padding-box' keyword
-PASS Can set 'shape-outside' to the 'content-box' keyword
+PASS Can set 'shape-outside' to CSS-wide keywords: initial
+PASS Can set 'shape-outside' to CSS-wide keywords: inherit
+PASS Can set 'shape-outside' to CSS-wide keywords: unset
+PASS Can set 'shape-outside' to CSS-wide keywords: revert
+FAIL Can set 'shape-outside' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'shape-outside' to the 'none' keyword: none
+PASS Can set 'shape-outside' to the 'margin-box' keyword: margin-box
+PASS Can set 'shape-outside' to the 'border-box' keyword: border-box
+PASS Can set 'shape-outside' to the 'padding-box' keyword: padding-box
+PASS Can set 'shape-outside' to the 'content-box' keyword: content-box
 PASS Can set 'shape-outside' to an image
 PASS Setting 'shape-outside' to a length throws TypeError
 PASS Setting 'shape-outside' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-rendering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-rendering-expected.txt
@@ -1,10 +1,13 @@
 
-PASS Can set 'shape-rendering' to CSS-wide keywords
-FAIL Can set 'shape-rendering' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'shape-rendering' to the 'auto' keyword
-FAIL Can set 'shape-rendering' to the 'optimizespeed' keyword assert_equals: expected "optimizespeed" but got "optimizeSpeed"
-PASS Can set 'shape-rendering' to the 'crispedges' keyword
-FAIL Can set 'shape-rendering' to the 'geometricprecision' keyword assert_equals: expected "geometricprecision" but got "geometricPrecision"
+PASS Can set 'shape-rendering' to CSS-wide keywords: initial
+PASS Can set 'shape-rendering' to CSS-wide keywords: inherit
+PASS Can set 'shape-rendering' to CSS-wide keywords: unset
+PASS Can set 'shape-rendering' to CSS-wide keywords: revert
+FAIL Can set 'shape-rendering' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'shape-rendering' to the 'auto' keyword: auto
+FAIL Can set 'shape-rendering' to the 'optimizespeed' keyword: optimizespeed assert_equals: expected "optimizespeed" but got "optimizeSpeed"
+PASS Can set 'shape-rendering' to the 'crispedges' keyword: crispedges
+FAIL Can set 'shape-rendering' to the 'geometricprecision' keyword: geometricprecision assert_equals: expected "geometricprecision" but got "geometricPrecision"
 PASS Setting 'shape-rendering' to a length throws TypeError
 PASS Setting 'shape-rendering' to a percent throws TypeError
 PASS Setting 'shape-rendering' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/speak-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/speak-expected.txt
@@ -1,9 +1,12 @@
 
-FAIL Can set 'speak' to CSS-wide keywords Invalid property speak
-FAIL Can set 'speak' to var() references Invalid property speak
-FAIL Can set 'speak' to the 'auto' keyword Invalid property speak
-FAIL Can set 'speak' to the 'never' keyword Invalid property speak
-FAIL Can set 'speak' to the 'always' keyword Invalid property speak
+FAIL Can set 'speak' to CSS-wide keywords: initial Invalid property speak
+FAIL Can set 'speak' to CSS-wide keywords: inherit Invalid property speak
+FAIL Can set 'speak' to CSS-wide keywords: unset Invalid property speak
+FAIL Can set 'speak' to CSS-wide keywords: revert Invalid property speak
+FAIL Can set 'speak' to var() references:  var(--A) Invalid property speak
+FAIL Can set 'speak' to the 'auto' keyword: auto Invalid property speak
+FAIL Can set 'speak' to the 'never' keyword: never Invalid property speak
+FAIL Can set 'speak' to the 'always' keyword: always Invalid property speak
 PASS Setting 'speak' to a length throws TypeError
 PASS Setting 'speak' to a percent throws TypeError
 PASS Setting 'speak' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-color-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'stop-color' to CSS-wide keywords
-FAIL Can set 'stop-color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'stop-color' to the 'currentcolor' keyword
+PASS Can set 'stop-color' to CSS-wide keywords: initial
+PASS Can set 'stop-color' to CSS-wide keywords: inherit
+PASS Can set 'stop-color' to CSS-wide keywords: unset
+PASS Can set 'stop-color' to CSS-wide keywords: revert
+FAIL Can set 'stop-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stop-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'stop-color' to a length throws TypeError
 PASS Setting 'stop-color' to a percent throws TypeError
 PASS Setting 'stop-color' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'stop-opacity' to CSS-wide keywords
-FAIL Can set 'stop-opacity' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'stop-opacity' to a number
+PASS Can set 'stop-opacity' to CSS-wide keywords: initial
+PASS Can set 'stop-opacity' to CSS-wide keywords: inherit
+PASS Can set 'stop-opacity' to CSS-wide keywords: unset
+PASS Can set 'stop-opacity' to CSS-wide keywords: revert
+FAIL Can set 'stop-opacity' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stop-opacity' to a number: 0
+PASS Can set 'stop-opacity' to a number: -3.14
+PASS Can set 'stop-opacity' to a number: 3.14
+PASS Can set 'stop-opacity' to a number: calc(2 + 3)
 PASS Setting 'stop-opacity' to a length throws TypeError
 FAIL Setting 'stop-opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'stop-opacity' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'stroke-dasharray' to CSS-wide keywords
-FAIL Can set 'stroke-dasharray' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'stroke-dasharray' to the 'none' keyword
+PASS Can set 'stroke-dasharray' to CSS-wide keywords: initial
+PASS Can set 'stroke-dasharray' to CSS-wide keywords: inherit
+PASS Can set 'stroke-dasharray' to CSS-wide keywords: unset
+PASS Can set 'stroke-dasharray' to CSS-wide keywords: revert
+FAIL Can set 'stroke-dasharray' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stroke-dasharray' to the 'none' keyword: none
 FAIL Setting 'stroke-dasharray' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 FAIL Setting 'stroke-dasharray' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'stroke-dasharray' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset-expected.txt
@@ -1,8 +1,17 @@
 
-PASS Can set 'stroke-dashoffset' to CSS-wide keywords
-FAIL Can set 'stroke-dashoffset' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'stroke-dashoffset' to a length
-PASS Can set 'stroke-dashoffset' to a percent
+PASS Can set 'stroke-dashoffset' to CSS-wide keywords: initial
+PASS Can set 'stroke-dashoffset' to CSS-wide keywords: inherit
+PASS Can set 'stroke-dashoffset' to CSS-wide keywords: unset
+PASS Can set 'stroke-dashoffset' to CSS-wide keywords: revert
+FAIL Can set 'stroke-dashoffset' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stroke-dashoffset' to a length: 0px
+PASS Can set 'stroke-dashoffset' to a length: -3.14em
+PASS Can set 'stroke-dashoffset' to a length: 3.14cm
+PASS Can set 'stroke-dashoffset' to a length: calc(0px + 0em)
+PASS Can set 'stroke-dashoffset' to a percent: 0%
+PASS Can set 'stroke-dashoffset' to a percent: -3.14%
+PASS Can set 'stroke-dashoffset' to a percent: 3.14%
+PASS Can set 'stroke-dashoffset' to a percent: calc(0% + 0%)
 PASS Setting 'stroke-dashoffset' to a time throws TypeError
 PASS Setting 'stroke-dashoffset' to an angle throws TypeError
 PASS Setting 'stroke-dashoffset' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linecap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linecap-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'stroke-linecap' to CSS-wide keywords
-FAIL Can set 'stroke-linecap' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'stroke-linecap' to the 'butt' keyword
-PASS Can set 'stroke-linecap' to the 'round' keyword
-PASS Can set 'stroke-linecap' to the 'square' keyword
+PASS Can set 'stroke-linecap' to CSS-wide keywords: initial
+PASS Can set 'stroke-linecap' to CSS-wide keywords: inherit
+PASS Can set 'stroke-linecap' to CSS-wide keywords: unset
+PASS Can set 'stroke-linecap' to CSS-wide keywords: revert
+FAIL Can set 'stroke-linecap' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stroke-linecap' to the 'butt' keyword: butt
+PASS Can set 'stroke-linecap' to the 'round' keyword: round
+PASS Can set 'stroke-linecap' to the 'square' keyword: square
 PASS Setting 'stroke-linecap' to a length throws TypeError
 PASS Setting 'stroke-linecap' to a percent throws TypeError
 PASS Setting 'stroke-linecap' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linejoin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linejoin-expected.txt
@@ -1,12 +1,15 @@
 
-PASS Can set 'stroke-linejoin' to CSS-wide keywords
-FAIL Can set 'stroke-linejoin' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'stroke-linejoin' to the 'crop' keyword Invalid values
-FAIL Can set 'stroke-linejoin' to the 'arcs' keyword Invalid values
-PASS Can set 'stroke-linejoin' to the 'miter' keyword
-PASS Can set 'stroke-linejoin' to the 'bevel' keyword
-PASS Can set 'stroke-linejoin' to the 'round' keyword
-FAIL Can set 'stroke-linejoin' to the 'stupid' keyword Invalid values
+PASS Can set 'stroke-linejoin' to CSS-wide keywords: initial
+PASS Can set 'stroke-linejoin' to CSS-wide keywords: inherit
+PASS Can set 'stroke-linejoin' to CSS-wide keywords: unset
+PASS Can set 'stroke-linejoin' to CSS-wide keywords: revert
+FAIL Can set 'stroke-linejoin' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'stroke-linejoin' to the 'crop' keyword: crop Invalid values
+FAIL Can set 'stroke-linejoin' to the 'arcs' keyword: arcs Invalid values
+PASS Can set 'stroke-linejoin' to the 'miter' keyword: miter
+PASS Can set 'stroke-linejoin' to the 'bevel' keyword: bevel
+PASS Can set 'stroke-linejoin' to the 'round' keyword: round
+FAIL Can set 'stroke-linejoin' to the 'stupid' keyword: stupid Invalid values
 PASS Setting 'stroke-linejoin' to a length throws TypeError
 PASS Setting 'stroke-linejoin' to a percent throws TypeError
 PASS Setting 'stroke-linejoin' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'stroke-miterlimit' to CSS-wide keywords
-FAIL Can set 'stroke-miterlimit' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'stroke-miterlimit' to a number assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'stroke-miterlimit' to CSS-wide keywords: initial
+PASS Can set 'stroke-miterlimit' to CSS-wide keywords: inherit
+PASS Can set 'stroke-miterlimit' to CSS-wide keywords: unset
+PASS Can set 'stroke-miterlimit' to CSS-wide keywords: revert
+FAIL Can set 'stroke-miterlimit' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stroke-miterlimit' to a number: 0
+FAIL Can set 'stroke-miterlimit' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'stroke-miterlimit' to a number: 3.14
+PASS Can set 'stroke-miterlimit' to a number: calc(2 + 3)
 PASS Setting 'stroke-miterlimit' to a length throws TypeError
 PASS Setting 'stroke-miterlimit' to a percent throws TypeError
 PASS Setting 'stroke-miterlimit' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'stroke-opacity' to CSS-wide keywords
-FAIL Can set 'stroke-opacity' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'stroke-opacity' to a number
+PASS Can set 'stroke-opacity' to CSS-wide keywords: initial
+PASS Can set 'stroke-opacity' to CSS-wide keywords: inherit
+PASS Can set 'stroke-opacity' to CSS-wide keywords: unset
+PASS Can set 'stroke-opacity' to CSS-wide keywords: revert
+FAIL Can set 'stroke-opacity' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stroke-opacity' to a number: 0
+PASS Can set 'stroke-opacity' to a number: -3.14
+PASS Can set 'stroke-opacity' to a number: 3.14
+PASS Can set 'stroke-opacity' to a number: calc(2 + 3)
 PASS Setting 'stroke-opacity' to a length throws TypeError
 FAIL Setting 'stroke-opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'stroke-opacity' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt
@@ -1,8 +1,17 @@
 
-PASS Can set 'stroke-width' to CSS-wide keywords
-FAIL Can set 'stroke-width' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'stroke-width' to a length assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
-FAIL Can set 'stroke-width' to a percent assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
+PASS Can set 'stroke-width' to CSS-wide keywords: initial
+PASS Can set 'stroke-width' to CSS-wide keywords: inherit
+PASS Can set 'stroke-width' to CSS-wide keywords: unset
+PASS Can set 'stroke-width' to CSS-wide keywords: revert
+FAIL Can set 'stroke-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stroke-width' to a length: 0px
+FAIL Can set 'stroke-width' to a length: -3.14em assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
+PASS Can set 'stroke-width' to a length: 3.14cm
+FAIL Can set 'stroke-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'stroke-width' to a percent: 0%
+FAIL Can set 'stroke-width' to a percent: -3.14% assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
+PASS Can set 'stroke-width' to a percent: 3.14%
+FAIL Can set 'stroke-width' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
 PASS Setting 'stroke-width' to a time throws TypeError
 PASS Setting 'stroke-width' to an angle throws TypeError
 PASS Setting 'stroke-width' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/tab-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/tab-size-expected.txt
@@ -1,8 +1,17 @@
 
-PASS Can set 'tab-size' to CSS-wide keywords
-FAIL Can set 'tab-size' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'tab-size' to a number assert_equals: expected 2 but got 1
-FAIL Can set 'tab-size' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'tab-size' to CSS-wide keywords: initial
+PASS Can set 'tab-size' to CSS-wide keywords: inherit
+PASS Can set 'tab-size' to CSS-wide keywords: unset
+PASS Can set 'tab-size' to CSS-wide keywords: revert
+FAIL Can set 'tab-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'tab-size' to a number: 0
+PASS Can set 'tab-size' to a number: -3.14
+PASS Can set 'tab-size' to a number: 3.14
+FAIL Can set 'tab-size' to a number: calc(2 + 3) assert_equals: expected 2 but got 1
+PASS Can set 'tab-size' to a length: 0px
+PASS Can set 'tab-size' to a length: -3.14em
+PASS Can set 'tab-size' to a length: 3.14cm
+FAIL Can set 'tab-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'tab-size' to a percent throws TypeError
 PASS Setting 'tab-size' to a time throws TypeError
 PASS Setting 'tab-size' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/table-layout-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/table-layout-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'table-layout' to CSS-wide keywords
-FAIL Can set 'table-layout' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'table-layout' to the 'auto' keyword
-PASS Can set 'table-layout' to the 'fixed' keyword
+PASS Can set 'table-layout' to CSS-wide keywords: initial
+PASS Can set 'table-layout' to CSS-wide keywords: inherit
+PASS Can set 'table-layout' to CSS-wide keywords: unset
+PASS Can set 'table-layout' to CSS-wide keywords: revert
+FAIL Can set 'table-layout' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'table-layout' to the 'auto' keyword: auto
+PASS Can set 'table-layout' to the 'fixed' keyword: fixed
 PASS Setting 'table-layout' to a length throws TypeError
 PASS Setting 'table-layout' to a percent throws TypeError
 PASS Setting 'table-layout' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'text-align' to CSS-wide keywords
-FAIL Can set 'text-align' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-align' to the 'center' keyword
-PASS Can set 'text-align' to the 'justify' keyword
+PASS Can set 'text-align' to CSS-wide keywords: initial
+PASS Can set 'text-align' to CSS-wide keywords: inherit
+PASS Can set 'text-align' to CSS-wide keywords: unset
+PASS Can set 'text-align' to CSS-wide keywords: revert
+FAIL Can set 'text-align' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-align' to the 'center' keyword: center
+PASS Can set 'text-align' to the 'justify' keyword: justify
 PASS Setting 'text-align' to a length throws TypeError
 PASS Setting 'text-align' to a percent throws TypeError
 PASS Setting 'text-align' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-last-expected.txt
@@ -1,13 +1,16 @@
 
-PASS Can set 'text-align-last' to CSS-wide keywords
-FAIL Can set 'text-align-last' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-align-last' to the 'auto' keyword
-PASS Can set 'text-align-last' to the 'start' keyword
-PASS Can set 'text-align-last' to the 'end' keyword
-PASS Can set 'text-align-last' to the 'left' keyword
-PASS Can set 'text-align-last' to the 'right' keyword
-PASS Can set 'text-align-last' to the 'center' keyword
-PASS Can set 'text-align-last' to the 'justify' keyword
+PASS Can set 'text-align-last' to CSS-wide keywords: initial
+PASS Can set 'text-align-last' to CSS-wide keywords: inherit
+PASS Can set 'text-align-last' to CSS-wide keywords: unset
+PASS Can set 'text-align-last' to CSS-wide keywords: revert
+FAIL Can set 'text-align-last' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-align-last' to the 'auto' keyword: auto
+PASS Can set 'text-align-last' to the 'start' keyword: start
+PASS Can set 'text-align-last' to the 'end' keyword: end
+PASS Can set 'text-align-last' to the 'left' keyword: left
+PASS Can set 'text-align-last' to the 'right' keyword: right
+PASS Can set 'text-align-last' to the 'center' keyword: center
+PASS Can set 'text-align-last' to the 'justify' keyword: justify
 PASS Setting 'text-align-last' to a length throws TypeError
 PASS Setting 'text-align-last' to a percent throws TypeError
 PASS Setting 'text-align-last' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-anchor-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'text-anchor' to CSS-wide keywords
-FAIL Can set 'text-anchor' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-anchor' to the 'start' keyword
-PASS Can set 'text-anchor' to the 'middle' keyword
-PASS Can set 'text-anchor' to the 'end' keyword
+PASS Can set 'text-anchor' to CSS-wide keywords: initial
+PASS Can set 'text-anchor' to CSS-wide keywords: inherit
+PASS Can set 'text-anchor' to CSS-wide keywords: unset
+PASS Can set 'text-anchor' to CSS-wide keywords: revert
+FAIL Can set 'text-anchor' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-anchor' to the 'start' keyword: start
+PASS Can set 'text-anchor' to the 'middle' keyword: middle
+PASS Can set 'text-anchor' to the 'end' keyword: end
 PASS Setting 'text-anchor' to a length throws TypeError
 PASS Setting 'text-anchor' to a percent throws TypeError
 PASS Setting 'text-anchor' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-combine-upright-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-combine-upright-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'text-combine-upright' to CSS-wide keywords
-FAIL Can set 'text-combine-upright' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-combine-upright' to the 'none' keyword
-PASS Can set 'text-combine-upright' to the 'all' keyword
+PASS Can set 'text-combine-upright' to CSS-wide keywords: initial
+PASS Can set 'text-combine-upright' to CSS-wide keywords: inherit
+PASS Can set 'text-combine-upright' to CSS-wide keywords: unset
+PASS Can set 'text-combine-upright' to CSS-wide keywords: revert
+FAIL Can set 'text-combine-upright' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-combine-upright' to the 'none' keyword: none
+PASS Can set 'text-combine-upright' to the 'all' keyword: all
 PASS Setting 'text-combine-upright' to a length throws TypeError
 PASS Setting 'text-combine-upright' to a percent throws TypeError
 PASS Setting 'text-combine-upright' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-color-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'text-decoration-color' to CSS-wide keywords
-FAIL Can set 'text-decoration-color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-decoration-color' to the 'currentcolor' keyword
+PASS Can set 'text-decoration-color' to CSS-wide keywords: initial
+PASS Can set 'text-decoration-color' to CSS-wide keywords: inherit
+PASS Can set 'text-decoration-color' to CSS-wide keywords: unset
+PASS Can set 'text-decoration-color' to CSS-wide keywords: revert
+FAIL Can set 'text-decoration-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-decoration-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'text-decoration-color' to a length throws TypeError
 PASS Setting 'text-decoration-color' to a percent throws TypeError
 PASS Setting 'text-decoration-color' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt
@@ -1,13 +1,16 @@
 
-PASS Can set 'text-decoration-line' to CSS-wide keywords
-FAIL Can set 'text-decoration-line' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-decoration-line' to the 'none' keyword
-PASS Can set 'text-decoration-line' to the 'underline' keyword
-PASS Can set 'text-decoration-line' to the 'overline' keyword
-PASS Can set 'text-decoration-line' to the 'line-through' keyword
-FAIL Can set 'text-decoration-line' to the 'blink' keyword assert_equals: expected "blink" but got "none"
-FAIL Can set 'text-decoration-line' to the 'spelling-error' keyword Invalid values
-FAIL Can set 'text-decoration-line' to the 'grammar-error' keyword Invalid values
+PASS Can set 'text-decoration-line' to CSS-wide keywords: initial
+PASS Can set 'text-decoration-line' to CSS-wide keywords: inherit
+PASS Can set 'text-decoration-line' to CSS-wide keywords: unset
+PASS Can set 'text-decoration-line' to CSS-wide keywords: revert
+FAIL Can set 'text-decoration-line' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-decoration-line' to the 'none' keyword: none
+PASS Can set 'text-decoration-line' to the 'underline' keyword: underline
+PASS Can set 'text-decoration-line' to the 'overline' keyword: overline
+PASS Can set 'text-decoration-line' to the 'line-through' keyword: line-through
+FAIL Can set 'text-decoration-line' to the 'blink' keyword: blink assert_equals: expected "blink" but got "none"
+FAIL Can set 'text-decoration-line' to the 'spelling-error' keyword: spelling-error Invalid values
+FAIL Can set 'text-decoration-line' to the 'grammar-error' keyword: grammar-error Invalid values
 PASS Setting 'text-decoration-line' to a length throws TypeError
 PASS Setting 'text-decoration-line' to a percent throws TypeError
 PASS Setting 'text-decoration-line' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-expected.txt
@@ -1,11 +1,14 @@
 
-FAIL Can set 'text-decoration-skip' to CSS-wide keywords assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'text-decoration-skip' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'text-decoration-skip' to the 'none' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'text-decoration-skip' to the 'objects' keyword Bad value for shorthand CSS property
-FAIL Can set 'text-decoration-skip' to the 'edges' keyword Bad value for shorthand CSS property
-FAIL Can set 'text-decoration-skip' to the 'box-decoration' keyword Bad value for shorthand CSS property
-FAIL Can set 'text-decoration-skip' to the 'spaces' keyword Bad value for shorthand CSS property
+FAIL Can set 'text-decoration-skip' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'text-decoration-skip' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'text-decoration-skip' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'text-decoration-skip' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'text-decoration-skip' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'text-decoration-skip' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'text-decoration-skip' to the 'objects' keyword: objects Bad value for shorthand CSS property
+FAIL Can set 'text-decoration-skip' to the 'edges' keyword: edges Bad value for shorthand CSS property
+FAIL Can set 'text-decoration-skip' to the 'box-decoration' keyword: box-decoration Bad value for shorthand CSS property
+FAIL Can set 'text-decoration-skip' to the 'spaces' keyword: spaces Bad value for shorthand CSS property
 PASS Setting 'text-decoration-skip' to a length throws TypeError
 PASS Setting 'text-decoration-skip' to a percent throws TypeError
 PASS Setting 'text-decoration-skip' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-ink-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-ink-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'text-decoration-skip-ink' to CSS-wide keywords
-FAIL Can set 'text-decoration-skip-ink' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-decoration-skip-ink' to the 'auto' keyword
-PASS Can set 'text-decoration-skip-ink' to the 'none' keyword
+PASS Can set 'text-decoration-skip-ink' to CSS-wide keywords: initial
+PASS Can set 'text-decoration-skip-ink' to CSS-wide keywords: inherit
+PASS Can set 'text-decoration-skip-ink' to CSS-wide keywords: unset
+PASS Can set 'text-decoration-skip-ink' to CSS-wide keywords: revert
+FAIL Can set 'text-decoration-skip-ink' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-decoration-skip-ink' to the 'auto' keyword: auto
+PASS Can set 'text-decoration-skip-ink' to the 'none' keyword: none
 PASS Setting 'text-decoration-skip-ink' to a length throws TypeError
 PASS Setting 'text-decoration-skip-ink' to a percent throws TypeError
 PASS Setting 'text-decoration-skip-ink' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-style-expected.txt
@@ -1,11 +1,14 @@
 
-PASS Can set 'text-decoration-style' to CSS-wide keywords
-FAIL Can set 'text-decoration-style' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-decoration-style' to the 'solid' keyword
-PASS Can set 'text-decoration-style' to the 'double' keyword
-PASS Can set 'text-decoration-style' to the 'dotted' keyword
-PASS Can set 'text-decoration-style' to the 'dashed' keyword
-PASS Can set 'text-decoration-style' to the 'wavy' keyword
+PASS Can set 'text-decoration-style' to CSS-wide keywords: initial
+PASS Can set 'text-decoration-style' to CSS-wide keywords: inherit
+PASS Can set 'text-decoration-style' to CSS-wide keywords: unset
+PASS Can set 'text-decoration-style' to CSS-wide keywords: revert
+FAIL Can set 'text-decoration-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-decoration-style' to the 'solid' keyword: solid
+PASS Can set 'text-decoration-style' to the 'double' keyword: double
+PASS Can set 'text-decoration-style' to the 'dotted' keyword: dotted
+PASS Can set 'text-decoration-style' to the 'dashed' keyword: dashed
+PASS Can set 'text-decoration-style' to the 'wavy' keyword: wavy
 PASS Setting 'text-decoration-style' to a length throws TypeError
 PASS Setting 'text-decoration-style' to a percent throws TypeError
 PASS Setting 'text-decoration-style' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-thickness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-thickness-expected.txt
@@ -1,9 +1,18 @@
 
-PASS Can set 'text-decoration-thickness' to CSS-wide keywords
-FAIL Can set 'text-decoration-thickness' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-decoration-thickness' to the 'auto' keyword
-PASS Can set 'text-decoration-thickness' to a length
-FAIL Can set 'text-decoration-thickness' to a percent Invalid values
+PASS Can set 'text-decoration-thickness' to CSS-wide keywords: initial
+PASS Can set 'text-decoration-thickness' to CSS-wide keywords: inherit
+PASS Can set 'text-decoration-thickness' to CSS-wide keywords: unset
+PASS Can set 'text-decoration-thickness' to CSS-wide keywords: revert
+FAIL Can set 'text-decoration-thickness' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-decoration-thickness' to the 'auto' keyword: auto
+PASS Can set 'text-decoration-thickness' to a length: 0px
+PASS Can set 'text-decoration-thickness' to a length: -3.14em
+PASS Can set 'text-decoration-thickness' to a length: 3.14cm
+PASS Can set 'text-decoration-thickness' to a length: calc(0px + 0em)
+FAIL Can set 'text-decoration-thickness' to a percent: 0% Invalid values
+FAIL Can set 'text-decoration-thickness' to a percent: -3.14% Invalid values
+FAIL Can set 'text-decoration-thickness' to a percent: 3.14% Invalid values
+FAIL Can set 'text-decoration-thickness' to a percent: calc(0% + 0%) Invalid values
 PASS Setting 'text-decoration-thickness' to a time throws TypeError
 PASS Setting 'text-decoration-thickness' to an angle throws TypeError
 PASS Setting 'text-decoration-thickness' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-emphasis-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-emphasis-color-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'text-emphasis-color' to CSS-wide keywords
-FAIL Can set 'text-emphasis-color' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-emphasis-color' to the 'currentcolor' keyword
+PASS Can set 'text-emphasis-color' to CSS-wide keywords: initial
+PASS Can set 'text-emphasis-color' to CSS-wide keywords: inherit
+PASS Can set 'text-emphasis-color' to CSS-wide keywords: unset
+PASS Can set 'text-emphasis-color' to CSS-wide keywords: revert
+FAIL Can set 'text-emphasis-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-emphasis-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'text-emphasis-color' to a length throws TypeError
 PASS Setting 'text-emphasis-color' to a percent throws TypeError
 PASS Setting 'text-emphasis-color' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt
@@ -1,8 +1,17 @@
 
-PASS Can set 'text-indent' to CSS-wide keywords
-FAIL Can set 'text-indent' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-indent' to a length
-PASS Can set 'text-indent' to a percent
+PASS Can set 'text-indent' to CSS-wide keywords: initial
+PASS Can set 'text-indent' to CSS-wide keywords: inherit
+PASS Can set 'text-indent' to CSS-wide keywords: unset
+PASS Can set 'text-indent' to CSS-wide keywords: revert
+FAIL Can set 'text-indent' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-indent' to a length: 0px
+PASS Can set 'text-indent' to a length: -3.14em
+PASS Can set 'text-indent' to a length: 3.14cm
+PASS Can set 'text-indent' to a length: calc(0px + 0em)
+PASS Can set 'text-indent' to a percent: 0%
+PASS Can set 'text-indent' to a percent: -3.14%
+PASS Can set 'text-indent' to a percent: 3.14%
+PASS Can set 'text-indent' to a percent: calc(0% + 0%)
 PASS Setting 'text-indent' to a time throws TypeError
 PASS Setting 'text-indent' to an angle throws TypeError
 PASS Setting 'text-indent' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-justify-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-justify-expected.txt
@@ -1,10 +1,13 @@
 
-PASS Can set 'text-justify' to CSS-wide keywords
-FAIL Can set 'text-justify' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-justify' to the 'auto' keyword
-PASS Can set 'text-justify' to the 'none' keyword
-PASS Can set 'text-justify' to the 'inter-word' keyword
-PASS Can set 'text-justify' to the 'inter-character' keyword
+PASS Can set 'text-justify' to CSS-wide keywords: initial
+PASS Can set 'text-justify' to CSS-wide keywords: inherit
+PASS Can set 'text-justify' to CSS-wide keywords: unset
+PASS Can set 'text-justify' to CSS-wide keywords: revert
+FAIL Can set 'text-justify' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-justify' to the 'auto' keyword: auto
+PASS Can set 'text-justify' to the 'none' keyword: none
+PASS Can set 'text-justify' to the 'inter-word' keyword: inter-word
+PASS Can set 'text-justify' to the 'inter-character' keyword: inter-character
 PASS Setting 'text-justify' to a length throws TypeError
 PASS Setting 'text-justify' to a percent throws TypeError
 PASS Setting 'text-justify' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-orientation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-orientation-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'text-orientation' to CSS-wide keywords
-FAIL Can set 'text-orientation' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-orientation' to the 'mixed' keyword
-PASS Can set 'text-orientation' to the 'upright' keyword
-PASS Can set 'text-orientation' to the 'sideways' keyword
+PASS Can set 'text-orientation' to CSS-wide keywords: initial
+PASS Can set 'text-orientation' to CSS-wide keywords: inherit
+PASS Can set 'text-orientation' to CSS-wide keywords: unset
+PASS Can set 'text-orientation' to CSS-wide keywords: revert
+FAIL Can set 'text-orientation' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-orientation' to the 'mixed' keyword: mixed
+PASS Can set 'text-orientation' to the 'upright' keyword: upright
+PASS Can set 'text-orientation' to the 'sideways' keyword: sideways
 PASS Setting 'text-orientation' to a length throws TypeError
 PASS Setting 'text-orientation' to a percent throws TypeError
 PASS Setting 'text-orientation' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-overflow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-overflow-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'text-overflow' to CSS-wide keywords
-FAIL Can set 'text-overflow' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-overflow' to the 'clip' keyword
-PASS Can set 'text-overflow' to the 'ellipsis' keyword
-FAIL Can set 'text-overflow' to the 'fade' keyword Invalid values
+PASS Can set 'text-overflow' to CSS-wide keywords: initial
+PASS Can set 'text-overflow' to CSS-wide keywords: inherit
+PASS Can set 'text-overflow' to CSS-wide keywords: unset
+PASS Can set 'text-overflow' to CSS-wide keywords: revert
+FAIL Can set 'text-overflow' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-overflow' to the 'clip' keyword: clip
+PASS Can set 'text-overflow' to the 'ellipsis' keyword: ellipsis
+FAIL Can set 'text-overflow' to the 'fade' keyword: fade Invalid values
 PASS Setting 'text-overflow' to a length throws TypeError
 PASS Setting 'text-overflow' to a percent throws TypeError
 PASS Setting 'text-overflow' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-rendering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-rendering-expected.txt
@@ -1,10 +1,13 @@
 
-PASS Can set 'text-rendering' to CSS-wide keywords
-FAIL Can set 'text-rendering' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-rendering' to the 'auto' keyword
-FAIL Can set 'text-rendering' to the 'optimizespeed' keyword assert_equals: expected "optimizespeed" but got "optimizeSpeed"
-FAIL Can set 'text-rendering' to the 'optimizelegibility' keyword assert_equals: expected "optimizelegibility" but got "optimizeLegibility"
-FAIL Can set 'text-rendering' to the 'geometricprecision' keyword assert_equals: expected "geometricprecision" but got "geometricPrecision"
+PASS Can set 'text-rendering' to CSS-wide keywords: initial
+PASS Can set 'text-rendering' to CSS-wide keywords: inherit
+PASS Can set 'text-rendering' to CSS-wide keywords: unset
+PASS Can set 'text-rendering' to CSS-wide keywords: revert
+FAIL Can set 'text-rendering' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-rendering' to the 'auto' keyword: auto
+FAIL Can set 'text-rendering' to the 'optimizespeed' keyword: optimizespeed assert_equals: expected "optimizespeed" but got "optimizeSpeed"
+FAIL Can set 'text-rendering' to the 'optimizelegibility' keyword: optimizelegibility assert_equals: expected "optimizelegibility" but got "optimizeLegibility"
+FAIL Can set 'text-rendering' to the 'geometricprecision' keyword: geometricprecision assert_equals: expected "geometricprecision" but got "geometricPrecision"
 PASS Setting 'text-rendering' to a length throws TypeError
 PASS Setting 'text-rendering' to a percent throws TypeError
 PASS Setting 'text-rendering' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-shadow-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'text-shadow' to CSS-wide keywords
-FAIL Can set 'text-shadow' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-shadow' to the 'none' keyword
+PASS Can set 'text-shadow' to CSS-wide keywords: initial
+PASS Can set 'text-shadow' to CSS-wide keywords: inherit
+PASS Can set 'text-shadow' to CSS-wide keywords: unset
+PASS Can set 'text-shadow' to CSS-wide keywords: revert
+FAIL Can set 'text-shadow' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-shadow' to the 'none' keyword: none
 PASS Setting 'text-shadow' to a length throws TypeError
 PASS Setting 'text-shadow' to a percent throws TypeError
 PASS Setting 'text-shadow' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-size-adjust-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-size-adjust-expected.txt
@@ -1,9 +1,15 @@
 
-FAIL Can set 'text-size-adjust' to CSS-wide keywords Invalid property text-size-adjust
-FAIL Can set 'text-size-adjust' to var() references Invalid property text-size-adjust
-FAIL Can set 'text-size-adjust' to the 'none' keyword Invalid property text-size-adjust
-FAIL Can set 'text-size-adjust' to the 'auto' keyword Invalid property text-size-adjust
-FAIL Can set 'text-size-adjust' to a percent Invalid property text-size-adjust
+FAIL Can set 'text-size-adjust' to CSS-wide keywords: initial Invalid property text-size-adjust
+FAIL Can set 'text-size-adjust' to CSS-wide keywords: inherit Invalid property text-size-adjust
+FAIL Can set 'text-size-adjust' to CSS-wide keywords: unset Invalid property text-size-adjust
+FAIL Can set 'text-size-adjust' to CSS-wide keywords: revert Invalid property text-size-adjust
+FAIL Can set 'text-size-adjust' to var() references:  var(--A) Invalid property text-size-adjust
+FAIL Can set 'text-size-adjust' to the 'none' keyword: none Invalid property text-size-adjust
+FAIL Can set 'text-size-adjust' to the 'auto' keyword: auto Invalid property text-size-adjust
+FAIL Can set 'text-size-adjust' to a percent: 0% Invalid property text-size-adjust
+FAIL Can set 'text-size-adjust' to a percent: -3.14% Invalid property text-size-adjust
+FAIL Can set 'text-size-adjust' to a percent: 3.14% Invalid property text-size-adjust
+FAIL Can set 'text-size-adjust' to a percent: calc(0% + 0%) Invalid property text-size-adjust
 PASS Setting 'text-size-adjust' to a length throws TypeError
 PASS Setting 'text-size-adjust' to a time throws TypeError
 PASS Setting 'text-size-adjust' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-transform-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-transform-expected.txt
@@ -1,11 +1,14 @@
 
-PASS Can set 'text-transform' to CSS-wide keywords
-FAIL Can set 'text-transform' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-transform' to the 'none' keyword
-PASS Can set 'text-transform' to the 'capitalize' keyword
-PASS Can set 'text-transform' to the 'uppercase' keyword
-PASS Can set 'text-transform' to the 'lowercase' keyword
-FAIL Can set 'text-transform' to the 'full-width' keyword Invalid values
+PASS Can set 'text-transform' to CSS-wide keywords: initial
+PASS Can set 'text-transform' to CSS-wide keywords: inherit
+PASS Can set 'text-transform' to CSS-wide keywords: unset
+PASS Can set 'text-transform' to CSS-wide keywords: revert
+FAIL Can set 'text-transform' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-transform' to the 'none' keyword: none
+PASS Can set 'text-transform' to the 'capitalize' keyword: capitalize
+PASS Can set 'text-transform' to the 'uppercase' keyword: uppercase
+PASS Can set 'text-transform' to the 'lowercase' keyword: lowercase
+FAIL Can set 'text-transform' to the 'full-width' keyword: full-width Invalid values
 PASS Setting 'text-transform' to a length throws TypeError
 PASS Setting 'text-transform' to a percent throws TypeError
 PASS Setting 'text-transform' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt
@@ -1,9 +1,18 @@
 
-PASS Can set 'text-underline-offset' to CSS-wide keywords
-FAIL Can set 'text-underline-offset' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-underline-offset' to the 'auto' keyword
-PASS Can set 'text-underline-offset' to a length
-FAIL Can set 'text-underline-offset' to a percent Invalid values
+PASS Can set 'text-underline-offset' to CSS-wide keywords: initial
+PASS Can set 'text-underline-offset' to CSS-wide keywords: inherit
+PASS Can set 'text-underline-offset' to CSS-wide keywords: unset
+PASS Can set 'text-underline-offset' to CSS-wide keywords: revert
+FAIL Can set 'text-underline-offset' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-underline-offset' to the 'auto' keyword: auto
+PASS Can set 'text-underline-offset' to a length: 0px
+PASS Can set 'text-underline-offset' to a length: -3.14em
+PASS Can set 'text-underline-offset' to a length: 3.14cm
+PASS Can set 'text-underline-offset' to a length: calc(0px + 0em)
+FAIL Can set 'text-underline-offset' to a percent: 0% Invalid values
+FAIL Can set 'text-underline-offset' to a percent: -3.14% Invalid values
+FAIL Can set 'text-underline-offset' to a percent: 3.14% Invalid values
+FAIL Can set 'text-underline-offset' to a percent: calc(0% + 0%) Invalid values
 PASS Setting 'text-underline-offset' to a time throws TypeError
 PASS Setting 'text-underline-offset' to an angle throws TypeError
 PASS Setting 'text-underline-offset' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-position-expected.txt
@@ -1,10 +1,13 @@
 
-PASS Can set 'text-underline-position' to CSS-wide keywords
-FAIL Can set 'text-underline-position' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'text-underline-position' to the 'auto' keyword
-PASS Can set 'text-underline-position' to the 'under' keyword
-FAIL Can set 'text-underline-position' to the 'left' keyword Invalid values
-FAIL Can set 'text-underline-position' to the 'right' keyword Invalid values
+PASS Can set 'text-underline-position' to CSS-wide keywords: initial
+PASS Can set 'text-underline-position' to CSS-wide keywords: inherit
+PASS Can set 'text-underline-position' to CSS-wide keywords: unset
+PASS Can set 'text-underline-position' to CSS-wide keywords: revert
+FAIL Can set 'text-underline-position' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-underline-position' to the 'auto' keyword: auto
+PASS Can set 'text-underline-position' to the 'under' keyword: under
+FAIL Can set 'text-underline-position' to the 'left' keyword: left Invalid values
+FAIL Can set 'text-underline-position' to the 'right' keyword: right Invalid values
 PASS Setting 'text-underline-position' to a length throws TypeError
 PASS Setting 'text-underline-position' to a percent throws TypeError
 PASS Setting 'text-underline-position' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/top-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/top-expected.txt
@@ -1,9 +1,18 @@
 
-PASS Can set 'top' to CSS-wide keywords
-FAIL Can set 'top' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'top' to the 'auto' keyword
-PASS Can set 'top' to a percent
-PASS Can set 'top' to a length
+PASS Can set 'top' to CSS-wide keywords: initial
+PASS Can set 'top' to CSS-wide keywords: inherit
+PASS Can set 'top' to CSS-wide keywords: unset
+PASS Can set 'top' to CSS-wide keywords: revert
+FAIL Can set 'top' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'top' to the 'auto' keyword: auto
+PASS Can set 'top' to a percent: 0%
+PASS Can set 'top' to a percent: -3.14%
+PASS Can set 'top' to a percent: 3.14%
+PASS Can set 'top' to a percent: calc(0% + 0%)
+PASS Can set 'top' to a length: 0px
+PASS Can set 'top' to a length: -3.14em
+PASS Can set 'top' to a length: 3.14cm
+PASS Can set 'top' to a length: calc(0px + 0em)
 PASS Setting 'top' to a time throws TypeError
 PASS Setting 'top' to an angle throws TypeError
 PASS Setting 'top' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/touch-action-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/touch-action-expected.txt
@@ -1,16 +1,19 @@
 
-PASS Can set 'touch-action' to CSS-wide keywords
-FAIL Can set 'touch-action' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'touch-action' to the 'auto' keyword
-PASS Can set 'touch-action' to the 'none' keyword
-PASS Can set 'touch-action' to the 'pan-x' keyword
-FAIL Can set 'touch-action' to the 'pan-left' keyword Invalid values
-FAIL Can set 'touch-action' to the 'pan-right' keyword Invalid values
-PASS Can set 'touch-action' to the 'pan-y' keyword
-FAIL Can set 'touch-action' to the 'pan-up' keyword Invalid values
-FAIL Can set 'touch-action' to the 'pan-down' keyword Invalid values
-PASS Can set 'touch-action' to the 'pinch-zoom' keyword
-PASS Can set 'touch-action' to the 'manipulation' keyword
+PASS Can set 'touch-action' to CSS-wide keywords: initial
+PASS Can set 'touch-action' to CSS-wide keywords: inherit
+PASS Can set 'touch-action' to CSS-wide keywords: unset
+PASS Can set 'touch-action' to CSS-wide keywords: revert
+FAIL Can set 'touch-action' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'touch-action' to the 'auto' keyword: auto
+PASS Can set 'touch-action' to the 'none' keyword: none
+PASS Can set 'touch-action' to the 'pan-x' keyword: pan-x
+FAIL Can set 'touch-action' to the 'pan-left' keyword: pan-left Invalid values
+FAIL Can set 'touch-action' to the 'pan-right' keyword: pan-right Invalid values
+PASS Can set 'touch-action' to the 'pan-y' keyword: pan-y
+FAIL Can set 'touch-action' to the 'pan-up' keyword: pan-up Invalid values
+FAIL Can set 'touch-action' to the 'pan-down' keyword: pan-down Invalid values
+PASS Can set 'touch-action' to the 'pinch-zoom' keyword: pinch-zoom
+PASS Can set 'touch-action' to the 'manipulation' keyword: manipulation
 PASS Setting 'touch-action' to a length throws TypeError
 PASS Setting 'touch-action' to a percent throws TypeError
 PASS Setting 'touch-action' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-box-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-box-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'transform-box' to CSS-wide keywords
-FAIL Can set 'transform-box' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'transform-box' to the 'border-box' keyword
-PASS Can set 'transform-box' to the 'fill-box' keyword
-PASS Can set 'transform-box' to the 'view-box' keyword
+PASS Can set 'transform-box' to CSS-wide keywords: initial
+PASS Can set 'transform-box' to CSS-wide keywords: inherit
+PASS Can set 'transform-box' to CSS-wide keywords: unset
+PASS Can set 'transform-box' to CSS-wide keywords: revert
+FAIL Can set 'transform-box' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'transform-box' to the 'border-box' keyword: border-box
+PASS Can set 'transform-box' to the 'fill-box' keyword: fill-box
+PASS Can set 'transform-box' to the 'view-box' keyword: view-box
 PASS Setting 'transform-box' to a length throws TypeError
 PASS Setting 'transform-box' to a percent throws TypeError
 PASS Setting 'transform-box' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-expected.txt
@@ -1,8 +1,13 @@
 
-PASS Can set 'transform' to CSS-wide keywords
-FAIL Can set 'transform' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'transform' to the 'none' keyword
-FAIL Can set 'transform' to a transform assert_equals: expected "CSSSkewY" but got "CSSSkewX"
+PASS Can set 'transform' to CSS-wide keywords: initial
+PASS Can set 'transform' to CSS-wide keywords: inherit
+PASS Can set 'transform' to CSS-wide keywords: unset
+PASS Can set 'transform' to CSS-wide keywords: revert
+FAIL Can set 'transform' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'transform' to the 'none' keyword: none
+PASS Can set 'transform' to a transform: translate(50%, 50%)
+PASS Can set 'transform' to a transform: perspective(10em)
+FAIL Can set 'transform' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) assert_equals: expected "CSSSkewY" but got "CSSSkewX"
 PASS Setting 'transform' to a length throws TypeError
 PASS Setting 'transform' to a percent throws TypeError
 PASS Setting 'transform' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-style-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'transform-style' to CSS-wide keywords
-FAIL Can set 'transform-style' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'transform-style' to the 'auto' keyword Invalid values
-PASS Can set 'transform-style' to the 'flat' keyword
-PASS Can set 'transform-style' to the 'preserve-3d' keyword
+PASS Can set 'transform-style' to CSS-wide keywords: initial
+PASS Can set 'transform-style' to CSS-wide keywords: inherit
+PASS Can set 'transform-style' to CSS-wide keywords: unset
+PASS Can set 'transform-style' to CSS-wide keywords: revert
+FAIL Can set 'transform-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'transform-style' to the 'auto' keyword: auto Invalid values
+PASS Can set 'transform-style' to the 'flat' keyword: flat
+PASS Can set 'transform-style' to the 'preserve-3d' keyword: preserve-3d
 PASS Setting 'transform-style' to a length throws TypeError
 PASS Setting 'transform-style' to a percent throws TypeError
 PASS Setting 'transform-style' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-delay-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-delay-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'transition-delay' to CSS-wide keywords
-FAIL Can set 'transition-delay' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'transition-delay' to a time
+PASS Can set 'transition-delay' to CSS-wide keywords: initial
+PASS Can set 'transition-delay' to CSS-wide keywords: inherit
+PASS Can set 'transition-delay' to CSS-wide keywords: unset
+PASS Can set 'transition-delay' to CSS-wide keywords: revert
+FAIL Can set 'transition-delay' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'transition-delay' to a time: 0s
+PASS Can set 'transition-delay' to a time: -3.14ms
+PASS Can set 'transition-delay' to a time: 3.14s
+PASS Can set 'transition-delay' to a time: calc(0s + 0ms)
 PASS Setting 'transition-delay' to a length throws TypeError
 PASS Setting 'transition-delay' to a percent throws TypeError
 PASS Setting 'transition-delay' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'transition-duration' to CSS-wide keywords
-FAIL Can set 'transition-duration' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'transition-duration' to a time Invalid values
+PASS Can set 'transition-duration' to CSS-wide keywords: initial
+PASS Can set 'transition-duration' to CSS-wide keywords: inherit
+PASS Can set 'transition-duration' to CSS-wide keywords: unset
+PASS Can set 'transition-duration' to CSS-wide keywords: revert
+FAIL Can set 'transition-duration' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'transition-duration' to a time: 0s
+FAIL Can set 'transition-duration' to a time: -3.14ms Invalid values
+PASS Can set 'transition-duration' to a time: 3.14s
+PASS Can set 'transition-duration' to a time: calc(0s + 0ms)
 PASS Setting 'transition-duration' to a length throws TypeError
 PASS Setting 'transition-duration' to a percent throws TypeError
 PASS Setting 'transition-duration' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-property-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'transition-property' to CSS-wide keywords
-FAIL Can set 'transition-property' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'transition-property' to the 'none' keyword
+PASS Can set 'transition-property' to CSS-wide keywords: initial
+PASS Can set 'transition-property' to CSS-wide keywords: inherit
+PASS Can set 'transition-property' to CSS-wide keywords: unset
+PASS Can set 'transition-property' to CSS-wide keywords: revert
+FAIL Can set 'transition-property' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'transition-property' to the 'none' keyword: none
 PASS Setting 'transition-property' to a length throws TypeError
 PASS Setting 'transition-property' to a percent throws TypeError
 PASS Setting 'transition-property' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-timing-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-timing-function-expected.txt
@@ -1,13 +1,16 @@
 
-PASS Can set 'transition-timing-function' to CSS-wide keywords
-FAIL Can set 'transition-timing-function' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'transition-timing-function' to the 'linear' keyword
-PASS Can set 'transition-timing-function' to the 'ease' keyword
-PASS Can set 'transition-timing-function' to the 'ease-in' keyword
-PASS Can set 'transition-timing-function' to the 'ease-out' keyword
-PASS Can set 'transition-timing-function' to the 'ease-in-out' keyword
-FAIL Can set 'transition-timing-function' to the 'step-start' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'transition-timing-function' to the 'step-end' keyword assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'transition-timing-function' to CSS-wide keywords: initial
+PASS Can set 'transition-timing-function' to CSS-wide keywords: inherit
+PASS Can set 'transition-timing-function' to CSS-wide keywords: unset
+PASS Can set 'transition-timing-function' to CSS-wide keywords: revert
+FAIL Can set 'transition-timing-function' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'transition-timing-function' to the 'linear' keyword: linear
+PASS Can set 'transition-timing-function' to the 'ease' keyword: ease
+PASS Can set 'transition-timing-function' to the 'ease-in' keyword: ease-in
+PASS Can set 'transition-timing-function' to the 'ease-out' keyword: ease-out
+PASS Can set 'transition-timing-function' to the 'ease-in-out' keyword: ease-in-out
+FAIL Can set 'transition-timing-function' to the 'step-start' keyword: step-start assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'transition-timing-function' to the 'step-end' keyword: step-end assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'transition-timing-function' to a length throws TypeError
 PASS Setting 'transition-timing-function' to a percent throws TypeError
 PASS Setting 'transition-timing-function' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/unicode-bidi-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/unicode-bidi-expected.txt
@@ -1,12 +1,15 @@
 
-PASS Can set 'unicode-bidi' to CSS-wide keywords
-FAIL Can set 'unicode-bidi' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'unicode-bidi' to the 'normal' keyword
-PASS Can set 'unicode-bidi' to the 'embed' keyword
-PASS Can set 'unicode-bidi' to the 'isolate' keyword
-PASS Can set 'unicode-bidi' to the 'bidi-override' keyword
-PASS Can set 'unicode-bidi' to the 'isolate-override' keyword
-PASS Can set 'unicode-bidi' to the 'plaintext' keyword
+PASS Can set 'unicode-bidi' to CSS-wide keywords: initial
+PASS Can set 'unicode-bidi' to CSS-wide keywords: inherit
+PASS Can set 'unicode-bidi' to CSS-wide keywords: unset
+PASS Can set 'unicode-bidi' to CSS-wide keywords: revert
+FAIL Can set 'unicode-bidi' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'unicode-bidi' to the 'normal' keyword: normal
+PASS Can set 'unicode-bidi' to the 'embed' keyword: embed
+PASS Can set 'unicode-bidi' to the 'isolate' keyword: isolate
+PASS Can set 'unicode-bidi' to the 'bidi-override' keyword: bidi-override
+PASS Can set 'unicode-bidi' to the 'isolate-override' keyword: isolate-override
+PASS Can set 'unicode-bidi' to the 'plaintext' keyword: plaintext
 PASS Setting 'unicode-bidi' to a length throws TypeError
 PASS Setting 'unicode-bidi' to a percent throws TypeError
 PASS Setting 'unicode-bidi' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select-expected.txt
@@ -1,11 +1,14 @@
 
-FAIL Can set 'user-select' to CSS-wide keywords Invalid property user-select
-FAIL Can set 'user-select' to var() references Invalid property user-select
-FAIL Can set 'user-select' to the 'auto' keyword Invalid property user-select
-FAIL Can set 'user-select' to the 'text' keyword Invalid property user-select
-FAIL Can set 'user-select' to the 'none' keyword Invalid property user-select
-FAIL Can set 'user-select' to the 'contain' keyword Invalid property user-select
-FAIL Can set 'user-select' to the 'all' keyword Invalid property user-select
+FAIL Can set 'user-select' to CSS-wide keywords: initial Invalid property user-select
+FAIL Can set 'user-select' to CSS-wide keywords: inherit Invalid property user-select
+FAIL Can set 'user-select' to CSS-wide keywords: unset Invalid property user-select
+FAIL Can set 'user-select' to CSS-wide keywords: revert Invalid property user-select
+FAIL Can set 'user-select' to var() references:  var(--A) Invalid property user-select
+FAIL Can set 'user-select' to the 'auto' keyword: auto Invalid property user-select
+FAIL Can set 'user-select' to the 'text' keyword: text Invalid property user-select
+FAIL Can set 'user-select' to the 'none' keyword: none Invalid property user-select
+FAIL Can set 'user-select' to the 'contain' keyword: contain Invalid property user-select
+FAIL Can set 'user-select' to the 'all' keyword: all Invalid property user-select
 PASS Setting 'user-select' to a length throws TypeError
 PASS Setting 'user-select' to a percent throws TypeError
 PASS Setting 'user-select' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vector-effect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vector-effect-expected.txt
@@ -1,8 +1,11 @@
 
-PASS Can set 'vector-effect' to CSS-wide keywords
-FAIL Can set 'vector-effect' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'vector-effect' to the 'non-scaling-stroke' keyword
-PASS Can set 'vector-effect' to the 'none' keyword
+PASS Can set 'vector-effect' to CSS-wide keywords: initial
+PASS Can set 'vector-effect' to CSS-wide keywords: inherit
+PASS Can set 'vector-effect' to CSS-wide keywords: unset
+PASS Can set 'vector-effect' to CSS-wide keywords: revert
+FAIL Can set 'vector-effect' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'vector-effect' to the 'non-scaling-stroke' keyword: non-scaling-stroke
+PASS Can set 'vector-effect' to the 'none' keyword: none
 PASS Setting 'vector-effect' to a length throws TypeError
 PASS Setting 'vector-effect' to a percent throws TypeError
 PASS Setting 'vector-effect' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vertical-align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vertical-align-expected.txt
@@ -1,9 +1,18 @@
 
-PASS Can set 'vertical-align' to CSS-wide keywords
-FAIL Can set 'vertical-align' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'vertical-align' to the 'baseline' keyword
-PASS Can set 'vertical-align' to a length
-PASS Can set 'vertical-align' to a percent
+PASS Can set 'vertical-align' to CSS-wide keywords: initial
+PASS Can set 'vertical-align' to CSS-wide keywords: inherit
+PASS Can set 'vertical-align' to CSS-wide keywords: unset
+PASS Can set 'vertical-align' to CSS-wide keywords: revert
+FAIL Can set 'vertical-align' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'vertical-align' to the 'baseline' keyword: baseline
+PASS Can set 'vertical-align' to a length: 0px
+PASS Can set 'vertical-align' to a length: -3.14em
+PASS Can set 'vertical-align' to a length: 3.14cm
+PASS Can set 'vertical-align' to a length: calc(0px + 0em)
+PASS Can set 'vertical-align' to a percent: 0%
+PASS Can set 'vertical-align' to a percent: -3.14%
+PASS Can set 'vertical-align' to a percent: 3.14%
+PASS Can set 'vertical-align' to a percent: calc(0% + 0%)
 PASS Setting 'vertical-align' to a time throws TypeError
 PASS Setting 'vertical-align' to an angle throws TypeError
 PASS Setting 'vertical-align' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/visibility-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/visibility-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'visibility' to CSS-wide keywords
-FAIL Can set 'visibility' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'visibility' to the 'visible' keyword
-PASS Can set 'visibility' to the 'hidden' keyword
-PASS Can set 'visibility' to the 'collapse' keyword
+PASS Can set 'visibility' to CSS-wide keywords: initial
+PASS Can set 'visibility' to CSS-wide keywords: inherit
+PASS Can set 'visibility' to CSS-wide keywords: unset
+PASS Can set 'visibility' to CSS-wide keywords: revert
+FAIL Can set 'visibility' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'visibility' to the 'visible' keyword: visible
+PASS Can set 'visibility' to the 'hidden' keyword: hidden
+PASS Can set 'visibility' to the 'collapse' keyword: collapse
 PASS Setting 'visibility' to a length throws TypeError
 PASS Setting 'visibility' to a percent throws TypeError
 PASS Setting 'visibility' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt
@@ -1,11 +1,14 @@
 
-PASS Can set 'white-space' to CSS-wide keywords
-FAIL Can set 'white-space' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'white-space' to the 'normal' keyword
-PASS Can set 'white-space' to the 'pre' keyword
-PASS Can set 'white-space' to the 'nowrap' keyword
-PASS Can set 'white-space' to the 'pre-wrap' keyword
-PASS Can set 'white-space' to the 'pre-line' keyword
+PASS Can set 'white-space' to CSS-wide keywords: initial
+PASS Can set 'white-space' to CSS-wide keywords: inherit
+PASS Can set 'white-space' to CSS-wide keywords: unset
+PASS Can set 'white-space' to CSS-wide keywords: revert
+FAIL Can set 'white-space' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'white-space' to the 'normal' keyword: normal
+PASS Can set 'white-space' to the 'pre' keyword: pre
+PASS Can set 'white-space' to the 'nowrap' keyword: nowrap
+PASS Can set 'white-space' to the 'pre-wrap' keyword: pre-wrap
+PASS Can set 'white-space' to the 'pre-line' keyword: pre-line
 PASS Setting 'white-space' to a length throws TypeError
 PASS Setting 'white-space' to a percent throws TypeError
 PASS Setting 'white-space' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt
@@ -1,7 +1,13 @@
 
-PASS Can set 'widows' to CSS-wide keywords
-FAIL Can set 'widows' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'widows' to a number assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+PASS Can set 'widows' to CSS-wide keywords: initial
+PASS Can set 'widows' to CSS-wide keywords: inherit
+PASS Can set 'widows' to CSS-wide keywords: unset
+PASS Can set 'widows' to CSS-wide keywords: revert
+FAIL Can set 'widows' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'widows' to a number: 0 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'widows' to a number: -3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'widows' to a number: 3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'widows' to a number: calc(2 + 3) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
 PASS Setting 'widows' to a length throws TypeError
 PASS Setting 'widows' to a percent throws TypeError
 PASS Setting 'widows' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt
@@ -1,30 +1,57 @@
 
-PASS Can set 'width' to CSS-wide keywords
-FAIL Can set 'width' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'width' to the 'auto' keyword
-FAIL Can set 'width' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'width' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'width' to CSS-wide keywords: initial
+PASS Can set 'width' to CSS-wide keywords: inherit
+PASS Can set 'width' to CSS-wide keywords: unset
+PASS Can set 'width' to CSS-wide keywords: revert
+FAIL Can set 'width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'width' to the 'auto' keyword: auto
+PASS Can set 'width' to a percent: 0%
+FAIL Can set 'width' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'width' to a percent: 3.14%
+FAIL Can set 'width' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'width' to a length: 0px
+PASS Can set 'width' to a length: -3.14em
+PASS Can set 'width' to a length: 3.14cm
+FAIL Can set 'width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'width' to a time throws TypeError
 PASS Setting 'width' to an angle throws TypeError
 PASS Setting 'width' to a flexible length throws TypeError
 FAIL Setting 'width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'width' to a URL throws TypeError
 PASS Setting 'width' to a transform throws TypeError
-PASS Can set 'min-width' to CSS-wide keywords
-FAIL Can set 'min-width' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'min-width' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'min-width' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'min-width' to CSS-wide keywords: initial
+PASS Can set 'min-width' to CSS-wide keywords: inherit
+PASS Can set 'min-width' to CSS-wide keywords: unset
+PASS Can set 'min-width' to CSS-wide keywords: revert
+FAIL Can set 'min-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'min-width' to a percent: 0%
+FAIL Can set 'min-width' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'min-width' to a percent: 3.14%
+FAIL Can set 'min-width' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'min-width' to a length: 0px
+PASS Can set 'min-width' to a length: -3.14em
+PASS Can set 'min-width' to a length: 3.14cm
+FAIL Can set 'min-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'min-width' to a time throws TypeError
 PASS Setting 'min-width' to an angle throws TypeError
 PASS Setting 'min-width' to a flexible length throws TypeError
 FAIL Setting 'min-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'min-width' to a URL throws TypeError
 PASS Setting 'min-width' to a transform throws TypeError
-PASS Can set 'max-width' to CSS-wide keywords
-FAIL Can set 'max-width' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'max-width' to the 'none' keyword
-FAIL Can set 'max-width' to a percent assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'max-width' to a length assert_equals: expected "px" but got "em"
+PASS Can set 'max-width' to CSS-wide keywords: initial
+PASS Can set 'max-width' to CSS-wide keywords: inherit
+PASS Can set 'max-width' to CSS-wide keywords: unset
+PASS Can set 'max-width' to CSS-wide keywords: revert
+FAIL Can set 'max-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'max-width' to the 'none' keyword: none
+PASS Can set 'max-width' to a percent: 0%
+FAIL Can set 'max-width' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'max-width' to a percent: 3.14%
+FAIL Can set 'max-width' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'max-width' to a length: 0px
+PASS Can set 'max-width' to a length: -3.14em
+PASS Can set 'max-width' to a length: 3.14cm
+FAIL Can set 'max-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
 PASS Setting 'max-width' to a time throws TypeError
 PASS Setting 'max-width' to an angle throws TypeError
 PASS Setting 'max-width' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt
@@ -1,7 +1,10 @@
 
-PASS Can set 'will-change' to CSS-wide keywords
-FAIL Can set 'will-change' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'will-change' to the 'auto' keyword
+PASS Can set 'will-change' to CSS-wide keywords: initial
+PASS Can set 'will-change' to CSS-wide keywords: inherit
+PASS Can set 'will-change' to CSS-wide keywords: unset
+PASS Can set 'will-change' to CSS-wide keywords: revert
+FAIL Can set 'will-change' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'will-change' to the 'auto' keyword: auto
 PASS Setting 'will-change' to a length throws TypeError
 PASS Setting 'will-change' to a percent throws TypeError
 PASS Setting 'will-change' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-break-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-break-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'word-break' to CSS-wide keywords
-FAIL Can set 'word-break' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'word-break' to the 'normal' keyword
-PASS Can set 'word-break' to the 'keep-all' keyword
-PASS Can set 'word-break' to the 'break-all' keyword
+PASS Can set 'word-break' to CSS-wide keywords: initial
+PASS Can set 'word-break' to CSS-wide keywords: inherit
+PASS Can set 'word-break' to CSS-wide keywords: unset
+PASS Can set 'word-break' to CSS-wide keywords: revert
+FAIL Can set 'word-break' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'word-break' to the 'normal' keyword: normal
+PASS Can set 'word-break' to the 'keep-all' keyword: keep-all
+PASS Can set 'word-break' to the 'break-all' keyword: break-all
 PASS Setting 'word-break' to a length throws TypeError
 PASS Setting 'word-break' to a percent throws TypeError
 PASS Setting 'word-break' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-spacing-expected.txt
@@ -1,9 +1,18 @@
 
-PASS Can set 'word-spacing' to CSS-wide keywords
-FAIL Can set 'word-spacing' to var() references assert_equals: expected 2 but got 1
-FAIL Can set 'word-spacing' to the 'normal' keyword assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
-PASS Can set 'word-spacing' to a length
-PASS Can set 'word-spacing' to a percent
+PASS Can set 'word-spacing' to CSS-wide keywords: initial
+PASS Can set 'word-spacing' to CSS-wide keywords: inherit
+PASS Can set 'word-spacing' to CSS-wide keywords: unset
+PASS Can set 'word-spacing' to CSS-wide keywords: revert
+FAIL Can set 'word-spacing' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'word-spacing' to the 'normal' keyword: normal assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
+PASS Can set 'word-spacing' to a length: 0px
+PASS Can set 'word-spacing' to a length: -3.14em
+PASS Can set 'word-spacing' to a length: 3.14cm
+PASS Can set 'word-spacing' to a length: calc(0px + 0em)
+PASS Can set 'word-spacing' to a percent: 0%
+PASS Can set 'word-spacing' to a percent: -3.14%
+PASS Can set 'word-spacing' to a percent: 3.14%
+PASS Can set 'word-spacing' to a percent: calc(0% + 0%)
 PASS Setting 'word-spacing' to a time throws TypeError
 PASS Setting 'word-spacing' to an angle throws TypeError
 PASS Setting 'word-spacing' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-wrap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-wrap-expected.txt
@@ -1,9 +1,12 @@
 
-PASS Can set 'word-wrap' to CSS-wide keywords
-FAIL Can set 'word-wrap' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'word-wrap' to the 'normal' keyword
-PASS Can set 'word-wrap' to the 'break-word' keyword
-FAIL Can set 'word-wrap' to the 'break-spaces' keyword Invalid values
+PASS Can set 'word-wrap' to CSS-wide keywords: initial
+PASS Can set 'word-wrap' to CSS-wide keywords: inherit
+PASS Can set 'word-wrap' to CSS-wide keywords: unset
+PASS Can set 'word-wrap' to CSS-wide keywords: revert
+FAIL Can set 'word-wrap' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'word-wrap' to the 'normal' keyword: normal
+PASS Can set 'word-wrap' to the 'break-word' keyword: break-word
+FAIL Can set 'word-wrap' to the 'break-spaces' keyword: break-spaces Invalid values
 PASS Setting 'word-wrap' to a length throws TypeError
 PASS Setting 'word-wrap' to a percent throws TypeError
 PASS Setting 'word-wrap' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/writing-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/writing-mode-expected.txt
@@ -1,11 +1,14 @@
 
-PASS Can set 'writing-mode' to CSS-wide keywords
-FAIL Can set 'writing-mode' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'writing-mode' to the 'horizontal-tb' keyword
-PASS Can set 'writing-mode' to the 'vertical-rl' keyword
-PASS Can set 'writing-mode' to the 'vertical-lr' keyword
-FAIL Can set 'writing-mode' to the 'sideways-rl' keyword Invalid values
-FAIL Can set 'writing-mode' to the 'sideways-lr' keyword Invalid values
+PASS Can set 'writing-mode' to CSS-wide keywords: initial
+PASS Can set 'writing-mode' to CSS-wide keywords: inherit
+PASS Can set 'writing-mode' to CSS-wide keywords: unset
+PASS Can set 'writing-mode' to CSS-wide keywords: revert
+FAIL Can set 'writing-mode' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'writing-mode' to the 'horizontal-tb' keyword: horizontal-tb
+PASS Can set 'writing-mode' to the 'vertical-rl' keyword: vertical-rl
+PASS Can set 'writing-mode' to the 'vertical-lr' keyword: vertical-lr
+FAIL Can set 'writing-mode' to the 'sideways-rl' keyword: sideways-rl Invalid values
+FAIL Can set 'writing-mode' to the 'sideways-lr' keyword: sideways-lr Invalid values
 PASS Setting 'writing-mode' to a length throws TypeError
 PASS Setting 'writing-mode' to a percent throws TypeError
 PASS Setting 'writing-mode' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt
@@ -1,8 +1,14 @@
 
-PASS Can set 'z-index' to CSS-wide keywords
-FAIL Can set 'z-index' to var() references assert_equals: expected 2 but got 1
-PASS Can set 'z-index' to the 'auto' keyword
-FAIL Can set 'z-index' to a number assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'z-index' to CSS-wide keywords: initial
+PASS Can set 'z-index' to CSS-wide keywords: inherit
+PASS Can set 'z-index' to CSS-wide keywords: unset
+PASS Can set 'z-index' to CSS-wide keywords: revert
+FAIL Can set 'z-index' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'z-index' to the 'auto' keyword: auto
+FAIL Can set 'z-index' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'z-index' to a number: -3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'z-index' to a number: 3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'z-index' to a number: calc(2 + 3) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
 PASS Setting 'z-index' to a length throws TypeError
 PASS Setting 'z-index' to a percent throws TypeError
 PASS Setting 'z-index' to a time throws TypeError


### PR DESCRIPTION
#### f4a83c543d2bd1ff0bbb6d8ab4d210dbc85bae25
<pre>
[CSS-Typed-OM] Create more subtests for StylePropertyMap tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=249177">https://bugs.webkit.org/show_bug.cgi?id=249177</a>

Reviewed by Tim Nguyen.

Create more subtests for StylePropertyMap tests, to make it clearer which
checks are actually failing.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/accent-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/all-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-end.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-start.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-play-state-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-timing-function-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backdrop-filter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backface-visibility-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-attachment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-blend-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-clip-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-image-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-collapse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-source-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/bottom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-sizing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/break-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caption-side-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caret-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clear-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-path-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-count-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-span-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/contain-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-increment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-reset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-set-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/cursor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/d-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/direction-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/display-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/dominant-baseline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/empty-cells-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/filter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-direction-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-wrap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/float-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-feature-settings-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-kerning-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-language-override-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-optical-sizing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-palette-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-presentation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-synthesis-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-alternates-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-caps-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-east-asian-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-emoji-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-ligatures-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-numeric-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variation-settings-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-flow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-areas-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/hyphens-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/isolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/left-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/lighting-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-break-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-step-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-image-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/marker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-image-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mix-blend-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-fit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-anchor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-distance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-path-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-rotate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-anchor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-wrap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overscroll-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/paint-order-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/pointer-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/quotes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resize-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resources/testsuite.js:
(input.new.CSSKeywordValue):
(testPropertyValid):
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/right-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-align-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-stop-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-gutter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-image-threshold-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-outside-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-rendering-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/speak-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linecap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linejoin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/tab-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/table-layout-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-last-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-anchor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-combine-upright-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-ink-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-thickness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-emphasis-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-justify-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-orientation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-overflow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-rendering-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-size-adjust-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-transform-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/top-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/touch-action-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-box-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-delay-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-property-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-timing-function-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/unicode-bidi-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vector-effect-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vertical-align-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/visibility-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-break-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-wrap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/writing-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt:

Canonical link: <a href="https://commits.webkit.org/257759@main">https://commits.webkit.org/257759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e232d18e70c2bda7a30cc067b3677c844d34415

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/99941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/9109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/33020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/109290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9991 "Failed to checkout and rebase branch from PR 7509") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/86405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105710 "Failed to checkout and rebase branch from PR 7509") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/9991 "Failed to checkout and rebase branch from PR 7509") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/33020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/9991 "Failed to checkout and rebase branch from PR 7509") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/33020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/33020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/2868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/86405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/33020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2734 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->