### PR TITLE
[@property] Parse identifier list syntax

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
@@ -65,7 +65,7 @@ PASS syntax:'banana', initialValue:'banan\61' is valid
 PASS syntax:'banan\61', initialValue:'banana' is valid
 PASS syntax:'<custom-ident>', initialValue:'banan\61' is valid
 PASS syntax:'big | bigger | BIGGER', initialValue:'bigger' is valid
-FAIL syntax:'foo+|bar', initialValue:'foo foo foo' is valid Invalid property syntax definition.
+FAIL syntax:'foo+|bar', initialValue:'foo foo foo' is valid The given initial value does not parse for the given syntax.
 PASS syntax:'banana	', initialValue:'banana' is valid
 PASS syntax:'
 banana\r

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
@@ -193,8 +193,8 @@ PASS CSSUnitValue rejected by set() for syntax <length># [attributeStyleMap]
 PASS CSSUnitValue rejected by set() for syntax <length># [styleMap]
 PASS Appending a string to * is not allowed [attributeStyleMap]
 PASS Appending a string to * is not allowed [styleMap]
-FAIL Appending a string to foo+ is not allowed [attributeStyleMap] Invalid property syntax definition.
-FAIL Appending a string to foo+ is not allowed [styleMap] Invalid property syntax definition.
+PASS Appending a string to foo+ is not allowed [attributeStyleMap]
+PASS Appending a string to foo+ is not allowed [styleMap]
 PASS Appending a string to <angle>+ is not allowed [attributeStyleMap]
 PASS Appending a string to <angle>+ is not allowed [styleMap]
 PASS Appending a string to <color>+ is not allowed [attributeStyleMap]
@@ -227,8 +227,8 @@ PASS Appending a string to <length># is not allowed [attributeStyleMap]
 PASS Appending a string to <length># is not allowed [styleMap]
 PASS Appending a CSSKeywordValue to * is not allowed [attributeStyleMap]
 PASS Appending a CSSKeywordValue to * is not allowed [styleMap]
-FAIL Appending a CSSKeywordValue to foo+ is not allowed [attributeStyleMap] Invalid property syntax definition.
-FAIL Appending a CSSKeywordValue to foo+ is not allowed [styleMap] Invalid property syntax definition.
+PASS Appending a CSSKeywordValue to foo+ is not allowed [attributeStyleMap]
+PASS Appending a CSSKeywordValue to foo+ is not allowed [styleMap]
 PASS Appending a CSSUnitValue to <angle>+ is not allowed [attributeStyleMap]
 PASS Appending a CSSUnitValue to <angle>+ is not allowed [styleMap]
 PASS Appending a CSSKeywordValue to <custom-ident>+ is not allowed [attributeStyleMap]

--- a/Source/WebCore/css/parser/CSSPropertySyntax.h
+++ b/Source/WebCore/css/parser/CSSPropertySyntax.h
@@ -69,6 +69,7 @@ struct CSSPropertySyntax {
 
 private:
     template<typename CharacterType> static std::optional<Component> parseComponent(StringParsingBuffer<CharacterType>);
+    static Type typeForTypeName(StringView);
 };
 
 }


### PR DESCRIPTION
#### 009a0ee1bc61a302f337561e47ef1458f0d6a462
<pre>
[@property] Parse identifier list syntax
<a href="https://bugs.webkit.org/show_bug.cgi?id=249161">https://bugs.webkit.org/show_bug.cgi?id=249161</a>
&lt;rdar://problem/103262360&gt;

Reviewed by Alan Baradlay.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt:
* Source/WebCore/css/parser/CSSPropertySyntax.cpp:
(WebCore::CSSPropertySyntax::parseComponent):

Allow ident+ and ident# syntax.

(WebCore::CSSPropertySyntax::parse):
(WebCore::CSSPropertySyntax::typeForTypeName):

Factor into a function.

* Source/WebCore/css/parser/CSSPropertySyntax.h:

Canonical link: <a href="https://commits.webkit.org/257786@main">https://commits.webkit.org/257786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ccc5450b08994f1465f8a5cc2f2d8d21438cd71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109368 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169603 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86546 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92468 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107267 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105789 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34328 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2984 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2943 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/46174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43283 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5345 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4793 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->