### PR TITLE
[ews-build.webkit.org] Don't consult results.webkit.org for non-main PRs

### DIFF
--- a/Tools/CISupport/ews-build/results_db.py
+++ b/Tools/CISupport/ews-build/results_db.py
@@ -96,18 +96,18 @@ class ResultsDatabase(object):
                 response.deliverBody(cls.JsonPrinter(finished))
                 data = yield finished
                 defer.returnValue(json.loads(data))
-            else:
-                logger(f'Failed to query results summary with status code {response.code}\n')
-                defer.returnValue({})
+                return
+            logger(f'Failed to query results summary with status code {response.code}\n')
         except error.ConnectError as e:
             logger(f'Failed to connect to {cls.HOSTNAME}: {e}\n')
-            defer.returnValue({})
         except ResponseFailed:
             logger(f'No response from {cls.HOSTNAME}\n')
-            defer.returnValue({})
         except json.decoder.JSONDecodeError:
             logger('Non-json response from results summary query\n')
-            defer.returnValue({})
+        except Exception as e:
+            logger(f'Unknown exception when consulting results database:\n{e}\n')
+
+        defer.returnValue({})
 
     @classmethod
     @defer.inlineCallbacks

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3278,6 +3278,7 @@ class RunWebKitTests(shell.Test, AddToLogMixin):
         logTextJson = self.log_observer_json.getStdout()
 
         first_results = LayoutTestFailures.results_from_string(logTextJson)
+        is_main = self.getProperty('github.base.ref', DEFAULT_BRANCH) == DEFAULT_BRANCH
 
         if first_results:
             self.setProperty('first_results_exceed_failure_limit', first_results.did_exceed_test_failure_limit)
@@ -3286,7 +3287,7 @@ class RunWebKitTests(shell.Test, AddToLogMixin):
             if first_results.failing_tests:
                 self._addToLog(self.test_failures_log_name, '\n'.join(first_results.failing_tests))
 
-            if first_results.failing_tests and not first_results.did_exceed_test_failure_limit:
+            if is_main and first_results.failing_tests and not first_results.did_exceed_test_failure_limit:
                 yield self.filter_failures_using_results_db(first_results.failing_tests)
                 self.setProperty('first_run_failures_filtered', sorted(self.failing_tests_filtered))
                 self.setProperty('results-db_first_run_pre_existing', sorted(self.preexisting_failures_in_results_db))
@@ -3504,6 +3505,7 @@ class ReRunWebKitTests(RunWebKitTests):
         logTextJson = self.log_observer_json.getStdout()
 
         second_results = LayoutTestFailures.results_from_string(logTextJson)
+        is_main = self.getProperty('github.base.ref', DEFAULT_BRANCH) == DEFAULT_BRANCH
 
         if second_results:
             self.setProperty('second_results_exceed_failure_limit', second_results.did_exceed_test_failure_limit)
@@ -3512,7 +3514,7 @@ class ReRunWebKitTests(RunWebKitTests):
             if second_results.failing_tests:
                 self._addToLog(self.test_failures_log_name, '\n'.join(second_results.failing_tests))
 
-            if second_results.failing_tests and not second_results.did_exceed_test_failure_limit:
+            if is_main and second_results.failing_tests and not second_results.did_exceed_test_failure_limit:
                 yield self.filter_failures_using_results_db(second_results.failing_tests)
                 self.setProperty('second_run_failures_filtered', sorted(self.failing_tests_filtered))
                 self.setProperty('results-db_second_run_pre_existing', sorted(self.preexisting_failures_in_results_db))


### PR DESCRIPTION
#### 14dcf9a35beb7346e83e2d664cb1923aee68c1b7
<pre>
[ews-build.webkit.org] Don&apos;t consult results.webkit.org for non-main PRs
<a href="https://bugs.webkit.org/show_bug.cgi?id=249166">https://bugs.webkit.org/show_bug.cgi?id=249166</a>

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/results_db.py:
(ResultsDatabase.get_results_summary): Catch all exceptions when making a request
to be more resiliant to failures.
* Tools/CISupport/ews-build/steps.py:
(RunWebKitTests.runCommand): Skip results.webkit.org checkout for non-main PRs.
(ReRunWebKitTests.runCommand): Ditto.

Canonical link: <a href="https://commits.webkit.org/257819@main">https://commits.webkit.org/257819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8febe243560e189e1e5cbb39139e199747bf864a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109380 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169618 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86559 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92480 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107279 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34333 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22296 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90640 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/imports-oom.js.default-wasm (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2996 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23811 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86576 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/403 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2954 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/46182 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29027 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43292 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89455 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4805 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19999 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2760 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->