### PR TITLE
StylePropertyMap should return CSS values exactly as they were set

### DIFF
--- a/LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value-expected.txt
+++ b/LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value-expected.txt
@@ -3,6 +3,8 @@ Checks that calling StylePropertyMap.set() with a negative value wraps it into a
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS target.attributeStyleMap.set('background-size', new CSSUnitValue(-32, 'px')) did not throw exception.
+PASS target.style.backgroundSize is "calc(-32px)"
 PASS target.attributeStyleMap.set('border-block-start-width', new CSSUnitValue(-32, 'px')) did not throw exception.
 PASS target.style.borderBlockStartWidth is "calc(-32px)"
 PASS target.attributeStyleMap.set('border-block-end-width', new CSSUnitValue(-32, 'px')) did not throw exception.
@@ -63,6 +65,8 @@ PASS target.attributeStyleMap.set('scroll-padding-block-end', new CSSUnitValue(-
 PASS target.style.scrollPaddingBlockEnd is "calc(-32px)"
 PASS target.attributeStyleMap.set('width', new CSSUnitValue(-32, 'px')) did not throw exception.
 PASS target.style.width is "calc(-32px)"
+PASS target.attributeStyleMap.set('background-size', new CSSUnitValue(-32, 'percent')) did not throw exception.
+PASS target.style.backgroundSize is "calc(-32%)"
 PASS target.attributeStyleMap.set('border-top-left-radius', new CSSUnitValue(-32, 'percent')) did not throw exception.
 PASS target.style.borderTopLeftRadius is "calc(-32%)"
 PASS target.attributeStyleMap.set('border-top-right-radius', new CSSUnitValue(-32, 'percent')) did not throw exception.
@@ -115,18 +119,14 @@ PASS target.attributeStyleMap.set('stroke-miterlimit', new CSSUnitValue(-32, 'nu
 PASS target.style.strokeMiterlimit is "calc(-32)"
 PASS target.attributeStyleMap.set('animation-duration', new CSSUnitValue(-32, 's')) did not throw exception.
 PASS target.style.animationDuration is "calc(-32s)"
-PASS target.attributeStyleMap.set('background-size', new CSSUnitValue(-32, 'percent')) did not throw exception.
-PASS target.style.backgroundSize is "calc(-32%) auto"
-PASS target.attributeStyleMap.set('background-size', new CSSUnitValue(-32, 'px')) did not throw exception.
-PASS target.style.backgroundSize is "calc(-32px) auto"
 PASS target.attributeStyleMap.set('font-weight', new CSSUnitValue(0, 'number')) did not throw exception.
-PASS target.style.fontWeight is "1"
+PASS target.style.fontWeight is "calc(0)"
 PASS target.attributeStyleMap.set('font-weight', new CSSUnitValue(-32, 'number')) did not throw exception.
-PASS target.style.fontWeight is "1"
+PASS target.style.fontWeight is "calc(-32)"
 PASS target.attributeStyleMap.set('font-weight', new CSSUnitValue(100, 'number')) did not throw exception.
 PASS target.style.fontWeight is "100"
 PASS target.attributeStyleMap.set('font-weight', new CSSUnitValue(1001, 'number')) did not throw exception.
-PASS target.style.fontWeight is "1000"
+PASS target.style.fontWeight is "calc(1001)"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value.html
+++ b/LayoutTests/fast/css/css-typed-om/style-property-map-set-negative-value.html
@@ -16,6 +16,7 @@ function toCamelCase(variable)
 target = document.getElementById("target");
 
 negative_length_properties = [
+    'background-size', // https://w3c.github.io/csswg-drafts/css-backgrounds/#the-background-size
     'border-block-start-width', 'border-block-end-width', 'border-inline-start-width', 'border-inline-end-width', // https://w3c.github.io/csswg-drafts/css-logical/#border-width
     'border-top-left-radius', 'border-top-right-radius', 'border-bottom-right-radius', 'border-bottom-left-radius', // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-radius
     'border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width', // https://w3c.github.io/csswg-drafts/css-backgrounds/#the-border-width
@@ -34,6 +35,7 @@ negative_length_properties = [
     'width', // https://w3c.github.io/csswg-drafts/css-sizing-3/#propdef-width
 ];
 negative_percent_properties = [
+    'background-size', // https://w3c.github.io/csswg-drafts/css-backgrounds/#the-background-size
     'border-top-left-radius', 'border-top-right-radius', 'border-bottom-right-radius', 'border-bottom-left-radius', // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-radius
     'border-image-slice', // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-slice
     'border-image-width', // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-width
@@ -80,21 +82,15 @@ for (let property of negative_time_properties) {
 
 // Special cases.
 
-// https://w3c.github.io/csswg-drafts/css-backgrounds/#the-background-size
-shouldNotThrow("target.attributeStyleMap.set('background-size', new CSSUnitValue(-32, 'percent'))");
-shouldBeEqualToString("target.style.backgroundSize", "calc(-32%) auto");
-shouldNotThrow("target.attributeStyleMap.set('background-size', new CSSUnitValue(-32, 'px'))");
-shouldBeEqualToString("target.style.backgroundSize", "calc(-32px) auto");
-
 // https://w3c.github.io/csswg-drafts/css-fonts/#font-weight-prop
 shouldNotThrow("target.attributeStyleMap.set('font-weight', new CSSUnitValue(0, 'number'))");
-shouldBeEqualToString("target.style.fontWeight", "1");
+shouldBeEqualToString("target.style.fontWeight", "calc(0)");
 shouldNotThrow("target.attributeStyleMap.set('font-weight', new CSSUnitValue(-32, 'number'))");
-shouldBeEqualToString("target.style.fontWeight", "1");
+shouldBeEqualToString("target.style.fontWeight", "calc(-32)");
 shouldNotThrow("target.attributeStyleMap.set('font-weight', new CSSUnitValue(100, 'number'))");
 shouldBeEqualToString("target.style.fontWeight", "100");
 shouldNotThrow("target.attributeStyleMap.set('font-weight', new CSSUnitValue(1001, 'number'))");
-shouldBeEqualToString("target.style.fontWeight", "1000");
+shouldBeEqualToString("target.style.fontWeight", "calc(1001)");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/accent-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/accent-color-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'accent-color' to CSS-wide keywords: initial
 PASS Can set 'accent-color' to CSS-wide keywords: inherit
 PASS Can set 'accent-color' to CSS-wide keywords: unset
 PASS Can set 'accent-color' to CSS-wide keywords: revert
-FAIL Can set 'accent-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'accent-color' to var() references:  var(--A)
 PASS Can set 'accent-color' to the 'currentcolor' keyword: currentcolor
 FAIL Can set 'accent-color' to the 'auto' keyword: auto assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 PASS Setting 'accent-color' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'alignment-baseline' to CSS-wide keywords: initial
 PASS Can set 'alignment-baseline' to CSS-wide keywords: inherit
 PASS Can set 'alignment-baseline' to CSS-wide keywords: unset
 PASS Can set 'alignment-baseline' to CSS-wide keywords: revert
-FAIL Can set 'alignment-baseline' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'alignment-baseline' to var() references:  var(--A)
 PASS Can set 'alignment-baseline' to the 'baseline' keyword: baseline
 FAIL Can set 'alignment-baseline' to the 'text-bottom' keyword: text-bottom Invalid values
 PASS Can set 'alignment-baseline' to the 'alphabetic' keyword: alphabetic

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'animation-delay' to CSS-wide keywords: initial
 PASS Can set 'animation-delay' to CSS-wide keywords: inherit
 PASS Can set 'animation-delay' to CSS-wide keywords: unset
 PASS Can set 'animation-delay' to CSS-wide keywords: revert
-FAIL Can set 'animation-delay' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-delay' to var() references:  var(--A)
 PASS Can set 'animation-delay' to a time: 0s
 PASS Can set 'animation-delay' to a time: -3.14ms
 PASS Can set 'animation-delay' to a time: 3.14s

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'animation-direction' to CSS-wide keywords: initial
 PASS Can set 'animation-direction' to CSS-wide keywords: inherit
 PASS Can set 'animation-direction' to CSS-wide keywords: unset
 PASS Can set 'animation-direction' to CSS-wide keywords: revert
-FAIL Can set 'animation-direction' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-direction' to var() references:  var(--A)
 PASS Can set 'animation-direction' to the 'normal' keyword: normal
 PASS Can set 'animation-direction' to the 'reverse' keyword: reverse
 PASS Can set 'animation-direction' to the 'alternate-reverse' keyword: alternate-reverse

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'animation-duration' to CSS-wide keywords: initial
 PASS Can set 'animation-duration' to CSS-wide keywords: inherit
 PASS Can set 'animation-duration' to CSS-wide keywords: unset
 PASS Can set 'animation-duration' to CSS-wide keywords: revert
-FAIL Can set 'animation-duration' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-duration' to var() references:  var(--A)
 PASS Can set 'animation-duration' to a time: 0s
 FAIL Can set 'animation-duration' to a time: -3.14ms assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'animation-duration' to a time: 3.14s

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'animation-fill-mode' to CSS-wide keywords: initial
 PASS Can set 'animation-fill-mode' to CSS-wide keywords: inherit
 PASS Can set 'animation-fill-mode' to CSS-wide keywords: unset
 PASS Can set 'animation-fill-mode' to CSS-wide keywords: revert
-FAIL Can set 'animation-fill-mode' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-fill-mode' to var() references:  var(--A)
 PASS Can set 'animation-fill-mode' to the 'none' keyword: none
 PASS Can set 'animation-fill-mode' to the 'forwards' keyword: forwards
 PASS Can set 'animation-fill-mode' to the 'backwards' keyword: backwards

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'animation-iteration-count' to CSS-wide keywords: initial
 PASS Can set 'animation-iteration-count' to CSS-wide keywords: inherit
 PASS Can set 'animation-iteration-count' to CSS-wide keywords: unset
 PASS Can set 'animation-iteration-count' to CSS-wide keywords: revert
-FAIL Can set 'animation-iteration-count' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-iteration-count' to var() references:  var(--A)
 PASS Can set 'animation-iteration-count' to the 'infinite' keyword: infinite
 PASS Can set 'animation-iteration-count' to a number: 0
 FAIL Can set 'animation-iteration-count' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'animation-name' to CSS-wide keywords: initial
 PASS Can set 'animation-name' to CSS-wide keywords: inherit
 PASS Can set 'animation-name' to CSS-wide keywords: unset
 PASS Can set 'animation-name' to CSS-wide keywords: revert
-FAIL Can set 'animation-name' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-name' to var() references:  var(--A)
 PASS Can set 'animation-name' to the 'none' keyword: none
 FAIL Can set 'animation-name' to the 'custom-ident' keyword: custom-ident Invalid values
 PASS Setting 'animation-name' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-play-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-play-state-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'animation-play-state' to CSS-wide keywords: initial
 PASS Can set 'animation-play-state' to CSS-wide keywords: inherit
 PASS Can set 'animation-play-state' to CSS-wide keywords: unset
 PASS Can set 'animation-play-state' to CSS-wide keywords: revert
-FAIL Can set 'animation-play-state' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-play-state' to var() references:  var(--A)
 PASS Can set 'animation-play-state' to the 'running' keyword: running
 PASS Can set 'animation-play-state' to the 'paused' keyword: paused
 PASS Setting 'animation-play-state' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-timing-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-timing-function-expected.txt
@@ -3,14 +3,14 @@ PASS Can set 'animation-timing-function' to CSS-wide keywords: initial
 PASS Can set 'animation-timing-function' to CSS-wide keywords: inherit
 PASS Can set 'animation-timing-function' to CSS-wide keywords: unset
 PASS Can set 'animation-timing-function' to CSS-wide keywords: revert
-FAIL Can set 'animation-timing-function' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'animation-timing-function' to var() references:  var(--A)
 PASS Can set 'animation-timing-function' to the 'linear' keyword: linear
 PASS Can set 'animation-timing-function' to the 'ease' keyword: ease
 PASS Can set 'animation-timing-function' to the 'ease-in' keyword: ease-in
 PASS Can set 'animation-timing-function' to the 'ease-out' keyword: ease-out
 PASS Can set 'animation-timing-function' to the 'ease-in-out' keyword: ease-in-out
-FAIL Can set 'animation-timing-function' to the 'step-start' keyword: step-start assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'animation-timing-function' to the 'step-end' keyword: step-end assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'animation-timing-function' to the 'step-start' keyword: step-start
+PASS Can set 'animation-timing-function' to the 'step-end' keyword: step-end
 PASS Setting 'animation-timing-function' to a length throws TypeError
 PASS Setting 'animation-timing-function' to a percent throws TypeError
 PASS Setting 'animation-timing-function' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backface-visibility-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backface-visibility-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'backface-visibility' to CSS-wide keywords: initial
 PASS Can set 'backface-visibility' to CSS-wide keywords: inherit
 PASS Can set 'backface-visibility' to CSS-wide keywords: unset
 PASS Can set 'backface-visibility' to CSS-wide keywords: revert
-FAIL Can set 'backface-visibility' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'backface-visibility' to var() references:  var(--A)
 PASS Can set 'backface-visibility' to the 'visible' keyword: visible
 PASS Can set 'backface-visibility' to the 'hidden' keyword: hidden
 PASS Setting 'backface-visibility' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-attachment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-attachment-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'background-attachment' to CSS-wide keywords: initial
 PASS Can set 'background-attachment' to CSS-wide keywords: inherit
 PASS Can set 'background-attachment' to CSS-wide keywords: unset
 PASS Can set 'background-attachment' to CSS-wide keywords: revert
-FAIL Can set 'background-attachment' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'background-attachment' to var() references:  var(--A)
 PASS Can set 'background-attachment' to the 'scroll' keyword: scroll
 PASS Can set 'background-attachment' to the 'fixed' keyword: fixed
 PASS Can set 'background-attachment' to the 'local' keyword: local

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-blend-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-blend-mode-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'background-blend-mode' to CSS-wide keywords: initial
 PASS Can set 'background-blend-mode' to CSS-wide keywords: inherit
 PASS Can set 'background-blend-mode' to CSS-wide keywords: unset
 PASS Can set 'background-blend-mode' to CSS-wide keywords: revert
-FAIL Can set 'background-blend-mode' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'background-blend-mode' to var() references:  var(--A)
 PASS Can set 'background-blend-mode' to the 'normal' keyword: normal
 PASS Can set 'background-blend-mode' to the 'multiply' keyword: multiply
 PASS Can set 'background-blend-mode' to the 'screen' keyword: screen

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-clip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-clip-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'background-clip' to CSS-wide keywords: initial
 PASS Can set 'background-clip' to CSS-wide keywords: inherit
 PASS Can set 'background-clip' to CSS-wide keywords: unset
 PASS Can set 'background-clip' to CSS-wide keywords: revert
-FAIL Can set 'background-clip' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'background-clip' to var() references:  var(--A)
 PASS Can set 'background-clip' to the 'border-box' keyword: border-box
 PASS Can set 'background-clip' to the 'padding-box' keyword: padding-box
 PASS Can set 'background-clip' to the 'content-box' keyword: content-box

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-color-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'background-color' to CSS-wide keywords: initial
 PASS Can set 'background-color' to CSS-wide keywords: inherit
 PASS Can set 'background-color' to CSS-wide keywords: unset
 PASS Can set 'background-color' to CSS-wide keywords: revert
-FAIL Can set 'background-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'background-color' to var() references:  var(--A)
 PASS Can set 'background-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'background-color' to a length throws TypeError
 PASS Setting 'background-color' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-image-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'background-image' to CSS-wide keywords: initial
 PASS Can set 'background-image' to CSS-wide keywords: inherit
 PASS Can set 'background-image' to CSS-wide keywords: unset
 PASS Can set 'background-image' to CSS-wide keywords: revert
-FAIL Can set 'background-image' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'background-image' to var() references:  var(--A)
 PASS Can set 'background-image' to the 'none' keyword: none
 PASS Can set 'background-image' to an image
 PASS Setting 'background-image' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-origin-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'background-origin' to CSS-wide keywords: initial
 PASS Can set 'background-origin' to CSS-wide keywords: inherit
 PASS Can set 'background-origin' to CSS-wide keywords: unset
 PASS Can set 'background-origin' to CSS-wide keywords: revert
-FAIL Can set 'background-origin' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'background-origin' to var() references:  var(--A)
 PASS Can set 'background-origin' to the 'border-box' keyword: border-box
 PASS Can set 'background-origin' to the 'padding-box' keyword: padding-box
 PASS Can set 'background-origin' to the 'content-box' keyword: content-box

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt
@@ -3,16 +3,16 @@ PASS Can set 'background-size' to CSS-wide keywords: initial
 PASS Can set 'background-size' to CSS-wide keywords: inherit
 PASS Can set 'background-size' to CSS-wide keywords: unset
 PASS Can set 'background-size' to CSS-wide keywords: revert
-FAIL Can set 'background-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Can set 'background-size' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'background-size' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'background-size' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'background-size' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-FAIL Can set 'background-size' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'background-size' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'background-size' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'background-size' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-FAIL Can set 'background-size' to the 'auto' keyword: auto assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'background-size' to var() references:  var(--A)
+PASS Can set 'background-size' to a length: 0px
+FAIL Can set 'background-size' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'background-size' to a length: 3.14cm
+PASS Can set 'background-size' to a length: calc(0px + 0em)
+PASS Can set 'background-size' to a percent: 0%
+FAIL Can set 'background-size' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'background-size' to a percent: 3.14%
+PASS Can set 'background-size' to a percent: calc(0% + 0%)
+PASS Can set 'background-size' to the 'auto' keyword: auto
 PASS Can set 'background-size' to the 'cover' keyword: cover
 PASS Can set 'background-size' to the 'contain' keyword: contain
 PASS Setting 'background-size' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'baseline-shift' to CSS-wide keywords: initial
 PASS Can set 'baseline-shift' to CSS-wide keywords: inherit
 PASS Can set 'baseline-shift' to CSS-wide keywords: unset
 PASS Can set 'baseline-shift' to CSS-wide keywords: revert
-FAIL Can set 'baseline-shift' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'baseline-shift' to var() references:  var(--A)
 PASS Can set 'baseline-shift' to the 'sub' keyword: sub
 PASS Can set 'baseline-shift' to the 'super' keyword: super
 PASS Can set 'baseline-shift' to a percent: 0%

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt
@@ -3,16 +3,16 @@ PASS Can set 'block-size' to CSS-wide keywords: initial
 PASS Can set 'block-size' to CSS-wide keywords: inherit
 PASS Can set 'block-size' to CSS-wide keywords: unset
 PASS Can set 'block-size' to CSS-wide keywords: revert
-FAIL Can set 'block-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'block-size' to var() references:  var(--A)
 PASS Can set 'block-size' to the 'auto' keyword: auto
 PASS Can set 'block-size' to a percent: 0%
 FAIL Can set 'block-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'block-size' to a percent: 3.14%
-FAIL Can set 'block-size' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'block-size' to a percent: calc(0% + 0%)
 PASS Can set 'block-size' to a length: 0px
 PASS Can set 'block-size' to a length: -3.14em
 PASS Can set 'block-size' to a length: 3.14cm
-FAIL Can set 'block-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'block-size' to a length: calc(0px + 0em)
 PASS Setting 'block-size' to a time throws TypeError
 PASS Setting 'block-size' to an angle throws TypeError
 PASS Setting 'block-size' to a flexible length throws TypeError
@@ -23,15 +23,15 @@ PASS Can set 'min-block-size' to CSS-wide keywords: initial
 PASS Can set 'min-block-size' to CSS-wide keywords: inherit
 PASS Can set 'min-block-size' to CSS-wide keywords: unset
 PASS Can set 'min-block-size' to CSS-wide keywords: revert
-FAIL Can set 'min-block-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'min-block-size' to var() references:  var(--A)
 PASS Can set 'min-block-size' to a percent: 0%
 FAIL Can set 'min-block-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'min-block-size' to a percent: 3.14%
-FAIL Can set 'min-block-size' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'min-block-size' to a percent: calc(0% + 0%)
 PASS Can set 'min-block-size' to a length: 0px
 PASS Can set 'min-block-size' to a length: -3.14em
 PASS Can set 'min-block-size' to a length: 3.14cm
-FAIL Can set 'min-block-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'min-block-size' to a length: calc(0px + 0em)
 PASS Setting 'min-block-size' to a time throws TypeError
 PASS Setting 'min-block-size' to an angle throws TypeError
 PASS Setting 'min-block-size' to a flexible length throws TypeError
@@ -42,16 +42,16 @@ PASS Can set 'max-block-size' to CSS-wide keywords: initial
 PASS Can set 'max-block-size' to CSS-wide keywords: inherit
 PASS Can set 'max-block-size' to CSS-wide keywords: unset
 PASS Can set 'max-block-size' to CSS-wide keywords: revert
-FAIL Can set 'max-block-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'max-block-size' to var() references:  var(--A)
 PASS Can set 'max-block-size' to the 'none' keyword: none
 PASS Can set 'max-block-size' to a percent: 0%
 FAIL Can set 'max-block-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'max-block-size' to a percent: 3.14%
-FAIL Can set 'max-block-size' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'max-block-size' to a percent: calc(0% + 0%)
 PASS Can set 'max-block-size' to a length: 0px
 PASS Can set 'max-block-size' to a length: -3.14em
 PASS Can set 'max-block-size' to a length: 3.14cm
-FAIL Can set 'max-block-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'max-block-size' to a length: calc(0px + 0em)
 PASS Setting 'max-block-size' to a time throws TypeError
 PASS Setting 'max-block-size' to an angle throws TypeError
 PASS Setting 'max-block-size' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-collapse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-collapse-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'border-collapse' to CSS-wide keywords: initial
 PASS Can set 'border-collapse' to CSS-wide keywords: inherit
 PASS Can set 'border-collapse' to CSS-wide keywords: unset
 PASS Can set 'border-collapse' to CSS-wide keywords: revert
-FAIL Can set 'border-collapse' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-collapse' to var() references:  var(--A)
 PASS Can set 'border-collapse' to the 'separate' keyword: separate
 PASS Can set 'border-collapse' to the 'collapse' keyword: collapse
 PASS Setting 'border-collapse' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-color-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'border-top-color' to CSS-wide keywords: initial
 PASS Can set 'border-top-color' to CSS-wide keywords: inherit
 PASS Can set 'border-top-color' to CSS-wide keywords: unset
 PASS Can set 'border-top-color' to CSS-wide keywords: revert
-FAIL Can set 'border-top-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-top-color' to var() references:  var(--A)
 PASS Can set 'border-top-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'border-top-color' to a length throws TypeError
 PASS Setting 'border-top-color' to a percent throws TypeError
@@ -22,7 +22,7 @@ PASS Can set 'border-left-color' to CSS-wide keywords: initial
 PASS Can set 'border-left-color' to CSS-wide keywords: inherit
 PASS Can set 'border-left-color' to CSS-wide keywords: unset
 PASS Can set 'border-left-color' to CSS-wide keywords: revert
-FAIL Can set 'border-left-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-left-color' to var() references:  var(--A)
 PASS Can set 'border-left-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'border-left-color' to a length throws TypeError
 PASS Setting 'border-left-color' to a percent throws TypeError
@@ -41,7 +41,7 @@ PASS Can set 'border-right-color' to CSS-wide keywords: initial
 PASS Can set 'border-right-color' to CSS-wide keywords: inherit
 PASS Can set 'border-right-color' to CSS-wide keywords: unset
 PASS Can set 'border-right-color' to CSS-wide keywords: revert
-FAIL Can set 'border-right-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-right-color' to var() references:  var(--A)
 PASS Can set 'border-right-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'border-right-color' to a length throws TypeError
 PASS Setting 'border-right-color' to a percent throws TypeError
@@ -60,7 +60,7 @@ PASS Can set 'border-bottom-color' to CSS-wide keywords: initial
 PASS Can set 'border-bottom-color' to CSS-wide keywords: inherit
 PASS Can set 'border-bottom-color' to CSS-wide keywords: unset
 PASS Can set 'border-bottom-color' to CSS-wide keywords: revert
-FAIL Can set 'border-bottom-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-bottom-color' to var() references:  var(--A)
 PASS Can set 'border-bottom-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'border-bottom-color' to a length throws TypeError
 PASS Setting 'border-bottom-color' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset-expected.txt
@@ -3,15 +3,15 @@ PASS Can set 'border-image-outset' to CSS-wide keywords: initial
 PASS Can set 'border-image-outset' to CSS-wide keywords: inherit
 PASS Can set 'border-image-outset' to CSS-wide keywords: unset
 PASS Can set 'border-image-outset' to CSS-wide keywords: revert
-FAIL Can set 'border-image-outset' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Can set 'border-image-outset' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-outset' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-outset' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-outset' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-image-outset' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-outset' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-outset' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-outset' to a number: calc(2 + 3) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+PASS Can set 'border-image-outset' to var() references:  var(--A)
+PASS Can set 'border-image-outset' to a length: 0px
+FAIL Can set 'border-image-outset' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-image-outset' to a length: 3.14cm
+PASS Can set 'border-image-outset' to a length: calc(0px + 0em)
+PASS Can set 'border-image-outset' to a number: 0
+FAIL Can set 'border-image-outset' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-image-outset' to a number: 3.14
+PASS Can set 'border-image-outset' to a number: calc(2 + 3)
 PASS Setting 'border-image-outset' to a percent throws TypeError
 PASS Setting 'border-image-outset' to a time throws TypeError
 PASS Setting 'border-image-outset' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat-expected.txt
@@ -3,11 +3,11 @@ PASS Can set 'border-image-repeat' to CSS-wide keywords: initial
 PASS Can set 'border-image-repeat' to CSS-wide keywords: inherit
 PASS Can set 'border-image-repeat' to CSS-wide keywords: unset
 PASS Can set 'border-image-repeat' to CSS-wide keywords: revert
-FAIL Can set 'border-image-repeat' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Can set 'border-image-repeat' to the 'stretch' keyword: stretch assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-repeat' to the 'repeat' keyword: repeat assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-repeat' to the 'round' keyword: round assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-repeat' to the 'space' keyword: space assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'border-image-repeat' to var() references:  var(--A)
+PASS Can set 'border-image-repeat' to the 'stretch' keyword: stretch
+PASS Can set 'border-image-repeat' to the 'repeat' keyword: repeat
+PASS Can set 'border-image-repeat' to the 'round' keyword: round
+PASS Can set 'border-image-repeat' to the 'space' keyword: space
 PASS Setting 'border-image-repeat' to a length throws TypeError
 PASS Setting 'border-image-repeat' to a percent throws TypeError
 PASS Setting 'border-image-repeat' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice-expected.txt
@@ -3,15 +3,15 @@ PASS Can set 'border-image-slice' to CSS-wide keywords: initial
 PASS Can set 'border-image-slice' to CSS-wide keywords: inherit
 PASS Can set 'border-image-slice' to CSS-wide keywords: unset
 PASS Can set 'border-image-slice' to CSS-wide keywords: revert
-FAIL Can set 'border-image-slice' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Can set 'border-image-slice' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-slice' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-slice' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-slice' to a number: calc(2 + 3) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-image-slice' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-slice' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-slice' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-slice' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+PASS Can set 'border-image-slice' to var() references:  var(--A)
+PASS Can set 'border-image-slice' to a number: 0
+FAIL Can set 'border-image-slice' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-image-slice' to a number: 3.14
+PASS Can set 'border-image-slice' to a number: calc(2 + 3)
+PASS Can set 'border-image-slice' to a percent: 0%
+FAIL Can set 'border-image-slice' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-image-slice' to a percent: 3.14%
+PASS Can set 'border-image-slice' to a percent: calc(0% + 0%)
 PASS Setting 'border-image-slice' to a length throws TypeError
 PASS Setting 'border-image-slice' to a time throws TypeError
 PASS Setting 'border-image-slice' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-source-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-source-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'border-image-source' to CSS-wide keywords: initial
 PASS Can set 'border-image-source' to CSS-wide keywords: inherit
 PASS Can set 'border-image-source' to CSS-wide keywords: unset
 PASS Can set 'border-image-source' to CSS-wide keywords: revert
-FAIL Can set 'border-image-source' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-image-source' to var() references:  var(--A)
 PASS Can set 'border-image-source' to the 'none' keyword: none
 PASS Can set 'border-image-source' to an image
 PASS Setting 'border-image-source' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width-expected.txt
@@ -3,20 +3,20 @@ PASS Can set 'border-image-width' to CSS-wide keywords: initial
 PASS Can set 'border-image-width' to CSS-wide keywords: inherit
 PASS Can set 'border-image-width' to CSS-wide keywords: unset
 PASS Can set 'border-image-width' to CSS-wide keywords: revert
-FAIL Can set 'border-image-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Can set 'border-image-width' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-width' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-width' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-image-width' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-width' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-width' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-width' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-image-width' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-width' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-width' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-image-width' to a number: calc(2 + 3) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-image-width' to the 'auto' keyword: auto assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'border-image-width' to var() references:  var(--A)
+PASS Can set 'border-image-width' to a length: 0px
+FAIL Can set 'border-image-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-image-width' to a length: 3.14cm
+PASS Can set 'border-image-width' to a length: calc(0px + 0em)
+PASS Can set 'border-image-width' to a percent: 0%
+FAIL Can set 'border-image-width' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-image-width' to a percent: 3.14%
+PASS Can set 'border-image-width' to a percent: calc(0% + 0%)
+PASS Can set 'border-image-width' to a number: 0
+FAIL Can set 'border-image-width' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-image-width' to a number: 3.14
+PASS Can set 'border-image-width' to a number: calc(2 + 3)
+PASS Can set 'border-image-width' to the 'auto' keyword: auto
 PASS Setting 'border-image-width' to a time throws TypeError
 PASS Setting 'border-image-width' to an angle throws TypeError
 PASS Setting 'border-image-width' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt
@@ -3,15 +3,15 @@ PASS Can set 'border-top-left-radius' to CSS-wide keywords: initial
 PASS Can set 'border-top-left-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-top-left-radius' to CSS-wide keywords: unset
 PASS Can set 'border-top-left-radius' to CSS-wide keywords: revert
-FAIL Can set 'border-top-left-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Can set 'border-top-left-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-top-left-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-top-left-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-top-left-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-top-left-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-top-left-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-top-left-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-top-left-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+PASS Can set 'border-top-left-radius' to var() references:  var(--A)
+PASS Can set 'border-top-left-radius' to a length: 0px
+FAIL Can set 'border-top-left-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-top-left-radius' to a length: 3.14cm
+PASS Can set 'border-top-left-radius' to a length: calc(0px + 0em)
+PASS Can set 'border-top-left-radius' to a percent: 0%
+FAIL Can set 'border-top-left-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-top-left-radius' to a percent: 3.14%
+PASS Can set 'border-top-left-radius' to a percent: calc(0% + 0%)
 PASS Setting 'border-top-left-radius' to a time throws TypeError
 PASS Setting 'border-top-left-radius' to an angle throws TypeError
 PASS Setting 'border-top-left-radius' to a flexible length throws TypeError
@@ -22,15 +22,15 @@ PASS Can set 'border-top-right-radius' to CSS-wide keywords: initial
 PASS Can set 'border-top-right-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-top-right-radius' to CSS-wide keywords: unset
 PASS Can set 'border-top-right-radius' to CSS-wide keywords: revert
-FAIL Can set 'border-top-right-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Can set 'border-top-right-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-top-right-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-top-right-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-top-right-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-top-right-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-top-right-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-top-right-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-top-right-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+PASS Can set 'border-top-right-radius' to var() references:  var(--A)
+PASS Can set 'border-top-right-radius' to a length: 0px
+FAIL Can set 'border-top-right-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-top-right-radius' to a length: 3.14cm
+PASS Can set 'border-top-right-radius' to a length: calc(0px + 0em)
+PASS Can set 'border-top-right-radius' to a percent: 0%
+FAIL Can set 'border-top-right-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-top-right-radius' to a percent: 3.14%
+PASS Can set 'border-top-right-radius' to a percent: calc(0% + 0%)
 PASS Setting 'border-top-right-radius' to a time throws TypeError
 PASS Setting 'border-top-right-radius' to an angle throws TypeError
 PASS Setting 'border-top-right-radius' to a flexible length throws TypeError
@@ -41,15 +41,15 @@ PASS Can set 'border-bottom-left-radius' to CSS-wide keywords: initial
 PASS Can set 'border-bottom-left-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-bottom-left-radius' to CSS-wide keywords: unset
 PASS Can set 'border-bottom-left-radius' to CSS-wide keywords: revert
-FAIL Can set 'border-bottom-left-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Can set 'border-bottom-left-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-bottom-left-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-bottom-left-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-bottom-left-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-bottom-left-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-bottom-left-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-bottom-left-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-bottom-left-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+PASS Can set 'border-bottom-left-radius' to var() references:  var(--A)
+PASS Can set 'border-bottom-left-radius' to a length: 0px
+FAIL Can set 'border-bottom-left-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-bottom-left-radius' to a length: 3.14cm
+PASS Can set 'border-bottom-left-radius' to a length: calc(0px + 0em)
+PASS Can set 'border-bottom-left-radius' to a percent: 0%
+FAIL Can set 'border-bottom-left-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-bottom-left-radius' to a percent: 3.14%
+PASS Can set 'border-bottom-left-radius' to a percent: calc(0% + 0%)
 PASS Setting 'border-bottom-left-radius' to a time throws TypeError
 PASS Setting 'border-bottom-left-radius' to an angle throws TypeError
 PASS Setting 'border-bottom-left-radius' to a flexible length throws TypeError
@@ -60,15 +60,15 @@ PASS Can set 'border-bottom-right-radius' to CSS-wide keywords: initial
 PASS Can set 'border-bottom-right-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-bottom-right-radius' to CSS-wide keywords: unset
 PASS Can set 'border-bottom-right-radius' to CSS-wide keywords: revert
-FAIL Can set 'border-bottom-right-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Can set 'border-bottom-right-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-bottom-right-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-bottom-right-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-bottom-right-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-bottom-right-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-bottom-right-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-bottom-right-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-bottom-right-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+PASS Can set 'border-bottom-right-radius' to var() references:  var(--A)
+PASS Can set 'border-bottom-right-radius' to a length: 0px
+FAIL Can set 'border-bottom-right-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-bottom-right-radius' to a length: 3.14cm
+PASS Can set 'border-bottom-right-radius' to a length: calc(0px + 0em)
+PASS Can set 'border-bottom-right-radius' to a percent: 0%
+FAIL Can set 'border-bottom-right-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-bottom-right-radius' to a percent: 3.14%
+PASS Can set 'border-bottom-right-radius' to a percent: calc(0% + 0%)
 PASS Setting 'border-bottom-right-radius' to a time throws TypeError
 PASS Setting 'border-bottom-right-radius' to an angle throws TypeError
 PASS Setting 'border-bottom-right-radius' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-style-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'border-top-style' to CSS-wide keywords: initial
 PASS Can set 'border-top-style' to CSS-wide keywords: inherit
 PASS Can set 'border-top-style' to CSS-wide keywords: unset
 PASS Can set 'border-top-style' to CSS-wide keywords: revert
-FAIL Can set 'border-top-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-top-style' to var() references:  var(--A)
 PASS Can set 'border-top-style' to the 'none' keyword: none
 PASS Can set 'border-top-style' to the 'solid' keyword: solid
 PASS Setting 'border-top-style' to a length throws TypeError
@@ -18,7 +18,7 @@ PASS Can set 'border-left-style' to CSS-wide keywords: initial
 PASS Can set 'border-left-style' to CSS-wide keywords: inherit
 PASS Can set 'border-left-style' to CSS-wide keywords: unset
 PASS Can set 'border-left-style' to CSS-wide keywords: revert
-FAIL Can set 'border-left-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-left-style' to var() references:  var(--A)
 PASS Can set 'border-left-style' to the 'none' keyword: none
 PASS Can set 'border-left-style' to the 'solid' keyword: solid
 PASS Setting 'border-left-style' to a length throws TypeError
@@ -33,7 +33,7 @@ PASS Can set 'border-right-style' to CSS-wide keywords: initial
 PASS Can set 'border-right-style' to CSS-wide keywords: inherit
 PASS Can set 'border-right-style' to CSS-wide keywords: unset
 PASS Can set 'border-right-style' to CSS-wide keywords: revert
-FAIL Can set 'border-right-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-right-style' to var() references:  var(--A)
 PASS Can set 'border-right-style' to the 'none' keyword: none
 PASS Can set 'border-right-style' to the 'solid' keyword: solid
 PASS Setting 'border-right-style' to a length throws TypeError
@@ -48,7 +48,7 @@ PASS Can set 'border-bottom-style' to CSS-wide keywords: initial
 PASS Can set 'border-bottom-style' to CSS-wide keywords: inherit
 PASS Can set 'border-bottom-style' to CSS-wide keywords: unset
 PASS Can set 'border-bottom-style' to CSS-wide keywords: revert
-FAIL Can set 'border-bottom-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-bottom-style' to var() references:  var(--A)
 PASS Can set 'border-bottom-style' to the 'none' keyword: none
 PASS Can set 'border-bottom-style' to the 'solid' keyword: solid
 PASS Setting 'border-bottom-style' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt
@@ -3,14 +3,14 @@ PASS Can set 'border-top-width' to CSS-wide keywords: initial
 PASS Can set 'border-top-width' to CSS-wide keywords: inherit
 PASS Can set 'border-top-width' to CSS-wide keywords: unset
 PASS Can set 'border-top-width' to CSS-wide keywords: revert
-FAIL Can set 'border-top-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-top-width' to var() references:  var(--A)
 PASS Can set 'border-top-width' to the 'thin' keyword: thin
 PASS Can set 'border-top-width' to the 'medium' keyword: medium
 PASS Can set 'border-top-width' to the 'thick' keyword: thick
 PASS Can set 'border-top-width' to a length: 0px
 PASS Can set 'border-top-width' to a length: -3.14em
 PASS Can set 'border-top-width' to a length: 3.14cm
-FAIL Can set 'border-top-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'border-top-width' to a length: calc(0px + 0em)
 PASS Setting 'border-top-width' to a percent throws TypeError
 PASS Setting 'border-top-width' to a time throws TypeError
 PASS Setting 'border-top-width' to an angle throws TypeError
@@ -22,14 +22,14 @@ PASS Can set 'border-left-width' to CSS-wide keywords: initial
 PASS Can set 'border-left-width' to CSS-wide keywords: inherit
 PASS Can set 'border-left-width' to CSS-wide keywords: unset
 PASS Can set 'border-left-width' to CSS-wide keywords: revert
-FAIL Can set 'border-left-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-left-width' to var() references:  var(--A)
 PASS Can set 'border-left-width' to the 'thin' keyword: thin
 PASS Can set 'border-left-width' to the 'medium' keyword: medium
 PASS Can set 'border-left-width' to the 'thick' keyword: thick
 PASS Can set 'border-left-width' to a length: 0px
 PASS Can set 'border-left-width' to a length: -3.14em
 PASS Can set 'border-left-width' to a length: 3.14cm
-FAIL Can set 'border-left-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'border-left-width' to a length: calc(0px + 0em)
 PASS Setting 'border-left-width' to a percent throws TypeError
 PASS Setting 'border-left-width' to a time throws TypeError
 PASS Setting 'border-left-width' to an angle throws TypeError
@@ -41,14 +41,14 @@ PASS Can set 'border-right-width' to CSS-wide keywords: initial
 PASS Can set 'border-right-width' to CSS-wide keywords: inherit
 PASS Can set 'border-right-width' to CSS-wide keywords: unset
 PASS Can set 'border-right-width' to CSS-wide keywords: revert
-FAIL Can set 'border-right-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-right-width' to var() references:  var(--A)
 PASS Can set 'border-right-width' to the 'thin' keyword: thin
 PASS Can set 'border-right-width' to the 'medium' keyword: medium
 PASS Can set 'border-right-width' to the 'thick' keyword: thick
 PASS Can set 'border-right-width' to a length: 0px
 PASS Can set 'border-right-width' to a length: -3.14em
 PASS Can set 'border-right-width' to a length: 3.14cm
-FAIL Can set 'border-right-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'border-right-width' to a length: calc(0px + 0em)
 PASS Setting 'border-right-width' to a percent throws TypeError
 PASS Setting 'border-right-width' to a time throws TypeError
 PASS Setting 'border-right-width' to an angle throws TypeError
@@ -60,14 +60,14 @@ PASS Can set 'border-bottom-width' to CSS-wide keywords: initial
 PASS Can set 'border-bottom-width' to CSS-wide keywords: inherit
 PASS Can set 'border-bottom-width' to CSS-wide keywords: unset
 PASS Can set 'border-bottom-width' to CSS-wide keywords: revert
-FAIL Can set 'border-bottom-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-bottom-width' to var() references:  var(--A)
 PASS Can set 'border-bottom-width' to the 'thin' keyword: thin
 PASS Can set 'border-bottom-width' to the 'medium' keyword: medium
 PASS Can set 'border-bottom-width' to the 'thick' keyword: thick
 PASS Can set 'border-bottom-width' to a length: 0px
 PASS Can set 'border-bottom-width' to a length: -3.14em
 PASS Can set 'border-bottom-width' to a length: 3.14cm
-FAIL Can set 'border-bottom-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'border-bottom-width' to a length: calc(0px + 0em)
 PASS Setting 'border-bottom-width' to a percent throws TypeError
 PASS Setting 'border-bottom-width' to a time throws TypeError
 PASS Setting 'border-bottom-width' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/bottom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/bottom-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'bottom' to CSS-wide keywords: initial
 PASS Can set 'bottom' to CSS-wide keywords: inherit
 PASS Can set 'bottom' to CSS-wide keywords: unset
 PASS Can set 'bottom' to CSS-wide keywords: revert
-FAIL Can set 'bottom' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'bottom' to var() references:  var(--A)
 PASS Can set 'bottom' to the 'auto' keyword: auto
 PASS Can set 'bottom' to a percent: 0%
 PASS Can set 'bottom' to a percent: -3.14%

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-shadow-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'box-shadow' to CSS-wide keywords: initial
 PASS Can set 'box-shadow' to CSS-wide keywords: inherit
 PASS Can set 'box-shadow' to CSS-wide keywords: unset
 PASS Can set 'box-shadow' to CSS-wide keywords: revert
-FAIL Can set 'box-shadow' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'box-shadow' to var() references:  var(--A)
 PASS Can set 'box-shadow' to the 'none' keyword: none
 PASS Setting 'box-shadow' to a length throws TypeError
 PASS Setting 'box-shadow' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-sizing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-sizing-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'box-sizing' to CSS-wide keywords: initial
 PASS Can set 'box-sizing' to CSS-wide keywords: inherit
 PASS Can set 'box-sizing' to CSS-wide keywords: unset
 PASS Can set 'box-sizing' to CSS-wide keywords: revert
-FAIL Can set 'box-sizing' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'box-sizing' to var() references:  var(--A)
 PASS Can set 'box-sizing' to the 'content-box' keyword: content-box
 PASS Can set 'box-sizing' to the 'border-box' keyword: border-box
 PASS Setting 'box-sizing' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/break-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/break-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'break-after' to CSS-wide keywords: initial
 PASS Can set 'break-after' to CSS-wide keywords: inherit
 PASS Can set 'break-after' to CSS-wide keywords: unset
 PASS Can set 'break-after' to CSS-wide keywords: revert
-FAIL Can set 'break-after' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'break-after' to var() references:  var(--A)
 PASS Can set 'break-after' to the 'auto' keyword: auto
 PASS Can set 'break-after' to the 'avoid' keyword: avoid
 PASS Can set 'break-after' to the 'avoid-column' keyword: avoid-column
@@ -28,7 +28,7 @@ PASS Can set 'break-before' to CSS-wide keywords: initial
 PASS Can set 'break-before' to CSS-wide keywords: inherit
 PASS Can set 'break-before' to CSS-wide keywords: unset
 PASS Can set 'break-before' to CSS-wide keywords: revert
-FAIL Can set 'break-before' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'break-before' to var() references:  var(--A)
 PASS Can set 'break-before' to the 'auto' keyword: auto
 PASS Can set 'break-before' to the 'avoid' keyword: avoid
 PASS Can set 'break-before' to the 'avoid-column' keyword: avoid-column
@@ -53,7 +53,7 @@ PASS Can set 'break-inside' to CSS-wide keywords: initial
 PASS Can set 'break-inside' to CSS-wide keywords: inherit
 PASS Can set 'break-inside' to CSS-wide keywords: unset
 PASS Can set 'break-inside' to CSS-wide keywords: revert
-FAIL Can set 'break-inside' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'break-inside' to var() references:  var(--A)
 PASS Can set 'break-inside' to the 'auto' keyword: auto
 PASS Can set 'break-inside' to the 'avoid' keyword: avoid
 PASS Can set 'break-inside' to the 'avoid-column' keyword: avoid-column

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caption-side-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caption-side-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'caption-side' to CSS-wide keywords: initial
 PASS Can set 'caption-side' to CSS-wide keywords: inherit
 PASS Can set 'caption-side' to CSS-wide keywords: unset
 PASS Can set 'caption-side' to CSS-wide keywords: revert
-FAIL Can set 'caption-side' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'caption-side' to var() references:  var(--A)
 PASS Can set 'caption-side' to the 'top' keyword: top
 PASS Can set 'caption-side' to the 'bottom' keyword: bottom
 PASS Setting 'caption-side' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caret-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caret-color-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'caret-color' to CSS-wide keywords: initial
 PASS Can set 'caret-color' to CSS-wide keywords: inherit
 PASS Can set 'caret-color' to CSS-wide keywords: unset
 PASS Can set 'caret-color' to CSS-wide keywords: revert
-FAIL Can set 'caret-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'caret-color' to var() references:  var(--A)
 PASS Can set 'caret-color' to the 'currentcolor' keyword: currentcolor
 PASS Can set 'caret-color' to the 'auto' keyword: auto
 PASS Setting 'caret-color' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'cx' to CSS-wide keywords: initial
 PASS Can set 'cx' to CSS-wide keywords: inherit
 PASS Can set 'cx' to CSS-wide keywords: unset
 PASS Can set 'cx' to CSS-wide keywords: revert
-FAIL Can set 'cx' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'cx' to var() references:  var(--A)
 PASS Can set 'cx' to a percent: 0%
 PASS Can set 'cx' to a percent: -3.14%
 PASS Can set 'cx' to a percent: 3.14%
@@ -22,7 +22,7 @@ PASS Can set 'cy' to CSS-wide keywords: initial
 PASS Can set 'cy' to CSS-wide keywords: inherit
 PASS Can set 'cy' to CSS-wide keywords: unset
 PASS Can set 'cy' to CSS-wide keywords: revert
-FAIL Can set 'cy' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'cy' to var() references:  var(--A)
 PASS Can set 'cy' to a percent: 0%
 PASS Can set 'cy' to a percent: -3.14%
 PASS Can set 'cy' to a percent: 3.14%

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clear-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clear-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'clear' to CSS-wide keywords: initial
 PASS Can set 'clear' to CSS-wide keywords: inherit
 PASS Can set 'clear' to CSS-wide keywords: unset
 PASS Can set 'clear' to CSS-wide keywords: revert
-FAIL Can set 'clear' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'clear' to var() references:  var(--A)
 PASS Can set 'clear' to the 'none' keyword: none
 PASS Can set 'clear' to the 'left' keyword: left
 PASS Can set 'clear' to the 'right' keyword: right

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'clip' to CSS-wide keywords: initial
 PASS Can set 'clip' to CSS-wide keywords: inherit
 PASS Can set 'clip' to CSS-wide keywords: unset
 PASS Can set 'clip' to CSS-wide keywords: revert
-FAIL Can set 'clip' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'clip' to var() references:  var(--A)
 PASS Can set 'clip' to the 'auto' keyword: auto
 PASS Setting 'clip' to a length throws TypeError
 PASS Setting 'clip' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-path-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-path-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'clip-path' to CSS-wide keywords: initial
 PASS Can set 'clip-path' to CSS-wide keywords: inherit
 PASS Can set 'clip-path' to CSS-wide keywords: unset
 PASS Can set 'clip-path' to CSS-wide keywords: revert
-FAIL Can set 'clip-path' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'clip-path' to var() references:  var(--A)
 PASS Can set 'clip-path' to the 'none' keyword: none
 PASS Can set 'clip-path' to the 'fill-box' keyword: fill-box
 PASS Can set 'clip-path' to the 'stroke-box' keyword: stroke-box

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-rule-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'clip-rule' to CSS-wide keywords: initial
 PASS Can set 'clip-rule' to CSS-wide keywords: inherit
 PASS Can set 'clip-rule' to CSS-wide keywords: unset
 PASS Can set 'clip-rule' to CSS-wide keywords: revert
-FAIL Can set 'clip-rule' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'clip-rule' to var() references:  var(--A)
 PASS Can set 'clip-rule' to the 'nonzero' keyword: nonzero
 PASS Can set 'clip-rule' to the 'evenodd' keyword: evenodd
 PASS Setting 'clip-rule' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'color' to CSS-wide keywords: initial
 PASS Can set 'color' to CSS-wide keywords: inherit
 PASS Can set 'color' to CSS-wide keywords: unset
 PASS Can set 'color' to CSS-wide keywords: revert
-FAIL Can set 'color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'color' to var() references:  var(--A)
 PASS Can set 'color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'color' to a length throws TypeError
 PASS Setting 'color' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-interpolation-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'color-interpolation' to CSS-wide keywords: initial
 PASS Can set 'color-interpolation' to CSS-wide keywords: inherit
 PASS Can set 'color-interpolation' to CSS-wide keywords: unset
 PASS Can set 'color-interpolation' to CSS-wide keywords: revert
-FAIL Can set 'color-interpolation' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'color-interpolation' to var() references:  var(--A)
 PASS Can set 'color-interpolation' to the 'auto' keyword: auto
 FAIL Can set 'color-interpolation' to the 'srgb' keyword: srgb assert_equals: expected "srgb" but got "sRGB"
 FAIL Can set 'color-interpolation' to the 'linearrgb' keyword: linearrgb assert_equals: expected "linearrgb" but got "linearRGB"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-count-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-count-expected.txt
@@ -3,12 +3,12 @@ PASS Can set 'column-count' to CSS-wide keywords: initial
 PASS Can set 'column-count' to CSS-wide keywords: inherit
 PASS Can set 'column-count' to CSS-wide keywords: unset
 PASS Can set 'column-count' to CSS-wide keywords: revert
-FAIL Can set 'column-count' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'column-count' to var() references:  var(--A)
 PASS Can set 'column-count' to the 'auto' keyword: auto
-FAIL Can set 'column-count' to a number: 0 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
-FAIL Can set 'column-count' to a number: -3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
-FAIL Can set 'column-count' to a number: 3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
-FAIL Can set 'column-count' to a number: calc(2 + 3) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'column-count' to a number: 0 assert_approx_equals: expected 1 +/- 0.000001 but got 0
+FAIL Can set 'column-count' to a number: -3.14 assert_approx_equals: expected 1 +/- 0.000001 but got 0
+PASS Can set 'column-count' to a number: 3.14
+PASS Can set 'column-count' to a number: calc(2 + 3)
 PASS Setting 'column-count' to a length throws TypeError
 PASS Setting 'column-count' to a percent throws TypeError
 PASS Setting 'column-count' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-color-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'column-rule-color' to CSS-wide keywords: initial
 PASS Can set 'column-rule-color' to CSS-wide keywords: inherit
 PASS Can set 'column-rule-color' to CSS-wide keywords: unset
 PASS Can set 'column-rule-color' to CSS-wide keywords: revert
-FAIL Can set 'column-rule-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'column-rule-color' to var() references:  var(--A)
 PASS Can set 'column-rule-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'column-rule-color' to a length throws TypeError
 PASS Setting 'column-rule-color' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-style-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'column-rule-style' to CSS-wide keywords: initial
 PASS Can set 'column-rule-style' to CSS-wide keywords: inherit
 PASS Can set 'column-rule-style' to CSS-wide keywords: unset
 PASS Can set 'column-rule-style' to CSS-wide keywords: revert
-FAIL Can set 'column-rule-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'column-rule-style' to var() references:  var(--A)
 PASS Can set 'column-rule-style' to the 'none' keyword: none
 PASS Can set 'column-rule-style' to the 'hidden' keyword: hidden
 PASS Can set 'column-rule-style' to the 'dotted' keyword: dotted

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt
@@ -3,14 +3,14 @@ PASS Can set 'column-rule-width' to CSS-wide keywords: initial
 PASS Can set 'column-rule-width' to CSS-wide keywords: inherit
 PASS Can set 'column-rule-width' to CSS-wide keywords: unset
 PASS Can set 'column-rule-width' to CSS-wide keywords: revert
-FAIL Can set 'column-rule-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'column-rule-width' to var() references:  var(--A)
 PASS Can set 'column-rule-width' to the 'thin' keyword: thin
 PASS Can set 'column-rule-width' to the 'medium' keyword: medium
 PASS Can set 'column-rule-width' to the 'thick' keyword: thick
 PASS Can set 'column-rule-width' to a length: 0px
 PASS Can set 'column-rule-width' to a length: -3.14em
 PASS Can set 'column-rule-width' to a length: 3.14cm
-FAIL Can set 'column-rule-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'column-rule-width' to a length: calc(0px + 0em)
 PASS Setting 'column-rule-width' to a percent throws TypeError
 PASS Setting 'column-rule-width' to a time throws TypeError
 PASS Setting 'column-rule-width' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-span-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-span-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'column-span' to CSS-wide keywords: initial
 PASS Can set 'column-span' to CSS-wide keywords: inherit
 PASS Can set 'column-span' to CSS-wide keywords: unset
 PASS Can set 'column-span' to CSS-wide keywords: revert
-FAIL Can set 'column-span' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'column-span' to var() references:  var(--A)
 PASS Can set 'column-span' to the 'none' keyword: none
 PASS Can set 'column-span' to the 'all' keyword: all
 PASS Setting 'column-span' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt
@@ -3,12 +3,12 @@ PASS Can set 'column-width' to CSS-wide keywords: initial
 PASS Can set 'column-width' to CSS-wide keywords: inherit
 PASS Can set 'column-width' to CSS-wide keywords: unset
 PASS Can set 'column-width' to CSS-wide keywords: revert
-FAIL Can set 'column-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'column-width' to var() references:  var(--A)
 PASS Can set 'column-width' to the 'auto' keyword: auto
 PASS Can set 'column-width' to a length: 0px
 PASS Can set 'column-width' to a length: -3.14em
 PASS Can set 'column-width' to a length: 3.14cm
-FAIL Can set 'column-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'column-width' to a length: calc(0px + 0em)
 PASS Setting 'column-width' to a percent throws TypeError
 PASS Setting 'column-width' to a time throws TypeError
 PASS Setting 'column-width' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/contain-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/contain-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'contain' to CSS-wide keywords: initial
 PASS Can set 'contain' to CSS-wide keywords: inherit
 PASS Can set 'contain' to CSS-wide keywords: unset
 PASS Can set 'contain' to CSS-wide keywords: revert
-FAIL Can set 'contain' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'contain' to var() references:  var(--A)
 PASS Can set 'contain' to the 'none' keyword: none
 PASS Can set 'contain' to the 'strict' keyword: strict
 PASS Can set 'contain' to the 'content' keyword: content

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'container-name' to CSS-wide keywords: initial
 PASS Can set 'container-name' to CSS-wide keywords: inherit
 PASS Can set 'container-name' to CSS-wide keywords: unset
 PASS Can set 'container-name' to CSS-wide keywords: revert
-FAIL Can set 'container-name' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'container-name' to var() references:  var(--A)
 PASS Can set 'container-name' to the 'none' keyword: none
 FAIL Can set 'container-name' to the 'my-container' keyword: my-container Invalid values
 PASS Setting 'container-name' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-type-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'container-type' to CSS-wide keywords: initial
 PASS Can set 'container-type' to CSS-wide keywords: inherit
 PASS Can set 'container-type' to CSS-wide keywords: unset
 PASS Can set 'container-type' to CSS-wide keywords: revert
-FAIL Can set 'container-type' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'container-type' to var() references:  var(--A)
 PASS Can set 'container-type' to the 'normal' keyword: normal
 PASS Can set 'container-type' to the 'size' keyword: size
 PASS Can set 'container-type' to the 'inline-size' keyword: inline-size

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'x' to CSS-wide keywords: initial
 PASS Can set 'x' to CSS-wide keywords: inherit
 PASS Can set 'x' to CSS-wide keywords: unset
 PASS Can set 'x' to CSS-wide keywords: revert
-FAIL Can set 'x' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'x' to var() references:  var(--A)
 PASS Can set 'x' to a percent: 0%
 PASS Can set 'x' to a percent: -3.14%
 PASS Can set 'x' to a percent: 3.14%
@@ -22,7 +22,7 @@ PASS Can set 'y' to CSS-wide keywords: initial
 PASS Can set 'y' to CSS-wide keywords: inherit
 PASS Can set 'y' to CSS-wide keywords: unset
 PASS Can set 'y' to CSS-wide keywords: revert
-FAIL Can set 'y' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'y' to var() references:  var(--A)
 PASS Can set 'y' to a percent: 0%
 PASS Can set 'y' to a percent: -3.14%
 PASS Can set 'y' to a percent: 3.14%

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-increment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-increment-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'counter-increment' to CSS-wide keywords: initial
 PASS Can set 'counter-increment' to CSS-wide keywords: inherit
 PASS Can set 'counter-increment' to CSS-wide keywords: unset
 PASS Can set 'counter-increment' to CSS-wide keywords: revert
-FAIL Can set 'counter-increment' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'counter-increment' to var() references:  var(--A)
 PASS Can set 'counter-increment' to the 'none' keyword: none
 PASS Setting 'counter-increment' to a length throws TypeError
 PASS Setting 'counter-increment' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-reset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-reset-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'counter-reset' to CSS-wide keywords: initial
 PASS Can set 'counter-reset' to CSS-wide keywords: inherit
 PASS Can set 'counter-reset' to CSS-wide keywords: unset
 PASS Can set 'counter-reset' to CSS-wide keywords: revert
-FAIL Can set 'counter-reset' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'counter-reset' to var() references:  var(--A)
 PASS Can set 'counter-reset' to the 'none' keyword: none
 PASS Setting 'counter-reset' to a length throws TypeError
 PASS Setting 'counter-reset' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/cursor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/cursor-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'cursor' to CSS-wide keywords: initial
 PASS Can set 'cursor' to CSS-wide keywords: inherit
 PASS Can set 'cursor' to CSS-wide keywords: unset
 PASS Can set 'cursor' to CSS-wide keywords: revert
-FAIL Can set 'cursor' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'cursor' to var() references:  var(--A)
 PASS Can set 'cursor' to the 'auto' keyword: auto
 PASS Can set 'cursor' to the 'default' keyword: default
 PASS Can set 'cursor' to the 'none' keyword: none

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/direction-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'direction' to CSS-wide keywords: initial
 PASS Can set 'direction' to CSS-wide keywords: inherit
 PASS Can set 'direction' to CSS-wide keywords: unset
 PASS Can set 'direction' to CSS-wide keywords: revert
-FAIL Can set 'direction' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'direction' to var() references:  var(--A)
 PASS Can set 'direction' to the 'ltr' keyword: ltr
 PASS Can set 'direction' to the 'rtl' keyword: rtl
 PASS Setting 'direction' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/display-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/display-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'display' to CSS-wide keywords: initial
 PASS Can set 'display' to CSS-wide keywords: inherit
 PASS Can set 'display' to CSS-wide keywords: unset
 PASS Can set 'display' to CSS-wide keywords: revert
-FAIL Can set 'display' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'display' to var() references:  var(--A)
 PASS Can set 'display' to the 'none' keyword: none
 PASS Can set 'display' to the 'block' keyword: block
 PASS Can set 'display' to the 'inline' keyword: inline

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/dominant-baseline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/dominant-baseline-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'dominant-baseline' to CSS-wide keywords: initial
 PASS Can set 'dominant-baseline' to CSS-wide keywords: inherit
 PASS Can set 'dominant-baseline' to CSS-wide keywords: unset
 PASS Can set 'dominant-baseline' to CSS-wide keywords: revert
-FAIL Can set 'dominant-baseline' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'dominant-baseline' to var() references:  var(--A)
 PASS Can set 'dominant-baseline' to the 'auto' keyword: auto
 FAIL Can set 'dominant-baseline' to the 'text-bottom' keyword: text-bottom Invalid values
 PASS Can set 'dominant-baseline' to the 'alphabetic' keyword: alphabetic

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/empty-cells-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/empty-cells-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'empty-cells' to CSS-wide keywords: initial
 PASS Can set 'empty-cells' to CSS-wide keywords: inherit
 PASS Can set 'empty-cells' to CSS-wide keywords: unset
 PASS Can set 'empty-cells' to CSS-wide keywords: revert
-FAIL Can set 'empty-cells' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'empty-cells' to var() references:  var(--A)
 PASS Can set 'empty-cells' to the 'show' keyword: show
 PASS Can set 'empty-cells' to the 'hide' keyword: hide
 PASS Setting 'empty-cells' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'fill-opacity' to CSS-wide keywords: initial
 PASS Can set 'fill-opacity' to CSS-wide keywords: inherit
 PASS Can set 'fill-opacity' to CSS-wide keywords: unset
 PASS Can set 'fill-opacity' to CSS-wide keywords: revert
-FAIL Can set 'fill-opacity' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'fill-opacity' to var() references:  var(--A)
 PASS Can set 'fill-opacity' to a number: 0
 PASS Can set 'fill-opacity' to a number: -3.14
 PASS Can set 'fill-opacity' to a number: 3.14

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-rule-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'fill-rule' to CSS-wide keywords: initial
 PASS Can set 'fill-rule' to CSS-wide keywords: inherit
 PASS Can set 'fill-rule' to CSS-wide keywords: unset
 PASS Can set 'fill-rule' to CSS-wide keywords: revert
-FAIL Can set 'fill-rule' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'fill-rule' to var() references:  var(--A)
 PASS Can set 'fill-rule' to the 'nonzero' keyword: nonzero
 PASS Can set 'fill-rule' to the 'evenodd' keyword: evenodd
 PASS Setting 'fill-rule' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/filter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/filter-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'filter' to CSS-wide keywords: initial
 PASS Can set 'filter' to CSS-wide keywords: inherit
 PASS Can set 'filter' to CSS-wide keywords: unset
 PASS Can set 'filter' to CSS-wide keywords: revert
-FAIL Can set 'filter' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'filter' to var() references:  var(--A)
 PASS Can set 'filter' to the 'none' keyword: none
 PASS Setting 'filter' to a length throws TypeError
 PASS Setting 'filter' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'flex-basis' to CSS-wide keywords: initial
 PASS Can set 'flex-basis' to CSS-wide keywords: inherit
 PASS Can set 'flex-basis' to CSS-wide keywords: unset
 PASS Can set 'flex-basis' to CSS-wide keywords: revert
-FAIL Can set 'flex-basis' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'flex-basis' to var() references:  var(--A)
 PASS Can set 'flex-basis' to the 'auto' keyword: auto
 PASS Can set 'flex-basis' to the 'content' keyword: content
 PASS Can set 'flex-basis' to the 'fit-content' keyword: fit-content
@@ -12,11 +12,11 @@ PASS Can set 'flex-basis' to the 'max-content' keyword: max-content
 PASS Can set 'flex-basis' to a length: 0px
 PASS Can set 'flex-basis' to a length: -3.14em
 PASS Can set 'flex-basis' to a length: 3.14cm
-FAIL Can set 'flex-basis' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'flex-basis' to a length: calc(0px + 0em)
 PASS Can set 'flex-basis' to a percent: 0%
 FAIL Can set 'flex-basis' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'flex-basis' to a percent: 3.14%
-FAIL Can set 'flex-basis' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'flex-basis' to a percent: calc(0% + 0%)
 PASS Setting 'flex-basis' to a time throws TypeError
 PASS Setting 'flex-basis' to an angle throws TypeError
 PASS Setting 'flex-basis' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-direction-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'flex-direction' to CSS-wide keywords: initial
 PASS Can set 'flex-direction' to CSS-wide keywords: inherit
 PASS Can set 'flex-direction' to CSS-wide keywords: unset
 PASS Can set 'flex-direction' to CSS-wide keywords: revert
-FAIL Can set 'flex-direction' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'flex-direction' to var() references:  var(--A)
 PASS Can set 'flex-direction' to the 'row' keyword: row
 PASS Can set 'flex-direction' to the 'row-reverse' keyword: row-reverse
 PASS Can set 'flex-direction' to the 'column' keyword: column

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt
@@ -3,11 +3,11 @@ PASS Can set 'flex-grow' to CSS-wide keywords: initial
 PASS Can set 'flex-grow' to CSS-wide keywords: inherit
 PASS Can set 'flex-grow' to CSS-wide keywords: unset
 PASS Can set 'flex-grow' to CSS-wide keywords: revert
-FAIL Can set 'flex-grow' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'flex-grow' to var() references:  var(--A)
 PASS Can set 'flex-grow' to a number: 0
 FAIL Can set 'flex-grow' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'flex-grow' to a number: 3.14
-FAIL Can set 'flex-grow' to a number: calc(2 + 3) assert_equals: expected 2 but got 1
+PASS Can set 'flex-grow' to a number: calc(2 + 3)
 PASS Setting 'flex-grow' to a length throws TypeError
 PASS Setting 'flex-grow' to a percent throws TypeError
 PASS Setting 'flex-grow' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt
@@ -3,11 +3,11 @@ PASS Can set 'flex-shrink' to CSS-wide keywords: initial
 PASS Can set 'flex-shrink' to CSS-wide keywords: inherit
 PASS Can set 'flex-shrink' to CSS-wide keywords: unset
 PASS Can set 'flex-shrink' to CSS-wide keywords: revert
-FAIL Can set 'flex-shrink' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'flex-shrink' to var() references:  var(--A)
 PASS Can set 'flex-shrink' to a number: 0
 FAIL Can set 'flex-shrink' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'flex-shrink' to a number: 3.14
-FAIL Can set 'flex-shrink' to a number: calc(2 + 3) assert_equals: expected 2 but got 1
+PASS Can set 'flex-shrink' to a number: calc(2 + 3)
 PASS Setting 'flex-shrink' to a length throws TypeError
 PASS Setting 'flex-shrink' to a percent throws TypeError
 PASS Setting 'flex-shrink' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-wrap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-wrap-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'flex-wrap' to CSS-wide keywords: initial
 PASS Can set 'flex-wrap' to CSS-wide keywords: inherit
 PASS Can set 'flex-wrap' to CSS-wide keywords: unset
 PASS Can set 'flex-wrap' to CSS-wide keywords: revert
-FAIL Can set 'flex-wrap' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'flex-wrap' to var() references:  var(--A)
 PASS Can set 'flex-wrap' to the 'nowrap' keyword: nowrap
 PASS Can set 'flex-wrap' to the 'wrap' keyword: wrap
 PASS Can set 'flex-wrap' to the 'wrap-reverse' keyword: wrap-reverse

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/float-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/float-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'float' to CSS-wide keywords: initial
 PASS Can set 'float' to CSS-wide keywords: inherit
 PASS Can set 'float' to CSS-wide keywords: unset
 PASS Can set 'float' to CSS-wide keywords: revert
-FAIL Can set 'float' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'float' to var() references:  var(--A)
 PASS Can set 'float' to the 'left' keyword: left
 PASS Can set 'float' to the 'right' keyword: right
 PASS Can set 'float' to the 'none' keyword: none

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-color-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'flood-color' to CSS-wide keywords: initial
 PASS Can set 'flood-color' to CSS-wide keywords: inherit
 PASS Can set 'flood-color' to CSS-wide keywords: unset
 PASS Can set 'flood-color' to CSS-wide keywords: revert
-FAIL Can set 'flood-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'flood-color' to var() references:  var(--A)
 PASS Can set 'flood-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'flood-color' to a length throws TypeError
 PASS Setting 'flood-color' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'flood-opacity' to CSS-wide keywords: initial
 PASS Can set 'flood-opacity' to CSS-wide keywords: inherit
 PASS Can set 'flood-opacity' to CSS-wide keywords: unset
 PASS Can set 'flood-opacity' to CSS-wide keywords: revert
-FAIL Can set 'flood-opacity' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'flood-opacity' to var() references:  var(--A)
 PASS Can set 'flood-opacity' to a number: 0
 PASS Can set 'flood-opacity' to a number: -3.14
 PASS Can set 'flood-opacity' to a number: 3.14

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-feature-settings-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-feature-settings-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'font-feature-settings' to CSS-wide keywords: initial
 PASS Can set 'font-feature-settings' to CSS-wide keywords: inherit
 PASS Can set 'font-feature-settings' to CSS-wide keywords: unset
 PASS Can set 'font-feature-settings' to CSS-wide keywords: revert
-FAIL Can set 'font-feature-settings' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-feature-settings' to var() references:  var(--A)
 PASS Can set 'font-feature-settings' to the 'normal' keyword: normal
 PASS Setting 'font-feature-settings' to a length throws TypeError
 PASS Setting 'font-feature-settings' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-kerning-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-kerning-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'font-kerning' to CSS-wide keywords: initial
 PASS Can set 'font-kerning' to CSS-wide keywords: inherit
 PASS Can set 'font-kerning' to CSS-wide keywords: unset
 PASS Can set 'font-kerning' to CSS-wide keywords: revert
-FAIL Can set 'font-kerning' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-kerning' to var() references:  var(--A)
 PASS Can set 'font-kerning' to the 'auto' keyword: auto
 PASS Can set 'font-kerning' to the 'normal' keyword: normal
 PASS Can set 'font-kerning' to the 'none' keyword: none

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-optical-sizing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-optical-sizing-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'font-optical-sizing' to CSS-wide keywords: initial
 PASS Can set 'font-optical-sizing' to CSS-wide keywords: inherit
 PASS Can set 'font-optical-sizing' to CSS-wide keywords: unset
 PASS Can set 'font-optical-sizing' to CSS-wide keywords: revert
-FAIL Can set 'font-optical-sizing' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-optical-sizing' to var() references:  var(--A)
 PASS Can set 'font-optical-sizing' to the 'auto' keyword: auto
 PASS Can set 'font-optical-sizing' to the 'none' keyword: none
 PASS Setting 'font-optical-sizing' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-palette-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-palette-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'font-palette' to CSS-wide keywords: initial
 PASS Can set 'font-palette' to CSS-wide keywords: inherit
 PASS Can set 'font-palette' to CSS-wide keywords: unset
 PASS Can set 'font-palette' to CSS-wide keywords: revert
-FAIL Can set 'font-palette' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-palette' to var() references:  var(--A)
 PASS Can set 'font-palette' to the 'normal' keyword: normal
 PASS Can set 'font-palette' to the 'light' keyword: light
 PASS Can set 'font-palette' to the 'dark' keyword: dark

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt
@@ -3,12 +3,12 @@ PASS Can set 'font-size-adjust' to CSS-wide keywords: initial
 PASS Can set 'font-size-adjust' to CSS-wide keywords: inherit
 PASS Can set 'font-size-adjust' to CSS-wide keywords: unset
 PASS Can set 'font-size-adjust' to CSS-wide keywords: revert
-FAIL Can set 'font-size-adjust' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-size-adjust' to var() references:  var(--A)
 PASS Can set 'font-size-adjust' to the 'none' keyword: none
 PASS Can set 'font-size-adjust' to a number: 0
 FAIL Can set 'font-size-adjust' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'font-size-adjust' to a number: 3.14
-FAIL Can set 'font-size-adjust' to a number: calc(2 + 3) assert_equals: expected 2 but got 1
+PASS Can set 'font-size-adjust' to a number: calc(2 + 3)
 PASS Setting 'font-size-adjust' to a length throws TypeError
 PASS Setting 'font-size-adjust' to a percent throws TypeError
 PASS Setting 'font-size-adjust' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'font-size' to CSS-wide keywords: initial
 PASS Can set 'font-size' to CSS-wide keywords: inherit
 PASS Can set 'font-size' to CSS-wide keywords: unset
 PASS Can set 'font-size' to CSS-wide keywords: revert
-FAIL Can set 'font-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-size' to var() references:  var(--A)
 PASS Can set 'font-size' to the 'xx-small' keyword: xx-small
 PASS Can set 'font-size' to the 'x-small' keyword: x-small
 PASS Can set 'font-size' to the 'small' keyword: small
@@ -16,11 +16,11 @@ PASS Can set 'font-size' to the 'smaller' keyword: smaller
 PASS Can set 'font-size' to a length: 0px
 PASS Can set 'font-size' to a length: -3.14em
 PASS Can set 'font-size' to a length: 3.14cm
-FAIL Can set 'font-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'font-size' to a length: calc(0px + 0em)
 PASS Can set 'font-size' to a percent: 0%
 PASS Can set 'font-size' to a percent: -3.14%
 PASS Can set 'font-size' to a percent: 3.14%
-FAIL Can set 'font-size' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'font-size' to a percent: calc(0% + 0%)
 PASS Setting 'font-size' to a time throws TypeError
 PASS Setting 'font-size' to an angle throws TypeError
 PASS Setting 'font-size' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'font-stretch' to CSS-wide keywords: initial
 PASS Can set 'font-stretch' to CSS-wide keywords: inherit
 PASS Can set 'font-stretch' to CSS-wide keywords: unset
 PASS Can set 'font-stretch' to CSS-wide keywords: revert
-FAIL Can set 'font-stretch' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-stretch' to var() references:  var(--A)
 FAIL Can set 'font-stretch' to the 'normal' keyword: normal assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'font-stretch' to the 'ultra-condensed' keyword: ultra-condensed assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'font-stretch' to the 'extra-condensed' keyword: extra-condensed assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
@@ -16,7 +16,7 @@ FAIL Can set 'font-stretch' to the 'ultra-expanded' keyword: ultra-expanded asse
 PASS Can set 'font-stretch' to a percent: 0%
 FAIL Can set 'font-stretch' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 FAIL Can set 'font-stretch' to a percent: 3.14% assert_approx_equals: expected 3.14 +/- 0.000001 but got 3
-FAIL Can set 'font-stretch' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'font-stretch' to a percent: calc(0% + 0%)
 PASS Setting 'font-stretch' to a length throws TypeError
 PASS Setting 'font-stretch' to a time throws TypeError
 PASS Setting 'font-stretch' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-style-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'font-style' to CSS-wide keywords: initial
 PASS Can set 'font-style' to CSS-wide keywords: inherit
 PASS Can set 'font-style' to CSS-wide keywords: unset
 PASS Can set 'font-style' to CSS-wide keywords: revert
-FAIL Can set 'font-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-style' to var() references:  var(--A)
 PASS Can set 'font-style' to the 'normal' keyword: normal
 PASS Can set 'font-style' to the 'italic' keyword: italic
 PASS Can set 'font-style' to the 'oblique' keyword: oblique

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-synthesis-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-synthesis-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'font-synthesis-weight' to CSS-wide keywords: initial
 PASS Can set 'font-synthesis-weight' to CSS-wide keywords: inherit
 PASS Can set 'font-synthesis-weight' to CSS-wide keywords: unset
 PASS Can set 'font-synthesis-weight' to CSS-wide keywords: revert
-FAIL Can set 'font-synthesis-weight' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-synthesis-weight' to var() references:  var(--A)
 PASS Can set 'font-synthesis-weight' to the 'auto' keyword: auto
 PASS Can set 'font-synthesis-weight' to the 'none' keyword: none
 PASS Setting 'font-synthesis-weight' to a length throws TypeError
@@ -18,7 +18,7 @@ PASS Can set 'font-synthesis-style' to CSS-wide keywords: initial
 PASS Can set 'font-synthesis-style' to CSS-wide keywords: inherit
 PASS Can set 'font-synthesis-style' to CSS-wide keywords: unset
 PASS Can set 'font-synthesis-style' to CSS-wide keywords: revert
-FAIL Can set 'font-synthesis-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-synthesis-style' to var() references:  var(--A)
 PASS Can set 'font-synthesis-style' to the 'auto' keyword: auto
 PASS Can set 'font-synthesis-style' to the 'none' keyword: none
 PASS Setting 'font-synthesis-style' to a length throws TypeError
@@ -33,7 +33,7 @@ PASS Can set 'font-synthesis-small-caps' to CSS-wide keywords: initial
 PASS Can set 'font-synthesis-small-caps' to CSS-wide keywords: inherit
 PASS Can set 'font-synthesis-small-caps' to CSS-wide keywords: unset
 PASS Can set 'font-synthesis-small-caps' to CSS-wide keywords: revert
-FAIL Can set 'font-synthesis-small-caps' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-synthesis-small-caps' to var() references:  var(--A)
 PASS Can set 'font-synthesis-small-caps' to the 'auto' keyword: auto
 PASS Can set 'font-synthesis-small-caps' to the 'none' keyword: none
 PASS Setting 'font-synthesis-small-caps' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-alternates-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-alternates-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'font-variant-alternates' to CSS-wide keywords: initial
 PASS Can set 'font-variant-alternates' to CSS-wide keywords: inherit
 PASS Can set 'font-variant-alternates' to CSS-wide keywords: unset
 PASS Can set 'font-variant-alternates' to CSS-wide keywords: revert
-FAIL Can set 'font-variant-alternates' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-variant-alternates' to var() references:  var(--A)
 PASS Can set 'font-variant-alternates' to the 'normal' keyword: normal
 FAIL Can set 'font-variant-alternates' to the 'historical-forms' keyword: historical-forms assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'font-variant-alternates' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-caps-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-caps-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'font-variant-caps' to CSS-wide keywords: initial
 PASS Can set 'font-variant-caps' to CSS-wide keywords: inherit
 PASS Can set 'font-variant-caps' to CSS-wide keywords: unset
 PASS Can set 'font-variant-caps' to CSS-wide keywords: revert
-FAIL Can set 'font-variant-caps' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-variant-caps' to var() references:  var(--A)
 PASS Can set 'font-variant-caps' to the 'normal' keyword: normal
 PASS Can set 'font-variant-caps' to the 'small-caps' keyword: small-caps
 PASS Can set 'font-variant-caps' to the 'all-small-caps' keyword: all-small-caps

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-east-asian-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-east-asian-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'font-variant-east-asian' to CSS-wide keywords: initial
 PASS Can set 'font-variant-east-asian' to CSS-wide keywords: inherit
 PASS Can set 'font-variant-east-asian' to CSS-wide keywords: unset
 PASS Can set 'font-variant-east-asian' to CSS-wide keywords: revert
-FAIL Can set 'font-variant-east-asian' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-variant-east-asian' to var() references:  var(--A)
 PASS Can set 'font-variant-east-asian' to the 'normal' keyword: normal
 PASS Can set 'font-variant-east-asian' to the 'jis78' keyword: jis78
 PASS Can set 'font-variant-east-asian' to the 'jis83' keyword: jis83

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-ligatures-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-ligatures-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'font-variant-ligatures' to CSS-wide keywords: initial
 PASS Can set 'font-variant-ligatures' to CSS-wide keywords: inherit
 PASS Can set 'font-variant-ligatures' to CSS-wide keywords: unset
 PASS Can set 'font-variant-ligatures' to CSS-wide keywords: revert
-FAIL Can set 'font-variant-ligatures' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-variant-ligatures' to var() references:  var(--A)
 PASS Can set 'font-variant-ligatures' to the 'normal' keyword: normal
 PASS Can set 'font-variant-ligatures' to the 'none' keyword: none
 PASS Can set 'font-variant-ligatures' to the 'common-ligatures' keyword: common-ligatures

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-numeric-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-numeric-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'font-variant-numeric' to CSS-wide keywords: initial
 PASS Can set 'font-variant-numeric' to CSS-wide keywords: inherit
 PASS Can set 'font-variant-numeric' to CSS-wide keywords: unset
 PASS Can set 'font-variant-numeric' to CSS-wide keywords: revert
-FAIL Can set 'font-variant-numeric' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-variant-numeric' to var() references:  var(--A)
 PASS Can set 'font-variant-numeric' to the 'normal' keyword: normal
 PASS Can set 'font-variant-numeric' to the 'lining-nums' keyword: lining-nums
 PASS Can set 'font-variant-numeric' to the 'oldstyle-nums' keyword: oldstyle-nums

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variation-settings-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variation-settings-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'font-variation-settings' to CSS-wide keywords: initial
 PASS Can set 'font-variation-settings' to CSS-wide keywords: inherit
 PASS Can set 'font-variation-settings' to CSS-wide keywords: unset
 PASS Can set 'font-variation-settings' to CSS-wide keywords: revert
-FAIL Can set 'font-variation-settings' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-variation-settings' to var() references:  var(--A)
 PASS Can set 'font-variation-settings' to the 'normal' keyword: normal
 PASS Setting 'font-variation-settings' to a length throws TypeError
 PASS Setting 'font-variation-settings' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt
@@ -3,15 +3,15 @@ PASS Can set 'font-weight' to CSS-wide keywords: initial
 PASS Can set 'font-weight' to CSS-wide keywords: inherit
 PASS Can set 'font-weight' to CSS-wide keywords: unset
 PASS Can set 'font-weight' to CSS-wide keywords: revert
-FAIL Can set 'font-weight' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'font-weight' to var() references:  var(--A)
 PASS Can set 'font-weight' to the 'normal' keyword: normal
 PASS Can set 'font-weight' to the 'bold' keyword: bold
 PASS Can set 'font-weight' to the 'bolder' keyword: bolder
 PASS Can set 'font-weight' to the 'lighter' keyword: lighter
-FAIL Can set 'font-weight' to a number: 0 assert_approx_equals: expected 0 +/- 0.000001 but got 1
-FAIL Can set 'font-weight' to a number: -3.14 assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
+FAIL Can set 'font-weight' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'font-weight' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 FAIL Can set 'font-weight' to a number: 3.14 assert_approx_equals: expected 3.14 +/- 0.000001 but got 3
-FAIL Can set 'font-weight' to a number: calc(2 + 3) assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
+PASS Can set 'font-weight' to a number: calc(2 + 3)
 PASS Setting 'font-weight' to a length throws TypeError
 PASS Setting 'font-weight' to a percent throws TypeError
 PASS Setting 'font-weight' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt
@@ -3,16 +3,16 @@ PASS Can set 'column-gap' to CSS-wide keywords: initial
 PASS Can set 'column-gap' to CSS-wide keywords: inherit
 PASS Can set 'column-gap' to CSS-wide keywords: unset
 PASS Can set 'column-gap' to CSS-wide keywords: revert
-FAIL Can set 'column-gap' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'column-gap' to var() references:  var(--A)
 PASS Can set 'column-gap' to the 'normal' keyword: normal
 PASS Can set 'column-gap' to a length: 0px
 PASS Can set 'column-gap' to a length: -3.14em
 PASS Can set 'column-gap' to a length: 3.14cm
-FAIL Can set 'column-gap' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'column-gap' to a length: calc(0px + 0em)
 PASS Can set 'column-gap' to a percent: 0%
 FAIL Can set 'column-gap' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'column-gap' to a percent: 3.14%
-FAIL Can set 'column-gap' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'column-gap' to a percent: calc(0% + 0%)
 PASS Setting 'column-gap' to a time throws TypeError
 PASS Setting 'column-gap' to an angle throws TypeError
 PASS Setting 'column-gap' to a flexible length throws TypeError
@@ -23,16 +23,16 @@ PASS Can set 'row-gap' to CSS-wide keywords: initial
 PASS Can set 'row-gap' to CSS-wide keywords: inherit
 PASS Can set 'row-gap' to CSS-wide keywords: unset
 PASS Can set 'row-gap' to CSS-wide keywords: revert
-FAIL Can set 'row-gap' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'row-gap' to var() references:  var(--A)
 PASS Can set 'row-gap' to the 'normal' keyword: normal
 PASS Can set 'row-gap' to a length: 0px
 PASS Can set 'row-gap' to a length: -3.14em
 PASS Can set 'row-gap' to a length: 3.14cm
-FAIL Can set 'row-gap' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'row-gap' to a length: calc(0px + 0em)
 PASS Can set 'row-gap' to a percent: 0%
 FAIL Can set 'row-gap' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'row-gap' to a percent: 3.14%
-FAIL Can set 'row-gap' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'row-gap' to a percent: calc(0% + 0%)
 PASS Setting 'row-gap' to a time throws TypeError
 PASS Setting 'row-gap' to an angle throws TypeError
 PASS Setting 'row-gap' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
@@ -1,11 +1,9 @@
 
-Harness Error (FAIL), message = 2 duplicate test names: "Can set 'grid-auto-columns' to a flexible length: 0fr", "Can set 'grid-auto-rows' to a flexible length: 0fr"
-
 PASS Can set 'grid-auto-columns' to CSS-wide keywords: initial
 PASS Can set 'grid-auto-columns' to CSS-wide keywords: inherit
 PASS Can set 'grid-auto-columns' to CSS-wide keywords: unset
 PASS Can set 'grid-auto-columns' to CSS-wide keywords: revert
-FAIL Can set 'grid-auto-columns' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-auto-columns' to var() references:  var(--A)
 PASS Can set 'grid-auto-columns' to the 'min-content' keyword: min-content
 PASS Can set 'grid-auto-columns' to the 'max-content' keyword: max-content
 PASS Can set 'grid-auto-columns' to the 'auto' keyword: auto
@@ -18,7 +16,7 @@ FAIL Can set 'grid-auto-columns' to a percent: -3.14% assert_equals: expected "C
 PASS Can set 'grid-auto-columns' to a percent: 3.14%
 PASS Can set 'grid-auto-columns' to a percent: calc(0% + 0%)
 PASS Can set 'grid-auto-columns' to a flexible length: 0fr
-PASS Can set 'grid-auto-columns' to a flexible length: 0fr
+PASS Can set 'grid-auto-columns' to a flexible length: 1fr
 FAIL Can set 'grid-auto-columns' to a flexible length: -3.14fr Invalid values
 PASS Setting 'grid-auto-columns' to a time throws TypeError
 PASS Setting 'grid-auto-columns' to an angle throws TypeError
@@ -31,7 +29,7 @@ PASS Can set 'grid-auto-rows' to CSS-wide keywords: initial
 PASS Can set 'grid-auto-rows' to CSS-wide keywords: inherit
 PASS Can set 'grid-auto-rows' to CSS-wide keywords: unset
 PASS Can set 'grid-auto-rows' to CSS-wide keywords: revert
-FAIL Can set 'grid-auto-rows' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-auto-rows' to var() references:  var(--A)
 PASS Can set 'grid-auto-rows' to the 'min-content' keyword: min-content
 PASS Can set 'grid-auto-rows' to the 'max-content' keyword: max-content
 PASS Can set 'grid-auto-rows' to the 'auto' keyword: auto
@@ -44,7 +42,7 @@ FAIL Can set 'grid-auto-rows' to a percent: -3.14% assert_equals: expected "CSSU
 PASS Can set 'grid-auto-rows' to a percent: 3.14%
 PASS Can set 'grid-auto-rows' to a percent: calc(0% + 0%)
 PASS Can set 'grid-auto-rows' to a flexible length: 0fr
-PASS Can set 'grid-auto-rows' to a flexible length: 0fr
+PASS Can set 'grid-auto-rows' to a flexible length: 1fr
 FAIL Can set 'grid-auto-rows' to a flexible length: -3.14fr Invalid values
 PASS Setting 'grid-auto-rows' to a time throws TypeError
 PASS Setting 'grid-auto-rows' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-flow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-flow-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'grid-auto-flow' to CSS-wide keywords: initial
 PASS Can set 'grid-auto-flow' to CSS-wide keywords: inherit
 PASS Can set 'grid-auto-flow' to CSS-wide keywords: unset
 PASS Can set 'grid-auto-flow' to CSS-wide keywords: revert
-FAIL Can set 'grid-auto-flow' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-auto-flow' to var() references:  var(--A)
 PASS Can set 'grid-auto-flow' to the 'row' keyword: row
 PASS Can set 'grid-auto-flow' to the 'column' keyword: column
 PASS Setting 'grid-auto-flow' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'grid-row-start' to CSS-wide keywords: initial
 PASS Can set 'grid-row-start' to CSS-wide keywords: inherit
 PASS Can set 'grid-row-start' to CSS-wide keywords: unset
 PASS Can set 'grid-row-start' to CSS-wide keywords: revert
-FAIL Can set 'grid-row-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-row-start' to var() references:  var(--A)
 PASS Can set 'grid-row-start' to the 'auto' keyword: auto
 PASS Setting 'grid-row-start' to a length throws TypeError
 PASS Setting 'grid-row-start' to a percent throws TypeError
@@ -20,7 +20,7 @@ PASS Can set 'grid-row-end' to CSS-wide keywords: initial
 PASS Can set 'grid-row-end' to CSS-wide keywords: inherit
 PASS Can set 'grid-row-end' to CSS-wide keywords: unset
 PASS Can set 'grid-row-end' to CSS-wide keywords: revert
-FAIL Can set 'grid-row-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-row-end' to var() references:  var(--A)
 PASS Can set 'grid-row-end' to the 'auto' keyword: auto
 PASS Setting 'grid-row-end' to a length throws TypeError
 PASS Setting 'grid-row-end' to a percent throws TypeError
@@ -37,7 +37,7 @@ PASS Can set 'grid-column-start' to CSS-wide keywords: initial
 PASS Can set 'grid-column-start' to CSS-wide keywords: inherit
 PASS Can set 'grid-column-start' to CSS-wide keywords: unset
 PASS Can set 'grid-column-start' to CSS-wide keywords: revert
-FAIL Can set 'grid-column-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-column-start' to var() references:  var(--A)
 PASS Can set 'grid-column-start' to the 'auto' keyword: auto
 PASS Setting 'grid-column-start' to a length throws TypeError
 PASS Setting 'grid-column-start' to a percent throws TypeError
@@ -54,7 +54,7 @@ PASS Can set 'grid-column-end' to CSS-wide keywords: initial
 PASS Can set 'grid-column-end' to CSS-wide keywords: inherit
 PASS Can set 'grid-column-end' to CSS-wide keywords: unset
 PASS Can set 'grid-column-end' to CSS-wide keywords: revert
-FAIL Can set 'grid-column-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-column-end' to var() references:  var(--A)
 PASS Can set 'grid-column-end' to the 'auto' keyword: auto
 PASS Setting 'grid-column-end' to a length throws TypeError
 PASS Setting 'grid-column-end' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-areas-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-areas-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'grid-template-areas' to CSS-wide keywords: initial
 PASS Can set 'grid-template-areas' to CSS-wide keywords: inherit
 PASS Can set 'grid-template-areas' to CSS-wide keywords: unset
 PASS Can set 'grid-template-areas' to CSS-wide keywords: revert
-FAIL Can set 'grid-template-areas' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-template-areas' to var() references:  var(--A)
 PASS Can set 'grid-template-areas' to the 'none' keyword: none
 PASS Setting 'grid-template-areas' to a length throws TypeError
 PASS Setting 'grid-template-areas' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'grid-template-columns' to CSS-wide keywords: initial
 PASS Can set 'grid-template-columns' to CSS-wide keywords: inherit
 PASS Can set 'grid-template-columns' to CSS-wide keywords: unset
 PASS Can set 'grid-template-columns' to CSS-wide keywords: revert
-FAIL Can set 'grid-template-columns' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-template-columns' to var() references:  var(--A)
 PASS Can set 'grid-template-columns' to the 'none' keyword: none
 FAIL Setting 'grid-template-columns' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 FAIL Setting 'grid-template-columns' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
@@ -19,7 +19,7 @@ PASS Can set 'grid-template-rows' to CSS-wide keywords: initial
 PASS Can set 'grid-template-rows' to CSS-wide keywords: inherit
 PASS Can set 'grid-template-rows' to CSS-wide keywords: unset
 PASS Can set 'grid-template-rows' to CSS-wide keywords: revert
-FAIL Can set 'grid-template-rows' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'grid-template-rows' to var() references:  var(--A)
 PASS Can set 'grid-template-rows' to the 'none' keyword: none
 FAIL Setting 'grid-template-rows' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 FAIL Setting 'grid-template-rows' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt
@@ -3,16 +3,16 @@ PASS Can set 'height' to CSS-wide keywords: initial
 PASS Can set 'height' to CSS-wide keywords: inherit
 PASS Can set 'height' to CSS-wide keywords: unset
 PASS Can set 'height' to CSS-wide keywords: revert
-FAIL Can set 'height' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'height' to var() references:  var(--A)
 PASS Can set 'height' to the 'auto' keyword: auto
 PASS Can set 'height' to a percent: 0%
 FAIL Can set 'height' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'height' to a percent: 3.14%
-FAIL Can set 'height' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'height' to a percent: calc(0% + 0%)
 PASS Can set 'height' to a length: 0px
 PASS Can set 'height' to a length: -3.14em
 PASS Can set 'height' to a length: 3.14cm
-FAIL Can set 'height' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'height' to a length: calc(0px + 0em)
 PASS Setting 'height' to a time throws TypeError
 PASS Setting 'height' to an angle throws TypeError
 PASS Setting 'height' to a flexible length throws TypeError
@@ -23,15 +23,15 @@ PASS Can set 'min-height' to CSS-wide keywords: initial
 PASS Can set 'min-height' to CSS-wide keywords: inherit
 PASS Can set 'min-height' to CSS-wide keywords: unset
 PASS Can set 'min-height' to CSS-wide keywords: revert
-FAIL Can set 'min-height' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'min-height' to var() references:  var(--A)
 PASS Can set 'min-height' to a percent: 0%
 FAIL Can set 'min-height' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'min-height' to a percent: 3.14%
-FAIL Can set 'min-height' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'min-height' to a percent: calc(0% + 0%)
 PASS Can set 'min-height' to a length: 0px
 PASS Can set 'min-height' to a length: -3.14em
 PASS Can set 'min-height' to a length: 3.14cm
-FAIL Can set 'min-height' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'min-height' to a length: calc(0px + 0em)
 PASS Setting 'min-height' to a time throws TypeError
 PASS Setting 'min-height' to an angle throws TypeError
 PASS Setting 'min-height' to a flexible length throws TypeError
@@ -42,16 +42,16 @@ PASS Can set 'max-height' to CSS-wide keywords: initial
 PASS Can set 'max-height' to CSS-wide keywords: inherit
 PASS Can set 'max-height' to CSS-wide keywords: unset
 PASS Can set 'max-height' to CSS-wide keywords: revert
-FAIL Can set 'max-height' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'max-height' to var() references:  var(--A)
 PASS Can set 'max-height' to the 'none' keyword: none
 PASS Can set 'max-height' to a percent: 0%
 FAIL Can set 'max-height' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'max-height' to a percent: 3.14%
-FAIL Can set 'max-height' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'max-height' to a percent: calc(0% + 0%)
 PASS Can set 'max-height' to a length: 0px
 PASS Can set 'max-height' to a length: -3.14em
 PASS Can set 'max-height' to a length: 3.14cm
-FAIL Can set 'max-height' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'max-height' to a length: calc(0px + 0em)
 PASS Setting 'max-height' to a time throws TypeError
 PASS Setting 'max-height' to an angle throws TypeError
 PASS Setting 'max-height' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'image-rendering' to CSS-wide keywords: initial
 PASS Can set 'image-rendering' to CSS-wide keywords: inherit
 PASS Can set 'image-rendering' to CSS-wide keywords: unset
 PASS Can set 'image-rendering' to CSS-wide keywords: revert
-FAIL Can set 'image-rendering' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'image-rendering' to var() references:  var(--A)
 PASS Can set 'image-rendering' to the 'auto' keyword: auto
 FAIL Can set 'image-rendering' to the 'smooth' keyword: smooth Invalid values
 FAIL Can set 'image-rendering' to the 'high-quality' keyword: high-quality Invalid values

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt
@@ -3,16 +3,16 @@ PASS Can set 'inline-size' to CSS-wide keywords: initial
 PASS Can set 'inline-size' to CSS-wide keywords: inherit
 PASS Can set 'inline-size' to CSS-wide keywords: unset
 PASS Can set 'inline-size' to CSS-wide keywords: revert
-FAIL Can set 'inline-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'inline-size' to var() references:  var(--A)
 PASS Can set 'inline-size' to the 'auto' keyword: auto
 PASS Can set 'inline-size' to a percent: 0%
 FAIL Can set 'inline-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'inline-size' to a percent: 3.14%
-FAIL Can set 'inline-size' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'inline-size' to a percent: calc(0% + 0%)
 PASS Can set 'inline-size' to a length: 0px
 PASS Can set 'inline-size' to a length: -3.14em
 PASS Can set 'inline-size' to a length: 3.14cm
-FAIL Can set 'inline-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'inline-size' to a length: calc(0px + 0em)
 PASS Setting 'inline-size' to a time throws TypeError
 PASS Setting 'inline-size' to an angle throws TypeError
 PASS Setting 'inline-size' to a flexible length throws TypeError
@@ -23,15 +23,15 @@ PASS Can set 'min-inline-size' to CSS-wide keywords: initial
 PASS Can set 'min-inline-size' to CSS-wide keywords: inherit
 PASS Can set 'min-inline-size' to CSS-wide keywords: unset
 PASS Can set 'min-inline-size' to CSS-wide keywords: revert
-FAIL Can set 'min-inline-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'min-inline-size' to var() references:  var(--A)
 PASS Can set 'min-inline-size' to a percent: 0%
 FAIL Can set 'min-inline-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'min-inline-size' to a percent: 3.14%
-FAIL Can set 'min-inline-size' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'min-inline-size' to a percent: calc(0% + 0%)
 PASS Can set 'min-inline-size' to a length: 0px
 PASS Can set 'min-inline-size' to a length: -3.14em
 PASS Can set 'min-inline-size' to a length: 3.14cm
-FAIL Can set 'min-inline-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'min-inline-size' to a length: calc(0px + 0em)
 PASS Setting 'min-inline-size' to a time throws TypeError
 PASS Setting 'min-inline-size' to an angle throws TypeError
 PASS Setting 'min-inline-size' to a flexible length throws TypeError
@@ -42,16 +42,16 @@ PASS Can set 'max-inline-size' to CSS-wide keywords: initial
 PASS Can set 'max-inline-size' to CSS-wide keywords: inherit
 PASS Can set 'max-inline-size' to CSS-wide keywords: unset
 PASS Can set 'max-inline-size' to CSS-wide keywords: revert
-FAIL Can set 'max-inline-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'max-inline-size' to var() references:  var(--A)
 PASS Can set 'max-inline-size' to the 'none' keyword: none
 PASS Can set 'max-inline-size' to a percent: 0%
 FAIL Can set 'max-inline-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'max-inline-size' to a percent: 3.14%
-FAIL Can set 'max-inline-size' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'max-inline-size' to a percent: calc(0% + 0%)
 PASS Can set 'max-inline-size' to a length: 0px
 PASS Can set 'max-inline-size' to a length: -3.14em
 PASS Can set 'max-inline-size' to a length: 3.14cm
-FAIL Can set 'max-inline-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'max-inline-size' to a length: calc(0px + 0em)
 PASS Setting 'max-inline-size' to a time throws TypeError
 PASS Setting 'max-inline-size' to an angle throws TypeError
 PASS Setting 'max-inline-size' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/isolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/isolation-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'isolation' to CSS-wide keywords: initial
 PASS Can set 'isolation' to CSS-wide keywords: inherit
 PASS Can set 'isolation' to CSS-wide keywords: unset
 PASS Can set 'isolation' to CSS-wide keywords: revert
-FAIL Can set 'isolation' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'isolation' to var() references:  var(--A)
 PASS Can set 'isolation' to the 'auto' keyword: auto
 PASS Can set 'isolation' to the 'isolate' keyword: isolate
 PASS Setting 'isolation' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/left-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/left-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'left' to CSS-wide keywords: initial
 PASS Can set 'left' to CSS-wide keywords: inherit
 PASS Can set 'left' to CSS-wide keywords: unset
 PASS Can set 'left' to CSS-wide keywords: revert
-FAIL Can set 'left' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'left' to var() references:  var(--A)
 PASS Can set 'left' to the 'auto' keyword: auto
 PASS Can set 'left' to a percent: 0%
 PASS Can set 'left' to a percent: -3.14%

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'letter-spacing' to CSS-wide keywords: initial
 PASS Can set 'letter-spacing' to CSS-wide keywords: inherit
 PASS Can set 'letter-spacing' to CSS-wide keywords: unset
 PASS Can set 'letter-spacing' to CSS-wide keywords: revert
-FAIL Can set 'letter-spacing' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'letter-spacing' to var() references:  var(--A)
 PASS Can set 'letter-spacing' to the 'normal' keyword: normal
 FAIL Can set 'letter-spacing' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSKeywordValue"
 PASS Can set 'letter-spacing' to a length: -3.14em

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/lighting-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/lighting-color-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'lighting-color' to CSS-wide keywords: initial
 PASS Can set 'lighting-color' to CSS-wide keywords: inherit
 PASS Can set 'lighting-color' to CSS-wide keywords: unset
 PASS Can set 'lighting-color' to CSS-wide keywords: revert
-FAIL Can set 'lighting-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'lighting-color' to var() references:  var(--A)
 PASS Can set 'lighting-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'lighting-color' to a length throws TypeError
 PASS Setting 'lighting-color' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-break-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-break-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'line-break' to CSS-wide keywords: initial
 PASS Can set 'line-break' to CSS-wide keywords: inherit
 PASS Can set 'line-break' to CSS-wide keywords: unset
 PASS Can set 'line-break' to CSS-wide keywords: revert
-FAIL Can set 'line-break' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'line-break' to var() references:  var(--A)
 PASS Can set 'line-break' to the 'auto' keyword: auto
 PASS Can set 'line-break' to the 'loose' keyword: loose
 PASS Can set 'line-break' to the 'normal' keyword: normal

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-expected.txt
@@ -3,20 +3,20 @@ PASS Can set 'line-height' to CSS-wide keywords: initial
 PASS Can set 'line-height' to CSS-wide keywords: inherit
 PASS Can set 'line-height' to CSS-wide keywords: unset
 PASS Can set 'line-height' to CSS-wide keywords: revert
-FAIL Can set 'line-height' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'line-height' to var() references:  var(--A)
 PASS Can set 'line-height' to the 'normal' keyword: normal
 PASS Can set 'line-height' to a length: 0px
 PASS Can set 'line-height' to a length: -3.14em
 PASS Can set 'line-height' to a length: 3.14cm
-FAIL Can set 'line-height' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'line-height' to a length: calc(0px + 0em)
 PASS Can set 'line-height' to a number: 0
 PASS Can set 'line-height' to a number: -3.14
 PASS Can set 'line-height' to a number: 3.14
-FAIL Can set 'line-height' to a number: calc(2 + 3) assert_equals: expected 2 but got 1
+PASS Can set 'line-height' to a number: calc(2 + 3)
 PASS Can set 'line-height' to a percent: 0%
 PASS Can set 'line-height' to a percent: -3.14%
 PASS Can set 'line-height' to a percent: 3.14%
-FAIL Can set 'line-height' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'line-height' to a percent: calc(0% + 0%)
 PASS Setting 'line-height' to a time throws TypeError
 PASS Setting 'line-height' to an angle throws TypeError
 PASS Setting 'line-height' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-image-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'list-style-image' to CSS-wide keywords: initial
 PASS Can set 'list-style-image' to CSS-wide keywords: inherit
 PASS Can set 'list-style-image' to CSS-wide keywords: unset
 PASS Can set 'list-style-image' to CSS-wide keywords: revert
-FAIL Can set 'list-style-image' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'list-style-image' to var() references:  var(--A)
 PASS Can set 'list-style-image' to the 'none' keyword: none
 PASS Can set 'list-style-image' to an image
 PASS Setting 'list-style-image' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-position-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'list-style-position' to CSS-wide keywords: initial
 PASS Can set 'list-style-position' to CSS-wide keywords: inherit
 PASS Can set 'list-style-position' to CSS-wide keywords: unset
 PASS Can set 'list-style-position' to CSS-wide keywords: revert
-FAIL Can set 'list-style-position' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'list-style-position' to var() references:  var(--A)
 PASS Can set 'list-style-position' to the 'inside' keyword: inside
 PASS Can set 'list-style-position' to the 'outside' keyword: outside
 PASS Setting 'list-style-position' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-type-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'list-style-type' to CSS-wide keywords: initial
 PASS Can set 'list-style-type' to CSS-wide keywords: inherit
 PASS Can set 'list-style-type' to CSS-wide keywords: unset
 PASS Can set 'list-style-type' to CSS-wide keywords: revert
-FAIL Can set 'list-style-type' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'list-style-type' to var() references:  var(--A)
 PASS Can set 'list-style-type' to the 'none' keyword: none
 FAIL Can set 'list-style-type' to the 'custom-ident' keyword: custom-ident Invalid values
 PASS Setting 'list-style-type' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'margin-block-start' to CSS-wide keywords: initial
 PASS Can set 'margin-block-start' to CSS-wide keywords: inherit
 PASS Can set 'margin-block-start' to CSS-wide keywords: unset
 PASS Can set 'margin-block-start' to CSS-wide keywords: revert
-FAIL Can set 'margin-block-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-block-start' to var() references:  var(--A)
 PASS Can set 'margin-block-start' to a percent: 0%
 PASS Can set 'margin-block-start' to a percent: -3.14%
 PASS Can set 'margin-block-start' to a percent: 3.14%
@@ -22,7 +22,7 @@ PASS Can set 'margin-block-end' to CSS-wide keywords: initial
 PASS Can set 'margin-block-end' to CSS-wide keywords: inherit
 PASS Can set 'margin-block-end' to CSS-wide keywords: unset
 PASS Can set 'margin-block-end' to CSS-wide keywords: revert
-FAIL Can set 'margin-block-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-block-end' to var() references:  var(--A)
 PASS Can set 'margin-block-end' to a percent: 0%
 PASS Can set 'margin-block-end' to a percent: -3.14%
 PASS Can set 'margin-block-end' to a percent: 3.14%
@@ -41,7 +41,7 @@ PASS Can set 'margin-inline-start' to CSS-wide keywords: initial
 PASS Can set 'margin-inline-start' to CSS-wide keywords: inherit
 PASS Can set 'margin-inline-start' to CSS-wide keywords: unset
 PASS Can set 'margin-inline-start' to CSS-wide keywords: revert
-FAIL Can set 'margin-inline-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-inline-start' to var() references:  var(--A)
 PASS Can set 'margin-inline-start' to a percent: 0%
 PASS Can set 'margin-inline-start' to a percent: -3.14%
 PASS Can set 'margin-inline-start' to a percent: 3.14%
@@ -60,7 +60,7 @@ PASS Can set 'margin-inline-end' to CSS-wide keywords: initial
 PASS Can set 'margin-inline-end' to CSS-wide keywords: inherit
 PASS Can set 'margin-inline-end' to CSS-wide keywords: unset
 PASS Can set 'margin-inline-end' to CSS-wide keywords: revert
-FAIL Can set 'margin-inline-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-inline-end' to var() references:  var(--A)
 PASS Can set 'margin-inline-end' to a percent: 0%
 PASS Can set 'margin-inline-end' to a percent: -3.14%
 PASS Can set 'margin-inline-end' to a percent: 3.14%
@@ -117,7 +117,7 @@ PASS Can set 'inset-block-start' to CSS-wide keywords: initial
 PASS Can set 'inset-block-start' to CSS-wide keywords: inherit
 PASS Can set 'inset-block-start' to CSS-wide keywords: unset
 PASS Can set 'inset-block-start' to CSS-wide keywords: revert
-FAIL Can set 'inset-block-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'inset-block-start' to var() references:  var(--A)
 PASS Can set 'inset-block-start' to a percent: 0%
 PASS Can set 'inset-block-start' to a percent: -3.14%
 PASS Can set 'inset-block-start' to a percent: 3.14%
@@ -136,7 +136,7 @@ PASS Can set 'inset-block-end' to CSS-wide keywords: initial
 PASS Can set 'inset-block-end' to CSS-wide keywords: inherit
 PASS Can set 'inset-block-end' to CSS-wide keywords: unset
 PASS Can set 'inset-block-end' to CSS-wide keywords: revert
-FAIL Can set 'inset-block-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'inset-block-end' to var() references:  var(--A)
 PASS Can set 'inset-block-end' to a percent: 0%
 PASS Can set 'inset-block-end' to a percent: -3.14%
 PASS Can set 'inset-block-end' to a percent: 3.14%
@@ -155,7 +155,7 @@ PASS Can set 'inset-inline-start' to CSS-wide keywords: initial
 PASS Can set 'inset-inline-start' to CSS-wide keywords: inherit
 PASS Can set 'inset-inline-start' to CSS-wide keywords: unset
 PASS Can set 'inset-inline-start' to CSS-wide keywords: revert
-FAIL Can set 'inset-inline-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'inset-inline-start' to var() references:  var(--A)
 PASS Can set 'inset-inline-start' to a percent: 0%
 PASS Can set 'inset-inline-start' to a percent: -3.14%
 PASS Can set 'inset-inline-start' to a percent: 3.14%
@@ -174,7 +174,7 @@ PASS Can set 'inset-inline-end' to CSS-wide keywords: initial
 PASS Can set 'inset-inline-end' to CSS-wide keywords: inherit
 PASS Can set 'inset-inline-end' to CSS-wide keywords: unset
 PASS Can set 'inset-inline-end' to CSS-wide keywords: revert
-FAIL Can set 'inset-inline-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'inset-inline-end' to var() references:  var(--A)
 PASS Can set 'inset-inline-end' to a percent: 0%
 PASS Can set 'inset-inline-end' to a percent: -3.14%
 PASS Can set 'inset-inline-end' to a percent: 3.14%
@@ -231,7 +231,7 @@ PASS Can set 'padding-block-start' to CSS-wide keywords: initial
 PASS Can set 'padding-block-start' to CSS-wide keywords: inherit
 PASS Can set 'padding-block-start' to CSS-wide keywords: unset
 PASS Can set 'padding-block-start' to CSS-wide keywords: revert
-FAIL Can set 'padding-block-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-block-start' to var() references:  var(--A)
 PASS Can set 'padding-block-start' to a percent: 0%
 FAIL Can set 'padding-block-start' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'padding-block-start' to a percent: 3.14%
@@ -250,7 +250,7 @@ PASS Can set 'padding-block-end' to CSS-wide keywords: initial
 PASS Can set 'padding-block-end' to CSS-wide keywords: inherit
 PASS Can set 'padding-block-end' to CSS-wide keywords: unset
 PASS Can set 'padding-block-end' to CSS-wide keywords: revert
-FAIL Can set 'padding-block-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-block-end' to var() references:  var(--A)
 PASS Can set 'padding-block-end' to a percent: 0%
 FAIL Can set 'padding-block-end' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'padding-block-end' to a percent: 3.14%
@@ -269,7 +269,7 @@ PASS Can set 'padding-inline-start' to CSS-wide keywords: initial
 PASS Can set 'padding-inline-start' to CSS-wide keywords: inherit
 PASS Can set 'padding-inline-start' to CSS-wide keywords: unset
 PASS Can set 'padding-inline-start' to CSS-wide keywords: revert
-FAIL Can set 'padding-inline-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-inline-start' to var() references:  var(--A)
 PASS Can set 'padding-inline-start' to a percent: 0%
 FAIL Can set 'padding-inline-start' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'padding-inline-start' to a percent: 3.14%
@@ -288,7 +288,7 @@ PASS Can set 'padding-inline-end' to CSS-wide keywords: initial
 PASS Can set 'padding-inline-end' to CSS-wide keywords: inherit
 PASS Can set 'padding-inline-end' to CSS-wide keywords: unset
 PASS Can set 'padding-inline-end' to CSS-wide keywords: revert
-FAIL Can set 'padding-inline-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-inline-end' to var() references:  var(--A)
 PASS Can set 'padding-inline-end' to a percent: 0%
 FAIL Can set 'padding-inline-end' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'padding-inline-end' to a percent: 3.14%
@@ -359,7 +359,7 @@ PASS Can set 'border-block-start-width' to CSS-wide keywords: initial
 PASS Can set 'border-block-start-width' to CSS-wide keywords: inherit
 PASS Can set 'border-block-start-width' to CSS-wide keywords: unset
 PASS Can set 'border-block-start-width' to CSS-wide keywords: revert
-FAIL Can set 'border-block-start-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-block-start-width' to var() references:  var(--A)
 FAIL Can set 'border-block-start-width' to the 'thin' keyword: thin assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-block-start-width' to the 'medium' keyword: medium assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-block-start-width' to the 'thick' keyword: thick assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
@@ -378,7 +378,7 @@ PASS Can set 'border-block-start-color' to CSS-wide keywords: initial
 PASS Can set 'border-block-start-color' to CSS-wide keywords: inherit
 PASS Can set 'border-block-start-color' to CSS-wide keywords: unset
 PASS Can set 'border-block-start-color' to CSS-wide keywords: revert
-FAIL Can set 'border-block-start-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-block-start-color' to var() references:  var(--A)
 FAIL Can set 'border-block-start-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'border-block-start-color' to a length throws TypeError
 PASS Setting 'border-block-start-color' to a percent throws TypeError
@@ -392,7 +392,7 @@ PASS Can set 'border-block-start-style' to CSS-wide keywords: initial
 PASS Can set 'border-block-start-style' to CSS-wide keywords: inherit
 PASS Can set 'border-block-start-style' to CSS-wide keywords: unset
 PASS Can set 'border-block-start-style' to CSS-wide keywords: revert
-FAIL Can set 'border-block-start-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-block-start-style' to var() references:  var(--A)
 PASS Can set 'border-block-start-style' to the 'none' keyword: none
 PASS Can set 'border-block-start-style' to the 'solid' keyword: solid
 PASS Setting 'border-block-start-style' to a length throws TypeError
@@ -421,7 +421,7 @@ PASS Can set 'border-block-end-width' to CSS-wide keywords: initial
 PASS Can set 'border-block-end-width' to CSS-wide keywords: inherit
 PASS Can set 'border-block-end-width' to CSS-wide keywords: unset
 PASS Can set 'border-block-end-width' to CSS-wide keywords: revert
-FAIL Can set 'border-block-end-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-block-end-width' to var() references:  var(--A)
 FAIL Can set 'border-block-end-width' to the 'thin' keyword: thin assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-block-end-width' to the 'medium' keyword: medium assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-block-end-width' to the 'thick' keyword: thick assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
@@ -440,7 +440,7 @@ PASS Can set 'border-block-end-color' to CSS-wide keywords: initial
 PASS Can set 'border-block-end-color' to CSS-wide keywords: inherit
 PASS Can set 'border-block-end-color' to CSS-wide keywords: unset
 PASS Can set 'border-block-end-color' to CSS-wide keywords: revert
-FAIL Can set 'border-block-end-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-block-end-color' to var() references:  var(--A)
 FAIL Can set 'border-block-end-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'border-block-end-color' to a length throws TypeError
 PASS Setting 'border-block-end-color' to a percent throws TypeError
@@ -454,7 +454,7 @@ PASS Can set 'border-block-end-style' to CSS-wide keywords: initial
 PASS Can set 'border-block-end-style' to CSS-wide keywords: inherit
 PASS Can set 'border-block-end-style' to CSS-wide keywords: unset
 PASS Can set 'border-block-end-style' to CSS-wide keywords: revert
-FAIL Can set 'border-block-end-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-block-end-style' to var() references:  var(--A)
 PASS Can set 'border-block-end-style' to the 'none' keyword: none
 PASS Can set 'border-block-end-style' to the 'solid' keyword: solid
 PASS Setting 'border-block-end-style' to a length throws TypeError
@@ -483,7 +483,7 @@ PASS Can set 'border-inline-start-width' to CSS-wide keywords: initial
 PASS Can set 'border-inline-start-width' to CSS-wide keywords: inherit
 PASS Can set 'border-inline-start-width' to CSS-wide keywords: unset
 PASS Can set 'border-inline-start-width' to CSS-wide keywords: revert
-FAIL Can set 'border-inline-start-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-inline-start-width' to var() references:  var(--A)
 FAIL Can set 'border-inline-start-width' to the 'thin' keyword: thin assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-inline-start-width' to the 'medium' keyword: medium assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-inline-start-width' to the 'thick' keyword: thick assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
@@ -502,7 +502,7 @@ PASS Can set 'border-inline-start-color' to CSS-wide keywords: initial
 PASS Can set 'border-inline-start-color' to CSS-wide keywords: inherit
 PASS Can set 'border-inline-start-color' to CSS-wide keywords: unset
 PASS Can set 'border-inline-start-color' to CSS-wide keywords: revert
-FAIL Can set 'border-inline-start-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-inline-start-color' to var() references:  var(--A)
 FAIL Can set 'border-inline-start-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'border-inline-start-color' to a length throws TypeError
 PASS Setting 'border-inline-start-color' to a percent throws TypeError
@@ -516,7 +516,7 @@ PASS Can set 'border-inline-start-style' to CSS-wide keywords: initial
 PASS Can set 'border-inline-start-style' to CSS-wide keywords: inherit
 PASS Can set 'border-inline-start-style' to CSS-wide keywords: unset
 PASS Can set 'border-inline-start-style' to CSS-wide keywords: revert
-FAIL Can set 'border-inline-start-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-inline-start-style' to var() references:  var(--A)
 PASS Can set 'border-inline-start-style' to the 'none' keyword: none
 PASS Can set 'border-inline-start-style' to the 'solid' keyword: solid
 PASS Setting 'border-inline-start-style' to a length throws TypeError
@@ -545,7 +545,7 @@ PASS Can set 'border-inline-end-width' to CSS-wide keywords: initial
 PASS Can set 'border-inline-end-width' to CSS-wide keywords: inherit
 PASS Can set 'border-inline-end-width' to CSS-wide keywords: unset
 PASS Can set 'border-inline-end-width' to CSS-wide keywords: revert
-FAIL Can set 'border-inline-end-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-inline-end-width' to var() references:  var(--A)
 FAIL Can set 'border-inline-end-width' to the 'thin' keyword: thin assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-inline-end-width' to the 'medium' keyword: medium assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-inline-end-width' to the 'thick' keyword: thick assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
@@ -564,7 +564,7 @@ PASS Can set 'border-inline-end-color' to CSS-wide keywords: initial
 PASS Can set 'border-inline-end-color' to CSS-wide keywords: inherit
 PASS Can set 'border-inline-end-color' to CSS-wide keywords: unset
 PASS Can set 'border-inline-end-color' to CSS-wide keywords: revert
-FAIL Can set 'border-inline-end-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-inline-end-color' to var() references:  var(--A)
 FAIL Can set 'border-inline-end-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Setting 'border-inline-end-color' to a length throws TypeError
 PASS Setting 'border-inline-end-color' to a percent throws TypeError
@@ -578,7 +578,7 @@ PASS Can set 'border-inline-end-style' to CSS-wide keywords: initial
 PASS Can set 'border-inline-end-style' to CSS-wide keywords: inherit
 PASS Can set 'border-inline-end-style' to CSS-wide keywords: unset
 PASS Can set 'border-inline-end-style' to CSS-wide keywords: revert
-FAIL Can set 'border-inline-end-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-inline-end-style' to var() references:  var(--A)
 PASS Can set 'border-inline-end-style' to the 'none' keyword: none
 PASS Can set 'border-inline-end-style' to the 'solid' keyword: solid
 PASS Setting 'border-inline-end-style' to a length throws TypeError
@@ -717,15 +717,15 @@ PASS Can set 'border-start-start-radius' to CSS-wide keywords: initial
 PASS Can set 'border-start-start-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-start-start-radius' to CSS-wide keywords: unset
 PASS Can set 'border-start-start-radius' to CSS-wide keywords: revert
-FAIL Can set 'border-start-start-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-start-start-radius' to var() references:  var(--A)
 FAIL Can set 'border-start-start-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'border-start-start-radius' to a percent: -3.14% Invalid values
 FAIL Can set 'border-start-start-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-start-start-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-start-start-radius' to a percent: calc(0% + 0%) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
 FAIL Can set 'border-start-start-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'border-start-start-radius' to a length: -3.14em Invalid values
-FAIL Can set 'border-start-start-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-start-start-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-start-start-radius' to a length: 3.14cm assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-start-start-radius' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
 PASS Setting 'border-start-start-radius' to a time throws TypeError
 PASS Setting 'border-start-start-radius' to an angle throws TypeError
 PASS Setting 'border-start-start-radius' to a flexible length throws TypeError
@@ -736,15 +736,15 @@ PASS Can set 'border-start-end-radius' to CSS-wide keywords: initial
 PASS Can set 'border-start-end-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-start-end-radius' to CSS-wide keywords: unset
 PASS Can set 'border-start-end-radius' to CSS-wide keywords: revert
-FAIL Can set 'border-start-end-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-start-end-radius' to var() references:  var(--A)
 FAIL Can set 'border-start-end-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'border-start-end-radius' to a percent: -3.14% Invalid values
 FAIL Can set 'border-start-end-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-start-end-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-start-end-radius' to a percent: calc(0% + 0%) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
 FAIL Can set 'border-start-end-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'border-start-end-radius' to a length: -3.14em Invalid values
-FAIL Can set 'border-start-end-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-start-end-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-start-end-radius' to a length: 3.14cm assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-start-end-radius' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
 PASS Setting 'border-start-end-radius' to a time throws TypeError
 PASS Setting 'border-start-end-radius' to an angle throws TypeError
 PASS Setting 'border-start-end-radius' to a flexible length throws TypeError
@@ -755,15 +755,15 @@ PASS Can set 'border-end-start-radius' to CSS-wide keywords: initial
 PASS Can set 'border-end-start-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-end-start-radius' to CSS-wide keywords: unset
 PASS Can set 'border-end-start-radius' to CSS-wide keywords: revert
-FAIL Can set 'border-end-start-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-end-start-radius' to var() references:  var(--A)
 FAIL Can set 'border-end-start-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'border-end-start-radius' to a percent: -3.14% Invalid values
 FAIL Can set 'border-end-start-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-end-start-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-end-start-radius' to a percent: calc(0% + 0%) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
 FAIL Can set 'border-end-start-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'border-end-start-radius' to a length: -3.14em Invalid values
-FAIL Can set 'border-end-start-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-end-start-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-end-start-radius' to a length: 3.14cm assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-end-start-radius' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
 PASS Setting 'border-end-start-radius' to a time throws TypeError
 PASS Setting 'border-end-start-radius' to an angle throws TypeError
 PASS Setting 'border-end-start-radius' to a flexible length throws TypeError
@@ -774,15 +774,15 @@ PASS Can set 'border-end-end-radius' to CSS-wide keywords: initial
 PASS Can set 'border-end-end-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-end-end-radius' to CSS-wide keywords: unset
 PASS Can set 'border-end-end-radius' to CSS-wide keywords: revert
-FAIL Can set 'border-end-end-radius' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'border-end-end-radius' to var() references:  var(--A)
 FAIL Can set 'border-end-end-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'border-end-end-radius' to a percent: -3.14% Invalid values
 FAIL Can set 'border-end-end-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-end-end-radius' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-end-end-radius' to a percent: calc(0% + 0%) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
 FAIL Can set 'border-end-end-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'border-end-end-radius' to a length: -3.14em Invalid values
-FAIL Can set 'border-end-end-radius' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-end-end-radius' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-end-end-radius' to a length: 3.14cm assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-end-end-radius' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
 PASS Setting 'border-end-end-radius' to a time throws TypeError
 PASS Setting 'border-end-end-radius' to an angle throws TypeError
 PASS Setting 'border-end-end-radius' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/margin-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'margin-top' to CSS-wide keywords: initial
 PASS Can set 'margin-top' to CSS-wide keywords: inherit
 PASS Can set 'margin-top' to CSS-wide keywords: unset
 PASS Can set 'margin-top' to CSS-wide keywords: revert
-FAIL Can set 'margin-top' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-top' to var() references:  var(--A)
 PASS Can set 'margin-top' to the 'auto' keyword: auto
 PASS Can set 'margin-top' to a percent: 0%
 PASS Can set 'margin-top' to a percent: -3.14%
@@ -23,7 +23,7 @@ PASS Can set 'margin-left' to CSS-wide keywords: initial
 PASS Can set 'margin-left' to CSS-wide keywords: inherit
 PASS Can set 'margin-left' to CSS-wide keywords: unset
 PASS Can set 'margin-left' to CSS-wide keywords: revert
-FAIL Can set 'margin-left' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-left' to var() references:  var(--A)
 PASS Can set 'margin-left' to the 'auto' keyword: auto
 PASS Can set 'margin-left' to a percent: 0%
 PASS Can set 'margin-left' to a percent: -3.14%
@@ -43,7 +43,7 @@ PASS Can set 'margin-right' to CSS-wide keywords: initial
 PASS Can set 'margin-right' to CSS-wide keywords: inherit
 PASS Can set 'margin-right' to CSS-wide keywords: unset
 PASS Can set 'margin-right' to CSS-wide keywords: revert
-FAIL Can set 'margin-right' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-right' to var() references:  var(--A)
 PASS Can set 'margin-right' to the 'auto' keyword: auto
 PASS Can set 'margin-right' to a percent: 0%
 PASS Can set 'margin-right' to a percent: -3.14%
@@ -63,7 +63,7 @@ PASS Can set 'margin-bottom' to CSS-wide keywords: initial
 PASS Can set 'margin-bottom' to CSS-wide keywords: inherit
 PASS Can set 'margin-bottom' to CSS-wide keywords: unset
 PASS Can set 'margin-bottom' to CSS-wide keywords: revert
-FAIL Can set 'margin-bottom' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'margin-bottom' to var() references:  var(--A)
 PASS Can set 'margin-bottom' to the 'auto' keyword: auto
 PASS Can set 'margin-bottom' to a percent: 0%
 PASS Can set 'margin-bottom' to a percent: -3.14%

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/marker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/marker-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'marker-start' to CSS-wide keywords: initial
 PASS Can set 'marker-start' to CSS-wide keywords: inherit
 PASS Can set 'marker-start' to CSS-wide keywords: unset
 PASS Can set 'marker-start' to CSS-wide keywords: revert
-FAIL Can set 'marker-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'marker-start' to var() references:  var(--A)
 PASS Can set 'marker-start' to the 'none' keyword: none
 PASS Setting 'marker-start' to a length throws TypeError
 PASS Setting 'marker-start' to a percent throws TypeError
@@ -18,7 +18,7 @@ PASS Can set 'marker-mid' to CSS-wide keywords: initial
 PASS Can set 'marker-mid' to CSS-wide keywords: inherit
 PASS Can set 'marker-mid' to CSS-wide keywords: unset
 PASS Can set 'marker-mid' to CSS-wide keywords: revert
-FAIL Can set 'marker-mid' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'marker-mid' to var() references:  var(--A)
 PASS Can set 'marker-mid' to the 'none' keyword: none
 PASS Setting 'marker-mid' to a length throws TypeError
 PASS Setting 'marker-mid' to a percent throws TypeError
@@ -31,7 +31,7 @@ PASS Can set 'marker-end' to CSS-wide keywords: initial
 PASS Can set 'marker-end' to CSS-wide keywords: inherit
 PASS Can set 'marker-end' to CSS-wide keywords: unset
 PASS Can set 'marker-end' to CSS-wide keywords: revert
-FAIL Can set 'marker-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'marker-end' to var() references:  var(--A)
 PASS Can set 'marker-end' to the 'none' keyword: none
 PASS Setting 'marker-end' to a length throws TypeError
 PASS Setting 'marker-end' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-image-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'mask-image' to CSS-wide keywords: initial
 PASS Can set 'mask-image' to CSS-wide keywords: inherit
 PASS Can set 'mask-image' to CSS-wide keywords: unset
 PASS Can set 'mask-image' to CSS-wide keywords: revert
-FAIL Can set 'mask-image' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'mask-image' to var() references:  var(--A)
 PASS Can set 'mask-image' to the 'none' keyword: none
 PASS Can set 'mask-image' to an image
 PASS Setting 'mask-image' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-type-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'mask-type' to CSS-wide keywords: initial
 PASS Can set 'mask-type' to CSS-wide keywords: inherit
 PASS Can set 'mask-type' to CSS-wide keywords: unset
 PASS Can set 'mask-type' to CSS-wide keywords: revert
-FAIL Can set 'mask-type' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'mask-type' to var() references:  var(--A)
 PASS Can set 'mask-type' to the 'luminance' keyword: luminance
 PASS Can set 'mask-type' to the 'alpha' keyword: alpha
 PASS Setting 'mask-type' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mix-blend-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mix-blend-mode-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'mix-blend-mode' to CSS-wide keywords: initial
 PASS Can set 'mix-blend-mode' to CSS-wide keywords: inherit
 PASS Can set 'mix-blend-mode' to CSS-wide keywords: unset
 PASS Can set 'mix-blend-mode' to CSS-wide keywords: revert
-FAIL Can set 'mix-blend-mode' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'mix-blend-mode' to var() references:  var(--A)
 PASS Can set 'mix-blend-mode' to the 'normal' keyword: normal
 PASS Can set 'mix-blend-mode' to the 'multiply' keyword: multiply
 PASS Can set 'mix-blend-mode' to the 'screen' keyword: screen

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-fit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-fit-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'object-fit' to CSS-wide keywords: initial
 PASS Can set 'object-fit' to CSS-wide keywords: inherit
 PASS Can set 'object-fit' to CSS-wide keywords: unset
 PASS Can set 'object-fit' to CSS-wide keywords: revert
-FAIL Can set 'object-fit' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'object-fit' to var() references:  var(--A)
 PASS Can set 'object-fit' to the 'fill' keyword: fill
 PASS Can set 'object-fit' to the 'contain' keyword: contain
 PASS Can set 'object-fit' to the 'cover' keyword: cover

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-position-expected.txt
@@ -6,5 +6,5 @@ PASS Can set 'object-position' to CSS-wide keywords: initial
 PASS Can set 'object-position' to CSS-wide keywords: inherit
 PASS Can set 'object-position' to CSS-wide keywords: unset
 PASS Can set 'object-position' to CSS-wide keywords: revert
-FAIL Can set 'object-position' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'object-position' to var() references:  var(--A)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-anchor-expected.txt
@@ -6,6 +6,6 @@ PASS Can set 'offset-anchor' to CSS-wide keywords: initial
 PASS Can set 'offset-anchor' to CSS-wide keywords: inherit
 PASS Can set 'offset-anchor' to CSS-wide keywords: unset
 PASS Can set 'offset-anchor' to CSS-wide keywords: revert
-FAIL Can set 'offset-anchor' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'offset-anchor' to var() references:  var(--A)
 PASS Can set 'offset-anchor' to the 'auto' keyword: auto
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-distance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-distance-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'offset-distance' to CSS-wide keywords: initial
 PASS Can set 'offset-distance' to CSS-wide keywords: inherit
 PASS Can set 'offset-distance' to CSS-wide keywords: unset
 PASS Can set 'offset-distance' to CSS-wide keywords: revert
-FAIL Can set 'offset-distance' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'offset-distance' to var() references:  var(--A)
 PASS Can set 'offset-distance' to a length: 0px
 PASS Can set 'offset-distance' to a length: -3.14em
 PASS Can set 'offset-distance' to a length: 3.14cm

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-path-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-path-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'offset-path' to CSS-wide keywords: initial
 PASS Can set 'offset-path' to CSS-wide keywords: inherit
 PASS Can set 'offset-path' to CSS-wide keywords: unset
 PASS Can set 'offset-path' to CSS-wide keywords: revert
-FAIL Can set 'offset-path' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'offset-path' to var() references:  var(--A)
 PASS Can set 'offset-path' to the 'none' keyword: none
 PASS Setting 'offset-path' to a length throws TypeError
 PASS Setting 'offset-path' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-position-expected.txt
@@ -6,6 +6,6 @@ PASS Can set 'offset-position' to CSS-wide keywords: initial
 PASS Can set 'offset-position' to CSS-wide keywords: inherit
 PASS Can set 'offset-position' to CSS-wide keywords: unset
 PASS Can set 'offset-position' to CSS-wide keywords: revert
-FAIL Can set 'offset-position' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'offset-position' to var() references:  var(--A)
 PASS Can set 'offset-position' to the 'auto' keyword: auto
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-rotate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-rotate-expected.txt
@@ -3,13 +3,13 @@ PASS Can set 'offset-rotate' to CSS-wide keywords: initial
 PASS Can set 'offset-rotate' to CSS-wide keywords: inherit
 PASS Can set 'offset-rotate' to CSS-wide keywords: unset
 PASS Can set 'offset-rotate' to CSS-wide keywords: revert
-FAIL Can set 'offset-rotate' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Can set 'offset-rotate' to the 'auto' keyword: auto assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'offset-rotate' to the 'reverse' keyword: reverse assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'offset-rotate' to an angle: 0deg assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'offset-rotate' to an angle: 3.14rad assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'offset-rotate' to an angle: -3.14deg assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'offset-rotate' to an angle: calc(0rad + 0deg) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+PASS Can set 'offset-rotate' to var() references:  var(--A)
+PASS Can set 'offset-rotate' to the 'auto' keyword: auto
+FAIL Can set 'offset-rotate' to the 'reverse' keyword: reverse assert_equals: expected "reverse" but got "auto"
+PASS Can set 'offset-rotate' to an angle: 0deg
+PASS Can set 'offset-rotate' to an angle: 3.14rad
+PASS Can set 'offset-rotate' to an angle: -3.14deg
+PASS Can set 'offset-rotate' to an angle: calc(0rad + 0deg)
 PASS Setting 'offset-rotate' to a length throws TypeError
 PASS Setting 'offset-rotate' to a percent throws TypeError
 PASS Setting 'offset-rotate' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'opacity' to CSS-wide keywords: initial
 PASS Can set 'opacity' to CSS-wide keywords: inherit
 PASS Can set 'opacity' to CSS-wide keywords: unset
 PASS Can set 'opacity' to CSS-wide keywords: revert
-FAIL Can set 'opacity' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'opacity' to var() references:  var(--A)
 PASS Can set 'opacity' to a number: 0
 PASS Can set 'opacity' to a number: -3.14
 PASS Can set 'opacity' to a number: 3.14

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt
@@ -3,11 +3,11 @@ PASS Can set 'order' to CSS-wide keywords: initial
 PASS Can set 'order' to CSS-wide keywords: inherit
 PASS Can set 'order' to CSS-wide keywords: unset
 PASS Can set 'order' to CSS-wide keywords: revert
-FAIL Can set 'order' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'order' to var() references:  var(--A)
 FAIL Can set 'order' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'order' to a number: -3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
-FAIL Can set 'order' to a number: 3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
-FAIL Can set 'order' to a number: calc(2 + 3) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'order' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'order' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'order' to a number: calc(2 + 3) assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 PASS Setting 'order' to a length throws TypeError
 PASS Setting 'order' to a percent throws TypeError
 PASS Setting 'order' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt
@@ -3,11 +3,11 @@ PASS Can set 'orphans' to CSS-wide keywords: initial
 PASS Can set 'orphans' to CSS-wide keywords: inherit
 PASS Can set 'orphans' to CSS-wide keywords: unset
 PASS Can set 'orphans' to CSS-wide keywords: revert
-FAIL Can set 'orphans' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Can set 'orphans' to a number: 0 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
-FAIL Can set 'orphans' to a number: -3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
-FAIL Can set 'orphans' to a number: 3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
-FAIL Can set 'orphans' to a number: calc(2 + 3) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+PASS Can set 'orphans' to var() references:  var(--A)
+FAIL Can set 'orphans' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'orphans' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'orphans' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'orphans' to a number: calc(2 + 3) assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 PASS Setting 'orphans' to a length throws TypeError
 PASS Setting 'orphans' to a percent throws TypeError
 PASS Setting 'orphans' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-color-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'outline-color' to CSS-wide keywords: initial
 PASS Can set 'outline-color' to CSS-wide keywords: inherit
 PASS Can set 'outline-color' to CSS-wide keywords: unset
 PASS Can set 'outline-color' to CSS-wide keywords: revert
-FAIL Can set 'outline-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'outline-color' to var() references:  var(--A)
 PASS Can set 'outline-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'outline-color' to a length throws TypeError
 PASS Setting 'outline-color' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-offset-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'outline-offset' to CSS-wide keywords: initial
 PASS Can set 'outline-offset' to CSS-wide keywords: inherit
 PASS Can set 'outline-offset' to CSS-wide keywords: unset
 PASS Can set 'outline-offset' to CSS-wide keywords: revert
-FAIL Can set 'outline-offset' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'outline-offset' to var() references:  var(--A)
 PASS Can set 'outline-offset' to a length: 0px
 PASS Can set 'outline-offset' to a length: -3.14em
 PASS Can set 'outline-offset' to a length: 3.14cm

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-style-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'outline-style' to CSS-wide keywords: initial
 PASS Can set 'outline-style' to CSS-wide keywords: inherit
 PASS Can set 'outline-style' to CSS-wide keywords: unset
 PASS Can set 'outline-style' to CSS-wide keywords: revert
-FAIL Can set 'outline-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'outline-style' to var() references:  var(--A)
 PASS Can set 'outline-style' to the 'auto' keyword: auto
 PASS Can set 'outline-style' to the 'none' keyword: none
 PASS Can set 'outline-style' to the 'dotted' keyword: dotted

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt
@@ -3,14 +3,14 @@ PASS Can set 'outline-width' to CSS-wide keywords: initial
 PASS Can set 'outline-width' to CSS-wide keywords: inherit
 PASS Can set 'outline-width' to CSS-wide keywords: unset
 PASS Can set 'outline-width' to CSS-wide keywords: revert
-FAIL Can set 'outline-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'outline-width' to var() references:  var(--A)
 PASS Can set 'outline-width' to the 'thin' keyword: thin
 PASS Can set 'outline-width' to the 'medium' keyword: medium
 PASS Can set 'outline-width' to the 'thick' keyword: thick
 PASS Can set 'outline-width' to a length: 0px
 PASS Can set 'outline-width' to a length: -3.14em
 PASS Can set 'outline-width' to a length: 3.14cm
-FAIL Can set 'outline-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'outline-width' to a length: calc(0px + 0em)
 PASS Setting 'outline-width' to a percent throws TypeError
 PASS Setting 'outline-width' to a time throws TypeError
 PASS Setting 'outline-width' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-anchor-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'overflow-anchor' to CSS-wide keywords: initial
 PASS Can set 'overflow-anchor' to CSS-wide keywords: inherit
 PASS Can set 'overflow-anchor' to CSS-wide keywords: unset
 PASS Can set 'overflow-anchor' to CSS-wide keywords: revert
-FAIL Can set 'overflow-anchor' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'overflow-anchor' to var() references:  var(--A)
 PASS Can set 'overflow-anchor' to the 'auto' keyword: auto
 PASS Can set 'overflow-anchor' to the 'none' keyword: none
 PASS Setting 'overflow-anchor' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'overflow-x' to CSS-wide keywords: initial
 PASS Can set 'overflow-x' to CSS-wide keywords: inherit
 PASS Can set 'overflow-x' to CSS-wide keywords: unset
 PASS Can set 'overflow-x' to CSS-wide keywords: revert
-FAIL Can set 'overflow-x' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'overflow-x' to var() references:  var(--A)
 PASS Can set 'overflow-x' to the 'visible' keyword: visible
 PASS Can set 'overflow-x' to the 'hidden' keyword: hidden
 PASS Can set 'overflow-x' to the 'clip' keyword: clip
@@ -21,7 +21,7 @@ PASS Can set 'overflow-y' to CSS-wide keywords: initial
 PASS Can set 'overflow-y' to CSS-wide keywords: inherit
 PASS Can set 'overflow-y' to CSS-wide keywords: unset
 PASS Can set 'overflow-y' to CSS-wide keywords: revert
-FAIL Can set 'overflow-y' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'overflow-y' to var() references:  var(--A)
 PASS Can set 'overflow-y' to the 'visible' keyword: visible
 PASS Can set 'overflow-y' to the 'hidden' keyword: hidden
 PASS Can set 'overflow-y' to the 'clip' keyword: clip

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-wrap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-wrap-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'overflow-wrap' to CSS-wide keywords: initial
 PASS Can set 'overflow-wrap' to CSS-wide keywords: inherit
 PASS Can set 'overflow-wrap' to CSS-wide keywords: unset
 PASS Can set 'overflow-wrap' to CSS-wide keywords: revert
-FAIL Can set 'overflow-wrap' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'overflow-wrap' to var() references:  var(--A)
 PASS Can set 'overflow-wrap' to the 'normal' keyword: normal
 PASS Can set 'overflow-wrap' to the 'break-word' keyword: break-word
 FAIL Can set 'overflow-wrap' to the 'break-spaces' keyword: break-spaces Invalid values

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overscroll-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overscroll-behavior-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'overscroll-behavior-x' to CSS-wide keywords: initial
 PASS Can set 'overscroll-behavior-x' to CSS-wide keywords: inherit
 PASS Can set 'overscroll-behavior-x' to CSS-wide keywords: unset
 PASS Can set 'overscroll-behavior-x' to CSS-wide keywords: revert
-FAIL Can set 'overscroll-behavior-x' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'overscroll-behavior-x' to var() references:  var(--A)
 PASS Can set 'overscroll-behavior-x' to the 'contain' keyword: contain
 PASS Can set 'overscroll-behavior-x' to the 'none' keyword: none
 PASS Can set 'overscroll-behavior-x' to the 'auto' keyword: auto
@@ -19,7 +19,7 @@ PASS Can set 'overscroll-behavior-y' to CSS-wide keywords: initial
 PASS Can set 'overscroll-behavior-y' to CSS-wide keywords: inherit
 PASS Can set 'overscroll-behavior-y' to CSS-wide keywords: unset
 PASS Can set 'overscroll-behavior-y' to CSS-wide keywords: revert
-FAIL Can set 'overscroll-behavior-y' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'overscroll-behavior-y' to var() references:  var(--A)
 PASS Can set 'overscroll-behavior-y' to the 'contain' keyword: contain
 PASS Can set 'overscroll-behavior-y' to the 'none' keyword: none
 PASS Can set 'overscroll-behavior-y' to the 'auto' keyword: auto

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt
@@ -3,15 +3,15 @@ PASS Can set 'padding-top' to CSS-wide keywords: initial
 PASS Can set 'padding-top' to CSS-wide keywords: inherit
 PASS Can set 'padding-top' to CSS-wide keywords: unset
 PASS Can set 'padding-top' to CSS-wide keywords: revert
-FAIL Can set 'padding-top' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-top' to var() references:  var(--A)
 PASS Can set 'padding-top' to a percent: 0%
 FAIL Can set 'padding-top' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'padding-top' to a percent: 3.14%
-FAIL Can set 'padding-top' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'padding-top' to a percent: calc(0% + 0%)
 PASS Can set 'padding-top' to a length: 0px
 PASS Can set 'padding-top' to a length: -3.14em
 PASS Can set 'padding-top' to a length: 3.14cm
-FAIL Can set 'padding-top' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'padding-top' to a length: calc(0px + 0em)
 PASS Setting 'padding-top' to a time throws TypeError
 PASS Setting 'padding-top' to an angle throws TypeError
 PASS Setting 'padding-top' to a flexible length throws TypeError
@@ -22,15 +22,15 @@ PASS Can set 'padding-left' to CSS-wide keywords: initial
 PASS Can set 'padding-left' to CSS-wide keywords: inherit
 PASS Can set 'padding-left' to CSS-wide keywords: unset
 PASS Can set 'padding-left' to CSS-wide keywords: revert
-FAIL Can set 'padding-left' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-left' to var() references:  var(--A)
 PASS Can set 'padding-left' to a percent: 0%
 FAIL Can set 'padding-left' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'padding-left' to a percent: 3.14%
-FAIL Can set 'padding-left' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'padding-left' to a percent: calc(0% + 0%)
 PASS Can set 'padding-left' to a length: 0px
 PASS Can set 'padding-left' to a length: -3.14em
 PASS Can set 'padding-left' to a length: 3.14cm
-FAIL Can set 'padding-left' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'padding-left' to a length: calc(0px + 0em)
 PASS Setting 'padding-left' to a time throws TypeError
 PASS Setting 'padding-left' to an angle throws TypeError
 PASS Setting 'padding-left' to a flexible length throws TypeError
@@ -41,15 +41,15 @@ PASS Can set 'padding-right' to CSS-wide keywords: initial
 PASS Can set 'padding-right' to CSS-wide keywords: inherit
 PASS Can set 'padding-right' to CSS-wide keywords: unset
 PASS Can set 'padding-right' to CSS-wide keywords: revert
-FAIL Can set 'padding-right' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-right' to var() references:  var(--A)
 PASS Can set 'padding-right' to a percent: 0%
 FAIL Can set 'padding-right' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'padding-right' to a percent: 3.14%
-FAIL Can set 'padding-right' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'padding-right' to a percent: calc(0% + 0%)
 PASS Can set 'padding-right' to a length: 0px
 PASS Can set 'padding-right' to a length: -3.14em
 PASS Can set 'padding-right' to a length: 3.14cm
-FAIL Can set 'padding-right' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'padding-right' to a length: calc(0px + 0em)
 PASS Setting 'padding-right' to a time throws TypeError
 PASS Setting 'padding-right' to an angle throws TypeError
 PASS Setting 'padding-right' to a flexible length throws TypeError
@@ -60,15 +60,15 @@ PASS Can set 'padding-bottom' to CSS-wide keywords: initial
 PASS Can set 'padding-bottom' to CSS-wide keywords: inherit
 PASS Can set 'padding-bottom' to CSS-wide keywords: unset
 PASS Can set 'padding-bottom' to CSS-wide keywords: revert
-FAIL Can set 'padding-bottom' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'padding-bottom' to var() references:  var(--A)
 PASS Can set 'padding-bottom' to a percent: 0%
 FAIL Can set 'padding-bottom' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'padding-bottom' to a percent: 3.14%
-FAIL Can set 'padding-bottom' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'padding-bottom' to a percent: calc(0% + 0%)
 PASS Can set 'padding-bottom' to a length: 0px
 PASS Can set 'padding-bottom' to a length: -3.14em
 PASS Can set 'padding-bottom' to a length: 3.14cm
-FAIL Can set 'padding-bottom' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'padding-bottom' to a length: calc(0px + 0em)
 PASS Setting 'padding-bottom' to a time throws TypeError
 PASS Setting 'padding-bottom' to an angle throws TypeError
 PASS Setting 'padding-bottom' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt
@@ -3,7 +3,7 @@ FAIL Can set 'page' to CSS-wide keywords: initial assert_not_equals: Computed va
 FAIL Can set 'page' to CSS-wide keywords: inherit assert_not_equals: Computed value must not be null got disallowed value null
 FAIL Can set 'page' to CSS-wide keywords: unset assert_not_equals: Computed value must not be null got disallowed value null
 FAIL Can set 'page' to CSS-wide keywords: revert assert_not_equals: Computed value must not be null got disallowed value null
-FAIL Can set 'page' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'page' to var() references:  var(--A) assert_not_equals: Computed value must not be null got disallowed value null
 FAIL Can set 'page' to the 'auto' keyword: auto assert_not_equals: Computed value must not be null got disallowed value null
 FAIL Can set 'page' to the 'custom-ident' keyword: custom-ident Invalid values
 PASS Setting 'page' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/paint-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/paint-order-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'paint-order' to CSS-wide keywords: initial
 PASS Can set 'paint-order' to CSS-wide keywords: inherit
 PASS Can set 'paint-order' to CSS-wide keywords: unset
 PASS Can set 'paint-order' to CSS-wide keywords: revert
-FAIL Can set 'paint-order' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'paint-order' to var() references:  var(--A)
 PASS Can set 'paint-order' to the 'normal' keyword: normal
 PASS Can set 'paint-order' to the 'fill' keyword: fill
 PASS Can set 'paint-order' to the 'stroke' keyword: stroke

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt
@@ -3,12 +3,12 @@ PASS Can set 'perspective' to CSS-wide keywords: initial
 PASS Can set 'perspective' to CSS-wide keywords: inherit
 PASS Can set 'perspective' to CSS-wide keywords: unset
 PASS Can set 'perspective' to CSS-wide keywords: revert
-FAIL Can set 'perspective' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'perspective' to var() references:  var(--A)
 PASS Can set 'perspective' to the 'none' keyword: none
 PASS Can set 'perspective' to a length: 0px
 PASS Can set 'perspective' to a length: -3.14em
 PASS Can set 'perspective' to a length: 3.14cm
-FAIL Can set 'perspective' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'perspective' to a length: calc(0px + 0em)
 PASS Setting 'perspective' to a percent throws TypeError
 PASS Setting 'perspective' to a time throws TypeError
 PASS Setting 'perspective' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/pointer-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/pointer-events-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'pointer-events' to CSS-wide keywords: initial
 PASS Can set 'pointer-events' to CSS-wide keywords: inherit
 PASS Can set 'pointer-events' to CSS-wide keywords: unset
 PASS Can set 'pointer-events' to CSS-wide keywords: revert
-FAIL Can set 'pointer-events' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'pointer-events' to var() references:  var(--A)
 PASS Can set 'pointer-events' to the 'bounding-box' keyword: bounding-box
 FAIL Can set 'pointer-events' to the 'visiblepainted' keyword: visiblepainted assert_equals: expected "visiblepainted" but got "visiblePainted"
 FAIL Can set 'pointer-events' to the 'visiblefill' keyword: visiblefill assert_equals: expected "visiblefill" but got "visibleFill"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/position-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'position' to CSS-wide keywords: initial
 PASS Can set 'position' to CSS-wide keywords: inherit
 PASS Can set 'position' to CSS-wide keywords: unset
 PASS Can set 'position' to CSS-wide keywords: revert
-FAIL Can set 'position' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'position' to var() references:  var(--A)
 PASS Can set 'position' to the 'relative' keyword: relative
 PASS Can set 'position' to the 'absolute' keyword: absolute
 PASS Setting 'position' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/quotes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/quotes-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'quotes' to CSS-wide keywords: initial
 PASS Can set 'quotes' to CSS-wide keywords: inherit
 PASS Can set 'quotes' to CSS-wide keywords: unset
 PASS Can set 'quotes' to CSS-wide keywords: revert
-FAIL Can set 'quotes' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'quotes' to var() references:  var(--A)
 PASS Can set 'quotes' to the 'none' keyword: none
 PASS Setting 'quotes' to a length throws TypeError
 PASS Setting 'quotes' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt
@@ -3,15 +3,15 @@ PASS Can set 'r' to CSS-wide keywords: initial
 PASS Can set 'r' to CSS-wide keywords: inherit
 PASS Can set 'r' to CSS-wide keywords: unset
 PASS Can set 'r' to CSS-wide keywords: revert
-FAIL Can set 'r' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'r' to var() references:  var(--A)
 PASS Can set 'r' to a percent: 0%
 FAIL Can set 'r' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'r' to a percent: 3.14%
-FAIL Can set 'r' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'r' to a percent: calc(0% + 0%)
 PASS Can set 'r' to a length: 0px
 PASS Can set 'r' to a length: -3.14em
 PASS Can set 'r' to a length: 3.14cm
-FAIL Can set 'r' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'r' to a length: calc(0px + 0em)
 PASS Setting 'r' to a time throws TypeError
 PASS Setting 'r' to an angle throws TypeError
 PASS Setting 'r' to a flexible length throws TypeError
@@ -22,16 +22,16 @@ PASS Can set 'rx' to CSS-wide keywords: initial
 PASS Can set 'rx' to CSS-wide keywords: inherit
 PASS Can set 'rx' to CSS-wide keywords: unset
 PASS Can set 'rx' to CSS-wide keywords: revert
-FAIL Can set 'rx' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'rx' to var() references:  var(--A)
 PASS Can set 'rx' to the 'auto' keyword: auto
 PASS Can set 'rx' to a percent: 0%
 FAIL Can set 'rx' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'rx' to a percent: 3.14%
-FAIL Can set 'rx' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'rx' to a percent: calc(0% + 0%)
 PASS Can set 'rx' to a length: 0px
 PASS Can set 'rx' to a length: -3.14em
 PASS Can set 'rx' to a length: 3.14cm
-FAIL Can set 'rx' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'rx' to a length: calc(0px + 0em)
 PASS Setting 'rx' to a time throws TypeError
 PASS Setting 'rx' to an angle throws TypeError
 PASS Setting 'rx' to a flexible length throws TypeError
@@ -42,16 +42,16 @@ PASS Can set 'ry' to CSS-wide keywords: initial
 PASS Can set 'ry' to CSS-wide keywords: inherit
 PASS Can set 'ry' to CSS-wide keywords: unset
 PASS Can set 'ry' to CSS-wide keywords: revert
-FAIL Can set 'ry' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'ry' to var() references:  var(--A)
 PASS Can set 'ry' to the 'auto' keyword: auto
 PASS Can set 'ry' to a percent: 0%
 FAIL Can set 'ry' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'ry' to a percent: 3.14%
-FAIL Can set 'ry' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'ry' to a percent: calc(0% + 0%)
 PASS Can set 'ry' to a length: 0px
 PASS Can set 'ry' to a length: -3.14em
 PASS Can set 'ry' to a length: 3.14cm
-FAIL Can set 'ry' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'ry' to a length: calc(0px + 0em)
 PASS Setting 'ry' to a time throws TypeError
 PASS Setting 'ry' to an angle throws TypeError
 PASS Setting 'ry' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resize-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'resize' to CSS-wide keywords: initial
 PASS Can set 'resize' to CSS-wide keywords: inherit
 PASS Can set 'resize' to CSS-wide keywords: unset
 PASS Can set 'resize' to CSS-wide keywords: revert
-FAIL Can set 'resize' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'resize' to var() references:  var(--A)
 PASS Can set 'resize' to the 'none' keyword: none
 PASS Can set 'resize' to the 'both' keyword: both
 PASS Can set 'resize' to the 'horizontal' keyword: horizontal

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resources/testsuite.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resources/testsuite.js
@@ -191,7 +191,7 @@ const gTestSyntaxExamples = {
       },
       {
         description: "one fraction",
-        input: new CSSUnitValue(0, 'fr')
+        input: new CSSUnitValue(1, 'fr')
       },
       {
         description: "negative fraction",
@@ -325,7 +325,7 @@ function testPropertyValid(propertyName, examples, specified, computed, descript
         assert_style_value_equals(computedResult, example.input,
           `Setting ${example.description} and getting its computed value`);
       }
-    }, `Can set '${propertyName}' to ${description}: ` + example.input);
+    }, `Can set '${propertyName}' to ${description}: ${example.input}`);
   }
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/right-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/right-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'right' to CSS-wide keywords: initial
 PASS Can set 'right' to CSS-wide keywords: inherit
 PASS Can set 'right' to CSS-wide keywords: unset
 PASS Can set 'right' to CSS-wide keywords: revert
-FAIL Can set 'right' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'right' to var() references:  var(--A)
 PASS Can set 'right' to the 'auto' keyword: auto
 PASS Can set 'right' to a percent: 0%
 PASS Can set 'right' to a percent: -3.14%

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-behavior-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'scroll-behavior' to CSS-wide keywords: initial
 PASS Can set 'scroll-behavior' to CSS-wide keywords: inherit
 PASS Can set 'scroll-behavior' to CSS-wide keywords: unset
 PASS Can set 'scroll-behavior' to CSS-wide keywords: revert
-FAIL Can set 'scroll-behavior' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-behavior' to var() references:  var(--A)
 PASS Can set 'scroll-behavior' to the 'auto' keyword: auto
 PASS Can set 'scroll-behavior' to the 'smooth' keyword: smooth
 PASS Setting 'scroll-behavior' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-margin-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'scroll-margin-top' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-top' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-top' to CSS-wide keywords: unset
 PASS Can set 'scroll-margin-top' to CSS-wide keywords: revert
-FAIL Can set 'scroll-margin-top' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-top' to var() references:  var(--A)
 PASS Can set 'scroll-margin-top' to a length: 0px
 PASS Can set 'scroll-margin-top' to a length: -3.14em
 PASS Can set 'scroll-margin-top' to a length: 3.14cm
@@ -19,7 +19,7 @@ PASS Can set 'scroll-margin-left' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-left' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-left' to CSS-wide keywords: unset
 PASS Can set 'scroll-margin-left' to CSS-wide keywords: revert
-FAIL Can set 'scroll-margin-left' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-left' to var() references:  var(--A)
 PASS Can set 'scroll-margin-left' to a length: 0px
 PASS Can set 'scroll-margin-left' to a length: -3.14em
 PASS Can set 'scroll-margin-left' to a length: 3.14cm
@@ -35,7 +35,7 @@ PASS Can set 'scroll-margin-right' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-right' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-right' to CSS-wide keywords: unset
 PASS Can set 'scroll-margin-right' to CSS-wide keywords: revert
-FAIL Can set 'scroll-margin-right' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-right' to var() references:  var(--A)
 PASS Can set 'scroll-margin-right' to a length: 0px
 PASS Can set 'scroll-margin-right' to a length: -3.14em
 PASS Can set 'scroll-margin-right' to a length: 3.14cm
@@ -51,7 +51,7 @@ PASS Can set 'scroll-margin-bottom' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-bottom' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-bottom' to CSS-wide keywords: unset
 PASS Can set 'scroll-margin-bottom' to CSS-wide keywords: revert
-FAIL Can set 'scroll-margin-bottom' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-bottom' to var() references:  var(--A)
 PASS Can set 'scroll-margin-bottom' to a length: 0px
 PASS Can set 'scroll-margin-bottom' to a length: -3.14em
 PASS Can set 'scroll-margin-bottom' to a length: 3.14cm
@@ -67,7 +67,7 @@ PASS Can set 'scroll-margin-inline-start' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-inline-start' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-inline-start' to CSS-wide keywords: unset
 PASS Can set 'scroll-margin-inline-start' to CSS-wide keywords: revert
-FAIL Can set 'scroll-margin-inline-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-inline-start' to var() references:  var(--A)
 PASS Can set 'scroll-margin-inline-start' to a length: 0px
 PASS Can set 'scroll-margin-inline-start' to a length: -3.14em
 PASS Can set 'scroll-margin-inline-start' to a length: 3.14cm
@@ -83,7 +83,7 @@ PASS Can set 'scroll-margin-block-start' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-block-start' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-block-start' to CSS-wide keywords: unset
 PASS Can set 'scroll-margin-block-start' to CSS-wide keywords: revert
-FAIL Can set 'scroll-margin-block-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-block-start' to var() references:  var(--A)
 PASS Can set 'scroll-margin-block-start' to a length: 0px
 PASS Can set 'scroll-margin-block-start' to a length: -3.14em
 PASS Can set 'scroll-margin-block-start' to a length: 3.14cm
@@ -99,7 +99,7 @@ PASS Can set 'scroll-margin-inline-end' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-inline-end' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-inline-end' to CSS-wide keywords: unset
 PASS Can set 'scroll-margin-inline-end' to CSS-wide keywords: revert
-FAIL Can set 'scroll-margin-inline-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-inline-end' to var() references:  var(--A)
 PASS Can set 'scroll-margin-inline-end' to a length: 0px
 PASS Can set 'scroll-margin-inline-end' to a length: -3.14em
 PASS Can set 'scroll-margin-inline-end' to a length: 3.14cm
@@ -115,7 +115,7 @@ PASS Can set 'scroll-margin-block-end' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-block-end' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-block-end' to CSS-wide keywords: unset
 PASS Can set 'scroll-margin-block-end' to CSS-wide keywords: revert
-FAIL Can set 'scroll-margin-block-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-margin-block-end' to var() references:  var(--A)
 PASS Can set 'scroll-margin-block-end' to a length: 0px
 PASS Can set 'scroll-margin-block-end' to a length: -3.14em
 PASS Can set 'scroll-margin-block-end' to a length: 3.14cm

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'scroll-padding-top' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-top' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-top' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-top' to CSS-wide keywords: revert
-FAIL Can set 'scroll-padding-top' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-top' to var() references:  var(--A)
 PASS Can set 'scroll-padding-top' to a percent: 0%
 FAIL Can set 'scroll-padding-top' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-top' to a percent: 3.14%
@@ -22,7 +22,7 @@ PASS Can set 'scroll-padding-left' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-left' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-left' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-left' to CSS-wide keywords: revert
-FAIL Can set 'scroll-padding-left' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-left' to var() references:  var(--A)
 PASS Can set 'scroll-padding-left' to a percent: 0%
 FAIL Can set 'scroll-padding-left' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-left' to a percent: 3.14%
@@ -41,7 +41,7 @@ PASS Can set 'scroll-padding-right' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-right' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-right' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-right' to CSS-wide keywords: revert
-FAIL Can set 'scroll-padding-right' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-right' to var() references:  var(--A)
 PASS Can set 'scroll-padding-right' to a percent: 0%
 FAIL Can set 'scroll-padding-right' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-right' to a percent: 3.14%
@@ -60,7 +60,7 @@ PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: revert
-FAIL Can set 'scroll-padding-bottom' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-bottom' to var() references:  var(--A)
 PASS Can set 'scroll-padding-bottom' to a percent: 0%
 FAIL Can set 'scroll-padding-bottom' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-bottom' to a percent: 3.14%
@@ -79,7 +79,7 @@ PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: revert
-FAIL Can set 'scroll-padding-inline-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-inline-start' to var() references:  var(--A)
 PASS Can set 'scroll-padding-inline-start' to a percent: 0%
 FAIL Can set 'scroll-padding-inline-start' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-inline-start' to a percent: 3.14%
@@ -98,7 +98,7 @@ PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: revert
-FAIL Can set 'scroll-padding-block-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-block-start' to var() references:  var(--A)
 PASS Can set 'scroll-padding-block-start' to a percent: 0%
 FAIL Can set 'scroll-padding-block-start' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-block-start' to a percent: 3.14%
@@ -117,7 +117,7 @@ PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: revert
-FAIL Can set 'scroll-padding-inline-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-inline-end' to var() references:  var(--A)
 PASS Can set 'scroll-padding-inline-end' to a percent: 0%
 FAIL Can set 'scroll-padding-inline-end' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-inline-end' to a percent: 3.14%
@@ -136,7 +136,7 @@ PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: revert
-FAIL Can set 'scroll-padding-block-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-padding-block-end' to var() references:  var(--A)
 PASS Can set 'scroll-padding-block-end' to a percent: 0%
 FAIL Can set 'scroll-padding-block-end' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-block-end' to a percent: 3.14%

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-align-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'scroll-snap-align' to CSS-wide keywords: initial
 PASS Can set 'scroll-snap-align' to CSS-wide keywords: inherit
 PASS Can set 'scroll-snap-align' to CSS-wide keywords: unset
 PASS Can set 'scroll-snap-align' to CSS-wide keywords: revert
-FAIL Can set 'scroll-snap-align' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-snap-align' to var() references:  var(--A)
 FAIL Can set 'scroll-snap-align' to the 'none' keyword: none assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 FAIL Can set 'scroll-snap-align' to the 'start' keyword: start assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 FAIL Can set 'scroll-snap-align' to the 'end' keyword: end assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-stop-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-stop-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'scroll-snap-stop' to CSS-wide keywords: initial
 PASS Can set 'scroll-snap-stop' to CSS-wide keywords: inherit
 PASS Can set 'scroll-snap-stop' to CSS-wide keywords: unset
 PASS Can set 'scroll-snap-stop' to CSS-wide keywords: revert
-FAIL Can set 'scroll-snap-stop' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-snap-stop' to var() references:  var(--A)
 PASS Can set 'scroll-snap-stop' to the 'normal' keyword: normal
 PASS Can set 'scroll-snap-stop' to the 'always' keyword: always
 PASS Setting 'scroll-snap-stop' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-type-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'scroll-snap-type' to CSS-wide keywords: initial
 PASS Can set 'scroll-snap-type' to CSS-wide keywords: inherit
 PASS Can set 'scroll-snap-type' to CSS-wide keywords: unset
 PASS Can set 'scroll-snap-type' to CSS-wide keywords: revert
-FAIL Can set 'scroll-snap-type' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'scroll-snap-type' to var() references:  var(--A)
 PASS Can set 'scroll-snap-type' to the 'none' keyword: none
 PASS Can set 'scroll-snap-type' to the 'x' keyword: x
 PASS Can set 'scroll-snap-type' to the 'y' keyword: y

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-image-threshold-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-image-threshold-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'shape-image-threshold' to CSS-wide keywords: initial
 PASS Can set 'shape-image-threshold' to CSS-wide keywords: inherit
 PASS Can set 'shape-image-threshold' to CSS-wide keywords: unset
 PASS Can set 'shape-image-threshold' to CSS-wide keywords: revert
-FAIL Can set 'shape-image-threshold' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'shape-image-threshold' to var() references:  var(--A)
 PASS Can set 'shape-image-threshold' to a number: 0
 PASS Can set 'shape-image-threshold' to a number: -3.14
 PASS Can set 'shape-image-threshold' to a number: 3.14

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt
@@ -3,15 +3,15 @@ PASS Can set 'shape-margin' to CSS-wide keywords: initial
 PASS Can set 'shape-margin' to CSS-wide keywords: inherit
 PASS Can set 'shape-margin' to CSS-wide keywords: unset
 PASS Can set 'shape-margin' to CSS-wide keywords: revert
-FAIL Can set 'shape-margin' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'shape-margin' to var() references:  var(--A)
 PASS Can set 'shape-margin' to a length: 0px
 PASS Can set 'shape-margin' to a length: -3.14em
 PASS Can set 'shape-margin' to a length: 3.14cm
-FAIL Can set 'shape-margin' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'shape-margin' to a length: calc(0px + 0em)
 PASS Can set 'shape-margin' to a percent: 0%
 FAIL Can set 'shape-margin' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'shape-margin' to a percent: 3.14%
-FAIL Can set 'shape-margin' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'shape-margin' to a percent: calc(0% + 0%)
 PASS Setting 'shape-margin' to a time throws TypeError
 PASS Setting 'shape-margin' to an angle throws TypeError
 PASS Setting 'shape-margin' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-outside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-outside-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'shape-outside' to CSS-wide keywords: initial
 PASS Can set 'shape-outside' to CSS-wide keywords: inherit
 PASS Can set 'shape-outside' to CSS-wide keywords: unset
 PASS Can set 'shape-outside' to CSS-wide keywords: revert
-FAIL Can set 'shape-outside' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'shape-outside' to var() references:  var(--A)
 PASS Can set 'shape-outside' to the 'none' keyword: none
 PASS Can set 'shape-outside' to the 'margin-box' keyword: margin-box
 PASS Can set 'shape-outside' to the 'border-box' keyword: border-box

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-rendering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-rendering-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'shape-rendering' to CSS-wide keywords: initial
 PASS Can set 'shape-rendering' to CSS-wide keywords: inherit
 PASS Can set 'shape-rendering' to CSS-wide keywords: unset
 PASS Can set 'shape-rendering' to CSS-wide keywords: revert
-FAIL Can set 'shape-rendering' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'shape-rendering' to var() references:  var(--A)
 PASS Can set 'shape-rendering' to the 'auto' keyword: auto
 FAIL Can set 'shape-rendering' to the 'optimizespeed' keyword: optimizespeed assert_equals: expected "optimizespeed" but got "optimizeSpeed"
 PASS Can set 'shape-rendering' to the 'crispedges' keyword: crispedges

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-color-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'stop-color' to CSS-wide keywords: initial
 PASS Can set 'stop-color' to CSS-wide keywords: inherit
 PASS Can set 'stop-color' to CSS-wide keywords: unset
 PASS Can set 'stop-color' to CSS-wide keywords: revert
-FAIL Can set 'stop-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stop-color' to var() references:  var(--A)
 PASS Can set 'stop-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'stop-color' to a length throws TypeError
 PASS Setting 'stop-color' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'stop-opacity' to CSS-wide keywords: initial
 PASS Can set 'stop-opacity' to CSS-wide keywords: inherit
 PASS Can set 'stop-opacity' to CSS-wide keywords: unset
 PASS Can set 'stop-opacity' to CSS-wide keywords: revert
-FAIL Can set 'stop-opacity' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stop-opacity' to var() references:  var(--A)
 PASS Can set 'stop-opacity' to a number: 0
 PASS Can set 'stop-opacity' to a number: -3.14
 PASS Can set 'stop-opacity' to a number: 3.14

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'stroke-dasharray' to CSS-wide keywords: initial
 PASS Can set 'stroke-dasharray' to CSS-wide keywords: inherit
 PASS Can set 'stroke-dasharray' to CSS-wide keywords: unset
 PASS Can set 'stroke-dasharray' to CSS-wide keywords: revert
-FAIL Can set 'stroke-dasharray' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stroke-dasharray' to var() references:  var(--A)
 PASS Can set 'stroke-dasharray' to the 'none' keyword: none
 FAIL Setting 'stroke-dasharray' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 FAIL Setting 'stroke-dasharray' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'stroke-dashoffset' to CSS-wide keywords: initial
 PASS Can set 'stroke-dashoffset' to CSS-wide keywords: inherit
 PASS Can set 'stroke-dashoffset' to CSS-wide keywords: unset
 PASS Can set 'stroke-dashoffset' to CSS-wide keywords: revert
-FAIL Can set 'stroke-dashoffset' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stroke-dashoffset' to var() references:  var(--A)
 PASS Can set 'stroke-dashoffset' to a length: 0px
 PASS Can set 'stroke-dashoffset' to a length: -3.14em
 PASS Can set 'stroke-dashoffset' to a length: 3.14cm

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linecap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linecap-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'stroke-linecap' to CSS-wide keywords: initial
 PASS Can set 'stroke-linecap' to CSS-wide keywords: inherit
 PASS Can set 'stroke-linecap' to CSS-wide keywords: unset
 PASS Can set 'stroke-linecap' to CSS-wide keywords: revert
-FAIL Can set 'stroke-linecap' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stroke-linecap' to var() references:  var(--A)
 PASS Can set 'stroke-linecap' to the 'butt' keyword: butt
 PASS Can set 'stroke-linecap' to the 'round' keyword: round
 PASS Can set 'stroke-linecap' to the 'square' keyword: square

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linejoin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linejoin-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'stroke-linejoin' to CSS-wide keywords: initial
 PASS Can set 'stroke-linejoin' to CSS-wide keywords: inherit
 PASS Can set 'stroke-linejoin' to CSS-wide keywords: unset
 PASS Can set 'stroke-linejoin' to CSS-wide keywords: revert
-FAIL Can set 'stroke-linejoin' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stroke-linejoin' to var() references:  var(--A)
 FAIL Can set 'stroke-linejoin' to the 'crop' keyword: crop Invalid values
 FAIL Can set 'stroke-linejoin' to the 'arcs' keyword: arcs Invalid values
 PASS Can set 'stroke-linejoin' to the 'miter' keyword: miter

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'stroke-miterlimit' to CSS-wide keywords: initial
 PASS Can set 'stroke-miterlimit' to CSS-wide keywords: inherit
 PASS Can set 'stroke-miterlimit' to CSS-wide keywords: unset
 PASS Can set 'stroke-miterlimit' to CSS-wide keywords: revert
-FAIL Can set 'stroke-miterlimit' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stroke-miterlimit' to var() references:  var(--A)
 PASS Can set 'stroke-miterlimit' to a number: 0
 FAIL Can set 'stroke-miterlimit' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'stroke-miterlimit' to a number: 3.14

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'stroke-opacity' to CSS-wide keywords: initial
 PASS Can set 'stroke-opacity' to CSS-wide keywords: inherit
 PASS Can set 'stroke-opacity' to CSS-wide keywords: unset
 PASS Can set 'stroke-opacity' to CSS-wide keywords: revert
-FAIL Can set 'stroke-opacity' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stroke-opacity' to var() references:  var(--A)
 PASS Can set 'stroke-opacity' to a number: 0
 PASS Can set 'stroke-opacity' to a number: -3.14
 PASS Can set 'stroke-opacity' to a number: 3.14

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt
@@ -3,15 +3,15 @@ PASS Can set 'stroke-width' to CSS-wide keywords: initial
 PASS Can set 'stroke-width' to CSS-wide keywords: inherit
 PASS Can set 'stroke-width' to CSS-wide keywords: unset
 PASS Can set 'stroke-width' to CSS-wide keywords: revert
-FAIL Can set 'stroke-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'stroke-width' to var() references:  var(--A)
 PASS Can set 'stroke-width' to a length: 0px
 FAIL Can set 'stroke-width' to a length: -3.14em assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
 PASS Can set 'stroke-width' to a length: 3.14cm
-FAIL Can set 'stroke-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'stroke-width' to a length: calc(0px + 0em)
 PASS Can set 'stroke-width' to a percent: 0%
 FAIL Can set 'stroke-width' to a percent: -3.14% assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
 PASS Can set 'stroke-width' to a percent: 3.14%
-FAIL Can set 'stroke-width' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'stroke-width' to a percent: calc(0% + 0%)
 PASS Setting 'stroke-width' to a time throws TypeError
 PASS Setting 'stroke-width' to an angle throws TypeError
 PASS Setting 'stroke-width' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/tab-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/tab-size-expected.txt
@@ -3,15 +3,15 @@ PASS Can set 'tab-size' to CSS-wide keywords: initial
 PASS Can set 'tab-size' to CSS-wide keywords: inherit
 PASS Can set 'tab-size' to CSS-wide keywords: unset
 PASS Can set 'tab-size' to CSS-wide keywords: revert
-FAIL Can set 'tab-size' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'tab-size' to var() references:  var(--A)
 PASS Can set 'tab-size' to a number: 0
 PASS Can set 'tab-size' to a number: -3.14
 PASS Can set 'tab-size' to a number: 3.14
-FAIL Can set 'tab-size' to a number: calc(2 + 3) assert_equals: expected 2 but got 1
+PASS Can set 'tab-size' to a number: calc(2 + 3)
 PASS Can set 'tab-size' to a length: 0px
 PASS Can set 'tab-size' to a length: -3.14em
 PASS Can set 'tab-size' to a length: 3.14cm
-FAIL Can set 'tab-size' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'tab-size' to a length: calc(0px + 0em)
 PASS Setting 'tab-size' to a percent throws TypeError
 PASS Setting 'tab-size' to a time throws TypeError
 PASS Setting 'tab-size' to an angle throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/table-layout-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/table-layout-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'table-layout' to CSS-wide keywords: initial
 PASS Can set 'table-layout' to CSS-wide keywords: inherit
 PASS Can set 'table-layout' to CSS-wide keywords: unset
 PASS Can set 'table-layout' to CSS-wide keywords: revert
-FAIL Can set 'table-layout' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'table-layout' to var() references:  var(--A)
 PASS Can set 'table-layout' to the 'auto' keyword: auto
 PASS Can set 'table-layout' to the 'fixed' keyword: fixed
 PASS Setting 'table-layout' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-align' to CSS-wide keywords: initial
 PASS Can set 'text-align' to CSS-wide keywords: inherit
 PASS Can set 'text-align' to CSS-wide keywords: unset
 PASS Can set 'text-align' to CSS-wide keywords: revert
-FAIL Can set 'text-align' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-align' to var() references:  var(--A)
 PASS Can set 'text-align' to the 'center' keyword: center
 PASS Can set 'text-align' to the 'justify' keyword: justify
 PASS Setting 'text-align' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-last-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-align-last' to CSS-wide keywords: initial
 PASS Can set 'text-align-last' to CSS-wide keywords: inherit
 PASS Can set 'text-align-last' to CSS-wide keywords: unset
 PASS Can set 'text-align-last' to CSS-wide keywords: revert
-FAIL Can set 'text-align-last' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-align-last' to var() references:  var(--A)
 PASS Can set 'text-align-last' to the 'auto' keyword: auto
 PASS Can set 'text-align-last' to the 'start' keyword: start
 PASS Can set 'text-align-last' to the 'end' keyword: end

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-anchor-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-anchor' to CSS-wide keywords: initial
 PASS Can set 'text-anchor' to CSS-wide keywords: inherit
 PASS Can set 'text-anchor' to CSS-wide keywords: unset
 PASS Can set 'text-anchor' to CSS-wide keywords: revert
-FAIL Can set 'text-anchor' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-anchor' to var() references:  var(--A)
 PASS Can set 'text-anchor' to the 'start' keyword: start
 PASS Can set 'text-anchor' to the 'middle' keyword: middle
 PASS Can set 'text-anchor' to the 'end' keyword: end

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-combine-upright-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-combine-upright-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-combine-upright' to CSS-wide keywords: initial
 PASS Can set 'text-combine-upright' to CSS-wide keywords: inherit
 PASS Can set 'text-combine-upright' to CSS-wide keywords: unset
 PASS Can set 'text-combine-upright' to CSS-wide keywords: revert
-FAIL Can set 'text-combine-upright' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-combine-upright' to var() references:  var(--A)
 PASS Can set 'text-combine-upright' to the 'none' keyword: none
 PASS Can set 'text-combine-upright' to the 'all' keyword: all
 PASS Setting 'text-combine-upright' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-color-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-decoration-color' to CSS-wide keywords: initial
 PASS Can set 'text-decoration-color' to CSS-wide keywords: inherit
 PASS Can set 'text-decoration-color' to CSS-wide keywords: unset
 PASS Can set 'text-decoration-color' to CSS-wide keywords: revert
-FAIL Can set 'text-decoration-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-decoration-color' to var() references:  var(--A)
 PASS Can set 'text-decoration-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'text-decoration-color' to a length throws TypeError
 PASS Setting 'text-decoration-color' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-decoration-line' to CSS-wide keywords: initial
 PASS Can set 'text-decoration-line' to CSS-wide keywords: inherit
 PASS Can set 'text-decoration-line' to CSS-wide keywords: unset
 PASS Can set 'text-decoration-line' to CSS-wide keywords: revert
-FAIL Can set 'text-decoration-line' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-decoration-line' to var() references:  var(--A)
 PASS Can set 'text-decoration-line' to the 'none' keyword: none
 PASS Can set 'text-decoration-line' to the 'underline' keyword: underline
 PASS Can set 'text-decoration-line' to the 'overline' keyword: overline

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-ink-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-ink-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-decoration-skip-ink' to CSS-wide keywords: initial
 PASS Can set 'text-decoration-skip-ink' to CSS-wide keywords: inherit
 PASS Can set 'text-decoration-skip-ink' to CSS-wide keywords: unset
 PASS Can set 'text-decoration-skip-ink' to CSS-wide keywords: revert
-FAIL Can set 'text-decoration-skip-ink' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-decoration-skip-ink' to var() references:  var(--A)
 PASS Can set 'text-decoration-skip-ink' to the 'auto' keyword: auto
 PASS Can set 'text-decoration-skip-ink' to the 'none' keyword: none
 PASS Setting 'text-decoration-skip-ink' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-style-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-decoration-style' to CSS-wide keywords: initial
 PASS Can set 'text-decoration-style' to CSS-wide keywords: inherit
 PASS Can set 'text-decoration-style' to CSS-wide keywords: unset
 PASS Can set 'text-decoration-style' to CSS-wide keywords: revert
-FAIL Can set 'text-decoration-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-decoration-style' to var() references:  var(--A)
 PASS Can set 'text-decoration-style' to the 'solid' keyword: solid
 PASS Can set 'text-decoration-style' to the 'double' keyword: double
 PASS Can set 'text-decoration-style' to the 'dotted' keyword: dotted

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-thickness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-thickness-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-decoration-thickness' to CSS-wide keywords: initial
 PASS Can set 'text-decoration-thickness' to CSS-wide keywords: inherit
 PASS Can set 'text-decoration-thickness' to CSS-wide keywords: unset
 PASS Can set 'text-decoration-thickness' to CSS-wide keywords: revert
-FAIL Can set 'text-decoration-thickness' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-decoration-thickness' to var() references:  var(--A)
 PASS Can set 'text-decoration-thickness' to the 'auto' keyword: auto
 PASS Can set 'text-decoration-thickness' to a length: 0px
 PASS Can set 'text-decoration-thickness' to a length: -3.14em

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-emphasis-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-emphasis-color-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-emphasis-color' to CSS-wide keywords: initial
 PASS Can set 'text-emphasis-color' to CSS-wide keywords: inherit
 PASS Can set 'text-emphasis-color' to CSS-wide keywords: unset
 PASS Can set 'text-emphasis-color' to CSS-wide keywords: revert
-FAIL Can set 'text-emphasis-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-emphasis-color' to var() references:  var(--A)
 PASS Can set 'text-emphasis-color' to the 'currentcolor' keyword: currentcolor
 PASS Setting 'text-emphasis-color' to a length throws TypeError
 PASS Setting 'text-emphasis-color' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-indent' to CSS-wide keywords: initial
 PASS Can set 'text-indent' to CSS-wide keywords: inherit
 PASS Can set 'text-indent' to CSS-wide keywords: unset
 PASS Can set 'text-indent' to CSS-wide keywords: revert
-FAIL Can set 'text-indent' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-indent' to var() references:  var(--A)
 PASS Can set 'text-indent' to a length: 0px
 PASS Can set 'text-indent' to a length: -3.14em
 PASS Can set 'text-indent' to a length: 3.14cm

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-justify-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-justify-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-justify' to CSS-wide keywords: initial
 PASS Can set 'text-justify' to CSS-wide keywords: inherit
 PASS Can set 'text-justify' to CSS-wide keywords: unset
 PASS Can set 'text-justify' to CSS-wide keywords: revert
-FAIL Can set 'text-justify' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-justify' to var() references:  var(--A)
 PASS Can set 'text-justify' to the 'auto' keyword: auto
 PASS Can set 'text-justify' to the 'none' keyword: none
 PASS Can set 'text-justify' to the 'inter-word' keyword: inter-word

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-orientation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-orientation-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-orientation' to CSS-wide keywords: initial
 PASS Can set 'text-orientation' to CSS-wide keywords: inherit
 PASS Can set 'text-orientation' to CSS-wide keywords: unset
 PASS Can set 'text-orientation' to CSS-wide keywords: revert
-FAIL Can set 'text-orientation' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-orientation' to var() references:  var(--A)
 PASS Can set 'text-orientation' to the 'mixed' keyword: mixed
 PASS Can set 'text-orientation' to the 'upright' keyword: upright
 PASS Can set 'text-orientation' to the 'sideways' keyword: sideways

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-overflow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-overflow-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-overflow' to CSS-wide keywords: initial
 PASS Can set 'text-overflow' to CSS-wide keywords: inherit
 PASS Can set 'text-overflow' to CSS-wide keywords: unset
 PASS Can set 'text-overflow' to CSS-wide keywords: revert
-FAIL Can set 'text-overflow' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-overflow' to var() references:  var(--A)
 PASS Can set 'text-overflow' to the 'clip' keyword: clip
 PASS Can set 'text-overflow' to the 'ellipsis' keyword: ellipsis
 FAIL Can set 'text-overflow' to the 'fade' keyword: fade Invalid values

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-rendering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-rendering-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-rendering' to CSS-wide keywords: initial
 PASS Can set 'text-rendering' to CSS-wide keywords: inherit
 PASS Can set 'text-rendering' to CSS-wide keywords: unset
 PASS Can set 'text-rendering' to CSS-wide keywords: revert
-FAIL Can set 'text-rendering' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-rendering' to var() references:  var(--A)
 PASS Can set 'text-rendering' to the 'auto' keyword: auto
 FAIL Can set 'text-rendering' to the 'optimizespeed' keyword: optimizespeed assert_equals: expected "optimizespeed" but got "optimizeSpeed"
 FAIL Can set 'text-rendering' to the 'optimizelegibility' keyword: optimizelegibility assert_equals: expected "optimizelegibility" but got "optimizeLegibility"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-shadow-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-shadow' to CSS-wide keywords: initial
 PASS Can set 'text-shadow' to CSS-wide keywords: inherit
 PASS Can set 'text-shadow' to CSS-wide keywords: unset
 PASS Can set 'text-shadow' to CSS-wide keywords: revert
-FAIL Can set 'text-shadow' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-shadow' to var() references:  var(--A)
 PASS Can set 'text-shadow' to the 'none' keyword: none
 PASS Setting 'text-shadow' to a length throws TypeError
 PASS Setting 'text-shadow' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-transform-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-transform-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-transform' to CSS-wide keywords: initial
 PASS Can set 'text-transform' to CSS-wide keywords: inherit
 PASS Can set 'text-transform' to CSS-wide keywords: unset
 PASS Can set 'text-transform' to CSS-wide keywords: revert
-FAIL Can set 'text-transform' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-transform' to var() references:  var(--A)
 PASS Can set 'text-transform' to the 'none' keyword: none
 PASS Can set 'text-transform' to the 'capitalize' keyword: capitalize
 PASS Can set 'text-transform' to the 'uppercase' keyword: uppercase

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-underline-offset' to CSS-wide keywords: initial
 PASS Can set 'text-underline-offset' to CSS-wide keywords: inherit
 PASS Can set 'text-underline-offset' to CSS-wide keywords: unset
 PASS Can set 'text-underline-offset' to CSS-wide keywords: revert
-FAIL Can set 'text-underline-offset' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-underline-offset' to var() references:  var(--A)
 PASS Can set 'text-underline-offset' to the 'auto' keyword: auto
 PASS Can set 'text-underline-offset' to a length: 0px
 PASS Can set 'text-underline-offset' to a length: -3.14em

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-position-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'text-underline-position' to CSS-wide keywords: initial
 PASS Can set 'text-underline-position' to CSS-wide keywords: inherit
 PASS Can set 'text-underline-position' to CSS-wide keywords: unset
 PASS Can set 'text-underline-position' to CSS-wide keywords: revert
-FAIL Can set 'text-underline-position' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'text-underline-position' to var() references:  var(--A)
 PASS Can set 'text-underline-position' to the 'auto' keyword: auto
 PASS Can set 'text-underline-position' to the 'under' keyword: under
 FAIL Can set 'text-underline-position' to the 'left' keyword: left Invalid values

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/top-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/top-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'top' to CSS-wide keywords: initial
 PASS Can set 'top' to CSS-wide keywords: inherit
 PASS Can set 'top' to CSS-wide keywords: unset
 PASS Can set 'top' to CSS-wide keywords: revert
-FAIL Can set 'top' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'top' to var() references:  var(--A)
 PASS Can set 'top' to the 'auto' keyword: auto
 PASS Can set 'top' to a percent: 0%
 PASS Can set 'top' to a percent: -3.14%

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/touch-action-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/touch-action-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'touch-action' to CSS-wide keywords: initial
 PASS Can set 'touch-action' to CSS-wide keywords: inherit
 PASS Can set 'touch-action' to CSS-wide keywords: unset
 PASS Can set 'touch-action' to CSS-wide keywords: revert
-FAIL Can set 'touch-action' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'touch-action' to var() references:  var(--A)
 PASS Can set 'touch-action' to the 'auto' keyword: auto
 PASS Can set 'touch-action' to the 'none' keyword: none
 PASS Can set 'touch-action' to the 'pan-x' keyword: pan-x

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-box-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-box-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'transform-box' to CSS-wide keywords: initial
 PASS Can set 'transform-box' to CSS-wide keywords: inherit
 PASS Can set 'transform-box' to CSS-wide keywords: unset
 PASS Can set 'transform-box' to CSS-wide keywords: revert
-FAIL Can set 'transform-box' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'transform-box' to var() references:  var(--A)
 PASS Can set 'transform-box' to the 'border-box' keyword: border-box
 PASS Can set 'transform-box' to the 'fill-box' keyword: fill-box
 PASS Can set 'transform-box' to the 'view-box' keyword: view-box

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'transform' to CSS-wide keywords: initial
 PASS Can set 'transform' to CSS-wide keywords: inherit
 PASS Can set 'transform' to CSS-wide keywords: unset
 PASS Can set 'transform' to CSS-wide keywords: revert
-FAIL Can set 'transform' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'transform' to var() references:  var(--A)
 PASS Can set 'transform' to the 'none' keyword: none
 PASS Can set 'transform' to a transform: translate(50%, 50%)
 PASS Can set 'transform' to a transform: perspective(10em)

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-style-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'transform-style' to CSS-wide keywords: initial
 PASS Can set 'transform-style' to CSS-wide keywords: inherit
 PASS Can set 'transform-style' to CSS-wide keywords: unset
 PASS Can set 'transform-style' to CSS-wide keywords: revert
-FAIL Can set 'transform-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'transform-style' to var() references:  var(--A)
 FAIL Can set 'transform-style' to the 'auto' keyword: auto Invalid values
 PASS Can set 'transform-style' to the 'flat' keyword: flat
 PASS Can set 'transform-style' to the 'preserve-3d' keyword: preserve-3d

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-delay-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-delay-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'transition-delay' to CSS-wide keywords: initial
 PASS Can set 'transition-delay' to CSS-wide keywords: inherit
 PASS Can set 'transition-delay' to CSS-wide keywords: unset
 PASS Can set 'transition-delay' to CSS-wide keywords: revert
-FAIL Can set 'transition-delay' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'transition-delay' to var() references:  var(--A)
 PASS Can set 'transition-delay' to a time: 0s
 PASS Can set 'transition-delay' to a time: -3.14ms
 PASS Can set 'transition-delay' to a time: 3.14s

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'transition-duration' to CSS-wide keywords: initial
 PASS Can set 'transition-duration' to CSS-wide keywords: inherit
 PASS Can set 'transition-duration' to CSS-wide keywords: unset
 PASS Can set 'transition-duration' to CSS-wide keywords: revert
-FAIL Can set 'transition-duration' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'transition-duration' to var() references:  var(--A)
 PASS Can set 'transition-duration' to a time: 0s
 FAIL Can set 'transition-duration' to a time: -3.14ms Invalid values
 PASS Can set 'transition-duration' to a time: 3.14s

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-property-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'transition-property' to CSS-wide keywords: initial
 PASS Can set 'transition-property' to CSS-wide keywords: inherit
 PASS Can set 'transition-property' to CSS-wide keywords: unset
 PASS Can set 'transition-property' to CSS-wide keywords: revert
-FAIL Can set 'transition-property' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'transition-property' to var() references:  var(--A)
 PASS Can set 'transition-property' to the 'none' keyword: none
 PASS Setting 'transition-property' to a length throws TypeError
 PASS Setting 'transition-property' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-timing-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-timing-function-expected.txt
@@ -3,14 +3,14 @@ PASS Can set 'transition-timing-function' to CSS-wide keywords: initial
 PASS Can set 'transition-timing-function' to CSS-wide keywords: inherit
 PASS Can set 'transition-timing-function' to CSS-wide keywords: unset
 PASS Can set 'transition-timing-function' to CSS-wide keywords: revert
-FAIL Can set 'transition-timing-function' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'transition-timing-function' to var() references:  var(--A)
 PASS Can set 'transition-timing-function' to the 'linear' keyword: linear
 PASS Can set 'transition-timing-function' to the 'ease' keyword: ease
 PASS Can set 'transition-timing-function' to the 'ease-in' keyword: ease-in
 PASS Can set 'transition-timing-function' to the 'ease-out' keyword: ease-out
 PASS Can set 'transition-timing-function' to the 'ease-in-out' keyword: ease-in-out
-FAIL Can set 'transition-timing-function' to the 'step-start' keyword: step-start assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'transition-timing-function' to the 'step-end' keyword: step-end assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'transition-timing-function' to the 'step-start' keyword: step-start
+PASS Can set 'transition-timing-function' to the 'step-end' keyword: step-end
 PASS Setting 'transition-timing-function' to a length throws TypeError
 PASS Setting 'transition-timing-function' to a percent throws TypeError
 PASS Setting 'transition-timing-function' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/unicode-bidi-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/unicode-bidi-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'unicode-bidi' to CSS-wide keywords: initial
 PASS Can set 'unicode-bidi' to CSS-wide keywords: inherit
 PASS Can set 'unicode-bidi' to CSS-wide keywords: unset
 PASS Can set 'unicode-bidi' to CSS-wide keywords: revert
-FAIL Can set 'unicode-bidi' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'unicode-bidi' to var() references:  var(--A)
 PASS Can set 'unicode-bidi' to the 'normal' keyword: normal
 PASS Can set 'unicode-bidi' to the 'embed' keyword: embed
 PASS Can set 'unicode-bidi' to the 'isolate' keyword: isolate

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vector-effect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vector-effect-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'vector-effect' to CSS-wide keywords: initial
 PASS Can set 'vector-effect' to CSS-wide keywords: inherit
 PASS Can set 'vector-effect' to CSS-wide keywords: unset
 PASS Can set 'vector-effect' to CSS-wide keywords: revert
-FAIL Can set 'vector-effect' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'vector-effect' to var() references:  var(--A)
 PASS Can set 'vector-effect' to the 'non-scaling-stroke' keyword: non-scaling-stroke
 PASS Can set 'vector-effect' to the 'none' keyword: none
 PASS Setting 'vector-effect' to a length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vertical-align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vertical-align-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'vertical-align' to CSS-wide keywords: initial
 PASS Can set 'vertical-align' to CSS-wide keywords: inherit
 PASS Can set 'vertical-align' to CSS-wide keywords: unset
 PASS Can set 'vertical-align' to CSS-wide keywords: revert
-FAIL Can set 'vertical-align' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'vertical-align' to var() references:  var(--A)
 PASS Can set 'vertical-align' to the 'baseline' keyword: baseline
 PASS Can set 'vertical-align' to a length: 0px
 PASS Can set 'vertical-align' to a length: -3.14em

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/visibility-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/visibility-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'visibility' to CSS-wide keywords: initial
 PASS Can set 'visibility' to CSS-wide keywords: inherit
 PASS Can set 'visibility' to CSS-wide keywords: unset
 PASS Can set 'visibility' to CSS-wide keywords: revert
-FAIL Can set 'visibility' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'visibility' to var() references:  var(--A)
 PASS Can set 'visibility' to the 'visible' keyword: visible
 PASS Can set 'visibility' to the 'hidden' keyword: hidden
 PASS Can set 'visibility' to the 'collapse' keyword: collapse

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'white-space' to CSS-wide keywords: initial
 PASS Can set 'white-space' to CSS-wide keywords: inherit
 PASS Can set 'white-space' to CSS-wide keywords: unset
 PASS Can set 'white-space' to CSS-wide keywords: revert
-FAIL Can set 'white-space' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'white-space' to var() references:  var(--A)
 PASS Can set 'white-space' to the 'normal' keyword: normal
 PASS Can set 'white-space' to the 'pre' keyword: pre
 PASS Can set 'white-space' to the 'nowrap' keyword: nowrap

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt
@@ -3,11 +3,11 @@ PASS Can set 'widows' to CSS-wide keywords: initial
 PASS Can set 'widows' to CSS-wide keywords: inherit
 PASS Can set 'widows' to CSS-wide keywords: unset
 PASS Can set 'widows' to CSS-wide keywords: revert
-FAIL Can set 'widows' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Can set 'widows' to a number: 0 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
-FAIL Can set 'widows' to a number: -3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
-FAIL Can set 'widows' to a number: 3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
-FAIL Can set 'widows' to a number: calc(2 + 3) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+PASS Can set 'widows' to var() references:  var(--A)
+FAIL Can set 'widows' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'widows' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'widows' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'widows' to a number: calc(2 + 3) assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 PASS Setting 'widows' to a length throws TypeError
 PASS Setting 'widows' to a percent throws TypeError
 PASS Setting 'widows' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt
@@ -3,16 +3,16 @@ PASS Can set 'width' to CSS-wide keywords: initial
 PASS Can set 'width' to CSS-wide keywords: inherit
 PASS Can set 'width' to CSS-wide keywords: unset
 PASS Can set 'width' to CSS-wide keywords: revert
-FAIL Can set 'width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'width' to var() references:  var(--A)
 PASS Can set 'width' to the 'auto' keyword: auto
 PASS Can set 'width' to a percent: 0%
 FAIL Can set 'width' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'width' to a percent: 3.14%
-FAIL Can set 'width' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'width' to a percent: calc(0% + 0%)
 PASS Can set 'width' to a length: 0px
 PASS Can set 'width' to a length: -3.14em
 PASS Can set 'width' to a length: 3.14cm
-FAIL Can set 'width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'width' to a length: calc(0px + 0em)
 PASS Setting 'width' to a time throws TypeError
 PASS Setting 'width' to an angle throws TypeError
 PASS Setting 'width' to a flexible length throws TypeError
@@ -23,15 +23,15 @@ PASS Can set 'min-width' to CSS-wide keywords: initial
 PASS Can set 'min-width' to CSS-wide keywords: inherit
 PASS Can set 'min-width' to CSS-wide keywords: unset
 PASS Can set 'min-width' to CSS-wide keywords: revert
-FAIL Can set 'min-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'min-width' to var() references:  var(--A)
 PASS Can set 'min-width' to a percent: 0%
 FAIL Can set 'min-width' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'min-width' to a percent: 3.14%
-FAIL Can set 'min-width' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'min-width' to a percent: calc(0% + 0%)
 PASS Can set 'min-width' to a length: 0px
 PASS Can set 'min-width' to a length: -3.14em
 PASS Can set 'min-width' to a length: 3.14cm
-FAIL Can set 'min-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'min-width' to a length: calc(0px + 0em)
 PASS Setting 'min-width' to a time throws TypeError
 PASS Setting 'min-width' to an angle throws TypeError
 PASS Setting 'min-width' to a flexible length throws TypeError
@@ -42,16 +42,16 @@ PASS Can set 'max-width' to CSS-wide keywords: initial
 PASS Can set 'max-width' to CSS-wide keywords: inherit
 PASS Can set 'max-width' to CSS-wide keywords: unset
 PASS Can set 'max-width' to CSS-wide keywords: revert
-FAIL Can set 'max-width' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'max-width' to var() references:  var(--A)
 PASS Can set 'max-width' to the 'none' keyword: none
 PASS Can set 'max-width' to a percent: 0%
 FAIL Can set 'max-width' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'max-width' to a percent: 3.14%
-FAIL Can set 'max-width' to a percent: calc(0% + 0%) assert_equals: expected 2 but got 1
+PASS Can set 'max-width' to a percent: calc(0% + 0%)
 PASS Can set 'max-width' to a length: 0px
 PASS Can set 'max-width' to a length: -3.14em
 PASS Can set 'max-width' to a length: 3.14cm
-FAIL Can set 'max-width' to a length: calc(0px + 0em) assert_equals: expected "px" but got "em"
+PASS Can set 'max-width' to a length: calc(0px + 0em)
 PASS Setting 'max-width' to a time throws TypeError
 PASS Setting 'max-width' to an angle throws TypeError
 PASS Setting 'max-width' to a flexible length throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'will-change' to CSS-wide keywords: initial
 PASS Can set 'will-change' to CSS-wide keywords: inherit
 PASS Can set 'will-change' to CSS-wide keywords: unset
 PASS Can set 'will-change' to CSS-wide keywords: revert
-FAIL Can set 'will-change' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'will-change' to var() references:  var(--A)
 PASS Can set 'will-change' to the 'auto' keyword: auto
 PASS Setting 'will-change' to a length throws TypeError
 PASS Setting 'will-change' to a percent throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-break-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-break-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'word-break' to CSS-wide keywords: initial
 PASS Can set 'word-break' to CSS-wide keywords: inherit
 PASS Can set 'word-break' to CSS-wide keywords: unset
 PASS Can set 'word-break' to CSS-wide keywords: revert
-FAIL Can set 'word-break' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'word-break' to var() references:  var(--A)
 PASS Can set 'word-break' to the 'normal' keyword: normal
 PASS Can set 'word-break' to the 'keep-all' keyword: keep-all
 PASS Can set 'word-break' to the 'break-all' keyword: break-all

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-spacing-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'word-spacing' to CSS-wide keywords: initial
 PASS Can set 'word-spacing' to CSS-wide keywords: inherit
 PASS Can set 'word-spacing' to CSS-wide keywords: unset
 PASS Can set 'word-spacing' to CSS-wide keywords: revert
-FAIL Can set 'word-spacing' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'word-spacing' to var() references:  var(--A)
 FAIL Can set 'word-spacing' to the 'normal' keyword: normal assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 PASS Can set 'word-spacing' to a length: 0px
 PASS Can set 'word-spacing' to a length: -3.14em

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-wrap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-wrap-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'word-wrap' to CSS-wide keywords: initial
 PASS Can set 'word-wrap' to CSS-wide keywords: inherit
 PASS Can set 'word-wrap' to CSS-wide keywords: unset
 PASS Can set 'word-wrap' to CSS-wide keywords: revert
-FAIL Can set 'word-wrap' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'word-wrap' to var() references:  var(--A)
 PASS Can set 'word-wrap' to the 'normal' keyword: normal
 PASS Can set 'word-wrap' to the 'break-word' keyword: break-word
 FAIL Can set 'word-wrap' to the 'break-spaces' keyword: break-spaces Invalid values

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/writing-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/writing-mode-expected.txt
@@ -3,7 +3,7 @@ PASS Can set 'writing-mode' to CSS-wide keywords: initial
 PASS Can set 'writing-mode' to CSS-wide keywords: inherit
 PASS Can set 'writing-mode' to CSS-wide keywords: unset
 PASS Can set 'writing-mode' to CSS-wide keywords: revert
-FAIL Can set 'writing-mode' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'writing-mode' to var() references:  var(--A)
 PASS Can set 'writing-mode' to the 'horizontal-tb' keyword: horizontal-tb
 PASS Can set 'writing-mode' to the 'vertical-rl' keyword: vertical-rl
 PASS Can set 'writing-mode' to the 'vertical-lr' keyword: vertical-lr

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt
@@ -3,12 +3,12 @@ PASS Can set 'z-index' to CSS-wide keywords: initial
 PASS Can set 'z-index' to CSS-wide keywords: inherit
 PASS Can set 'z-index' to CSS-wide keywords: unset
 PASS Can set 'z-index' to CSS-wide keywords: revert
-FAIL Can set 'z-index' to var() references:  var(--A) assert_equals: expected 2 but got 1
+PASS Can set 'z-index' to var() references:  var(--A)
 PASS Can set 'z-index' to the 'auto' keyword: auto
 FAIL Can set 'z-index' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'z-index' to a number: -3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
-FAIL Can set 'z-index' to a number: 3.14 assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
-FAIL Can set 'z-index' to a number: calc(2 + 3) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'z-index' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'z-index' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'z-index' to a number: calc(2 + 3) assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 PASS Setting 'z-index' to a length throws TypeError
 PASS Setting 'z-index' to a percent throws TypeError
 PASS Setting 'z-index' to a time throws TypeError

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -554,8 +554,19 @@ LengthBox CSSToStyleMap::mapNinePieceImageQuad(CSSValue& value)
 
     // Retrieve the primitive value.
     auto& borderWidths = downcast<CSSPrimitiveValue>(value);
+    if (LIKELY(borderWidths.quadValue()))
+        return mapNinePieceImageQuad(*borderWidths.quadValue());
 
-    return mapNinePieceImageQuad(*borderWidths.quadValue());
+    // Values coming from CSS Type OM may not have been converted to a Quad yet.
+    if (!borderWidths.isNumber() && !borderWidths.isLength())
+        return LengthBox();
+
+    auto quad = Quad::create();
+    quad->setTop(&borderWidths);
+    quad->setRight(&borderWidths);
+    quad->setBottom(&borderWidths);
+    quad->setLeft(&borderWidths);
+    return mapNinePieceImageQuad(quad);
 }
 
 LengthBox CSSToStyleMap::mapNinePieceImageQuad(Quad& quad)

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -267,7 +267,7 @@ RefPtr<CSSValue> CSSUnitValue::toCSSValueWithProperty(CSSPropertyID propertyID) 
         auto sumNode = CSSCalcOperationNode::createSum(Vector { node.releaseNonNull() });
         if (!sumNode)
             return nullptr;
-        return CSSCalcValue::create(sumNode.releaseNonNull(), true /* allowsNegativePercentage */);
+        return CSSPrimitiveValue::create(CSSCalcValue::create(sumNode.releaseNonNull(), true /* allowsNegativePercentage */));
     }
     return toCSSValue();
 }

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
@@ -104,7 +104,11 @@ bool InlineStylePropertyMap::setProperty(CSSPropertyID propertyID, Ref<CSSValue>
         return false;
     bool didFailParsing = false;
     bool important = false;
+    // FIXME: We should be able to validate CSSValues without having to serialize to text and go through the
+    // parser. This is inefficient.
     m_element->setInlineStyleProperty(propertyID, value->cssText(), important, &didFailParsing);
+    if (!didFailParsing)
+        m_element->setInlineStyleProperty(propertyID, WTFMove(value));
     return !didFailParsing;
 }
 

--- a/Source/WebCore/css/typedom/numeric/CSSMathValue.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathValue.h
@@ -30,6 +30,7 @@
 #include "CSSMathOperator.h"
 #include "CSSNumericArray.h"
 #include "CSSNumericValue.h"
+#include "CSSPrimitiveValue.h"
 #include "CSSStyleValue.h"
 
 namespace WebCore {
@@ -68,7 +69,7 @@ public:
         auto node = toCalcExpressionNode();
         if (!node)
             return nullptr;
-        return CSSCalcValue::create(node.releaseNonNull());
+        return CSSPrimitiveValue::create(CSSCalcValue::create(node.releaseNonNull()));
     }
 };
 

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
@@ -181,7 +181,7 @@ void CSSTransformValue::serialize(StringBuilder& builder, OptionSet<Serializatio
 
 RefPtr<CSSValue> CSSTransformValue::toCSSValue() const
 {
-    auto cssValueList = CSSValueList::createSpaceSeparated();
+    auto cssValueList = CSSTransformListValue::create();
     for (auto& component : m_components) {
         if (auto cssComponent = component->toCSSValue())
             cssValueList->append(cssComponent.releaseNonNull());


### PR DESCRIPTION
#### bfd520b659e89b66f32b4863609a704e8c81357f
<pre>
StylePropertyMap should return CSS values exactly as they were set
<a href="https://bugs.webkit.org/show_bug.cgi?id=249019">https://bugs.webkit.org/show_bug.cgi?id=249019</a>

Reviewed by Antti Koivisto.

StylePropertyMap should return CSS values exactly as they were set. However,
our implementation passes the input to the CSS parser which may result in a
slightly different representation (sometimes simplified, sometimes converted).
Feeding the input through the CSS parser is useful because it validates that
the value is valid for the property in question. Also, our StyleBuilder makes a
lot of assumptions about the type / format of the value for a given CSS
property so we cannot let the JS set CSS property values that do not match the
expected type / format.

To address the issue, we now check if setting the property value as a string
through the CSS parser succeeded or not. If it succeeded then we set the CSS
value from the JavaScript as-is. To support this I had to make some fixes to
our StyleBuilder to be more permissive in terms of what types of CSSValues it
supports for each property.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/accent-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-play-state-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-timing-function-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backface-visibility-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-attachment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-blend-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-clip-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-image-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-collapse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-source-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/bottom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-sizing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/break-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caption-side-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caret-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clear-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-path-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-count-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-span-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/contain-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-increment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-reset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/cursor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/direction-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/display-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/dominant-baseline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/empty-cells-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/filter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-direction-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-wrap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/float-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-feature-settings-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-kerning-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-optical-sizing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-palette-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-synthesis-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-alternates-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-caps-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-east-asian-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-ligatures-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-numeric-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variation-settings-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-flow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-areas-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/isolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/left-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/lighting-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-break-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-image-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/marker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-image-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mix-blend-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-fit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-anchor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-distance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-path-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-rotate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-anchor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-wrap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overscroll-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/paint-order-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/pointer-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/quotes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resize-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/right-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-align-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-stop-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-image-threshold-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-outside-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-rendering-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linecap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linejoin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/tab-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/table-layout-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-last-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-anchor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-combine-upright-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-ink-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-thickness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-emphasis-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-justify-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-orientation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-overflow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-rendering-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-transform-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/top-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/touch-action-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-box-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-delay-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-property-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-timing-function-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/unicode-bidi-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vector-effect-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vertical-align-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/visibility-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-break-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-wrap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/writing-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt:
* Source/WebCore/css/CSSValue.h:
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::CSSUnitValue::toCSSValueWithProperty const):
* Source/WebCore/css/typedom/InlineStylePropertyMap.cpp:
(WebCore::InlineStylePropertyMap::setProperty):
* Source/WebCore/css/typedom/numeric/CSSMathValue.h:

Canonical link: <a href="https://commits.webkit.org/257815@main">https://commits.webkit.org/257815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ca8750400658f0bd3a77de963c4adeb33429057

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109433 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169667 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86760 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92530 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107323 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105861 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3038 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23858 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3003 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43339 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5369 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4849 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->