### PR TITLE
WheelEventTestMonitor needs to work with UI-side scrolling

### DIFF
--- a/Source/WebCore/page/WheelEventTestMonitor.cpp
+++ b/Source/WebCore/page/WheelEventTestMonitor.cpp
@@ -116,6 +116,8 @@ void WheelEventTestMonitor::receivedWheelEventWithPhases(PlatformWheelEventPhase
 #if ENABLE(KINETIC_SCROLLING)
     Locker locker { m_lock };
 
+    LOG_WITH_STREAM(WheelEventTestMonitor, stream << "      (=) WheelEventTestMonitor::receivedWheelEventWithPhases: phase=" << phase << " momentumPhase=" << momentumPhase);
+
     if (phase == PlatformWheelEventPhase::Ended || phase == PlatformWheelEventPhase::Cancelled)
         m_receivedWheelEndOrCancel = true;
 

--- a/Source/WebCore/page/WheelEventTestMonitor.h
+++ b/Source/WebCore/page/WheelEventTestMonitor.h
@@ -113,7 +113,26 @@ private:
     WheelEventTestMonitor::DeferReason m_reason;
 };
 
-WTF::TextStream& operator<<(WTF::TextStream&, WheelEventTestMonitor::DeferReason);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, WheelEventTestMonitor::DeferReason);
 WTF::TextStream& operator<<(WTF::TextStream&, const WheelEventTestMonitor::ScrollableAreaReasonMap&);
 
 } // namespace WebCore
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::WheelEventTestMonitor::DeferReason> {
+    using values = EnumValues<
+        WebCore::WheelEventTestMonitor::DeferReason,
+        WebCore::WheelEventTestMonitor::DeferReason::HandlingWheelEvent,
+        WebCore::WheelEventTestMonitor::DeferReason::HandlingWheelEventOnMainThread,
+        WebCore::WheelEventTestMonitor::DeferReason::PostMainThreadWheelEventHandling,
+        WebCore::WheelEventTestMonitor::DeferReason::RubberbandInProgress,
+        WebCore::WheelEventTestMonitor::DeferReason::ScrollSnapInProgress,
+        WebCore::WheelEventTestMonitor::DeferReason::ScrollAnimationInProgress,
+        WebCore::WheelEventTestMonitor::DeferReason::ScrollingThreadSyncNeeded,
+        WebCore::WheelEventTestMonitor::DeferReason::ContentScrollInProgress,
+        WebCore::WheelEventTestMonitor::DeferReason::RequestedScrollPosition
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -172,7 +172,7 @@ public:
 
     ScrollingTreeFrameScrollingNode* rootNode() const { return m_rootNode.get(); }
     std::optional<ScrollingNodeID> latchedNodeID() const;
-    void clearLatchedNode();
+    WEBCORE_EXPORT void clearLatchedNode();
 
     bool hasFixedOrSticky() const { return !!m_fixedOrStickyNodeCount; }
     void fixedOrStickyNodeAdded() { ++m_fixedOrStickyNodeCount; }

--- a/Source/WebCore/platform/PlatformWheelEvent.h
+++ b/Source/WebCore/platform/PlatformWheelEvent.h
@@ -67,7 +67,7 @@ enum class PlatformWheelEventPhase : uint8_t {
 #endif
 };
 
-WTF::TextStream& operator<<(WTF::TextStream&, PlatformWheelEventPhase);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, PlatformWheelEventPhase);
 
 
 #if PLATFORM(WIN)
@@ -285,3 +285,23 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, EventHandling);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, WheelScrollGestureState);
 
 } // namespace WebCore
+
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::PlatformWheelEventPhase> {
+    using values = EnumValues<
+        WebCore::PlatformWheelEventPhase
+        , WebCore::PlatformWheelEventPhase::None
+#if ENABLE(KINETIC_SCROLLING)
+        , WebCore::PlatformWheelEventPhase::Began
+        , WebCore::PlatformWheelEventPhase::Stationary
+        , WebCore::PlatformWheelEventPhase::Changed
+        , WebCore::PlatformWheelEventPhase::Ended
+        , WebCore::PlatformWheelEventPhase::Cancelled
+        , WebCore::PlatformWheelEventPhase::MayBegin
+#endif
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -722,6 +722,7 @@ def headers_for_type(type):
         'WebCore::PasteboardWebContent': ['<WebCore/Pasteboard.h>'],
         'WebCore::PixelFormat': ['<WebCore/ImageBufferBackend.h>'],
         'WebCore::PlatformTextTrackData': ['<WebCore/PlatformTextTrack.h>'],
+        'WebCore::PlatformWheelEventPhase': ['<WebCore/PlatformWheelEvent.h>'],
         'WebCore::PlaybackSessionModel::PlaybackState': ['<WebCore/PlaybackSessionModel.h>'],
         'WebCore::PluginInfo': ['<WebCore/PluginData.h>'],
         'WebCore::PluginLoadClientPolicy': ['<WebCore/PluginData.h>'],

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -91,7 +91,7 @@ struct WKAppPrivacyReportTestingData {
 - (void)_setThrottleStateForTesting:(int)type;
 
 - (void)_doAfterProcessingAllPendingMouseEvents:(dispatch_block_t)action;
-- (void)_startMonitoringWheelEvents;
+- (void)_startMonitoringWheelEventsResettingLatching:(BOOL)resetLatching;
 
 + (void)_setApplicationBundleIdentifier:(NSString *)bundleIdentifier;
 + (void)_clearApplicationBundleIdentifierTestingOverride;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -293,9 +293,9 @@
     });
 }
 
-- (void)_startMonitoringWheelEvents
+- (void)_startMonitoringWheelEventsResettingLatching:(BOOL)resetLatching
 {
-    _page->startMonitoringWheelEventsForTesting();
+    _page->startMonitoringWheelEventsForTesting(resetLatching);
 }
 
 + (void)_setApplicationBundleIdentifier:(NSString *)bundleIdentifier

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -286,9 +286,26 @@ void RemoteScrollingCoordinatorProxy::reportSynchronousScrollingReasonsChanged(M
     m_webPageProxy.logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::SwitchedScrollingMode), timestamp, reasons.toRaw());
 }
 
-void RemoteScrollingCoordinatorProxy::startMonitoringWheelEventsForTesting()
+void RemoteScrollingCoordinatorProxy::startMonitoringWheelEventsForTesting(bool resetLatching)
 {
     m_scrollingTree->setIsMonitoringWheelEvents(true);
+    if (resetLatching)
+        scrollingTree()->clearLatchedNode();
+}
+
+void RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase)
+{
+    m_webPageProxy.send(Messages::RemoteScrollingCoordinator::ReceivedWheelEventWithPhases(phase, momentumPhase));
+}
+
+void RemoteScrollingCoordinatorProxy::deferWheelEventTestCompletionForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
+{
+    m_webPageProxy.send(Messages::RemoteScrollingCoordinator::StartDeferringScrollingTestCompletionForNode(nodeID, reason));
+}
+
+void RemoteScrollingCoordinatorProxy::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
+{
+    m_webPageProxy.send(Messages::RemoteScrollingCoordinator::StopDeferringScrollingTestCompletionForNode(nodeID, reason));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -125,7 +125,11 @@ public:
     void reportExposedUnfilledArea(MonotonicTime, unsigned unfilledArea);
     void reportSynchronousScrollingReasonsChanged(MonotonicTime, OptionSet<WebCore::SynchronousScrollingReason>);
 
-    void startMonitoringWheelEventsForTesting();
+    void startMonitoringWheelEventsForTesting(bool resetLatching);
+
+    void receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase);
+    void deferWheelEventTestCompletionForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
+    void removeWheelEventTestCompletionDeferralForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
 
 protected:
     RemoteScrollingTree* scrollingTree() const { return m_scrollingTree.get(); }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -110,6 +110,21 @@ void RemoteScrollingTree::reportSynchronousScrollingReasonsChanged(MonotonicTime
     m_scrollingCoordinatorProxy.reportSynchronousScrollingReasonsChanged(timestamp, reasons);
 }
 
+void RemoteScrollingTree::receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase)
+{
+    m_scrollingCoordinatorProxy.receivedWheelEventWithPhases(phase, momentumPhase);
+}
+
+void RemoteScrollingTree::deferWheelEventTestCompletionForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
+{
+    m_scrollingCoordinatorProxy.deferWheelEventTestCompletionForReason(nodeID, reason);
+}
+
+void RemoteScrollingTree::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
+{
+    m_scrollingCoordinatorProxy.removeWheelEventTestCompletionDeferralForReason(nodeID, reason);
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -30,6 +30,7 @@
 #include "RemoteScrollingCoordinator.h"
 #include <WebCore/ScrollingConstraints.h>
 #include <WebCore/ScrollingTree.h>
+#include <WebCore/WheelEventTestMonitor.h>
 
 namespace WebCore {
 class PlatformMouseEvent;
@@ -64,6 +65,10 @@ protected:
     explicit RemoteScrollingTree(RemoteScrollingCoordinatorProxy&);
 
     Ref<WebCore::ScrollingTreeNode> createScrollingTreeNode(WebCore::ScrollingNodeType, WebCore::ScrollingNodeID) override;
+
+    void receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase) override;
+    void deferWheelEventTestCompletionForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason) override;
+    void removeWheelEventTestCompletionDeferralForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason) override;
 
     RemoteScrollingCoordinatorProxy& m_scrollingCoordinatorProxy;
 };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3072,11 +3072,11 @@ void WebPageProxy::handleWheelEvent(const NativeWebWheelEvent& event)
     }
 }
 
-void WebPageProxy::startMonitoringWheelEventsForTesting()
+void WebPageProxy::startMonitoringWheelEventsForTesting(bool resetLatching)
 {
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(COCOA)
     if (m_scrollingCoordinatorProxy)
-        m_scrollingCoordinatorProxy->startMonitoringWheelEventsForTesting();
+        m_scrollingCoordinatorProxy->startMonitoringWheelEventsForTesting(resetLatching);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1055,7 +1055,7 @@ public:
 
     bool isProcessingWheelEvents() const;
     void handleWheelEvent(const NativeWebWheelEvent&);
-    void startMonitoringWheelEventsForTesting();
+    void startMonitoringWheelEventsForTesting(bool resetLatching);
 
     bool isProcessingKeyboardEvents() const;
     bool handleKeyboardEvent(const NativeWebKeyboardEvent&);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -82,6 +82,10 @@ private:
     void animatedScrollDidEndForNode(WebCore::ScrollingNodeID);
     void currentSnapPointIndicesChangedForNode(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
 
+    void receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase);
+    void startDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
+    void stopDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
+
     WebPage* m_webPage;
 
     HashSet<WebCore::ScrollingNodeID> m_nodesWithActiveRubberBanding;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
@@ -27,6 +27,10 @@ messages -> RemoteScrollingCoordinator {
     AnimatedScrollDidEndForNode(uint64_t nodeID);
     CurrentSnapPointIndicesChangedForNode(uint64_t nodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
     ScrollingStateInUIProcessChanged(WebKit::RemoteScrollingUIState uiState);
+
+    ReceivedWheelEventWithPhases(enum:uint8_t WebCore::PlatformWheelEventPhase phase, enum:uint8_t WebCore::PlatformWheelEventPhase momentumPhase);
+    StartDeferringScrollingTestCompletionForNode(uint64_t nodeID, WebCore::WheelEventTestMonitor::DeferReason reason);
+    StopDeferringScrollingTestCompletionForNode(uint64_t nodeID, WebCore::WheelEventTestMonitor::DeferReason reason);
 }
 
 #endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -40,11 +40,12 @@
 #import <WebCore/Frame.h>
 #import <WebCore/FrameView.h>
 #import <WebCore/GraphicsLayer.h>
+#import <WebCore/Page.h>
 #import <WebCore/RenderLayerCompositor.h>
 #import <WebCore/RenderView.h>
 #import <WebCore/ScrollingTreeFixedNodeCocoa.h>
 #import <WebCore/ScrollingTreeStickyNodeCocoa.h>
-
+#import <WebCore/WheelEventTestMonitor.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -144,6 +145,24 @@ void RemoteScrollingCoordinator::addNodeWithActiveRubberBanding(ScrollingNodeID 
 void RemoteScrollingCoordinator::removeNodeWithActiveRubberBanding(ScrollingNodeID nodeID)
 {
     m_nodesWithActiveRubberBanding.remove(nodeID);
+}
+
+void RemoteScrollingCoordinator::receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase)
+{
+    if (auto monitor = m_page->wheelEventTestMonitor())
+        monitor->receivedWheelEventWithPhases(phase, momentumPhase);
+}
+
+void RemoteScrollingCoordinator::startDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID nodeID, WebCore::WheelEventTestMonitor::DeferReason reason)
+{
+    if (auto monitor = m_page->wheelEventTestMonitor())
+        monitor->deferForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
+}
+
+void RemoteScrollingCoordinator::stopDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID nodeID, WebCore::WheelEventTestMonitor::DeferReason reason)
+{
+    if (auto monitor = m_page->wheelEventTestMonitor())
+        monitor->removeDeferralForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
 }
 
 } // namespace WebKit

--- a/Tools/WebKitTestRunner/EventSenderProxy.h
+++ b/Tools/WebKitTestRunner/EventSenderProxy.h
@@ -68,7 +68,7 @@ public:
     void setWheelHasPreciseDeltas(bool);
 #endif
     void continuousMouseScrollBy(int x, int y, bool paged);
-    void monitorWheelEvents();
+    void monitorWheelEvents(bool resetLatching);
 
 #if PLATFORM(MAC)
     enum class WheelEventPhase : uint8_t {

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
@@ -513,12 +513,14 @@ void EventSendingController::monitorWheelEvents(MonitorWheelEventsOptions* optio
 {
     auto page = InjectedBundle::singleton().page()->page();
     
+    bool resetLatching = options ? options->resetLatching : true;
     m_sentWheelPhaseEndOrCancel = false;
     m_sentWheelMomentumPhaseEnd = false;
-    WKBundlePageStartMonitoringScrollOperations(page, options ? options->resetLatching : true);
+    WKBundlePageStartMonitoringScrollOperations(page, resetLatching);
 
     auto body = adoptWK(WKMutableDictionaryCreate());
     setValue(body, "SubMessage", "MonitorWheelEvents");
+    setValue(body, "ResetLatching", resetLatching);
     postPageMessage("EventSender", body);
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm
@@ -99,7 +99,7 @@ void EventSenderProxy::continuousMouseScrollBy(int x, int y, bool paged)
 {
 }
 
-void EventSenderProxy::monitorWheelEvents()
+void EventSenderProxy::monitorWheelEvents(bool)
 {
 }
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1862,7 +1862,8 @@ void TestController::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         }
 
         if (WKStringIsEqualToUTF8CString(subMessageName, "MonitorWheelEvents")) {
-            m_eventSenderProxy->monitorWheelEvents();
+            bool resetLatching = booleanValue(dictionary, "ResetLatching");
+            m_eventSenderProxy->monitorWheelEvents(resetLatching);
             return;
         }
 

--- a/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
@@ -312,7 +312,7 @@ void EventSenderProxy::continuousMouseScrollBy(int horizontal, int vertical, boo
         horizontal / pixelsPerScrollTick, vertical / pixelsPerScrollTick, m_position.x, m_position.y, WheelEventPhase::NoPhase, WheelEventPhase::NoPhase, m_hasPreciseDeltas);
 }
 
-void EventSenderProxy::monitorWheelEvents()
+void EventSenderProxy::monitorWheelEvents(bool)
 {
 }
 

--- a/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
@@ -194,7 +194,7 @@ void EventSenderProxy::continuousMouseScrollBy(int, int, bool)
 {
 }
 
-void EventSenderProxy::monitorWheelEvents()
+void EventSenderProxy::monitorWheelEvents(bool)
 {
 }
 

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -824,9 +824,9 @@ void EventSenderProxy::sendWheelEvent(EventTimestamp timestamp, double windowX, 
     }
 }
 
-void EventSenderProxy::monitorWheelEvents()
+void EventSenderProxy::monitorWheelEvents(bool resetLatching)
 {
-    [m_testController->mainWebView()->platformView() _startMonitoringWheelEvents];
+    [m_testController->mainWebView()->platformView() _startMonitoringWheelEventsResettingLatching:resetLatching];
 }
 
 #if ENABLE(MAC_GESTURE_EVENTS)

--- a/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
+++ b/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
@@ -149,7 +149,7 @@ void EventSenderProxy::continuousMouseScrollBy(int, int, bool)
 {
 }
 
-void EventSenderProxy::monitorWheelEvents()
+void EventSenderProxy::monitorWheelEvents(bool)
 {
 }
 


### PR DESCRIPTION
#### 27c4b75ef25c1f274959eabd6946b625721abac9
<pre>
WheelEventTestMonitor needs to work with UI-side scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=249202">https://bugs.webkit.org/show_bug.cgi?id=249202</a>
&lt;rdar://problem/103283228&gt;

Reviewed by NOBODY (OOPS!).

Send WheelEventTestMonitor defer/stopDeferring messages from the UI process to the
WheelEventTestMonitor in the web process, allowing more wheel event layout tests to work with
UI-side compositing. These messages go from the RemoteScrollingTree to
RemoteScrollingCoordinatorProxy, via IPC to RemoteScrollingCoordinator which gets the
WheelEventTestMonitor from Page.

In 258002@main I hooked up startMonitoringWheelEventsForTesting() for UI-side compositing, but we
also need to pass along the &quot;reset latching&quot; bit, so do that.

* Source/WebCore/page/WheelEventTestMonitor.cpp:
(WebCore::WheelEventTestMonitor::receivedWheelEventWithPhases):
* Source/WebCore/page/WheelEventTestMonitor.h:
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/platform/PlatformWheelEvent.h:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _startMonitoringWheelEventsResettingLatching:]):
(-[WKWebView _startMonitoringWheelEvents]): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::startMonitoringWheelEventsForTesting):
(WebKit::RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases):
(WebKit::RemoteScrollingCoordinatorProxy::deferWheelEventTestCompletionForReason):
(WebKit::RemoteScrollingCoordinatorProxy::removeWheelEventTestCompletionDeferralForReason):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::receivedWheelEventWithPhases):
(WebKit::RemoteScrollingTree::deferWheelEventTestCompletionForReason):
(WebKit::RemoteScrollingTree::removeWheelEventTestCompletionDeferralForReason):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::startMonitoringWheelEventsForTesting):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::receivedWheelEventWithPhases):
(WebKit::RemoteScrollingCoordinator::startDeferringScrollingTestCompletionForNode):
(WebKit::RemoteScrollingCoordinator::stopDeferringScrollingTestCompletionForNode):
* Tools/WebKitTestRunner/EventSenderProxy.h:
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp:
(WTR::EventSendingController::monitorWheelEvents):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveMessageFromInjectedBundle):
* Tools/WebKitTestRunner/mac/EventSenderProxy.mm:
(WTR::EventSenderProxy::monitorWheelEvents):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27c4b75ef25c1f274959eabd6946b625721abac9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100788 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110086 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170361 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/688 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93190 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107933 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34824 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/104310 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90122 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77798 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3625 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24383 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/663 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43882 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5426 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->