### PR TITLE
Instantiate a RemoteFrame upon cross-origin iframe navigation when site isolation is enabled

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1250,6 +1250,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/ReducedResolutionSeconds.h
     page/RemoteDOMWindow.h
     page/RemoteFrame.h
+    page/RemoteFrameClient.h
     page/RenderingUpdateScheduler.h
     page/ScreenOrientationLockType.h
     page/ScreenOrientationType.h

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -161,7 +161,7 @@ void HTMLFrameElementBase::didFinishInsertingNode()
 void HTMLFrameElementBase::didAttachRenderers()
 {
     if (RenderWidget* part = renderWidget()) {
-        if (RefPtr<Frame> frame = contentFrame())
+        if (RefPtr frame = dynamicDowncast<LocalFrame>(contentFrame()))
             part->setWidget(frame->view());
     }
 }
@@ -205,7 +205,7 @@ void HTMLFrameElementBase::setFocus(bool received, FocusVisibility visibility)
     if (Page* page = document().page()) {
         CheckedRef focusController { page->focusController() };
         if (received)
-            focusController->setFocusedFrame(contentFrame());
+            focusController->setFocusedFrame(dynamicDowncast<LocalFrame>(contentFrame()));
         else if (focusController->focusedFrame() == contentFrame()) // Focus may have already been given to another frame, don't take it away.
             focusController->setFocusedFrame(nullptr);
     }

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -51,7 +51,7 @@ RenderWidget* HTMLFrameOwnerElement::renderWidget() const
     return downcast<RenderWidget>(renderer());
 }
 
-void HTMLFrameOwnerElement::setContentFrame(Frame& frame)
+void HTMLFrameOwnerElement::setContentFrame(AbstractFrame& frame)
 {
     // Make sure we will not end up with two frames referencing the same owner element.
     ASSERT(!m_contentFrame || m_contentFrame->ownerElement() != this);
@@ -76,7 +76,7 @@ void HTMLFrameOwnerElement::clearContentFrame()
 
 void HTMLFrameOwnerElement::disconnectContentFrame()
 {
-    if (RefPtr<Frame> frame = m_contentFrame.get()) {
+    if (RefPtr frame = dynamicDowncast<LocalFrame>(m_contentFrame.get())) {
         frame->loader().frameDetached();
         frame->disconnectOwnerElement();
     }
@@ -90,7 +90,9 @@ HTMLFrameOwnerElement::~HTMLFrameOwnerElement()
 
 Document* HTMLFrameOwnerElement::contentDocument() const
 {
-    return m_contentFrame ? m_contentFrame->document() : nullptr;
+    if (auto* localFrame = dynamicDowncast<LocalFrame>(m_contentFrame.get()))
+        return localFrame->document();
+    return nullptr;
 }
 
 WindowProxy* HTMLFrameOwnerElement::contentWindow() const

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -20,9 +20,10 @@
 
 #pragma once
 
-#include "Frame.h"
+#include "AbstractFrame.h"
 #include "HTMLElement.h"
 #include "ReferrerPolicy.h"
+#include "SecurityContext.h"
 #include <wtf/HashCountedSet.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -35,11 +36,11 @@ class HTMLFrameOwnerElement : public HTMLElement {
 public:
     virtual ~HTMLFrameOwnerElement();
 
-    Frame* contentFrame() const { return m_contentFrame.get(); }
+    AbstractFrame* contentFrame() const { return m_contentFrame.get(); }
     WEBCORE_EXPORT WindowProxy* contentWindow() const;
     WEBCORE_EXPORT Document* contentDocument() const;
 
-    void setContentFrame(Frame&);
+    WEBCORE_EXPORT void setContentFrame(AbstractFrame&);
     void clearContentFrame();
 
     void disconnectContentFrame();
@@ -73,7 +74,7 @@ private:
     bool isKeyboardFocusable(KeyboardEvent*) const override;
     bool isFrameOwnerElement() const final { return true; }
 
-    WeakPtr<Frame> m_contentFrame;
+    WeakPtr<AbstractFrame> m_contentFrame;
     SandboxFlags m_sandboxFlags { SandboxNone };
 };
 

--- a/Source/WebCore/html/PDFDocument.cpp
+++ b/Source/WebCore/html/PDFDocument.cpp
@@ -191,7 +191,10 @@ void PDFDocument::postMessageToIframe(const String& name, JSC::JSObject* data)
     if (data)
         message->putDirect(vm, JSC::Identifier::fromString(vm, "data"_s), data);
 
-    auto* contentWindow = m_iframe->contentFrame()->window();
+    auto* contentFrame = dynamicDowncast<LocalFrame>(m_iframe->contentFrame());
+    if (!contentFrame)
+        return;
+    auto* contentWindow = contentFrame->window();
     auto* contentWindowGlobalObject = m_iframe->contentDocument()->globalObject();
 
     WindowPostMessageOptions options;

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -799,7 +799,7 @@ void InspectorFrontendHost::inspectedPageDidNavigate(const String& newURLString)
 
 ExceptionOr<JSC::JSValue> InspectorFrontendHost::evaluateScriptInExtensionTab(HTMLIFrameElement& extensionFrameElement, const String& scriptSource)
 {
-    Frame* frame = extensionFrameElement.contentFrame();
+    auto* frame = dynamicDowncast<LocalFrame>(extensionFrameElement.contentFrame());
     if (!frame)
         return Exception { InvalidStateError, "Unable to find global object for <iframe>"_s };
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3608,7 +3608,7 @@ void FrameLoader::continueLoadAfterNavigationPolicy(const ResourceRequest& reque
         if (m_frame.isMainFrame() || navigationPolicyDecision != NavigationPolicyDecision::StopAllLoads)
             checkCompleted();
         else {
-            // Don't call checkCompleted until Frame::didFinishLoadInAnotherProcess,
+            // Don't call checkCompleted until RemoteFrame::didFinishLoadInAnotherProcess,
             // to prevent onload from happening until iframes finish loading in other processes.
             ASSERT(m_frame.settings().siteIsolationEnabled());
         }

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -227,7 +227,7 @@ Frame* FrameLoader::SubframeLoader::loadOrRedirectSubframe(HTMLFrameOwnerElement
     URL upgradedRequestURL = requestURL;
     initiatingDocument.contentSecurityPolicy()->upgradeInsecureRequestIfNeeded(upgradedRequestURL, ContentSecurityPolicy::InsecureRequestType::Load);
 
-    RefPtr frame = ownerElement.contentFrame();
+    RefPtr frame = dynamicDowncast<LocalFrame>(ownerElement.contentFrame());
     if (frame) {
         CompletionHandler<void()> stopDelayingLoadEvent = [] { };
         if (upgradedRequestURL.protocolIsJavaScript()) {
@@ -244,7 +244,7 @@ Frame* FrameLoader::SubframeLoader::loadOrRedirectSubframe(HTMLFrameOwnerElement
         return nullptr;
 
     ASSERT(ownerElement.contentFrame() == frame || !ownerElement.contentFrame());
-    return ownerElement.contentFrame();
+    return dynamicDowncast<LocalFrame>(ownerElement.contentFrame());
 }
 
 RefPtr<Frame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerElement& ownerElement, const URL& url, const AtomString& name, const String& referrer)

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -527,7 +527,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const String& markupString, Fr
         Node& node = *nodePtr;
         Frame* childFrame;
         if ((is<HTMLFrameElementBase>(node) || is<HTMLObjectElement>(node))
-            && (childFrame = downcast<HTMLFrameOwnerElement>(node).contentFrame())) {
+            && (childFrame = dynamicDowncast<LocalFrame>(downcast<HTMLFrameOwnerElement>(node).contentFrame()))) {
             if (frameFilter && !frameFilter(*childFrame))
                 continue;
             if (auto subframeArchive = create(*childFrame->document(), WTFMove(frameFilter)))

--- a/Source/WebCore/page/AbstractFrame.cpp
+++ b/Source/WebCore/page/AbstractFrame.cpp
@@ -27,19 +27,26 @@
 #include "AbstractFrame.h"
 
 #include "DocumentInlines.h"
+#include "Frame.h"
 #include "HTMLFrameOwnerElement.h"
 #include "Page.h"
 #include "WindowProxy.h"
 
 namespace WebCore {
 
-AbstractFrame::AbstractFrame(Page& page, FrameIdentifier frameID, AbstractFrame* parent)
+static AbstractFrame* parentFrame(HTMLFrameOwnerElement* ownerElement)
+{
+    return ownerElement ? ownerElement->document().frame() : nullptr;
+}
+
+AbstractFrame::AbstractFrame(Page& page, FrameIdentifier frameID, HTMLFrameOwnerElement* ownerElement)
     : m_page(page)
     , m_frameID(frameID)
-    , m_treeNode(*this, parent)
+    , m_treeNode(*this, parentFrame(ownerElement))
     , m_windowProxy(WindowProxy::create(*this))
+    , m_ownerElement(ownerElement)
 {
-    if (parent)
+    if (auto* parent = parentFrame(ownerElement))
         parent->tree().appendChild(*this);
 }
 
@@ -59,9 +66,26 @@ Page* AbstractFrame::page() const
     return m_page.get();
 }
 
+HTMLFrameOwnerElement* AbstractFrame::ownerElement() const
+{
+    return m_ownerElement.get();
+}
+
 void AbstractFrame::detachFromPage()
 {
     m_page = nullptr;
+}
+
+void AbstractFrame::disconnectOwnerElement()
+{
+    if (m_ownerElement) {
+        m_ownerElement->clearContentFrame();
+        m_ownerElement = nullptr;
+    }
+
+    // FIXME: This is a layering violation. Move this code so AbstractFrame doesn't do anything with its Document.
+    if (auto* document = is<LocalFrame>(*this) ? downcast<LocalFrame>(*this).document() : nullptr)
+        document->frameWasDisconnectedFromOwner();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/AbstractFrame.h
+++ b/Source/WebCore/page/AbstractFrame.h
@@ -36,6 +36,7 @@ namespace WebCore {
 class AbstractDOMWindow;
 class HTMLFrameOwnerElement;
 class Page;
+class WeakPtrImplWithEventTargetData;
 class WindowProxy;
 
 // FIXME: Rename Frame to LocalFrame and AbstractFrame to Frame.
@@ -53,9 +54,11 @@ public:
     FrameIdentifier frameID() const { return m_frameID; }
     WEBCORE_EXPORT Page* page() const;
     WEBCORE_EXPORT void detachFromPage();
+    WEBCORE_EXPORT HTMLFrameOwnerElement* ownerElement() const;
+    WEBCORE_EXPORT void disconnectOwnerElement();
 
 protected:
-    AbstractFrame(Page&, FrameIdentifier, AbstractFrame* parent);
+    AbstractFrame(Page&, FrameIdentifier, HTMLFrameOwnerElement*);
     void resetWindowProxy();
 
 private:
@@ -65,6 +68,7 @@ private:
     const FrameIdentifier m_frameID;
     mutable FrameTree m_treeNode;
     Ref<WindowProxy> m_windowProxy;
+    WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_ownerElement;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2347,7 +2347,7 @@ static std::pair<bool, RefPtr<Frame>> contentFrameForNode(Node* target)
     if (!is<HTMLFrameElementBase>(target))
         return { false, nullptr };
 
-    return { true, downcast<HTMLFrameElementBase>(*target).contentFrame() };
+    return { true, dynamicDowncast<LocalFrame>(downcast<HTMLFrameElementBase>(*target).contentFrame()) };
 }
 
 static std::optional<DragOperation> convertDropZoneOperationToDragOperation(const String& dragOperation)

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -290,9 +290,9 @@ FocusNavigationScope FocusNavigationScope::scopeOwnedByScopeOwner(Element& eleme
 
 FocusNavigationScope FocusNavigationScope::scopeOwnedByIFrame(HTMLFrameOwnerElement& frame)
 {
-    ASSERT(frame.contentFrame());
-    ASSERT(frame.contentFrame()->document());
-    return FocusNavigationScope(*frame.contentFrame()->document());
+    ASSERT(is<LocalFrame>(frame.contentFrame()));
+    ASSERT(downcast<LocalFrame>(frame.contentFrame())->document());
+    return FocusNavigationScope(*downcast<LocalFrame>(frame.contentFrame())->document());
 }
 
 static inline void dispatchEventsOnWindowAndFocusedElement(Document* document, bool focused)
@@ -425,9 +425,10 @@ Element* FocusController::findFocusableElementDescendingIntoSubframes(FocusDirec
     // 2) the deepest-nested HTMLFrameOwnerElement.
     while (is<HTMLFrameOwnerElement>(element)) {
         HTMLFrameOwnerElement& owner = downcast<HTMLFrameOwnerElement>(*element);
-        if (!owner.contentFrame() || !owner.contentFrame()->document())
+        auto* localContentFrame = dynamicDowncast<LocalFrame>(owner.contentFrame());
+        if (!localContentFrame || !localContentFrame->document())
             break;
-        owner.contentFrame()->document()->updateLayoutIgnorePendingStylesheets();
+        localContentFrame->document()->updateLayoutIgnorePendingStylesheets();
         Element* foundElement = findFocusableElementWithinScope(direction, FocusNavigationScope::scopeOwnedByIFrame(owner), nullptr, event);
         if (!foundElement)
             break;
@@ -528,7 +529,7 @@ bool FocusController::advanceFocusInDocumentOrder(FocusDirection direction, Keyb
             return false;
 
         document->setFocusedElement(nullptr);
-        setFocusedFrame(owner.contentFrame());
+        setFocusedFrame(dynamicDowncast<LocalFrame>(owner.contentFrame()));
         return true;
     }
     
@@ -1088,7 +1089,7 @@ bool FocusController::advanceFocusDirectionallyInContainer(Node* container, cons
         // If we have an iframe without the src attribute, it will not have a contentFrame().
         // We ASSERT here to make sure that
         // updateFocusCandidateIfNeeded() will never consider such an iframe as a candidate.
-        ASSERT(frameElement->contentFrame());
+        ASSERT(is<LocalFrame>(frameElement->contentFrame()));
 
         if (focusCandidate.isOffscreenAfterScrolling) {
             scrollInDirection(&focusCandidate.visibleNode->document(), direction);
@@ -1099,8 +1100,8 @@ bool FocusController::advanceFocusDirectionallyInContainer(Node* container, cons
         Element* focusedElement = focusedOrMainFrame().document()->focusedElement();
         if (focusedElement && !hasOffscreenRect(focusedElement))
             rect = nodeRectInAbsoluteCoordinates(focusedElement, true /* ignore border */);
-        frameElement->contentFrame()->document()->updateLayoutIgnorePendingStylesheets();
-        if (!advanceFocusDirectionallyInContainer(frameElement->contentFrame()->document(), rect, direction, event)) {
+        dynamicDowncast<LocalFrame>(frameElement->contentFrame())->document()->updateLayoutIgnorePendingStylesheets();
+        if (!advanceFocusDirectionallyInContainer(dynamicDowncast<LocalFrame>(frameElement->contentFrame())->document(), rect, direction, event)) {
             // The new frame had nothing interesting, need to find another candidate.
             return advanceFocusDirectionallyInContainer(container, nodeRectInAbsoluteCoordinates(focusCandidate.visibleNode, true), direction, event);
         }

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -151,12 +151,11 @@ static inline float parentTextZoomFactor(Frame* frame)
 }
 
 Frame::Frame(Page& page, HTMLFrameOwnerElement* ownerElement, UniqueRef<FrameLoaderClient>&& frameLoaderClient, FrameIdentifier identifier)
-    : AbstractFrame(page, identifier, ownerElement ? ownerElement->document().frame() : nullptr)
+    : AbstractFrame(page, identifier, ownerElement)
     , m_mainFrame(ownerElement ? page.mainFrame() : *this)
     , m_settings(&page.settings())
     , m_loader(makeUniqueRef<FrameLoader>(*this, WTFMove(frameLoaderClient)))
     , m_navigationScheduler(makeUniqueRef<NavigationScheduler>(*this))
-    , m_ownerElement(ownerElement)
     , m_script(makeUniqueRef<ScriptController>(*this))
     , m_pageZoomFactor(parentPageZoomFactor(this))
     , m_textZoomFactor(parentTextZoomFactor(this))
@@ -213,11 +212,6 @@ Frame::~Frame()
 
     if (!isMainFrame())
         m_mainFrame.selfOnlyDeref();
-}
-
-HTMLFrameOwnerElement* Frame::ownerElement() const
-{
-    return m_ownerElement.get();
 }
 
 void Frame::addDestructionObserver(FrameDestructionObserver& observer)
@@ -344,8 +338,8 @@ void Frame::invalidateContentEventRegionsIfNeeded(InvalidateContentEventRegionsR
     if (!m_doc->renderView()->compositor().viewNeedsToInvalidateEventRegionOfEnclosingCompositingLayerForRepaint())
         return;
 
-    if (m_ownerElement)
-        m_ownerElement->document().invalidateEventRegionsForFrame(*m_ownerElement);
+    if (RefPtr ownerElement = this->ownerElement())
+        ownerElement->document().invalidateEventRegionsForFrame(*ownerElement);
 }
 
 #if ENABLE(ORIENTATION_EVENTS)
@@ -717,13 +711,13 @@ RenderView* Frame::contentRenderer() const
 
 RenderWidget* Frame::ownerRenderer() const
 {
-    auto* ownerElement = m_ownerElement.get();
+    RefPtr ownerElement = this->ownerElement();
     if (!ownerElement)
         return nullptr;
     auto* object = ownerElement->renderer();
     // FIXME: If <object> is ever fixed to disassociate itself from frames
     // that it has started but canceled, then this can turn into an ASSERT
-    // since m_ownerElement would be nullptr when the load is canceled.
+    // since ownerElement would be nullptr when the load is canceled.
     // https://bugs.webkit.org/show_bug.cgi?id=18585
     if (!is<RenderWidget>(object))
         return nullptr;
@@ -788,17 +782,6 @@ void Frame::willDetachPage()
     // - When adding a document to the back/forward cache, the tree is torn down before instantiating
     //   the CachedPage+CachedFrame object tree.
     ASSERT(!document() || !document()->renderView());
-}
-
-void Frame::disconnectOwnerElement()
-{
-    if (m_ownerElement) {
-        m_ownerElement->clearContentFrame();
-        m_ownerElement = nullptr;
-    }
-
-    if (auto* document = this->document())
-        document->frameWasDisconnectedFromOwner();
 }
 
 String Frame::displayStringModifiedByEncoding(const String& str) const
@@ -1111,11 +1094,6 @@ bool Frame::arePluginsEnabled()
     return settings().arePluginsEnabled();
 }
 
-void Frame::didFinishLoadInAnotherProcess()
-{
-    m_loader->checkCompleted();
-}
-
 void Frame::resetScript()
 {
     resetWindowProxy();
@@ -1149,7 +1127,7 @@ Frame* Frame::contentFrameFromWindowOrFrameElement(JSContextRef context, JSValue
     auto* jsNode = JSC::jsDynamicCast<JSNode*>(value);
     if (!jsNode || !is<HTMLFrameOwnerElement>(jsNode->wrapped()))
         return nullptr;
-    return downcast<HTMLFrameOwnerElement>(jsNode->wrapped()).contentFrame();
+    return dynamicDowncast<LocalFrame>(downcast<HTMLFrameOwnerElement>(jsNode->wrapped()).contentFrame());
 }
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -138,12 +138,9 @@ public:
     void removeDestructionObserver(FrameDestructionObserver&);
 
     WEBCORE_EXPORT void willDetachPage();
-    void disconnectOwnerElement();
 
     Frame& mainFrame() const;
     bool isMainFrame() const { return this == static_cast<void*>(&m_mainFrame); }
-
-    WEBCORE_EXPORT HTMLFrameOwnerElement* ownerElement() const;
 
     Document* document() const;
     FrameView* view() const;
@@ -298,8 +295,6 @@ public:
 
     WEBCORE_EXPORT bool arePluginsEnabled();
 
-    WEBCORE_EXPORT void didFinishLoadInAnotherProcess();
-
 private:
     friend class NavigationDisabler;
 
@@ -320,7 +315,6 @@ private:
     UniqueRef<FrameLoader> m_loader;
     mutable UniqueRef<NavigationScheduler> m_navigationScheduler;
 
-    WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_ownerElement;
     RefPtr<FrameView> m_view;
     RefPtr<Document> m_doc;
 

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -67,7 +67,7 @@ public:
 
     WEBCORE_EXPORT void appendChild(AbstractFrame&);
     void detachFromParent() { m_parent = nullptr; }
-    void removeChild(AbstractFrame&);
+    WEBCORE_EXPORT void removeChild(AbstractFrame&);
 
     AbstractFrame* child(unsigned index) const;
     AbstractFrame* child(const AtomString& name) const;

--- a/Source/WebCore/page/ModalContainerObserver.cpp
+++ b/Source/WebCore/page/ModalContainerObserver.cpp
@@ -238,7 +238,7 @@ void ModalContainerObserver::updateModalContainerIfNeeded(const FrameView& view)
         }
 
         for (auto& frameOwner : descendantsOfType<HTMLFrameOwnerElement>(*element)) {
-            RefPtr contentFrame = frameOwner.contentFrame();
+            RefPtr contentFrame = dynamicDowncast<LocalFrame>(frameOwner.contentFrame());
             if (!contentFrame)
                 continue;
 

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -145,7 +145,7 @@ void PageSerializer::SerializerMarkupAccumulator::appendCustomAttributes(StringB
         return;
 
     const HTMLFrameOwnerElement& frameOwner = downcast<HTMLFrameOwnerElement>(element);
-    Frame* frame = frameOwner.contentFrame();
+    auto* frame = dynamicDowncast<LocalFrame>(frameOwner.contentFrame());
     if (!frame)
         return;
 

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -35,18 +35,13 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RemoteDOMWindow);
 
-RemoteDOMWindow::RemoteDOMWindow(Ref<RemoteFrame>&& frame, GlobalWindowIdentifier&& identifier)
+RemoteDOMWindow::RemoteDOMWindow(RemoteFrame& frame, GlobalWindowIdentifier&& identifier)
     : AbstractDOMWindow(WTFMove(identifier))
-    , m_frame(WTFMove(frame))
+    , m_frame(frame)
 {
-    m_frame->setWindow(this);
 }
 
-RemoteDOMWindow::~RemoteDOMWindow()
-{
-    if (m_frame)
-        m_frame->setWindow(nullptr);
-}
+RemoteDOMWindow::~RemoteDOMWindow() = default;
 
 WindowProxy* RemoteDOMWindow::self() const
 {

--- a/Source/WebCore/page/RemoteDOMWindow.h
+++ b/Source/WebCore/page/RemoteDOMWindow.h
@@ -47,9 +47,9 @@ class Location;
 class RemoteDOMWindow final : public AbstractDOMWindow {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(RemoteDOMWindow, WEBCORE_EXPORT);
 public:
-    static Ref<RemoteDOMWindow> create(Ref<RemoteFrame>&& frame, GlobalWindowIdentifier&& identifier)
+    static Ref<RemoteDOMWindow> create(RemoteFrame& frame, GlobalWindowIdentifier&& identifier)
     {
-        return adoptRef(*new RemoteDOMWindow(WTFMove(frame), WTFMove(identifier)));
+        return adoptRef(*new RemoteDOMWindow(frame, WTFMove(identifier)));
     }
 
     ~RemoteDOMWindow() final;
@@ -71,12 +71,12 @@ public:
     void postMessage(JSC::JSGlobalObject&, DOMWindow& incumbentWindow, JSC::JSValue message, const String& targetOrigin, Vector<JSC::Strong<JSC::JSObject>>&&);
 
 private:
-    WEBCORE_EXPORT RemoteDOMWindow(Ref<RemoteFrame>&&, GlobalWindowIdentifier&&);
+    WEBCORE_EXPORT RemoteDOMWindow(RemoteFrame&, GlobalWindowIdentifier&&);
 
     bool isRemoteDOMWindow() const final { return true; }
     bool isLocalDOMWindow() const final { return false; }
 
-    RefPtr<RemoteFrame> m_frame;
+    WeakPtr<RemoteFrame> m_frame;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -27,11 +27,14 @@
 #include "RemoteFrame.h"
 
 #include "RemoteDOMWindow.h"
+#include "RemoteFrameClient.h"
 
 namespace WebCore {
 
-RemoteFrame::RemoteFrame(Page& page, FrameIdentifier frameID, AbstractFrame* parent)
-    : AbstractFrame(page, frameID, parent)
+RemoteFrame::RemoteFrame(Page& page, FrameIdentifier frameID, HTMLFrameOwnerElement* ownerElement, UniqueRef<RemoteFrameClient>&& client)
+    : AbstractFrame(page, frameID, ownerElement)
+    , m_window(RemoteDOMWindow::create(*this, GlobalWindowIdentifier { Process::identifier(), WindowIdentifier::generate() }))
+    , m_client(WTFMove(client))
 {
 }
 
@@ -39,17 +42,23 @@ RemoteFrame::~RemoteFrame() = default;
 
 AbstractDOMWindow* RemoteFrame::virtualWindow() const
 {
-    return window();
+    return &window();
 }
 
-void RemoteFrame::setWindow(RemoteDOMWindow* window)
-{
-    m_window = WeakPtr { window };
-}
-
-RemoteDOMWindow* RemoteFrame::window() const
+RemoteDOMWindow& RemoteFrame::window() const
 {
     return m_window.get();
+}
+
+void RemoteFrame::didFinishLoadInAnotherProcess()
+{
+    auto* ownerElement = this->ownerElement();
+    if (!ownerElement)
+        return;
+
+    // FIXME: Do something so that this would not have caused the load event to fire before a state change
+    // but now does cause the load event to fire.
+    ownerElement->document().checkCompleted();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -32,32 +32,37 @@
 namespace WebCore {
 
 class RemoteDOMWindow;
+class RemoteFrameClient;
 class WeakPtrImplWithEventTargetData;
 
 class RemoteFrame final : public AbstractFrame {
 public:
-    static Ref<RemoteFrame> create(Page& page, FrameIdentifier frameID, AbstractFrame* parent)
+    static Ref<RemoteFrame> create(Page& page, FrameIdentifier frameID, HTMLFrameOwnerElement* ownerElement, UniqueRef<RemoteFrameClient>&& client)
     {
-        return adoptRef(*new RemoteFrame(page, frameID, parent));
+        return adoptRef(*new RemoteFrame(page, frameID, ownerElement, WTFMove(client)));
     }
     ~RemoteFrame();
 
-    void setWindow(RemoteDOMWindow*);
-    RemoteDOMWindow* window() const;
+    RemoteDOMWindow& window() const;
 
     void setOpener(AbstractFrame* opener) { m_opener = opener; }
     AbstractFrame* opener() const { return m_opener.get(); }
 
+    WEBCORE_EXPORT void didFinishLoadInAnotherProcess();
+
+    const RemoteFrameClient& client() const { return m_client.get(); }
+    RemoteFrameClient& client() { return m_client.get(); }
+
 private:
-    WEBCORE_EXPORT explicit RemoteFrame(Page&, FrameIdentifier, AbstractFrame* parent);
+    WEBCORE_EXPORT explicit RemoteFrame(Page&, FrameIdentifier, HTMLFrameOwnerElement*, UniqueRef<RemoteFrameClient>&&);
 
     FrameType frameType() const final { return FrameType::Remote; }
 
     AbstractDOMWindow* virtualWindow() const final;
 
-    WeakPtr<RemoteDOMWindow, WeakPtrImplWithEventTargetData> m_window;
-
+    Ref<RemoteDOMWindow> m_window;
     RefPtr<AbstractFrame> m_opener;
+    UniqueRef<RemoteFrameClient> m_client;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/FastMalloc.h>
+
+namespace WebCore {
+
+class RemoteFrameClient {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    virtual ~RemoteFrameClient() { }
+};
+
+}

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -810,6 +810,7 @@ WebProcess/WebCoreSupport/WebPermissionController.cpp
 WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
 WebProcess/WebCoreSupport/WebPopupMenu.cpp
 WebProcess/WebCoreSupport/WebProgressTrackerClient.cpp
+WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
 WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
 WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
 WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1281,6 +1281,7 @@
 		5C19A5201FD0B29500EEA323 /* URLSchemeTaskParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C19A51F1FD0B14700EEA323 /* URLSchemeTaskParameters.h */; };
 		5C20CBA01BB1ECD800895BB1 /* NetworkSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C20CB9E1BB0DD1800895BB1 /* NetworkSession.h */; };
 		5C20F679276A6DB6006CAC22 /* ArgumentCoders.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A3D610413A7F03A00F95D4E /* ArgumentCoders.cpp */; };
+		5C2397D52949235800BB4E10 /* WebRemoteFrameClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C2397D32949235700BB4E10 /* WebRemoteFrameClient.h */; };
 		5C26958520043212005C439B /* WKOpenPanelParametersPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C26958420042F12005C439B /* WKOpenPanelParametersPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5C291274290A669A00452A3E /* WebFrameProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C291272290A669900452A3E /* WebFrameProxyMessageReceiver.cpp */; };
 		5C291275290A669A00452A3E /* WebFrameMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C291273290A669A00452A3E /* WebFrameMessageReceiver.cpp */; };
@@ -5485,6 +5486,8 @@
 		5C1B38E02667140700B1545B /* WebPageNetworkParameters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebPageNetworkParameters.cpp; sourceTree = "<group>"; };
 		5C20CB9B1BB0DCD200895BB1 /* NetworkSessionCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkSessionCocoa.mm; sourceTree = "<group>"; };
 		5C20CB9E1BB0DD1800895BB1 /* NetworkSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkSession.h; sourceTree = "<group>"; };
+		5C2397D32949235700BB4E10 /* WebRemoteFrameClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebRemoteFrameClient.h; sourceTree = "<group>"; };
+		5C2397D42949235700BB4E10 /* WebRemoteFrameClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebRemoteFrameClient.cpp; sourceTree = "<group>"; };
 		5C26958420042F12005C439B /* WKOpenPanelParametersPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKOpenPanelParametersPrivate.h; sourceTree = "<group>"; };
 		5C29126F290A11FF00452A3E /* WebFrameProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebFrameProxy.messages.in; sourceTree = "<group>"; };
 		5C291270290A149300452A3E /* WebFrame.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebFrame.messages.in; sourceTree = "<group>"; };
@@ -12232,6 +12235,8 @@
 				D3B9484311FF4B6500032B39 /* WebPopupMenu.h */,
 				1A1E093118861D3800D2DC49 /* WebProgressTrackerClient.cpp */,
 				1A1E093218861D3800D2DC49 /* WebProgressTrackerClient.h */,
+				5C2397D42949235700BB4E10 /* WebRemoteFrameClient.cpp */,
+				5C2397D32949235700BB4E10 /* WebRemoteFrameClient.h */,
 				4671FF1E23217EFF001B64C7 /* WebResourceLoadObserver.cpp */,
 				4671FF1D23217EFF001B64C7 /* WebResourceLoadObserver.h */,
 				46DC53C128EB3D90005376B0 /* WebScreenOrientationManager.cpp */,
@@ -15693,6 +15698,7 @@
 				517B5F73275E9609002DC22D /* WebPushDaemonMain.h in Headers */,
 				517B5F97275EC5E5002DC22D /* WebPushMessage.h in Headers */,
 				DDA0A35C27E55E4F005E086E /* WebQuotaManager.h in Headers */,
+				5C2397D52949235800BB4E10 /* WebRemoteFrameClient.h in Headers */,
 				461CCCA6231485AA00B659B9 /* WebRemoteObjectRegistry.h in Headers */,
 				DDA0A29227E55E4D005E086E /* WebResource.h in Headers */,
 				A5860E71230F67FC00461AAE /* WebResourceInterceptController.h in Headers */,

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -529,7 +529,7 @@ void WebAutomationSessionProxy::resolveChildFrameWithNodeHandle(WebCore::PageIde
         return;
     }
 
-    WebCore::Frame* coreFrameFromElement = downcast<WebCore::HTMLFrameElementBase>(*coreElement).contentFrame();
+    auto* coreFrameFromElement = dynamicDowncast<WebCore::LocalFrame>(downcast<WebCore::HTMLFrameElementBase>(*coreElement).contentFrame());
     if (!coreFrameFromElement) {
         completionHandler(frameNotFoundErrorType, std::nullopt);
         return;

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -424,7 +424,7 @@ RefPtr<WebFrame> InjectedBundleNodeHandle::htmlFrameElementContentFrame()
     if (!is<HTMLFrameElement>(m_node))
         return nullptr;
 
-    Frame* frame = downcast<HTMLFrameElement>(*m_node).contentFrame();
+    auto* frame = dynamicDowncast<LocalFrame>(downcast<HTMLFrameElement>(*m_node).contentFrame());
     if (!frame)
         return nullptr;
 
@@ -436,7 +436,7 @@ RefPtr<WebFrame> InjectedBundleNodeHandle::htmlIFrameElementContentFrame()
     if (!is<HTMLIFrameElement>(m_node))
         return nullptr;
 
-    Frame* frame = downcast<HTMLIFrameElement>(*m_node).contentFrame();
+    auto* frame = dynamicDowncast<LocalFrame>(downcast<HTMLFrameElement>(*m_node).contentFrame());
     if (!frame)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebRemoteFrameClient.h"
+
+namespace WebKit {
+
+WebRemoteFrameClient::WebRemoteFrameClient(Ref<WebFrame>&& frame)
+    : m_frame(WTFMove(frame))
+{
+}
+
+}

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/RemoteFrameClient.h>
+
+namespace WebKit {
+
+class WebRemoteFrameClient final : public WebCore::RemoteFrameClient {
+public:
+    explicit WebRemoteFrameClient(Ref<WebFrame>&&);
+
+    WebFrame& webFrame() const { return m_frame.get(); }
+
+private:
+    Ref<WebFrame> m_frame;
+};
+
+}

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -48,6 +48,7 @@
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
 #include "WebProcess.h"
+#include "WebRemoteFrameClient.h"
 #include "WebsitePoliciesData.h"
 #include <JavaScriptCore/APICast.h>
 #include <JavaScriptCore/JSContextRef.h>
@@ -78,6 +79,8 @@
 #include <WebCore/JSRange.h>
 #include <WebCore/Page.h>
 #include <WebCore/PluginDocument.h>
+#include <WebCore/RemoteDOMWindow.h>
+#include <WebCore/RemoteFrame.h>
 #include <WebCore/RenderLayerCompositor.h>
 #include <WebCore/RenderTreeAsText.h>
 #include <WebCore/RenderView.h>
@@ -184,14 +187,17 @@ WebPage* WebFrame::page() const
 
 WebFrame* WebFrame::fromCoreFrame(const AbstractFrame& frame)
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(frame);
-    if (!localFrame)
-        return nullptr;
-    auto* webFrameLoaderClient = toWebFrameLoaderClient(localFrame->loader().client());
-    if (!webFrameLoaderClient)
-        return nullptr;
-
-    return &webFrameLoaderClient->webFrame();
+    if (auto* localFrame = dynamicDowncast<LocalFrame>(frame)) {
+        auto* webFrameLoaderClient = toWebFrameLoaderClient(localFrame->loader().client());
+        if (!webFrameLoaderClient)
+            return nullptr;
+        return &webFrameLoaderClient->webFrame();
+    }
+    if (auto* remoteFrame = dynamicDowncast<RemoteFrame>(frame)) {
+        auto& client = static_cast<const WebRemoteFrameClient&>(remoteFrame->client());
+        return &client.webFrame();
+    }
+    return nullptr;
 }
 
 WebCore::Frame* WebFrame::coreFrame() const
@@ -256,14 +262,38 @@ void WebFrame::continueWillSubmitForm(FormSubmitListenerIdentifier listenerID)
 
 void WebFrame::didCommitLoadInAnotherProcess()
 {
-    // FIXME: Replace m_coreFrame with a RemoteFrame.
+    RefPtr coreFrame = m_coreFrame.get();
+    if (!coreFrame)
+        return;
+
+    RefPtr webPage = m_page.get();
+    if (!webPage)
+        return;
+
+    auto* corePage = webPage->corePage();
+    if (!corePage)
+        return;
+
+    RefPtr parent = coreFrame->tree().parent();
+    if (!parent)
+        return;
+
+    RefPtr ownerElement = coreFrame->ownerElement();
+    parent->tree().removeChild(*coreFrame);
+    coreFrame->disconnectOwnerElement();
+    auto client = makeUniqueRef<WebRemoteFrameClient>(*this);
+    auto newFrame = WebCore::RemoteFrame::create(*corePage, m_frameID, ownerElement.get(), WTFMove(client));
+    m_coreFrame = newFrame.get();
+    if (ownerElement) {
+        // FIXME: This is also done in the WebCore::Frame constructor. Move one to make this more symmetric.
+        ownerElement->setContentFrame(*m_coreFrame);
+    }
 }
 
 void WebFrame::didFinishLoadInAnotherProcess()
 {
-    // FIXME: m_coreFrame should be a RemoteFrame by now, and this should be a function on RemoteFrame.
-    if (auto* localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get()))
-        localFrame->didFinishLoadInAnotherProcess();
+    if (auto* remoteFrame = dynamicDowncast<WebCore::RemoteFrame>(m_coreFrame.get()))
+        remoteFrame->didFinishLoadInAnotherProcess();
 }
 
 void WebFrame::invalidatePolicyListeners()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1974,16 +1974,13 @@ WebPage& WebPage::fromCorePage(Page& page)
     return static_cast<WebChromeClient&>(page.chrome().client()).page();
 }
 
-static std::optional<FrameTreeNodeData> frameTreeNodeData(Frame& frame)
+static std::optional<FrameTreeNodeData> frameTreeNodeData(AbstractFrame& frame)
 {
     std::optional<FrameTreeNodeData> info;
     if (auto* webFrame = WebFrame::fromCoreFrame(frame)) {
         Vector<FrameTreeNodeData> children;
         for (auto* childFrame = frame.tree().firstChild(); childFrame; childFrame = childFrame->tree().nextSibling()) {
-            auto* localChild = dynamicDowncast<LocalFrame>(childFrame);
-            if (!localChild)
-                continue;
-            if (auto childInfo = frameTreeNodeData(*localChild))
+            if (auto childInfo = frameTreeNodeData(*childFrame))
                 children.append(WTFMove(*childInfo));
         }
         info = FrameTreeNodeData {

--- a/Source/WebKitLegacy/win/DOMHTMLClasses.cpp
+++ b/Source/WebKitLegacy/win/DOMHTMLClasses.cpp
@@ -1586,7 +1586,7 @@ HRESULT DOMHTMLIFrameElement::contentFrame(_COM_Outptr_opt_ IWebFrame** result)
     *result = nullptr;
     ASSERT(m_element);
     HTMLIFrameElement& iFrameElement = downcast<HTMLIFrameElement>(*m_element);
-    COMPtr<IWebFrame> webFrame = kit(iFrameElement.contentFrame());
+    COMPtr<IWebFrame> webFrame = kit(dynamicDowncast<LocalFrame>(iFrameElement.contentFrame()));
     if (!webFrame)
         return E_FAIL;
     return webFrame.copyRefTo(result);


### PR DESCRIPTION
#### b6353876dac02d9eca484847c6990996244f103a
<pre>
Instantiate a RemoteFrame upon cross-origin iframe navigation when site isolation is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=249261">https://bugs.webkit.org/show_bug.cgi?id=249261</a>

Reviewed by Tim Horton and Chris Dumez.

This introduces RemoteFrameClient which is kind of like the RemoteFrame equivalent of FrameLoaderClient
for when a RemoteFrame needs to tell the layer above it to do things.  Right now it doesn&apos;t have any actions,
but it will.  It&apos;s also needed for the non-local implementation of WebFrame::fromCoreFrame.

HTMLFrameOwnerElement needs to be able to own a RemoteFrame, so it now owns an AbstractFrame.
Like elsewhere where we do dynamicDowncast&lt;LocalFrame&gt;, there is work yet to do, but that will be done later.

A RemoteFrame needs to own a RemoteDOMWindow like a Frame owns a Document which owns a DOMWindow.
To make this ownership work, I changed the RefPtr&lt;RemoteFrame&gt; to a WeakPtr&lt;RemoteFrame&gt; in RemoteDOMWindow
to prevent reference cycles.

In WebFrame::didCommitLoadInAnotherProcess, I disconnect the Frame and replace it with a RemoteFrame that
is hooked up well enough to pass the existing tests.  More tests need to be written and work needs to be done
there still.

In order to have most of the data available for the tests that use WKWebView._frames to verify things about
site isolation and processes, I had to make frameTreeNodeData take an AbstractFrame so it can return some
meaningful data.  Like almost everything in this PR, there&apos;s still room to fix things there, too!

I wrote an API test that doesn&apos;t really add coverage to this new work that wasn&apos;t already there, but it
sets up for the work I was trying to do when I found I needed to do this first.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::didAttachRenderers):
(WebCore::HTMLFrameElementBase::setFocus):
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::setContentFrame):
(WebCore::HTMLFrameOwnerElement::disconnectContentFrame):
(WebCore::HTMLFrameOwnerElement::contentDocument const):
* Source/WebCore/html/HTMLFrameOwnerElement.h:
(WebCore::HTMLFrameOwnerElement::contentFrame const):
* Source/WebCore/inspector/InspectorFrontendHost.cpp:
(WebCore::InspectorFrontendHost::evaluateScriptInExtensionTab):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::loadOrRedirectSubframe):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):
* Source/WebCore/page/AbstractFrame.cpp:
(WebCore::parentFrame):
(WebCore::AbstractFrame::AbstractFrame):
(WebCore::AbstractFrame::ownerElement const):
(WebCore::AbstractFrame::disconnectOwnerElement):
* Source/WebCore/page/AbstractFrame.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::contentFrameForNode):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusNavigationScope::scopeOwnedByIFrame):
(WebCore::FocusController::findFocusableElementDescendingIntoSubframes):
(WebCore::FocusController::advanceFocusInDocumentOrder):
(WebCore::FocusController::advanceFocusDirectionallyInContainer):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::Frame):
(WebCore::Frame::invalidateContentEventRegionsIfNeeded):
(WebCore::Frame::ownerRenderer const):
(WebCore::Frame::contentFrameFromWindowOrFrameElement):
(WebCore::Frame::ownerElement const): Deleted.
(WebCore::Frame::disconnectOwnerElement): Deleted.
(WebCore::Frame::didFinishLoadInAnotherProcess): Deleted.
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/page/ModalContainerObserver.cpp:
(WebCore::ModalContainerObserver::updateModalContainerIfNeeded):
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::SerializerMarkupAccumulator::appendCustomAttributes):
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::RemoteDOMWindow):
(WebCore::RemoteDOMWindow::~RemoteDOMWindow): Deleted.
* Source/WebCore/page/RemoteDOMWindow.h:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::RemoteFrame):
(WebCore::m_client):
(WebCore::RemoteFrame::virtualWindow const):
(WebCore::RemoteFrame::window const):
(WebCore::RemoteFrame::didFinishLoadInAnotherProcess):
(WebCore::RemoteFrame::setWindow): Deleted.
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/RemoteFrameClient.h: Copied from Source/WebCore/page/RemoteFrame.cpp.
(WebCore::RemoteFrameClient::~RemoteFrameClient):
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::resolveChildFrameWithNodeHandle):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::htmlFrameElementContentFrame):
(WebKit::InjectedBundleNodeHandle::htmlIFrameElementContentFrame):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp: Copied from Source/WebCore/page/RemoteFrame.cpp.
(WebKit::WebRemoteFrameClient::WebRemoteFrameClient):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h: Copied from Source/WebCore/page/RemoteFrame.cpp.
(WebKit::WebRemoteFrameClient::webFrame const):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::fromCoreFrame):
(WebKit::WebFrame::didCommitLoadInAnotherProcess):
(WebKit::WebFrame::didFinishLoadInAnotherProcess):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::frameTreeNodeData):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::enableSiteIsolation):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/257833@main">https://commits.webkit.org/257833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fabeacf26b3199ac98593f99d7f60df820b4ad95

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109490 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169725 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10209 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92585 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107379 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105926 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7718 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90998 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22393 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3089 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23908 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3064 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9194 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43394 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5379 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4899 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->