### PR TITLE
WebGL tests are slow in debug due to sync IPC reply logging even when disabled

### DIFF
--- a/Source/WebKit/Platform/IPC/HandleMessage.h
+++ b/Source/WebKit/Platform/IPC/HandleMessage.h
@@ -109,6 +109,9 @@ void logReply(const Connection& connection, MessageName messageName, const T&...
     if (!sizeof...(T))
         return;
 
+    if (LOG_CHANNEL(IPCMessages).state != WTFLogChannelState::On)
+        return;
+
     auto stream = textStreamForLogging(connection, messageName, nullptr, ForReply::Yes);
 
     unsigned argIndex = 0;


### PR DESCRIPTION
#### 8f7373eda214f9130d7c1144266ec95d35658851
<pre>
WebGL tests are slow in debug due to sync IPC reply logging even when disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=249219">https://bugs.webkit.org/show_bug.cgi?id=249219</a>
rdar://problem/103298421

Reviewed by Cameron McCormack.

When replying to a IPC sync message, do not construct log TextStream if the
logging channel is disabled.

Speeds up Debug build webgl/2.0.y/conformance2/state/gl-object-get-calls.html
with  WebGL GPUP. This test does a lot of sync messages.

* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::logReply):

Canonical link: <a href="https://commits.webkit.org/257842@main">https://commits.webkit.org/257842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e387fef29ebdd967669bcb664473cd52a1a71140

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109371 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86549 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92471 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107270 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7612 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34330 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89519 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22290 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2987 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23805 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/46176 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43286 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5385 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4796 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->