### PR TITLE
Images are not loaded in element application

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-invalid-http-header-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-invalid-http-header-expected.txt
@@ -1,0 +1,5 @@
+This tests that a blob-URL JavaScript script loads with Content Security Policy containing invalid characters for an HTTP header value.
+
+PASS executed blob-URL script.
+PASS fired load event for blob-URL script.
+

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-invalid-http-header.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-invalid-http-header.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline' blob:;
+                                                    connect-src 'self';">
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+</head>
+<p>This tests that a blob-URL JavaScript script loads with Content Security Policy containing invalid characters for an HTTP header value.</p>
+<pre id="console"></pre>
+<script>
+function log(message)
+{
+    document.getElementById("console").appendChild(document.createTextNode(message + "\n"));
+}
+
+function done()
+{
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+var script = document.createElement("script");
+script.onload = function () {
+    log("PASS fired load event for blob-URL script.");
+    done();
+}
+script.onerror = function () {
+    log("FAIL should not have fired error event for blob-URL script.");
+    done();
+}
+script.src = window.URL.createObjectURL(new Blob(["log('PASS executed blob-URL script.');"]));
+document.head.appendChild(script);
+</script>
+</html>


### PR DESCRIPTION
#### d89d47f7fd454c799ae34539434109f3e422bede
<pre>
Images are not loaded in element application
<a href="https://bugs.webkit.org/show_bug.cgi?id=249213">https://bugs.webkit.org/show_bug.cgi?id=249213</a>

Reviewed by Xabier Rodriguez-Calvar.

Element application uses the fetch api to download images and convert
them to a blob that is then requested. The problem is that the blob
request is failing due to invalid HTTP header in response. The invalid
header is Content-Security-Policy that is generated by the blob loader
using the security context policy. The document policy comes from
http-equiv meta and contains newlines, which are allowed there, but
invalid for an HTTP header value.

Test: http/tests/security/contentSecurityPolicy/blob-url-invalid-http-header.html

* LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-invalid-http-header-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-invalid-http-header.html: Added.
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::responseHeaders const): Make the http header value valid if needed.

Canonical link: <a href="https://commits.webkit.org/258130@main">https://commits.webkit.org/258130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cc599912eb48cc6ee03e4df5c6d90322c325af4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109354 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169589 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86506 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92454 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107254 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90902 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34317 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22295 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2971 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23810 "Found 1 new test failure: media/video-timeupdate-during-playback.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46164 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43291 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5582 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4780 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->