### PR TITLE
Allow setting custom identifiers via the CSS Typed OM API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'animation-name' to CSS-wide keywords: unset
 PASS Can set 'animation-name' to CSS-wide keywords: revert
 PASS Can set 'animation-name' to var() references:  var(--A)
 PASS Can set 'animation-name' to the 'none' keyword: none
-FAIL Can set 'animation-name' to the 'custom-ident' keyword: custom-ident Invalid values
+PASS Can set 'animation-name' to the 'custom-ident' keyword: custom-ident
 PASS Setting 'animation-name' to a length throws TypeError
 PASS Setting 'animation-name' to a percent throws TypeError
 PASS Setting 'animation-name' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'container-name' to CSS-wide keywords: unset
 PASS Can set 'container-name' to CSS-wide keywords: revert
 PASS Can set 'container-name' to var() references:  var(--A)
 PASS Can set 'container-name' to the 'none' keyword: none
-FAIL Can set 'container-name' to the 'my-container' keyword: my-container Invalid values
+PASS Can set 'container-name' to the 'my-container' keyword: my-container
 PASS Setting 'container-name' to a length throws TypeError
 PASS Setting 'container-name' to a percent throws TypeError
 PASS Setting 'container-name' to a time throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt
@@ -5,7 +5,7 @@ FAIL Can set 'page' to CSS-wide keywords: unset assert_not_equals: Computed valu
 FAIL Can set 'page' to CSS-wide keywords: revert assert_not_equals: Computed value must not be null got disallowed value null
 FAIL Can set 'page' to var() references:  var(--A) assert_not_equals: Computed value must not be null got disallowed value null
 FAIL Can set 'page' to the 'auto' keyword: auto assert_not_equals: Computed value must not be null got disallowed value null
-FAIL Can set 'page' to the 'custom-ident' keyword: custom-ident Invalid values
+FAIL Can set 'page' to the 'custom-ident' keyword: custom-ident assert_not_equals: Computed value must not be null got disallowed value null
 PASS Setting 'page' to a length throws TypeError
 PASS Setting 'page' to a percent throws TypeError
 PASS Setting 'page' to a time throws TypeError

--- a/Source/WebCore/css/typedom/CSSKeywordValue.cpp
+++ b/Source/WebCore/css/typedom/CSSKeywordValue.cpp
@@ -78,7 +78,7 @@ RefPtr<CSSValue> CSSKeywordValue::toCSSValue() const
 {
     auto keyword = cssValueKeywordID(m_value);
     if (keyword == CSSValueInvalid)
-        return nullptr;
+        return CSSPrimitiveValue::create(m_value, CSSUnitType::CustomIdent);
     return CSSPrimitiveValue::createIdentifier(keyword);
 }
 


### PR DESCRIPTION
#### 66c0e84643e55fdac3b63d8bac7b958abe0d7120
<pre>
Allow setting custom identifiers via the CSS Typed OM API
<a href="https://bugs.webkit.org/show_bug.cgi?id=249270">https://bugs.webkit.org/show_bug.cgi?id=249270</a>

Reviewed by Simon Fraser.

Allow setting custom identifiers via the CSS Typed OM API:
- <a href="https://drafts.css-houdini.org/css-typed-om/#reify-ident">https://drafts.css-houdini.org/css-typed-om/#reify-ident</a>
- <a href="https://w3c.github.io/csswg-drafts/css-values-4/#identifier-value">https://w3c.github.io/csswg-drafts/css-values-4/#identifier-value</a>

Previously, we would fail to convert the CSSKeywordValue into a CSSValue if
the identifier is a pre-defined keyword. We now construct a &lt;custom-ident&gt;
CSSPrimitiveValue in this case.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt:
* Source/WebCore/css/typedom/CSSKeywordValue.cpp:
(WebCore::CSSKeywordValue::toCSSValue const):

Canonical link: <a href="https://commits.webkit.org/257859@main">https://commits.webkit.org/257859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b14b358a478d787d1b17c17ec54f78d0305fd3e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109469 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169705 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10187 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92566 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107359 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34402 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22377 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3072 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23892 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3044 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43378 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5395 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4882 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->