### PR TITLE
v2: "make analyze" should run clang static analyzer in deep mode

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -160,7 +160,7 @@ testing t: force
 
 analyze:
 	@$(call set_webkit_configuration,--debug)
-	@$(call invoke_xcode,$(PATH_TO_SCAN_BUILD),build analyze,)
+	@$(call invoke_xcode,$(PATH_TO_SCAN_BUILD),build analyze,CLANG_STATIC_ANALYZER_MODE=deep)
 
 clean:
 ifndef XCODE_TARGET


### PR DESCRIPTION
#### 403e78eb6ddb81c1319cca7045b09199474573ed
<pre>
v2: &quot;make analyze&quot; should run clang static analyzer in deep mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=249251">https://bugs.webkit.org/show_bug.cgi?id=249251</a>
&lt;rdar://103318218&gt;

Reviewed by Ryan Haddad.

Pass &apos;CLANG_STATIC_ANALYZER_MODE=deep&apos; to xcodebuild to run
clang static analyzer in deep mode.

* Makefile.shared:
(analyze):

Canonical link: <a href="https://commits.webkit.org/257816@main">https://commits.webkit.org/257816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ec13991ee7f89e1b48993283b2bb1d254a609bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109446 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10158 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86773 "Build is being retried. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92543 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107335 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105877 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34385 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90694 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3050 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23865 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86652 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/475 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3017 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/86773 "Build is being retried. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29044 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9148 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43346 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89532 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20016 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2759 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->