### PR TITLE
Re-land [Wasm-GC] Implement packed types in arrays

### DIFF
--- a/JSTests/wasm/gc/arrays.js
+++ b/JSTests/wasm/gc/arrays.js
@@ -34,7 +34,7 @@ function testArrayDeclaration() {
   assert.throws(
     () => new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x84\x80\x80\x80\x00\x01\x5e\xff\x02")),
     WebAssembly.CompileError,
-    "Module doesn't parse at byte 17: can't get array's element Type"
+    "Module doesn't parse at byte 16: can't get array's element Type"
   )
 
   /*

--- a/JSTests/wasm/gc/packed-arrays.js
+++ b/JSTests/wasm/gc/packed-arrays.js
@@ -1,0 +1,474 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+function check(createModuleString, type, expectedVal) {
+    let m = instantiate(createModuleString(type));
+    assert.eq(m.exports.f(), expectedVal);
+}
+
+function testArrayGetPacked() {
+    let f = (type) => `
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+          (array.new_canon_default 0 (i32.const 5))
+          (i32.const 2)
+          (array.get_u 0)))
+    `;
+    check(f, "i8", 0);
+    check(f, "i16", 0);
+}
+
+function testArrayGetUWithNewCanonPacked() {
+    /*
+     * maxint32 => truncate to 0xFF => zero-extend to 0x000000FF (i8) or 0x0000FFFF (i16)
+     */
+    {
+        let f = (type) => `
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+          (array.new_canon 0 (i32.const 0x7FFF_FFFF) (i32.const 5))
+          (i32.const 2)
+          (array.get_u 0)))
+    `;
+        check(f, "i8", 255);
+        check(f, "i16", 0xFFFF);
+    }
+
+    /*
+     * -1 => truncate to 0xFF => zero-extend to 0x000000FF (i8) or 0x0000FFFF (i16)
+     */
+    {
+        let f = (type) => `
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+          (array.new_canon 0 (i32.const 0xFFFF_FFFF) (i32.const 5))
+          (i32.const 2)
+          (array.get_u 0)))
+    `;
+        check(f, "i8", 255);
+        check(f, "i16", 0xFFFF);
+    }
+
+    /*
+     * 0x4000_0000 => truncate to 0 => zero-extend to 0
+     */
+    {
+        let f = (type) => `
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+          (array.new_canon 0 (i32.const 0x4000_0000) (i32.const 5))
+          (i32.const 2)
+          (array.get_u 0)))
+    `;
+        check(f, "i8", 0);
+        check(f, "i16", 0);
+    }
+
+    /*
+     * 0x00000080 => truncate to 0x80  => zero-extend to 128
+     */
+ {
+     let f = (type) => `
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+          (array.new_canon 0 (i32.const 0x80) (i32.const 5))
+          (i32.const 2)
+          (array.get_u 0)))
+    `;
+     check(f, "i8", 128);
+     check(f, "i16", 128);
+  }
+
+    /*
+     * 0xaaaa_aaaa => truncate to 0xaa  => zero-extend to 0xaa (i8) or 0xaaaa (i16)
+     */
+ {
+     let f = (type) => `
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+          (array.new_canon 0 (i32.const 0xaaaa_aaaa) (i32.const 5))
+          (i32.const 2)
+          (array.get_u 0)))
+    `;
+     check(f, "i8", 0xaa);
+     check(f, "i16", 0xaaaa);
+  }
+
+}
+
+// These tests test two different things at once (that array.get_s sign-extends properly,
+// and that array.new_canon truncates properly)
+function testArrayGetSWithNewCanonPacked() {
+    /*
+     * maxint32 => truncate to 0xFF (or 0xFFFF) => sign-extend to 0xFFFFFFFF
+     */
+
+    {
+        let f = (type) => `
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+          (array.new_canon 0 (i32.const 0x7FFF_FFFF) (i32.const 5))
+          (i32.const 2)
+          (array.get_s 0)))
+    `;
+        check(f, "i8", -1);
+        check(f, "i16", -1);
+    }
+
+    /*
+     * -1 => truncate to 0xFF (or 0xFFFF) => sign-extend to 0xFFFFFFFF
+     */
+
+    {
+        let f = (type) => `
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+          (array.new_canon 0 (i32.const 0xFFFF_FFFF) (i32.const 5))
+          (i32.const 2)
+          (array.get_s 0)))
+    `;
+        check(f, "i8", -1);
+        check(f, "i16", -1);
+    }
+
+    /*
+     * 0x4000_0000 => truncate to 0 => sign-extend to 0
+     */
+
+  {
+      let f = (type) => `
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+          (array.new_canon 0 (i32.const 0x4000_0000) (i32.const 5))
+          (i32.const 2)
+          (array.get_s 0)))
+    `;
+      check(f, "i8", 0);
+      check(f, "i16", 0);
+  }
+
+    /*
+     * 0x0000_0080 => truncate to 0x80 => sign-extend to -128 (i8) or 128 (i16)
+     */
+
+  {
+      let f = (type) => `
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+          (array.new_canon 0 (i32.const 0x0000_0080) (i32.const 5))
+          (i32.const 2)
+          (array.get_s 0)))
+    `;
+      check(f, "i8", -128);
+      check(f, "i16", 128);
+  }
+
+    /*
+     * 0x0000_8000 => truncate to 0 (i8) 0x8000 (i16) => sign-extend to 0 (i8) or 0xffff8000 (-32768) (i16)
+     */
+
+    {
+      let f = (type) => `
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+          (array.new_canon 0 (i32.const 0x0000_8000) (i32.const 5))
+          (i32.const 2)
+          (array.get_s 0)))
+    `;
+        check(f, "i8", 0);
+        check(f, "i16", -32768);
+    }
+
+
+    /*
+     * 0xaaaa_aaaa => truncate to 0xaa (i8) or 0xaaaa (i16) => sign-extend to 0xffff_ffaa (-86) (i8) or 0xffff_aaaa (-21846) (i16)
+     */
+
+    {
+        let f = (type) => `
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+          (array.new_canon 0 (i32.const 0xaaaa_aaaa) (i32.const 5))
+          (i32.const 2)
+          (array.get_s 0)))
+    `;
+        check(f, "i8", -86);
+        check(f, "i16", -21846);
+    }
+
+}
+
+// Should be an error to initialize a packed array with an i64 value
+function testTypeMismatch64() {
+    let check = (type) => assert.throws(
+        () => compile(`
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+          (array.new_canon 0 (i64.const 0) (i32.const 5))
+          (i32.const 2)
+          (array.get_u 0)))
+    `),
+        WebAssembly.CompileError,
+        "array.new value to type I64 expected I32"
+    );
+    check("i8");
+    check("i16");
+}
+
+
+// Should be an error to use array.get on a packed array -- need get_s or get_u
+function testTypeMismatchArrayGet() {
+    let f = (type) => () => compile(`
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+          (array.new_canon 0 (i32.const 0) (i32.const 5))
+          (i32.const 2)
+          (array.get 0)))
+    `);
+    assert.throws(f("i8"),
+                  WebAssembly.CompileError,
+                  "array.get applied to packed array of I8 -- use array.get_s or array.get_u");
+    assert.throws(f("i16"),
+                  WebAssembly.CompileError,
+                  "array.get applied to packed array of I16 -- use array.get_s or array.get_u");
+}
+
+/*
+Should be an error to use i8 or i16 outside an array context
+*/
+function testPackedTypeOutOfContext() {
+/*
+(module
+  (func (export "f") (result i8)
+    (i32.const 2)))
+*/
+    assert.throws(() => new WebAssembly.Instance(module("\x00\x61\x73\x6D\x01\x00\x00\x00\x01\x85\x80\x80\x80\x00\x01\x60\x00\x01\x7A\x03\x82\x80\x80\x80\x00\x01\x00\x07\x85\x80\x80\x80\x00\x01\x01\x66\x00\x00\x0A\x8A\x80\x80\x80\x00\x01\x84\x80\x80\x80\x00\x00\x41\x02\x0B")),
+                  WebAssembly.CompileError,
+                  "WebAssembly.Module doesn't parse at byte 19: can't get 0th Type's return value");
+/*
+(module
+  (func (export "f") (param i16) (result i32)
+    (i32.const 2)))
+*/
+    assert.throws(() => new WebAssembly.Instance(module("\x00\x61\x73\x6D\x01\x00\x00\x00\x01\x86\x80\x80\x80\x00\x01\x60\x01\x79\x01\x7F\x03\x82\x80\x80\x80\x00\x01\x00\x07\x85\x80\x80\x80\x00\x01\x01\x66\x00\x00\x0A\x8A\x80\x80\x80\x00\x01\x84\x80\x80\x80\x00\x00\x41\x02\x0B")),
+                  WebAssembly.CompileError,
+                  "WebAssembly.Module doesn't parse at byte 18: can't get 0th argument Type");
+/*
+(module
+  (type (func (param i8) (result i32))))
+*/
+    assert.throws(() => new WebAssembly.Instance(module("\x00\x61\x73\x6D\x01\x00\x00\x00\x01\x86\x80\x80\x80\x00\x01\x60\x01\x7A\x01\x7F")),
+                  WebAssembly.CompileError,
+                  "WebAssembly.Module doesn't parse at byte 18: can't get 0th argument Type");
+/*
+(module
+  (type (func (param i32) (result i16))))
+*/
+    assert.throws(() => new WebAssembly.Instance(module("\x00\x61\x73\x6D\x01\x00\x00\x00\x01\x86\x80\x80\x80\x00\x01\x60\x01\x7F\x01\x79")),
+                  WebAssembly.CompileError,
+                  "WebAssembly.Module doesn't parse at byte 20: can't get 0th Type's return value");
+/*
+(module
+  (global (mut i8) (i32.const 0)))
+*/
+    assert.throws(() => new WebAssembly.Instance(module("\x00\x61\x73\x6D\x01\x00\x00\x00\x06\x86\x80\x80\x80\x00\x01\x7A\x01\x41\x00\x0B")),
+                  WebAssembly.CompileError,
+                  "WebAssembly.Module doesn't parse at byte 16: can't get Global's value type");
+/*
+(module
+  (global (mut i16) (i32.const 0)))
+*/
+    assert.throws(() => new WebAssembly.Instance(module("\x00\x61\x73\x6D\x01\x00\x00\x00\x06\x86\x80\x80\x80\x00\x01\x79\x01\x41\x00\x0B")),
+                  WebAssembly.CompileError,
+                  "WebAssembly.Module doesn't parse at byte 16: can't get Global's value type");
+}
+
+// Tests that setting `element` in an array of `type` is a type error; also takes `elementType`
+// so the right error message can be tested for
+function testTypeError(type, element, elementType) {
+    assert.throws(() => compile(`
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+        (array.new_canon_default 0 (i32.const 5))
+        (i32.const 2)`
+        + element +
+        `\n(array.set 0)
+        (array.get_u 0)))`),
+                  WebAssembly.CompileError,
+                  "array.set value to type " + elementType + " expected I32");
+}
+
+// Tests that setting an element in a null array of type `type` is a runtime error
+function testTrapsNull(type) {
+    let m = instantiate(`
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+        (ref.null 0)
+        (i32.const 2)
+        (i32.const 17)
+        (array.set 0)
+        (i32.const 0)))`);
+    assert.throws(() => { m.exports.f(); },
+                  WebAssembly.RuntimeError,
+                  "array.set to a null reference");
+}
+
+// Tests that setting `index` in a `type` array of length `len` is a runtime error
+function testTrapsOutOfBounds(type, len, index) {
+    let m = instantiate(`
+      (module
+        (type (array (mut ` + type + `)))
+        (func (export "f") (result i32)
+        (array.new_canon_default 0 (i32.const ` + len + `))
+        (i32.const ` + index + `)
+        (i32.const 17)
+        (array.set 0)
+        (i32.const 0)))`);
+    assert.throws(() => { m.exports.f(); },
+                  WebAssembly.RuntimeError,
+                  "Out of bounds array.set");
+}
+
+// Tests that if we set a[`index`] to (i32.const `value`), where a is a `type` array of length `len`, the following get operation returns (i32.const `value`)
+function testSetGetRoundtrip(type, len, index, value) {
+    let m = instantiate(`
+      (module
+        (type (array (mut ` + type + `)))
+        (global (mut (ref null 0)) (ref.null 0))
+        (func (export "init")
+           (global.set 0 (array.new_canon_default 0 (i32.const ` + len + `))))
+        (func (export "f") (result i32)
+          (array.set 0 (global.get 0) (i32.const ` + index + `) (i32.const ` + value + `))
+          (array.get_u 0 (global.get 0) (i32.const ` + index + `))))`);
+    m.exports.init();
+    assert.eq(m.exports.f(), value);
+}
+
+// Creates an array a of type `type`, sets a[i] (for some in-bounds i) to `inValue`, and gets `a[i]` using `signMode`; compares the result to `outValue`
+function testSetGetTruncate(type, signMode, inValue, outValue) {
+    let m = instantiate(`
+      (module
+        (type (array (mut ` + type + `)))
+        (global (mut (ref null 0)) (ref.null 0))
+        (func (export "init")
+           (global.set 0 (array.new_canon_default 0 (i32.const 5))))
+        (func (export "f") (result i32)
+          (array.set 0 (global.get 0) (i32.const 3) (i32.const ` + inValue + `))
+          (array.get_` + signMode + ` 0 (global.get 0) (i32.const 3))))`);
+    m.exports.init();
+    assert.eq(m.exports.f(), outValue);
+}
+
+/*
+  array.set
+  for both i8 and i16:
+
+  test that it's a type error to pass in a non-i32 value when setting a packed array element
+  test that it traps correctly for null
+    and if the index is out of bounds
+  test array lengths 0, 1, 5
+  test indices 0, 1, and (for length 5) 3 and 4
+
+  test that set/get roundtrips for within-bounds values
+  test that set/get returns the properly truncated value for each combination of type and sign-extension
+ */
+
+function testArraySet() {
+    for (const type of ["i8", "i16"]) {
+        testTypeError(type, "(i64.const 3)", "I64");
+        testTrapsNull(type);
+        testTrapsOutOfBounds(type, 5, 5);
+        testTrapsOutOfBounds(type, 5, 7);
+        testTrapsOutOfBounds(type, 0, 1);
+        for (const length of [0, 1, 5]) {
+            for (const index of [0, 1, 3, 4]) {
+                if (index < length) {
+                    testSetGetRoundtrip(type, length, index, 17);
+                } else {
+                    testTrapsOutOfBounds(type, length, index);
+                }
+            }
+        }
+    }
+    // testSetGetTruncate(type, signMode, inValue, outValue)
+    testSetGetTruncate("i8", "u", 0xFFFF_FFFF, 255);
+    testSetGetTruncate("i8", "u", 0x4000_0000, 0);
+    testSetGetTruncate("i8", "u", 0x80, 128);
+    testSetGetTruncate("i8", "s", 0xFFFF_FFFF, -1);
+    testSetGetTruncate("i8", "s", 0x4000_0000, 0);
+    testSetGetTruncate("i8", "s", 0x80, -128);
+    testSetGetTruncate("i16", "u", 0xFFFF_FFFF, 0xFFFF);
+    testSetGetTruncate("i16", "u", 0x4000_0000, 0);
+    testSetGetTruncate("i16", "u", 0x80, 128);
+    testSetGetTruncate("i16", "s", 0xFFFF_FFFF, -1);
+    testSetGetTruncate("i16", "s", 0x4000_0000, 0);
+    testSetGetTruncate("i16", "s", 0x80, 128);
+    testSetGetTruncate("i16", "s", 0x7FFF_FFFF, -1);
+    testSetGetTruncate("i16", "s", 0x4000_0000, 0);
+    testSetGetTruncate("i16", "s", 0x80, 128);
+    testSetGetTruncate("i16", "s", 0x8000, -32768);
+    testSetGetTruncate("i16", "s", 0xaaaa_aaaa, -21846);
+}
+
+function testArrayGetUnreachable() {
+/*
+(module
+   (type (array (mut i8)))
+   (func (export "f") (result i32)
+      (return)
+      (array.new_canon_default 0 (i32.const 5))
+      (i32.const 2)
+      (array.get_s -1)))
+*/
+    assert.throws(() => new WebAssembly.Instance(module("\x00\x61\x73\x6D\x01\x00\x00\x00\x01\x88\x80\x80\x80\x00\x02\x5E\x7A\x01\x60\x00\x01\x7F\x03\x82\x80\x80\x80\x00\x01\x01\x07\x85\x80\x80\x80\x00\x01\x01\x66\x00\x00\x0A\x95\x80\x80\x80\x00\x01\x8F\x80\x80\x80\x00\x00\x41\x2A\x0F\x41\x05\xFB\x12\x00\x41\x02\xFB\x14\xFF\xFF")),
+                  WebAssembly.CompileError,
+                  "WebAssembly.Module doesn't parse at byte 15: can't get type index immediate for array.get_s in unreachable context");
+/*
+(module
+   (type (array (mut i8)))
+   (func (export "f") (result i32)
+      (return)
+      (array.new_canon_default 0 (i32.const 5))
+      (i32.const 2)
+      (array.get_u -1)))
+*/
+    assert.throws(() => new WebAssembly.Instance(module("\x00\x61\x73\x6D\x01\x00\x00\x00\x01\x88\x80\x80\x80\x00\x02\x5E\x7A\x01\x60\x00\x01\x7F\x03\x82\x80\x80\x80\x00\x01\x01\x07\x85\x80\x80\x80\x00\x01\x01\x66\x00\x00\x0A\x95\x80\x80\x80\x00\x01\x8F\x80\x80\x80\x00\x00\x41\x2A\x0F\x41\x05\xFB\x12\x00\x41\x02\xFB\x15\xFF\xFF")),
+                  WebAssembly.CompileError,
+                  "WebAssembly.Module doesn't parse at byte 15: can't get type index immediate for array.get_u in unreachable context");
+}
+
+testArrayGetPacked();
+testArrayGetUWithNewCanonPacked();
+testArrayGetSWithNewCanonPacked();
+testTypeMismatch64();
+testTypeMismatchArrayGet();
+testPackedTypeOutOfContext();
+testArraySet();
+testArrayGetUnreachable();

--- a/JSTests/wasm/wasm.json
+++ b/JSTests/wasm/wasm.json
@@ -25,6 +25,10 @@
         "rec":       { "type": "varint7", "value":  -49, "b3type": "B3::Void",   "width": 0 },
         "void":      { "type": "varint7", "value":  -64, "b3type": "B3::Void",   "width": 0 }
     },
+    "packed_type": {
+        "i8":        { "type": "varint7", "value":  -6},
+        "i16":       { "type": "varint7", "value":  -7}
+    },
     "value_type": ["i32", "i64", "f32", "f64", "externref", "funcref", "v128"],
     "block_type": ["i32", "i64", "f32", "f64", "void", "externref", "funcref", "v128"],
     "ref_type": ["funcref", "externref", "ref", "ref_null"],
@@ -266,6 +270,8 @@
         "array.new":           { "category": "gc",         "value": 251, "return": ["arrayref"],                     "parameter": ["any", "i32", "rtt"],          "immediate": [{"name": "type_index", "type": "varuint32"}], "extendedOp": 17 },
         "array.new_default":   { "category": "gc",         "value": 251, "return": ["arrayref"],                     "parameter": ["i32", "rtt"],                 "immediate": [{"name": "type_index", "type": "varuint32"}], "extendedOp": 18 },
         "array.get":           { "category": "gc",         "value": 251, "return": ["any"],                          "parameter": ["arrayref", "i32"],            "immediate": [{"name": "type_index", "type": "varuint32"}], "extendedOp": 19 },
+        "array.get_s":         { "category": "gc",         "value": 251, "return": ["any"],                          "parameter": ["arrayref", "i32"],            "immediate": [{"name": "type_index", "type": "varuint32"}], "extendedOp": 20 },
+        "array.get_u":         { "category": "gc",         "value": 251, "return": ["any"],                          "parameter": ["arrayref", "i32"],            "immediate": [{"name": "type_index", "type": "varuint32"}], "extendedOp": 21 },
         "array.set":           { "category": "gc",         "value": 251, "return": [],                               "parameter": ["arrayref", "i32", "any"],     "immediate": [{"name": "type_index", "type": "varuint32"}], "extendedOp": 22 },
         "array.len":           { "category": "gc",         "value": 251, "return": ["i32"],                          "parameter": ["arrayref"],                   "immediate": [{"name": "type_index", "type": "varuint32"}], "extendedOp": 23 },
         "i31.new":             { "category": "gc",         "value": 251, "return": ["i31ref"],                       "parameter": ["i32"],                        "immediate": [], "extendedOp": 32 },

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -1878,6 +1878,7 @@ op :array_get,
         arrayref: VirtualRegister,
         index: VirtualRegister,
         typeIndex: unsigned,
+        arrayGetKind: unsigned,
     }
 
 op :array_set,

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -555,7 +555,7 @@ public:
     PartialResult WARN_UNUSED_RETURN addI31GetU(ExpressionType ref, ExpressionType& result);
     PartialResult WARN_UNUSED_RETURN addArrayNew(uint32_t index, ExpressionType size, ExpressionType value, ExpressionType& result);
     PartialResult WARN_UNUSED_RETURN addArrayNewDefault(uint32_t index, ExpressionType size, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayGet(uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType& result);
+    PartialResult WARN_UNUSED_RETURN addArrayGet(GCOpType arrayGetKind, uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType& result);
     PartialResult WARN_UNUSED_RETURN addArraySet(uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType value);
     PartialResult WARN_UNUSED_RETURN addArrayLen(ExpressionType arrayref, ExpressionType& result);
     PartialResult WARN_UNUSED_RETURN addStructNew(uint32_t typeIndex, Vector<ExpressionType>& args, ExpressionType& result);
@@ -658,6 +658,7 @@ private:
     Value* emitAtomicCompareExchange(ExtAtomicOpType, Type, Value* pointer, Value* expected, Value*, uint32_t offset);
 
     void emitStructSet(Value*, uint32_t, const StructType&, ExpressionType&);
+    ExpressionType WARN_UNUSED_RETURN pushArrayNew(uint32_t typeIndex, Value* initValue, ExpressionType size);
 
     void unify(Value* phi, const ExpressionType source);
     void unifyValuesWithBlock(const Stack& resultStack, const ControlData& block);
@@ -2300,7 +2301,11 @@ void B3IRGenerator::emitStructSet(Value* structValue, uint32_t fieldIndex, const
 {
     Value* payloadBase = m_currentBlock->appendNew<MemoryValue>(m_proc, memoryKind(Load), Int64, origin(), structValue, JSWebAssemblyStruct::offsetOfPayload());
     int32_t fieldOffset = fixupPointerPlusOffset(payloadBase, *structType.getFieldOffset(fieldIndex));
-    const auto& fieldType = structType.field(fieldIndex).type;
+
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246981
+    ASSERT(structType.field(fieldIndex).type.is<Type>());
+
+    Type fieldType = structType.field(fieldIndex).type.as<Type>();
     switch (fieldType.kind) {
     case TypeKind::I32:
     case TypeKind::Funcref:
@@ -2609,13 +2614,23 @@ auto B3IRGenerator::addI31GetU(ExpressionType ref, ExpressionType& result) -> Pa
     return { };
 }
 
+Variable* B3IRGenerator::pushArrayNew(uint32_t typeIndex, Value* initValue, ExpressionType size)
+{
+    // FIXME: Emit this inline.
+    // https://bugs.webkit.org/show_bug.cgi?id=245405
+    return push(m_currentBlock->appendNew<CCallValue>(m_proc, toB3Type(Types::Arrayref), origin(),
+        m_currentBlock->appendNew<ConstPtrValue>(m_proc, origin(), tagCFunction<OperationPtrTag>(operationWasmArrayNew)),
+        instanceValue(), m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex),
+        get(size), initValue));
+}
+
 auto B3IRGenerator::addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType value, ExpressionType& result) -> PartialResult
 {
 #if ASSERT_ENABLED
     Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex];
     ASSERT(arraySignature.is<ArrayType>());
-    Wasm::Type elementType = arraySignature.as<ArrayType>()->elementType().type;
-    ASSERT(toB3Type(elementType) == value->type());
+    const StorageType& elementType = arraySignature.as<ArrayType>()->elementType().type;
+    ASSERT(toB3Type(elementType.unpacked()) == value->type());
 #endif
 
     Value* initValue = get(value);
@@ -2628,44 +2643,33 @@ auto B3IRGenerator::addArrayNew(uint32_t typeIndex, ExpressionType size, Express
         initValue = patchpoint;
     }
 
-    // FIXME: Emit this inline.
-    // https://bugs.webkit.org/show_bug.cgi?id=245405
-    result = push(m_currentBlock->appendNew<CCallValue>(m_proc, toB3Type(Types::Arrayref), origin(),
-        m_currentBlock->appendNew<ConstPtrValue>(m_proc, origin(), tagCFunction<OperationPtrTag>(operationWasmArrayNew)),
-        instanceValue(), m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex),
-        get(size), initValue));
+    result = pushArrayNew(typeIndex, initValue, size);
 
     return { };
 }
 
 auto B3IRGenerator::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result) -> PartialResult
 {
-    // FIXME: Abstract and generalize with addArrayNew.
     Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex];
     ASSERT(arraySignature.is<ArrayType>());
-    Wasm::Type elementType = arraySignature.as<ArrayType>()->elementType().type;
 
     Value* initValue;
-    if (Wasm::isRefType(elementType))
+    if (Wasm::isRefType(arraySignature.as<ArrayType>()->elementType().type))
         initValue = m_currentBlock->appendNew<Const64Value>(m_proc, origin(), JSValue::encode(jsNull()));
     else
         initValue = m_currentBlock->appendNew<Const64Value>(m_proc, origin(), 0);
 
-    // FIXME: Emit this inline.
-    // https://bugs.webkit.org/show_bug.cgi?id=245405
-    result = push(m_currentBlock->appendNew<CCallValue>(m_proc, toB3Type(Types::Arrayref), origin(),
-        m_currentBlock->appendNew<ConstPtrValue>(m_proc, origin(), tagCFunction<OperationPtrTag>(operationWasmArrayNew)),
-        instanceValue(), m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex),
-        get(size), initValue));
+    result = pushArrayNew(typeIndex, initValue, size);
 
     return { };
 }
 
-auto B3IRGenerator::addArrayGet(uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType& result) -> PartialResult
+auto B3IRGenerator::addArrayGet(GCOpType arrayGetKind, uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType& result) -> PartialResult
 {
     Wasm::TypeDefinition& arraySignature = m_info.typeSignatures[typeIndex];
     ASSERT(arraySignature.is<ArrayType>());
-    Wasm::Type elementType = arraySignature.as<ArrayType>()->elementType().type;
+    Wasm::StorageType elementType = arraySignature.as<ArrayType>()->elementType().type;
+    Wasm::Type resultType = elementType.unpacked();
 
     // Ensure arrayref is non-null.
     {
@@ -2694,10 +2698,10 @@ auto B3IRGenerator::addArrayGet(uint32_t typeIndex, ExpressionType arrayref, Exp
         instanceValue(), m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex),
         get(arrayref), get(index));
 
-    switch (toB3Type(elementType).kind()) {
+    switch (toB3Type(resultType).kind()) {
     case B3::Float:
     case B3::Double: {
-        PatchpointValue* patchpoint = m_currentBlock->appendNew<PatchpointValue>(m_proc, toB3Type(elementType), origin());
+        PatchpointValue* patchpoint = m_currentBlock->appendNew<PatchpointValue>(m_proc, toB3Type(resultType), origin());
         patchpoint->appendSomeRegister(arrayResult);
         patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
             jit.move64ToDouble(params[1].gpr(), params[0].fpr());
@@ -2706,12 +2710,28 @@ auto B3IRGenerator::addArrayGet(uint32_t typeIndex, ExpressionType arrayref, Exp
         break;
     }
     case B3::Int32: {
-        PatchpointValue* patchpoint = m_currentBlock->appendNew<PatchpointValue>(m_proc, toB3Type(elementType), origin());
+        PatchpointValue* patchpoint = m_currentBlock->appendNew<PatchpointValue>(m_proc, toB3Type(resultType), origin());
         patchpoint->appendSomeRegister(arrayResult);
         patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
             jit.move(params[1].gpr(), params[0].gpr());
         });
-        result = push(patchpoint);
+        Value* postProcess = patchpoint;
+        switch (arrayGetKind) {
+        case GCOpType::ArrayGet:
+        case GCOpType::ArrayGetU:
+            break;
+        case GCOpType::ArrayGetS: {
+            size_t elementSize = elementType.as<PackedType>() == PackedType::I8 ? sizeof(uint8_t) : sizeof(uint16_t);
+            uint8_t bitShift = (sizeof(uint32_t) - elementSize) * 8;
+            Value* shiftLeft = m_currentBlock->appendNew<Value>(m_proc, B3::Shl, origin(), patchpoint, m_currentBlock->appendNew<Const32Value>(m_proc, origin(), bitShift));
+            postProcess = m_currentBlock->appendNew<Value>(m_proc, B3::SShr, origin(), shiftLeft, m_currentBlock->appendNew<Const32Value>(m_proc, origin(), bitShift));
+            break;
+        }
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            return { };
+        }
+        result = push(postProcess);
         break;
     }
     case B3::Int64:
@@ -2812,7 +2832,11 @@ auto B3IRGenerator::addStructGet(ExpressionType structReference, const StructTyp
 {
     Value* payloadBase = m_currentBlock->appendNew<MemoryValue>(m_proc, memoryKind(Load), pointerType(), origin(), get(structReference), JSWebAssemblyStruct::offsetOfPayload());
     int32_t fieldOffset = fixupPointerPlusOffset(payloadBase, *structType.getFieldOffset(fieldIndex));
-    switch (structType.field(fieldIndex).type.kind) {
+
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246981
+    ASSERT(structType.field(fieldIndex).type.is<Type>());
+
+    switch (structType.field(fieldIndex).type.as<Type>().kind) {
     case TypeKind::I32:
         result = push(m_currentBlock->appendNew<MemoryValue>(m_proc, memoryKind(Load), Int32, origin(), payloadBase, fieldOffset));
         break;

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -104,6 +104,14 @@ inline bool isRefType(Type type)
     return type.isFuncref() || type.isExternref();
 }
 
+// If this is a type, returns true iff it's a ref type; if it's a packed type, returns false
+inline bool isRefType(StorageType type)
+{
+    if (type.is<Type>())
+        return isRefType(type.as<Type>());
+    return false;
+}
+
 inline bool isExternref(Type type)
 {
     if (Options::useWebAssemblyTypedFunctionReferences())
@@ -155,7 +163,7 @@ inline bool isRefWithTypeIndex(Type type)
 }
 
 // Determine if the ref type has a placeholder type index that is used
-// for an unresoled recursive reference in a recursion group.
+// for an unresolved recursive reference in a recursion group.
 inline bool isRefWithRecursiveReference(Type type)
 {
     if (!Options::useWebAssemblyGC())
@@ -168,6 +176,14 @@ inline bool isRefWithRecursiveReference(Type type)
     }
 
     return false;
+}
+
+inline bool isRefWithRecursiveReference(StorageType storageType)
+{
+    if (storageType.is<PackedType>())
+        return false;
+
+    return isRefWithRecursiveReference(storageType.as<Type>());
 }
 
 inline bool isTypeIndexHeapType(int32_t heapType)
@@ -212,6 +228,15 @@ inline bool isSubtype(Type sub, Type parent)
     return sub == parent;
 }
 
+inline bool isSubtype(StorageType sub, StorageType parent)
+{
+    if (sub.is<PackedType>() || parent.is<PackedType>())
+        return sub == parent;
+
+    ASSERT(sub.is<Type>() && parent.is<Type>());
+    return isSubtype(sub.as<Type>(), parent.as<Type>());
+}
+
 inline bool isValidHeapTypeKind(TypeKind kind)
 {
     switch (kind) {
@@ -230,6 +255,14 @@ inline bool isValidHeapTypeKind(TypeKind kind)
 inline bool isDefaultableType(Type type)
 {
     return !type.isRef();
+}
+
+inline bool isDefaultableType(StorageType type)
+{
+    if (type.is<Type>())
+        return !type.as<Type>().isRef();
+    // All packed types are defaultable.
+    return true;
 }
 
 enum class ExternalKind : uint8_t {

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -143,7 +143,7 @@ private:
     PartialResult WARN_UNUSED_RETURN unify(const ControlType&);
 
 #define WASM_TRY_POP_EXPRESSION_STACK_INTO(result, what) do {                               \
-        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in " what); \
+        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in ", what); \
         result = m_expressionStack.takeLast();                                              \
         m_context.didPopValueFromStack();                                                   \
     } while (0)
@@ -1733,10 +1733,11 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     case GCPrefix: {
         WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled");
 
-        uint8_t extOp;
-        WASM_PARSER_FAIL_IF(!parseUInt8(extOp), "can't parse extended GC opcode");
+        uint8_t extOpInt;
+        WASM_PARSER_FAIL_IF(!parseUInt8(extOpInt), "can't parse extended GC opcode");
 
-        switch (static_cast<GCOpType>(extOp)) {
+        GCOpType extOp = static_cast<GCOpType>(extOpInt);
+        switch (extOp) {
         case GCOpType::I31New: {
             TypedExpression value;
             WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "i31.new");
@@ -1777,12 +1778,13 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             const TypeDefinition& typeDefinition = m_info.typeSignatures[typeIndex].get();
             WASM_VALIDATOR_FAIL_IF(!typeDefinition.is<ArrayType>(), "array.new index ", typeIndex, " does not reference an array definition");
-            const Type elementType = typeDefinition.as<ArrayType>()->elementType().type;
+            // If this is a packed array, then the value has to have type i32
+            const Type unpackedElementType = typeDefinition.as<ArrayType>()->elementType().type.unpacked();
 
             TypedExpression value, size;
             WASM_TRY_POP_EXPRESSION_STACK_INTO(size, "array.new");
             WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "array.new");
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), elementType), "array.new value to type ", value.type(), " expected ", elementType);
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), unpackedElementType), "array.new value to type ", value.type(), " expected ", unpackedElementType);
             WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind, "array.new index to type ", size.type(), " expected ", TypeKind::I32);
 
             ExpressionType result;
@@ -1798,7 +1800,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             const TypeDefinition& typeDefinition = m_info.typeSignatures[typeIndex].get();
             WASM_VALIDATOR_FAIL_IF(!typeDefinition.is<ArrayType>(), "array.new_default index ", typeIndex, " does not reference an array definition");
-            const Type elementType = typeDefinition.as<ArrayType>()->elementType().type;
+            const StorageType elementType = typeDefinition.as<ArrayType>()->elementType().type;
             WASM_VALIDATOR_FAIL_IF(!isDefaultableType(elementType), "array.new_default index ", typeIndex, " does not reference an array definition with a defaultable type");
 
             TypedExpression size;
@@ -1811,25 +1813,38 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             m_expressionStack.constructAndAppend(Type { TypeKind::Ref, TypeInformation::get(typeDefinition) }, result);
             return { };
         }
-        case GCOpType::ArrayGet: {
+        case GCOpType::ArrayGet:
+        case GCOpType::ArrayGetS:
+        case GCOpType::ArrayGetU: {
             uint32_t typeIndex;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(typeIndex), "can't get type index for array.get");
-            WASM_VALIDATOR_FAIL_IF(typeIndex >= m_info.typeCount(), "array.get index ", typeIndex, " is out of bounds");
+            const char* opName = extOp == GCOpType::ArrayGet ? "array.get" : extOp == GCOpType::ArrayGetS ? "array.get_s" : "array.get_u";
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(typeIndex), "can't get type index for ", opName);
+            WASM_VALIDATOR_FAIL_IF(typeIndex >= m_info.typeCount(), opName, " index ", typeIndex, " is out of bounds");
 
             const TypeDefinition& typeDefinition = m_info.typeSignatures[typeIndex].get();
-            WASM_VALIDATOR_FAIL_IF(!typeDefinition.is<ArrayType>(), "array.get index ", typeIndex, " does not reference an array definition");
-            const Type elementType = typeDefinition.as<ArrayType>()->elementType().type;
+            WASM_VALIDATOR_FAIL_IF(!typeDefinition.is<ArrayType>(), opName, " index ", typeIndex, " does not reference an array definition");
+            const StorageType elementType = typeDefinition.as<ArrayType>()->elementType().type;
+            // The type of the result will be unpacked if the array is packed.
+            const Type resultType = elementType.unpacked();
+
+            // array.get_s and array.get_u are only valid for packed arrays
+            if (extOp == GCOpType::ArrayGetS || extOp == GCOpType::ArrayGetU)
+                WASM_PARSER_FAIL_IF(!elementType.is<PackedType>(), opName, " applied to wrong type of array -- expected: i8 or i16, found ", elementType.as<Type>().kind);
+
+            // array.get is not valid for packed arrays
+            if (extOp == GCOpType::ArrayGet)
+                WASM_PARSER_FAIL_IF(elementType.is<PackedType>(), opName, " applied to packed array of ", elementType.as<PackedType>(), " -- use array.get_s or array.get_u");
 
             TypedExpression arrayref, index;
             WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "array.get");
             WASM_TRY_POP_EXPRESSION_STACK_INTO(arrayref, "array.get");
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(arrayref.type(), Type { TypeKind::RefNull, TypeInformation::get(typeDefinition) }), "array.get arrayref to type ", arrayref.type().kind, " expected arrayref");
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(arrayref.type(), Type { TypeKind::RefNull, TypeInformation::get(typeDefinition) }), opName, " arrayref to type ", arrayref.type().kind, " expected arrayref");
             WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != index.type().kind, "array.get index to type ", index.type(), " expected ", TypeKind::I32);
 
             ExpressionType result;
-            WASM_TRY_ADD_TO_CONTEXT(addArrayGet(typeIndex, arrayref, index, result));
+            WASM_TRY_ADD_TO_CONTEXT(addArrayGet(extOp, typeIndex, arrayref, index, result));
 
-            m_expressionStack.constructAndAppend(elementType, result);
+            m_expressionStack.constructAndAppend(resultType, result);
             return { };
         }
         case GCOpType::ArraySet: {
@@ -1841,6 +1856,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_VALIDATOR_FAIL_IF(!typeDefinition.is<ArrayType>(), "array.set index ", typeIndex, " does not reference an array definition");
             WASM_VALIDATOR_FAIL_IF(!typeDefinition.is<ArrayType>(), "array.set index ", typeIndex, " does not reference an array definition");
             const FieldType elementType = typeDefinition.as<ArrayType>()->elementType();
+            const Type unpackedElementType = elementType.type.unpacked();
+
             WASM_VALIDATOR_FAIL_IF(elementType.mutability != Mutability::Mutable, "array.set index ", typeIndex, " does not reference a mutable array definition");
 
             TypedExpression arrayref, index, value;
@@ -1849,7 +1866,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(arrayref, "array.set");
             WASM_VALIDATOR_FAIL_IF(!isSubtype(arrayref.type(), Type { TypeKind::RefNull, TypeInformation::get(typeDefinition) }), "array.set arrayref to type ", arrayref.type(), " expected arrayref");
             WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != index.type().kind, "array.set index to type ", index.type(), " expected ", TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), elementType.type), "array.set value to type ", value.type(), " expected ", elementType.type);
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), unpackedElementType), "array.set value to type ", value.type(), " expected ", unpackedElementType);
 
             WASM_TRY_ADD_TO_CONTEXT(addArraySet(typeIndex, arrayref, index, value));
 
@@ -1883,7 +1900,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             for (size_t i = firstArgumentIndex; i < m_expressionStack.size(); ++i) {
                 TypedExpression arg = m_expressionStack.at(i);
-                const auto& fieldType = structType->field(StructFieldCount(i - firstArgumentIndex)).type;
+                const auto& fieldType = structType->field(StructFieldCount(i - firstArgumentIndex)).type.unpacked();
                 WASM_VALIDATOR_FAIL_IF(!isSubtype(arg.type(), fieldType), "argument type mismatch in struct.new, got ", arg.type(), ", expected ", fieldType);
                 args.uncheckedAppend(arg);
                 m_context.didPopValueFromStack();
@@ -1904,7 +1921,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             const auto& structType = *m_info.typeSignatures[structGetInput.indices.structTypeIndex]->template as<StructType>();
             WASM_TRY_ADD_TO_CONTEXT(addStructGet(structGetInput.structReference, structType, structGetInput.indices.fieldIndex, result));
 
-            m_expressionStack.constructAndAppend(structGetInput.field.type, result);
+            m_expressionStack.constructAndAppend(structGetInput.field.type.unpacked(), result);
             return { };
         }
         case GCOpType::StructSet: {
@@ -1916,14 +1933,14 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             const auto& field = structSetInput.field;
             WASM_PARSER_FAIL_IF(field.mutability != Mutability::Mutable, "the field ", structSetInput.indices.fieldIndex, " can't be set because it is immutable");
-            WASM_PARSER_FAIL_IF(!isSubtype(value.type(), field.type), "type mismatch in struct.set");
+            WASM_PARSER_FAIL_IF(!isSubtype(value.type(), field.type.unpacked()), "type mismatch in struct.set");
 
             const auto& structType = *m_info.typeSignatures[structSetInput.indices.structTypeIndex]->template as<StructType>();
             WASM_TRY_ADD_TO_CONTEXT(addStructSet(structSetInput.structReference, structType, structSetInput.indices.fieldIndex, value));
             return { };
         }
         default:
-            WASM_PARSER_FAIL_IF(true, "invalid extended GC op ", extOp);
+            WASM_PARSER_FAIL_IF(true, "invalid extended GC op ", extOpInt);
             break;
         }
         return { };
@@ -2924,6 +2941,16 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         case GCOpType::ArrayGet: {
             uint32_t unused;
             WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.get in unreachable context");
+            return { };
+        }
+        case GCOpType::ArrayGetS: {
+            uint32_t unused;
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.get_s in unreachable context");
+            return { };
+        }
+        case GCOpType::ArrayGetU: {
+            uint32_t unused;
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.get_u in unreachable context");
             return { };
         }
         case GCOpType::ArraySet: {

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -314,7 +314,7 @@ public:
     PartialResult WARN_UNUSED_RETURN addI31GetU(ExpressionType ref, ExpressionType& result);
     PartialResult WARN_UNUSED_RETURN addArrayNew(uint32_t index, ExpressionType size, ExpressionType value, ExpressionType& result);
     PartialResult WARN_UNUSED_RETURN addArrayNewDefault(uint32_t index, ExpressionType size, ExpressionType& result);
-    PartialResult WARN_UNUSED_RETURN addArrayGet(uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType& result);
+    PartialResult WARN_UNUSED_RETURN addArrayGet(GCOpType arrayGetKind, uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType& result);
     PartialResult WARN_UNUSED_RETURN addArraySet(uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType value);
     PartialResult WARN_UNUSED_RETURN addArrayLen(ExpressionType arrayref, ExpressionType& result);
     PartialResult WARN_UNUSED_RETURN addStructNew(uint32_t index, Vector<ExpressionType>& args, ExpressionType& result);
@@ -1952,10 +1952,10 @@ auto LLIntGenerator::addArrayNewDefault(uint32_t index, ExpressionType size, Exp
     return { };
 }
 
-auto LLIntGenerator::addArrayGet(uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType& result) -> PartialResult
+auto LLIntGenerator::addArrayGet(GCOpType arrayGetKind, uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType& result) -> PartialResult
 {
     result = push();
-    WasmArrayGet::emit(this, result, arrayref, index, typeIndex);
+    WasmArrayGet::emit(this, result, arrayref, index, typeIndex, static_cast<unsigned>(arrayGetKind));
 
     return { };
 }

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -880,8 +880,11 @@ JSC_DEFINE_JIT_OPERATION(operationWasmStructNew, EncodedJSValue, (Instance* inst
     const StructType& structType = *structTypeDefinition->as<StructType>();
 
     JSWebAssemblyStruct* structValue = JSWebAssemblyStruct::tryCreate(globalObject, globalObject->webAssemblyStructStructure(), jsInstance, typeIndex);
-    for (unsigned i = 0; i < structType.fieldCount(); ++i)
-        structValue->set(globalObject, i, toJSValue(globalObject, structType.field(i).type, arguments[i]));
+    for (unsigned i = 0; i < structType.fieldCount(); ++i) {
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246981
+        ASSERT(structType.field(i).type.is<Type>());
+        structValue->set(globalObject, i, toJSValue(globalObject, structType.field(i).type.as<Type>(), arguments[i]));
+    }
     return JSValue::encode(structValue);
 }
 
@@ -910,7 +913,11 @@ JSC_DEFINE_JIT_OPERATION(operationWasmStructSet, void, (Instance* instance, Enco
     JSObject* structureAsObject = jsCast<JSObject*>(structReference);
     ASSERT(structureAsObject->inherits<JSWebAssemblyStruct>());
     JSWebAssemblyStruct* structPointer = jsCast<JSWebAssemblyStruct*>(structureAsObject);
-    const auto fieldType = structPointer->structType()->field(fieldIndex).type;
+
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246981
+    ASSERT(structPointer->structType()->field(fieldIndex).type.is<Type>());
+
+    const auto fieldType = structPointer->structType()->field(fieldIndex).type.as<Type>();
     return structPointer->set(jsInstance->globalObject(), fieldIndex, toJSValue(jsInstance->globalObject(), fieldType, argument));
 }
 
@@ -1154,25 +1161,46 @@ JSC_DEFINE_JIT_OPERATION(operationWasmArrayNew, EncodedJSValue, (Instance* insta
     ASSERT(arraySignature.is<ArrayType>());
     Wasm::FieldType fieldType = arraySignature.as<ArrayType>()->elementType();
 
+    size_t elementSize = fieldType.type.elementSize();
+
     JSWebAssemblyArray* array = nullptr;
-    switch (fieldType.type.kind) {
-    case Wasm::TypeKind::I32:
-    case Wasm::TypeKind::F32: {
+
+    switch (elementSize) {
+    case sizeof(uint8_t): {
+        // `encValue` must be an unboxed int32 (since the typechecker guarantees that its type is i32); so it's safe to truncate it in the cases below.
+        ASSERT(encValue <= UINT32_MAX);
+        FixedVector<uint8_t> values(size);
+        for (unsigned i = 0; i < size; i++)
+            values[i] = static_cast<uint8_t>(encValue);
+        array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values));
+        break;
+    }
+    case sizeof(uint16_t): {
+        ASSERT(encValue <= UINT32_MAX);
+        FixedVector<uint16_t> values(size);
+        for (unsigned i = 0; i < size; i++)
+            values[i] = static_cast<uint16_t>(encValue);
+        array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values));
+        break;
+    }
+    case sizeof(uint32_t): {
+        ASSERT(encValue <= UINT32_MAX);
         FixedVector<uint32_t> values(size);
         for (unsigned i = 0; i < size; i++)
             values[i] = static_cast<uint32_t>(encValue);
-        array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType.type, size, WTFMove(values));
+        array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values));
         break;
     }
-    default: {
+    case sizeof(uint64_t): {
         FixedVector<uint64_t> values(size);
         for (unsigned i = 0; i < size; i++)
             values[i] = static_cast<uint64_t>(encValue);
-        array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType.type, size, WTFMove(values));
+        array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values));
         break;
     }
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
     }
-
     return JSValue::encode(JSValue(array));
 }
 

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -780,6 +780,36 @@ auto SectionParser::parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&
     return { };
 }
 
+auto SectionParser::parsePackedType(PackedType& packedType) -> PartialResult
+{
+    int8_t kind;
+    WASM_PARSER_FAIL_IF(!parseInt7(kind), "invalid type in struct field or array element");
+    if (isValidPackedType(kind)) {
+        packedType = static_cast<PackedType>(kind);
+        return { };
+    }
+    return fail("expected a packed type but got ", kind);
+}
+
+auto SectionParser::parseStorageType(StorageType& storageType) -> PartialResult
+{
+    ASSERT(Options::useWebAssemblyGC());
+
+    int8_t kind;
+    WASM_PARSER_FAIL_IF(!peekInt7(kind), "invalid type in struct field or array element");
+    if (isValidTypeKind(kind)) {
+        Type elementType;
+        WASM_PARSER_FAIL_IF(!parseValueType(m_info, elementType), "invalid type in struct field or array element");
+        storageType = StorageType { elementType };
+        return { };
+    }
+
+    PackedType elementType;
+    WASM_PARSER_FAIL_IF(!parsePackedType(elementType), "invalid type in struct field or array element");
+    storageType = StorageType { elementType };
+    return { };
+}
+
 auto SectionParser::parseStructType(uint32_t position, RefPtr<TypeDefinition>& structType) -> PartialResult
 {
     ASSERT(Options::useWebAssemblyGC());
@@ -792,15 +822,18 @@ auto SectionParser::parseStructType(uint32_t position, RefPtr<TypeDefinition>& s
 
     Checked<unsigned, RecordOverflow> structInstancePayloadSize { 0 };
     for (uint32_t fieldIndex = 0; fieldIndex < fieldCount; ++fieldIndex) {
-        Type fieldType;
-        WASM_PARSER_FAIL_IF(!parseValueType(m_info, fieldType), "can't get ", fieldIndex, "th field Type");
+        StorageType fieldType;
+        WASM_PARSER_FAIL_IF(!parseStorageType(fieldType), "can't get ", fieldIndex, "th field Type");
+
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246981
+        WASM_PARSER_FAIL_IF(fieldType.is<PackedType>(), "packed types in structs are not supported yet");
 
         uint8_t mutability;
         WASM_PARSER_FAIL_IF(!parseUInt8(mutability), position, "can't get ", fieldIndex, "th field mutability");
         WASM_PARSER_FAIL_IF(mutability != 0x0 && mutability != 0x1, "invalid Field's mutability: 0x", hex(mutability, 2, Lowercase));
 
         fields.uncheckedAppend(FieldType { fieldType, static_cast<Mutability>(mutability) });
-        structInstancePayloadSize += typeKindSizeInBytes(fieldType.kind);
+        structInstancePayloadSize += typeSizeInBytes(fieldType);
         WASM_PARSER_FAIL_IF(structInstancePayloadSize.hasOverflowed(), "struct layout is too big");
     }
 
@@ -812,8 +845,8 @@ auto SectionParser::parseArrayType(uint32_t position, RefPtr<TypeDefinition>& ar
 {
     ASSERT(Options::useWebAssemblyGC());
 
-    Type elementType;
-    WASM_PARSER_FAIL_IF(!parseValueType(m_info, elementType), "can't get array's element Type");
+    StorageType elementType;
+    WASM_PARSER_FAIL_IF(!parseStorageType(elementType), "can't get array's element Type");
 
     uint8_t mutability;
     WASM_PARSER_FAIL_IF(!parseUInt8(mutability), position, "can't get array's mutability");

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.h
@@ -70,6 +70,8 @@ private:
     PartialResult WARN_UNUSED_RETURN parseI32InitExpr(std::optional<I32InitExpr>&, ASCIILiteral failMessage);
 
     PartialResult WARN_UNUSED_RETURN parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&);
+    PartialResult WARN_UNUSED_RETURN parsePackedType(PackedType&);
+    PartialResult WARN_UNUSED_RETURN parseStorageType(StorageType&);
     PartialResult WARN_UNUSED_RETURN parseStructType(uint32_t position, RefPtr<TypeDefinition>&);
     PartialResult WARN_UNUSED_RETURN parseArrayType(uint32_t position, RefPtr<TypeDefinition>&);
     PartialResult WARN_UNUSED_RETURN parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition>&);

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -217,8 +217,108 @@ enum Mutability : uint8_t {
     Immutable = 0
 };
 
-struct FieldType {
-    Type type;
+struct StorageType {
+public:
+    template <typename T>
+    bool is() const { return std::holds_alternative<T>(m_storageType); }
+
+    template <typename T>
+    const T as() const { ASSERT(is<T>()); return *std::get_if<T>(&m_storageType); }
+
+    StorageType() = default;
+
+    explicit StorageType(Type t)
+    {
+        m_storageType = std::variant<Type, PackedType>(t);
+    }
+
+    explicit StorageType(PackedType t)
+    {
+        m_storageType = std::variant<Type, PackedType>(t);
+    }
+
+    // Return a value type suitable for validating instruction arguments. Packed types cannot show up as value types and need to be unpacked to I32.
+    Type unpacked() const
+    {
+        if (is<Type>())
+            return as<Type>();
+        return Types::I32;
+    }
+
+    size_t elementSize() const
+    {
+        if (is<Type>()) {
+            switch (as<Type>().kind) {
+            case Wasm::TypeKind::I32:
+            case Wasm::TypeKind::F32:
+                return sizeof(uint32_t);
+            default:
+                return sizeof(uint64_t);
+            }
+        }
+        switch (as<PackedType>()) {
+        case PackedType::I8:
+            return sizeof(uint8_t);
+        case PackedType::I16:
+            return sizeof(uint16_t);
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    bool operator==(const StorageType& rhs) const
+    {
+        if (rhs.is<PackedType>())
+            return (is<PackedType>() && as<PackedType>() == rhs.as<PackedType>());
+        if (!is<Type>())
+            return false;
+        return(as<Type>() == rhs.as<Type>());
+    }
+    bool operator!=(const StorageType& rhs) const { return !(*this == rhs); };
+
+    int8_t typeCode() const
+    {
+        if (is<Type>())
+            return static_cast<int8_t>(as<Type>().kind);
+        return static_cast<int8_t>(as<PackedType>());
+    }
+
+    TypeIndex index() const
+    {
+        if (is<Type>())
+            return as<Type>().index;
+        return 0;
+    }
+    void dump(WTF::PrintStream& out) const;
+
+private:
+    std::variant<Type, PackedType> m_storageType;
+
+};
+
+inline const char* makeString(const StorageType& storageType)
+{
+    return(storageType.is<Type>() ? makeString(storageType.as<Type>().kind) :
+        makeString(storageType.as<PackedType>()));
+}
+
+inline size_t typeSizeInBytes(const StorageType& storageType)
+{
+    if (storageType.is<PackedType>()) {
+        switch (storageType.as<PackedType>()) {
+        case PackedType::I8: {
+            return 1;
+        }
+        case PackedType::I16: {
+            return 2;
+        }
+        }
+    }
+    return typeKindSizeInBytes(storageType.as<Type>().kind);
+}
+
+class FieldType {
+public:
+    StorageType type;
     Mutability mutability;
 
     bool operator==(const FieldType& rhs) const { return type == rhs.type && mutability == rhs.mutability; }

--- a/Source/JavaScriptCore/wasm/generateWasm.py
+++ b/Source/JavaScriptCore/wasm/generateWasm.py
@@ -39,6 +39,7 @@ class Wasm:
                 self.expectedVersionNumber = str(pre["value"])
         self.preamble = wasm["preamble"]
         self.types = wasm["type"]
+        self.packed_types = wasm["packed_type"]
         self.opcodes = wasm["opcode"]
         self.header = """/*
  * Copyright (C) 2016-2017 Apple Inc. All rights reserved.

--- a/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
+++ b/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
@@ -50,11 +50,21 @@ def cppMacro(wasmOpcode, value, b3, inc, *extraArgs):
     extraArgsStr = ", " + ", ".join(extraArgs) if len(extraArgs) else ""
     return " \\\n    macro(" + wasm.toCpp(wasmOpcode) + ", " + hex(int(value)) + ", " + b3 + ", " + str(inc) + extraArgsStr + ")"
 
+
+def cppMacroPacked(wasmOpcode, value):
+    return " \\\n    macro(" + wasm.toCpp(wasmOpcode) + ", " + hex(int(value)) + ")"
+
+
 def typeMacroizer():
     inc = 0
     for ty in wasm.types:
         yield cppMacro(ty, wasm.types[ty]["value"], wasm.types[ty]["b3type"], inc, ty, str(wasm.types[ty]["width"]))
         inc += 1
+
+
+def packedTypeMacroizer():
+    for ty in wasm.packed_types:
+        yield cppMacroPacked(ty, wasm.packed_types[ty]["value"])
 
 
 def typeMacroizerFiltered(filter):
@@ -64,6 +74,8 @@ def typeMacroizerFiltered(filter):
 
 type_definitions = ["#define FOR_EACH_WASM_TYPE(macro)"]
 type_definitions.extend([t for t in typeMacroizer()])
+type_definitions.extend(["\n\n#define FOR_EACH_WASM_PACKED_TYPE(macro)"])
+type_definitions.extend([t for t in packedTypeMacroizer()])
 type_definitions = "".join(type_definitions)
 
 type_definitions_except_funcref_externref = ["#define FOR_EACH_WASM_TYPE_EXCEPT_FUNCREF_AND_EXTERNREF(macro)"]
@@ -229,6 +241,12 @@ enum class TypeKind : int8_t {
 };
 #undef CREATE_ENUM_VALUE
 
+#define CREATE_ENUM_VALUE(name, id) name = id,
+enum class PackedType: int8_t {
+    FOR_EACH_WASM_PACKED_TYPE(CREATE_ENUM_VALUE)
+};
+#undef CREATE_ENUM_VALUE
+
 using TypeIndex = uintptr_t;
 
 inline bool typeIndexIsType(TypeIndex index)
@@ -305,11 +323,35 @@ inline bool isValidTypeKind(Int i)
 }
 #undef CREATE_CASE
 
+#define CREATE_CASE(name, id, ...) case id: return true;
+template <typename Int>
+inline bool isValidPackedType(Int i)
+{
+    switch (i) {
+    default: return false;
+    FOR_EACH_WASM_PACKED_TYPE(CREATE_CASE)
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return false;
+}
+#undef CREATE_CASE
+
 #define CREATE_CASE(name, ...) case TypeKind::name: return #name;
 inline const char* makeString(TypeKind kind)
 {
     switch (kind) {
     FOR_EACH_WASM_TYPE(CREATE_CASE)
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+}
+#undef CREATE_CASE
+
+#define CREATE_CASE(name, ...) case PackedType::name: return #name;
+inline const char* makeString(PackedType packedType)
+{
+    switch (packedType) {
+    FOR_EACH_WASM_PACKED_TYPE(CREATE_CASE)
     }
     RELEASE_ASSERT_NOT_REACHED();
     return nullptr;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -83,7 +83,12 @@ uint64_t JSWebAssemblyStruct::get(uint32_t fieldIndex) const
     using Wasm::TypeKind;
 
     const uint8_t* targetPointer = fieldPointer(fieldIndex);
-    switch (fieldType(fieldIndex).type.kind) {
+
+    // FIXME: packed types in structs not supported yet:
+    // https://bugs.webkit.org/show_bug.cgi?id=246981
+    ASSERT(fieldType(fieldIndex).type.is<Wasm::Type>());
+
+    switch (fieldType(fieldIndex).type.as<Wasm::Type>().kind) {
     case TypeKind::I32:
     case TypeKind::F32:
         return *bitwise_cast<uint32_t*>(targetPointer);
@@ -106,7 +111,12 @@ void JSWebAssemblyStruct::set(JSGlobalObject* globalObject, uint32_t fieldIndex,
     using Wasm::TypeKind;
 
     uint8_t* targetPointer = fieldPointer(fieldIndex);
-    switch (fieldType(fieldIndex).type.kind) {
+
+    // FIXME: packed types in structs not supported yet:
+    // https://bugs.webkit.org/show_bug.cgi?id=246981
+    ASSERT(fieldType(fieldIndex).type.is<Wasm::Type>());
+
+    switch (fieldType(fieldIndex).type.as<Wasm::Type>().kind) {
     case TypeKind::I32: {
         *bitwise_cast<int32_t*>(targetPointer) = argument.toInt32(globalObject);
         return;

--- a/Source/JavaScriptCore/wasm/wasm.json
+++ b/Source/JavaScriptCore/wasm/wasm.json
@@ -25,6 +25,10 @@
         "rec":       { "type": "varint7", "value":  -49, "b3type": "B3::Void",   "width": 0 },
         "void":      { "type": "varint7", "value":  -64, "b3type": "B3::Void",   "width": 0 }
     },
+    "packed_type": {
+        "i8":        { "type": "varint7", "value":  -6},
+        "i16":       { "type": "varint7", "value":  -7}
+    },
     "value_type": ["i32", "i64", "f32", "f64", "externref", "funcref", "v128"],
     "block_type": ["i32", "i64", "f32", "f64", "void", "externref", "funcref", "v128"],
     "ref_type": ["funcref", "externref", "ref", "ref_null"],
@@ -266,6 +270,8 @@
         "array.new":           { "category": "gc",         "value": 251, "return": ["arrayref"],                     "parameter": ["any", "i32", "rtt"],          "immediate": [{"name": "type_index", "type": "varuint32"}], "extendedOp": 17 },
         "array.new_default":   { "category": "gc",         "value": 251, "return": ["arrayref"],                     "parameter": ["i32", "rtt"],                 "immediate": [{"name": "type_index", "type": "varuint32"}], "extendedOp": 18 },
         "array.get":           { "category": "gc",         "value": 251, "return": ["any"],                          "parameter": ["arrayref", "i32"],            "immediate": [{"name": "type_index", "type": "varuint32"}], "extendedOp": 19 },
+        "array.get_s":         { "category": "gc",         "value": 251, "return": ["any"],                          "parameter": ["arrayref", "i32"],            "immediate": [{"name": "type_index", "type": "varuint32"}], "extendedOp": 20 },
+        "array.get_u":         { "category": "gc",         "value": 251, "return": ["any"],                          "parameter": ["arrayref", "i32"],            "immediate": [{"name": "type_index", "type": "varuint32"}], "extendedOp": 21 },
         "array.set":           { "category": "gc",         "value": 251, "return": [],                               "parameter": ["arrayref", "i32", "any"],     "immediate": [{"name": "type_index", "type": "varuint32"}], "extendedOp": 22 },
         "array.len":           { "category": "gc",         "value": 251, "return": ["i32"],                          "parameter": ["arrayref"],                   "immediate": [{"name": "type_index", "type": "varuint32"}], "extendedOp": 23 },
         "i31.new":             { "category": "gc",         "value": 251, "return": ["i31ref"],                       "parameter": ["i32"],                        "immediate": [], "extendedOp": 32 },


### PR DESCRIPTION
#### 24d6d56cfb68eb45f2336bde3133bfefb40d8356
<pre>
Re-land [Wasm-GC] Implement packed types in arrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=247576">https://bugs.webkit.org/show_bug.cgi?id=247576</a>

Reviewed by Justin Michaud.

This patch implements support for packed types (i8, i16) in Wasm GC
arrays. Packed types are represented with new entries in wasm.json and
are only allowed for use in StorageTypes, which are a new kind of type
used for struct and array type definition fields.

Packed structs are not yet allowed with this patch.

Relanded patch fixes an invalid move in the Air generator for non-x86
platforms. It also refactors StorageType use slightly and also
eliminates redundant LLInt opcodes.

* JSTests/wasm/gc/arrays.js:
(testArrayDeclaration):
* JSTests/wasm/gc/packed-arrays.js: Added.
(module):
(check):
(testArrayGetPacked):
(testArrayGetUWithNewCanonPacked):
(testArrayGetSWithNewCanonPacked):
(testTypeMismatch64):
(testTypeMismatchArrayGet):
(testPackedTypeOutOfContext):
(testSetGetTruncate):
(testArraySet):
(testArrayGetUnreachable):
* JSTests/wasm/wasm.json:
* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::ExpressionType&gt;::addArrayNewDefault):
(JSC::Wasm::ExpressionType&gt;::addArrayGet):
(JSC::Wasm::ExpressionType&gt;::addStructGet):
(JSC::Wasm::ExpressionType&gt;::addStructSet):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::emitStructSet):
(JSC::Wasm::B3IRGenerator::pushArrayNew):
(JSC::Wasm::B3IRGenerator::addArrayNew):
(JSC::Wasm::B3IRGenerator::addArrayNewDefault):
(JSC::Wasm::B3IRGenerator::addArrayGet):
(JSC::Wasm::B3IRGenerator::addStructGet):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::isRefType):
(JSC::Wasm::isRefWithRecursiveReference):
(JSC::Wasm::isSubtype):
(JSC::Wasm::isDefaultableType):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::addArrayGet):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parsePackedType):
(JSC::Wasm::SectionParser::parseStorageType):
(JSC::Wasm::SectionParser::parseStructType):
(JSC::Wasm::SectionParser::parseArrayType):
* Source/JavaScriptCore/wasm/WasmSectionParser.h:
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::StructType::dump const):
(JSC::Wasm::StructType::StructType):
(JSC::Wasm::ArrayType::dump const):
(JSC::Wasm::StorageType::dump const):
(JSC::Wasm::computeStructTypeHash):
(JSC::Wasm::computeArrayTypeHash):
(JSC::Wasm::TypeDefinition::replacePlaceholders const):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::StorageType::is const):
(JSC::Wasm::StorageType::as const):
(JSC::Wasm::StorageType::StorageType):
(JSC::Wasm::StorageType::unpacked const):
(JSC::Wasm::StorageType::elementSize const):
(JSC::Wasm::StorageType::operator== const):
(JSC::Wasm::StorageType::operator!= const):
(JSC::Wasm::StorageType::typeCode const):
(JSC::Wasm::StorageType::index const):
(JSC::Wasm::makeString):
(JSC::Wasm::typeSizeInBytes):
* Source/JavaScriptCore/wasm/generateWasm.py:
(Wasm.__init__):
* Source/JavaScriptCore/wasm/generateWasmOpsHeader.py:
(cppMacro):
(cppMacroPacked):
(packedTypeMacroizer):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp:
(JSC::JSWebAssemblyArray::JSWebAssemblyArray):
(JSC::JSWebAssemblyArray::~JSWebAssemblyArray):
(JSC::JSWebAssemblyArray::visitChildrenImpl):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::get const):
(JSC::JSWebAssemblyStruct::set):
* Source/JavaScriptCore/wasm/wasm.json:

Canonical link: <a href="https://commits.webkit.org/258463@main">https://commits.webkit.org/258463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43a8888a9512cd4b691bdffa75108afeac078336

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111311 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171513 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2039 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94386 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109065 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37099 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91137 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24005 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/92366 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4706 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25441 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88541 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2313 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1880 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29449 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44929 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91455 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5806 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6545 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20443 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->