### PR TITLE
[@property] Support list values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
@@ -5,8 +5,8 @@ PASS syntax:'<length>', initialValue:'2px' is valid
 PASS syntax:' <number>', initialValue:'5' is valid
 PASS syntax:'<percentage> ', initialValue:'10%' is valid
 PASS syntax:'<color>+', initialValue:'red' is valid
-FAIL syntax:' <length>+ | <percentage>', initialValue:'2px 8px' is valid The given initial value does not parse for the given syntax.
-FAIL syntax:' <length>+ | <color>#', initialValue:'red, blue' is valid The given initial value does not parse for the given syntax.
+PASS syntax:' <length>+ | <percentage>', initialValue:'2px 8px' is valid
+PASS syntax:' <length>+ | <color>#', initialValue:'red, blue' is valid
 PASS syntax:'<length>|<percentage>|<length-percentage>', initialValue:'2px' is valid
 PASS syntax:'<color> | <image> | <url> | <integer> | <angle>', initialValue:'red' is valid
 PASS syntax:'<time> | <resolution> | <transform-list> | <custom-ident>', initialValue:'red' is valid
@@ -23,14 +23,14 @@ PASS syntax:'<length>', initialValue:' calc(-2px)' is valid
 PASS syntax:'<length>', initialValue:'calc(2px*4 + 10px)' is valid
 PASS syntax:'<length>', initialValue:'7.1e-4cm' is valid
 PASS syntax:'<length>', initialValue:'calc(7in - 12px)' is valid
-FAIL syntax:'<length>+', initialValue:'2px 7px calc(8px)' is valid The given initial value does not parse for the given syntax.
-FAIL syntax:'<length>#', initialValue:'2px, 7px, calc(8px)' is valid The given initial value does not parse for the given syntax.
+PASS syntax:'<length>+', initialValue:'2px 7px calc(8px)' is valid
+PASS syntax:'<length>#', initialValue:'2px, 7px, calc(8px)' is valid
 PASS syntax:'<percentage>', initialValue:'-9.3e3%' is valid
 PASS syntax:'<length-percentage>', initialValue:'-54%' is valid
 PASS syntax:'<length-percentage>', initialValue:'0' is valid
 PASS syntax:'<length-percentage>', initialValue:'calc(-11px + 10.4%)' is valid
 PASS syntax:'<length>', initialValue:'10vmin' is valid
-FAIL syntax:'<percentage> | <length>+', initialValue:'calc(100vh - 10px) 30px' is valid The given initial value does not parse for the given syntax.
+PASS syntax:'<percentage> | <length>+', initialValue:'calc(100vh - 10px) 30px' is valid
 PASS syntax:'<number>', initialValue:'-109' is valid
 PASS syntax:'<number>', initialValue:'2.3e4' is valid
 PASS syntax:'<integer>', initialValue:'-109' is valid
@@ -65,7 +65,7 @@ PASS syntax:'banana', initialValue:'banan\61' is valid
 PASS syntax:'banan\61', initialValue:'banana' is valid
 PASS syntax:'<custom-ident>', initialValue:'banan\61' is valid
 PASS syntax:'big | bigger | BIGGER', initialValue:'bigger' is valid
-FAIL syntax:'foo+|bar', initialValue:'foo foo foo' is valid The given initial value does not parse for the given syntax.
+PASS syntax:'foo+|bar', initialValue:'foo foo foo' is valid
 PASS syntax:'banana	', initialValue:'banana' is valid
 PASS syntax:'
 banana\r
@@ -157,8 +157,8 @@ PASS syntax:'<length>', initialValue:'calc(4px + 3em)' is invalid
 PASS syntax:'<length>', initialValue:'calc(4px + calc(8 * 2em))' is invalid
 PASS syntax:'<length>+', initialValue:'calc(2ex + 16px)' is invalid
 PASS syntax:'<length>+', initialValue:'10px calc(20px + 4rem)' is invalid
-FAIL syntax:'<length>+', initialValue:'' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
-FAIL syntax:'<length>#', initialValue:'' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
+PASS syntax:'<length>+', initialValue:'' is invalid
+PASS syntax:'<length>#', initialValue:'' is invalid
 PASS syntax:'<length>', initialValue:'10px;' is invalid
 PASS syntax:'<length-percentage>', initialValue:'calc(2px + 10% + 7ex)' is invalid
 PASS syntax:'<percentage>', initialValue:'0' is invalid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-expected.txt
@@ -17,16 +17,16 @@ PASS <length> values are computed correctly [10lh]
 PASS <length-percentage> values are computed correctly [17em]
 PASS <length-percentage> values are computed correctly [18%]
 PASS <length-percentage> values are computed correctly [calc(19em - 2%)]
-FAIL <length># values are computed correctly [10px, 3em] assert_equals: expected "10px, 30px" but got "0px"
-FAIL <length># values are computed correctly [4em ,9px] assert_equals: expected "40px, 9px" but got "0px"
+PASS <length># values are computed correctly [10px, 3em]
+PASS <length># values are computed correctly [4em ,9px]
 PASS <length># values are computed correctly [8em]
-FAIL <length-percentage># values are computed correctly [3% , 10vmax  , 22px] assert_equals: expected "3%, 80px, 22px" but got "0px"
-FAIL <length-percentage># values are computed correctly [calc(50% + 1em), 4px] assert_equals: expected "calc(50% + 10px), 4px" but got "0px"
+PASS <length-percentage># values are computed correctly [3% , 10vmax  , 22px]
+PASS <length-percentage># values are computed correctly [calc(50% + 1em), 4px]
 PASS <length-percentage># values are computed correctly [calc(13% + 37px)]
-FAIL <length>+ values are computed correctly [10px 3em] assert_equals: expected "10px 30px" but got "0px"
-FAIL <length>+ values are computed correctly [4em 9px] assert_equals: expected "40px 9px" but got "0px"
-FAIL <length-percentage>+ values are computed correctly [3% 10vmax 22px] assert_equals: expected "3% 80px 22px" but got "0px"
-FAIL <length-percentage>+ values are computed correctly [calc(50% + 1em) 4px] assert_equals: expected "calc(50% + 10px) 4px" but got "0px"
+PASS <length>+ values are computed correctly [10px 3em]
+PASS <length>+ values are computed correctly [4em 9px]
+PASS <length-percentage>+ values are computed correctly [3% 10vmax 22px]
+PASS <length-percentage>+ values are computed correctly [calc(50% + 1em) 4px]
 FAIL <transform-function> values are computed correctly [translateX(2px)] The given initial value does not parse for the given syntax.
 FAIL <transform-function> values are computed correctly [translateX(10em)] The given initial value does not parse for the given syntax.
 FAIL <transform-function> values are computed correctly [translateX(calc(11em + 10%))] The given initial value does not parse for the given syntax.
@@ -36,7 +36,7 @@ PASS <integer> values are computed correctly [calc(15 + 15)]
 PASS <integer> values are computed correctly [calc(2.4)]
 PASS <integer> values are computed correctly [calc(2.6)]
 PASS <integer> values are computed correctly [calc(2.6 + 3.1)]
-FAIL <integer>+ values are computed correctly [15 calc(2.4) calc(2.6)] assert_equals: expected "15 2 3" but got "0"
+PASS <integer>+ values are computed correctly [15 calc(2.4) calc(2.6)]
 PASS <color> values are computed correctly [#ff0000]
 PASS <color> values are computed correctly [#000f00]
 PASS <color> values are computed correctly [#00000a]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-initial-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-initial-expected.txt
@@ -13,7 +13,7 @@ FAIL Initial value for <transform-function> correctly computed [rotate(42deg)] T
 FAIL Initial value for <transform-list> correctly computed [scale(calc(2 + 2))] The given initial value does not parse for the given syntax.
 FAIL Initial value for <transform-list> correctly computed [scale(calc(2 + 1)) translateX(calc(3px + 1px))] The given initial value does not parse for the given syntax.
 PASS Initial value for <url> correctly computed [url(a)]
-FAIL Initial value for <url>+ correctly computed [url(a) url(a)] The given initial value does not parse for the given syntax.
+PASS Initial value for <url>+ correctly computed [url(a) url(a)]
 PASS Initial inherited value can be substituted [purple, color]
 PASS Initial non-inherited value can be substituted [pink, background-color]
 PASS Initial non-inherited value can be substituted [	foo	, --x]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
@@ -17,8 +17,8 @@ FAIL Computed <url> is reified as CSSStyleValue assert_false: expected false got
 FAIL Computed ident is reified as CSSKeywordValue assert_false: expected false got true
 FAIL First computed value correctly reified in space-separated list assert_false: expected false got true
 FAIL First computed value correctly reified in comma-separated list assert_false: expected false got true
-FAIL All computed values correctly reified in space-separated list The given initial value does not parse for the given syntax.
-FAIL All computed values correctly reified in comma-separated list The given initial value does not parse for the given syntax.
+FAIL All computed values correctly reified in space-separated list assert_equals: expected 2 but got 1
+FAIL All computed values correctly reified in comma-separated list assert_equals: expected 2 but got 1
 PASS Specified * is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
 PASS Specified * is reified as CSSUnparsedValue from get/getAll [styleMap]
 PASS Specified foo is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties-expected.txt
@@ -1,11 +1,11 @@
 
 FAIL var() references work with registered properties assert_equals: expected " 20px" but got "20px"
-FAIL References to registered var()-properties work in registered lists assert_equals: expected "1px, 10px, 2px" but got "0px"
-FAIL References to mixed registered and unregistered var()-properties work in registered lists assert_equals: expected "1px, 20px, 10px, 2px" but got "0px"
-FAIL Registered lists may be concatenated assert_equals: expected "1px, 10px, 2px, 1px, 20px, 10px, 2px" but got "0px"
+PASS References to registered var()-properties work in registered lists
+PASS References to mixed registered and unregistered var()-properties work in registered lists
+PASS Registered lists may be concatenated
 PASS Font-relative units are absolutized when substituting
 PASS Calc expressions are resolved when substituting
-FAIL Lists with relative units are absolutized when substituting assert_equals: expected "110px, 120px" but got "0px"
+PASS Lists with relative units are absolutized when substituting
 FAIL Values are absolutized when substituting into properties with universal syntax assert_equals: expected " 100px" but got "100px"
 PASS Valid fallback does not invalidate var()-reference [<length>, 10px]
 PASS Valid fallback does not invalidate var()-reference [<length> | <color>, red]

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -223,12 +223,24 @@ bool CSSValue::traverseSubresources(const Function<bool(const CachedResource&)>&
 
 void CSSValue::collectDirectComputationalDependencies(HashSet<CSSPropertyID>& values) const
 {
+    if (auto* asList = dynamicDowncast<CSSValueList>(*this)) {
+        for (auto& listValue : *asList)
+            listValue->collectDirectComputationalDependencies(values);
+        return;
+    }
+
     if (is<CSSPrimitiveValue>(*this))
         downcast<CSSPrimitiveValue>(*this).collectDirectComputationalDependencies(values);
 }
 
 void CSSValue::collectDirectRootComputationalDependencies(HashSet<CSSPropertyID>& values) const
 {
+    if (auto* asList = dynamicDowncast<CSSValueList>(*this)) {
+        for (auto& listValue : *asList)
+            listValue->collectDirectRootComputationalDependencies(values);
+        return;
+    }
+
     if (is<CSSPrimitiveValue>(*this))
         downcast<CSSPrimitiveValue>(*this).collectDirectRootComputationalDependencies(values);
 }

--- a/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
+++ b/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
@@ -51,7 +51,7 @@ ExceptionOr<void> DOMCSSRegisterCustomProperty::registerProperty(Document& docum
         return Exception { SyntaxError, "Invalid property syntax definition."_s };
 
     RefPtr<CSSCustomPropertyValue> initialValue;
-    if (!descriptor.initialValue.isEmpty()) {
+    if (!descriptor.initialValue.isNull()) {
         CSSTokenizer tokenizer(descriptor.initialValue);
         auto styleResolver = Style::Resolver::create(document);
 
@@ -60,7 +60,7 @@ ExceptionOr<void> DOMCSSRegisterCustomProperty::registerProperty(Document& docum
         auto style = styleResolver->defaultStyleForElement(nullptr);
 
         HashSet<CSSPropertyID> dependencies;
-        CSSPropertyParser::collectParsedCustomPropertyValueDependencies(*syntax, false, dependencies, tokenizer.tokenRange(), strictCSSParserContext());
+        CSSPropertyParser::collectParsedCustomPropertyValueDependencies(*syntax, true /* isInitial */, dependencies, tokenizer.tokenRange(), strictCSSParserContext());
 
         if (!dependencies.isEmpty())
             return Exception { SyntaxError, "The given initial value must be computationally independent."_s };
@@ -74,12 +74,6 @@ ExceptionOr<void> DOMCSSRegisterCustomProperty::registerProperty(Document& docum
 
         if (!initialValue || !initialValue->isResolved())
             return Exception { SyntaxError, "The given initial value does not parse for the given syntax."_s };
-
-        initialValue->collectDirectComputationalDependencies(dependencies);
-        initialValue->collectDirectRootComputationalDependencies(dependencies);
-
-        if (!dependencies.isEmpty())
-            return Exception { SyntaxError, "The given initial value must be computationally independent."_s };
     }
 
     CSSRegisteredCustomProperty property { AtomString { descriptor.name }, *syntax, descriptor.inherits, WTFMove(initialValue) };

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -67,7 +67,7 @@ private:
     std::pair<RefPtr<CSSValue>, CSSPropertySyntax::Type> consumeCustomPropertyValueWithSyntax(const CSSPropertySyntax&);
     bool canParseTypedCustomPropertyValue(const CSSPropertySyntax&);
     RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const CSSPropertySyntax&, Style::BuilderState&);
-    void collectParsedCustomPropertyValueDependencies(const CSSPropertySyntax&, bool isRoot, HashSet<CSSPropertyID>& dependencies);
+    void collectParsedCustomPropertyValueDependencies(const CSSPropertySyntax&, bool isInitial, HashSet<CSSPropertyID>& dependencies);
 
     bool inQuirksMode() const { return m_context.mode == HTMLQuirksMode; }
 


### PR DESCRIPTION
#### f266283a31249f27645c470313b8ee346c4f0daa
<pre>
[@property] Support list values
<a href="https://bugs.webkit.org/show_bug.cgi?id=249216">https://bugs.webkit.org/show_bug.cgi?id=249216</a>
&lt;rdar://problem/103300866&gt;

Reviewed by Chris Dumez.

Consume values with &lt;type&gt;+ and &lt;type&gt;# syntax definitions.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-initial-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties-expected.txt:
* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::equals const):
(WebCore::CSSCustomPropertyValue::customCSSText const):
* Source/WebCore/css/CSSCustomPropertyValue.h:

Add list value support.
Handle ident values with SyntaxValue too.
Use URL type for URLs.

* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::collectDirectComputationalDependencies const):
(WebCore::CSSValue::collectDirectRootComputationalDependencies const):

Collect from lists too.

* Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp:
(WebCore::DOMCSSRegisterCustomProperty::registerProperty):

Test for null initial value string instead of empty (empty string needs to be considered as an initial value).
Remove unnecessary collectDirect*ComputationalDependencies calls.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeCustomPropertyValueWithSyntax):

Consume lists.

(WebCore::CSSPropertyParser::collectParsedCustomPropertyValueDependencies):
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue):

Resolve syntax values in lists.

Canonical link: <a href="https://commits.webkit.org/257844@main">https://commits.webkit.org/257844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c938f30b8f35c9c678f0917cca765ae4f505368

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109519 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169752 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10257 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107408 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105961 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91032 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34444 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3118 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23943 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3096 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9224 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43431 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5383 "'git push ...'") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4928 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->