### PR TITLE
[WebGPU] Depth buffer / texture support

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -133,10 +133,6 @@ bool CommandEncoder::validateRenderPassDescriptor(const WGPURenderPassDescriptor
             return false;
     }
 
-    // FIXME: support depth/stencil
-    if (descriptor.depthStencilAttachment)
-        return false;
-
     // FIXME: support occlusion
     if (descriptor.occlusionQuerySet)
         return false;
@@ -184,7 +180,24 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
         // mtlAttachment.resolveDepthPlane = 0;
     }
 
-    // FIXME: Depth + stencil texture support
+    if (const auto* attachment = descriptor.depthStencilAttachment) {
+        const auto& mtlAttachment = mtlDescriptor.depthAttachment;
+        ASSERT("FIXME: Add support for depthReadOnly" && !attachment->depthReadOnly);
+        mtlAttachment.clearDepth = attachment->clearDepth;
+        mtlAttachment.texture = fromAPI(attachment->view).texture();
+        mtlAttachment.loadAction = loadAction(attachment->depthLoadOp);
+        mtlAttachment.storeAction = storeAction(attachment->depthStoreOp);
+    }
+
+    if (const auto* attachment = descriptor.depthStencilAttachment) {
+        const auto& mtlAttachment = mtlDescriptor.stencilAttachment;
+        ASSERT("FIXME: Add support for stencilReadOnly" && !attachment->stencilReadOnly);
+        // FIXME: assign the correct stencil texture
+        // mtlAttachment.texture = fromAPI(attachment->view).texture();
+        mtlAttachment.clearStencil = attachment->clearStencil;
+        mtlAttachment.loadAction = loadAction(attachment->stencilLoadOp);
+        mtlAttachment.storeAction = storeAction(attachment->stencilStoreOp);
+    }
 
     auto mtlRenderCommandEncoder = [m_commandBuffer renderCommandEncoderWithDescriptor:mtlDescriptor];
 

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -193,6 +193,8 @@ void RenderPassEncoder::setPipeline(const RenderPipeline& pipeline)
     m_primitiveType = pipeline.primitiveType();
 
     [m_renderCommandEncoder setRenderPipelineState:pipeline.renderPipelineState()];
+    if (pipeline.depthStencilState())
+        [m_renderCommandEncoder setDepthStencilState:pipeline.depthStencilState()];
     [m_renderCommandEncoder setCullMode:pipeline.cullMode()];
     [m_renderCommandEncoder setFrontFacingWinding:pipeline.frontFace()];
 }

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -41,9 +41,9 @@ class Device;
 class RenderPipeline : public WGPURenderPipelineImpl, public RefCounted<RenderPipeline> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, Device& device)
+    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, id<MTLDepthStencilState> depthStencilState, Device& device)
     {
-        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, device));
+        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthStencilState, device));
     }
 
     static Ref<RenderPipeline> createInvalid(Device& device)
@@ -59,6 +59,7 @@ public:
     bool isValid() const { return m_renderPipelineState; }
 
     id<MTLRenderPipelineState> renderPipelineState() const { return m_renderPipelineState; }
+    id<MTLDepthStencilState> depthStencilState() const { return m_depthStencilState; }
     MTLPrimitiveType primitiveType() const { return m_primitiveType; }
     MTLWinding frontFace() const { return m_frontFace; }
     MTLCullMode cullMode() const { return m_cullMode; }
@@ -66,7 +67,7 @@ public:
     Device& device() const { return m_device; }
 
 private:
-    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, Device&);
+    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, id<MTLDepthStencilState>, Device&);
     RenderPipeline(Device&);
 
     const id<MTLRenderPipelineState> m_renderPipelineState { nil };
@@ -76,6 +77,7 @@ private:
     std::optional<MTLIndexType> m_indexType;
     MTLWinding m_frontFace;
     MTLCullMode m_cullMode;
+    id<MTLDepthStencilState> m_depthStencilState;
 };
 
 } // namespace WebGPU

--- a/Websites/webkit.org/demos/webgpu/instanced-textured-cube.html
+++ b/Websites/webkit.org/demos/webgpu/instanced-textured-cube.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=600">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+<title>WebGPU Instanced Textured Cubes with Depth Buffer</title>
+<link rel="stylesheet" href="css/style.css">
+<style>
+body {
+    font-family: system-ui;
+    color: #f7f7ff;
+    background-color: rgb(38, 38, 127);
+    text-align: center;
+}
+canvas {
+    margin: 0 auto;
+}
+</style>
+</head>
+<body>
+<div id="contents">
+    <h1>Instanced Textured Cubes with Depth Buffer</h1>
+    <canvas></canvas>
+</div>
+<div id="error">
+    <h2>WebGPU not available</h2>
+    <p>
+        Make sure you are on a system with WebGPU enabled. In
+        Safari, first make sure the Developer Menu is visible (Preferences >
+        Advanced), then Develop > Experimental Features > WebGPU.
+    </p>
+    <p>
+        In addition, you must be using Safari Technology Preview 92 or above.
+        You can get the latest STP <a href="https://developer.apple.com/safari/download/">here</a>.
+    </p>
+</div>
+<script src="scripts/instanced-textured-cube.js"></script>
+</body>
+</html>

--- a/Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js
@@ -1,0 +1,356 @@
+async function helloCube() {
+    if (!navigator.gpu || GPUBufferUsage.COPY_SRC === undefined) {
+        document.body.className = 'error';
+        return;
+    }
+
+    const canvas = document.querySelector("canvas");
+    canvas.width = 600;
+    canvas.height = 600;
+    
+    const adapter = await navigator.gpu.requestAdapter();
+    const device = await adapter.requestDevice();
+    
+    /*** Vertex Buffer Setup ***/
+    
+    /* Vertex Data */
+    const vertexStride = 10 * 4;
+    const vertexDataSize = vertexStride * 36;
+    
+    /* GPUBufferDfescriptor */
+    const vertexDataBufferDescriptor = {
+        size: vertexDataSize,
+        usage: GPUBufferUsage.VERTEX,
+        mappedAtCreation: true
+    };
+
+    /* GPUBuffer */
+    const vertexBuffer = device.createBuffer(vertexDataBufferDescriptor);
+    const vertexWriteArray = new Float32Array(vertexBuffer.getMappedRange());
+    vertexWriteArray.set([
+        // float4 position, float4 color, float2 uv
+        .5, -.5, .5, 1,   1, 0, 1, 1,  1, 1,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  0, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,  0, 0,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  1, 0,
+        .5, -.5, .5, 1,   1, 0, 1, 1,  1, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,  0, 0,
+
+        .5, .5, .5, 1,    1, 1, 1, 1,  1, 1,
+        .5, -.5, .5, 1,   1, 0, 1, 1,  0, 1,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  0, 0,
+        .5, .5, -.5, 1,   1, 1, 0, 1,  1, 0,
+        .5, .5, .5, 1,    1, 1, 1, 1,  1, 1,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  0, 0,
+
+        -.5, .5, .5, 1,   0, 1, 1, 1,  1, 1,
+        .5, .5, .5, 1,    1, 1, 1, 1,  0, 1,
+        .5, .5, -.5, 1,   1, 1, 0, 1,  0, 0,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  1, 0,
+        -.5, .5, .5, 1,   0, 1, 1, 1,  1, 1,
+        .5, .5, -.5, 1,   1, 1, 0, 1,  0, 0,
+
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  1, 1,
+        -.5, .5, .5, 1,   0, 1, 1, 1,  0, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  0, 0,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,  1, 0,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  1, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  0, 0,
+
+        .5, .5, .5, 1,    1, 1, 1, 1,  1, 1,
+        -.5, .5, .5, 1,   0, 1, 1, 1,  0, 1,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  0, 0,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  0, 0,
+        .5, -.5, .5, 1,   1, 0, 1, 1,  1, 0,
+        .5, .5, .5, 1,    1, 1, 1, 1,  1, 1,
+    
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  1, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,  0, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  0, 0,
+        .5, .5, -.5, 1,   1, 1, 0, 1,  1, 0,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  1, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  0, 0,
+    ]);
+    vertexBuffer.unmap();
+
+    const instanceRows = 3;
+    const instanceColumns = 3;
+    const instanceCount = instanceRows * instanceColumns;
+    const uniformBufferSize = 12 * instanceCount;
+    const uniformBuffer = device.createBuffer({
+        size: uniformBufferSize,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    
+    const translationBufferSize = 4 * 4 * instanceCount;
+    const translationBuffer = device.createBuffer({
+        size: translationBufferSize,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    
+    /* GPUTexture */
+    const image = new Image();
+    const imageLoadPromise = new Promise(resolve => {
+        image.onload = () => resolve();
+        image.src = "resources/webkit-logo.png"
+    });
+    await Promise.resolve(imageLoadPromise);
+
+    const textureSize = {
+        width: image.width,
+        height: image.height,
+        depth: 1
+    };
+
+    const textureDescriptor = {
+        size: textureSize,
+        arrayLayerCount: 1,
+        mipLevelCount: 1,
+        sampleCount: 1,
+        dimension: "2d",
+        format: "bgra8unorm",
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST
+    };
+    const texture = device.createTexture(textureDescriptor);
+    
+    const imageBitmap = await createImageBitmap(image);
+
+    device.queue.copyExternalImageToTexture(
+        { source: imageBitmap },
+        { texture: texture },
+        [image.width, image.height]
+    );
+
+    const sampler = device.createSampler({
+        magFilter: "linear",
+        minFilter: "linear"
+    });
+
+    /*** Shader Setup ***/
+    
+    const uniformBindGroupLayout = device.createBindGroupLayout({ entries: [
+        { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: {} },
+        { binding: 1, visibility: GPUShaderStage.VERTEX, buffer: {} },
+        { binding: 2, visibility: GPUShaderStage.FRAGMENT, texture: {} },
+        { binding: 3, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
+    ] });
+
+    const uniformBindGroup = device.createBindGroup({
+        layout: uniformBindGroupLayout,
+        entries: [
+          {
+            binding: 0,
+            resource: {
+              buffer: uniformBuffer,
+              offset: 0
+            },
+          },
+          {
+            binding: 1,
+            resource: {
+              buffer: translationBuffer,
+              offset: 0
+            },
+          },
+          {
+            binding: 2,
+            resource: texture.createView(),
+          },
+          {
+            binding: 3,
+            resource: sampler,
+          },
+        ],
+      });
+
+    const mslSource = `
+                #define vertexInputPackedFloatSize 10
+                #include <metal_stdlib>
+                using namespace metal;
+                struct VertexIn {
+                   float4 position;
+                   float4 color;
+                   float2 uv;
+                };
+    
+                struct VertexOut {
+                   float4 position [[position]];
+                   float4 color;
+                   float2 uv;
+                };
+    
+                struct VertexShaderArguments {
+                    device float *time [[id(0)]];
+                    device float4 *translation [[id(1)]];
+                };
+    
+                struct FragmentShaderArguments {
+                    texture2d<half> colorTexture;
+                    sampler textureSampler;
+                };
+    
+                vertex VertexOut vsmain(const device float *vertices [[buffer(0)]], const device VertexShaderArguments &values [[buffer(1)]], unsigned VertexIndex [[vertex_id]], unsigned InstanceIndex [[instance_id]])
+                {
+                    VertexOut vout;
+                    unsigned offset = InstanceIndex * 3;
+                    float alpha = values.time[offset];
+                    float beta = values.time[offset + 1];
+                    float gamma = values.time[offset + 2];
+                    float cA = cos(alpha);
+                    float sA = sin(alpha);
+                    float cB = cos(beta);
+                    float sB = sin(beta);
+                    float cG = cos(gamma);
+                    float sG = sin(gamma);
+    
+                    float4x4 m = float4x4(cA * cB,  sA * cB,   -sB, 0,
+                                          cA*sB*sG - sA*cG,  sA*sB*sG + cA*cG,   cB * sG, 0,
+                                          cA*sB*cG + sA*sG, sA*sB*cG - cA*sG, cB * cG, 0,
+                                          0,     0,     0, 1);
+                    float4 translation = values.translation[InstanceIndex];
+
+                    VertexIn vin = *(device VertexIn*)(vertices + VertexIndex * vertexInputPackedFloatSize);
+                    vout.position = vin.position * m + translation;
+                    vout.position.z = 1 - (vout.position.z + 0.5) * 0.5;
+                    vout.color = vin.color;
+                    vout.uv = vin.uv;
+                    return vout;
+                }
+
+                fragment float4 fsmain(VertexOut in [[stage_in]], device FragmentShaderArguments &values [[buffer(1)]])
+                {
+                    return 0.5 * in.color + 0.5 * float4(values.colorTexture.sample(values.textureSampler, in.uv));
+                }
+    `;
+
+    const shaderModule = device.createShaderModule({ code: mslSource, isWHLSL: false, hints: [ {layout: "auto" }, ] });
+    
+    /* GPUPipelineStageDescriptors */
+    const vertexStageDescriptor = { module: shaderModule, entryPoint: "vsmain" };
+
+    const fragmentStageDescriptor = { module: shaderModule, entryPoint: "fsmain", targets: [ {format: "bgra8unorm" }, ],  };
+
+    /* GPURenderPipelineDescriptor */
+
+    const renderPipelineDescriptor = {
+        layout: "auto",
+        vertex: vertexStageDescriptor,
+        fragment: fragmentStageDescriptor,
+        primitive: {
+            topology: "triangle-list",
+            cullMode: "none"
+        },
+        depthStencil: {
+            format: "depth24plus",
+            depthWriteEnabled: true,
+            depthCompare: "less-equal"
+        }
+    };
+
+    const depthTexture = device.createTexture({
+        size: [ canvas.width, canvas.height ],
+        format: 'depth24plus',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const depthTextureView = depthTexture.createView();
+
+    /* GPURenderPipeline */
+    const renderPipeline = device.createRenderPipeline(renderPipelineDescriptor);
+    
+    /*** Swap Chain Setup ***/
+    function frameUpdate() {
+        const d = new Date();
+        const seconds = d.getMilliseconds() / 1000.0 + d.getSeconds();
+        const secondsBuffer = new Float32Array(instanceCount * 3);
+        const translations = new Float32Array(instanceCount * 4);
+        const pi = 6.28318530718;
+        for (let i = 0; i < instanceCount; ++i) {
+            const offset = (pi * i) / instanceCount;
+            const speed = 2;
+            secondsBuffer[i * 3] = seconds * speed * (pi / 60.0) + offset;
+            secondsBuffer[i * 3 + 1] = seconds * (speed * 0.5) * (pi / 60.0) + offset;
+            secondsBuffer[i * 3 + 2] = seconds * (speed * 0.1) * (pi / 60.0) + offset;
+
+            const x = i % instanceColumns;
+            const y = i / instanceColumns;
+
+            const xOffset = Math.floor((x - (instanceColumns - 1) / 2));
+            const yOffset = Math.floor((y - (instanceColumns - 1) / 2));
+            translations[i * 4] = xOffset;
+            translations[i * 4 + 1] = yOffset;
+            translations[i * 4 + 2] = 0;
+            translations[i * 4 + 3] = 1;
+        }
+
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, uniformBufferSize);
+        device.queue.writeBuffer(translationBuffer, 0, translations, 0, translationBufferSize);
+
+        const gpuContext = canvas.getContext("webgpu");
+        
+        /* GPUCanvasConfiguration */
+        const canvasConfiguration = { device: device, format: "bgra8unorm" };
+        gpuContext.configure(canvasConfiguration);
+        /* GPUTexture */
+        const currentTexture = gpuContext.getCurrentTexture();
+        
+        /*** Render Pass Setup ***/
+        
+        /* Acquire Texture To Render To */
+        
+        /* GPUTextureView */
+        const renderAttachment = currentTexture.createView();
+        
+        /* GPUColor */
+        const darkBlue = { r: 0.15, g: 0.15, b: 0.5, a: 1 };
+        
+        /* GPURenderPassColorATtachmentDescriptor */
+        const colorAttachmentDescriptor = {
+            view: renderAttachment,
+            loadOp: "clear",
+            storeOp: "store",
+            clearColor: darkBlue
+        };
+        
+        /* GPURenderPassDescriptor */
+        const depthAttachment = {
+            view: depthTextureView,
+            depthClearValue: 1.0,
+            depthLoadOp: "clear",
+            depthStoreOp: "store",
+            stencilLoadOp: "clear",
+            stencilStoreOp: "store",
+        };
+        const renderPassDescriptor = {
+            colorAttachments: [colorAttachmentDescriptor],
+            depthStencilAttachment: depthAttachment
+        };
+        
+        /*** Rendering ***/
+        
+        /* GPUCommandEncoder */
+        const commandEncoder = device.createCommandEncoder();
+        /* GPURenderPassEncoder */
+        const renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+        
+        renderPassEncoder.setPipeline(renderPipeline);
+        const vertexBufferSlot = 0;
+        renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
+        renderPassEncoder.setBindGroup(1, uniformBindGroup);
+        renderPassEncoder.draw(36, instanceCount, 0, 0); // 36 vertices, 10 instances, 0th vertex, 0th instance.
+        renderPassEncoder.end();
+        
+        /* GPUComamndBuffer */
+        const commandBuffer = commandEncoder.finish();
+        
+        /* GPUQueue */
+        const queue = device.queue;
+        queue.submit([commandBuffer]);
+
+        requestAnimationFrame(frameUpdate);
+    }
+
+    requestAnimationFrame(frameUpdate);
+}
+
+window.addEventListener("DOMContentLoaded", helloCube);


### PR DESCRIPTION
#### c578df6c965c6b8937a9b7d31de11a848fe2c8cc
<pre>
[WebGPU] Depth buffer / texture support
<a href="https://bugs.webkit.org/show_bug.cgi?id=249037">https://bugs.webkit.org/show_bug.cgi?id=249037</a>
&lt;radar://101571337&gt;

Reviewed by Dean Jackson.

Add depth buffer support along with a test case which shows
several intersecting rotating textured cubes.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::validateRenderPassDescriptor const):
(WebGPU::CommandEncoder::beginRenderPass):
Create the depth state.

* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setPipeline):
Set the depth stencil state if it exists.

* Source/WebGPU/WebGPU/RenderPipeline.h:
(WebGPU::RenderPipeline::create):
(WebGPU::RenderPipeline::depthStencilState const):

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::topologyType):
Set input topology type.

(WebGPU::Device::validateRenderPipeline):
Depth stencil is supported.

(WebGPU::convertToMTLCompare):
Convert compare function to metal compare function.

(WebGPU::Device::createRenderPipeline):
(WebGPU::RenderPipeline::RenderPipeline):

* Websites/webkit.org/demos/webgpu/instanced-textured-cube.html: Added.
* Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js: Added.
(async helloCube.frameUpdate):
(async helloCube):
Add a test case showing 9 cubes rotating with different offsets and intersecting
other cubes to illustrate a working depth buffer.

Canonical link: <a href="https://commits.webkit.org/257807@main">https://commits.webkit.org/257807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef09be2723bb84213b7056b887b9a6e95846fd1a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109338 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86472 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92438 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107238 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90872 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34306 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22263 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2955 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23776 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46150 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9048 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43254 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5359 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4763 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->