### PR TITLE
[Curl] Only redirect when known redirect status codes

### DIFF
--- a/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
@@ -156,18 +156,7 @@ String ResourceResponse::platformSuggestedFilename() const
 
 bool ResourceResponse::shouldRedirect()
 {
-    auto statusCode = httpStatusCode();
-    if (statusCode < 300 || 400 <= statusCode)
-        return false;
-
-    // Some 3xx status codes aren't actually redirects.
-    if (statusCode == 300 || statusCode == 304 || statusCode == 305 || statusCode == 306)
-        return false;
-
-    if (httpHeaderField(HTTPHeaderName::Location).isEmpty())
-        return false;
-
-    return true;
+    return isRedirection() && !httpHeaderField(HTTPHeaderName::Location).isEmpty();
 }
 
 bool ResourceResponse::isMovedPermanently() const


### PR DESCRIPTION
#### 466ea4fe035b3fc7bb19aeb38718e9fe28f2c873
<pre>
[Curl] Only redirect when known redirect status codes
<a href="https://bugs.webkit.org/show_bug.cgi?id=249209">https://bugs.webkit.org/show_bug.cgi?id=249209</a>

Reviewed by NOBODY (OOPS!).

Redirect according to the WebKit defined redirect code.

* Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp:
(WebCore::ResourceResponse::shouldRedirect):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/466ea4fe035b3fc7bb19aeb38718e9fe28f2c873

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109342 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169575 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86476 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92442 "Updated gtk dependencies (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107242 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90874 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/92442 "Updated gtk dependencies (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22265 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/92442 "Updated gtk dependencies (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2959 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23778 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46154 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43256 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4767 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->