### PR TITLE
[Live Range Selection] fast/events/autoscroll-in-textarea.html fails

### DIFF
--- a/LayoutTests/fast/events/autoscroll-in-textarea.html
+++ b/LayoutTests/fast/events/autoscroll-in-textarea.html
@@ -56,7 +56,7 @@ if (window.eventSender) {
     eventSender.mouseUp();
 
     var log = document.getElementById("log");
-    var selectedText = window.getSelection().toString();
+    var selectedText = textarea.value.substring(textarea.selectionStart, textarea.selectionEnd);
     if (selectedText.indexOf("k") != -1)
         log.innerText = "PASSED the selection did not jump down.";
     else


### PR DESCRIPTION
#### 6a4542da0db32e9af44fc88d1096758648454d15
<pre>
[Live Range Selection] fast/events/autoscroll-in-textarea.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=249188">https://bugs.webkit.org/show_bug.cgi?id=249188</a>

Reviewed by Darin Adler.

The test failure was caused by getSelection().toString() no longer returning
the selected text inside textarea. Fixed it by using textarea&apos;s selectionStart
and selectionEnd to get the selected substring.

* LayoutTests/fast/events/autoscroll-in-textarea.html:

Canonical link: <a href="https://commits.webkit.org/257771@main">https://commits.webkit.org/257771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fd2dc021bf34b25cf2dea6abef8898883b4bc9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109301 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169538 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86418 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92400 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107204 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105723 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34274 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2921 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23740 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2879 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/46116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43214 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5332 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4729 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->