### PR TITLE
Address Web Extensions API review feedback.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -27,8 +27,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import <WebKit/_WKWebExtensionPermission.h>
 #import <WebKit/_WKWebExtensionMatchPattern.h>
+#import <WebKit/_WKWebExtensionPermission.h>
 
 #if TARGET_OS_IPHONE
 @class UIImage;
@@ -39,7 +39,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /*! @abstract Indicates a @link WKWebExtension @/link error. */
-WK_EXTERN NSErrorDomain const _WKWebExtensionErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+WK_EXTERN NSErrorDomain const _WKWebExtensionErrorDomain NS_SWIFT_NAME(_WKWebExtension.ErrorDomain) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 /*!
  @abstract Constants used by NSError to indicate errors in the @link WKWebExtension @/link domain.
@@ -115,9 +115,9 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 
 /*!
  @abstract The active errors for the extension.
- @discussion This property returns an array of NSError objects if there are any errors, or `nil` if there are no errors.
+ @discussion This property returns an array of NSError objects if there are any errors, or an empty array if there are no errors.
  */
-@property (nonatomic, nullable, readonly, copy) NSArray<NSError *> *errors;
+@property (nonatomic, readonly, copy) NSArray<NSError *> *errors;
 
 /*! @abstract The parsed manifest as a dictionary. */
 @property (nonatomic, readonly, copy) NSDictionary<NSString *, id> *manifest;
@@ -133,10 +133,10 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
  @param manifestVersion The version number to check.
  @result Returns `YES` if the extension specified a manifest version that is greater than or equal to `manifestVersion`.
  */
-- (BOOL)usesManifestVersion:(double)manifestVersion;
+- (BOOL)supportsManifestVersion:(double)manifestVersion;
 
 /*! @abstract The default locale for the extension. Returns `nil` if there was no default locale specified. */
-@property (nonatomic, readonly, copy) NSLocale *defaultLocale;
+@property (nonatomic, nullable, readonly, copy) NSLocale *defaultLocale;
 
 /*! @abstract The localized extension name. Returns `nil` if there was no name specified. */
 @property (nonatomic, nullable, readonly, copy) NSString *displayName;
@@ -156,39 +156,19 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 /*! @abstract The extension version. Returns `nil` if there was no version specified. */
 @property (nonatomic, nullable, readonly, copy) NSString *version;
 
+/*!
+ @abstract Returns the extension's icon image for the specified size.
+ @param size The size to use when looking up the icon.
+ @result The extension's icon image, or `nil` if the icon was unable to be loaded.
+ @discussion This icon should represent the extension in settings or other areas that show the extension. The returned image will be the best
+ match for the specified size that is available in the extension's icon set. If no matching icon can be found, the method will return `nil`.
+ @seealso actionIconForSize:
+ */
 #if TARGET_OS_IPHONE
-
-/*!
- @abstract Returns the extension's icon image for the specified size.
- @param size The size to use when looking up the icon.
- @result The extension's icon image, or `nil` if the icon was unable to be loaded.
- @discussion This icon should represent the extension in settings or other areas that show the extension. The returned image will be the best
- match for the specified size that is available in the extension's icon set. If no matching icon can be found, the method will return `nil`.
- @seealso actionIconForSize:
- */
 - (nullable UIImage *)iconForSize:(CGSize)size;
-
-/*!
- @abstract Returns the action icon for the specified size.
- @param size The size to use when looking up the action icon.
- @result The action icon, or `nil` if the icon was unable to be loaded.
- @discussion This icon should represent the extension in action sheets or toolbars. The returned image will be the best match for the specified
- size that is available in the extension's action icon set. If no matching icon is available, the method will fall back to the extension's icon.
- @seealso iconForSize:
- */
-- (nullable UIImage *)actionIconForSize:(CGSize)size;
-
 #else
-
-/*!
- @abstract Returns the extension's icon image for the specified size.
- @param size The size to use when looking up the icon.
- @result The extension's icon image, or `nil` if the icon was unable to be loaded.
- @discussion This icon should represent the extension in settings or other areas that show the extension. The returned image will be the best
- match for the specified size that is available in the extension's icon set. If no matching icon can be found, the method will return `nil`.
- @seealso actionIconForSize:
- */
 - (nullable NSImage *)iconForSize:(CGSize)size;
+#endif
 
 /*!
  @abstract Returns the action icon for the specified size.
@@ -198,8 +178,10 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
  size that is available in the extension's action icon set. If no matching icon is available, the method will fall back to the extension's icon.
  @seealso iconForSize:
  */
+#if TARGET_OS_IPHONE
+- (nullable UIImage *)actionIconForSize:(CGSize)size;
+#else
 - (nullable NSImage *)actionIconForSize:(CGSize)size;
-
 #endif
 
 /*! @abstract The set of permissions that the extension requires for its base functionality. */

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -159,9 +159,9 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
     return _webExtension->manifestVersion();
 }
 
-- (BOOL)usesManifestVersion:(double)version
+- (BOOL)supportsManifestVersion:(double)version
 {
-    return _webExtension->usesManifestVersion(version);
+    return _webExtension->supportsManifestVersion(version);
 }
 
 - (NSLocale *)defaultLocale
@@ -321,7 +321,7 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
     return 0;
 }
 
-- (BOOL)usesManifestVersion:(double)version
+- (BOOL)supportsManifestVersion:(double)version
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -37,40 +37,40 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /*! @abstract Indicates a @link WKWebExtensionContext @/link error. */
-WK_EXTERN NSErrorDomain const _WKWebExtensionContextErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+WK_EXTERN NSErrorDomain const _WKWebExtensionContextErrorDomain NS_SWIFT_NAME(_WKWebExtensionContext.ErrorDomain) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 /*!
  @abstract Constants used by NSError to indicate errors in the @link WKWebExtensionContext @/link domain.
  @constant WKWebExtensionContextErrorUnknown  Indicates that an unknown error occurred.
  @constant WKWebExtensionContextErrorAlreadyLoaded  Indicates that the context is already loaded by a @link WKWebExtensionController @/link.
  @constant WKWebExtensionContextErrorNotLoaded  Indicates that the context is not loaded by a @link WKWebExtensionController @/link.
- @constant WKWebExtensionContextErrorBaseURLTaken  Indicates that another context is already using the specified base URL.
+ @constant WKWebExtensionContextErrorBaseURLAlreadyInUse  Indicates that another context is already using the specified base URL.
  */
 typedef NS_ERROR_ENUM(_WKWebExtensionContextErrorDomain, _WKWebExtensionContextError) {
     _WKWebExtensionContextErrorUnknown = 1,
     _WKWebExtensionContextErrorAlreadyLoaded,
     _WKWebExtensionContextErrorNotLoaded,
-    _WKWebExtensionContextErrorBaseURLTaken,
+    _WKWebExtensionContextErrorBaseURLAlreadyInUse,
 } NS_SWIFT_NAME(_WKWebExtensionContext.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 /*!
- @abstract Constants used to indicate permission state in @link WKWebExtensionContext @/link.
- @constant WKWebExtensionContextPermissionStateDeniedExplicitly  Indicates that the permission was explicitly denied.
- @constant WKWebExtensionContextPermissionStateDeniedImplicitly  Indicates that the permission was implicitly denied because of another explicitly denied permission.
- @constant WKWebExtensionContextPermissionStateRequestedImplicitly  Indicates that the permission was implicitly requested because of another explicitly requested permission.
- @constant WKWebExtensionContextPermissionStateUnknown  Indicates that an unknown permission state.
- @constant WKWebExtensionContextPermissionStateRequestedExplicitly  Indicates that the permission was explicitly requested.
- @constant WKWebExtensionContextPermissionStateGrantedImplicitly  Indicates that the permission was implicitly granted because of another explicitly granted permission.
- @constant WKWebExtensionContextPermissionStateGrantedExplicitly  Indicates that the permission was explicitly granted permission.
+ @abstract Constants used to indicate permission status in @link WKWebExtensionContext @/link.
+ @constant WKWebExtensionContextPermissionStatusDeniedExplicitly  Indicates that the permission was explicitly denied.
+ @constant WKWebExtensionContextPermissionStatusDeniedImplicitly  Indicates that the permission was implicitly denied because of another explicitly denied permission.
+ @constant WKWebExtensionContextPermissionStatusRequestedImplicitly  Indicates that the permission was implicitly requested because of another explicitly requested permission.
+ @constant WKWebExtensionContextPermissionStatusUnknown  Indicates that an unknown permission status.
+ @constant WKWebExtensionContextPermissionStatusRequestedExplicitly  Indicates that the permission was explicitly requested.
+ @constant WKWebExtensionContextPermissionStatusGrantedImplicitly  Indicates that the permission was implicitly granted because of another explicitly granted permission.
+ @constant WKWebExtensionContextPermissionStatusGrantedExplicitly  Indicates that the permission was explicitly granted permission.
  */
-typedef NS_ENUM(NSInteger, _WKWebExtensionContextPermissionState) {
-    _WKWebExtensionContextPermissionStateDeniedExplicitly    = -3,
-    _WKWebExtensionContextPermissionStateDeniedImplicitly    = -2,
-    _WKWebExtensionContextPermissionStateRequestedImplicitly = -1,
-    _WKWebExtensionContextPermissionStateUnknown             =  0,
-    _WKWebExtensionContextPermissionStateRequestedExplicitly =  1,
-    _WKWebExtensionContextPermissionStateGrantedImplicitly   =  2,
-    _WKWebExtensionContextPermissionStateGrantedExplicitly   =  3,
+typedef NS_ENUM(NSInteger, _WKWebExtensionContextPermissionStatus) {
+    _WKWebExtensionContextPermissionStatusDeniedExplicitly    = -3,
+    _WKWebExtensionContextPermissionStatusDeniedImplicitly    = -2,
+    _WKWebExtensionContextPermissionStatusRequestedImplicitly = -1,
+    _WKWebExtensionContextPermissionStatusUnknown             =  0,
+    _WKWebExtensionContextPermissionStatusRequestedExplicitly =  1,
+    _WKWebExtensionContextPermissionStatusGrantedImplicitly   =  2,
+    _WKWebExtensionContextPermissionStatusGrantedExplicitly   =  3,
 } NS_SWIFT_NAME(_WKWebExtensionContext.PermissionState) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 /*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly granted permissions. */
@@ -133,7 +133,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
  @param extension The extension to use for the new web extension context.
  @result An initialized web extension context.
  */
-+ (instancetype)contextWithExtension:(_WKWebExtension *)extension;
++ (instancetype)contextForExtension:(_WKWebExtension *)extension;
 
 /*!
  @abstract Returns a web extension context initialized with a specified extension.
@@ -141,7 +141,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
  @result An initialized web extension context.
  @discussion This is a designated initializer.
  */
-- (instancetype)initWithExtension:(_WKWebExtension *)extension NS_DESIGNATED_INITIALIZER;
+- (instancetype)initForExtension:(_WKWebExtension *)extension NS_DESIGNATED_INITIALIZER;
 
 /*! @abstract The extension this context represents. */
 @property (nonatomic, readonly, strong) _WKWebExtension *webExtension;
@@ -180,48 +180,48 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 /*!
  @abstract The currently granted permissions and their expiration dates.
  @discussion Permissions that don't expire will have a distant future date. This will never include expired entries at time of access.
- Setting this property will replace all existing entries. Use this property for saving and restoring permission state in bulk.
+ Setting this property will replace all existing entries. Use this property for saving and restoring permission status in bulk.
 
  Permissions in this dictionary should be explicitly granted by the user before being added. Any permissions in this collection will not be
  presented for approval again until they expire.
- @seealso setPermissionState:forPermission:
- @seealso setPermissionState:forPermission:expirationDate:
+ @seealso setPermissionStatus:forPermission:
+ @seealso setPermissionStatus:forPermission:expirationDate:
  */
 @property (nonatomic, copy) NSDictionary<_WKWebExtensionPermission, NSDate *> *grantedPermissions;
 
 /*!
  @abstract The currently granted permission match patterns and their expiration dates.
  @discussion Match patterns that don't expire will have a distant future date. This will never include expired entries at time of access.
- Setting this property will replace all existing entries. Use this property for saving and restoring permission state in bulk.
+ Setting this property will replace all existing entries. Use this property for saving and restoring permission status in bulk.
 
  Match patterns in this dictionary should be explicitly granted by the user before being added. Any match pattern in this collection will not be
  presented for approval again until they expire.
- @seealso setPermissionState:forMatchPattern:
- @seealso setPermissionState:forMatchPattern:expirationDate:
+ @seealso setPermissionStatus:forMatchPattern:
+ @seealso setPermissionStatus:forMatchPattern:expirationDate:
  */
 @property (nonatomic, copy) NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *grantedPermissionMatchPatterns;
 
 /*!
  @abstract The currently denied permissions and their expiration dates.
  @discussion Permissions that don't expire will have a distant future date. This will never include expired entries at time of access.
- Setting this property will replace all existing entries. Use this property for saving and restoring permission state in bulk.
+ Setting this property will replace all existing entries. Use this property for saving and restoring permission status in bulk.
 
  Permissions in this dictionary should be explicitly denied by the user before being added. Any match pattern in this collection will not be
  presented for approval again until they expire.
- @seealso setPermissionState:forPermission:
- @seealso setPermissionState:forPermission:expirationDate:
+ @seealso setPermissionStatus:forPermission:
+ @seealso setPermissionStatus:forPermission:expirationDate:
  */
 @property (nonatomic, copy) NSDictionary<_WKWebExtensionPermission, NSDate *> *deniedPermissions;
 
 /*!
  @abstract The currently denied permission match patterns and their expiration dates.
  @discussion Match patterns that don't expire will have a distant future date. This will never include expired entries at time of access.
- Setting this property will replace all existing entries. Use this property for saving and restoring permission state in bulk.
+ Setting this property will replace all existing entries. Use this property for saving and restoring permission status in bulk.
 
  Match patterns in this dictionary should be explicitly denied by the user before being added. Any match pattern in this collection will not be
  presented for approval again until they expire.
- @seealso setPermissionState:forMatchPattern:
- @seealso setPermissionState:forMatchPattern:expirationDate:
+ @seealso setPermissionStatus:forMatchPattern:
+ @seealso setPermissionStatus:forMatchPattern:expirationDate:
  */
 @property (nonatomic, copy) NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *deniedPermissionMatchPatterns;
 
@@ -248,8 +248,8 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
  @abstract Checks the specified permission against the currently granted permissions.
  @seealso currentPermissions
  @seealso hasPermission:inTab:
- @seealso permissionStateForPermission:
- @seealso permissionStateForPermission:inTab:
+ @seealso permissionStatusForPermission:
+ @seealso permissionStatusForPermission:inTab:
 */
 - (BOOL)hasPermission:(_WKWebExtensionPermission)permission;
 
@@ -258,8 +258,8 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
  @discussion Permissions can be granted on a per-tab basis. When the tab is known, permission checks should always use this method.
  @seealso currentPermissions
  @seealso hasPermission:
- @seealso permissionStateForPermission:
- @seealso permissionStateForPermission:inTab:
+ @seealso permissionStatusForPermission:
+ @seealso permissionStatusForPermission:inTab:
  */
 - (BOOL)hasPermission:(_WKWebExtensionPermission)permission inTab:(nullable id <_WKWebExtensionTab>)tab;
 
@@ -267,10 +267,10 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
  @abstract Checks the specified URL against the currently granted permission match patterns.
  @seealso currentPermissionMatchPatterns
  @seealso hasAccessToURL:inTab:
- @seealso permissionStateForURL:
- @seealso permissionStateForURL:inTab:
- @seealso permissionStateForMatchPattern:
- @seealso permissionStateForMatchPattern:inTab:
+ @seealso permissionStatusForURL:
+ @seealso permissionStatusForURL:inTab:
+ @seealso permissionStatusForMatchPattern:
+ @seealso permissionStatusForMatchPattern:inTab:
  */
 - (BOOL)hasAccessToURL:(NSURL *)url;
 
@@ -279,10 +279,10 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
  @discussion Some match patterns can be granted on a per-tab basis. When the tab is known, access checks should always use this method.
  @seealso currentPermissionMatchPatterns
  @seealso hasAccessToURL:
- @seealso permissionStateForURL:
- @seealso permissionStateForURL:inTab:
- @seealso permissionStateForMatchPattern:
- @seealso permissionStateForMatchPattern:inTab:
+ @seealso permissionStatusForURL:
+ @seealso permissionStatusForURL:inTab:
+ @seealso permissionStatusForMatchPattern:
+ @seealso permissionStatusForMatchPattern:inTab:
  */
 - (BOOL)hasAccessToURL:(NSURL *)url inTab:(nullable id <_WKWebExtensionTab>)tab;
 
@@ -312,110 +312,110 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 /*!
  @abstract Checks the specified permission against the currently denied, granted, and requested permissions.
  @discussion Permissions can be granted on a per-tab basis. When the tab is known, access checks should always use the method that checks in a tab.
- @seealso permissionStateForPermission:inTab:
+ @seealso permissionStatusForPermission:inTab:
  @seealso hasPermission:
 */
-- (_WKWebExtensionContextPermissionState)permissionStateForPermission:(_WKWebExtensionPermission)permission;
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForPermission:(_WKWebExtensionPermission)permission;
 
 /*!
  @abstract Checks the specified permission against the currently denied, granted, and requested permissions in a specific tab.
  @discussion Permissions can be granted on a per-tab basis. When the tab is known, access checks should always use this method.
- @seealso permissionStateForPermission:
+ @seealso permissionStatusForPermission:
  @seealso hasPermission:inTab:
 */
-- (_WKWebExtensionContextPermissionState)permissionStateForPermission:(_WKWebExtensionPermission)permission inTab:(nullable id <_WKWebExtensionTab>)tab;
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForPermission:(_WKWebExtensionPermission)permission inTab:(nullable id <_WKWebExtensionTab>)tab;
 
 /*!
- @abstract Sets the state of a permission in all tabs and global contexts with a distant future expiration date.
- @discussion This method will update `grantedPermissions` and `deniedPermissions`. Use this method for changing a single permission's state.
- Only `WKWebExtensionContextPermissionStateDeniedExplicitly`, `WKWebExtensionContextPermissionStateUnknown`, and `WKWebExtensionContextPermissionStateGrantedExplicitly`
+ @abstract Sets the status of a permission in all tabs and global contexts with a distant future expiration date.
+ @discussion This method will update `grantedPermissions` and `deniedPermissions`. Use this method for changing a single permission's status.
+ Only `WKWebExtensionContextPermissionStatusDeniedExplicitly`, `WKWebExtensionContextPermissionStatusUnknown`, and `WKWebExtensionContextPermissionStatusGrantedExplicitly`
  states are allowed to be set using this method.
- @seealso setPermissionState:forPermission:expirationDate:
- @seealso setPermissionState:forPermission:inTab:
+ @seealso setPermissionStatus:forPermission:expirationDate:
+ @seealso setPermissionStatus:forPermission:inTab:
 */
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forPermission:(_WKWebExtensionPermission)permission;
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forPermission:(_WKWebExtensionPermission)permission;
 
 /*!
- @abstract Sets the state of a permission in all tabs and global contexts with a specific expiration date.
- @discussion This method will update `grantedPermissions` and `deniedPermissions`. Use this method for changing a single permission's state.
- Passing a `nil` expiration date will be treated as a distant future date. Only `WKWebExtensionContextPermissionStateDeniedExplicitly`, `WKWebExtensionContextPermissionStateUnknown`,
- and `WKWebExtensionContextPermissionStateGrantedExplicitly` states are allowed to be set using this method.
- @seealso setPermissionState:forPermission:
- @seealso setPermissionState:forPermission:inTab:
+ @abstract Sets the status of a permission in all tabs and global contexts with a specific expiration date.
+ @discussion This method will update `grantedPermissions` and `deniedPermissions`. Use this method for changing a single permission's status.
+ Passing a `nil` expiration date will be treated as a distant future date. Only `WKWebExtensionContextPermissionStatusDeniedExplicitly`, `WKWebExtensionContextPermissionStatusUnknown`,
+ and `WKWebExtensionContextPermissionStatusGrantedExplicitly` states are allowed to be set using this method.
+ @seealso setPermissionStatus:forPermission:
+ @seealso setPermissionStatus:forPermission:inTab:
 */
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forPermission:(_WKWebExtensionPermission)permission expirationDate:(nullable NSDate *)expirationDate;
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forPermission:(_WKWebExtensionPermission)permission expirationDate:(nullable NSDate *)expirationDate;
 
 /*!
  @abstract Checks the specified URL against the currently denied, granted, and requested permission match patterns.
  @discussion URLs and match patterns can be granted on a per-tab basis. When the tab is known, access checks should always use the method that checks in a tab.
- @seealso permissionStateForURL:inTab:
+ @seealso permissionStatusForURL:inTab:
  @seealso hasAccessToURL:
 */
-- (_WKWebExtensionContextPermissionState)permissionStateForURL:(NSURL *)url NS_SWIFT_NAME(permissionState(forURL:));
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForURL:(NSURL *)url NS_SWIFT_NAME(permissionStatus(forURL:));
 
 /*!
  @abstract Checks the specified URL against the currently denied, granted, and requested permission match patterns in a specific tab.
  @discussion URLs and match patterns can be granted on a per-tab basis. When the tab is known, access checks should always use this method.
- @seealso permissionStateForURL:
+ @seealso permissionStatusForURL:
  @seealso hasAccessToURL:inTab:
 */
-- (_WKWebExtensionContextPermissionState)permissionStateForURL:(NSURL *)url inTab:(nullable id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(permissionState(forURL:in:));
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForURL:(NSURL *)url inTab:(nullable id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(permissionStatus(forURL:in:));
 
 /*!
- @abstract Sets the state of a URL in all tabs and global contexts with a distant future expiration date.
- @discussion The URL is converted into a match pattern and will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single URL's state.
- Only `WKWebExtensionContextPermissionStateDeniedExplicitly`, `WKWebExtensionContextPermissionStateUnknown`, and `WKWebExtensionContextPermissionStateGrantedExplicitly`
+ @abstract Sets the status of a URL in all tabs and global contexts with a distant future expiration date.
+ @discussion The URL is converted into a match pattern and will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single URL's status.
+ Only `WKWebExtensionContextPermissionStatusDeniedExplicitly`, `WKWebExtensionContextPermissionStatusUnknown`, and `WKWebExtensionContextPermissionStatusGrantedExplicitly`
  states are allowed to be set using this method.
- @seealso setPermissionState:forURL:expirationDate:
- @seealso setPermissionState:forURL:inTab:
+ @seealso setPermissionStatus:forURL:expirationDate:
+ @seealso setPermissionStatus:forURL:inTab:
 */
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url NS_SWIFT_NAME(setPermissionState(_:forURL:));
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forURL:(NSURL *)url NS_SWIFT_NAME(setPermissionState(_:forURL:));
 
 /*!
- @abstract Sets the state of a URL in all tabs and global contexts with a specific expiration date.
- @discussion The URL is converted into a match pattern and will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single URL's state.
- Passing a `nil` expiration date will be treated as a distant future date. Only `WKWebExtensionContextPermissionStateDeniedExplicitly`, `WKWebExtensionContextPermissionStateUnknown`,
- and `WKWebExtensionContextPermissionStateGrantedExplicitly` states are allowed to be set using this method.
- @seealso setPermissionState:forURL:
- @seealso setPermissionState:forURL:inTab:
+ @abstract Sets the status of a URL in all tabs and global contexts with a specific expiration date.
+ @discussion The URL is converted into a match pattern and will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single URL's status.
+ Passing a `nil` expiration date will be treated as a distant future date. Only `WKWebExtensionContextPermissionStatusDeniedExplicitly`, `WKWebExtensionContextPermissionStatusUnknown`,
+ and `WKWebExtensionContextPermissionStatusGrantedExplicitly` states are allowed to be set using this method.
+ @seealso setPermissionStatus:forURL:
+ @seealso setPermissionStatus:forURL:inTab:
 */
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url expirationDate:(nullable NSDate *)expirationDate NS_SWIFT_NAME(setPermissionState(_:forURL:expirationDate:));
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forURL:(NSURL *)url expirationDate:(nullable NSDate *)expirationDate NS_SWIFT_NAME(setPermissionState(_:forURL:expirationDate:));
 
 /*!
  @abstract Checks the specified match pattern against the currently denied, granted, and requested permission match patterns.
  @discussion Match patterns can be granted on a per-tab basis. When the tab is known, access checks should always use the method that checks in a tab.
- @seealso permissionStateForMatchPattern:inTab:
+ @seealso permissionStatusForMatchPattern:inTab:
  @seealso hasAccessToURL:inTab:
 */
-- (_WKWebExtensionContextPermissionState)permissionStateForMatchPattern:(_WKWebExtensionMatchPattern *)pattern;
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForMatchPattern:(_WKWebExtensionMatchPattern *)pattern;
 
 /*!
  @abstract Checks the specified match pattern against the currently denied, granted, and requested permission match patterns in a specific tab.
  @discussion Match patterns can be granted on a per-tab basis. When the tab is known, access checks should always use this method.
- @seealso permissionStateForMatchPattern:
+ @seealso permissionStatusForMatchPattern:
  @seealso hasAccessToURL:inTab:
 */
-- (_WKWebExtensionContextPermissionState)permissionStateForMatchPattern:(_WKWebExtensionMatchPattern *)pattern inTab:(nullable id <_WKWebExtensionTab>)tab;
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForMatchPattern:(_WKWebExtensionMatchPattern *)pattern inTab:(nullable id <_WKWebExtensionTab>)tab;
 
 /*!
- @abstract Sets the state of a match pattern in all tabs and global contexts with a distant future expiration date.
- @discussion This method will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single match pattern's state.
- Only `WKWebExtensionContextPermissionStateDeniedExplicitly`, `WKWebExtensionContextPermissionStateUnknown`, and `WKWebExtensionContextPermissionStateGrantedExplicitly`
+ @abstract Sets the status of a match pattern in all tabs and global contexts with a distant future expiration date.
+ @discussion This method will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single match pattern's status.
+ Only `WKWebExtensionContextPermissionStatusDeniedExplicitly`, `WKWebExtensionContextPermissionStatusUnknown`, and `WKWebExtensionContextPermissionStatusGrantedExplicitly`
  states are allowed to be set using this method.
- @seealso setPermissionState:forMatchPattern:expirationDate:
- @seealso setPermissionState:forMatchPattern:inTab:
+ @seealso setPermissionStatus:forMatchPattern:expirationDate:
+ @seealso setPermissionStatus:forMatchPattern:inTab:
 */
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern;
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forMatchPattern:(_WKWebExtensionMatchPattern *)pattern;
 
 /*!
- @abstract Sets the state of a match pattern in all tabs and global contexts with a specific expiration date.
- @discussion This method will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single match pattern's state.
- Passing a `nil` expiration date will be treated as a distant future date. Only `WKWebExtensionContextPermissionStateDeniedExplicitly`, `WKWebExtensionContextPermissionStateUnknown`,
- and `WKWebExtensionContextPermissionStateGrantedExplicitly` states are allowed to be set using this method.
- @seealso setPermissionState:forMatchPattern:
- @seealso setPermissionState:forMatchPattern:inTab:
+ @abstract Sets the status of a match pattern in all tabs and global contexts with a specific expiration date.
+ @discussion This method will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single match pattern's status.
+ Passing a `nil` expiration date will be treated as a distant future date. Only `WKWebExtensionContextPermissionStatusDeniedExplicitly`, `WKWebExtensionContextPermissionStatusUnknown`,
+ and `WKWebExtensionContextPermissionStatusGrantedExplicitly` states are allowed to be set using this method.
+ @seealso setPermissionStatus:forMatchPattern:
+ @seealso setPermissionStatus:forMatchPattern:inTab:
 */
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern expirationDate:(nullable NSDate *)expirationDate;
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forMatchPattern:(_WKWebExtensionMatchPattern *)pattern expirationDate:(nullable NSDate *)expirationDate;
 
 /*!
  @abstract Returns a Boolean value indicating if a user gesture has been noted for the specified tab.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -60,14 +60,14 @@ _WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotifi
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-+ (instancetype)contextWithExtension:(_WKWebExtension *)extension
++ (instancetype)contextForExtension:(_WKWebExtension *)extension
 {
     NSParameterAssert(extension);
 
-    return [[self alloc] initWithExtension:extension];
+    return [[self alloc] initForExtension:extension];
 }
 
-- (instancetype)initWithExtension:(_WKWebExtension *)extension
+- (instancetype)initForExtension:(_WKWebExtension *)extension
 {
     NSParameterAssert(extension);
 
@@ -304,134 +304,134 @@ static inline NSSet<_WKWebExtensionMatchPattern *> *toAPI(const WebKit::WebExten
     return _webExtensionContext->hasPermission(url, tab);
 }
 
-static inline _WKWebExtensionContextPermissionState toAPI(WebKit::WebExtensionContext::PermissionState state)
+static inline _WKWebExtensionContextPermissionStatus toAPI(WebKit::WebExtensionContext::PermissionState status)
 {
-    switch (state) {
+    switch (status) {
     case WebKit::WebExtensionContext::PermissionState::DeniedExplicitly:
-        return _WKWebExtensionContextPermissionStateDeniedExplicitly;
+        return _WKWebExtensionContextPermissionStatusDeniedExplicitly;
     case WebKit::WebExtensionContext::PermissionState::DeniedImplicitly:
-        return _WKWebExtensionContextPermissionStateDeniedImplicitly;
+        return _WKWebExtensionContextPermissionStatusDeniedImplicitly;
     case WebKit::WebExtensionContext::PermissionState::RequestedImplicitly:
-        return _WKWebExtensionContextPermissionStateRequestedImplicitly;
+        return _WKWebExtensionContextPermissionStatusRequestedImplicitly;
     case WebKit::WebExtensionContext::PermissionState::Unknown:
-        return _WKWebExtensionContextPermissionStateUnknown;
+        return _WKWebExtensionContextPermissionStatusUnknown;
     case WebKit::WebExtensionContext::PermissionState::RequestedExplicitly:
-        return _WKWebExtensionContextPermissionStateRequestedExplicitly;
+        return _WKWebExtensionContextPermissionStatusRequestedExplicitly;
     case WebKit::WebExtensionContext::PermissionState::GrantedImplicitly:
-        return _WKWebExtensionContextPermissionStateGrantedImplicitly;
+        return _WKWebExtensionContextPermissionStatusGrantedImplicitly;
     case WebKit::WebExtensionContext::PermissionState::GrantedExplicitly:
-        return _WKWebExtensionContextPermissionStateGrantedExplicitly;
+        return _WKWebExtensionContextPermissionStatusGrantedExplicitly;
     }
 }
 
-static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensionContextPermissionState state)
+static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensionContextPermissionStatus status)
 {
-    switch (state) {
-    case _WKWebExtensionContextPermissionStateDeniedExplicitly:
+    switch (status) {
+    case _WKWebExtensionContextPermissionStatusDeniedExplicitly:
         return WebKit::WebExtensionContext::PermissionState::DeniedExplicitly;
-    case _WKWebExtensionContextPermissionStateDeniedImplicitly:
+    case _WKWebExtensionContextPermissionStatusDeniedImplicitly:
         return WebKit::WebExtensionContext::PermissionState::DeniedImplicitly;
-    case _WKWebExtensionContextPermissionStateRequestedImplicitly:
+    case _WKWebExtensionContextPermissionStatusRequestedImplicitly:
         return WebKit::WebExtensionContext::PermissionState::RequestedImplicitly;
-    case _WKWebExtensionContextPermissionStateUnknown:
+    case _WKWebExtensionContextPermissionStatusUnknown:
         return WebKit::WebExtensionContext::PermissionState::Unknown;
-    case _WKWebExtensionContextPermissionStateRequestedExplicitly:
+    case _WKWebExtensionContextPermissionStatusRequestedExplicitly:
         return WebKit::WebExtensionContext::PermissionState::RequestedExplicitly;
-    case _WKWebExtensionContextPermissionStateGrantedImplicitly:
+    case _WKWebExtensionContextPermissionStatusGrantedImplicitly:
         return WebKit::WebExtensionContext::PermissionState::GrantedImplicitly;
-    case _WKWebExtensionContextPermissionStateGrantedExplicitly:
+    case _WKWebExtensionContextPermissionStatusGrantedExplicitly:
         return WebKit::WebExtensionContext::PermissionState::GrantedExplicitly;
     }
 }
 
-- (_WKWebExtensionContextPermissionState)permissionStateForPermission:(_WKWebExtensionPermission)permission
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForPermission:(_WKWebExtensionPermission)permission
 {
     NSParameterAssert(permission);
 
-    return [self permissionStateForPermission:permission inTab:nil];
+    return [self permissionStatusForPermission:permission inTab:nil];
 }
 
-- (_WKWebExtensionContextPermissionState)permissionStateForPermission:(_WKWebExtensionPermission)permission inTab:(id<_WKWebExtensionTab>)tab
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForPermission:(_WKWebExtensionPermission)permission inTab:(id<_WKWebExtensionTab>)tab
 {
     NSParameterAssert(permission);
 
     return toAPI(_webExtensionContext->permissionState(permission, tab));
 }
 
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forPermission:(_WKWebExtensionPermission)permission
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forPermission:(_WKWebExtensionPermission)permission
 {
-    NSParameterAssert(state == _WKWebExtensionContextPermissionStateDeniedExplicitly || state == _WKWebExtensionContextPermissionStateUnknown || state == _WKWebExtensionContextPermissionStateGrantedExplicitly);
+    NSParameterAssert(status == _WKWebExtensionContextPermissionStatusDeniedExplicitly || status == _WKWebExtensionContextPermissionStatusUnknown || status == _WKWebExtensionContextPermissionStatusGrantedExplicitly);
     NSParameterAssert(permission);
 
-    [self setPermissionState:state forPermission:permission expirationDate:nil];
+    [self setPermissionStatus:status forPermission:permission expirationDate:nil];
 }
 
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forPermission:(_WKWebExtensionPermission)permission expirationDate:(NSDate *)expirationDate
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forPermission:(_WKWebExtensionPermission)permission expirationDate:(NSDate *)expirationDate
 {
-    NSParameterAssert(state == _WKWebExtensionContextPermissionStateDeniedExplicitly || state == _WKWebExtensionContextPermissionStateUnknown || state == _WKWebExtensionContextPermissionStateGrantedExplicitly);
+    NSParameterAssert(status == _WKWebExtensionContextPermissionStatusDeniedExplicitly || status == _WKWebExtensionContextPermissionStatusUnknown || status == _WKWebExtensionContextPermissionStatusGrantedExplicitly);
     NSParameterAssert(permission);
 
-    _webExtensionContext->setPermissionState(toImpl(state), permission, toImpl(expirationDate));
+    _webExtensionContext->setPermissionState(toImpl(status), permission, toImpl(expirationDate));
 }
 
-- (_WKWebExtensionContextPermissionState)permissionStateForURL:(NSURL *)url
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForURL:(NSURL *)url
 {
     NSParameterAssert(url);
 
-    return [self permissionStateForURL:url inTab:nil];
+    return [self permissionStatusForURL:url inTab:nil];
 }
 
-- (_WKWebExtensionContextPermissionState)permissionStateForURL:(NSURL *)url inTab:(id<_WKWebExtensionTab>)tab
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForURL:(NSURL *)url inTab:(id<_WKWebExtensionTab>)tab
 {
     NSParameterAssert(url);
 
     return toAPI(_webExtensionContext->permissionState(url, tab));
 }
 
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forURL:(NSURL *)url
 {
-    NSParameterAssert(state == _WKWebExtensionContextPermissionStateDeniedExplicitly || state == _WKWebExtensionContextPermissionStateUnknown || state == _WKWebExtensionContextPermissionStateGrantedExplicitly);
+    NSParameterAssert(status == _WKWebExtensionContextPermissionStatusDeniedExplicitly || status == _WKWebExtensionContextPermissionStatusUnknown || status == _WKWebExtensionContextPermissionStatusGrantedExplicitly);
     NSParameterAssert(url);
 
-    [self setPermissionState:state forURL:url expirationDate:nil];
+    [self setPermissionStatus:status forURL:url expirationDate:nil];
 }
 
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url expirationDate:(NSDate *)expirationDate
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forURL:(NSURL *)url expirationDate:(NSDate *)expirationDate
 {
-    NSParameterAssert(state == _WKWebExtensionContextPermissionStateDeniedExplicitly || state == _WKWebExtensionContextPermissionStateUnknown || state == _WKWebExtensionContextPermissionStateGrantedExplicitly);
+    NSParameterAssert(status == _WKWebExtensionContextPermissionStatusDeniedExplicitly || status == _WKWebExtensionContextPermissionStatusUnknown || status == _WKWebExtensionContextPermissionStatusGrantedExplicitly);
     NSParameterAssert(url);
 
-    _webExtensionContext->setPermissionState(toImpl(state), url, toImpl(expirationDate));
+    _webExtensionContext->setPermissionState(toImpl(status), url, toImpl(expirationDate));
 }
 
-- (_WKWebExtensionContextPermissionState)permissionStateForMatchPattern:(_WKWebExtensionMatchPattern *)pattern
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForMatchPattern:(_WKWebExtensionMatchPattern *)pattern
 {
     NSParameterAssert(pattern);
 
-    return [self permissionStateForMatchPattern:pattern inTab:nil];
+    return [self permissionStatusForMatchPattern:pattern inTab:nil];
 }
 
-- (_WKWebExtensionContextPermissionState)permissionStateForMatchPattern:(_WKWebExtensionMatchPattern *)pattern inTab:(id<_WKWebExtensionTab>)tab
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForMatchPattern:(_WKWebExtensionMatchPattern *)pattern inTab:(id<_WKWebExtensionTab>)tab
 {
     NSParameterAssert(pattern);
 
     return toAPI(_webExtensionContext->permissionState(pattern._webExtensionMatchPattern, tab));
 }
 
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forMatchPattern:(_WKWebExtensionMatchPattern *)pattern
 {
-    NSParameterAssert(state == _WKWebExtensionContextPermissionStateDeniedExplicitly || state == _WKWebExtensionContextPermissionStateUnknown || state == _WKWebExtensionContextPermissionStateGrantedExplicitly);
+    NSParameterAssert(status == _WKWebExtensionContextPermissionStatusDeniedExplicitly || status == _WKWebExtensionContextPermissionStatusUnknown || status == _WKWebExtensionContextPermissionStatusGrantedExplicitly);
     NSParameterAssert(pattern);
 
-    [self setPermissionState:state forMatchPattern:pattern expirationDate:nil];
+    [self setPermissionStatus:status forMatchPattern:pattern expirationDate:nil];
 }
 
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern expirationDate:(NSDate *)expirationDate
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forMatchPattern:(_WKWebExtensionMatchPattern *)pattern expirationDate:(NSDate *)expirationDate
 {
-    NSParameterAssert(state == _WKWebExtensionContextPermissionStateDeniedExplicitly || state == _WKWebExtensionContextPermissionStateUnknown || state == _WKWebExtensionContextPermissionStateGrantedExplicitly);
+    NSParameterAssert(status == _WKWebExtensionContextPermissionStatusDeniedExplicitly || status == _WKWebExtensionContextPermissionStatusUnknown || status == _WKWebExtensionContextPermissionStatusGrantedExplicitly);
     NSParameterAssert(pattern);
 
-    _webExtensionContext->setPermissionState(toImpl(state), pattern._webExtensionMatchPattern, toImpl(expirationDate));
+    _webExtensionContext->setPermissionState(toImpl(status), pattern._webExtensionMatchPattern, toImpl(expirationDate));
 }
 
 - (BOOL)hasAccessToAllURLs
@@ -480,12 +480,12 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 
 #else // ENABLE(WK_WEB_EXTENSIONS)
 
-+ (instancetype)contextWithExtension:(_WKWebExtension *)extension
++ (instancetype)contextForExtension:(_WKWebExtension *)extension
 {
     return nil;
 }
 
-- (instancetype)initWithExtension:(_WKWebExtension *)extension
+- (instancetype)initForExtension:(_WKWebExtension *)extension
 {
     return nil;
 }
@@ -607,57 +607,57 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
     return NO;
 }
 
-- (_WKWebExtensionContextPermissionState)permissionStateForPermission:(_WKWebExtensionPermission)permission
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForPermission:(_WKWebExtensionPermission)permission
 {
-    return _WKWebExtensionContextPermissionStateUnknown;
+    return _WKWebExtensionContextPermissionStatusUnknown;
 }
 
-- (_WKWebExtensionContextPermissionState)permissionStateForPermission:(_WKWebExtensionPermission)permission inTab:(id<_WKWebExtensionTab>)tab
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForPermission:(_WKWebExtensionPermission)permission inTab:(id<_WKWebExtensionTab>)tab
 {
-    return _WKWebExtensionContextPermissionStateUnknown;
+    return _WKWebExtensionContextPermissionStatusUnknown;
 }
 
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forPermission:(_WKWebExtensionPermission)permission
-{
-}
-
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forPermission:(_WKWebExtensionPermission)permission expirationDate:(NSDate *)expirationDate
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forPermission:(_WKWebExtensionPermission)permission
 {
 }
 
-- (_WKWebExtensionContextPermissionState)permissionStateForURL:(NSURL *)url
-{
-    return _WKWebExtensionContextPermissionStateUnknown;
-}
-
-- (_WKWebExtensionContextPermissionState)permissionStateForURL:(NSURL *)url inTab:(id<_WKWebExtensionTab>)tab
-{
-    return _WKWebExtensionContextPermissionStateUnknown;
-}
-
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forPermission:(_WKWebExtensionPermission)permission expirationDate:(NSDate *)expirationDate
 {
 }
 
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url expirationDate:(NSDate *)expirationDate
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForURL:(NSURL *)url
+{
+    return _WKWebExtensionContextPermissionStatusUnknown;
+}
+
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForURL:(NSURL *)url inTab:(id<_WKWebExtensionTab>)tab
+{
+    return _WKWebExtensionContextPermissionStatusUnknown;
+}
+
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forURL:(NSURL *)url
 {
 }
 
-- (_WKWebExtensionContextPermissionState)permissionStateForMatchPattern:(_WKWebExtensionMatchPattern *)pattern
-{
-    return _WKWebExtensionContextPermissionStateUnknown;
-}
-
-- (_WKWebExtensionContextPermissionState)permissionStateForMatchPattern:(_WKWebExtensionMatchPattern *)pattern inTab:(id<_WKWebExtensionTab>)tab
-{
-    return _WKWebExtensionContextPermissionStateUnknown;
-}
-
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forURL:(NSURL *)url expirationDate:(NSDate *)expirationDate
 {
 }
 
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern expirationDate:(NSDate *)expirationDate
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForMatchPattern:(_WKWebExtensionMatchPattern *)pattern
+{
+    return _WKWebExtensionContextPermissionStatusUnknown;
+}
+
+- (_WKWebExtensionContextPermissionStatus)permissionStatusForMatchPattern:(_WKWebExtensionMatchPattern *)pattern inTab:(id<_WKWebExtensionTab>)tab
+{
+    return _WKWebExtensionContextPermissionStatusUnknown;
+}
+
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forMatchPattern:(_WKWebExtensionMatchPattern *)pattern
+{
+}
+
+- (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forMatchPattern:(_WKWebExtensionMatchPattern *)pattern expirationDate:(NSDate *)expirationDate
 {
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h
@@ -29,11 +29,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class _WKWebExtensionController;
+
 /*!
  @abstract A `WKWebExtensionControllerConfiguration` object with which to initialize a web extension controller.
  @discussion Contains properties used to configure a @link WKWebExtensionController @/link.
 */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+NS_SWIFT_NAME(_WKWebExtensionController.Configuration)
 @interface _WKWebExtensionControllerConfiguration : NSObject <NSSecureCoding, NSCopying>
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h
@@ -29,6 +29,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class _WKWebExtension;
+
 /*! @abstract Indicates a @link WKWebExtensionMatchPattern @/link error. */
 WK_EXTERN NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
@@ -66,6 +68,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebExtensionMatchPatternOptions) {
  consist of three parts: scheme, host, and path.
  */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+NS_SWIFT_NAME(_WKWebExtension.MatchPattern)
 @interface _WKWebExtensionMatchPattern : NSObject <NSSecureCoding, NSCopying>
 
 + (instancetype)new NS_UNAVAILABLE;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -142,8 +142,8 @@ static _WKWebExtensionContextError toAPI(WebExtensionContext::Error error)
         return _WKWebExtensionContextErrorAlreadyLoaded;
     case WebExtensionContext::Error::NotLoaded:
         return _WKWebExtensionContextErrorNotLoaded;
-    case WebExtensionContext::Error::BaseURLTaken:
-        return _WKWebExtensionContextErrorBaseURLTaken;
+    case WebExtensionContext::Error::BaseURLAlreadyInUse:
+        return _WKWebExtensionContextErrorBaseURLAlreadyInUse;
     }
 }
 
@@ -165,8 +165,8 @@ NSError *WebExtensionContext::createError(Error error, NSString *customLocalized
         localizedDescription = WEB_UI_STRING("Extension context is not loaded.", "WKWebExtensionContextErrorNotLoaded description");
         break;
 
-    case Error::BaseURLTaken:
-        localizedDescription = WEB_UI_STRING("Another extension context is loaded with the same base URL.", "WKWebExtensionContextErrorBaseURLTaken description");
+    case Error::BaseURLAlreadyInUse:
+        localizedDescription = WEB_UI_STRING("Another extension context is loaded with the same base URL.", "WKWebExtensionContextErrorBaseURLAlreadyInUse description");
         break;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -68,7 +68,7 @@ bool WebExtensionController::load(WebExtensionContext& extensionContext, NSError
     if (!m_extensionContextBaseURLMap.add(extensionContext.baseURL(), extensionContext)) {
         m_extensionContexts.remove(extensionContext);
         if (outError)
-            *outError = extensionContext.createError(WebExtensionContext::Error::BaseURLTaken);
+            *outError = extensionContext.createError(WebExtensionContext::Error::BaseURLAlreadyInUse);
         return false;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -141,7 +141,7 @@ public:
     NSDictionary *manifest();
 
     double manifestVersion();
-    bool usesManifestVersion(double version) { return manifestVersion() >= version; }
+    bool supportsManifestVersion(double version) { return manifestVersion() >= version; }
 
 #if PLATFORM(MAC)
     SecStaticCodeRef bundleStaticCode();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -103,7 +103,7 @@ public:
         Unknown = 1,
         AlreadyLoaded,
         NotLoaded,
-        BaseURLTaken,
+        BaseURLAlreadyInUse,
     };
 
     enum class PermissionState : int8_t {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -38,7 +38,7 @@ bool WebExtensionAPIExtension::isPropertyAllowed(String name, WebPage*)
 {
     // This method was removed in manifest version 3.
     if (name == "getURL"_s)
-        return !extensionContext().usesManifestVersion(3);
+        return !extensionContext().supportsManifestVersion(3);
 
     ASSERT_NOT_REACHED();
     return false;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -56,7 +56,7 @@ public:
     NSDictionary *manifest() { return m_manifest.get(); }
 
     double manifestVersion() { return m_manifestVersion; }
-    bool usesManifestVersion(double version) { return manifestVersion() >= version; }
+    bool supportsManifestVersion(double version) { return manifestVersion() >= version; }
 
     bool inTestingMode() { return m_testingMode; }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -80,7 +80,7 @@ TEST(WKWebExtension, DisplayStringParsing)
     EXPECT_NULL(testExtension.displayVersion);
     EXPECT_NULL(testExtension.version);
     EXPECT_NULL(testExtension.displayDescription);
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
 
     testManifestDictionary[@"name"] = @"Test";
@@ -93,7 +93,7 @@ TEST(WKWebExtension, DisplayStringParsing)
     EXPECT_NS_EQUAL(testExtension.displayVersion, @"1.0");
     EXPECT_NS_EQUAL(testExtension.version, @"1.0");
     EXPECT_NS_EQUAL(testExtension.displayDescription, @"Test description.");
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     testManifestDictionary[@"short_name"] = @"Tst";
     testManifestDictionary[@"version_name"] = @"1.0 Final";
@@ -104,78 +104,78 @@ TEST(WKWebExtension, DisplayStringParsing)
     EXPECT_NS_EQUAL(testExtension.displayVersion, @"1.0 Final");
     EXPECT_NS_EQUAL(testExtension.version, @"1.0");
     EXPECT_NS_EQUAL(testExtension.displayDescription, @"Test description.");
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 }
 
 TEST(WKWebExtension, ActionParsing)
 {
     NSDictionary *testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0" };
     auto testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"browser_action": @{ } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"page_action": @{ } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"browser_action": @{ }, @"page_action": @{ } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"safari_action": @{ } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"browser_action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"page_action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     // action should be ignored in manifest v2.
     testManifestDictionary = @{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     // Manifest v3 looks for the "action" key.
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     // Manifest v3 should never find a browser_action.
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"browser_action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     // Or a page action.
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"page_action": @{ @"default_title": @"Button Title" } };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 }
@@ -190,21 +190,21 @@ TEST(WKWebExtension, ContentScriptsParsing)
     auto webkitURL = [NSURL URLWithString:@"https://webkit.org/"];
     auto exampleURL = [NSURL URLWithString:@"https://example.com/"];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js", @1, @"" ], @"css": @[ @NO, @"test.css", @"" ], @"matches": @[ @"*://*/" ], @"exclude_matches": @[ @"*://*.example.com/" ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js", @1, @"" ], @"css": @[ @NO, @"test.css", @"" ], @"matches": @[ @"*://*.example.com/" ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
@@ -213,7 +213,7 @@ TEST(WKWebExtension, ContentScriptsParsing)
     testManifestDictionary[@"content_scripts"] = @[ ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
@@ -221,7 +221,7 @@ TEST(WKWebExtension, ContentScriptsParsing)
     testManifestDictionary[@"content_scripts"] = @{ @"invalid": @YES };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
@@ -229,7 +229,7 @@ TEST(WKWebExtension, ContentScriptsParsing)
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
@@ -237,7 +237,7 @@ TEST(WKWebExtension, ContentScriptsParsing)
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ @"*://*.example.com/" ], @"run_at": @"invalid" } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
     EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
@@ -449,14 +449,14 @@ TEST(WKWebExtension, BackgroundParsing)
     EXPECT_TRUE(testExtension.backgroundContentIsPersistent);
 #endif
     EXPECT_FALSE(testExtension._backgroundContentUsesModules);
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     testManifestDictionary[@"background"] = @{ @"page": @"test.html", @"persistent": @NO };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
 #if TARGET_OS_IPHONE
     testManifestDictionary[@"background"] = @{ @"scripts": @[ @"test-1.js", @"", @"test-2.js" ], @"persistent": @NO };
@@ -472,21 +472,21 @@ TEST(WKWebExtension, BackgroundParsing)
 #else
     EXPECT_TRUE(testExtension.backgroundContentIsPersistent);
 #endif
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     testManifestDictionary[@"background"] = @{ @"service_worker": @"test.js" };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     testManifestDictionary[@"background"] = @{ @"service_worker": @"test.js", @"persistent": @NO };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     // Invalid cases
 
@@ -496,7 +496,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_TRUE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 #endif
@@ -507,7 +507,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -518,7 +518,7 @@ TEST(WKWebExtension, BackgroundParsing)
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
     EXPECT_FALSE(testExtension._backgroundContentUsesModules);
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -527,7 +527,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -536,7 +536,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -545,7 +545,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -554,7 +554,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -563,7 +563,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -572,7 +572,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -581,7 +581,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -590,7 +590,7 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_FALSE(testExtension.hasBackgroundContent);
     EXPECT_FALSE(testExtension.backgroundContentIsPersistent);
-    EXPECT_NOT_NULL(testExtension.errors);
+    EXPECT_NE(testExtension.errors.count, 0ul);;
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 
@@ -599,14 +599,14 @@ TEST(WKWebExtension, BackgroundParsing)
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_TRUE(testExtension._backgroundContentUsesModules);
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     testManifestDictionary[@"background"] = @{ @"scripts": @[ @"test.js", @"test2.js" ], @"type": @"module", @"persistent": @NO };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_TRUE(testExtension.hasBackgroundContent);
     EXPECT_TRUE(testExtension._backgroundContentUsesModules);
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
@@ -71,7 +71,7 @@ TEST(WKWebExtensionAPIExtension, GetURL)
 
     auto *manifest = @{ @"manifest_version": @2, @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO } };
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initWithExtension:extension.get()]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     // Set a base URL so it is a known value and not the default random one.
     manager.get().context.baseURL = [NSURL URLWithString:baseURLString];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -72,7 +72,7 @@ TEST(WKWebExtensionAPIRuntime, GetURL)
     ]);
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initWithExtension:extension.get()]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     // Set a base URL so it is a known value and not the default random one.
     manager.get().context.baseURL = [NSURL URLWithString:baseURLString];
@@ -92,7 +92,7 @@ TEST(WKWebExtensionAPIRuntime, Id)
     ]);
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initWithExtension:extension.get()]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     // Set an uniqueIdentifier so it is a known value and not the default random one.
     manager.get().context.uniqueIdentifier = uniqueIdentifier;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
@@ -43,20 +43,20 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
 
     NSMutableDictionary *testManifestDictionary = [@{ @"manifest_version": @2, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"permissions": @[ ] } mutableCopy];
     _WKWebExtension *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+    _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
     EXPECT_FALSE(testContext.hasAccessToAllHosts);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStatusUnknown);
     EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
     EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
@@ -64,20 +64,20 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
 
     testManifestDictionary[@"permissions"] = @[ @"tabs", @"https://*.example.com/*" ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+    testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
     EXPECT_FALSE(testContext.hasAccessToAllHosts);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateRequestedExplicitly);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedExplicitly);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStatusRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStatusUnknown);
     EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
     EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
@@ -85,20 +85,20 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
 
     testManifestDictionary[@"permissions"] = @[ @"tabs", @"<all_urls>" ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+    testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
     EXPECT_FALSE(testContext.hasAccessToAllHosts);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateRequestedExplicitly);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStatusRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStatusRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStatusRequestedImplicitly);
     EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
     EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
@@ -106,20 +106,20 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
 
     testManifestDictionary[@"permissions"] = @[ @"tabs", @"*://*/*" ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+    testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
     EXPECT_FALSE(testContext.hasAccessToAllHosts);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateRequestedExplicitly);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStatusRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStatusRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStatusRequestedImplicitly);
     EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
     EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
@@ -129,20 +129,20 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
     testManifestDictionary[@"permissions"] = @[ ];
     testManifestDictionary[@"host_permissions"] = @[ ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+    testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
     EXPECT_FALSE(testContext.hasAccessToAllHosts);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStatusUnknown);
     EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
     EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
@@ -151,20 +151,20 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
     testManifestDictionary[@"permissions"] = @[ @"tabs" ];
     testManifestDictionary[@"host_permissions"] = @[ @"https://*.example.com/*" ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+    testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
     EXPECT_FALSE(testContext.hasAccessToAllHosts);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateRequestedExplicitly);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedExplicitly);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStatusRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStatusUnknown);
     EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
     EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
@@ -172,20 +172,20 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
 
     testManifestDictionary[@"host_permissions"] = @[ @"<all_urls>" ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+    testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
     EXPECT_FALSE(testContext.hasAccessToAllHosts);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateRequestedExplicitly);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStatusRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStatusRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStatusRequestedImplicitly);
     EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
     EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
@@ -193,20 +193,20 @@ TEST(WKWebExtensionContext, DefaultPermissionChecks)
 
     testManifestDictionary[@"host_permissions"] = @[ @"*://*/*" ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+    testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
     EXPECT_FALSE(testContext.hasAccessToAllHosts);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateRequestedExplicitly);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStateRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStatusRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStatusRequestedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://unknown.com/"]], _WKWebExtensionContextPermissionStatusRequestedImplicitly);
     EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
     EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
@@ -220,51 +220,51 @@ TEST(WKWebExtensionContext, PermissionGranting)
 
     // Test defaults.
     _WKWebExtension *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
-    _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+    _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([testContext hasPermission:_WKWebExtensionPermissionCookies]);
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
     EXPECT_FALSE(testContext.hasAccessToAllHosts);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://webkit.org/"]]);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStateRequestedExplicitly);
-    EXPECT_EQ([testContext permissionStateForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStateUnknown);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedExplicitly);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateUnknown);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionTabs], _WKWebExtensionContextPermissionStatusRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStatusForPermission:_WKWebExtensionPermissionCookies], _WKWebExtensionContextPermissionStatusUnknown);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStatusUnknown);
     EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
     EXPECT_EQ(testContext.deniedPermissions.count, 0ul);
     EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
 
     // Grant a specific permission.
-    [testContext setPermissionState:_WKWebExtensionContextPermissionStateGrantedExplicitly forPermission:_WKWebExtensionPermissionTabs];
+    [testContext setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:_WKWebExtensionPermissionTabs];
 
     EXPECT_TRUE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_EQ(testContext.grantedPermissions.count, 1ul);
 
     // Grant a specific URL.
-    [testContext setPermissionState:_WKWebExtensionContextPermissionStateGrantedExplicitly forURL:[NSURL URLWithString:@"https://example.com/"]];
+    [testContext setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:[NSURL URLWithString:@"https://example.com/"]];
 
     EXPECT_TRUE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 1ul);
 
     // Deny a specific URL.
-    [testContext setPermissionState:_WKWebExtensionContextPermissionStateDeniedExplicitly forURL:[NSURL URLWithString:@"https://example.com/"]];
+    [testContext setPermissionStatus:_WKWebExtensionContextPermissionStatusDeniedExplicitly forURL:[NSURL URLWithString:@"https://example.com/"]];
 
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
     EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 1ul);
 
     // Deny a specific permission.
-    [testContext setPermissionState:_WKWebExtensionContextPermissionStateDeniedExplicitly forPermission:_WKWebExtensionPermissionTabs];
+    [testContext setPermissionStatus:_WKWebExtensionContextPermissionStatusDeniedExplicitly forPermission:_WKWebExtensionPermissionTabs];
 
     EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
     EXPECT_EQ(testContext.deniedPermissions.count, 1ul);
 
     // Reset all permissions.
-    [testContext setPermissionState:_WKWebExtensionContextPermissionStateUnknown forURL:[NSURL URLWithString:@"https://example.com/"]];
-    [testContext setPermissionState:_WKWebExtensionContextPermissionStateUnknown forPermission:_WKWebExtensionPermissionTabs];
+    [testContext setPermissionStatus:_WKWebExtensionContextPermissionStatusUnknown forURL:[NSURL URLWithString:@"https://example.com/"]];
+    [testContext setPermissionStatus:_WKWebExtensionContextPermissionStatusUnknown forPermission:_WKWebExtensionPermissionTabs];
 
     EXPECT_EQ(testContext.grantedPermissions.count, 0ul);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
@@ -272,28 +272,28 @@ TEST(WKWebExtensionContext, PermissionGranting)
     EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
 
     // Grant the all URLs match pattern.
-    [testContext setPermissionState:_WKWebExtensionContextPermissionStateGrantedExplicitly forMatchPattern:_WKWebExtensionMatchPattern.allURLsMatchPattern];
+    [testContext setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:_WKWebExtensionMatchPattern.allURLsMatchPattern];
 
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 1ul);
     EXPECT_TRUE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateGrantedImplicitly);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateGrantedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusGrantedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStatusGrantedImplicitly);
 
     // Reset a specific URL (should do nothing).
-    [testContext setPermissionState:_WKWebExtensionContextPermissionStateUnknown forURL:[NSURL URLWithString:@"https://example.com/"]];
+    [testContext setPermissionStatus:_WKWebExtensionContextPermissionStatusUnknown forURL:[NSURL URLWithString:@"https://example.com/"]];
 
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 1ul);
     EXPECT_TRUE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateGrantedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusGrantedImplicitly);
 
     // Deny a specific URL (should do nothing).
-    [testContext setPermissionState:_WKWebExtensionContextPermissionStateDeniedExplicitly forURL:[NSURL URLWithString:@"https://example.com/"]];
+    [testContext setPermissionStatus:_WKWebExtensionContextPermissionStatusDeniedExplicitly forURL:[NSURL URLWithString:@"https://example.com/"]];
 
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 1ul);
     EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 1ul);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateDeniedExplicitly);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStateGrantedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusDeniedExplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://webkit.org/"]], _WKWebExtensionContextPermissionStatusGrantedImplicitly);
 
     // Reset all match patterns.
     testContext.grantedPermissionMatchPatterns = @{ };
@@ -327,7 +327,7 @@ TEST(WKWebExtensionContext, PermissionGranting)
 
     EXPECT_TRUE(testContext.hasAccessToAllURLs);
     EXPECT_TRUE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateGrantedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusGrantedImplicitly);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 1ul);
     EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
 
@@ -344,7 +344,7 @@ TEST(WKWebExtensionContext, PermissionGranting)
 
     EXPECT_TRUE(testContext.hasAccessToAllURLs);
     EXPECT_TRUE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateGrantedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusGrantedImplicitly);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 1ul);
     EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
 
@@ -360,11 +360,11 @@ TEST(WKWebExtensionContext, PermissionGranting)
     EXPECT_EQ(testContext.deniedPermissionMatchPatterns.count, 0ul);
 
     // Test granting a match pattern that expire in 2 seconds.
-    [testContext setPermissionState:_WKWebExtensionContextPermissionStateGrantedExplicitly forMatchPattern:_WKWebExtensionMatchPattern.allURLsMatchPattern expirationDate:[NSDate dateWithTimeIntervalSinceNow:2]];
+    [testContext setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:_WKWebExtensionMatchPattern.allURLsMatchPattern expirationDate:[NSDate dateWithTimeIntervalSinceNow:2]];
 
     EXPECT_TRUE(testContext.hasAccessToAllURLs);
     EXPECT_TRUE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateGrantedImplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusGrantedImplicitly);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 1ul);
 
     // Sleep until after the match pattern expires.
@@ -372,11 +372,11 @@ TEST(WKWebExtensionContext, PermissionGranting)
 
     EXPECT_FALSE(testContext.hasAccessToAllURLs);
     EXPECT_FALSE([testContext hasAccessToURL:[NSURL URLWithString:@"https://example.com/"]]);
-    EXPECT_EQ([testContext permissionStateForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStateRequestedExplicitly);
+    EXPECT_EQ([testContext permissionStatusForURL:[NSURL URLWithString:@"https://example.com/"]], _WKWebExtensionContextPermissionStatusRequestedExplicitly);
     EXPECT_EQ(testContext.grantedPermissionMatchPatterns.count, 0ul);
 
     // Test granting a permission that expire in 2 seconds.
-    [testContext setPermissionState:_WKWebExtensionContextPermissionStateGrantedExplicitly forPermission:_WKWebExtensionPermissionTabs expirationDate:[NSDate dateWithTimeIntervalSinceNow:2]];
+    [testContext setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:_WKWebExtensionPermissionTabs expirationDate:[NSDate dateWithTimeIntervalSinceNow:2]];
 
     EXPECT_TRUE([testContext hasPermission:_WKWebExtensionPermissionTabs]);
     EXPECT_EQ(testContext.grantedPermissions.count, 1ul);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
@@ -65,16 +65,16 @@ TEST(WKWebExtensionController, LoadingAndUnloadingContexts)
     EXPECT_EQ(testController.extensionContexts.count, 0ul);
 
     _WKWebExtension *testExtensionOne = [[_WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @2, @"name": @"Test One", @"description": @"Test One", @"version": @"1.0" }];
-    _WKWebExtensionContext *testContextOne = [[_WKWebExtensionContext alloc] initWithExtension:testExtensionOne];
+    _WKWebExtensionContext *testContextOne = [[_WKWebExtensionContext alloc] initForExtension:testExtensionOne];
 
-    EXPECT_NULL(testExtensionOne.errors);
+    EXPECT_EQ(testExtensionOne.errors.count, 0ul);
     EXPECT_FALSE(testContextOne.loaded);
     EXPECT_NULL([testController extensionContextForExtension:testExtensionOne]);
 
     _WKWebExtension *testExtensionTwo = [[_WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @2, @"name": @"Test Two", @"description": @"Test Two", @"version": @"1.0" }];
-    _WKWebExtensionContext *testContextTwo = [[_WKWebExtensionContext alloc] initWithExtension:testExtensionTwo];
+    _WKWebExtensionContext *testContextTwo = [[_WKWebExtensionContext alloc] initForExtension:testExtensionTwo];
 
-    EXPECT_NULL(testExtensionTwo.errors);
+    EXPECT_EQ(testExtensionTwo.errors.count, 0ul);
     EXPECT_FALSE(testContextTwo.loaded);
     EXPECT_NULL([testController extensionContextForExtension:testExtensionTwo]);
 
@@ -82,7 +82,7 @@ TEST(WKWebExtensionController, LoadingAndUnloadingContexts)
     EXPECT_TRUE([testController loadExtensionContext:testContextOne error:&error]);
     EXPECT_NULL(error);
 
-    EXPECT_NULL(testExtensionOne.errors);
+    EXPECT_EQ(testExtensionOne.errors.count, 0ul);
     EXPECT_TRUE(testContextOne.loaded);
 
     EXPECT_EQ(testController.extensions.count, 1ul);
@@ -93,7 +93,7 @@ TEST(WKWebExtensionController, LoadingAndUnloadingContexts)
     EXPECT_NS_EQUAL(error.domain, _WKWebExtensionContextErrorDomain);
     EXPECT_EQ(error.code, _WKWebExtensionContextErrorAlreadyLoaded);
 
-    EXPECT_NULL(testExtensionOne.errors);
+    EXPECT_EQ(testExtensionOne.errors.count, 0ul);
     EXPECT_TRUE(testContextOne.loaded);
 
     EXPECT_EQ(testController.extensions.count, 1ul);
@@ -102,7 +102,7 @@ TEST(WKWebExtensionController, LoadingAndUnloadingContexts)
     EXPECT_TRUE([testController loadExtensionContext:testContextTwo error:&error]);
     EXPECT_NULL(error);
 
-    EXPECT_NULL(testExtensionTwo.errors);
+    EXPECT_EQ(testExtensionTwo.errors.count, 0ul);
     EXPECT_TRUE(testContextTwo.loaded);
 
     EXPECT_EQ(testController.extensions.count, 2ul);
@@ -111,7 +111,7 @@ TEST(WKWebExtensionController, LoadingAndUnloadingContexts)
     EXPECT_TRUE([testController unloadExtensionContext:testContextOne error:&error]);
     EXPECT_NULL(error);
 
-    EXPECT_NULL(testExtensionTwo.errors);
+    EXPECT_EQ(testExtensionTwo.errors.count, 0ul);
     EXPECT_FALSE(testContextOne.loaded);
 
     EXPECT_EQ(testController.extensions.count, 1ul);
@@ -120,7 +120,7 @@ TEST(WKWebExtensionController, LoadingAndUnloadingContexts)
     EXPECT_TRUE([testController unloadExtensionContext:testContextTwo error:&error]);
     EXPECT_NULL(error);
 
-    EXPECT_NULL(testExtensionTwo.errors);
+    EXPECT_EQ(testExtensionTwo.errors.count, 0ul);
     EXPECT_FALSE(testContextTwo.loaded);
 
     EXPECT_EQ(testController.extensions.count, 0ul);
@@ -131,7 +131,7 @@ TEST(WKWebExtensionController, LoadingAndUnloadingContexts)
     EXPECT_NS_EQUAL(error.domain, _WKWebExtensionContextErrorDomain);
     EXPECT_EQ(error.code, _WKWebExtensionContextErrorNotLoaded);
 
-    EXPECT_NULL(testExtensionTwo.errors);
+    EXPECT_EQ(testExtensionTwo.errors.count, 0ul);
     EXPECT_FALSE(testContextOne.loaded);
 }
 
@@ -145,10 +145,10 @@ TEST(WKWebExtensionController, BackgroundPageLoading)
     NSMutableDictionary *manifest = [@{ @"manifest_version": @2, @"name": @"Test One", @"description": @"Test One", @"version": @"1.0", @"background": @{ @"page": @"background.html", @"persistent": @NO } } mutableCopy];
 
     _WKWebExtension *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources];
-    _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+    _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
     _WKWebExtensionController *testController = [[_WKWebExtensionController alloc] init];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     NSError *error;
     EXPECT_TRUE([testController loadExtensionContext:testContext error:&error]);
@@ -158,19 +158,19 @@ TEST(WKWebExtensionController, BackgroundPageLoading)
     TestWebKitAPI::Util::runFor(4_s);
 
     // No errors means success.
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     EXPECT_TRUE([testController unloadExtensionContext:testContext error:&error]);
     EXPECT_NULL(error);
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     manifest[@"background"] = @{ @"service_worker": @"background.js" };
 
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources];
-    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+    testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     EXPECT_TRUE([testController loadExtensionContext:testContext error:&error]);
     EXPECT_NULL(error);
@@ -179,12 +179,12 @@ TEST(WKWebExtensionController, BackgroundPageLoading)
     TestWebKitAPI::Util::runFor(4_s);
 
     // No errors means success.
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     EXPECT_TRUE([testController unloadExtensionContext:testContext error:&error]);
     EXPECT_NULL(error);
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     testContext.baseURL = [NSURL URLWithString:@"test-extension://aaabbbcccddd"];
 
@@ -195,12 +195,12 @@ TEST(WKWebExtensionController, BackgroundPageLoading)
     TestWebKitAPI::Util::runFor(4_s);
 
     // No errors means success.
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     EXPECT_TRUE([testController unloadExtensionContext:testContext error:&error]);
     EXPECT_NULL(error);
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 }
 
 TEST(WKWebExtensionController, BackgroundPageWithModulesLoading)
@@ -213,10 +213,10 @@ TEST(WKWebExtensionController, BackgroundPageWithModulesLoading)
     NSMutableDictionary *manifest = [@{ @"manifest_version": @2, @"name": @"Test One", @"description": @"Test One", @"version": @"1.0", @"background": @{ @"scripts": @[ @"main.js", @"exports.js" ], @"type": @"module", @"persistent": @NO } } mutableCopy];
 
     _WKWebExtension *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources];
-    _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+    _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
     _WKWebExtensionController *testController = [[_WKWebExtensionController alloc] init];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     NSError *error;
     EXPECT_TRUE([testController loadExtensionContext:testContext error:&error]);
@@ -226,19 +226,19 @@ TEST(WKWebExtensionController, BackgroundPageWithModulesLoading)
     TestWebKitAPI::Util::runFor(4_s);
 
     // No errors means success.
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     EXPECT_TRUE([testController unloadExtensionContext:testContext error:&error]);
     EXPECT_NULL(error);
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     manifest[@"background"] = @{ @"service_worker": @"main.js", @"type": @"module" };
 
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources];
-    testContext = [[_WKWebExtensionContext alloc] initWithExtension:testExtension];
+    testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 
     EXPECT_TRUE([testController loadExtensionContext:testContext error:&error]);
     EXPECT_NULL(error);
@@ -247,7 +247,7 @@ TEST(WKWebExtensionController, BackgroundPageWithModulesLoading)
     TestWebKitAPI::Util::runFor(4_s);
 
     // No errors means success.
-    EXPECT_NULL(testExtension.errors);
+    EXPECT_EQ(testExtension.errors.count, 0ul);;
 }
 
 TEST(WKWebExtensionController, ContentScriptLoading)
@@ -273,10 +273,10 @@ TEST(WKWebExtensionController, ContentScriptLoading)
     ]);
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"content.js": contentScript }]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initWithExtension:extension.get()]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     _WKWebExtensionMatchPattern *matchPattern = [_WKWebExtensionMatchPattern matchPatternWithString:@"*://localhost/*"];
-    [manager.get().context setPermissionState:_WKWebExtensionContextPermissionStateGrantedExplicitly forMatchPattern:matchPattern];
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get()._webExtensionController = manager.get().controller;

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -38,7 +38,7 @@
 
 @interface TestWebExtensionManager : NSObject
 
-- (instancetype)initWithExtension:(_WKWebExtension *)extension;
+- (instancetype)initForExtension:(_WKWebExtension *)extension;
 
 @property (nonatomic, strong) _WKWebExtension *extension;
 @property (nonatomic, strong) _WKWebExtensionContext *context;

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -37,13 +37,13 @@
     bool _done;
 }
 
-- (instancetype)initWithExtension:(_WKWebExtension *)extension
+- (instancetype)initForExtension:(_WKWebExtension *)extension
 {
     if (!(self = [super init]))
         return nil;
 
     _extension = extension;
-    _context = [[_WKWebExtensionContext alloc] initWithExtension:extension];
+    _context = [[_WKWebExtensionContext alloc] initForExtension:extension];
     _controller = [[_WKWebExtensionController alloc] initWithConfiguration:_WKWebExtensionControllerConfiguration.nonPersistentConfiguration];
 
     _context._testingMode = YES;
@@ -140,7 +140,7 @@ namespace Util {
 
 RetainPtr<TestWebExtensionManager> loadAndRunExtension(_WKWebExtension *extension)
 {
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initWithExtension:extension]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension]);
     [manager loadAndRun];
     return manager;
 }


### PR DESCRIPTION
#### ea93ede6c8286408da95f2f625c94d6351d69225
<pre>
Address Web Extensions API review feedback.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249271">https://bugs.webkit.org/show_bug.cgi?id=249271</a>

Reviewed by Brian Weinstein.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
(-[_WKWebExtension supportsManifestVersion:]):
(-[_WKWebExtension usesManifestVersion:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
(NS_ERROR_ENUM):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(+[_WKWebExtensionContext contextForExtension:]):
(-[_WKWebExtensionContext initForExtension:]):
(toAPI):
(toImpl):
(-[_WKWebExtensionContext permissionStatusForPermission:]):
(-[_WKWebExtensionContext permissionStatusForPermission:inTab:]):
(-[_WKWebExtensionContext setPermissionStatus:forPermission:]):
(-[_WKWebExtensionContext setPermissionStatus:forPermission:expirationDate:]):
(-[_WKWebExtensionContext permissionStatusForURL:]):
(-[_WKWebExtensionContext permissionStatusForURL:inTab:]):
(-[_WKWebExtensionContext setPermissionStatus:forURL:]):
(-[_WKWebExtensionContext setPermissionStatus:forURL:expirationDate:]):
(-[_WKWebExtensionContext permissionStatusForMatchPattern:]):
(-[_WKWebExtensionContext permissionStatusForMatchPattern:inTab:]):
(-[_WKWebExtensionContext setPermissionStatus:forMatchPattern:]):
(-[_WKWebExtensionContext setPermissionStatus:forMatchPattern:expirationDate:]):
(+[_WKWebExtensionContext contextWithExtension:]): Deleted.
(-[_WKWebExtensionContext initWithExtension:]): Deleted.
(-[_WKWebExtensionContext permissionStateForPermission:]): Deleted.
(-[_WKWebExtensionContext permissionStateForPermission:inTab:]): Deleted.
(-[_WKWebExtensionContext setPermissionState:forPermission:]): Deleted.
(-[_WKWebExtensionContext setPermissionState:forPermission:expirationDate:]): Deleted.
(-[_WKWebExtensionContext permissionStateForURL:]): Deleted.
(-[_WKWebExtensionContext permissionStateForURL:inTab:]): Deleted.
(-[_WKWebExtensionContext setPermissionState:forURL:]): Deleted.
(-[_WKWebExtensionContext setPermissionState:forURL:expirationDate:]): Deleted.
(-[_WKWebExtensionContext permissionStateForMatchPattern:]): Deleted.
(-[_WKWebExtensionContext permissionStateForMatchPattern:inTab:]): Deleted.
(-[_WKWebExtensionContext setPermissionState:forMatchPattern:]): Deleted.
(-[_WKWebExtensionContext setPermissionState:forMatchPattern:expirationDate:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::createError):
(WebKit::WebExtension::errors):
(WebKit::WebExtension::actionIcon):
(WebKit::WebExtension::populateActionPropertiesIfNeeded):
(WebKit::WebExtension::populateBackgroundPropertiesIfNeeded):
(WebKit::WebExtension::populatePermissionsPropertiesIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::toAPI):
(WebKit::WebExtensionContext::createError):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::load):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
(WebKit::WebExtension::supportsManifestVersion):
(WebKit::WebExtension::usesManifestVersion): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
(WebKit::WebExtensionAPIExtension::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:]):
(TestWebKitAPI::Util::loadAndRunExtension):
(-[TestWebExtensionManager initWithExtension:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/257824@main">https://commits.webkit.org/257824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b0ac731cc631b480b8f98c47c5aa740134c4297

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100137 "61 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109471 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169707 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10189 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92568 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107361 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105906 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34404 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3073 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23894 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3046 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43380 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4883 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2764 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->