### PR TITLE
[JSC] Rewrite every SSE functions with AVX

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -1113,22 +1113,34 @@ public:
 
     void sqrtDouble(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.sqrtsd_rr(src, dst);
+        if (supportsAVX())
+            m_assembler.vsqrtsd_rrr(src, dst, dst);
+        else
+            m_assembler.sqrtsd_rr(src, dst);
     }
 
     void sqrtDouble(Address src, FPRegisterID dst)
     {
-        m_assembler.sqrtsd_mr(src.offset, src.base, dst);
+        if (supportsAVX())
+            m_assembler.vsqrtsd_mrr(src.offset, src.base, dst, dst);
+        else
+            m_assembler.sqrtsd_mr(src.offset, src.base, dst);
     }
 
     void sqrtFloat(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.sqrtss_rr(src, dst);
+        if (supportsAVX())
+            m_assembler.vsqrtss_rrr(src, dst, dst);
+        else
+            m_assembler.sqrtss_rr(src, dst);
     }
 
     void sqrtFloat(Address src, FPRegisterID dst)
     {
-        m_assembler.sqrtss_mr(src.offset, src.base, dst);
+        if (supportsAVX())
+            m_assembler.vsqrtss_mrr(src.offset, src.base, dst, dst);
+        else
+            m_assembler.sqrtss_mr(src.offset, src.base, dst);
     }
 
     void absDouble(FPRegisterID src, FPRegisterID dst)
@@ -1136,7 +1148,10 @@ public:
         ASSERT(src != dst);
         static constexpr double negativeZeroConstant = -0.0;
         loadDouble(TrustedImmPtr(&negativeZeroConstant), dst);
-        m_assembler.andnpd_rr(src, dst);
+        if (supportsAVX())
+            m_assembler.vandnpd_rrr(src, dst, dst);
+        else
+            m_assembler.andnpd_rr(src, dst);
     }
 
     void negateDouble(FPRegisterID src, FPRegisterID dst)
@@ -1144,77 +1159,122 @@ public:
         ASSERT(src != dst);
         static constexpr double negativeZeroConstant = -0.0;
         loadDouble(TrustedImmPtr(&negativeZeroConstant), dst);
-        m_assembler.xorpd_rr(src, dst);
+        if (supportsAVX())
+            m_assembler.vxorpd_rrr(src, dst, dst);
+        else
+            m_assembler.xorpd_rr(src, dst);
     }
 
     void ceilDouble(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.roundsd_rr(src, dst, X86Assembler::RoundingType::TowardInfiniti);
+        if (supportsAVX())
+            m_assembler.vroundsd_i8rrr(X86Assembler::RoundingType::TowardInfiniti, src, dst, dst);
+        else
+            m_assembler.roundsd_rr(src, dst, X86Assembler::RoundingType::TowardInfiniti);
     }
 
     void ceilDouble(Address src, FPRegisterID dst)
     {
-        m_assembler.roundsd_mr(src.offset, src.base, dst, X86Assembler::RoundingType::TowardInfiniti);
+        if (supportsAVX())
+            m_assembler.vroundsd_i8mrr(X86Assembler::RoundingType::TowardInfiniti, src.offset, src.base, dst, dst);
+        else
+            m_assembler.roundsd_mr(src.offset, src.base, dst, X86Assembler::RoundingType::TowardInfiniti);
     }
 
     void ceilFloat(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.roundss_rr(src, dst, X86Assembler::RoundingType::TowardInfiniti);
+        if (supportsAVX())
+            m_assembler.vroundss_i8rrr(X86Assembler::RoundingType::TowardInfiniti, src, dst, dst);
+        else
+            m_assembler.roundss_rr(src, dst, X86Assembler::RoundingType::TowardInfiniti);
     }
 
     void ceilFloat(Address src, FPRegisterID dst)
     {
-        m_assembler.roundss_mr(src.offset, src.base, dst, X86Assembler::RoundingType::TowardInfiniti);
+        if (supportsAVX())
+            m_assembler.vroundss_i8mrr(X86Assembler::RoundingType::TowardInfiniti, src.offset, src.base, dst, dst);
+        else
+            m_assembler.roundss_mr(src.offset, src.base, dst, X86Assembler::RoundingType::TowardInfiniti);
     }
 
     void floorDouble(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.roundsd_rr(src, dst, X86Assembler::RoundingType::TowardNegativeInfiniti);
+        if (supportsAVX())
+            m_assembler.vroundsd_i8rrr(X86Assembler::RoundingType::TowardNegativeInfiniti, src, dst, dst);
+        else
+            m_assembler.roundsd_rr(src, dst, X86Assembler::RoundingType::TowardNegativeInfiniti);
     }
 
     void floorDouble(Address src, FPRegisterID dst)
     {
-        m_assembler.roundsd_mr(src.offset, src.base, dst, X86Assembler::RoundingType::TowardNegativeInfiniti);
+        if (supportsAVX())
+            m_assembler.vroundsd_i8mrr(X86Assembler::RoundingType::TowardNegativeInfiniti, src.offset, src.base, dst, dst);
+        else
+            m_assembler.roundsd_mr(src.offset, src.base, dst, X86Assembler::RoundingType::TowardNegativeInfiniti);
     }
 
     void floorFloat(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.roundss_rr(src, dst, X86Assembler::RoundingType::TowardNegativeInfiniti);
+        if (supportsAVX())
+            m_assembler.vroundss_i8rrr(X86Assembler::RoundingType::TowardNegativeInfiniti, src, dst, dst);
+        else
+            m_assembler.roundss_rr(src, dst, X86Assembler::RoundingType::TowardNegativeInfiniti);
     }
 
     void floorFloat(Address src, FPRegisterID dst)
     {
-        m_assembler.roundss_mr(src.offset, src.base, dst, X86Assembler::RoundingType::TowardNegativeInfiniti);
+        if (supportsAVX())
+            m_assembler.vroundss_i8mrr(X86Assembler::RoundingType::TowardNegativeInfiniti, src.offset, src.base, dst, dst);
+        else
+            m_assembler.roundss_mr(src.offset, src.base, dst, X86Assembler::RoundingType::TowardNegativeInfiniti);
     }
 
     void roundTowardNearestIntDouble(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.roundsd_rr(src, dst, X86Assembler::RoundingType::ToNearestWithTiesToEven);
+        if (supportsAVX())
+            m_assembler.vroundsd_i8rrr(X86Assembler::RoundingType::ToNearestWithTiesToEven, src, dst, dst);
+        else
+            m_assembler.roundsd_rr(src, dst, X86Assembler::RoundingType::ToNearestWithTiesToEven);
     }
 
     void roundTowardNearestIntFloat(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.roundss_rr(src, dst, X86Assembler::RoundingType::ToNearestWithTiesToEven);
+        if (supportsAVX())
+            m_assembler.vroundss_i8rrr(X86Assembler::RoundingType::ToNearestWithTiesToEven, src, dst, dst);
+        else
+            m_assembler.roundss_rr(src, dst, X86Assembler::RoundingType::ToNearestWithTiesToEven);
     }
 
     void roundTowardZeroDouble(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.roundsd_rr(src, dst, X86Assembler::RoundingType::TowardZero);
+        if (supportsAVX())
+            m_assembler.vroundsd_i8rrr(X86Assembler::RoundingType::TowardZero, src, dst, dst);
+        else
+            m_assembler.roundsd_rr(src, dst, X86Assembler::RoundingType::TowardZero);
     }
 
     void roundTowardZeroDouble(Address src, FPRegisterID dst)
     {
-        m_assembler.roundsd_mr(src.offset, src.base, dst, X86Assembler::RoundingType::TowardZero);
+        if (supportsAVX())
+            m_assembler.vroundsd_i8mrr(X86Assembler::RoundingType::TowardZero, src.offset, src.base, dst, dst);
+        else
+            m_assembler.roundsd_mr(src.offset, src.base, dst, X86Assembler::RoundingType::TowardZero);
     }
 
     void roundTowardZeroFloat(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.roundss_rr(src, dst, X86Assembler::RoundingType::TowardZero);
+        if (supportsAVX())
+            m_assembler.vroundss_i8rrr(X86Assembler::RoundingType::TowardZero, src, dst, dst);
+        else
+            m_assembler.roundss_rr(src, dst, X86Assembler::RoundingType::TowardZero);
     }
 
     void roundTowardZeroFloat(Address src, FPRegisterID dst)
     {
-        m_assembler.roundss_mr(src.offset, src.base, dst, X86Assembler::RoundingType::TowardZero);
+        if (supportsAVX())
+            m_assembler.vroundss_i8mrr(X86Assembler::RoundingType::TowardZero, src.offset, src.base, dst, dst);
+        else
+            m_assembler.roundss_mr(src.offset, src.base, dst, X86Assembler::RoundingType::TowardZero);
     }
 
     // Memory access operations:
@@ -1459,7 +1519,11 @@ public:
     //
     void moveDouble(FPRegisterID src, FPRegisterID dest)
     {
-        if (src != dest)
+        if (src == dest)
+            return;
+        if (supportsAVX())
+            m_assembler.vmovaps_rr(src, dest);
+        else
             m_assembler.movaps_rr(src, dest);
     }
 
@@ -1475,12 +1539,18 @@ public:
 
     void loadDouble(Address address, FPRegisterID dest)
     {
-        m_assembler.movsd_mr(address.offset, address.base, dest);
+        if (supportsAVX())
+            m_assembler.vmovsd_mr(address.offset, address.base, dest);
+        else
+            m_assembler.movsd_mr(address.offset, address.base, dest);
     }
 
     void loadDouble(BaseIndex address, FPRegisterID dest)
     {
-        m_assembler.movsd_mr(address.offset, address.base, address.index, address.scale, dest);
+        if (supportsAVX())
+            m_assembler.vmovsd_mr(address.offset, address.base, address.index, address.scale, dest);
+        else
+            m_assembler.movsd_mr(address.offset, address.base, address.index, address.scale, dest);
     }
 
     void loadFloat(TrustedImmPtr address, FPRegisterID dest)
@@ -1495,52 +1565,82 @@ public:
 
     void loadFloat(Address address, FPRegisterID dest)
     {
-        m_assembler.movss_mr(address.offset, address.base, dest);
+        if (supportsAVX())
+            m_assembler.vmovss_mr(address.offset, address.base, dest);
+        else
+            m_assembler.movss_mr(address.offset, address.base, dest);
     }
 
     void loadFloat(BaseIndex address, FPRegisterID dest)
     {
-        m_assembler.movss_mr(address.offset, address.base, address.index, address.scale, dest);
+        if (supportsAVX())
+            m_assembler.vmovss_mr(address.offset, address.base, address.index, address.scale, dest);
+        else
+            m_assembler.movss_mr(address.offset, address.base, address.index, address.scale, dest);
     }
 
     void storeDouble(FPRegisterID src, Address address)
     {
-        m_assembler.movsd_rm(src, address.offset, address.base);
+        if (supportsAVX())
+            m_assembler.vmovsd_rm(src, address.offset, address.base);
+        else
+            m_assembler.movsd_rm(src, address.offset, address.base);
     }
     
     void storeDouble(FPRegisterID src, BaseIndex address)
     {
-        m_assembler.movsd_rm(src, address.offset, address.base, address.index, address.scale);
+        if (supportsAVX())
+            m_assembler.vmovsd_rm(src, address.offset, address.base, address.index, address.scale);
+        else
+            m_assembler.movsd_rm(src, address.offset, address.base, address.index, address.scale);
     }
 
     void storeFloat(FPRegisterID src, Address address)
     {
-        m_assembler.movss_rm(src, address.offset, address.base);
+        if (supportsAVX())
+            m_assembler.vmovss_rm(src, address.offset, address.base);
+        else
+            m_assembler.movss_rm(src, address.offset, address.base);
     }
 
     void storeFloat(FPRegisterID src, BaseIndex address)
     {
-        m_assembler.movss_rm(src, address.offset, address.base, address.index, address.scale);
+        if (supportsAVX())
+            m_assembler.vmovss_rm(src, address.offset, address.base, address.index, address.scale);
+        else
+            m_assembler.movss_rm(src, address.offset, address.base, address.index, address.scale);
     }
     
     void convertDoubleToFloat(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.cvtsd2ss_rr(src, dst);
+        if (supportsAVX())
+            m_assembler.vcvtsd2ss_rrr(src, dst, dst);
+        else
+            m_assembler.cvtsd2ss_rr(src, dst);
     }
 
     void convertDoubleToFloat(Address address, FPRegisterID dst)
     {
-        m_assembler.cvtsd2ss_mr(address.offset, address.base, dst);
+        if (supportsAVX())
+            m_assembler.vcvtsd2ss_mrr(address.offset, address.base, dst, dst);
+        else
+            m_assembler.cvtsd2ss_mr(address.offset, address.base, dst);
     }
 
     void convertFloatToDouble(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.cvtss2sd_rr(src, dst);
+        if (supportsAVX())
+            m_assembler.vcvtss2sd_rrr(src, dst, dst);
+        else
+            m_assembler.cvtss2sd_rr(src, dst);
     }
 
     void convertFloatToDouble(Address address, FPRegisterID dst)
     {
-        m_assembler.cvtss2sd_mr(address.offset, address.base, dst);
+        if (supportsAVX())
+            m_assembler.vcvtss2sd_mrr(address.offset, address.base, dst, dst);
+        else
+            m_assembler.cvtss2sd_mr(address.offset, address.base, dst);
     }
 
     void addDouble(FPRegisterID src, FPRegisterID dest)
@@ -1661,31 +1761,49 @@ public:
 
     void divDouble(FPRegisterID src, FPRegisterID dest)
     {
-        m_assembler.divsd_rr(src, dest);
+        // https://www.felixcloutier.com/x86/divsd
+        // VEX.LIG.F2.0F.WIG 5E /r VDIVSD xmm1, xmm2, xmm3/m64
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        if (supportsAVX())
+            m_assembler.vdivsd_rrr(src, dest, dest);
+        else
+            m_assembler.divsd_rr(src, dest);
     }
 
     void divDouble(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
     {
         // B := A / B is invalid.
         ASSERT(op1 == dest || op2 != dest);
-
-        moveDouble(op1, dest);
-        divDouble(op2, dest);
+        if (supportsAVX())
+            m_assembler.vdivsd_rrr(op2, op1, dest);
+        else {
+            moveDouble(op1, dest);
+            divDouble(op2, dest);
+        }
     }
 
     void divDouble(Address src, FPRegisterID dest)
     {
-        m_assembler.divsd_mr(src.offset, src.base, dest);
+        if (supportsAVX())
+            m_assembler.vdivsd_mrr(src.offset, src.base, dest, dest);
+        else
+            m_assembler.divsd_mr(src.offset, src.base, dest);
     }
 
     void divFloat(FPRegisterID src, FPRegisterID dest)
     {
-        m_assembler.divss_rr(src, dest);
+        if (supportsAVX())
+            m_assembler.vdivss_rrr(src, dest, dest);
+        else
+            m_assembler.divss_rr(src, dest);
     }
 
     void divFloat(Address src, FPRegisterID dest)
     {
-        m_assembler.divss_mr(src.offset, src.base, dest);
+        if (supportsAVX())
+            m_assembler.vdivss_mrr(src.offset, src.base, dest, dest);
+        else
+            m_assembler.divss_mr(src.offset, src.base, dest);
     }
 
     void subDouble(FPRegisterID src, FPRegisterID dest)
@@ -1889,143 +2007,217 @@ public:
     void andDouble(FPRegisterID src, FPRegisterID dst)
     {
         // ANDPS is defined on 128bits and is shorter than ANDPD.
-        m_assembler.andps_rr(src, dst);
+        if (supportsAVX())
+            m_assembler.vandps_rrr(src, dst, dst);
+        else
+            m_assembler.andps_rr(src, dst);
     }
 
     void andDouble(FPRegisterID src1, FPRegisterID src2, FPRegisterID dst)
     {
-        if (src1 == dst)
-            andDouble(src2, dst);
+        if (supportsAVX())
+            m_assembler.vandps_rrr(src2, src1, dst);
         else {
-            moveDouble(src2, dst);
-            andDouble(src1, dst);
+            if (src1 == dst)
+                andDouble(src2, dst);
+            else {
+                moveDouble(src2, dst);
+                andDouble(src1, dst);
+            }
         }
     }
 
     void andFloat(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.andps_rr(src, dst);
+        if (supportsAVX())
+            m_assembler.vandps_rrr(src, dst, dst);
+        else
+            m_assembler.andps_rr(src, dst);
     }
 
     void andFloat(FPRegisterID src1, FPRegisterID src2, FPRegisterID dst)
     {
-        if (src1 == dst)
-            andFloat(src2, dst);
+        if (supportsAVX())
+            m_assembler.vandps_rrr(src2, src1, dst);
         else {
-            moveDouble(src2, dst);
-            andFloat(src1, dst);
+            if (src1 == dst)
+                andFloat(src2, dst);
+            else {
+                moveDouble(src2, dst);
+                andFloat(src1, dst);
+            }
         }
     }
 
     void orDouble(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.orps_rr(src, dst);
+        if (supportsAVX())
+            m_assembler.vorps_rrr(src, dst, dst);
+        else
+            m_assembler.orps_rr(src, dst);
     }
 
     void orDouble(FPRegisterID src1, FPRegisterID src2, FPRegisterID dst)
     {
-        if (src1 == dst)
-            orDouble(src2, dst);
+        if (supportsAVX())
+            m_assembler.vorps_rrr(src2, src1, dst);
         else {
-            moveDouble(src2, dst);
-            orDouble(src1, dst);
+            if (src1 == dst)
+                orDouble(src2, dst);
+            else {
+                moveDouble(src2, dst);
+                orDouble(src1, dst);
+            }
         }
     }
 
     void orFloat(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.orps_rr(src, dst);
+        if (supportsAVX())
+            m_assembler.vorps_rrr(src, dst, dst);
+        else
+            m_assembler.orps_rr(src, dst);
     }
 
     void orFloat(FPRegisterID src1, FPRegisterID src2, FPRegisterID dst)
     {
-        if (src1 == dst)
-            orFloat(src2, dst);
+        if (supportsAVX())
+            m_assembler.vorps_rrr(src2, src1, dst);
         else {
-            moveDouble(src2, dst);
-            orFloat(src1, dst);
+            if (src1 == dst)
+                orFloat(src2, dst);
+            else {
+                moveDouble(src2, dst);
+                orFloat(src1, dst);
+            }
         }
     }
 
     void xorDouble(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.xorps_rr(src, dst);
+        if (supportsAVX())
+            m_assembler.vxorps_rrr(src, dst, dst);
+        else
+            m_assembler.xorps_rr(src, dst);
     }
 
     void xorDouble(FPRegisterID src1, FPRegisterID src2, FPRegisterID dst)
     {
-        if (src1 == dst)
-            xorDouble(src2, dst);
+        if (supportsAVX())
+            m_assembler.vxorps_rrr(src2, src1, dst);
         else {
-            moveDouble(src2, dst);
-            xorDouble(src1, dst);
+            if (src1 == dst)
+                xorDouble(src2, dst);
+            else {
+                moveDouble(src2, dst);
+                xorDouble(src1, dst);
+            }
         }
     }
 
     void xorFloat(FPRegisterID src, FPRegisterID dst)
     {
-        m_assembler.xorps_rr(src, dst);
+        if (supportsAVX())
+            m_assembler.vxorps_rrr(src, dst, dst);
+        else
+            m_assembler.xorps_rr(src, dst);
     }
 
     void xorFloat(FPRegisterID src1, FPRegisterID src2, FPRegisterID dst)
     {
-        if (src1 == dst)
-            xorFloat(src2, dst);
+        if (supportsAVX())
+            m_assembler.vxorps_rrr(src2, src1, dst);
         else {
-            moveDouble(src2, dst);
-            xorFloat(src1, dst);
+            if (src1 == dst)
+                xorFloat(src2, dst);
+            else {
+                moveDouble(src2, dst);
+                xorFloat(src1, dst);
+            }
         }
     }
 
     void convertInt32ToDouble(RegisterID src, FPRegisterID dest)
     {
-        m_assembler.cvtsi2sd_rr(src, dest);
+        if (supportsAVX())
+            m_assembler.vcvtsi2sd_rrr(src, dest, dest);
+        else
+            m_assembler.cvtsi2sd_rr(src, dest);
     }
 
     void convertInt32ToDouble(Address src, FPRegisterID dest)
     {
-        m_assembler.cvtsi2sd_mr(src.offset, src.base, dest);
+        if (supportsAVX())
+            m_assembler.vcvtsi2sd_mrr(src.offset, src.base, dest, dest);
+        else
+            m_assembler.cvtsi2sd_mr(src.offset, src.base, dest);
     }
 
     void convertInt32ToFloat(RegisterID src, FPRegisterID dest)
     {
-        m_assembler.cvtsi2ss_rr(src, dest);
+        if (supportsAVX())
+            m_assembler.vcvtsi2ss_rrr(src, dest, dest);
+        else
+            m_assembler.cvtsi2ss_rr(src, dest);
     }
 
     void convertInt32ToFloat(Address src, FPRegisterID dest)
     {
-        m_assembler.cvtsi2ss_mr(src.offset, src.base, dest);
+        if (supportsAVX())
+            m_assembler.vcvtsi2ss_mrr(src.offset, src.base, dest, dest);
+        else
+            m_assembler.cvtsi2ss_mr(src.offset, src.base, dest);
     }
 
     Jump branchDouble(DoubleCondition cond, FPRegisterID left, FPRegisterID right)
     {
-        if (cond & DoubleConditionBitInvert)
-            m_assembler.ucomisd_rr(left, right);
-        else
-            m_assembler.ucomisd_rr(right, left);
+        if (cond & DoubleConditionBitInvert) {
+            if (supportsAVX())
+                m_assembler.vucomisd_rr(left, right);
+            else
+                m_assembler.ucomisd_rr(left, right);
+        } else {
+            if (supportsAVX())
+                m_assembler.vucomisd_rr(right, left);
+            else
+                m_assembler.ucomisd_rr(right, left);
+        }
         return jumpAfterFloatingPointCompare(cond, left, right);
     }
 
     Jump branchFloat(DoubleCondition cond, FPRegisterID left, FPRegisterID right)
     {
-        if (cond & DoubleConditionBitInvert)
-            m_assembler.ucomiss_rr(left, right);
-        else
-            m_assembler.ucomiss_rr(right, left);
+        if (cond & DoubleConditionBitInvert) {
+            if (supportsAVX())
+                m_assembler.vucomiss_rr(left, right);
+            else
+                m_assembler.ucomiss_rr(left, right);
+        } else {
+            if (supportsAVX())
+                m_assembler.vucomiss_rr(right, left);
+            else
+                m_assembler.ucomiss_rr(right, left);
+        }
         return jumpAfterFloatingPointCompare(cond, left, right);
     }
 
     void compareDouble(DoubleCondition cond, FPRegisterID left, FPRegisterID right, RegisterID dest)
     {
         floatingPointCompare(cond, left, right, dest, [this] (FPRegisterID arg1, FPRegisterID arg2) {
-            m_assembler.ucomisd_rr(arg1, arg2);
+            if (supportsAVX())
+                m_assembler.vucomisd_rr(arg1, arg2);
+            else
+                m_assembler.ucomisd_rr(arg1, arg2);
         });
     }
 
     void compareFloat(DoubleCondition cond, FPRegisterID left, FPRegisterID right, RegisterID dest)
     {
         floatingPointCompare(cond, left, right, dest, [this] (FPRegisterID arg1, FPRegisterID arg2) {
-            m_assembler.ucomiss_rr(arg1, arg2);
+            if (supportsAVX())
+                m_assembler.vucomiss_rr(arg1, arg2);
+            else
+                m_assembler.ucomiss_rr(arg1, arg2);
         });
     }
 
@@ -2036,18 +2228,27 @@ public:
     enum BranchTruncateType { BranchIfTruncateFailed, BranchIfTruncateSuccessful };
     Jump branchTruncateDoubleToInt32(FPRegisterID src, RegisterID dest, BranchTruncateType branchType = BranchIfTruncateFailed)
     {
-        m_assembler.cvttsd2si_rr(src, dest);
+        if (supportsAVX())
+            m_assembler.vcvttsd2si_rr(src, dest);
+        else
+            m_assembler.cvttsd2si_rr(src, dest);
         return branch32(branchType ? NotEqual : Equal, dest, TrustedImm32(0x80000000));
     }
 
     void truncateDoubleToInt32(FPRegisterID src, RegisterID dest)
     {
-        m_assembler.cvttsd2si_rr(src, dest);
+        if (supportsAVX())
+            m_assembler.vcvttsd2si_rr(src, dest);
+        else
+            m_assembler.cvttsd2si_rr(src, dest);
     }
 
     void truncateFloatToInt32(FPRegisterID src, RegisterID dest)
     {
-        m_assembler.cvttss2si_rr(src, dest);
+        if (supportsAVX())
+            m_assembler.vcvttss2si_rr(src, dest);
+        else
+            m_assembler.cvttss2si_rr(src, dest);
     }
 
     // Convert 'src' to an integer, and places the resulting 'dest'.
@@ -2056,13 +2257,19 @@ public:
     // (specifically, in this case, 0).
     void branchConvertDoubleToInt32(FPRegisterID src, RegisterID dest, JumpList& failureCases, FPRegisterID fpTemp, bool negZeroCheck = true)
     {
-        m_assembler.cvttsd2si_rr(src, dest);
+        if (supportsAVX())
+            m_assembler.vcvttsd2si_rr(src, dest);
+        else
+            m_assembler.cvttsd2si_rr(src, dest);
 
         // If the result is zero, it might have been -0.0, and the double comparison won't catch this!
 #if CPU(X86_64)
         if (negZeroCheck) {
             Jump valueIsNonZero = branchTest32(NonZero, dest);
-            m_assembler.movmskpd_rr(src, scratchRegister());
+            if (supportsAVX())
+                m_assembler.vmovmskpd_rr(src, scratchRegister());
+            else
+                m_assembler.movmskpd_rr(src, scratchRegister());
             failureCases.append(branchTest32(NonZero, scratchRegister(), TrustedImm32(1)));
             valueIsNonZero.link(this);
         }
@@ -2073,51 +2280,54 @@ public:
 
         // Convert the integer result back to float & compare to the original value - if not equal or unordered (NaN) then jump.
         convertInt32ToDouble(dest, fpTemp);
-        m_assembler.ucomisd_rr(fpTemp, src);
+        if (supportsAVX())
+            m_assembler.vucomisd_rr(fpTemp, src);
+        else
+            m_assembler.ucomisd_rr(fpTemp, src);
         failureCases.append(m_assembler.jp());
         failureCases.append(m_assembler.jne());
     }
 
     void moveZeroToDouble(FPRegisterID reg)
     {
-        m_assembler.xorps_rr(reg, reg);
+        if (supportsAVX())
+            m_assembler.vxorps_rrr(reg, reg, reg);
+        else
+            m_assembler.xorps_rr(reg, reg);
     }
 
     Jump branchDoubleNonZero(FPRegisterID reg, FPRegisterID scratch)
     {
-        m_assembler.xorpd_rr(scratch, scratch);
+        if (supportsAVX())
+            m_assembler.vxorpd_rrr(scratch, scratch, scratch);
+        else
+            m_assembler.xorpd_rr(scratch, scratch);
         return branchDouble(DoubleNotEqualAndOrdered, reg, scratch);
     }
 
     Jump branchDoubleZeroOrNaN(FPRegisterID reg, FPRegisterID scratch)
     {
-        m_assembler.xorpd_rr(scratch, scratch);
+        if (supportsAVX())
+            m_assembler.vxorpd_rrr(scratch, scratch, scratch);
+        else
+            m_assembler.xorpd_rr(scratch, scratch);
         return branchDouble(DoubleEqualOrUnordered, reg, scratch);
     }
 
-    void lshiftPacked(TrustedImm32 imm, XMMRegisterID reg)
+    void move32ToFloat(RegisterID src, FPRegisterID dst)
     {
-        m_assembler.psllq_i8r(imm.m_value, reg);
+        if (supportsAVX())
+            m_assembler.vmovd_rr(src, dst);
+        else
+            m_assembler.movd_rr(src, dst);
     }
 
-    void rshiftPacked(TrustedImm32 imm, XMMRegisterID reg)
+    void moveFloatTo32(FPRegisterID src, RegisterID dst)
     {
-        m_assembler.psrlq_i8r(imm.m_value, reg);
-    }
-
-    void orPacked(XMMRegisterID src, XMMRegisterID dst)
-    {
-        m_assembler.por_rr(src, dst);
-    }
-
-    void move32ToFloat(RegisterID src, XMMRegisterID dst)
-    {
-        m_assembler.movd_rr(src, dst);
-    }
-
-    void moveFloatTo32(XMMRegisterID src, RegisterID dst)
-    {
-        m_assembler.movd_rr(src, dst);
+        if (supportsAVX())
+            m_assembler.vmovd_rr(src, dst);
+        else
+            m_assembler.movd_rr(src, dst);
     }
 
     // Stack manipulation operations:
@@ -2201,10 +2411,17 @@ public:
 
     void moveConditionallyDouble(DoubleCondition cond, FPRegisterID left, FPRegisterID right, RegisterID src, RegisterID dest)
     {
-        if (cond & DoubleConditionBitInvert)
-            m_assembler.ucomisd_rr(left, right);
-        else
-            m_assembler.ucomisd_rr(right, left);
+        if (cond & DoubleConditionBitInvert) {
+            if (supportsAVX())
+                m_assembler.vucomisd_rr(left, right);
+            else
+                m_assembler.ucomisd_rr(left, right);
+        } else {
+            if (supportsAVX())
+                m_assembler.vucomisd_rr(right, left);
+            else
+                m_assembler.ucomisd_rr(right, left);
+        }
         moveConditionallyAfterFloatingPointCompare(cond, left, right, src, dest);
     }
 
@@ -2223,19 +2440,33 @@ public:
             src = elseCase;
         }
 
-        if (cond & DoubleConditionBitInvert)
-            m_assembler.ucomisd_rr(left, right);
-        else
-            m_assembler.ucomisd_rr(right, left);
+        if (cond & DoubleConditionBitInvert) {
+            if (supportsAVX())
+                m_assembler.vucomisd_rr(left, right);
+            else
+                m_assembler.ucomisd_rr(left, right);
+        } else {
+            if (supportsAVX())
+                m_assembler.vucomisd_rr(right, left);
+            else
+                m_assembler.ucomisd_rr(right, left);
+        }
         moveConditionallyAfterFloatingPointCompare(cond, left, right, src, dest);
     }
 
     void moveConditionallyFloat(DoubleCondition cond, FPRegisterID left, FPRegisterID right, RegisterID src, RegisterID dest)
     {
-        if (cond & DoubleConditionBitInvert)
-            m_assembler.ucomiss_rr(left, right);
-        else
-            m_assembler.ucomiss_rr(right, left);
+        if (cond & DoubleConditionBitInvert) {
+            if (supportsAVX())
+                m_assembler.vucomiss_rr(left, right);
+            else
+                m_assembler.ucomiss_rr(left, right);
+        } else {
+            if (supportsAVX())
+                m_assembler.vucomiss_rr(right, left);
+            else
+                m_assembler.ucomiss_rr(right, left);
+        }
         moveConditionallyAfterFloatingPointCompare(cond, left, right, src, dest);
     }
 
@@ -2254,10 +2485,17 @@ public:
             src = elseCase;
         }
 
-        if (cond & DoubleConditionBitInvert)
-            m_assembler.ucomiss_rr(left, right);
-        else
-            m_assembler.ucomiss_rr(right, left);
+        if (cond & DoubleConditionBitInvert) {
+            if (supportsAVX())
+                m_assembler.vucomiss_rr(left, right);
+            else
+                m_assembler.ucomiss_rr(left, right);
+        } else {
+            if (supportsAVX())
+                m_assembler.vucomiss_rr(right, left);
+            else
+                m_assembler.ucomiss_rr(right, left);
+        }
         moveConditionallyAfterFloatingPointCompare(cond, left, right, src, dest);
     }
     
@@ -2325,10 +2563,17 @@ public:
 
     void moveConditionallyDouble(DoubleCondition cond, FPRegisterID left, FPRegisterID right, RegisterID src, RegisterID dest)
     {
-        if (cond & DoubleConditionBitInvert)
-            m_assembler.ucomisd_rr(left, right);
-        else
-            m_assembler.ucomisd_rr(right, left);
+        if (cond & DoubleConditionBitInvert) {
+            if (supportsAVX())
+                m_assembler.vucomisd_rr(left, right);
+            else
+                m_assembler.ucomisd_rr(left, right);
+        } else {
+            if (supportsAVX())
+                m_assembler.vucomisd_rr(right, left);
+            else
+                m_assembler.ucomisd_rr(right, left);
+        }
 
         if (cond == DoubleEqualAndOrdered) {
             if (left == right) {

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -261,8 +261,10 @@ private:
     typedef enum {
         OP2_UD2                         = 0xB,
         OP2_MOVSD_VsdWsd                = 0x10,
-        OP2_MOVSD_WsdVsd                = 0x11,
+        OP2_MOVUPS_VsdWsd               = 0x10,
         OP2_MOVSS_VsdWsd                = 0x10,
+        OP2_MOVSD_WsdVsd                = 0x11,
+        OP2_MOVUPS_WsdVsd               = 0x11,
         OP2_MOVSS_WsdVsd                = 0x11,
         OP2_MOVDDUP_VqWq                = 0x12,
         OP2_MOVHLPS_VqUq                = 0x12,
@@ -271,10 +273,13 @@ private:
         OP2_UNPCKHPD_VpdWpd             = 0x15,
         OP2_MOVSHDUP_VqWq               = 0x16,
         OP2_MOVAPD_VpdWpd               = 0x28,
-        OP2_MOVAPS_VpdWpd               = 0x28,
+        OP2_MOVAPS_VpsWps               = 0x28,
+        OP2_MOVAPS_WpsVps               = 0x29,
+        OP2_CVTSI2SS_VssEs              = 0x2A,
         OP2_CVTSI2SD_VsdEd              = 0x2A,
         OP2_CVTTSD2SI_GdWsd             = 0x2C,
         OP2_CVTTSS2SI_GdWsd             = 0x2C,
+        OP2_UCOMISS_VssWss              = 0x2E,
         OP2_UCOMISD_VsdWsd              = 0x2E,
         OP2_RDTSC                       = 0x31,
         OP2_3BYTE_ESCAPE_38             = 0x38,
@@ -282,6 +287,7 @@ private:
         OP2_CMOVCC                      = 0x40,
         OP2_MOVMSKPD_VdEd               = 0x50,
         OP2_SQRTSD_VsdWsd               = 0x51,
+        OP2_SQRTSS_VssWss               = 0x51,
         OP2_ANDPS_VpsWps                = 0x54,
         OP2_ANDPD_VpdWpd                = 0x54,
         OP2_ANDNPS_VpsWps               = 0x55,
@@ -315,6 +321,7 @@ private:
         OP2_PSLLQ_UdqIb                 = 0x73,
         OP2_PSRLQ_UdqIb                 = 0x73,
         OP2_MOVD_EdVd                   = 0x7E,
+        OP2_MOVQ_QqPq                   = 0x7E,
         OP2_JCC_rel32                   = 0x80,
         OP_SETCC                        = 0x90,
         OP2_CPUID                       = 0xA2,
@@ -373,6 +380,8 @@ private:
         OP2_MULPD_VpdWpd                = 0x59,
         OP2_DIVPS_VpsWps                = 0x5E,
         OP2_DIVPD_VpdWpd                = 0x5E,
+        OP2_DIVSS_VpsWps                = 0x5E,
+        OP2_DIVSD_VpdWpd                = 0x5E,
         OP2_SQRTPS_VpsWps               = 0x51,
         OP2_SQRTPD_VpdWpd               = 0x51,
         OP2_PMADDWD_VdqWdq              = 0xF5,
@@ -3794,7 +3803,7 @@ public:
 
     void movaps_rr(XMMRegisterID src, XMMRegisterID dst)
     {
-        m_formatter.twoByteOp(OP2_MOVAPS_VpdWpd, (RegisterID)dst, (RegisterID)src);
+        m_formatter.twoByteOp(OP2_MOVAPS_VpsWps, (RegisterID)dst, (RegisterID)src);
     }
 
     void movhlps_rr(XMMRegisterID src, XMMRegisterID dst)
@@ -3847,13 +3856,13 @@ public:
     void movss_mr(int offset, RegisterID base, XMMRegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_F3);
-        m_formatter.twoByteOp(OP2_MOVSD_VsdWsd, (RegisterID)dst, base, offset);
+        m_formatter.twoByteOp(OP2_MOVSS_VsdWsd, (RegisterID)dst, base, offset);
     }
 
     void movss_mr(int offset, RegisterID base, RegisterID index, int scale, XMMRegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_F3);
-        m_formatter.twoByteOp(OP2_MOVSD_VsdWsd, dst, base, index, scale, offset);
+        m_formatter.twoByteOp(OP2_MOVSS_VsdWsd, dst, base, index, scale, offset);
     }
 
     void movshdup_rr(XMMRegisterID src, XMMRegisterID dst)
@@ -3882,12 +3891,12 @@ public:
     void movss_mr(const void* address, XMMRegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_F3);
-        m_formatter.twoByteOpAddr(OP2_MOVSD_VsdWsd, (RegisterID)dst, bitwise_cast<uint32_t>(address));
+        m_formatter.twoByteOpAddr(OP2_MOVSS_VsdWsd, (RegisterID)dst, bitwise_cast<uint32_t>(address));
     }
     void movss_rm(XMMRegisterID src, const void* address)
     {
         m_formatter.prefix(PRE_SSE_F3);
-        m_formatter.twoByteOpAddr(OP2_MOVSD_WsdVsd, (RegisterID)src, bitwise_cast<uint32_t>(address));
+        m_formatter.twoByteOpAddr(OP2_MOVSS_WsdVsd, (RegisterID)src, bitwise_cast<uint32_t>(address));
     }
 #endif
 
@@ -4091,13 +4100,13 @@ public:
     void sqrtss_rr(XMMRegisterID src, XMMRegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_F3);
-        m_formatter.twoByteOp(OP2_SQRTSD_VsdWsd, (RegisterID)dst, (RegisterID)src);
+        m_formatter.twoByteOp(OP2_SQRTSS_VssWss, (RegisterID)dst, (RegisterID)src);
     }
 
     void sqrtss_mr(int offset, RegisterID base, XMMRegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_F3);
-        m_formatter.twoByteOp(OP2_SQRTSD_VsdWsd, (RegisterID)dst, base, offset);
+        m_formatter.twoByteOp(OP2_SQRTSS_VssWss, (RegisterID)dst, base, offset);
     }
 
     void roundss_rr(XMMRegisterID src, XMMRegisterID dst, RoundingType rounding)
@@ -4454,14 +4463,6 @@ public:
         // VEX.128.66.0F38.W0 18 /r VBROADCASTSS xmm1, m32
         // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
         m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp38, OP3_VBROADCASTSS_VxWd, (RegisterID)dst, (RegisterID)0, base, offset);
-    }
-
-    void vmovq_rr(RegisterID src, FPRegisterID dest)
-    {
-        // https://www.felixcloutier.com/x86/movd:movq
-        // VEX.128.66.0F.W1 6E /r VMOVQ xmm1, r64/m64
-        // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
-        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, VexW::W1, OP2_MOVQ_PqQq, (RegisterID)dest, (RegisterID)0, (RegisterID)src);
     }
 
     void vpunpcklqdq_rrr(XMMRegisterID xmm3, XMMRegisterID xmm2, XMMRegisterID xmm1)
@@ -4990,6 +4991,74 @@ public:
         m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_DIVPD_VpdWpd, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
     }
 
+    void vdivsd_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/divsd
+        // VEX.LIG.F2.0F.WIG 5E /r VDIVSD xmm1, xmm2, xmm3/m64
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_DIVSD_VpdWpd, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vdivsd_mrr(int offset, RegisterID base, XMMRegisterID src2, XMMRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/divsd
+        // VEX.LIG.F2.0F.WIG 5E /r VDIVSD xmm1, xmm2, xmm3/m64
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_DIVSD_VpdWpd, (RegisterID)dest, (RegisterID)src2, base, (RegisterID)offset);
+    }
+
+    void vdivss_rrr(XMMRegisterID right, XMMRegisterID left, XMMRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/divss
+        // VEX.LIG.F3.0F.WIG 5E /r VDIVSS xmm1, xmm2, xmm3/m32
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_DIVSS_VpsWps, (RegisterID)dest, (RegisterID)left, (RegisterID)right);
+    }
+
+    void vdivss_mrr(int offset, RegisterID base, XMMRegisterID src2, XMMRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/divss
+        // VEX.LIG.F3.0F.WIG 5E /r VDIVSS xmm1, xmm2, xmm3/m32
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_DIVSS_VpsWps, (RegisterID)dest, (RegisterID)src2, base, (RegisterID)offset);
+    }
+
+    void vroundsd_i8rrr(RoundingType rounding, FPRegisterID src1, FPRegisterID src2, FPRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/roundsd
+        // VEX.LIG.66.0F3A.WIG 0B /r ib VROUNDSD xmm1, xmm2, xmm3/m64, imm8
+        // RVMI    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    imm8
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, OP3_ROUNDSD_VsdWsdIb, (RegisterID)dest, (RegisterID)src2, (RegisterID)src1);
+        m_formatter.immediate8(static_cast<uint8_t>(rounding));
+    }
+
+    void vroundsd_i8mrr(RoundingType rounding, int offset, RegisterID base, FPRegisterID src2, FPRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/roundsd
+        // VEX.LIG.66.0F3A.WIG 0B /r ib VROUNDSD xmm1, xmm2, xmm3/m64, imm8
+        // RVMI    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    imm8
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, OP3_ROUNDSD_VsdWsdIb, (RegisterID)dest, (RegisterID)src2, base, offset);
+        m_formatter.immediate8(static_cast<uint8_t>(rounding));
+    }
+
+    void vroundss_i8rrr(RoundingType rounding, FPRegisterID src1, FPRegisterID src2, FPRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/roundss
+        // VEX.LIG.66.0F3A.WIG 0A /r ib VROUNDSS xmm1, xmm2, xmm3/m32, imm8
+        // RVMI    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    imm8
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, OP3_ROUNDSS_VssWssIb, (RegisterID)dest, (RegisterID)src2, (RegisterID)src1);
+        m_formatter.immediate8(static_cast<uint8_t>(rounding));
+    }
+
+    void vroundss_i8mrr(RoundingType rounding, int offset, RegisterID base, FPRegisterID src2, FPRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/roundss
+        // VEX.LIG.66.0F3A.WIG 0A /r ib VROUNDSS xmm1, xmm2, xmm3/m32, imm8
+        // RVMI    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    imm8
+        m_formatter.vexNdsLigWigThreeByteOp(PRE_SSE_66, VexImpliedBytes::ThreeBytesOp3A, OP3_ROUNDSS_VssWssIb, (RegisterID)dest, (RegisterID)src2, base, offset);
+        m_formatter.immediate8(static_cast<uint8_t>(rounding));
+    }
+
     void vroundps_rr(FPRegisterID src, FPRegisterID dest, RoundingType rounding)
     {
         // https://www.felixcloutier.com/x86/roundps
@@ -5351,14 +5420,6 @@ public:
         m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_PMOVMSKB_EqWdq, (RegisterID)dest, (RegisterID)0, (RegisterID)input);
     }
 
-    void vmovaps_rr(XMMRegisterID input, XMMRegisterID dest)
-    {
-        // https://www.felixcloutier.com/x86/movaps
-        // VEX.128.0F.WIG 28 /r VMOVAPS xmm1, xmm2/m128
-        // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
-        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVAPS_VpdWpd, (RegisterID)dest, (RegisterID)0, (RegisterID)input);
-    }
-
     void vmovshdup_rr(XMMRegisterID input, XMMRegisterID dest)
     {
         // https://www.felixcloutier.com/x86/movshdup
@@ -5481,6 +5542,38 @@ public:
         UNUSED_PARAM(dest);
     }
 
+    void vmovd_rr(RegisterID src, XMMRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/movd:movq
+        // VEX.128.66.0F.W0 6E / VMOVD xmm1, r32/m32
+        // A   NA   ModRM:reg (w)   ModRM:r/m (r)   NA   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_MOVD_VdEd, (RegisterID)dest, (RegisterID)0, src);
+    }
+
+    void vmovd_rr(XMMRegisterID src, RegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/movd:movq
+        // VEX.128.66.0F.W0 7E /r VMOVD r32/m32, xmm1
+        // B   NA   ModRM:r/m (w)   ModRM:reg (r)   NA   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_MOVD_EdVd, (RegisterID)src, (RegisterID)0, dest);
+    }
+
+    void vmovq_rr(RegisterID src, XMMRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/movd:movq
+        // VEX.128.66.0F.W1 6E /r VMOVQ xmm1, r64/m64
+        // A   NA   ModRM:reg (w)   ModRM:r/m (r)   NA   NA
+        m_formatter.vexNdsLigTwoByteOp(PRE_SSE_66, VexW::W1, OP2_MOVQ_PqQq, (RegisterID)dest, (RegisterID)0, src);
+    }
+
+    void vmovq_rr(XMMRegisterID src, RegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/movd:movq
+        // VEX.128.66.0F.W1 7E /r VMOVQ r64/m64, xmm1
+        // B   NA   ModRM:r/m (w)   ModRM:reg (r)   NA   NA
+        m_formatter.vexNdsLigTwoByteOp(PRE_SSE_66, VexW::W1, OP2_MOVQ_QqPq, (RegisterID)src, (RegisterID)0, dest);
+    }
+
     void vmovdqa_rr(XMMRegisterID vn, XMMRegisterID vd)
     {
         // https://www.felixcloutier.com/x86/movdqa:vmovdqa32:vmovdqa64
@@ -5568,7 +5661,7 @@ public:
         // https://www.felixcloutier.com/x86/movups
         // VEX.128.0F.WIG 10 /r VMOVUPS xmm1, xmm2/m128
         // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
-        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVSD_VsdWsd, (RegisterID)dst, (RegisterID)0, base, offset);
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVUPS_VsdWsd, (RegisterID)dst, (RegisterID)0, base, offset);
     }
 
     void vmovups_mr(int offset, RegisterID base, RegisterID index, int scale, XMMRegisterID dst)
@@ -5576,7 +5669,7 @@ public:
         // https://www.felixcloutier.com/x86/movups
         // VEX.128.0F.WIG 10 /r VMOVUPS xmm1, xmm2/m128
         // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
-        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVSD_VsdWsd, (RegisterID)dst, (RegisterID)0, offset, base, index, scale);
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVUPS_VsdWsd, (RegisterID)dst, (RegisterID)0, offset, base, index, scale);
     }
 
     void vmovups_rm(XMMRegisterID src, int offset, RegisterID base)
@@ -5584,7 +5677,7 @@ public:
         // https://www.felixcloutier.com/x86/movups
         // VEX.128.0F.WIG 11 /r VMOVUPS xmm2/m128, xmm1
         // B    NA    ModRM:r/m (w)    ModRM:reg (r)    NA    NA
-        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVSD_WsdVsd, (RegisterID)src, (RegisterID)0, base, offset);
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVUPS_WsdVsd, (RegisterID)src, (RegisterID)0, base, offset);
     }
 
     void vmovups_rm(XMMRegisterID src, int offset, RegisterID base, RegisterID index, int scale)
@@ -5592,7 +5685,111 @@ public:
         // https://www.felixcloutier.com/x86/movups
         // VEX.128.0F.WIG 11 /r VMOVUPS xmm2/m128, xmm1
         // B    NA    ModRM:r/m (w)    ModRM:reg (r)    NA    NA
-        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVSD_WsdVsd, (RegisterID)src, (RegisterID)0, offset, base, index, scale);
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVUPS_WsdVsd, (RegisterID)src, (RegisterID)0, offset, base, index, scale);
+    }
+
+    void vmovaps_rr(XMMRegisterID src, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/movaps
+        // VEX.128.0F.WIG 28 /r VMOVAPS xmm1, xmm2/m128
+        // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVAPS_VpsWps, (RegisterID)dst, (RegisterID)0, (RegisterID)src);
+    }
+
+    void vmovaps_mr(int offset, RegisterID base, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/movaps
+        // VEX.128.0F.WIG 28 /r VMOVAPS xmm1, xmm2/m128
+        // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVAPS_VpsWps, (RegisterID)dst, (RegisterID)0, base, offset);
+    }
+
+    void vmovaps_mr(int offset, RegisterID base, RegisterID index, int scale, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/movaps
+        // VEX.128.0F.WIG 28 /r VMOVAPS xmm1, xmm2/m128
+        // A    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVAPS_VpsWps, (RegisterID)dst, (RegisterID)0, offset, base, index, scale);
+    }
+
+    void vmovaps_rm(XMMRegisterID src, int offset, RegisterID base)
+    {
+        // https://www.felixcloutier.com/x86/movaps
+        // VEX.128.0F.WIG 29 /r VMOVAPS xmm2/m128, xmm1
+        // B    NA    ModRM:r/m (w)    ModRM:reg (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVAPS_WpsVps, (RegisterID)src, (RegisterID)0, base, offset);
+    }
+
+    void vmovaps_rm(XMMRegisterID src, int offset, RegisterID base, RegisterID index, int scale)
+    {
+        // https://www.felixcloutier.com/x86/movaps
+        // VEX.128.0F.WIG 29 /r VMOVAPS xmm2/m128, xmm1
+        // B    NA    ModRM:r/m (w)    ModRM:reg (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_MOVAPS_WpsVps, (RegisterID)src, (RegisterID)0, offset, base, index, scale);
+    }
+
+    void vmovsd_mr(int offset, RegisterID base, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/movsd
+        // VEX.LIG.F2.0F.WIG 10 /r VMOVSD xmm1, m64
+        // D    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_MOVSD_VsdWsd, (RegisterID)dst, (RegisterID)0, base, offset);
+    }
+
+    void vmovsd_mr(int offset, RegisterID base, RegisterID index, int scale, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/movsd
+        // VEX.LIG.F2.0F.WIG 10 /r VMOVSD xmm1, m64
+        // D    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_MOVSD_VsdWsd, (RegisterID)dst, (RegisterID)0, offset, base, index, scale);
+    }
+
+    void vmovsd_rm(XMMRegisterID src, int offset, RegisterID base)
+    {
+        // https://www.felixcloutier.com/x86/movsd
+        // VEX.LIG.F2.0F.WIG 11 /r VMOVSD m64, xmm1
+        // C    NA    ModRM:r/m (w)    ModRM:reg (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_MOVSD_WsdVsd, (RegisterID)src, (RegisterID)0, base, offset);
+    }
+
+    void vmovsd_rm(XMMRegisterID src, int offset, RegisterID base, RegisterID index, int scale)
+    {
+        // https://www.felixcloutier.com/x86/movsd
+        // VEX.LIG.F2.0F.WIG 11 /r VMOVSD m64, xmm1
+        // C    NA    ModRM:r/m (w)    ModRM:reg (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_MOVSD_WsdVsd, (RegisterID)src, (RegisterID)0, offset, base, index, scale);
+    }
+
+    void vmovss_mr(int offset, RegisterID base, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/movss
+        // VEX.LIG.F3.0F.WIG 10 /r VMOVSS xmm1, m32
+        // D    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_MOVSS_VsdWsd, (RegisterID)dst, (RegisterID)0, base, offset);
+    }
+
+    void vmovss_mr(int offset, RegisterID base, RegisterID index, int scale, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/movss
+        // VEX.LIG.F3.0F.WIG 10 /r VMOVSS xmm1, m32
+        // D    NA    ModRM:reg (w)    ModRM:r/m (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_MOVSS_VsdWsd, (RegisterID)dst, (RegisterID)0, offset, base, index, scale);
+    }
+
+    void vmovss_rm(XMMRegisterID src, int offset, RegisterID base)
+    {
+        // https://www.felixcloutier.com/x86/movss
+        // VEX.LIG.F3.0F.WIG 11 /r VMOVSS m32, xmm1
+        // C    NA    ModRM:r/m (w)    ModRM:reg (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_MOVSS_WsdVsd, (RegisterID)src, (RegisterID)0, base, offset);
+    }
+
+    void vmovss_rm(XMMRegisterID src, int offset, RegisterID base, RegisterID index, int scale)
+    {
+        // https://www.felixcloutier.com/x86/movss
+        // VEX.LIG.F3.0F.WIG 11 /r VMOVSS m32, xmm1
+        // C    NA    ModRM:r/m (w)    ModRM:reg (r)    NA    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_MOVSS_WsdVsd, (RegisterID)src, (RegisterID)0, offset, base, index, scale);
     }
 
     void vmulsd_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dst)
@@ -5689,6 +5886,198 @@ public:
         // VEX.LIG.F3.0F.WIG 5C /r VSUBSS xmm1,xmm2, xmm3/m32
         // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    NA
         m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_SUBSD_VsdWsd, (RegisterID)dst, (RegisterID)b, offset, base, index, scale);
+    }
+
+    void vsqrtsd_rrr(XMMRegisterID src1, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/sqrtsd
+        // VEX.LIG.F2.0F.WIG 51/r VSQRTSD xmm1,xmm2, xmm3/m64
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_SQRTSD_VsdWsd, (RegisterID)dst, (RegisterID)src2, (RegisterID)src1);
+    }
+
+    void vsqrtsd_mrr(int offset, RegisterID base, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/sqrtsd
+        // VEX.LIG.F2.0F.WIG 51/r VSQRTSD xmm1,xmm2, xmm3/m64
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_SQRTSD_VsdWsd, (RegisterID)dst, (RegisterID)src2, base, offset);
+    }
+
+    void vsqrtss_rrr(XMMRegisterID src1, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/sqrtss
+        // VEX.LIG.F3.0F.WIG 51 /r VSQRTSS xmm1, xmm2, xmm3/m32
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_SQRTSS_VssWss, (RegisterID)dst, (RegisterID)src2, (RegisterID)src1);
+    }
+
+    void vsqrtss_mrr(int offset, RegisterID base, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/sqrtss
+        // VEX.LIG.F3.0F.WIG 51 /r VSQRTSS xmm1, xmm2, xmm3/m32
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_SQRTSS_VssWss, (RegisterID)dst, (RegisterID)src2, base, offset);
+    }
+
+    void vcvtsd2ss_rrr(XMMRegisterID src1, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvtsd2ss
+        // VEX.LIG.F2.0F.WIG 5A /r VCVTSD2SS xmm1,xmm2, xmm3/m64
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_CVTSD2SS_VsdWsd, (RegisterID)dst, (RegisterID)src2, (RegisterID)src1);
+    }
+
+    void vcvtsd2ss_mrr(int offset, RegisterID base, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvtsd2ss
+        // VEX.LIG.F2.0F.WIG 5A /r VCVTSD2SS xmm1,xmm2, xmm3/m64
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_CVTSD2SS_VsdWsd, (RegisterID)dst, (RegisterID)src2, base, offset);
+    }
+
+    void vcvtss2sd_rrr(XMMRegisterID src1, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvtss2sd
+        // VEX.LIG.F3.0F.WIG 5A /r VCVTSS2SD xmm1, xmm2, xmm3/m32
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_CVTSS2SD_VsdWsd, (RegisterID)dst, (RegisterID)src2, (RegisterID)src1);
+    }
+
+    void vcvtss2sd_mrr(int offset, RegisterID base, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvtss2sd
+        // VEX.LIG.F3.0F.WIG 5A /r VCVTSS2SD xmm1, xmm2, xmm3/m32
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_CVTSS2SD_VsdWsd, (RegisterID)dst, (RegisterID)src2, base, offset);
+    }
+
+    void vcvtsi2sd_rrr(RegisterID src1, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvtsi2sd
+        // VEX.LIG.F2.0F.W0 2A /r VCVTSI2SD xmm1, xmm2, r/m32
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_CVTSI2SD_VsdEd, (RegisterID)dst, (RegisterID)src2, (RegisterID)src1);
+    }
+
+    void vcvtsi2sd_mrr(int offset, RegisterID base, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvtsi2sd
+        // VEX.LIG.F2.0F.W0 2A /r VCVTSI2SD xmm1, xmm2, r/m32
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_CVTSI2SD_VsdEd, (RegisterID)dst, (RegisterID)src2, base, offset);
+    }
+
+    void vcvtsi2ss_rrr(RegisterID src1, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvtsi2ss
+        // VEX.LIG.F3.0F.W0 2A /r VCVTSI2SS xmm1, xmm2, r/m32
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_CVTSI2SS_VssEs, (RegisterID)dst, (RegisterID)src2, (RegisterID)src1);
+    }
+
+    void vcvtsi2ss_mrr(int offset, RegisterID base, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvtsi2ss
+        // VEX.LIG.F3.0F.W0 2A /r VCVTSI2SS xmm1, xmm2, r/m32
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_CVTSI2SS_VssEs, (RegisterID)dst, (RegisterID)src2, base, offset);
+    }
+
+    void vcvttsd2si_rr(XMMRegisterID src, RegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvttsd2si
+        // VEX.LIG.F2.0F.W0 2C /r VCVTTSD2SI r32, xmm1/m64
+        // A   NA   ModRM:reg (w)   ModRM:r/m (r)   NA   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F2, OP2_CVTTSD2SI_GdWsd, dst, (RegisterID)0, (RegisterID)src);
+    }
+
+    void vcvttss2si_rr(XMMRegisterID src, RegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvttss2si
+        // VEX.LIG.F3.0F.W0 2C /r VCVTTSS2SI r32, xmm1/m32
+        // A   NA   ModRM:reg (w)   ModRM:r/m (r)   NA   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_F3, OP2_CVTTSS2SI_GdWsd, dst, (RegisterID)0, (RegisterID)src);
+    }
+
+    void vcvttsd2siq_rr(XMMRegisterID src, RegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvttsd2si
+        // VEX.LIG.F2.0F.W1 2C /r VCVTTSD2SI r64, xmm1/m64
+        // B   Tuple1 Fixed   ModRM:reg (w)   ModRM:r/m (r)   NA   NA
+        m_formatter.vexNdsLigTwoByteOp(PRE_SSE_F2, VexW::W1, OP2_CVTTSD2SI_GdWsd, dst, (RegisterID)0, (RegisterID)src);
+    }
+
+    void vcvttss2siq_rr(XMMRegisterID src, RegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvttss2si
+        // VEX.LIG.F3.0F.W1 2C /r VCVTTSS2SI r64, xmm1/m32
+        // A   NA   ModRM:reg (w)   ModRM:r/m (r)   NA   NA
+        m_formatter.vexNdsLigTwoByteOp(PRE_SSE_F3, VexW::W1, OP2_CVTTSS2SI_GdWsd, dst, (RegisterID)0, (RegisterID)src);
+    }
+
+    void vcvtsi2sdq_rrr(RegisterID src1, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvtsi2sd
+        // VEX.LIG.F2.0F.W1 2A /r VCVTSI2SD xmm1, xmm2, r/m64
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        m_formatter.vexNdsLigTwoByteOp(PRE_SSE_F2, VexW::W1, OP2_CVTSI2SD_VsdEd, (RegisterID)dst, (RegisterID)src2, src1);
+    }
+
+    void vcvtsi2sdq_mrr(int offset, RegisterID base, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvtsi2sd
+        // VEX.LIG.F2.0F.W1 2A /r VCVTSI2SD xmm1, xmm2, r/m64
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        m_formatter.vexNdsLigTwoByteOp(PRE_SSE_F2, VexW::W1, OP2_CVTSI2SD_VsdEd, (RegisterID)dst, (RegisterID)src2, base, offset);
+    }
+
+    void vcvtsi2ssq_rrr(RegisterID src1, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvtsi2ss.html
+        // VEX.LIG.F3.0F.W1 2A /r VCVTSI2SS xmm1, xmm2, r/m64
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        m_formatter.vexNdsLigTwoByteOp(PRE_SSE_F3, VexW::W1, OP2_CVTSI2SS_VssEs, (RegisterID)dst, (RegisterID)src2, src1);
+    }
+
+    void vcvtsi2ssq_mrr(int offset, RegisterID base, XMMRegisterID src2, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/cvtsi2ss.html
+        // VEX.LIG.F3.0F.W1 2A /r VCVTSI2SS xmm1, xmm2, r/m64
+        // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
+        m_formatter.vexNdsLigTwoByteOp(PRE_SSE_F3, VexW::W1, OP2_CVTSI2SS_VssEs, (RegisterID)dst, (RegisterID)src2, base, offset);
+    }
+
+    void vucomisd_rr(XMMRegisterID src, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/ucomisd
+        // VEX.LIG.66.0F.WIG 2E /r VUCOMISD xmm1, xmm2/m64
+        // A   NA   ModRM:reg (r)   ModRM:r/m (r)   NA   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_UCOMISD_VsdWsd, (RegisterID)dst, (RegisterID)0, (RegisterID)src);
+    }
+
+    void vucomisd_mr(int offset, RegisterID base, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/ucomisd
+        // VEX.LIG.66.0F.WIG 2E /r VUCOMISD xmm1, xmm2/m64
+        // A   NA   ModRM:reg (r)   ModRM:r/m (r)   NA   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_UCOMISD_VsdWsd, (RegisterID)dst, (RegisterID)0, base, offset);
+    }
+
+    void vucomiss_rr(XMMRegisterID src, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/ucomiss
+        // VEX.LIG.0F.WIG 2E /r VUCOMISS xmm1, xmm2/m32
+        // A   NA   ModRM:reg (r)   ModRM:r/m (r)   NA   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_UCOMISS_VssWss, (RegisterID)dst, (RegisterID)0, (RegisterID)src);
+    }
+
+    void vucomiss_mr(int offset, RegisterID base, XMMRegisterID dst)
+    {
+        // https://www.felixcloutier.com/x86/ucomiss
+        // VEX.LIG.0F.WIG 2E /r VUCOMISS xmm1, xmm2/m32
+        // A   NA   ModRM:reg (r)   ModRM:r/m (r)   NA   NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_UCOMISS_VssWss, (RegisterID)dst, (RegisterID)0, base, offset);
     }
 
     // Assembler admin methods:
@@ -6493,18 +6882,7 @@ private:
         //   xmm2 = VEX.vvvv (r)
         //   xmm3 = ModRM:r/m (r)
         // And xmm1 = dest, xmm2 = a, xmm3 = b
-        void vexNdsLigWigTwoByteOp(OneByteOpcodeID simdPrefix, TwoByteOpcodeID opcode, RegisterID dest, RegisterID a, RegisterID b)
-        {
-            SingleInstructionBufferWriter writer(m_buffer);
-            if (regRequiresRex(b))
-                writer.threeBytesVexNds(simdPrefix, VexImpliedBytes::TwoBytesOp, dest, a, b);
-            else
-                writer.twoBytesVex(simdPrefix, a, dest);
-            writer.putByteUnchecked(opcode);
-            writer.registerModRM(dest, b);
-        }
-
-        void vexNdsLigWigTwoByteOp(OneByteOpcodeID simdPrefix, VexW vexW, TwoByteOpcodeID opcode, RegisterID dest, RegisterID a, RegisterID b)
+        void vexNdsLigTwoByteOp(OneByteOpcodeID simdPrefix, VexW vexW, TwoByteOpcodeID opcode, RegisterID dest, RegisterID a, RegisterID b)
         {
             SingleInstructionBufferWriter writer(m_buffer);
             // Section 3.1.1.2 from Intel SDM volume 2:
@@ -6517,6 +6895,33 @@ private:
             writer.registerModRM(dest, b);
         }
 
+        void vexNdsLigTwoByteOp(OneByteOpcodeID simdPrefix, VexW vexW, TwoByteOpcodeID opcode, RegisterID dest, RegisterID a, RegisterID base, int offset)
+        {
+            SingleInstructionBufferWriter writer(m_buffer);
+            if (regRequiresRex(base) || vexW == VexW::W1)
+                writer.threeBytesVexNds(simdPrefix, VexImpliedBytes::TwoBytesOp, dest, a, base);
+            else
+                writer.twoBytesVex(simdPrefix, a, dest);
+            writer.putByteUnchecked(opcode);
+            writer.memoryModRM(dest, base, offset);
+        }
+
+        void vexNdsLigTwoByteOp(OneByteOpcodeID simdPrefix, VexW vexW, TwoByteOpcodeID opcode, RegisterID dest, RegisterID a, int offset, RegisterID base, RegisterID index, int scale)
+        {
+            SingleInstructionBufferWriter writer(m_buffer);
+            if (regRequiresRex(base, index) || vexW == VexW::W1)
+                writer.threeBytesVexNds(simdPrefix, VexImpliedBytes::TwoBytesOp, dest, a, index, base);
+            else
+                writer.twoBytesVex(simdPrefix, a, dest);
+            writer.putByteUnchecked(opcode);
+            writer.memoryModRM(dest, base, index, scale, offset);
+        }
+
+        void vexNdsLigWigTwoByteOp(OneByteOpcodeID simdPrefix, TwoByteOpcodeID opcode, RegisterID dest, RegisterID a, RegisterID b)
+        {
+            vexNdsLigTwoByteOp(simdPrefix, VexW::W0, opcode, dest, a, b);
+        }
+
         void vexNdsLigWigCommutativeTwoByteOp(OneByteOpcodeID simdPrefix, TwoByteOpcodeID opcode, RegisterID dest, RegisterID a, RegisterID b)
         {
             // Since this is a commutative operation, we can try switching the arguments.
@@ -6527,24 +6932,12 @@ private:
 
         void vexNdsLigWigTwoByteOp(OneByteOpcodeID simdPrefix, TwoByteOpcodeID opcode, RegisterID dest, RegisterID a, RegisterID base, int offset)
         {
-            SingleInstructionBufferWriter writer(m_buffer);
-            if (regRequiresRex(base))
-                writer.threeBytesVexNds(simdPrefix, VexImpliedBytes::TwoBytesOp, dest, a, base);
-            else
-                writer.twoBytesVex(simdPrefix, a, dest);
-            writer.putByteUnchecked(opcode);
-            writer.memoryModRM(dest, base, offset);
+            vexNdsLigTwoByteOp(simdPrefix, VexW::W0, opcode, dest, a, base, offset);
         }
 
         void vexNdsLigWigTwoByteOp(OneByteOpcodeID simdPrefix, TwoByteOpcodeID opcode, RegisterID dest, RegisterID a, int offset, RegisterID base, RegisterID index, int scale)
         {
-            SingleInstructionBufferWriter writer(m_buffer);
-            if (regRequiresRex(base, index))
-                writer.threeBytesVexNds(simdPrefix, VexImpliedBytes::TwoBytesOp, dest, a, index, base);
-            else
-                writer.twoBytesVex(simdPrefix, a, dest);
-            writer.putByteUnchecked(opcode);
-            writer.memoryModRM(dest, base, index, scale, offset);
+            vexNdsLigTwoByteOp(simdPrefix, VexW::W0, opcode, dest, a, offset, base, index, scale);
         }
 
         // Typically, xmm1 = dest, xmm2 = a, xmm3 = b


### PR DESCRIPTION
#### cd20066f121f8af3d4a191a30ae93dc06cb30795
<pre>
[JSC] Rewrite every SSE functions with AVX
<a href="https://bugs.webkit.org/show_bug.cgi?id=249281">https://bugs.webkit.org/show_bug.cgi?id=249281</a>
rdar://103330419

Reviewed by Michael Saboff.

This patch rewrites every FloatingPoint code generation with AVX instead of SSE.
This paves the way to reducing AVX &lt;-&gt; SSE penalty once AVX SIMD is enabled.

* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h:
(JSC::MacroAssemblerX86Common::sqrtDouble):
(JSC::MacroAssemblerX86Common::sqrtFloat):
(JSC::MacroAssemblerX86Common::absDouble):
(JSC::MacroAssemblerX86Common::negateDouble):
(JSC::MacroAssemblerX86Common::ceilDouble):
(JSC::MacroAssemblerX86Common::ceilFloat):
(JSC::MacroAssemblerX86Common::floorDouble):
(JSC::MacroAssemblerX86Common::floorFloat):
(JSC::MacroAssemblerX86Common::roundTowardNearestIntDouble):
(JSC::MacroAssemblerX86Common::roundTowardNearestIntFloat):
(JSC::MacroAssemblerX86Common::roundTowardZeroDouble):
(JSC::MacroAssemblerX86Common::roundTowardZeroFloat):
(JSC::MacroAssemblerX86Common::moveDouble):
(JSC::MacroAssemblerX86Common::loadDouble):
(JSC::MacroAssemblerX86Common::loadFloat):
(JSC::MacroAssemblerX86Common::storeDouble):
(JSC::MacroAssemblerX86Common::storeFloat):
(JSC::MacroAssemblerX86Common::convertDoubleToFloat):
(JSC::MacroAssemblerX86Common::convertFloatToDouble):
(JSC::MacroAssemblerX86Common::divDouble):
(JSC::MacroAssemblerX86Common::divFloat):
(JSC::MacroAssemblerX86Common::andDouble):
(JSC::MacroAssemblerX86Common::andFloat):
(JSC::MacroAssemblerX86Common::orDouble):
(JSC::MacroAssemblerX86Common::orFloat):
(JSC::MacroAssemblerX86Common::xorDouble):
(JSC::MacroAssemblerX86Common::xorFloat):
(JSC::MacroAssemblerX86Common::convertInt32ToDouble):
(JSC::MacroAssemblerX86Common::convertInt32ToFloat):
(JSC::MacroAssemblerX86Common::branchDouble):
(JSC::MacroAssemblerX86Common::branchFloat):
(JSC::MacroAssemblerX86Common::compareDouble):
(JSC::MacroAssemblerX86Common::compareFloat):
(JSC::MacroAssemblerX86Common::branchTruncateDoubleToInt32):
(JSC::MacroAssemblerX86Common::truncateDoubleToInt32):
(JSC::MacroAssemblerX86Common::truncateFloatToInt32):
(JSC::MacroAssemblerX86Common::branchConvertDoubleToInt32):
(JSC::MacroAssemblerX86Common::moveZeroToDouble):
(JSC::MacroAssemblerX86Common::branchDoubleNonZero):
(JSC::MacroAssemblerX86Common::branchDoubleZeroOrNaN):
(JSC::MacroAssemblerX86Common::move32ToFloat):
(JSC::MacroAssemblerX86Common::moveFloatTo32):
(JSC::MacroAssemblerX86Common::moveConditionallyDouble):
(JSC::MacroAssemblerX86Common::moveConditionallyFloat):
(JSC::MacroAssemblerX86Common::lshiftPacked): Deleted.
(JSC::MacroAssemblerX86Common::rshiftPacked): Deleted.
(JSC::MacroAssemblerX86Common::orPacked): Deleted.
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::addDouble):
(JSC::MacroAssemblerX86_64::convertInt32ToDouble):
(JSC::MacroAssemblerX86_64::move32ToFloat):
(JSC::MacroAssemblerX86_64::move64ToDouble):
(JSC::MacroAssemblerX86_64::moveDoubleTo64):
(JSC::MacroAssemblerX86_64::moveVector):
(JSC::MacroAssemblerX86_64::truncateDoubleToUint32):
(JSC::MacroAssemblerX86_64::truncateDoubleToInt64):
(JSC::MacroAssemblerX86_64::truncateDoubleToUint64):
(JSC::MacroAssemblerX86_64::truncateFloatToUint32):
(JSC::MacroAssemblerX86_64::truncateFloatToInt64):
(JSC::MacroAssemblerX86_64::truncateFloatToUint64):
(JSC::MacroAssemblerX86_64::convertInt64ToDouble):
(JSC::MacroAssemblerX86_64::convertInt64ToFloat):
(JSC::MacroAssemblerX86_64::convertUInt64ToDouble):
(JSC::MacroAssemblerX86_64::convertUInt64ToFloat):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::movaps_rr):
(JSC::X86Assembler::movss_mr):
(JSC::X86Assembler::movss_rm):
(JSC::X86Assembler::sqrtss_rr):
(JSC::X86Assembler::sqrtss_mr):
(JSC::X86Assembler::vdivsd_rrr):
(JSC::X86Assembler::vdivsd_mrr):
(JSC::X86Assembler::vdivss_rrr):
(JSC::X86Assembler::vdivss_mrr):
(JSC::X86Assembler::vroundsd_i8rrr):
(JSC::X86Assembler::vroundsd_i8mrr):
(JSC::X86Assembler::vroundss_i8rrr):
(JSC::X86Assembler::vroundss_i8mrr):
(JSC::X86Assembler::vmovd_rr):
(JSC::X86Assembler::vmovq_rr):
(JSC::X86Assembler::vmovups_mr):
(JSC::X86Assembler::vmovups_rm):
(JSC::X86Assembler::vmovaps_rr):
(JSC::X86Assembler::vmovaps_mr):
(JSC::X86Assembler::vmovaps_rm):
(JSC::X86Assembler::vmovsd_mr):
(JSC::X86Assembler::vmovsd_rm):
(JSC::X86Assembler::vmovss_mr):
(JSC::X86Assembler::vmovss_rm):
(JSC::X86Assembler::vsqrtsd_rrr):
(JSC::X86Assembler::vsqrtsd_mrr):
(JSC::X86Assembler::vsqrtss_rrr):
(JSC::X86Assembler::vsqrtss_mrr):
(JSC::X86Assembler::vcvtsd2ss_rrr):
(JSC::X86Assembler::vcvtsd2ss_mrr):
(JSC::X86Assembler::vcvtss2sd_rrr):
(JSC::X86Assembler::vcvtss2sd_mrr):
(JSC::X86Assembler::vcvtsi2sd_rrr):
(JSC::X86Assembler::vcvtsi2sd_mrr):
(JSC::X86Assembler::vcvtsi2ss_rrr):
(JSC::X86Assembler::vcvtsi2ss_mrr):
(JSC::X86Assembler::vcvttsd2si_rr):
(JSC::X86Assembler::vcvttss2si_rr):
(JSC::X86Assembler::vcvttsd2siq_rr):
(JSC::X86Assembler::vcvttss2siq_rr):
(JSC::X86Assembler::vcvtsi2sdq_rrr):
(JSC::X86Assembler::vcvtsi2sdq_mrr):
(JSC::X86Assembler::vcvtsi2ssq_rrr):
(JSC::X86Assembler::vcvtsi2ssq_mrr):
(JSC::X86Assembler::vucomisd_rr):
(JSC::X86Assembler::vucomisd_mr):
(JSC::X86Assembler::vucomiss_rr):
(JSC::X86Assembler::vucomiss_mr):
(JSC::X86Assembler::X86InstructionFormatter::SingleInstructionBufferWriter::memoryModRM):

Canonical link: <a href="https://commits.webkit.org/257831@main">https://commits.webkit.org/257831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e596ead91d96a44b40daf760a5b7b4634f68a04b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109491 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169726 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10211 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92586 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107380 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105928 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90735 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3090 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23910 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86706 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/526 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3065 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29057 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9195 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43396 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89588 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20029 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2767 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->