### PR TITLE
Change Record to CrossThreadRecord in CacheStorageEngineConnection::PutRecords message

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -131,12 +131,12 @@ ExceptionOr<Ref<FetchResponse>> FetchResponse::create(ScriptExecutionContext& co
     r->suspendIfNeeded();
 
     r->m_contentType = contentType;
-    AtomString mimeType { extractMIMETypeFromMediaType(contentType) };
-    r->m_internalResponse.setMimeType(mimeType.isEmpty() ? AtomString { defaultMIMEType() } : mimeType);
-    r->m_internalResponse.setTextEncodingName(extractCharsetFromMediaType(contentType).toAtomString());
+    auto mimeType = extractMIMETypeFromMediaType(contentType);
+    r->m_internalResponse.setMimeType(mimeType.isEmpty() ? defaultMIMEType() : mimeType);
+    r->m_internalResponse.setTextEncodingName(extractCharsetFromMediaType(contentType).toString());
 
     r->m_internalResponse.setHTTPStatusCode(status);
-    r->m_internalResponse.setHTTPStatusText(statusText);
+    r->m_internalResponse.setHTTPStatusText(statusText.releaseString());
 
     return r;
 }

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -220,7 +220,7 @@ int WebSocketHandshake::readServerHandshake(const uint8_t* header, size_t len)
 {
     m_mode = Incomplete;
     int statusCode;
-    AtomString statusText;
+    String statusText;
     int lineLength = readStatusLine(header, len, statusCode, statusText);
     if (lineLength == -1)
         return -1;
@@ -356,7 +356,7 @@ static inline bool headerHasValidHTTPVersion(StringView httpStatusLine)
 // Returns the header length (including "\r\n"), or -1 if we have not received enough data yet.
 // If the line is malformed or the status code is not a 3-digit number,
 // statusCode and statusText will be set to -1 and a null string, respectively.
-int WebSocketHandshake::readStatusLine(const uint8_t* header, size_t headerLength, int& statusCode, AtomString& statusText)
+int WebSocketHandshake::readStatusLine(const uint8_t* header, size_t headerLength, int& statusCode, String& statusText)
 {
     // Arbitrary size limit to prevent the server from sending an unbounded
     // amount of data with no newlines and forcing us to buffer it all.
@@ -426,7 +426,7 @@ int WebSocketHandshake::readStatusLine(const uint8_t* header, size_t headerLengt
     }
 
     statusCode = parseInteger<int>(statusCodeString).value();
-    statusText = AtomString(space2 + 1, end - space2 - 3); // Exclude "\r\n".
+    statusText = String(space2 + 1, end - space2 - 3); // Exclude "\r\n".
     return lineLength;
 }
 

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.h
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.h
@@ -88,7 +88,7 @@ public:
 
 private:
 
-    int readStatusLine(const uint8_t* header, size_t headerLength, int& statusCode, AtomString& statusText);
+    int readStatusLine(const uint8_t* header, size_t headerLength, int& statusCode, String& statusText);
 
     // Reads all headers except for the two predefined ones.
     const uint8_t* readHTTPHeaders(const uint8_t* start, const uint8_t* end);

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -116,7 +116,7 @@ public:
         m_statusCode = response.httpStatusCode();
 
         // FIXME: This assumes text only responses. We should support non-text responses as well.
-        PAL::TextEncoding textEncoding(response.textEncodingName().string());
+        PAL::TextEncoding textEncoding(response.textEncodingName());
         bool useDetector = false;
         if (!textEncoding.isValid()) {
             textEncoding = PAL::UTF8Encoding();
@@ -1274,9 +1274,9 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithResponse(const
     if (status)
         overrideResponse.setHTTPStatusCode(*status);
     if (!!statusText)
-        overrideResponse.setHTTPStatusText(AtomString { statusText });
+        overrideResponse.setHTTPStatusText(statusText);
     if (!!mimeType)
-        overrideResponse.setMimeType(AtomString { mimeType });
+        overrideResponse.setMimeType(mimeType);
     if (headers) {
         HTTPHeaderMap explicitHeaders;
         for (auto& header : *headers) {
@@ -1332,7 +1332,7 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithRespons
     ResourceResponse response(pendingRequest->m_loader->url(), mimeType, data->size(), String());
     response.setSource(ResourceResponse::Source::InspectorOverride);
     response.setHTTPStatusCode(status);
-    response.setHTTPStatusText(AtomString { statusText });
+    response.setHTTPStatusText(statusText);
     HTTPHeaderMap explicitHeaders;
     for (auto& header : headers.get()) {
         auto headerValue = header.value->asString();

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1903,7 +1903,7 @@ URL DocumentLoader::documentURL() const
 #if PLATFORM(IOS_FAMILY)
 
 // FIXME: This method seems to violate the encapsulation of this class.
-void DocumentLoader::setResponseMIMEType(const AtomString& responseMIMEType)
+void DocumentLoader::setResponseMIMEType(const String& responseMIMEType)
 {
     m_response.setMimeType(responseMIMEType);
 }

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -206,7 +206,7 @@ public:
     const String& responseMIMEType() const;
 #if PLATFORM(IOS_FAMILY)
     // FIXME: This method seems to violate the encapsulation of this class.
-    WEBCORE_EXPORT void setResponseMIMEType(const AtomString&);
+    WEBCORE_EXPORT void setResponseMIMEType(const String&);
 #endif
     const String& currentContentType() const;
     void replaceRequestURLForSameDocumentNavigation(const URL&);

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -575,7 +575,7 @@ void BlobResourceHandle::notifyResponseOnSuccess()
     response.setHTTPStatusText(isRangeRequest ? httpPartialContentText : httpOKText);
 
     response.setHTTPHeaderField(HTTPHeaderName::ContentType, m_blobData->contentType());
-    response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toAtomString());
+    response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toString());
     response.setHTTPHeaderField(HTTPHeaderName::ContentLength, String::number(m_totalRemainingSize));
     addPolicyContainerHeaders(response, m_blobData->policyContainer());
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -94,13 +94,13 @@ ResourceResponseBase::CrossThreadData ResourceResponseBase::crossThreadData() co
     CrossThreadData data;
 
     data.url = url().isolatedCopy();
-    data.mimeType = mimeType().string().isolatedCopy();
+    data.mimeType = mimeType().isolatedCopy();
     data.expectedContentLength = expectedContentLength();
-    data.textEncodingName = textEncodingName().string().isolatedCopy();
+    data.textEncodingName = textEncodingName().isolatedCopy();
 
     data.httpStatusCode = httpStatusCode();
-    data.httpStatusText = httpStatusText().string().isolatedCopy();
-    data.httpVersion = httpVersion().string().isolatedCopy();
+    data.httpStatusText = httpStatusText().isolatedCopy();
+    data.httpVersion = httpVersion().isolatedCopy();
 
     data.httpHeaderFields = httpHeaderFields().isolatedCopy();
     if (m_networkLoadMetrics)
@@ -118,13 +118,13 @@ ResourceResponse ResourceResponseBase::fromCrossThreadData(CrossThreadData&& dat
     ResourceResponse response;
 
     response.setURL(data.url);
-    response.setMimeType(AtomString { data.mimeType });
+    response.setMimeType(WTFMove(data.mimeType));
     response.setExpectedContentLength(data.expectedContentLength);
-    response.setTextEncodingName(AtomString { WTFMove(data.textEncodingName) });
+    response.setTextEncodingName(WTFMove(data.textEncodingName));
 
     response.setHTTPStatusCode(data.httpStatusCode);
-    response.setHTTPStatusText(AtomString { data.httpStatusText });
-    response.setHTTPVersion(AtomString { data.httpVersion });
+    response.setHTTPStatusText(WTFMove(data.httpStatusText));
+    response.setHTTPVersion(WTFMove(data.httpVersion));
 
     response.m_httpHeaderFields = WTFMove(data.httpHeaderFields);
     if (data.networkLoadMetrics)
@@ -232,14 +232,14 @@ void ResourceResponseBase::setURL(const URL& url)
     // FIXME: Should invalidate or update platform response if present.
 }
 
-const AtomString& ResourceResponseBase::mimeType() const
+const String& ResourceResponseBase::mimeType() const
 {
     lazyInit(CommonFieldsOnly);
 
     return m_mimeType; 
 }
 
-void ResourceResponseBase::setMimeType(const AtomString& mimeType)
+void ResourceResponseBase::setMimeType(const String& mimeType)
 {
     lazyInit(CommonFieldsOnly);
     m_isNull = false;
@@ -268,14 +268,14 @@ void ResourceResponseBase::setExpectedContentLength(long long expectedContentLen
     // FIXME: Should invalidate or update platform response if present.
 }
 
-const AtomString& ResourceResponseBase::textEncodingName() const
+const String& ResourceResponseBase::textEncodingName() const
 {
     lazyInit(CommonFieldsOnly);
 
     return m_textEncodingName;
 }
 
-void ResourceResponseBase::setTextEncodingName(AtomString&& encodingName)
+void ResourceResponseBase::setTextEncodingName(String&& encodingName)
 {
     lazyInit(CommonFieldsOnly);
     m_isNull = false;
@@ -345,14 +345,14 @@ bool ResourceResponseBase::isRedirection() const
     return isRedirectionStatusCode(m_httpStatusCode);
 }
 
-const AtomString& ResourceResponseBase::httpStatusText() const
+const String& ResourceResponseBase::httpStatusText() const
 {
     lazyInit(AllFields);
 
     return m_httpStatusText; 
 }
 
-void ResourceResponseBase::setHTTPStatusText(const AtomString& statusText)
+void ResourceResponseBase::setHTTPStatusText(const String& statusText)
 {
     lazyInit(AllFields);
 
@@ -361,14 +361,14 @@ void ResourceResponseBase::setHTTPStatusText(const AtomString& statusText)
     // FIXME: Should invalidate or update platform response if present.
 }
 
-const AtomString& ResourceResponseBase::httpVersion() const
+const String& ResourceResponseBase::httpVersion() const
 {
     lazyInit(AllFields);
     
     return m_httpVersion;
 }
 
-void ResourceResponseBase::setHTTPVersion(const AtomString& versionText)
+void ResourceResponseBase::setHTTPVersion(const String& versionText)
 {
     lazyInit(AllFields);
     

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -98,24 +98,24 @@ public:
     WEBCORE_EXPORT const URL& url() const;
     WEBCORE_EXPORT void setURL(const URL&);
 
-    WEBCORE_EXPORT const AtomString& mimeType() const;
-    WEBCORE_EXPORT void setMimeType(const AtomString&);
+    WEBCORE_EXPORT const String& mimeType() const;
+    WEBCORE_EXPORT void setMimeType(const String&);
 
     WEBCORE_EXPORT long long expectedContentLength() const;
     WEBCORE_EXPORT void setExpectedContentLength(long long expectedContentLength);
 
-    WEBCORE_EXPORT const AtomString& textEncodingName() const;
-    WEBCORE_EXPORT void setTextEncodingName(AtomString&&);
+    WEBCORE_EXPORT const String& textEncodingName() const;
+    WEBCORE_EXPORT void setTextEncodingName(String&&);
 
     WEBCORE_EXPORT int httpStatusCode() const;
     WEBCORE_EXPORT void setHTTPStatusCode(int);
     WEBCORE_EXPORT bool isRedirection() const;
 
-    WEBCORE_EXPORT const AtomString& httpStatusText() const;
-    WEBCORE_EXPORT void setHTTPStatusText(const AtomString&);
+    WEBCORE_EXPORT const String& httpStatusText() const;
+    WEBCORE_EXPORT void setHTTPStatusText(const String&);
 
-    WEBCORE_EXPORT const AtomString& httpVersion() const;
-    WEBCORE_EXPORT void setHTTPVersion(const AtomString&);
+    WEBCORE_EXPORT const String& httpVersion() const;
+    WEBCORE_EXPORT void setHTTPVersion(const String&);
     WEBCORE_EXPORT bool isHTTP09() const;
 
     WEBCORE_EXPORT const HTTPHeaderMap& httpHeaderFields() const;
@@ -256,11 +256,11 @@ private:
 
 protected:
     URL m_url;
-    AtomString m_mimeType;
+    String m_mimeType;
     long long m_expectedContentLength { 0 };
-    AtomString m_textEncodingName;
-    AtomString m_httpStatusText;
-    AtomString m_httpVersion;
+    String m_textEncodingName;
+    String m_httpStatusText;
+    String m_httpVersion;
     HTTPHeaderMap m_httpHeaderFields;
     Box<NetworkLoadMetrics> m_networkLoadMetrics;
 
@@ -348,7 +348,7 @@ bool ResourceResponseBase::decode(Decoder& decoder, ResourceResponseBase& respon
         return false;
     response.m_url = WTFMove(*url);
 
-    std::optional<AtomString> mimeType;
+    std::optional<String> mimeType;
     decoder >> mimeType;
     if (!mimeType)
         return false;
@@ -360,19 +360,19 @@ bool ResourceResponseBase::decode(Decoder& decoder, ResourceResponseBase& respon
         return false;
     response.m_expectedContentLength = *expectedContentLength;
 
-    std::optional<AtomString> textEncodingName;
+    std::optional<String> textEncodingName;
     decoder >> textEncodingName;
     if (!textEncodingName)
         return false;
     response.m_textEncodingName = WTFMove(*textEncodingName);
 
-    std::optional<AtomString> httpStatusText;
+    std::optional<String> httpStatusText;
     decoder >> httpStatusText;
     if (!httpStatusText)
         return false;
     response.m_httpStatusText = WTFMove(*httpStatusText);
 
-    std::optional<AtomString> httpVersion;
+    std::optional<String> httpVersion;
     decoder >> httpVersion;
     if (!httpVersion)
         return false;

--- a/Source/WebCore/platform/network/cf/ResourceResponseCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/ResourceResponseCFNet.cpp
@@ -45,7 +45,7 @@ CFURLResponseRef ResourceResponse::cfURLResponse() const
     if (!m_cfResponse && !m_isNull) {
         RetainPtr<CFURLRef> url = m_url.createCFURL();
         // FIXME: This creates a very incomplete CFURLResponse, which does not even have a status code.
-        m_cfResponse = adoptCF(CFURLResponseCreate(0, url.get(), m_mimeType.string().createCFString().get(), m_expectedContentLength, m_textEncodingName.string().createCFString().get(), kCFURLCacheStorageAllowed));
+        m_cfResponse = adoptCF(CFURLResponseCreate(0, url.get(), m_mimeType.createCFString().get(), m_expectedContentLength, m_textEncodingName.createCFString().get(), kCFURLCacheStorageAllowed));
     }
 
     return m_cfResponse.get();
@@ -74,7 +74,7 @@ void ResourceResponse::platformLazyInit(InitLevel initLevel)
         // Workaround for <rdar://problem/8757088>, can be removed once that is fixed.
         unsigned textEncodingNameLength = m_textEncodingName.length();
         if (textEncodingNameLength >= 2 && m_textEncodingName[0U] == '"' && m_textEncodingName[textEncodingNameLength - 1] == '"')
-            m_textEncodingName = StringView { m_textEncodingName }.substring(1, textEncodingNameLength - 2).toAtomString();
+            m_textEncodingName = StringView { m_textEncodingName }.substring(1, textEncodingNameLength - 2).toString();
 
         CFHTTPMessageRef httpResponse = CFURLResponseGetHTTPResponse(m_cfResponse.get());
         if (httpResponse) {
@@ -95,7 +95,7 @@ void ResourceResponse::platformLazyInit(InitLevel initLevel)
     if (m_initLevel < AllFields && initLevel == AllFields) {
         CFHTTPMessageRef httpResponse = CFURLResponseGetHTTPResponse(m_cfResponse.get());
         if (httpResponse) {
-            m_httpVersion = AtomString { String(adoptCF(CFHTTPMessageCopyVersion(httpResponse)).get()).convertToASCIIUppercase() };
+            m_httpVersion = String { String(adoptCF(CFHTTPMessageCopyVersion(httpResponse)).get()).convertToASCIIUppercase() };
 
             RetainPtr<CFStringRef> statusLine = adoptCF(CFHTTPMessageCopyResponseStatusLine(httpResponse));
             m_httpStatusText = extractReasonPhraseFromHTTPStatusLine(statusLine.get());

--- a/Source/WebCore/platform/network/curl/CurlCacheEntry.cpp
+++ b/Source/WebCore/platform/network/curl/CurlCacheEntry.cpp
@@ -189,8 +189,8 @@ void CurlCacheEntry::setResponseFromCachedHeaders(ResourceResponse& response)
     }
     response.setExpectedContentLength(contentLength); // -1 on parse error or null
 
-    response.setMimeType(AtomString { extractMIMETypeFromMediaType(response.httpHeaderField(HTTPHeaderName::ContentType)) });
-    response.setTextEncodingName(extractCharsetFromMediaType(response.httpHeaderField(HTTPHeaderName::ContentType)).toAtomString());
+    response.setMimeType(extractMIMETypeFromMediaType(response.httpHeaderField(HTTPHeaderName::ContentType)));
+    response.setTextEncodingName(extractCharsetFromMediaType(response.httpHeaderField(HTTPHeaderName::ContentType)).toString());
 }
 
 void CurlCacheEntry::didFail()

--- a/Source/WebCore/platform/network/curl/ResourceHandleCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceHandleCurl.cpp
@@ -549,8 +549,8 @@ void ResourceHandle::handleDataURL()
         charset = "US-ASCII"_s;
 
     ResourceResponse response;
-    response.setMimeType(AtomString { mimeType });
-    response.setTextEncodingName(charset.toAtomString());
+    response.setMimeType(mimeType);
+    response.setTextEncodingName(charset.toString());
     response.setURL(d->m_firstRequest.url());
 
     if (base64) {

--- a/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
@@ -103,8 +103,8 @@ ResourceResponse::ResourceResponse(CurlResponse& response)
         break;
     }
 
-    setMimeType(AtomString { extractMIMETypeFromMediaType(httpHeaderField(HTTPHeaderName::ContentType)).convertToASCIILowercase() });
-    setTextEncodingName(extractCharsetFromMediaType(httpHeaderField(HTTPHeaderName::ContentType)).toAtomString());
+    setMimeType(extractMIMETypeFromMediaType(httpHeaderField(HTTPHeaderName::ContentType)).convertToASCIILowercase());
+    setTextEncodingName(extractCharsetFromMediaType(httpHeaderField(HTTPHeaderName::ContentType)).toString());
     setCertificateInfo(WTFMove(response.certificateInfo));
     setSource(ResourceResponse::Source::Network);
 }
@@ -142,7 +142,7 @@ void ResourceResponse::setStatusLine(StringView header)
     // Extract the http status text
     if (statusCodeEndPosition != notFound) {
         auto statusText = statusLine.substring(statusCodeEndPosition + 1).stripLeadingAndTrailingMatchedCharacters(isSpaceOrNewline);
-        setHTTPStatusText(statusText.toAtomString());
+        setHTTPStatusText(statusText.toString());
     }
 }
 

--- a/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
@@ -55,7 +55,7 @@ ResourceResponse::ResourceResponse(SoupMessage* soupMessage, const CString& snif
     }
 
     m_httpStatusCode = soup_message_get_status(soupMessage);
-    setHTTPStatusText(AtomString::fromLatin1(soup_message_get_reason_phrase(soupMessage)));
+    setHTTPStatusText(String::fromLatin1(soup_message_get_reason_phrase(soupMessage)));
 
     m_certificate = soup_message_get_tls_peer_certificate(soupMessage);
     m_tlsErrors = soup_message_get_tls_peer_certificate_errors(soupMessage);
@@ -69,10 +69,10 @@ ResourceResponse::ResourceResponse(SoupMessage* soupMessage, const CString& snif
         contentType = String::fromLatin1(sniffedContentType.data());
     else
         contentType = String::fromLatin1(officialType);
-    setMimeType(AtomString { extractMIMETypeFromMediaType(contentType) });
+    setMimeType(extractMIMETypeFromMediaType(contentType));
     if (m_mimeType.isEmpty() && m_httpStatusCode != SOUP_STATUS_NOT_MODIFIED)
-        setMimeType(AtomString { MIMETypeRegistry::mimeTypeForPath(m_url.path()) });
-    setTextEncodingName(extractCharsetFromMediaType(contentType).toAtomString());
+        setMimeType(MIMETypeRegistry::mimeTypeForPath(m_url.path()));
+    setTextEncodingName(extractCharsetFromMediaType(contentType).toString());
 
     setExpectedContentLength(soup_message_headers_get_content_length(responseHeaders));
 }

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -263,7 +263,7 @@ void NetworkDataTaskBlob::dispatchDidReceiveResponse(Error errorCode)
         response.setHTTPStatusText(isRangeRequest ? httpPartialContentText : httpOKText);
 
         response.setHTTPHeaderField(HTTPHeaderName::ContentType, m_blobData->contentType());
-        response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toAtomString());
+        response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toString());
         response.setHTTPHeaderField(HTTPHeaderName::ContentLength, String::number(m_totalRemainingSize));
         addPolicyContainerHeaders(response, m_blobData->policyContainer());
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -798,7 +798,7 @@ static BrowsingContextGroupSwitchDecision toBrowsingContextGroupSwitchDecision(c
 
 void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedResponse, PrivateRelayed privateRelayed, ResponseCompletionHandler&& completionHandler)
 {
-    LOADER_RELEASE_LOG("didReceiveResponse: (httpStatusCode=%d, MIMEType=%" PUBLIC_LOG_STRING ", expectedContentLength=%" PRId64 ", hasCachedEntryForValidation=%d, hasNetworkLoadChecker=%d)", receivedResponse.httpStatusCode(), receivedResponse.mimeType().string().utf8().data(), receivedResponse.expectedContentLength(), !!m_cacheEntryForValidation, !!m_networkLoadChecker);
+    LOADER_RELEASE_LOG("didReceiveResponse: (httpStatusCode=%d, MIMEType=%" PUBLIC_LOG_STRING ", expectedContentLength=%" PRId64 ", hasCachedEntryForValidation=%d, hasNetworkLoadChecker=%d)", receivedResponse.httpStatusCode(), receivedResponse.mimeType().utf8().data(), receivedResponse.expectedContentLength(), !!m_cacheEntryForValidation, !!m_networkLoadChecker);
 
 #if ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
     if (m_contentFilter && !m_contentFilter->continueAfterResponseReceived(receivedResponse))

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -216,7 +216,7 @@ void ServiceWorkerFetchTask::processResponse(ResourceResponse&& response, bool n
     if (m_isDone)
         return;
 
-    SWFETCH_RELEASE_LOG("processResponse: (httpStatusCode=%d, MIMEType=%" PUBLIC_LOG_STRING ", expectedContentLength=%" PRId64 ", needsContinueDidReceiveResponseMessage=%d, source=%u)", response.httpStatusCode(), response.mimeType().string().utf8().data(), response.expectedContentLength(), needsContinueDidReceiveResponseMessage, static_cast<unsigned>(response.source()));
+    SWFETCH_RELEASE_LOG("processResponse: (httpStatusCode=%d, MIMEType=%" PUBLIC_LOG_STRING ", expectedContentLength=%" PRId64 ", needsContinueDidReceiveResponseMessage=%d, source=%u)", response.httpStatusCode(), response.mimeType().utf8().data(), response.expectedContentLength(), needsContinueDidReceiveResponseMessage, static_cast<unsigned>(response.source()));
     m_wasHandled = true;
     if (m_timeoutTimer)
         m_timeoutTimer->stop();

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -1713,8 +1713,8 @@ void NetworkDataTaskSoup::didGetFileInfo(GFileInfo* info)
         m_response.setExpectedContentLength(-1);
     } else {
         auto contentType = String::fromLatin1(g_file_info_get_content_type(info));
-        m_response.setMimeType(AtomString { extractMIMETypeFromMediaType(contentType) });
-        m_response.setTextEncodingName(extractCharsetFromMediaType(contentType).toAtomString());
+        m_response.setMimeType(extractMIMETypeFromMediaType(contentType));
+        m_response.setTextEncodingName(extractCharsetFromMediaType(contentType).toString());
         if (m_response.mimeType().isEmpty())
             m_response.setMimeType(AtomString { MIMETypeRegistry::mimeTypeForPath(m_response.url().path().toString()) });
         m_response.setExpectedContentLength(g_file_info_get_size(info));

--- a/Source/WebKit/Shared/API/glib/WebKitURIResponse.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitURIResponse.cpp
@@ -239,7 +239,7 @@ const gchar* webkit_uri_response_get_mime_type(WebKitURIResponse* response)
 {
     g_return_val_if_fail(WEBKIT_IS_URI_RESPONSE(response), 0);
 
-    response->priv->mimeType = response->priv->resourceResponse.mimeType().string().utf8();
+    response->priv->mimeType = response->priv->resourceResponse.mimeType().utf8();
     return response->priv->mimeType.data();
 }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
@@ -224,17 +224,17 @@ static void webkitURISchemeRequestReadCallback(GInputStream* inputStream, GAsync
     if (!priv->bytesRead) {
         auto contentType = String::fromLatin1(webKitURISchemeResponseGetContentType(resp).data());
         ResourceResponse response(priv->task->request().url(), extractMIMETypeFromMediaType(contentType), webKitURISchemeResponseGetStreamLength(resp), emptyString());
-        response.setTextEncodingName(extractCharsetFromMediaType(contentType).toAtomString());
+        response.setTextEncodingName(extractCharsetFromMediaType(contentType).toString());
         const CString& statusMessage = webKitURISchemeResponseGetStatusMessage(resp);
         if (statusMessage.isNull()) {
             response.setHTTPStatusCode(200);
             response.setHTTPStatusText("OK"_s);
         } else {
             response.setHTTPStatusCode(webKitURISchemeResponseGetStatusCode(resp));
-            response.setHTTPStatusText(AtomString::fromLatin1(statusMessage.data()));
+            response.setHTTPStatusText(String::fromLatin1(statusMessage.data()));
         }
         if (response.mimeType().isEmpty())
-            response.setMimeType(AtomString { MIMETypeRegistry::mimeTypeForPath(response.url().path()) });
+            response.setMimeType(MIMETypeRegistry::mimeTypeForPath(response.url().path()));
         if (auto* headers = webKitURISchemeResponseGetHeaders(resp))
             response.updateFromSoupMessageHeaders(headers);
         priv->task->didReceiveResponse(response);


### PR DESCRIPTION
#### d8ee2e055346dc5e2dd0e39b229794ac47658c33
<pre>
Change AtomString to String in ResourceResponse
<a href="https://bugs.webkit.org/show_bug.cgi?id=249240">https://bugs.webkit.org/show_bug.cgi?id=249240</a>
rdar://103319623

Reviewed by Youenn Fablet.

Making this change so we can dispatch message that contains ResourceResponse to WorkQueueMessageReceiver, which handles
message on a WorkQueue (not tied to a thread).

* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::create):
* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::WebSocketHandshake::readServerHandshake):
(WebCore::WebSocketHandshake::readStatusLine):
* Source/WebCore/Modules/websockets/WebSocketHandshake.h:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::interceptWithResponse):
(WebCore::InspectorNetworkAgent::interceptRequestWithResponse):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::setResponseMIMEType):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::notifyResponseOnSuccess):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::crossThreadData const):
(WebCore::ResourceResponseBase::fromCrossThreadData):
(WebCore::ResourceResponseBase::mimeType const):
(WebCore::ResourceResponseBase::setMimeType):
(WebCore::ResourceResponseBase::textEncodingName const):
(WebCore::ResourceResponseBase::setTextEncodingName):
(WebCore::ResourceResponseBase::httpStatusText const):
(WebCore::ResourceResponseBase::setHTTPStatusText):
(WebCore::ResourceResponseBase::httpVersion const):
(WebCore::ResourceResponseBase::setHTTPVersion):
* Source/WebCore/platform/network/ResourceResponseBase.h:
(WebCore::ResourceResponseBase::decode):
* Source/WebCore/platform/network/cf/ResourceResponseCFNet.cpp:
(WebCore::ResourceResponse::cfURLResponse const):
(WebCore::ResourceResponse::platformLazyInit):
* Source/WebCore/platform/network/curl/CurlCacheEntry.cpp:
(WebCore::CurlCacheEntry::setResponseFromCachedHeaders):
* Source/WebCore/platform/network/curl/ResourceHandleCurl.cpp:
(WebCore::ResourceHandle::handleDataURL):
* Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp:
(WebCore::ResourceResponse::ResourceResponse):
(WebCore::ResourceResponse::setStatusLine):
* Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp:
(WebCore::ResourceResponse::ResourceResponse):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::dispatchDidReceiveResponse):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didReceiveResponse):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::processResponse):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::didGetFileInfo):
* Source/WebKit/Shared/API/glib/WebKitURIResponse.cpp:
(webkit_uri_response_get_mime_type):
* Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp:
(webkitURISchemeRequestReadCallback):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8ee2e055346dc5e2dd0e39b229794ac47658c33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100160 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109492 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169727 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10250 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92587 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107381 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91041 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34419 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22436 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77357 "Found 4 new API test failures: /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/js-exception, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/console-api, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/security-error, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3091 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23952 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3066 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9196 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43440 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4901 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->