### PR TITLE
[Curl] Remove unnecessary function from ResourceResponseCurl

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlResourceHandleDelegate.cpp
+++ b/Source/WebCore/platform/network/curl/CurlResourceHandleDelegate.cpp
@@ -106,7 +106,6 @@ void CurlResourceHandleDelegate::curlDidReceiveResponse(CurlRequest& request, Cu
         return;
 
     m_response = ResourceResponse(receivedResponse);
-    m_response.setCertificateInfo(WTFMove(receivedResponse.certificateInfo));
 
     updateNetworkLoadMetrics(receivedResponse.networkLoadMetrics);
     m_response.setDeprecatedNetworkLoadMetrics(Box<NetworkLoadMetrics>::create(WTFMove(receivedResponse.networkLoadMetrics)));

--- a/Source/WebCore/platform/network/curl/ResourceResponse.h
+++ b/Source/WebCore/platform/network/curl/ResourceResponse.h
@@ -46,11 +46,9 @@ public:
     {
     }
 
-    ResourceResponse(const CurlResponse&);
+    ResourceResponse(CurlResponse&);
 
     void appendHTTPHeaderField(const String&);
-
-    void setCertificateInfo(CertificateInfo&&);
 
     bool shouldRedirect();
     bool isMovedPermanently() const;

--- a/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
@@ -78,7 +78,7 @@ bool ResourceResponse::isAppendableHeader(const String &key)
     return false;
 }
 
-ResourceResponse::ResourceResponse(const CurlResponse& response)
+ResourceResponse::ResourceResponse(CurlResponse& response)
     : ResourceResponseBase()
 {
     setURL(response.url);
@@ -105,6 +105,7 @@ ResourceResponse::ResourceResponse(const CurlResponse& response)
 
     setMimeType(AtomString { extractMIMETypeFromMediaType(httpHeaderField(HTTPHeaderName::ContentType)).convertToASCIILowercase() });
     setTextEncodingName(extractCharsetFromMediaType(httpHeaderField(HTTPHeaderName::ContentType)).toAtomString());
+    setCertificateInfo(WTFMove(response.certificateInfo));
     setSource(ResourceResponse::Source::Network);
 }
 
@@ -143,11 +144,6 @@ void ResourceResponse::setStatusLine(StringView header)
         auto statusText = statusLine.substring(statusCodeEndPosition + 1).stripLeadingAndTrailingMatchedCharacters(isSpaceOrNewline);
         setHTTPStatusText(statusText.toAtomString());
     }
-}
-
-void ResourceResponse::setCertificateInfo(CertificateInfo&& certificateInfo)
-{
-    m_certificateInfo = WTFMove(certificateInfo);
 }
 
 String ResourceResponse::platformSuggestedFilename() const

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -166,7 +166,6 @@ void NetworkDataTaskCurl::curlDidReceiveResponse(CurlRequest& request, CurlRespo
         return;
 
     m_response = ResourceResponse(receivedResponse);
-    m_response.setCertificateInfo(WTFMove(receivedResponse.certificateInfo));
 
     updateNetworkLoadMetrics(receivedResponse.networkLoadMetrics);
     m_response.setDeprecatedNetworkLoadMetrics(Box<NetworkLoadMetrics>::create(WTFMove(receivedResponse.networkLoadMetrics)));


### PR DESCRIPTION
#### fb94f2d792cdc223901a30ded2301b80f093c30c
<pre>
[Curl] Remove unnecessary function from ResourceResponseCurl
<a href="https://bugs.webkit.org/show_bug.cgi?id=249195">https://bugs.webkit.org/show_bug.cgi?id=249195</a>

Reviewed by Fujii Hironori.

Remove ResourceResponse::setCertificateInfo. Also, we configure
CertificateInfo in a ResourceResponse constructor.

* Source/WebCore/platform/network/curl/CurlResourceHandleDelegate.cpp:
(WebCore::CurlResourceHandleDelegate::curlDidReceiveResponse):
* Source/WebCore/platform/network/curl/ResourceResponse.h:
* Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp:
(WebCore::ResourceResponse::ResourceResponse):
(WebCore::ResourceResponse::setCertificateInfo): Deleted.
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::curlDidReceiveResponse):

Canonical link: <a href="https://commits.webkit.org/257777@main">https://commits.webkit.org/257777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b98e3d4369afaa0f5d34e7c51498bfb6403d3c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109340 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86474 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92440 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107240 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105761 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2957 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2917 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/46152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9051 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4765 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2745 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->