### PR TITLE
[ews-build.webkit.org] Prioritize Commit-Queue over Merge-Queue

### DIFF
--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -139,7 +139,7 @@ def prioritizeBuilders(buildmaster, builders):
     def key(b):
         request_time = yield b.getOldestRequestTime()
         return (
-            'build' not in b.name.lower(),
+            'build' not in b.name.lower() and 'unsafe' not in b.name.lower() and 'commit' not in b.name.lower(),
             bool(b.building) or bool(b.old_building),
             request_time or datetime.now(timezone.utc),
         )

--- a/Tools/CISupport/ews-build/loadConfig_unittest.py
+++ b/Tools/CISupport/ews-build/loadConfig_unittest.py
@@ -284,6 +284,18 @@ class TestPrioritizeBuilders(unittest.TestCase):
             [builder.name for builder in sorted_builders],
         )
 
+    def test_starvation_prioritize_commit_queue(self):
+        builders = [
+            self.MockBuilder('Commit-Queue', oldestRequestTime=datetime.now(timezone.utc) - timedelta(seconds=10)),
+            self.MockBuilder('Merge-Queue', oldestRequestTime=datetime.now(timezone.utc) - timedelta(seconds=60)),
+            self.MockBuilder('Unsafe-Merge-Queue', oldestRequestTime=datetime.now(timezone.utc) - timedelta(seconds=20)),
+        ]
+        sorted_builders = loadConfig.prioritizeBuilders(None, builders)
+        self.assertEqual(
+            ['Unsafe-Merge-Queue', 'Commit-Queue', 'Merge-Queue'],
+            [builder.name for builder in sorted_builders],
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#### b50ae4bd2b1193152044dbd05012442713f3ea05
<pre>
[ews-build.webkit.org] Prioritize Commit-Queue over Merge-Queue
<a href="https://bugs.webkit.org/show_bug.cgi?id=249192">https://bugs.webkit.org/show_bug.cgi?id=249192</a>
rdar://103275000

Reviewed by Aakash Jain.

Prioritize Commit-Queue over Merge-Queue since Commit-Queue is mostly
used for reverts via webkit-bot these days.

* Tools/CISupport/ews-build/loadConfig.py:
(prioritizeBuilders.key): Prioritize queues with &apos;commit&apos; and &apos;unsafe&apos; in their names.
* Tools/CISupport/ews-build/loadConfig_unittest.py:
(TestPrioritizeBuilders.test_starvation_prioritize_commit_queue):

Canonical link: <a href="https://commits.webkit.org/257801@main">https://commits.webkit.org/257801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ebb95347492821adbac50781c3726934fc1931e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109308 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169543 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86425 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107209 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34276 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22232 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2926 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23745 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46125 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/98885 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9019 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43219 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4734 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2756 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->