### PR TITLE
Add filtering for WebNavigation events.

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.h
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface _WKWebExtensionUtilities : NSObject
+
+/// Verifies that a dictionary:
+///  - Contains a required set of string keys, as listed in `requiredKeys`.
+///  - Has no unexpected keys beyond the required keys and an additional set of optional keys, listed in `optionalKeys`.
+///  - Has values that are the appropriate type for each key, as specified by `keyTypes`. The keys in this dictionary
+///    correspond to keys in the original dictionary being validated, and the values in `keyTypes` may be:
+///     - An Objective-C class, that the value in the original dictionary must be a kind of.
+///     - An array containing one class, specifying that the value in the original dictionary must be an array with
+///      elements that are a kind of the specified class.
+/// If the dictionary is valid, returns YES. Otherwise returns NO and sets `outExceptionString` to a message describing
+/// what validation failed.
++ (BOOL)validateContentsOfDictionary:(NSDictionary<NSString *, id> *)dictionary requiredKeys:(nullable NSArray<NSString *> *)requiredKeys optionalKeys:(nullable NSArray<NSString *> *)optionalKeys keyToExpectedValueType:(NSDictionary<NSString *, id> *)keyTypes outExceptionString:(NSString * _Nullable * _Nonnull)outExceptionString;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // ENABLE(WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.mm
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "config.h"
+#import "_WKWebExtensionUtilities.h"
+
+#import "CocoaHelpers.h"
+
+@implementation _WKWebExtensionUtilities
+
+static NSString *classToClassString(Class classType, BOOL plural = NO)
+{
+    static NSMapTable<Class, NSString *> *classTypeToSingularClassString;
+    static NSMapTable<Class, NSString *> *classTypeToPluralClassString;
+
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        classTypeToSingularClassString = [NSMapTable strongToStrongObjectsMapTable];
+        [classTypeToSingularClassString setObject:@"a boolean value" forKey:[@YES class]];
+        [classTypeToSingularClassString setObject:@"a number value" forKey:[NSNumber class]];
+        [classTypeToSingularClassString setObject:@"a string value" forKey:[NSString class]];
+        [classTypeToSingularClassString setObject:@"an array" forKey:[NSArray class]];
+        [classTypeToSingularClassString setObject:@"an object" forKey:[NSDictionary class]];
+
+        classTypeToPluralClassString = [NSMapTable strongToStrongObjectsMapTable];
+        [classTypeToPluralClassString setObject:@"boolean values" forKey:[@YES class]];
+        [classTypeToPluralClassString setObject:@"number values" forKey:[NSNumber class]];
+        [classTypeToPluralClassString setObject:@"string values" forKey:[NSString class]];
+        [classTypeToPluralClassString setObject:@"arrays" forKey:[NSArray class]];
+        [classTypeToPluralClassString setObject:@"objects" forKey:[NSDictionary class]];
+    });
+
+    NSMapTable<Class, NSString *> *classTypeToClassString = plural ? classTypeToPluralClassString : classTypeToSingularClassString;
+
+    if (NSString *result = [classTypeToClassString objectForKey:classType])
+        return result;
+
+    for (Class superclass in classTypeToClassString) {
+        if ([classType isSubclassOfClass:superclass])
+            return [classTypeToClassString objectForKey:superclass];
+    }
+
+    ASSERT_NOT_REACHED();
+    return @"unknown";
+}
+
++ (BOOL)validateContentsOfDictionary:(NSDictionary<NSString *, id> *)dictionary requiredKeys:(NSArray<NSString *> *)requiredKeys optionalKeys:(NSArray<NSString *> *)optionalKeys keyToExpectedValueType:(NSDictionary<NSString *, id> *)keyTypes outExceptionString:(NSString **)outExceptionString
+{
+    NSMutableSet<NSString *> *remainingRequiredKeys = [[NSMutableSet alloc] initWithArray:requiredKeys];
+    NSSet<NSString *> *requiredKeysSet = [[NSSet alloc] initWithArray:requiredKeys];
+    NSSet<NSString *> *optionalKeysSet = [[NSSet alloc] initWithArray:optionalKeys];
+
+    __block NSString *errorString;
+    [dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSObject *value, BOOL* stop) {
+        // This should never be hit, since the dictionary comes from JavaScript and all keys are strings.
+        ASSERT([key isKindOfClass:[NSString class]]);
+
+        if (![requiredKeysSet containsObject:key] && ![optionalKeysSet containsObject:key]) {
+            // FIXME: Add logging here?
+            return;
+        }
+
+        id expectedValueType = keyTypes[key];
+        NSArray<Class> *validClassesArray = dynamic_objc_cast<NSArray>(expectedValueType);
+        if (validClassesArray) {
+            ASSERT(validClassesArray.count == 1UL);
+            Class expectedElementType = validClassesArray.firstObject;
+            NSArray<id> *arrayValue = dynamic_objc_cast<NSArray>(value);
+            if (!arrayValue) {
+                *stop = YES;
+                errorString = [NSString stringWithFormat:@"Expected an array for '%@'.", key];
+                return;
+            }
+
+            for (NSObject *element in arrayValue) {
+                if (![element isKindOfClass:expectedElementType]) {
+                    *stop = YES;
+                    errorString = [NSString stringWithFormat:@"Expected %@ in the array for '%@', found %@ instead.", classToClassString(expectedElementType, YES), key, classToClassString(element.class)];
+                    return;
+                }
+            }
+        } else if (![value isKindOfClass:expectedValueType]) {
+            *stop = YES;
+            errorString = [NSString stringWithFormat:@"Expected %@ for '%@', found %@ instead.", classToClassString(expectedValueType), key, classToClassString(value.class)];
+            return;
+        }
+
+        if ([requiredKeysSet containsObject:key])
+            [remainingRequiredKeys removeObject:key];
+    }];
+
+    // Prioritize type errors over missing required key errors, since the dictionary *might* actually have
+    // all the required keys, but we stopped checking. We do know for sure that the type is wrong though.
+    if (remainingRequiredKeys.count && !errorString) {
+        NSString *missingRequiredKeys = [[remainingRequiredKeys allObjects] componentsJoinedByString:@", "];
+        errorString = [NSString stringWithFormat:@"Missing required keys: %@.", missingRequiredKeys];
+    }
+
+    if (errorString)
+        *outExceptionString = errorString;
+    return !errorString;
+}
+
+@end
+#endif // ENABLE(WEB_EXTENSIONS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -816,6 +816,10 @@
 		3375A37129429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3375A37029429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		3375A37529429DF50028536D /* WebExtensionAPIWebNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3375A37329429DF50028536D /* WebExtensionAPIWebNavigation.h */; };
 		3375A3772942A19D0028536D /* JSWebExtensionAPIWebNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3375A3762942A19C0028536D /* JSWebExtensionAPIWebNavigation.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		337822432947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.mm in Sources */ = {isa = PBXBuildFile; fileRef = 337822412947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		337822442947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 337822422947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.h */; };
+		337822472947FBA5002106BB /* _WKWebExtensionUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 337822452947FBA4002106BB /* _WKWebExtensionUtilities.h */; };
+		337822482947FBA5002106BB /* _WKWebExtensionUtilities.mm in Sources */ = {isa = PBXBuildFile; fileRef = 337822462947FBA4002106BB /* _WKWebExtensionUtilities.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		33F68338293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 33F68336293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		33F6833E293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 33F6833D293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h */; };
 		33F68340293FFB3F005C63C0 /* WebExtensionAPIWebNavigationEventCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 33F6833F293FFB3F005C63C0 /* WebExtensionAPIWebNavigationEventCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -4541,6 +4545,10 @@
 		3375A37029429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIWebNavigationCocoa.mm; sourceTree = "<group>"; };
 		3375A37329429DF50028536D /* WebExtensionAPIWebNavigation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIWebNavigation.h; sourceTree = "<group>"; };
 		3375A3762942A19C0028536D /* JSWebExtensionAPIWebNavigation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = JSWebExtensionAPIWebNavigation.mm; path = DerivedSources/WebKit/JSWebExtensionAPIWebNavigation.mm; sourceTree = BUILT_PRODUCTS_DIR; };
+		337822412947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionWebNavigationURLFilter.mm; sourceTree = "<group>"; };
+		337822422947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionWebNavigationURLFilter.h; sourceTree = "<group>"; };
+		337822452947FBA4002106BB /* _WKWebExtensionUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionUtilities.h; sourceTree = "<group>"; };
+		337822462947FBA4002106BB /* _WKWebExtensionUtilities.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionUtilities.mm; sourceTree = "<group>"; };
 		33F68335293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JSWebExtensionAPIWebNavigationEvent.h; path = DerivedSources/WebKit/JSWebExtensionAPIWebNavigationEvent.h; sourceTree = BUILT_PRODUCTS_DIR; };
 		33F68336293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = JSWebExtensionAPIWebNavigationEvent.mm; path = DerivedSources/WebKit/JSWebExtensionAPIWebNavigationEvent.mm; sourceTree = BUILT_PRODUCTS_DIR; };
 		33F6833D293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIWebNavigationEvent.h; sourceTree = "<group>"; };
@@ -8826,6 +8834,8 @@
 		1C3D0ABF291AE6200093F67E /* Cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				337822422947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.h */,
+				337822412947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.mm */,
 				1C3D0AC0291AE6200093F67E /* WebExtensionControllerProxyCocoa.mm */,
 			);
 			path = Cocoa;
@@ -12094,6 +12104,8 @@
 		B6114A8A293AE03600380B1B /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				337822452947FBA4002106BB /* _WKWebExtensionUtilities.h */,
+				337822462947FBA4002106BB /* _WKWebExtensionUtilities.mm */,
 				B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */,
 			);
 			path = Extensions;
@@ -14599,6 +14611,8 @@
 				1C8B2363289AE89400020CDC /* _WKWebExtensionPermission.h in Headers */,
 				1C3BEB712888842A00E66E38 /* _WKWebExtensionPrivate.h in Headers */,
 				1C049840289AFF9B0010308B /* _WKWebExtensionTab.h in Headers */,
+				337822472947FBA5002106BB /* _WKWebExtensionUtilities.h in Headers */,
+				337822442947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.h in Headers */,
 				1C049841289AFF9B0010308B /* _WKWebExtensionWindow.h in Headers */,
 				1AE286781C7E76510069AC4F /* _WKWebsiteDataSize.h in Headers */,
 				1AE286801C7F92C00069AC4F /* _WKWebsiteDataSizeInternal.h in Headers */,
@@ -17830,6 +17844,8 @@
 				1C1549D729381DFF001B9E5B /* _WKWebExtensionControllerConfiguration.mm in Sources */,
 				1C1CE972288DF5030098D3A1 /* _WKWebExtensionMatchPattern.mm in Sources */,
 				1C049838289AF5AD0010308B /* _WKWebExtensionPermission.mm in Sources */,
+				337822482947FBA5002106BB /* _WKWebExtensionUtilities.mm in Sources */,
+				337822432947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.mm in Sources */,
 				572EBBDA2538F6B4000552B3 /* AppAttestInternalSoftLink.mm in Sources */,
 				517B5F7E275E97B6002DC22D /* AppBundleRequest.mm in Sources */,
 				EBA8D3B227A5E33F00CB7900 /* ApplePushServiceConnection.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm
@@ -33,6 +33,7 @@
 #import "WebExtensionContextMessages.h"
 #import "WebPageProxy.h"
 #import "WebProcess.h"
+#import "_WKWebExtensionWebNavigationURLFilter.h"
 #import <JavaScriptCore/APICast.h>
 #import <JavaScriptCore/ScriptCallStack.h>
 #import <JavaScriptCore/ScriptCallStackFactory.h>
@@ -48,17 +49,26 @@ void WebExtensionAPIWebNavigationEvent::invokeListenersWithArgument(id argument1
     if (m_listeners.isEmpty())
         return;
 
-    // FIXME: Honor the targetURL making sure it matches the filter for each listener.
+    for (auto& listener : m_listeners) {
+        _WKWebExtensionWebNavigationURLFilter *filter = listener.second.get();
+        if (filter && ![filter matchesURL:targetURL])
+            continue;
 
-    for (auto& listener : m_listeners)
-        listener->call(argument1);
+        listener.first->call(argument1);
+    }
 }
 
 void WebExtensionAPIWebNavigationEvent::addListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener, NSDictionary *filter, NSString **exceptionString)
 {
-    // FIXME: Save the filter associated with each of these listeners.
+    _WKWebExtensionWebNavigationURLFilter *parsedFilter;
+    if (filter) {
+        parsedFilter = [[_WKWebExtensionWebNavigationURLFilter alloc] initWithDictionary:filter outErrorMessage:exceptionString];
+        if (!parsedFilter)
+            return;
+    }
 
-    m_listeners.append(listener);
+    FilterAndCallbackPair filterPair = FilterAndCallbackPair(listener, parsedFilter);
+    m_listeners.append(filterPair);
 
     if (!page)
         return;
@@ -69,7 +79,7 @@ void WebExtensionAPIWebNavigationEvent::addListener(WebPage* page, RefPtr<WebExt
 void WebExtensionAPIWebNavigationEvent::removeListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener)
 {
     m_listeners.removeAllMatching([&](auto& entry) {
-        return entry->callbackFunction() == listener->callbackFunction();
+        return entry.first->callbackFunction() == listener->callbackFunction();
     });
 
     if (!page)
@@ -81,7 +91,7 @@ void WebExtensionAPIWebNavigationEvent::removeListener(WebPage* page, RefPtr<Web
 bool WebExtensionAPIWebNavigationEvent::hasListener(RefPtr<WebExtensionCallbackHandler> listener)
 {
     return m_listeners.containsIf([&](auto& entry) {
-        return entry->callbackFunction() == listener->callbackFunction();
+        return entry.first->callbackFunction() == listener->callbackFunction();
     });
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
@@ -37,6 +37,7 @@ OBJC_CLASS JSValue;
 OBJC_CLASS NSDictionary;
 OBJC_CLASS NSString;
 OBJC_CLASS NSURL;
+OBJC_CLASS _WKWebExtensionWebNavigationURLFilter;
 
 namespace WebKit {
 
@@ -44,7 +45,8 @@ class WebExtensionAPIWebNavigationEvent : public WebExtensionAPIObject, public J
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebNavigationEvent, webNavigationEvent);
 
 public:
-    using ListenerVector = Vector<RefPtr<WebExtensionCallbackHandler>>;
+    using FilterAndCallbackPair = std::pair<RefPtr<WebExtensionCallbackHandler>, RetainPtr<_WKWebExtensionWebNavigationURLFilter>>;
+    using ListenerVector = Vector<FilterAndCallbackPair>;
 
     void invokeListenersWithArgument(id argument, NSURL *targetURL);
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.h
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface _WKWebExtensionWebNavigationURLFilter : NSObject
+
+- (nullable instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dictionary outErrorMessage:(NSString * _Nullable * _Nonnull)outErrorMessage;
+
+- (BOOL)matchesURL:(NSURL *)url;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
@@ -1,0 +1,406 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "config.h"
+#import "_WKWebExtensionWebNavigationURLFilter.h"
+
+#import "_WKWebExtensionUtilities.h"
+#import <WebKit/WebNSURLExtras.h>
+#import <wtf/RetainPtr.h>
+
+typedef NS_ENUM(NSInteger, PredicateType) {
+    PredicateTypeHostContains,
+    PredicateTypeHostEquals,
+    PredicateTypeHostPrefix,
+    PredicateTypeHostSuffix,
+    PredicateTypePathContains,
+    PredicateTypePathEquals,
+    PredicateTypePathPrefix,
+    PredicateTypePathSuffix,
+    PredicateTypeQueryContains,
+    PredicateTypeQueryEquals,
+    PredicateTypeQueryPrefix,
+    PredicateTypeQuerySuffix,
+    PredicateTypeURLContains,
+    PredicateTypeURLEquals,
+    PredicateTypeURLMatches,
+    PredicateTypeOriginAndPathMatches,
+    PredicateTypeURLPrefix,
+    PredicateTypeURLSuffix,
+    PredicateTypeSchemes,
+    PredicateTypePorts,
+};
+
+static NSString *urlKey = @"url";
+
+static NSString *hostContainsKey = @"hostContains";
+static NSString *hostEqualsKey = @"hostEquals";
+static NSString *hostPrefixKey = @"hostPrefix";
+static NSString *hostSuffixKey = @"hostSuffix";
+static NSString *pathContainsKey = @"pathContains";
+static NSString *pathEqualsKey = @"pathEquals";
+static NSString *pathPrefixKey = @"pathPrefix";
+static NSString *pathSuffixKey = @"pathSuffix";
+static NSString *queryContainsKey = @"queryContains";
+static NSString *queryEqualsKey = @"queryEquals";
+static NSString *queryPrefixKey = @"queryPrefix";
+static NSString *querySuffixKey = @"querySuffix";
+static NSString *urlContainsKey = @"urlContains";
+static NSString *urlEqualsKey = @"urlEquals";
+static NSString *urlMatchesKey = @"urlMatches";
+static NSString *originAndPathMatchesKey = @"originAndPathMatches";
+static NSString *urlPrefixKey = @"urlPrefix";
+static NSString *urlSuffixKey = @"urlSuffix";
+static NSString *schemesKey = @"schemes";
+static NSString *portsKey = @"ports";
+
+@interface _WKWebExtensionWebNavigationURLPredicate : NSObject
+- (instancetype)init NS_UNAVAILABLE;
+@end
+
+@implementation _WKWebExtensionWebNavigationURLPredicate {
+    PredicateType _type;
+    id _value;
+}
+
+- (instancetype)initWithTypeString:(NSString *)typeString value:(id)rawValue outErrorMessage:(NSString **)outErrorMessage
+{
+    if (!(self = [super init]))
+        return nil;
+
+    static NSDictionary<NSString *, NSNumber *> *stringToTypeMap = @{
+        hostContainsKey: @(PredicateTypeHostContains),
+        hostEqualsKey: @(PredicateTypeHostEquals),
+        hostPrefixKey: @(PredicateTypeHostPrefix),
+        hostSuffixKey: @(PredicateTypeHostSuffix),
+        pathContainsKey: @(PredicateTypePathContains),
+        pathEqualsKey: @(PredicateTypePathEquals),
+        pathPrefixKey: @(PredicateTypePathPrefix),
+        pathSuffixKey: @(PredicateTypePathSuffix),
+        queryContainsKey: @(PredicateTypeQueryContains),
+        queryEqualsKey: @(PredicateTypeQueryEquals),
+        queryPrefixKey: @(PredicateTypeQueryPrefix),
+        querySuffixKey: @(PredicateTypeQuerySuffix),
+        urlContainsKey: @(PredicateTypeURLContains),
+        urlEqualsKey: @(PredicateTypeURLEquals),
+        urlMatchesKey: @(PredicateTypeURLMatches),
+        originAndPathMatchesKey: @(PredicateTypeOriginAndPathMatches),
+        urlPrefixKey: @(PredicateTypeURLPrefix),
+        urlSuffixKey: @(PredicateTypeURLSuffix),
+        schemesKey: @(PredicateTypeSchemes),
+        portsKey: @(PredicateTypePorts),
+    };
+
+    NSNumber *typeAsNumber = stringToTypeMap[typeString];
+    ASSERT(typeAsNumber);
+
+    _type = (PredicateType)typeAsNumber.integerValue;
+
+    switch (_type) {
+    case PredicateTypeHostContains:
+    case PredicateTypeHostEquals:
+    case PredicateTypeHostPrefix:
+    case PredicateTypeHostSuffix:
+    case PredicateTypePathContains:
+    case PredicateTypePathEquals:
+    case PredicateTypePathPrefix:
+    case PredicateTypePathSuffix:
+    case PredicateTypeQueryContains:
+    case PredicateTypeQueryEquals:
+    case PredicateTypeQueryPrefix:
+    case PredicateTypeQuerySuffix:
+    case PredicateTypeURLContains:
+    case PredicateTypeURLEquals:
+    case PredicateTypeURLPrefix:
+    case PredicateTypeURLSuffix:
+        ASSERT([rawValue isKindOfClass:[NSString class]]);
+        _value = [rawValue copy];
+        break;
+
+    case PredicateTypeURLMatches:
+    case PredicateTypeOriginAndPathMatches:
+        ASSERT([rawValue isKindOfClass:[NSString class]]);
+        _value = [NSRegularExpression regularExpressionWithPattern:rawValue options:0 error:nil];
+        if (!_value) {
+            *outErrorMessage = [NSString stringWithFormat:@"\"%@\" is not a valid regular expression.", rawValue];
+            return nil;
+        }
+
+        break;
+
+    case PredicateTypeSchemes:
+        ASSERT([rawValue isKindOfClass:[NSArray class]]);
+        _value = [rawValue copy];
+        break;
+
+    case PredicateTypePorts: {
+        NSMutableIndexSet *ports = [[NSMutableIndexSet alloc] init];
+        ASSERT([rawValue isKindOfClass:[NSArray class]]);
+        const NSInteger maximumPortNumber = 65535;
+        for (id portOrRange in rawValue) {
+            if (NSNumber *number = dynamic_objc_cast<NSNumber>(portOrRange)) {
+                NSInteger integerValue = number.integerValue;
+                if ([number isKindOfClass:@YES.class]) {
+                    *outErrorMessage = [NSString stringWithFormat:@"Array elements of '%@\' filters must be integers or arrays.", typeString];
+                    return nil;
+                }
+
+                if (integerValue < 0 || integerValue > maximumPortNumber) {
+                    *outErrorMessage = [NSString stringWithFormat:@"%zd is not a valid port number.", integerValue];
+                    return nil;
+                }
+
+                [ports addIndex:(NSUInteger)integerValue];
+            } else if (NSArray<NSNumber *> *rangeArray = dynamic_objc_cast<NSArray>(portOrRange)) {
+                if (rangeArray.count != 2) {
+                    *outErrorMessage = @"Port range arrays must contain 2 integers.";
+                    return nil;
+                }
+
+                for (NSNumber *number in rangeArray) {
+                    if (![number isKindOfClass:NSNumber.class] || [number isKindOfClass:@YES.class]) {
+                        *outErrorMessage = @"Port range arrays must contain 2 integers.";
+                        return nil;
+                    }
+
+                    NSInteger integerValue = number.integerValue;
+                    if (integerValue < 0 || integerValue > maximumPortNumber) {
+                        *outErrorMessage = [NSString stringWithFormat:@"%zd is not a valid port number.", integerValue];
+                        return nil;
+                    }
+                }
+
+                NSUInteger firstPort = rangeArray[0].unsignedIntegerValue;
+                NSUInteger lastPort = rangeArray[1].unsignedIntegerValue;
+                if (firstPort > lastPort) {
+                    *outErrorMessage = [NSString stringWithFormat:@"%zd-%zu is not a valid port range.", firstPort, lastPort];
+                    return nil;
+                }
+
+                [ports addIndexesInRange:NSMakeRange(firstPort, lastPort - firstPort + 1)];
+            } else {
+                *outErrorMessage = [NSString stringWithFormat:@"Values in '%@' array must be integers or arrays of integers.", typeString];
+                return nil;
+            }
+        }
+
+        _value = [ports copy];
+        break;
+    }
+    }
+
+    return self;
+}
+
+- (BOOL)matchesURL:(NSURL *)url
+{
+    NSString *stringValue = _value;
+    NSArray<NSString *> *stringArrayValue = _value;
+    NSIndexSet *indexSetValue = _value;
+    NSRegularExpression *regexValue = _value;
+
+    switch (_type) {
+    case PredicateTypeHostContains:
+        // This filter type adds an implicit '.' before the URL's host.
+        return [[@"." stringByAppendingString:url.host ?: @""] containsString:stringValue];
+    case PredicateTypeHostEquals:
+        return [url.host isEqualToString:stringValue];
+    case PredicateTypeHostPrefix:
+        return [url.host hasPrefix:stringValue];
+    case PredicateTypeHostSuffix:
+        return [url.host hasSuffix:stringValue];
+    case PredicateTypePathContains:
+        return [url.path containsString:stringValue];
+    case PredicateTypePathEquals:
+        return [url.path isEqualToString:stringValue];
+    case PredicateTypePathPrefix:
+        return [url.path hasPrefix:stringValue];
+    case PredicateTypePathSuffix:
+        return [url.path hasSuffix:stringValue];
+    case PredicateTypeQueryContains:
+        return [url.query containsString:stringValue];
+    case PredicateTypeQueryEquals:
+        return [url.query isEqualToString:stringValue];
+    case PredicateTypeQueryPrefix:
+        return [url.query hasPrefix:stringValue];
+    case PredicateTypeQuerySuffix:
+        return [url.query hasSuffix:stringValue];
+    case PredicateTypeURLContains:
+        return [url._webkit_URLByRemovingFragment.absoluteString containsString:stringValue];
+    case PredicateTypeURLEquals:
+        return [url._webkit_URLByRemovingFragment.absoluteString isEqualToString:stringValue];
+    case PredicateTypeURLMatches: {
+        NSString *stringForMatching = url._webkit_URLByRemovingFragment.absoluteString;
+        return [regexValue rangeOfFirstMatchInString:stringForMatching options:0 range:NSMakeRange(0, stringForMatching.length)].location != NSNotFound;
+    }
+    case PredicateTypeOriginAndPathMatches: {
+        NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+        components.fragment = nil;
+        components.query = nil;
+        NSString *stringForMatching = components.string;
+        return [regexValue rangeOfFirstMatchInString:stringForMatching options:0 range:NSMakeRange(0, stringForMatching.length)].location != NSNotFound;
+    }
+    case PredicateTypeURLPrefix:
+        return [url._webkit_URLByRemovingFragment.absoluteString hasPrefix:stringValue];
+    case PredicateTypeURLSuffix:
+        return [url._webkit_URLByRemovingFragment.absoluteString hasSuffix:stringValue];
+    case PredicateTypeSchemes:
+        return [stringArrayValue containsObject:url.scheme];
+    case PredicateTypePorts:
+        return [indexSetValue containsIndex:url.port.unsignedIntegerValue];
+    }
+
+    ASSERT_NOT_REACHED();
+    return NO;
+}
+
+@end
+
+@implementation _WKWebExtensionWebNavigationURLFilter {
+    NSArray<NSArray<_WKWebExtensionWebNavigationURLPredicate *> *> *_predicateGroups;
+}
+
+- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dictionary outErrorMessage:(NSString **)outErrorMessage
+{
+    static NSArray<NSString *> *requiredKeys = @[
+        urlKey,
+    ];
+
+    static NSDictionary<NSString *, id> *types = @{
+        urlKey: @[ [NSDictionary class] ],
+    };
+
+    if (![_WKWebExtensionUtilities validateContentsOfDictionary:dictionary requiredKeys:requiredKeys optionalKeys:nil keyToExpectedValueType:types outExceptionString:outErrorMessage])
+        return nil;
+
+    static NSArray<NSString *> *optionalURLDictionaryKeys = @[
+        hostContainsKey,
+        hostEqualsKey,
+        hostPrefixKey,
+        hostSuffixKey,
+        pathContainsKey,
+        pathEqualsKey,
+        pathPrefixKey,
+        pathSuffixKey,
+        queryContainsKey,
+        queryEqualsKey,
+        queryPrefixKey,
+        querySuffixKey,
+        urlContainsKey,
+        urlEqualsKey,
+        urlMatchesKey,
+        originAndPathMatchesKey,
+        urlPrefixKey,
+        urlSuffixKey,
+        schemesKey,
+        portsKey,
+    ];
+
+    static NSDictionary<NSString *, id> *URLDictionaryTypes = @{
+        hostContainsKey: [NSString class],
+        hostEqualsKey: [NSString class],
+        hostPrefixKey: [NSString class],
+        hostSuffixKey: [NSString class],
+        pathContainsKey: [NSString class],
+        pathEqualsKey: [NSString class],
+        pathPrefixKey: [NSString class],
+        pathSuffixKey: [NSString class],
+        queryContainsKey: [NSString class],
+        queryEqualsKey: [NSString class],
+        queryPrefixKey: [NSString class],
+        querySuffixKey: [NSString class],
+        urlContainsKey: [NSString class],
+        urlEqualsKey: [NSString class],
+        urlMatchesKey: [NSString class],
+        originAndPathMatchesKey: [NSString class],
+        urlPrefixKey: [NSString class],
+        urlSuffixKey: [NSString class],
+        schemesKey: @[ [NSString class] ],
+        portsKey: [NSArray class], // Array of (integer or (array of integer))
+    };
+
+    NSMutableArray<NSArray<_WKWebExtensionWebNavigationURLPredicate *> *> *predicateGroups = [[NSMutableArray alloc] init];
+
+    for (NSDictionary<NSString *, id> *urlDictionary in dictionary[urlKey]) {
+        if (![_WKWebExtensionUtilities validateContentsOfDictionary:urlDictionary requiredKeys:nil optionalKeys:optionalURLDictionaryKeys keyToExpectedValueType:URLDictionaryTypes outExceptionString:outErrorMessage])
+            return nil;
+
+        NSMutableArray<_WKWebExtensionWebNavigationURLPredicate *> *predicates = [[NSMutableArray alloc] init];
+
+        __block NSString *errorMessage;
+        [urlDictionary enumerateKeysAndObjectsUsingBlock:^(NSString *key, id obj, BOOL* stop) {
+            _WKWebExtensionWebNavigationURLPredicate *predicate = [[_WKWebExtensionWebNavigationURLPredicate alloc] initWithTypeString:key value:obj outErrorMessage:&errorMessage];
+            if (predicate)
+                [predicates addObject:predicate];
+            else
+                *stop = YES;
+        }];
+
+        if (errorMessage) {
+            *outErrorMessage = errorMessage;
+            return nil;
+        }
+
+        [predicateGroups addObject:predicates];
+    }
+
+    if (!(self = [super init]))
+        return nil;
+
+    _predicateGroups = predicateGroups.count ? predicateGroups : nil;
+
+    return self;
+}
+
+- (BOOL)matchesURL:(NSURL *)url
+{
+    if (!_predicateGroups)
+        return YES;
+
+    for (NSArray<_WKWebExtensionWebNavigationURLPredicate *> *predicateGroup in _predicateGroups) {
+        BOOL allPredicatesInGroupMatch = YES;
+        for (_WKWebExtensionWebNavigationURLPredicate *predicate in predicateGroup) {
+            if (![predicate matchesURL:url]) {
+                allPredicatesInGroupMatch = NO;
+                break;
+            }
+        }
+
+        if (allPredicatesInGroupMatch)
+            return YES;
+    }
+
+    return NO;
+}
+
+@end
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 0b8cd1e53947aed4b0679d330162f563f190b828
<pre>
Add filtering for WebNavigation events.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249258">https://bugs.webkit.org/show_bug.cgi?id=249258</a>
rdar://102820594

Reviewed by Timothy Hatcher.

When a webNavigation event listener is added, parse and save the filter that was included with the listener.

When attempting to fire a webNavigation event, check the given URL and see if it passes the included filter.

The filter parsing + managing code is written in Objective-C, and more tests are coming in upcoming patches.

* Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.h: Added.
* Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.mm: Added.
(classToClassString):
(+[_WKWebExtensionUtilities validateContentsOfDictionary:requiredKeys:optionalKeys:keyToExpectedValueType:outExceptionString:]): Validates
the contents of the given dictionary, checking for the presence of required keys, possible optional keys, and type checking.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj: Add new files.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm:
(WebKit::WebExtensionAPIWebNavigationEvent::invokeListenersWithArgument): If the listener has a filter, only invoke the listener if the filter
matches the target URL.
(WebKit::WebExtensionAPIWebNavigationEvent::addListener): Handle the filter.
(WebKit::WebExtensionAPIWebNavigationEvent::removeListener): Ditto.
(WebKit::WebExtensionAPIWebNavigationEvent::hasListener): Ditto.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h: Change the listener vector to a vector of pairs.
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.h: Copied from Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h.
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm: Added.
(-[_WKWebExtensionWebNavigationURLPredicate initWithTypeString:value:outErrorMessage:]):
(-[_WKWebExtensionWebNavigationURLPredicate matchesURL:]):
(-[_WKWebExtensionWebNavigationURLFilter initWithDictionary:outErrorMessage:]):
(-[_WKWebExtensionWebNavigationURLFilter matchesURL:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm:
(TestWebKitAPI::TEST): Add some basic tests around filtering.

Canonical link: <a href="https://commits.webkit.org/257875@main">https://commits.webkit.org/257875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94452198562194b546fc3c7844ca06bcdda4dca7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100270 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109594 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10341 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107481 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106046 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3191 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3172 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9299 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5404 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5000 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->