### PR TITLE
webpushd and webpushtool cleanup

### DIFF
--- a/Source/WebKit/Configurations/webpushtool.xcconfig
+++ b/Source/WebKit/Configurations/webpushtool.xcconfig
@@ -24,7 +24,6 @@
 #include "BaseTarget.xcconfig"
 
 PRODUCT_NAME = webpushtool;
-SKIP_INSTALL = YES;
 
 EXCLUDED_SOURCE_FILE_NAMES[sdk=appletv*] = *;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=watch*] = *;

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -608,6 +608,7 @@
 )
 
 (allow mach-lookup (with telemetry) (global-name "com.apple.webkit.adattributiond.service"))
+(allow mach-lookup (with telemetry) (global-name "com.apple.webkit.webpushd.service"))
 
 ;; Access to MobileGestalt
 (deny mach-lookup 

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -52,8 +52,8 @@ static void printUsageAndTerminate(NSString *message)
     fprintf(stderr, "    Stream debug messages from webpushd\n");
     fprintf(stderr, "  --reconnect\n");
     fprintf(stderr, "    Reconnect after connection is lost\n");
-    fprintf(stderr, "  --push <target app identifier> <registration URL> <message>\n");
-    fprintf(stderr, "    Inject a test push messasge to the target app and registration URL\n");
+    fprintf(stderr, "  --push <target app identifier> <partition string> <registration URL> <message>\n");
+    fprintf(stderr, "    Inject a test push message to the target app, push partition, and registration URL\n");
     fprintf(stderr, "\n");
 
     exit(-1);
@@ -63,6 +63,10 @@ static std::unique_ptr<PushMessageForTesting> pushMessageFromArguments(NSEnumera
 {
     NSString *appIdentifier = [enumerator nextObject];
     if (!appIdentifier)
+        return nullptr;
+
+    NSString *pushPartition = [enumerator nextObject];
+    if (!pushPartition)
         return nullptr;
 
     NSString *registrationString = [enumerator nextObject];
@@ -77,7 +81,7 @@ static std::unique_ptr<PushMessageForTesting> pushMessageFromArguments(NSEnumera
     if (!message)
         return nullptr;
 
-    PushMessageForTesting pushMessage = { appIdentifier, registrationString, registrationURL, message };
+    PushMessageForTesting pushMessage = { appIdentifier, pushPartition, registrationURL, message };
     return makeUniqueWithoutFastMallocCheck<PushMessageForTesting>(WTFMove(pushMessage));
 }
 


### PR DESCRIPTION
#### eefb819e8ac6d596ce62a7ff261910642d628ecb
<pre>
webpushd and webpushtool cleanup
<a href="https://bugs.webkit.org/show_bug.cgi?id=249200">https://bugs.webkit.org/show_bug.cgi?id=249200</a>
rdar://103282970

Reviewed by Tim Horton.

-Allow Networking to connect to webpushd
-Actually install webpushtool
-Make webpushtool do the right thing for injected pushes

* Source/WebKit/Configurations/webpushtool.xcconfig:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::sendAuditToken):
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
(printUsageAndTerminate):
(pushMessageFromArguments):

Canonical link: <a href="https://commits.webkit.org/257798@main">https://commits.webkit.org/257798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee143b3b71752d3bf7788b0515fa3de723186c3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109387 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169626 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104039 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86569 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92487 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107286 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105808 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34339 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22302 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3003 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23817 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86583 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/410 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2961 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/46188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29029 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43298 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89462 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5354 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4812 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20001 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->