### PR TITLE
[WebGPU] Implement multisampling support

### DIFF
--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -205,13 +205,6 @@ bool Device::validateRenderPipeline(const WGPURenderPipelineDescriptor& descript
             return false;
     }
 
-    // Does not support multisampling
-    if (descriptor.multisample.count > 1)
-        return false;
-
-    if (descriptor.multisample.alphaToCoverageEnabled)
-        return false;
-
     return true;
 }
 
@@ -311,6 +304,9 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
         // FIXME: set stencil state
         mtlDepthStencilState = [m_device newDepthStencilStateWithDescriptor:depthStencilState];
     }
+
+    mtlRenderPipelineDescriptor.rasterSampleCount = descriptor.multisample.count ?: 1;
+    mtlRenderPipelineDescriptor.alphaToCoverageEnabled = descriptor.multisample.alphaToCoverageEnabled;
 
     if (descriptor.primitive.nextInChain)
         return RenderPipeline::createInvalid(*this);

--- a/Websites/webkit.org/demos/webgpu/hello-triangle-msaa.html
+++ b/Websites/webkit.org/demos/webgpu/hello-triangle-msaa.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=600">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+<title>WebGPU Hello Triangle</title>
+<link rel="stylesheet" href="css/style.css">
+<style>
+body {
+    font-family: system-ui;
+    color: #f7f7ff;
+    background-color: rgb(38, 38, 127);
+    text-align: center;
+}
+canvas {
+    margin: 0 auto;
+}
+</style>
+</head>
+<body>
+<div id="contents">
+    <h1>Simple Triangle (MSAA)</h1>
+    <canvas></canvas>
+</div>
+<div id="error">
+    <h2>WebGPU not available</h2>
+    <p>
+        Make sure you are on a system with WebGPU enabled. In
+        Safari, first make sure the Developer Menu is visible (Preferences >
+        Advanced), then Develop > Experimental Features > WebGPU.
+    </p>
+    <p>
+        In addition, you must be using Safari Technology Preview 92 or above.
+        You can get the latest STP <a href="https://developer.apple.com/safari/download/">here</a>.
+    </p>
+</div>
+<script src="scripts/hello-triangle-msaa.js"></script>
+</body>
+</html>

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-triangle-msaa.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-triangle-msaa.js
@@ -1,0 +1,137 @@
+async function helloTriangle() {
+    if (!navigator.gpu || GPUBufferUsage.COPY_SRC === undefined) {
+        document.body.className = 'error';
+        return;
+    }
+
+    const canvas = document.querySelector("canvas");
+    canvas.width = 600;
+    canvas.height = 600;
+
+    const adapter = await navigator.gpu.requestAdapter();
+    const device = await adapter.requestDevice();
+    
+    const msaaRenderTarget = device.createTexture({
+        size: [ canvas.width, canvas.height ],
+        sampleCount: 4,
+        format: 'bgra8unorm',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    /*** Vertex Buffer Setup ***/
+    
+    /* Vertex Data */
+    const vertexStride = 8 * 4;
+    const vertexDataSize = vertexStride * 3;
+    
+    /* GPUBufferDescriptor */
+    const vertexDataBufferDescriptor = {
+        size: vertexDataSize,
+        usage: GPUBufferUsage.VERTEX
+    };
+
+    /* GPUBuffer */
+    const vertexBuffer = device.createBuffer(vertexDataBufferDescriptor);
+    
+    /*** Shader Setup ***/
+    const mtlSource = `
+                #include <metal_stdlib>
+                using namespace metal;
+                struct Vertex {
+                   float4 position [[position]];
+                   float4 color;
+                };
+
+                vertex Vertex vsmain(unsigned VertexIndex [[vertex_id]])
+                {
+                   float2 pos[3] = {
+                       float2( 0.0,  1.0),
+                       float2(-1.0, -1.0),
+                       float2( 1.0, -1.0),
+                   };
+
+                   Vertex vout;
+                   vout.position = float4(pos[VertexIndex], 0.0, 1.0);
+                   vout.color = float4(pos[VertexIndex] + float2(0.5, 0.5), 0.0, 1.0);
+                   return vout;
+                }
+
+                fragment float4 fsmain(Vertex in [[stage_in]])
+                {
+                    return in.color;
+                }
+    `;
+
+    const shaderModule = device.createShaderModule({ code: mtlSource, isWHLSL: false, hints: [ {layout: "auto" }, ] });
+    
+    /* GPUPipelineStageDescriptors */
+    const vertexStageDescriptor = { module: shaderModule, entryPoint: "vsmain" };
+
+    const fragmentStageDescriptor = { module: shaderModule, entryPoint: "fsmain", targets: [ {format: "bgra8unorm" }, ],  };
+
+    /* GPURenderPipelineDescriptor */
+
+    const renderPipelineDescriptor = {
+        layout: "auto",
+        vertex: vertexStageDescriptor,
+        fragment: fragmentStageDescriptor,
+        primitive: { topology: "triangle-list" },
+        multisample: { count: 4 }
+    };
+    /* GPURenderPipeline */
+    const renderPipeline = device.createRenderPipeline(renderPipelineDescriptor);
+    
+    /*** Swap Chain Setup ***/
+    
+    const gpuContext = canvas.getContext("webgpu");
+    
+    /* GPUCanvasConfiguration */
+    const canvasConfiguration = { device: device, format: "bgra8unorm" };
+    gpuContext.configure(canvasConfiguration);
+    /* GPUTexture */
+    const currentTexture = gpuContext.getCurrentTexture();
+    
+    /*** Render Pass Setup ***/
+    
+    /* Acquire Texture To Render To */
+    
+    /* GPUTextureView */
+    const renderAttachment = currentTexture.createView();
+    
+    /* GPUColor */
+    const darkBlue = { r: 0.15, g: 0.15, b: 0.5, a: 1 };
+    
+    /* GPURenderPassColorAttachment */
+    const colorAttachmentDescriptor = {
+        view: msaaRenderTarget.createView(),
+        resolveTarget: renderAttachment,
+        loadOp: "clear",
+        storeOp: "store",
+        clearColor: darkBlue
+    };
+    
+    /* GPURenderPassDescriptor */
+    const renderPassDescriptor = { colorAttachments: [colorAttachmentDescriptor] };
+    
+    /*** Rendering ***/
+    
+    /* GPUCommandEncoder */
+    const commandEncoder = device.createCommandEncoder();
+    /* GPURenderPassEncoder */
+    const renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+    
+    renderPassEncoder.setPipeline(renderPipeline);
+    const vertexBufferSlot = 0;
+    renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
+    renderPassEncoder.draw(3, 1, 0, 0); // 3 vertices, 1 instance, 0th vertex, 0th instance.
+    renderPassEncoder.end();
+    
+    /* GPUComamndBuffer */
+    const commandBuffer = commandEncoder.finish();
+    
+    /* GPUQueue */
+    const queue = device.queue;
+    queue.submit([commandBuffer]);
+}
+
+window.addEventListener("DOMContentLoaded", helloTriangle);


### PR DESCRIPTION
#### aa48f5eefbcbb29cf34aad072e42a6a030093d6f
<pre>
[WebGPU] Implement multisampling support
<a href="https://bugs.webkit.org/show_bug.cgi?id=249203">https://bugs.webkit.org/show_bug.cgi?id=249203</a>
&lt;radar://54533542&gt;

Reviewed by Dean Jackson.

Implement MSAA and add a test, including alphaToCoverage support,
but I didn&apos;t implement sampleMask yet because it is poorly defined
in the WebGPU specification.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::validateRenderPassDescriptor const):
(WebGPU::CommandEncoder::beginRenderPass):
Use MTLStoreActionStoreAndMultisampleResolve so we don&apos;t need a seperate
command encoder and resolve pass.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::validateRenderPipeline):
(WebGPU::Device::createRenderPipeline):
Configure the pipeline state.

* Websites/webkit.org/demos/webgpu/hello-triangle-msaa.html: Added.
* Websites/webkit.org/demos/webgpu/scripts/hello-triangle-msaa.js: Added.
(async helloTriangle):
Add demo / test.

Canonical link: <a href="https://commits.webkit.org/257834@main">https://commits.webkit.org/257834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5ada1b1c21dfc8b46e00ec8e992cb5232b4bd85

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109482 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10201 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92579 "Updated gtk dependencies (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107372 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105918 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90992 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/92579 "Updated gtk dependencies (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22387 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/92579 "Updated gtk dependencies (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3083 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23902 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3057 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9187 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43388 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5380 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4893 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->