### PR TITLE
HTMLTemplateElement should have shadowRootMode attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic.tentative-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Declarative Shadow DOM: Basic test
-FAIL Declarative Shadow DOM: Feature detection assert_true: Unable to feature detect expected true got false
-FAIL Shadowrootmode reflection assert_equals: The shadowRootMode IDL should reflect the content attribute expected (string) "open" but got (undefined) undefined
+PASS Declarative Shadow DOM: Feature detection
+PASS Shadowrootmode reflection
 PASS Declarative Shadow DOM: Fragment parser basic test
 PASS Declarative Shadow DOM: Invalid shadow root attribute
 PASS Declarative Shadow DOM: Closed shadow root attribute

--- a/Source/WebCore/html/HTMLTemplateElement.cpp
+++ b/Source/WebCore/html/HTMLTemplateElement.cpp
@@ -86,6 +86,27 @@ DocumentFragment& HTMLTemplateElement::content() const
     return *m_content;
 }
 
+const AtomString& HTMLTemplateElement::shadowRootMode() const
+{
+    static MainThreadNeverDestroyed<const AtomString> open("open"_s);
+    static MainThreadNeverDestroyed<const AtomString> closed("closed"_s);
+
+    auto modeString = attributeWithoutSynchronization(HTMLNames::shadowrootmodeAttr);
+    if (equalLettersIgnoringASCIICase(modeString, "closed"_s))
+        return closed;
+    if (equalLettersIgnoringASCIICase(modeString, "open"_s))
+        return open;
+    return nullAtom();
+}
+
+void HTMLTemplateElement::setShadowRootMode(const AtomString& value)
+{
+    if (value.isNull())
+        removeAttribute(HTMLNames::shadowrootmodeAttr);
+    else
+        setAttribute(HTMLNames::shadowrootmodeAttr, value);
+}
+
 void HTMLTemplateElement::setDeclarativeShadowRoot(ShadowRoot& shadowRoot)
 {
     m_declarativeShadowRoot = shadowRoot;

--- a/Source/WebCore/html/HTMLTemplateElement.h
+++ b/Source/WebCore/html/HTMLTemplateElement.h
@@ -47,6 +47,9 @@ public:
     DocumentFragment& content() const;
     DocumentFragment* contentIfAvailable() const;
 
+    const AtomString& shadowRootMode() const;
+    void setShadowRootMode(const AtomString&);
+
     void setDeclarativeShadowRoot(ShadowRoot&);
     void attachAsDeclarativeShadowRootIfNeeded(Element&);
 

--- a/Source/WebCore/html/HTMLTemplateElement.idl
+++ b/Source/WebCore/html/HTMLTemplateElement.idl
@@ -33,4 +33,5 @@
     Exposed=Window
 ] interface HTMLTemplateElement : HTMLElement {
     readonly attribute DocumentFragment content;
+    [CEReactions=NotNeeded, EnabledBySetting=DeclarativeShadowDOMEnabled] attribute [AtomString] DOMString? shadowRootMode;
 };

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -534,8 +534,8 @@ void HTMLConstructionSite::insertHTMLElement(AtomHTMLToken&& token)
 
 void HTMLConstructionSite::insertHTMLTemplateElement(AtomHTMLToken&& token)
 {
-    if (m_document.settings().streamingDeclarativeShadowDOMEnabled() && m_parserContentPolicy.contains(ParserContentPolicy::AllowDeclarativeShadowDOM)
-        && !currentElement().document().templateDocumentHost()) {
+    if (m_document.settings().declarativeShadowDOMEnabled() && m_document.settings().streamingDeclarativeShadowDOMEnabled()
+        && m_parserContentPolicy.contains(ParserContentPolicy::AllowDeclarativeShadowDOM) && !currentElement().document().templateDocumentHost()) {
         std::optional<ShadowRootMode> mode;
         bool delegatesFocus = false;
         for (auto& attribute : token.attributes()) {


### PR DESCRIPTION
#### 350f4f7ded4367ff4ca04675f4c9fb198e972f67
<pre>
HTMLTemplateElement should have shadowRootMode attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=249287">https://bugs.webkit.org/show_bug.cgi?id=249287</a>

Reviewed by Chris Dumez.

Add shadowRootMode IDL attribute to HTMLTemplateElement.

* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic.tentative-expected.txt:
* Source/WebCore/html/HTMLTemplateElement.cpp:
(WebCore::HTMLTemplateElement::shadowRootMode const): Added.
(WebCore::HTMLTemplateElement::setShadowRootMode): Added.
* Source/WebCore/html/HTMLTemplateElement.h:
* Source/WebCore/html/HTMLTemplateElement.idl:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::insertHTMLTemplateElement): Fixed a bug that this wasn&apos;t checking whether declarative
shadow DOM is enabled or not. This is necessary now since the streaming is always enabled as of 257820@main.

Canonical link: <a href="https://commits.webkit.org/257887@main">https://commits.webkit.org/257887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e2f2d05763decc8a3d29287bbef6f23480559d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100284 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109607 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169832 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10355 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92699 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107492 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106060 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34507 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22501 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3202 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24019 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3185 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9310 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43509 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5011 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2799 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->