### PR TITLE
[ews] Improve logging in case of an exception in ews django app

### DIFF
--- a/Tools/CISupport/ews-app/ews/fetcher.py
+++ b/Tools/CISupport/ews-app/ews/fetcher.py
@@ -25,6 +25,7 @@ import logging
 import pytz
 import threading
 import time
+import traceback
 
 from ews.common.bugzilla import Bugzilla
 from ews.common.buildbot import Buildbot
@@ -50,7 +51,7 @@ class FetchLoop():
                 BugzillaPatchFetcher().fetch()
                 BugzillaPatchFetcher().fetch_commit_queue_patches()
             except Exception as e:
-                _log.error('Exception in BugzillaPatchFetcher: {}'.format(e))
+                _log.error('Exception in BugzillaPatchFetcher: {}\n{}'.format(e, traceback.format_exc()))
             time.sleep(self.interval)
 
 


### PR DESCRIPTION
#### 735a7dc89754b8f1599899991ab34232269c9b7a
<pre>
[ews] Improve logging in case of an exception in ews django app
<a href="https://bugs.webkit.org/show_bug.cgi?id=249237">https://bugs.webkit.org/show_bug.cgi?id=249237</a>
rdar://103308150

Reviewed by Jonathan Bedard.

* Tools/CISupport/ews-app/ews/fetcher.py:
(FetchLoop.run):

Canonical link: <a href="https://commits.webkit.org/257805@main">https://commits.webkit.org/257805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc9377061825c2f22dcd9bfa16f41ba65abeb303

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100074 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/9240 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/33150 "The change is no longer eligible for processing.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/109417 "The change is no longer eligible for processing.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/104071 "The change is no longer eligible for processing.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10124 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/86745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92515 "The change is no longer eligible for processing.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105842 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/33150 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92515 "The change is no longer eligible for processing.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/33150 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92515 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/33150 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/2987 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/86745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9119 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/33150 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2757 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->