### PR TITLE
Add encoding and decoding support for BasicShape

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2094,6 +2094,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     svg/SVGLengthValue.h
     svg/SVGParserUtilities.h
     svg/SVGParsingError.h
+    svg/SVGPathByteStream.h
+    svg/SVGPathConsumer.h
+    svg/SVGPathUtilities.h
     svg/SVGPreserveAspectRatioValue.h
     svg/SVGStringList.h
     svg/SVGTests.h

--- a/Source/WebCore/css/BasicShapeFunctions.cpp
+++ b/Source/WebCore/css/BasicShapeFunctions.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 
 static Ref<CSSPrimitiveValue> valueForCenterCoordinate(CSSValuePool& pool, const RenderStyle& style, const BasicShapeCenterCoordinate& center, BoxOrient orientation)
 {
-    if (center.direction() == BasicShapeCenterCoordinate::TopLeft)
+    if (center.direction() == BasicShapeCenterCoordinate::Direction::TopLeft)
         return pool.createValue(center.length(), style);
 
     CSSValueID keyword = orientation == BoxOrient::Horizontal ? CSSValueRight : CSSValueBottom;
@@ -53,11 +53,11 @@ static Ref<CSSPrimitiveValue> valueForCenterCoordinate(CSSValuePool& pool, const
 static Ref<CSSPrimitiveValue> basicShapeRadiusToCSSValue(const RenderStyle& style, CSSValuePool& pool, const BasicShapeRadius& radius)
 {
     switch (radius.type()) {
-    case BasicShapeRadius::Value:
+    case BasicShapeRadius::Type::Value:
         return pool.createValue(radius.value(), style);
-    case BasicShapeRadius::ClosestSide:
+    case BasicShapeRadius::Type::ClosestSide:
         return pool.createIdentifierValue(CSSValueClosestSide);
-    case BasicShapeRadius::FarthestSide:
+    case BasicShapeRadius::Type::FarthestSide:
         return pool.createIdentifierValue(CSSValueFarthestSide);
     }
 
@@ -191,36 +191,36 @@ static BasicShapeCenterCoordinate convertToCenterCoordinate(const CSSToLengthCon
     switch (keyword) {
     case CSSValueTop:
     case CSSValueLeft:
-        direction = BasicShapeCenterCoordinate::TopLeft;
+        direction = BasicShapeCenterCoordinate::Direction::TopLeft;
         break;
     case CSSValueRight:
     case CSSValueBottom:
-        direction = BasicShapeCenterCoordinate::BottomRight;
+        direction = BasicShapeCenterCoordinate::Direction::BottomRight;
         break;
     case CSSValueCenter:
-        direction = BasicShapeCenterCoordinate::TopLeft;
+        direction = BasicShapeCenterCoordinate::Direction::TopLeft;
         offset = Length(50, LengthType::Percent);
         break;
     default:
         ASSERT_NOT_REACHED();
-        direction = BasicShapeCenterCoordinate::TopLeft;
+        direction = BasicShapeCenterCoordinate::Direction::TopLeft;
         break;
     }
 
-    return BasicShapeCenterCoordinate(direction, offset);
+    return BasicShapeCenterCoordinate(direction, WTFMove(offset));
 }
 
 static BasicShapeRadius cssValueToBasicShapeRadius(const CSSToLengthConversionData& conversionData, CSSPrimitiveValue* radius)
 {
     if (!radius)
-        return BasicShapeRadius(BasicShapeRadius::ClosestSide);
+        return BasicShapeRadius(BasicShapeRadius::Type::ClosestSide);
 
     if (radius->isValueID()) {
         switch (radius->valueID()) {
         case CSSValueClosestSide:
-            return BasicShapeRadius(BasicShapeRadius::ClosestSide);
+            return BasicShapeRadius(BasicShapeRadius::Type::ClosestSide);
         case CSSValueFarthestSide:
-            return BasicShapeRadius(BasicShapeRadius::FarthestSide);
+            return BasicShapeRadius(BasicShapeRadius::Type::FarthestSide);
         default:
             ASSERT_NOT_REACHED();
             break;
@@ -305,7 +305,7 @@ Ref<BasicShape> basicShapeForValue(const CSSToLengthConversionData& conversionDa
 float floatValueForCenterCoordinate(const BasicShapeCenterCoordinate& center, float boxDimension)
 {
     float offset = floatValueForLength(center.length(), boxDimension);
-    if (center.direction() == BasicShapeCenterCoordinate::TopLeft)
+    if (center.direction() == BasicShapeCenterCoordinate::Direction::TopLeft)
         return offset;
     return boxDimension - offset;
 }

--- a/Source/WebCore/rendering/style/BasicShapes.cpp
+++ b/Source/WebCore/rendering/style/BasicShapes.cpp
@@ -49,7 +49,7 @@ namespace WebCore {
 
 void BasicShapeCenterCoordinate::updateComputedLength()
 {
-    if (m_direction == TopLeft) {
+    if (m_direction == BasicShapeCenterCoordinate::Direction::TopLeft) {
         m_computedLength = m_length.isUndefined() ? Length(0, LengthType::Fixed) : m_length;
         return;
     }
@@ -145,6 +145,18 @@ static const Path& cachedTransformedByteStreamPath(const SVGPathByteStream& stre
     return cache.get().get(SVGPathTransformedByteStream { stream, zoom, offset });
 }
 
+Ref<BasicShapeCircle> BasicShapeCircle::create(BasicShapeCenterCoordinate&& centerX, BasicShapeCenterCoordinate&& centerY, BasicShapeRadius&& radius)
+{
+    return adoptRef(*new BasicShapeCircle(WTFMove(centerX), WTFMove(centerY), WTFMove(radius)));
+}
+
+BasicShapeCircle::BasicShapeCircle(BasicShapeCenterCoordinate&& centerX, BasicShapeCenterCoordinate&& centerY, BasicShapeRadius&& radius)
+    : m_centerX(WTFMove(centerX))
+    , m_centerY(WTFMove(centerY))
+    , m_radius(WTFMove(radius))
+{
+}
+
 bool BasicShapeCircle::operator==(const BasicShape& other) const
 {
     if (type() != other.type())
@@ -158,7 +170,7 @@ bool BasicShapeCircle::operator==(const BasicShape& other) const
 
 float BasicShapeCircle::floatValueForRadiusInBox(float boxWidth, float boxHeight) const
 {
-    if (m_radius.type() == BasicShapeRadius::Value)
+    if (m_radius.type() == BasicShapeRadius::Type::Value)
         return floatValueForLength(m_radius.value(), std::hypot(boxWidth, boxHeight) / sqrtOfTwoFloat);
 
     float centerX = floatValueForCenterCoordinate(m_centerX, boxWidth);
@@ -166,10 +178,10 @@ float BasicShapeCircle::floatValueForRadiusInBox(float boxWidth, float boxHeight
 
     float widthDelta = std::abs(boxWidth - centerX);
     float heightDelta = std::abs(boxHeight - centerY);
-    if (m_radius.type() == BasicShapeRadius::ClosestSide)
+    if (m_radius.type() == BasicShapeRadius::Type::ClosestSide)
         return std::min(std::min(std::abs(centerX), widthDelta), std::min(std::abs(centerY), heightDelta));
 
-    // If radius.type() == BasicShapeRadius::FarthestSide.
+    // If radius.type() == BasicShapeRadius::Type::FarthestSide.
     return std::max(std::max(std::abs(centerX), widthDelta), std::max(std::abs(centerY), heightDelta));
 }
 
@@ -209,6 +221,19 @@ void BasicShapeCircle::dump(TextStream& ts) const
     ts.dumpProperty("radius", radius());
 }
 
+Ref<BasicShapeEllipse> BasicShapeEllipse::create(BasicShapeCenterCoordinate&& centerX, BasicShapeCenterCoordinate&& centerY, BasicShapeRadius&& radiusX, BasicShapeRadius&& radiusY)
+{
+    return adoptRef(*new BasicShapeEllipse(WTFMove(centerX), WTFMove(centerY), WTFMove(radiusX), WTFMove(radiusY)));
+}
+
+BasicShapeEllipse::BasicShapeEllipse(BasicShapeCenterCoordinate&& centerX, BasicShapeCenterCoordinate&& centerY, BasicShapeRadius&& radiusX, BasicShapeRadius&& radiusY)
+    : m_centerX(WTFMove(centerX))
+    , m_centerY(WTFMove(centerY))
+    , m_radiusX(WTFMove(radiusX))
+    , m_radiusY(WTFMove(radiusY))
+{
+}
+
 bool BasicShapeEllipse::operator==(const BasicShape& other) const
 {
     if (type() != other.type())
@@ -223,14 +248,14 @@ bool BasicShapeEllipse::operator==(const BasicShape& other) const
 
 float BasicShapeEllipse::floatValueForRadiusInBox(const BasicShapeRadius& radius, float center, float boxWidthOrHeight) const
 {
-    if (radius.type() == BasicShapeRadius::Value)
+    if (radius.type() == BasicShapeRadius::Type::Value)
         return floatValueForLength(radius.value(), std::abs(boxWidthOrHeight));
 
     float widthOrHeightDelta = std::abs(boxWidthOrHeight - center);
-    if (radius.type() == BasicShapeRadius::ClosestSide)
+    if (radius.type() == BasicShapeRadius::Type::ClosestSide)
         return std::min(std::abs(center), widthOrHeightDelta);
 
-    ASSERT(radius.type() == BasicShapeRadius::FarthestSide);
+    ASSERT(radius.type() == BasicShapeRadius::Type::FarthestSide);
     return std::max(std::abs(center), widthOrHeightDelta);
 }
 
@@ -259,8 +284,8 @@ Ref<BasicShape> BasicShapeEllipse::blend(const BasicShape& other, const Blending
     auto& otherEllipse = downcast<BasicShapeEllipse>(other);
     auto result = BasicShapeEllipse::create();
 
-    if (m_radiusX.type() != BasicShapeRadius::Value || otherEllipse.radiusX().type() != BasicShapeRadius::Value
-        || m_radiusY.type() != BasicShapeRadius::Value || otherEllipse.radiusY().type() != BasicShapeRadius::Value) {
+    if (m_radiusX.type() != BasicShapeRadius::Type::Value || otherEllipse.radiusX().type() != BasicShapeRadius::Type::Value
+        || m_radiusY.type() != BasicShapeRadius::Type::Value || otherEllipse.radiusY().type() != BasicShapeRadius::Type::Value) {
         result->setCenterX(otherEllipse.centerX());
         result->setCenterY(otherEllipse.centerY());
         result->setRadiusX(otherEllipse.radiusX());
@@ -281,6 +306,17 @@ void BasicShapeEllipse::dump(TextStream& ts) const
     ts.dumpProperty("center-y", centerY());
     ts.dumpProperty("radius-x", radiusX());
     ts.dumpProperty("radius-y", radiusY());
+}
+
+Ref<BasicShapePolygon> BasicShapePolygon::create(WindRule windRule, Vector<Length>&& values)
+{
+    return adoptRef(*new BasicShapePolygon(windRule, WTFMove(values)));
+}
+
+BasicShapePolygon::BasicShapePolygon(WindRule windRule, Vector<Length>&& values)
+    : m_windRule(windRule)
+    , m_values(WTFMove(values))
+{
 }
 
 bool BasicShapePolygon::operator==(const BasicShape& other) const
@@ -346,8 +382,20 @@ void BasicShapePolygon::dump(TextStream& ts) const
     ts.dumpProperty("path", values());
 }
 
+Ref<BasicShapePath> BasicShapePath::create(std::unique_ptr<SVGPathByteStream>&& byteStream, float zoom, WindRule windRule)
+{
+    return adoptRef(*new BasicShapePath(WTFMove(byteStream), zoom, windRule));
+}
+
 BasicShapePath::BasicShapePath(std::unique_ptr<SVGPathByteStream>&& byteStream)
     : m_byteStream(WTFMove(byteStream))
+{
+}
+
+BasicShapePath::BasicShapePath(std::unique_ptr<SVGPathByteStream>&& byteStream, float zoom, WindRule windRule)
+    : m_byteStream(WTFMove(byteStream))
+    , m_zoom(zoom)
+    , m_windRule(windRule)
 {
 }
 
@@ -392,6 +440,23 @@ void BasicShapePath::dump(TextStream& ts) const
 {
     ts.dumpProperty("wind-rule", windRule());
     // FIXME: print the byte stream?
+}
+
+Ref<BasicShapeInset> BasicShapeInset::create(Length&& right, Length&& top, Length&& bottom, Length&& left, LengthSize&& topLeftRadius, LengthSize&& topRightRadius, LengthSize&& bottomRightRadius, LengthSize&& bottomLeftRadius)
+{
+    return adoptRef(*new BasicShapeInset(WTFMove(right), WTFMove(top), WTFMove(bottom), WTFMove(left), WTFMove(topLeftRadius), WTFMove(topRightRadius), WTFMove(bottomRightRadius), WTFMove(bottomLeftRadius)));
+}
+
+BasicShapeInset::BasicShapeInset(Length&& right, Length&& top, Length&& bottom, Length&& left, LengthSize&& topLeftRadius, LengthSize&& topRightRadius, LengthSize&& bottomRightRadius, LengthSize&& bottomLeftRadius)
+    : m_right(WTFMove(right))
+    , m_top(WTFMove(top))
+    , m_bottom(WTFMove(bottom))
+    , m_left(WTFMove(left))
+    , m_topLeftRadius(WTFMove(topLeftRadius))
+    , m_topRightRadius(WTFMove(topRightRadius))
+    , m_bottomRightRadius(WTFMove(bottomRightRadius))
+    , m_bottomLeftRadius(WTFMove(bottomLeftRadius))
+{
 }
 
 bool BasicShapeInset::operator==(const BasicShape& other) const
@@ -466,9 +531,9 @@ void BasicShapeInset::dump(TextStream& ts) const
 static TextStream& operator<<(TextStream& ts, BasicShapeRadius::Type radiusType)
 {
     switch (radiusType) {
-    case BasicShapeRadius::Value: ts << "value"; break;
-    case BasicShapeRadius::ClosestSide: ts << "closest-side"; break;
-    case BasicShapeRadius::FarthestSide: ts << "farthest-side"; break;
+    case BasicShapeRadius::Type::Value: ts << "value"; break;
+    case BasicShapeRadius::Type::ClosestSide: ts << "closest-side"; break;
+    case BasicShapeRadius::Type::FarthestSide: ts << "farthest-side"; break;
     }
     return ts;
 }
@@ -482,7 +547,7 @@ TextStream& operator<<(TextStream& ts, const BasicShapeRadius& radius)
 
 TextStream& operator<<(TextStream& ts, const BasicShapeCenterCoordinate& coordinate)
 {
-    ts.dumpProperty("direction", coordinate.direction() == BasicShapeCenterCoordinate::TopLeft ? "top left" : "bottom right");
+    ts.dumpProperty("direction", coordinate.direction() == BasicShapeCenterCoordinate::Direction::TopLeft ? "top left" : "bottom right");
     ts.dumpProperty("length", coordinate.length());
     return ts;
 }

--- a/Source/WebCore/svg/SVGPathByteStream.h
+++ b/Source/WebCore/svg/SVGPathByteStream.h
@@ -65,6 +65,11 @@ public:
         *this = WTFMove(other);
     }
 
+    SVGPathByteStream(Data&& data)
+        : m_data(WTFMove(data))
+    {
+    }
+
     SVGPathByteStream& operator=(const SVGPathByteStream& other)
     {
         if (*this == other)
@@ -98,6 +103,8 @@ public:
     bool isEmpty() const { return m_data.isEmpty(); }
     unsigned size() const { return m_data.size(); }
     void shrinkToFit() { m_data.shrinkToFit(); }
+
+    const Data& data() const { return m_data; }
 
 private:
     Data m_data;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1951,3 +1951,77 @@ struct WebCore::GraphicsContextGLAttributes {
     WebCore::PerspectiveTransformOperation
     WebCore::IdentityTransformOperation
 }
+
+struct WebCore::LengthSize {
+    WebCore::Length width;
+    WebCore::Length height;
+}
+
+class WebCore::SVGPathByteStream {
+    Vector<unsigned char> data();
+}
+
+header: <WebCore/BasicShapes.h>
+[Nested, CustomHeader] enum class WebCore::BasicShapeCenterCoordinate::Direction : uint8_t {
+    TopLeft,
+    BottomRight
+}
+
+[CustomHeader] class WebCore::BasicShapeCenterCoordinate {
+    WebCore::BasicShapeCenterCoordinate::Direction direction();
+    WebCore::Length length();
+}
+
+[Nested, CustomHeader] enum class WebCore::BasicShapeRadius::Type : uint8_t {
+    Value,
+    ClosestSide,
+    FarthestSide
+};
+
+[CustomHeader] class WebCore::BasicShapeRadius {
+    WebCore::Length value();
+    WebCore::BasicShapeRadius::Type type();
+}
+
+[Return=Ref, CustomHeader] class WebCore::BasicShapeCircle {
+    WebCore::BasicShapeCenterCoordinate centerX();
+    WebCore::BasicShapeCenterCoordinate centerY();
+    WebCore::BasicShapeRadius radius();
+}
+
+[Return=Ref, CustomHeader] class WebCore::BasicShapeEllipse {
+    WebCore::BasicShapeCenterCoordinate centerX();
+    WebCore::BasicShapeCenterCoordinate centerY();
+    WebCore::BasicShapeRadius radiusX();
+    WebCore::BasicShapeRadius radiusY();
+}
+
+[Return=Ref, CustomHeader] class WebCore::BasicShapePolygon {
+    WebCore::WindRule windRule();
+    Vector<WebCore::Length> values();
+}
+
+[Return=Ref, CustomHeader] class WebCore::BasicShapePath {
+    std::unique_ptr<WebCore::SVGPathByteStream> byteStream();
+    float zoom();
+    WebCore::WindRule windRule();
+}
+
+[Return=Ref, CustomHeader] class WebCore::BasicShapeInset {
+    WebCore::Length right();
+    WebCore::Length top();
+    WebCore::Length bottom();
+    WebCore::Length left();
+    WebCore::LengthSize topLeftRadius();
+    WebCore::LengthSize topRightRadius();
+    WebCore::LengthSize bottomRightRadius();
+    WebCore::LengthSize bottomLeftRadius();
+}
+
+[RefCounted, CustomHeader] class WebCore::BasicShape subclasses {
+    WebCore::BasicShapeCircle
+    WebCore::BasicShapeEllipse
+    WebCore::BasicShapePolygon
+    WebCore::BasicShapePath
+    WebCore::BasicShapeInset
+}


### PR DESCRIPTION
#### 119135cc02cd8471687431118bb9a36d6c36e12b
<pre>
Add encoding and decoding support for BasicShape
<a href="https://bugs.webkit.org/show_bug.cgi?id=249226">https://bugs.webkit.org/show_bug.cgi?id=249226</a>

Reviewed by Alex Christensen.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/BasicShapeFunctions.cpp:
(WebCore::valueForCenterCoordinate):
(WebCore::basicShapeRadiusToCSSValue):
(WebCore::convertToCenterCoordinate):
(WebCore::cssValueToBasicShapeRadius):
(WebCore::floatValueForCenterCoordinate):
* Source/WebCore/rendering/style/BasicShapes.cpp:
(WebCore::BasicShapeCenterCoordinate::updateComputedLength):
(WebCore::BasicShapeCircle::create):
(WebCore::BasicShapeCircle::BasicShapeCircle):
(WebCore::BasicShapeCircle::floatValueForRadiusInBox const):
(WebCore::BasicShapeEllipse::create):
(WebCore::BasicShapeEllipse::BasicShapeEllipse):
(WebCore::BasicShapeEllipse::floatValueForRadiusInBox const):
(WebCore::BasicShapeEllipse::blend const):
(WebCore::BasicShapePolygon::create):
(WebCore::BasicShapePolygon::BasicShapePolygon):
(WebCore::BasicShapePath::create):
(WebCore::BasicShapePath::BasicShapePath):
(WebCore::BasicShapeInset::create):
(WebCore::BasicShapeInset::BasicShapeInset):
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/BasicShapes.h:
(WebCore::BasicShapeCenterCoordinate::BasicShapeCenterCoordinate):
(WebCore::BasicShapeCenterCoordinate::blend const):
(WebCore::BasicShapeRadius::BasicShapeRadius):
(WebCore::BasicShapeRadius::canBlend const):
(WebCore::BasicShapeRadius::blend const):
* Source/WebCore/svg/SVGPathByteStream.h:
(WebCore::SVGPathByteStream::SVGPathByteStream):
(WebCore::SVGPathByteStream::data const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/257796@main">https://commits.webkit.org/257796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be9e75726ed7c21a8198f604397bdaf5e89a6123

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/100060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/9227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/33138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/109405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104058 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/10110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/86654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105827 "Failed to checkout and rebase branch from PR 7550") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/10110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/33138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/10110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/33138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/33138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/2975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/86654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/33138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2754 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->