### PR TITLE
Don't allow text selection to start on a HTMLMediaElement

### DIFF
--- a/LayoutTests/media/video-controls-start-selection-expected.txt
+++ b/LayoutTests/media/video-controls-start-selection-expected.txt
@@ -1,0 +1,7 @@
+PASS document.getSelection().rangeCount is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Start selection on video with controls
+
+ Some text here

--- a/LayoutTests/media/video-controls-start-selection.html
+++ b/LayoutTests/media/video-controls-start-selection.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<p>Start selection on video with controls</p>
+<video controls></video>
+<span>Some text here</span>
+<script>
+    var video = document.querySelector('video');
+    var span = document.querySelector('span');
+    if (window.eventSender) {
+        eventSender.mouseMoveTo(video.offsetLeft + video.offsetWidth / 2, video.offsetTop + video.offsetHeight / 2);
+        eventSender.mouseDown();
+        eventSender.mouseMoveTo(span.offsetLeft + span.offsetWidth / 2, span.offsetTop + span.offsetHeight / 2);
+        eventSender.mouseUp();
+    }
+    shouldBe('document.getSelection().rangeCount', '0');
+</script>

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -678,6 +678,7 @@ private:
     void didFinishInsertingNode() override;
     void removedFromAncestor(RemovalType, ContainerNode&) override;
     void didRecalcStyle(Style::Change) override;
+    bool canStartSelection() const override { return false; } 
     bool isInteractiveContent() const override;
 
     void setFullscreenMode(VideoFullscreenMode);


### PR DESCRIPTION
#### 45eab14f59252dde66d9a3bf9bffedada1ecfd34
<pre>
Don&apos;t allow text selection to start on a HTMLMediaElement

Don&apos;t allow text selection to start on a HTMLMediaElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=249249">https://bugs.webkit.org/show_bug.cgi?id=249249</a>

Reviewed by Ryosuke Niwa.

This patch is to align Webkit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://src.chromium.org/viewvc/blink?revision=196741&amp">https://src.chromium.org/viewvc/blink?revision=196741&amp</a>;view=revision

This patch introduces a bool function with the return value of &apos;false&apos; to disable text selection on media element controls.

* Source/WebCore/html/HTMLMediaElement.h: Add &apos;bool&apos; with return value of &apos;false&apos;
* LayoutTests/media/video-controls-start-selection.html: Add Test Case
* LayoutTests/media/video-controls-start-selection-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/257876@main">https://commits.webkit.org/257876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0c726954de51af404b47de0bac40931f370b11a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109476 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169712 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10237 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92573 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107366 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34409 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22384 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3077 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23899 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3051 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43385 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5414 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4887 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->