### PR TITLE
Add encoding and decoding support for PathOperation

### DIFF
--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -39,12 +39,24 @@ Ref<ReferencePathOperation> ReferencePathOperation::create(const String& url, co
     return adoptRef(*new ReferencePathOperation(url, fragment, element));
 }
 
+Ref<ReferencePathOperation> ReferencePathOperation::create(std::optional<Path>&& path)
+{
+    return adoptRef(*new ReferencePathOperation(WTFMove(path)));
+}
 
 ReferencePathOperation::ReferencePathOperation(const String& url, const AtomString& fragment, const RefPtr<SVGElement> element)
     : PathOperation(Reference)
     , m_url(url)
     , m_fragment(fragment)
     , m_element(element)
+{
+    if (is<SVGPathElement>(m_element) || is<SVGGeometryElement>(m_element))
+        m_path = pathFromGraphicsElement(m_element.get());
+}
+
+ReferencePathOperation::ReferencePathOperation(std::optional<Path>&& path)
+    : PathOperation(Reference)
+    , m_path(WTFMove(path))
 {
 }
 
@@ -53,11 +65,9 @@ const SVGElement* ReferencePathOperation::element() const
     return m_element.get();
 }
 
-const std::optional<Path> ReferencePathOperation::getPath(const FloatRect&, FloatPoint, OffsetRotation) const
+Ref<RayPathOperation> RayPathOperation::create(float angle, Size size, bool isContaining, FloatRect&& containingBlockBoundingRect, FloatPoint&& position)
 {
-    if (!is<SVGPathElement>(m_element.get()) && !is<SVGGeometryElement>(m_element.get()))
-        return std::nullopt;
-    return pathFromGraphicsElement(m_element.get());
+    return adoptRef(*new RayPathOperation(angle, size, isContaining, WTFMove(containingBlockBoundingRect), WTFMove(position)));
 }
 
 double RayPathOperation::lengthForPath() const

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2025,3 +2025,53 @@ header: <WebCore/BasicShapes.h>
     WebCore::BasicShapePath
     WebCore::BasicShapeInset
 }
+
+header: <WebCore/RenderStyleConstants.h>
+[CustomHeader] enum class WebCore::CSSBoxType : uint8_t {
+    BoxMissing,
+    MarginBox,
+    BorderBox,
+    PaddingBox,
+    ContentBox,
+    FillBox,
+    StrokeBox,
+    ViewBox
+};
+
+header: <WebCore/PathOperation.h>
+[Return=Ref, CustomHeader] class WebCore::ReferencePathOperation {
+    std::optional<WebCore::Path> path();
+}
+
+[Return=Ref, CustomHeader] class WebCore::ShapePathOperation {
+    Ref<WebCore::BasicShape> shape();
+    WebCore::CSSBoxType referenceBox();
+}
+
+[Return=Ref, CustomHeader] class WebCore::BoxPathOperation {
+    WebCore::Path path();
+    WebCore::CSSBoxType referenceBox();
+}
+
+[Nested, CustomHeader] enum class WebCore::RayPathOperation::Size : uint8_t {
+    ClosestSide,
+    ClosestCorner,
+    FarthestSide,
+    FarthestCorner,
+    Sides
+};
+
+[Return=Ref, CustomHeader] class WebCore::RayPathOperation {
+    float angle();
+    WebCore::RayPathOperation::Size size();
+    bool isContaining();
+    WebCore::FloatRect containingBlockBoundingRect();
+    WebCore::FloatPoint position();
+}
+
+[RefCounted] class WebCore::PathOperation subclasses {
+    WebCore::ReferencePathOperation,
+    WebCore::ShapePathOperation,
+    WebCore::BoxPathOperation,
+    WebCore::RayPathOperation
+}


### PR DESCRIPTION
#### fd75c72c681f7918ffcd26ecdb52f6a72d8ed423
<pre>
Add encoding and decoding support for PathOperation
<a href="https://bugs.webkit.org/show_bug.cgi?id=249234">https://bugs.webkit.org/show_bug.cgi?id=249234</a>

Reviewed by Alex Christensen.

Straightforward encoding work except for ReferencePathOperation where we resolve the Path
and store it.

* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::ReferencePathOperation::create):
(WebCore::ReferencePathOperation::ReferencePathOperation):
(WebCore::ReferencePathOperation::path const):
(WebCore::RayPathOperation::create):
(WebCore::ReferencePathOperation::getPath const): Deleted.
* Source/WebCore/rendering/PathOperation.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/257832@main">https://commits.webkit.org/257832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1939b666a970d1b0a6ab7791e350d92980933505

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109434 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169668 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86762 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92531 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107324 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7666 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34377 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22349 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3039 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23864 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3004 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9136 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43345 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4850 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2768 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->