### PR TITLE
Recalculate intrinsic widths in the old containing block chain when going out of flow

### DIFF
--- a/LayoutTests/fast/block/positioning/static-to-abspos-parent-is-stf-expected.txt
+++ b/LayoutTests/fast/block/positioning/static-to-abspos-parent-is-stf-expected.txt
@@ -1,0 +1,5 @@
+Change from position:static to position:absolute when the parent is a shrink-to-fit container. The parent needs to recalculate its intrinsic size when this happens.
+
+There should be a black square below.
+
+PASS

--- a/LayoutTests/fast/block/positioning/static-to-abspos-parent-is-stf.html
+++ b/LayoutTests/fast/block/positioning/static-to-abspos-parent-is-stf.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="../../../resources/check-layout.js"></script>
+<p>Change from position:static to position:absolute when the parent is a shrink-to-fit container.
+    The parent needs to recalculate its intrinsic size when this happens.</p>
+<p>There should be a black <em>square</em> below.</p>
+<div id="container" style="float:left; border:20px solid black;" data-expected-width="40" data-expected-height="40">
+    <div id="test" style="width:100px; height:100px;"></div>
+</div>
+<p id="result" style="clear:both;"></p>
+<script>
+    var test = document.getElementById("test");
+    test.offsetTop;
+    test.style.position = "absolute";
+    checkLayout("#container", document.getElementById("result"));
+</script>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -284,7 +284,13 @@ void RenderBox::styleWillChange(StyleDifference diff, const RenderStyle& newStyl
         // When a layout hint happens and an object's position style changes, we have to do a layout
         // to dirty the render tree using the old position value now.
         if (diff == StyleDifference::Layout && parent() && oldStyle->position() != newStyle.position()) {
-            markContainingBlocksForLayout();
+            if (!oldStyle->hasOutOfFlowPosition() && newStyle.hasOutOfFlowPosition()) {
+                // We are about to go out of flow. Before that takes place, we need to mark the
+                // current containing block chain for preferred widths recalculation.
+                setNeedsLayoutAndPrefWidthsRecalc();
+            } else
+                markContainingBlocksForLayout();
+            
             if (oldStyle->position() != PositionType::Static && newStyle.hasOutOfFlowPosition())
                 parent()->setChildNeedsLayout();
             if (isFloating() && !isOutOfFlowPositioned() && newStyle.hasOutOfFlowPosition())


### PR DESCRIPTION
#### ca04468e9d7160d8fbc0d50879d984d2052abd02
<pre>
Recalculate intrinsic widths in the old containing block chain when going out of flow

Recalculate intrinsic widths in the old containing block chain when going out of flow
<a href="https://bugs.webkit.org/show_bug.cgi?id=249259">https://bugs.webkit.org/show_bug.cgi?id=249259</a>

Reviewed by Alan Baradlay.

This patch is to align Webkit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://src.chromium.org/viewvc/blink?revision=200836&amp">https://src.chromium.org/viewvc/blink?revision=200836&amp</a>;view=revision

When an object goes out of flow, it no longer contributes to the intrinisic
widths of its parents. We need to mark them for recalculation while we can
still walk that ancestry chain, i.e. before applying the style change.

* Source/WebCore/rendering/RenderBox.cpp:
(RenderBox::styleWillChange): Add logic for recalculation
* LayoutTests/fast/block/positioning/static-to-abpos-parent-is-stf.html: Add Test Case
* LayoutTests/fast/block/positioning/static-to-abpos-parent-is-stf-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/257980@main">https://commits.webkit.org/257980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/388202a051753ab3a2cb7fcd104eb68b5b67215b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109486 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169721 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10240 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92582 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107375 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34413 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89644 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77348 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3086 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23911 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3060 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43397 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5468 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4896 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->