### PR TITLE
Queue and fire API events for Web Extensions.

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
@@ -86,7 +86,7 @@ void WebExtensionAPIEvent::addListener(WebPage* page, RefPtr<WebExtensionCallbac
     if (!page)
         return;
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(page->webPageProxyIdentifier(), m_type));
+    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(page->webPageProxyIdentifier(), m_type), extensionContext().identifier());
 }
 
 void WebExtensionAPIEvent::removeListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener)
@@ -98,7 +98,7 @@ void WebExtensionAPIEvent::removeListener(WebPage* page, RefPtr<WebExtensionCall
     if (!page)
         return;
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(page->webPageProxyIdentifier(), m_type));
+    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(page->webPageProxyIdentifier(), m_type), extensionContext().identifier());
 }
 
 bool WebExtensionAPIEvent::hasListener(RefPtr<WebExtensionCallbackHandler> listener)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm
@@ -73,7 +73,7 @@ void WebExtensionAPIWebNavigationEvent::addListener(WebPage* page, RefPtr<WebExt
     if (!page)
         return;
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(page->webPageProxyIdentifier(), m_type));
+    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(page->webPageProxyIdentifier(), m_type), extensionContext().identifier());
 }
 
 void WebExtensionAPIWebNavigationEvent::removeListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener)
@@ -85,7 +85,7 @@ void WebExtensionAPIWebNavigationEvent::removeListener(WebPage* page, RefPtr<Web
     if (!page)
         return;
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(page->webPageProxyIdentifier(), m_type));
+    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(page->webPageProxyIdentifier(), m_type), extensionContext().identifier());
 }
 
 bool WebExtensionAPIWebNavigationEvent::hasListener(RefPtr<WebExtensionCallbackHandler> listener)


### PR DESCRIPTION
#### 0ea5fe052ea303c25413797a41e1523d3c3d30c8
<pre>
Queue and fire API events for Web Extensions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249254">https://bugs.webkit.org/show_bug.cgi?id=249254</a>

Reviewed by Timothy Hatcher.

This patch adds support for queuing and firing API events for web extensions.

Testing:
I added an event listener in the background page of a test extension, and with this code below,
I tested that the completion handler was successfully called.
EventListenerTypeSet set;
set.add(WebExtensionEventListenerType::ActionOnClicked);
fireEvents(set, makeBlockPtr([ protectedThis = Ref { *this }]() {
    RELEASE_LOG(Extensions, &quot;KIARA&quot;);
}));

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::loadBackgroundContentIfNecessary):
(WebKit::WebExtensionContext::scheduleBackgroundContentToUnload):

(WebKit::WebExtensionContext::queueStartupAndInstallEventsForExtensionIfNecessary):
Queue and fire event listeners.

(WebKit::WebExtensionContext::performTasksAfterBackgroundContentLoads):
(WebKit::WebExtensionContext::fireEvents):
Call the completion handler for persistent background pages. For non-persistent backgrounds, wake
up the background page and queue the listener to fire after the background is loaded.

(WebKit::WebExtensionContext::queueEventToFireAfterBackgroundContentLoads):
Add completion handler to queue of listeners to fires.

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm:
(WebKit::WebExtensionAPIEvent::addListener):
(WebKit::WebExtensionAPIEvent::removeListener):
Add the extension context identifier. Without this, we won&apos;t know which context this message is for.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm:
(WebKit::WebExtensionAPIWebNavigationEvent::addListener):
(WebKit::WebExtensionAPIWebNavigationEvent::removeListener):
Add the extension context identifier. Without this, we won&apos;t know which context this message is for.

Canonical link: <a href="https://commits.webkit.org/257958@main">https://commits.webkit.org/257958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5cd8db3a7264c2b03903594c8b8f8b21f195e28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100501 "Failed to checkout and rebase branch from PR 7581") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/9650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/33552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/109821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/10578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106280 "Failed to checkout and rebase branch from PR 7581") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/10578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/33552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/10578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/33552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/33552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/3379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/33552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->