### PR TITLE
Allow subgrids to participate in masonry layout.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1555,9 +1555,7 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-content/mas
  imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-003.html [ ImageOnlyFailure ]
  imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-004.html [ ImageOnlyFailure ]
  imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-005.html [ ImageOnlyFailure ]
- imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-006.html [ ImageOnlyFailure ]
  imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-item-placement-005.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-columns-item-placement-auto-flow-next-001.html [ ImageOnlyFailure ]
  imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/justify-content/masonry-justify-content-003.html [ ImageOnlyFailure ]
  imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/justify-content/masonry-justify-content-004.html [ ImageOnlyFailure ]
  imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/justify-tracks/masonry-justify-tracks-001.html [ ImageOnlyFailure ]
@@ -1566,7 +1564,7 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/ma
  imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/justify-tracks/masonry-justify-tracks-stretch-002.html [ ImageOnlyFailure ]
  imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-subgrid-001.html [ ImageOnlyFailure ]
  imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-subgrid-002.html [ ImageOnlyFailure ]
-
+imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-001.html [ ImageOnlyFailure ]
 
 webkit.org/b/236958 imported/w3c/web-platform-tests/css/css-grid/subgrid/repeat-auto-fill-003.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-001-expected.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Masonry columns subgrid line names 001</title>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+    <meta name="assert" content="Subgrid with definite grid axis position should inherit line names">
+    <link rel="match" href="masonry-columns-subgrid-named-lines-001-ref.html">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-rows: [one] 50px [two] 50px [three] 50px;
+    grid-template-columns: none;
+    grid-auto-flow: column;
+    gap: 4px 2px;
+    padding: 1px 3px 5px 7px;
+    border: solid;
+    border-width: 3px 5px 1px 1px;
+    background: lightgrey;
+}
+item {
+    background: grey;
+    width: 3ch;
+    position: relative;
+}
+subgrid {
+    display: grid;
+    grid-template: subgrid / subgrid;
+    grid-auto-flow: column;
+    grid-auto-columns: auto;
+    grid-row: 1 / span 3;
+    background: yellow;
+}
+</style>
+</head>
+<body>
+<grid>
+<item>1</item>
+<item>2</item>
+<item>3</item>
+<subgrid>
+    <item>4c</item>
+    <item>4a</item>
+    <item>4b</item>
+</subgrid>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-001.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+     <meta charset="utf-8">
+    <title>Masonry columns subgrid line names 001</title>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+    <meta name="assert" content="Subgrid with definite grid axis position should inherit line names">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-rows: [one] 50px [two] 50px [three] 50px;
+    grid-template-columns: masonry;
+    gap: 4px 2px;
+    padding: 1px 3px 5px 7px;
+    border: solid;
+    border-width: 3px 5px 1px 1px;
+    background: lightgrey;
+}
+item {
+    background: grey;
+    width: 3ch;
+    position: relative;
+}
+subgrid {
+    display: grid;
+    grid: subgrid / subgrid;
+    grid-row: 1 / span 3;
+    background: yellow;
+}
+.row-one {
+    grid-row-start: one;
+}
+.row-two {
+    grid-row-start: two;
+}
+.row-three {
+    grid-row-start: three;
+}
+</style>
+</head>
+<body>
+<grid>
+<item>1</item>
+<item>2</item>
+<item>3</item>
+<subgrid>
+    <item class="row-two"> 4a </item>
+    <item class="row-three"> 4b </item>
+    <item class="row-one"> 4c </item>
+</subgrid>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-002-expected.html
@@ -1,0 +1,52 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Masonry columns subgrid line names 002</title>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+    <meta name="assert" content="Auto-placed subgrid should NOT inherit line names">
+    <link rel="match" href="masonry-columns-subgrid-named-lines-002-ref.html">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-rows: [one] 50px [two] 80px [three] 30px;
+    grid-template-columns: auto;
+    grid-auto-flow: column;
+    gap: 4px 2px;
+    padding: 1px 3px 5px 7px;
+    border: solid;
+    border-width: 3px 5px 1px 1px;
+    background: lightgrey;
+}
+item {
+    background: grey;
+    width: 3ch;
+    position: relative;
+}
+subgrid {
+    display: grid;
+    grid-template: subgrid / auto;
+    grid-auto-flow: column;
+    grid-auto-columns: auto;
+    grid-row: 1 / span 2;
+    background: yellow;
+}
+.row-two {
+    grid-row-start: 2;
+}
+</style>
+</head>
+<body>
+<grid>
+<item>1</item>
+<item>2</item>
+<item>3</item>
+<subgrid>
+    <item class="row-two">4a</item>
+    <item class="row-two">4b</item>
+    <item class="row-two">4c</item>
+</subgrid>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-002.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Masonry columns subgrid line names 002</title>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+    <meta name="assert" content="Auto-placed subgrid should NOT inherit line names">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-rows: [one] 50px [two] 80px [three] 30px;
+    grid-template-columns: masonry;
+    gap: 4px 2px;
+    padding: 1px 3px 5px 7px;
+    border: solid;
+    border-width: 3px 5px 1px 1px;
+    background: lightgrey;
+}
+item {
+    background: grey;
+    width: 3ch;
+    position: relative;
+}
+subgrid {
+    display: grid;
+    grid: subgrid / subgrid;
+    grid-row: span 2;
+    background: yellow;
+}
+.one {
+    grid-row-start: one;
+}
+.two {
+    grid-row-start: two;
+}
+.three {
+    grid-row-start: three;
+}
+</style>
+</head>
+<body>
+<grid>
+<item>1</item>
+<item>2</item>
+<item>3</item>
+<subgrid>
+    <item class="two">4a</item>
+    <item class="one">4b</item>
+    <item class="one">4c</item>
+</subgrid>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-003-expected.html
@@ -1,0 +1,61 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Masonry columns subgrid line names 003</title>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+    <meta name="assert" content="Auto-placed subgrid should be able to use their own named lines">
+    <link rel="match" href="masonry-columns-subgrid-named-lines-003-ref.html">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-rows: 50px 80px 30px;
+    grid-template-columns: auto;
+    grid-auto-flow: column;
+    gap: 4px 2px;
+    padding: 1px 3px 5px 7px;
+    border: solid;
+    border-width: 3px 5px 1px 1px;
+    background: lightgrey;
+}
+item {
+    background: grey;
+    width: 3ch;
+    position: relative;
+}
+subgrid {
+    display: grid;
+    grid-auto-flow: column;
+    grid-template: subgrid [sub-one] [sub-two] / auto;
+    grid-auto-columns: auto;
+    grid-row: span 2;
+    background: yellow;
+}
+.row-one {
+    grid-row-start: sub-one;
+}
+.row-two {
+    grid-row-start: sub-two;
+}
+.row-three {
+    grid-row-start: three;
+}
+.column-one {
+    grid-column-start: 1
+}
+</style>
+</head>
+<body>
+<grid>
+<item>1</item>
+<item>2</item>
+<item>3</item>
+<subgrid>
+    <item class="row-two">4a</item>
+    <item class="column-one row-one">4b</item>
+    <item class="row-two">4c</item>
+</subgrid>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-003.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Masonry columns subgrid line names 003</title>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+    <meta name="assert" content="Auto-placed subgrid should be able to use their own named lines">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-rows: 50px 80px 30px;
+    grid-template-columns: masonry;
+    gap: 4px 2px;
+    padding: 1px 3px 5px 7px;
+    border: solid;
+    border-width: 3px 5px 1px 1px;
+    background: lightgrey;
+}
+item {
+    background: grey;
+    width: 3ch;
+    position: relative;
+}
+subgrid {
+    display: grid;
+    grid-template: subgrid [sub-one] [sub-two] / subgrid; 
+    grid-row: span 2;
+    background: yellow;
+}
+.one {
+    grid-row-start: sub-one;
+}
+.two {
+    grid-row-start: sub-two;
+}
+.three {
+    grid-row-start: three;
+}
+</style>
+</head>
+<body>
+<grid>
+<item>1</item>
+<item>2</item>
+<item>3</item>
+<subgrid>
+    <item class="two">4a</item>
+    <item class="one">4b</item>
+    <item class="two">4c</item>
+</subgrid>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-001-expected.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Masonry rows subgrid line names 001</title>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+    <meta name="assert" content="Subgrid with definite grid axis position should inherit line names">
+    <link rel="match" href="masonry-rows-subgrid-named-lines-001-ref.html">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-columns: [one] 50px [two] 50px [three] 50px;
+    grid-template-rows: none;
+    gap: 4px 2px;
+    padding: 1px 3px 5px 7px;
+    border: solid;
+    border-width: 3px 5px 1px 1px;
+    background: lightgrey;
+}
+item {
+    background: grey;
+    width: 3ch;
+    position: relative;
+}
+subgrid {
+    display: grid;
+    grid: none / subgrid;
+    grid-column: 1 / span 3;
+    background: yellow;
+}
+</style>
+</head>
+<body>
+<grid>
+<item>1</item>
+<item>2</item>
+<item>3</item>
+<subgrid>
+    <item>4c</item>
+    <item>4a</item>
+    <item>4b</item>
+</subgrid>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-001.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Masonry rows subgrid line names 001</title>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+    <meta name="assert" content="Subgrid with definite grid axis position should inherit line names">
+    <link rel="match" href="masonry-rows-subgrid-named-lines-001-ref.html">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-columns: [one] 50px [two] 50px [three] 50px;
+    grid-template-rows: masonry;
+    gap: 4px 2px;
+    padding: 1px 3px 5px 7px;
+    border: solid;
+    border-width: 3px 5px 1px 1px;
+    background: lightgrey;
+}
+item {
+    background: grey;
+    width: 3ch;
+    position: relative;
+}
+subgrid {
+    display: grid;
+    grid: subgrid / subgrid;
+    grid-column: 1 / span 3;
+    background: yellow;
+}
+.column-one {
+    grid-column-start: one;
+}
+.column-two {
+    grid-column-start: two;
+}
+.column-three {
+    grid-column-start: three;
+}
+</style>
+</head>
+<body>
+<grid>
+<item>1</item>
+<item>2</item>
+<item>3</item>
+<subgrid>
+    <item class="column-two">4a</item>
+    <item class="column-three">4b</item>
+    <item class="column-one">4c</item>
+</subgrid>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-002-expected.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Masonry rows subgrid line names 002</title>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+    <meta name="assert" content="Auto-placed subgrid should NOT inherit line names">
+    <link rel="match" href="masonry-rows-subgrid-named-lines-002-ref.html">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-columns: [one] 50px [two] 80px [three] 30px;
+    grid-template-rows: none;
+    gap: 4px 2px;
+    padding: 1px 3px 5px 7px;
+    border: solid;
+    border-width: 3px 5px 1px 1px;
+    background: lightgrey;
+}
+item {
+    background: grey;
+    width: 3ch;
+    position: relative;
+}
+subgrid {
+    display: grid;
+    grid: none / subgrid;
+    grid-column: span 2;
+    background: yellow;
+}
+.column-two {
+    grid-column: 2;
+}
+</style>
+</head>
+<body>
+<grid>
+<item>1</item>
+<item>2</item>
+<item>3</item>
+<subgrid>
+    <item class="column-two">4a</item>
+    <item class="column-two">4b</item>
+    <item class="column-two">4c</item>
+</subgrid>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-002.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Masonry rows subgrid line names 002</title>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+    <meta name="assert" content="Auto-placed subgrid should NOT inherit line names">
+    <link rel="match" href="masonry-rows-subgrid-named-lines-002-ref.html">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-columns: [one] 50px [two] 80px [three] 30px;
+    grid-template-rows: masonry;
+    gap: 4px 2px;
+    padding: 1px 3px 5px 7px;
+    border: solid;
+    border-width: 3px 5px 1px 1px;
+    background: lightgrey;
+}
+item {
+    background: grey;
+    width: 3ch;
+    position: relative;
+}
+subgrid {
+    display: grid;
+    grid: subgrid / subgrid;
+    grid-column: span 2;
+    background: yellow;
+}
+.column-one {
+    grid-column-start: one;
+}
+.column-two {
+    grid-column-start: two;
+}
+.column-three {
+    grid-column-start: three;
+}
+</style>
+</head>
+<body>
+<grid>
+<item>1</item>
+<item>2</item>
+<item>3</item>
+<subgrid>
+    <item class="column-two">4a</item>
+    <item class="column-one">4b</item>
+    <item class="column-two">4c</item>
+</subgrid>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-003-expected.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Masonry rows subgrid line names 003</title>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+    <meta name="assert" content="Auto-placed subgrid should be able to use their own named lines">
+    <link rel="match" href="masonry-rows-subgrid-named-lines-003-ref.html">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-columns: 50px 80px 30px;
+    grid-template-rows: auto;
+    gap: 4px 2px;
+    padding: 1px 3px 5px 7px;
+    border: solid;
+    border-width: 3px 5px 1px 1px;
+    background: lightgrey;
+}
+item {
+    background: grey;
+    width: 3ch;
+    position: relative;
+}
+subgrid {
+    display: grid;
+    grid: none / subgrid [sub-one] [sub-two];
+    grid-column: auto / span 2;
+    background: yellow;
+}
+.column-one {
+    grid-column-start: sub-one;
+}
+.column-two {
+    grid-column-start: sub-two;
+}
+.row-one {
+    grid-row-start: 1;
+}
+</style>
+</head>
+<body>
+<grid>
+<item>1</item>
+<item>2</item>
+<item>3</item>
+<subgrid>
+    <item class="column-two">4a</item>
+    <item class="column-one row-one"> 4b </item>
+    <item class="column-two">4c</item>
+</subgrid>
+</grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-003.html
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Masonry rows subgrid line names 003</title>
+    <link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+    <meta name="assert" content="Auto-placed subgrid should be able to use their own named lines">
+    <link rel="match" href="masonry-rows-subgrid-named-lines-003-ref.html">
+<style>
+grid {
+    display: inline-grid;
+    grid-template-columns: 50px 80px 30px;
+    grid-template-rows: masonry;
+    gap: 4px 2px;
+    padding: 1px 3px 5px 7px;
+    border: solid;
+    border-width: 3px 5px 1px 1px;
+    background: lightgrey;
+}
+item {
+    background: grey;
+    width: 3ch;
+    position: relative;
+}
+subgrid {
+    display: grid;
+    grid-template-rows: subgrid;
+    grid-template-columns: subgrid [sub-one] [sub-two];
+    grid-column: span 2;
+    background: yellow;
+}
+.column-one {
+    grid-column-start: sub-one;
+}
+.column-two {
+    grid-column-start: sub-two;
+}
+.column-three {
+    grid-column-start: three;
+}
+</style>
+</head>
+<body>
+<grid>
+<item>1</item>
+<item>2</item>
+<item>3</item>
+<subgrid>
+    <item class="column-two">4a</item>
+    <item class="column-one">4b</item>
+    <item class="column-two">4c</item>
+</subgrid>
+</grid>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -882,6 +882,8 @@ webkit.org/b/219614 inspector/model/font-calculate-properties.html [ Failure ]
 webkit.org/b/223252 imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-003.html [ Failure ]
 webkit.org/b/223252 imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-004.html [ Failure ]
 
+webkit.org/b/249364 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-006.html [ ImageOnlyFailure ]
+
 webkit.org/b/243466 imported/w3c/web-platform-tests/css/css-contain/contain-size-select-elem-001.html [ ImageOnlyFailure ]
 webkit.org/b/243466 imported/w3c/web-platform-tests/css/css-contain/contain-size-select-elem-002.html [ ImageOnlyFailure ]
 

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -140,8 +140,9 @@ void GridMasonryLayout::placeItemsWithDefiniteGridAxisPosition()
         ASSERT(!itemSpan.isIndefinite());
 
         itemSpan.translate(m_renderGrid.currentGrid().explicitGridStart(gridAxisDirection()));
-
-        insertIntoGridAndLayoutItem(*item, gridAreaForDefiniteGridAxisItem(*item));
+        auto gridArea = gridAreaForDefiniteGridAxisItem(*item);
+        m_renderGrid.currentGrid().clampAreaToSubgridIfNeeded(gridArea);
+        insertIntoGridAndLayoutItem(*item, gridArea);
     }
 }
 
@@ -169,6 +170,8 @@ void GridMasonryLayout::setItemGridAxisContainingBlockToGridArea(RenderBox& chil
         child.setOverridingContainingBlockContentLogicalWidth(m_renderGrid.m_trackSizingAlgorithm.estimatedGridAreaBreadthForChild(child, ForColumns));
     else
         child.setOverridingContainingBlockContentLogicalHeight(m_renderGrid.m_trackSizingAlgorithm.estimatedGridAreaBreadthForChild(child, ForRows));
+    // FIXME(249230): Try to cache masonry layout sizes
+    child.setChildNeedsLayout(MarkOnlyThis);
 }
 
 void GridMasonryLayout::insertIntoGridAndLayoutItem(RenderBox& child, const GridArea& area)

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -211,7 +211,7 @@ const GridTrackSize& GridTrackSizingAlgorithm::rawGridTrackSize(GridTrackSizingD
 
 LayoutUnit GridTrackSizingAlgorithm::computeTrackBasedSize() const
 {
-    if (m_renderGrid->style().gridMasonryRows() || m_renderGrid->style().gridMasonryColumns())
+    if (isDirectionInMasonryDirection())
         return m_renderGrid->masonryContentSize();
     
     LayoutUnit size;
@@ -1681,6 +1681,11 @@ GridTrackSizingAlgorithm::StateMachine::~StateMachine()
 {
     m_algorithm.advanceNextState();
     m_algorithm.m_needsSetup = true;
+}
+
+bool GridTrackSizingAlgorithm::isDirectionInMasonryDirection() const
+{
+    return (m_renderGrid->areMasonryRows() && m_direction == ForRows) || (m_renderGrid->areMasonryColumns() && m_direction == ForColumns);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -205,6 +205,8 @@ private:
     void advanceNextState();
     bool isValidTransition() const;
 
+    bool isDirectionInMasonryDirection() const;
+
     // Data.
     bool wasSetup() const { return !!m_strategy; }
     bool m_needsSetup { true };

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2812,7 +2812,7 @@ bool RenderBox::sizesLogicalWidthToFitContent(SizeType widthType) const
         return true;
 
     if (isGridItem())
-        return !hasStretchedLogicalWidth();
+        return downcast<RenderGrid>(parent())->areMasonryColumns() || !hasStretchedLogicalWidth();
 
     // This code may look a bit strange.  Basically width:intrinsic should clamp the size when testing both
     // min-width and width.  max-width is only clamped if it is also intrinsic.

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -103,6 +103,9 @@ public:
     // nested subgrids, where ancestor may not be our direct parent.
     bool isSubgridOf(GridTrackSizingDirection, const RenderGrid& ancestor);
 
+    bool areMasonryRows() const;
+    bool areMasonryColumns() const;
+
     const Grid& currentGrid() const;
     Grid& currentGrid();
 
@@ -235,8 +238,6 @@ private:
 
     bool computeGridPositionsForOutOfFlowChild(const RenderBox&, GridTrackSizingDirection, int&, bool&, int&, bool&) const;
 
-    bool areMasonryRows() const;
-    bool areMasonryColumns() const;
     AutoRepeatType autoRepeatColumnsType() const;
     AutoRepeatType autoRepeatRowsType() const;
 

--- a/Source/WebCore/rendering/style/GridPositionsResolver.cpp
+++ b/Source/WebCore/rendering/style/GridPositionsResolver.cpp
@@ -233,6 +233,9 @@ NamedLineCollection::NamedLineCollection(const RenderGrid& initialGrid, const St
     while (isRowAxis ? grid->isSubgridColumns() : grid->isSubgridRows()) {
         const auto* parent = downcast<RenderGrid>(grid->parent());
 
+        // auto-placed subgrids inside a masonry grid do not inherit any line names
+        if ((parent->areMasonryRows() && (grid->style().gridItemColumnStart().isAuto() || grid->style().gridItemColumnStart().isSpan())) || (parent->areMasonryColumns() && (grid->style().gridItemRowStart().isAuto() || grid->style().gridItemRowStart().isSpan())))
+            return; 
         // Translate our explicit grid set of lines into the coordinate space of the
         // parent grid, adjusting direction/side as needed.
         if (grid->isHorizontalWritingMode() != parent->isHorizontalWritingMode()) {


### PR DESCRIPTION
#### 15f5b0f32da7334c055e80173df8078ba2598262
<pre>
Allow subgrids to participate in masonry layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248403">https://bugs.webkit.org/show_bug.cgi?id=248403</a>
rdar://102720861

Reviewed by Brent Fulgham.

Subgrids should be able to participate in masonry layout in the same
axis as their parent grids. This patch allows this to happen by&apos;
modifying isMasonryRows/Columns to return true when the parent grid is
participating in masonry in the appropriate axis and if the same axis is
being subgridded. In these scenarios, isSubgrid(ForRows/ForColumns) will
need to return false because the axis cannot be subgridded in the same
sense. However, the grid axis can still be subgridded normally.

Also, if a subgrid is being auto-placed, then it cannot inherit any of
its parent grid&apos;s line names. NamedLineCollection has been modified to
check if a subgrid is participating in masonry layout via isMasonryRows
and isMasonryColumns. It then checks to see if the grid axis is being
automatically positioned. If both of these are true, then it will exit
early and not inherit any line names.

Spec reference: <a href="https://drafts.csswg.org/css-grid-3/#subgrids">https://drafts.csswg.org/css-grid-3/#subgrids</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-columns-subgrid-named-lines-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-rows-subgrid-named-lines-003.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::placeItemsWithDefiniteGridAxisPosition):
(WebCore::GridMasonryLayout::setItemGridAxisContainingBlockToGridArea):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::computeTrackBasedSize const):
(WebCore::GridTrackSizingAlgorithm::isDirectionInMasonryDirection const):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::sizesLogicalWidthToFitContent const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutBlock):
(WebCore::RenderGrid::isMasonryRows const):
(WebCore::RenderGrid::isMasonryColumns const):
(WebCore::RenderGrid::isSubgrid const):
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/style/GridPositionsResolver.cpp:
(WebCore::NamedLineCollection::NamedLineCollection):

Canonical link: <a href="https://commits.webkit.org/257916@main">https://commits.webkit.org/257916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5955738683499555a39d454b7cbe31ecce7833e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109672 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169891 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/125 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92756 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107550 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34542 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22551 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3258 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24068 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3251 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43558 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5437 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5067 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->