### PR TITLE
RemoteGraphicsContextGL crashes if platform graphics context creation fails

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3948,6 +3948,9 @@ webgl/2.0.y/conformance/textures/misc/texture-corner-case-videos.html [ Failure 
 
 webkit.org/b/243819 webgl/2.0.y/deqp/functional/gles3/negativetextureapi.html [ Pass ]
 
+# Until more platforms ship with WebGL GPUP
+webgl/webgl-fail-platform-context-creation-no-crash.html [ Failure Pass ]
+
 # pre-wrap progression. Other rendering engines agree with the result.
 webkit.org/b/206168 [ Debug ] fast/dom/insert-span-into-long-text-bug-28245.html [ Skip ]
 

--- a/LayoutTests/webgl/webgl-fail-platform-context-creation-no-crash-expected.txt
+++ b/LayoutTests/webgl/webgl-fail-platform-context-creation-no-crash-expected.txt
@@ -1,0 +1,15 @@
+This test tests that WebGL platform context creation can fail and it doesn't crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 5 PASS, 0 FAIL
+
+
+PASS [object WebGLRenderingContext] is non-null.
+PASS "failPlatformContextCreationForTesting" in glWorks.getContextAttributes() is true
+PASS Received context lost error for glFails
+PASS glWorks.NO_ERROR is glWorks.getError()
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/webgl-fail-platform-context-creation-no-crash.html
+++ b/LayoutTests/webgl/webgl-fail-platform-context-creation-no-crash.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseGPUProcessForWebGLEnabled=true runSingly=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebKit test for creating WebGL context when it can fail</title>
+<link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
+<script src="resources/webgl_test_files/js/js-test-pre.js"></script>
+<script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+<script src="resources/test-shader-implementation-language.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvasWorks"></canvas>
+<canvas id="canvasFails"></canvas>
+<script>
+"use strict";
+description("This test tests that WebGL platform context creation can fail and it doesn't crash.");
+// At the time of writing, the GPU process would crash if ANGLE was not present and
+// GraphicsContextGL creation would fail.
+
+debug("");
+var glWorks;
+var glFails;
+function runTest() {
+    glWorks = canvasWorks.getContext("webgl");
+    shouldBeNonNull(glWorks);
+    shouldBeTrue('"failPlatformContextCreationForTesting" in glWorks.getContextAttributes()'); // Expects support for "DOM Testing APIs Enabled internal setting"
+    glFails = canvasFails.getContext("webgl", { failPlatformContextCreationForTesting: true });
+    if (!glFails) {
+        testPassed("Context was not returned");
+        shouldBe("glWorks.NO_ERROR", "glWorks.getError()" );
+        finishTest();
+    } else {
+        canvasWorks.addEventListener('webglcontextcreationerror', () => {
+        testFailed("Received context creation error for glWorks");
+        }, false);
+        canvasWorks.addEventListener('webglcontextlost', () => {
+            testFailed("Received context lost error for glWorks");
+        }, false);
+        canvasFails.addEventListener('webglcontextcreationerror', () => {
+            testPassed("Received context creation error for glFails");
+            shouldBe("glWorks.NO_ERROR", "glWorks.getError()" );
+            finishTest();
+            clearTimeout(timeout);
+        }, false);
+        canvasFails.addEventListener('webglcontextlost', () => {
+            testPassed("Received context lost error for glFails");
+            shouldBe("glWorks.NO_ERROR", "glWorks.getError()" );
+            finishTest();
+            clearTimeout(timeout);
+        }, false);
+
+        var timeout = setTimeout(() => {
+            testFailed("Timeout while waiting for canvas creation error.");
+            finishTest();
+        }, 2000);
+    }
+}
+window.onload = runTest;
+
+var successfullyParsed = true;
+</script>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -251,6 +251,18 @@ DOMPasteAccessRequestsEnabled:
     WebCore:
       default: false
 
+DOMTestingAPIsEnabled:
+  type: bool
+  humanReadableName: "Additional Testing APIs for DOM Objects"
+  humanReadableDescription: "Enable additional testing APIs for DOM objects"
+  defaultValue:
+    WebCore:
+      default: false
+    WebKit:
+      default: false
+    WebKitLegacy:
+      default: false
+
 # FIXME: This is on by default in WebKit2 (for everything but WatchOS). Perhaps we should consider turning it on for WebKitLegacy as well.
 DataListElementEnabled:
   type: bool

--- a/Source/WebCore/html/canvas/WebGLContextAttributes.idl
+++ b/Source/WebCore/html/canvas/WebGLContextAttributes.idl
@@ -45,5 +45,6 @@ enum WebGLPowerPreference {
     GLboolean preserveDrawingBuffer = false;
     WebGLPowerPreference powerPreference = "default";
     GLboolean failIfMajorPerformanceCaveat = false;
+    [EnabledBySetting=DOMTestingAPIsEnabled] GLboolean failPlatformContextCreationForTesting = false;
     [Conditional=WEBXR, EnabledBySetting=WebXREnabled] boolean xrCompatible = false;
 };

--- a/Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h
@@ -59,6 +59,7 @@ struct GraphicsContextGLAttributes {
     bool failIfMajorPerformanceCaveat { false };
     using PowerPreference = GraphicsContextGLPowerPreference;
     PowerPreference powerPreference { PowerPreference::Default };
+    bool failPlatformContextCreationForTesting { false };
 
     // Additional attributes.
     bool shareResources { true };

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -79,6 +79,8 @@ static void wipeAlphaChannelFromPixels(int width, int height, unsigned char* pix
 
 bool GraphicsContextGLANGLE::initialize()
 {
+    if (contextAttributes().failPlatformContextCreationForTesting)
+        return false;
     if (!platformInitializeContext())
         return false;
     String extensionsString = String::fromLatin1(reinterpret_cast<const char*>(GL_GetString(GL_EXTENSIONS)));

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1916,6 +1916,7 @@ struct WebCore::GraphicsContextGLAttributes {
     bool preserveDrawingBuffer;
     bool failIfMajorPerformanceCaveat;
     WebCore::GraphicsContextGLPowerPreference powerPreference;
+    bool failPlatformContextCreationForTesting;
     bool shareResources;
     bool noExtensions;
     float devicePixelRatio;

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -85,6 +85,7 @@ const TestFeatures& TestOptions::defaults()
             { "ContentChangeObserverEnabled", false },
             { "CustomPasteboardDataEnabled", true },
             { "DOMPasteAllowed", true },
+            { "DOMTestingAPIsEnabled", true },
             { "DataTransferItemsEnabled", true },
             { "DeveloperExtrasEnabled", true },
             { "DirectoryUploadEnabled", true },


### PR DESCRIPTION
#### a8076cd4346043611ad3d4a09d264f5a6af9f0e5
<pre>
RemoteGraphicsContextGL crashes if platform graphics context creation fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=249214">https://bugs.webkit.org/show_bug.cgi?id=249214</a>
rdar://103277903

Reviewed by Matt Woodrow.

Creating GraphicsContextGL would fail if ANGLE shared library is not present.
This is as intended, on macOS this happens in recovery OS.
GPUP RemoteGraphicsContextGL would access nullptr when the unusable context
would be destroyed.

Guard for the nullptr context.
Move the IPC stream connection opening in the functions that execute on
stream work queue and start receiving messages from the stream only when
the context creation succeeds. This way the payload functions do not need
the nullptr guard, which they do not have.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:
* Source/WebCore/html/canvas/WebGLContextAttributes.idl:
* Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::initialize):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::initialize):
(WebKit::RemoteGraphicsContextGL::stopListeningForIPC):
(WebKit::RemoteGraphicsContextGL::workQueueInitialize):
(WebKit::RemoteGraphicsContextGL::workQueueUninitialize):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):

Canonical link: <a href="https://commits.webkit.org/257843@main">https://commits.webkit.org/257843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96637167dc40b6764b6e2c7105b970def1ab257c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109516 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169749 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10249 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92610 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107405 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105958 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34438 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90761 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3115 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23940 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86739 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/556 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3093 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29066 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9221 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43428 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89619 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5386 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4925 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20038 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->