### PR TITLE
[JSC] Fix x64 CompareIntegerVector

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -2467,7 +2467,7 @@ public:
         }
     }
 
-    void compareIntegerVector(RelationalCondition cond, SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
+    void compareIntegerVector(RelationalCondition cond, SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest, FPRegisterID scratch)
     {
         RELEASE_ASSERT(supportsAVXForSIMD());
         RELEASE_ASSERT(scalarTypeIsIntegral(simdInfo.lane));
@@ -2502,19 +2502,18 @@ public:
             RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Shouldn't emit integer vector Above comparisons directly.");
             break;
         case AboveOrEqual:
-            // FIXME: these functions need to take scratch register since left can be dest.
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpmaxub_rrr(right, left, dest);
-                m_assembler.vpcmpeqb_rrr(left, dest, dest);
+                m_assembler.vpmaxub_rrr(right, left, scratch);
+                m_assembler.vpcmpeqb_rrr(left, scratch, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpmaxuw_rrr(right, left, dest);
-                m_assembler.vpcmpeqw_rrr(left, dest, dest);
+                m_assembler.vpmaxuw_rrr(right, left, scratch);
+                m_assembler.vpcmpeqw_rrr(left, scratch, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpmaxud_rrr(right, left, dest);
-                m_assembler.vpcmpeqd_rrr(left, dest, dest);
+                m_assembler.vpmaxud_rrr(right, left, scratch);
+                m_assembler.vpcmpeqd_rrr(left, scratch, dest);
                 break;
             case SIMDLane::i64x2:
                 RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("i64x2 unsigned comparisons are not supported.");
@@ -2529,19 +2528,18 @@ public:
             RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Shouldn't emit integer vector Below comparisons directly.");
             break;
         case BelowOrEqual:
-            // FIXME: these functions need to take scratch register since left can be dest.
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpminub_rrr(right, left, dest);
-                m_assembler.vpcmpeqb_rrr(left, dest, dest);
+                m_assembler.vpminub_rrr(right, left, scratch);
+                m_assembler.vpcmpeqb_rrr(left, scratch, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpminuw_rrr(right, left, dest);
-                m_assembler.vpcmpeqw_rrr(left, dest, dest);
+                m_assembler.vpminuw_rrr(right, left, scratch);
+                m_assembler.vpcmpeqw_rrr(left, scratch, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpminud_rrr(right, left, dest);
-                m_assembler.vpcmpeqd_rrr(left, dest, dest);
+                m_assembler.vpminud_rrr(right, left, scratch);
+                m_assembler.vpcmpeqd_rrr(left, scratch, dest);
                 break;
             case SIMDLane::i64x2:
                 RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("i64x2 unsigned comparisons are not supported.");
@@ -2569,19 +2567,18 @@ public:
             }
             break;
         case GreaterThanOrEqual:
-            // FIXME: these functions need to take scratch register since left can be dest.
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpmaxsb_rrr(right, left, dest);
-                m_assembler.vpcmpeqb_rrr(left, dest, dest);
+                m_assembler.vpmaxsb_rrr(right, left, scratch);
+                m_assembler.vpcmpeqb_rrr(left, scratch, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpmaxsw_rrr(right, left, dest);
-                m_assembler.vpcmpeqw_rrr(left, dest, dest);
+                m_assembler.vpmaxsw_rrr(right, left, scratch);
+                m_assembler.vpcmpeqw_rrr(left, scratch, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpmaxsd_rrr(right, left, dest);
-                m_assembler.vpcmpeqd_rrr(left, dest, dest);
+                m_assembler.vpmaxsd_rrr(right, left, scratch);
+                m_assembler.vpcmpeqd_rrr(left, scratch, dest);
                 break;
             case SIMDLane::i64x2:
                 // Intel doesn't support 64-bit packed maximum/minimum without AVX512, so this condition should have been transformed
@@ -2611,19 +2608,18 @@ public:
             }
             break;
         case LessThanOrEqual:
-            // FIXME: these functions need to take scratch register since left can be dest.
             switch (simdInfo.lane) {
             case SIMDLane::i8x16:
-                m_assembler.vpminsb_rrr(right, left, dest);
-                m_assembler.vpcmpeqb_rrr(left, dest, dest);
+                m_assembler.vpminsb_rrr(right, left, scratch);
+                m_assembler.vpcmpeqb_rrr(left, scratch, dest);
                 break;
             case SIMDLane::i16x8:
-                m_assembler.vpminsw_rrr(right, left, dest);
-                m_assembler.vpcmpeqw_rrr(left, dest, dest);
+                m_assembler.vpminsw_rrr(right, left, scratch);
+                m_assembler.vpcmpeqw_rrr(left, scratch, dest);
                 break;
             case SIMDLane::i32x4:
-                m_assembler.vpminsd_rrr(right, left, dest);
-                m_assembler.vpcmpeqd_rrr(left, dest, dest);
+                m_assembler.vpminsd_rrr(right, left, scratch);
+                m_assembler.vpcmpeqd_rrr(left, scratch, dest);
                 break;
             case SIMDLane::i64x2:
                 // Intel doesn't support 64-bit packed maximum/minimum without AVX512, so this condition should have been transformed

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1713,8 +1713,11 @@ RetDouble U:F:64 /return
 64: CompareFloatingPointVector U:G:32, U:G:Ptr, U:F:128, U:F:128, D:F:128
     DoubleCond, SIMDInfo, Tmp, Tmp, Tmp
 
-64: CompareIntegerVector U:G:32, U:G:Ptr, U:F:128, U:F:128, D:F:128
+arm64: CompareIntegerVector U:G:32, U:G:Ptr, U:F:128, U:F:128, D:F:128
     RelCond, SIMDInfo, Tmp, Tmp, Tmp
+
+x86_64: CompareIntegerVector U:G:32, U:G:Ptr, U:F:128, U:F:128, D:F:128, S:F:128
+    RelCond, SIMDInfo, Tmp, Tmp, Tmp, Tmp
 
 arm64: CompareIntegerVectorWithZero U:G:32, U:G:Ptr, U:F:128, D:F:128
     RelCond, SIMDInfo, Tmp, Tmp


### PR DESCRIPTION
#### 0aa3e359ab03198c250afecead9196d4e1d7fd2b
<pre>
[JSC] Fix x64 CompareIntegerVector
<a href="https://bugs.webkit.org/show_bug.cgi?id=249288">https://bugs.webkit.org/show_bug.cgi?id=249288</a>
rdar://103335482

Reviewed by Mark Lam.

This patch fixes a bug in x64 CompareIntegerVector, where it does noot account the cases where the left,
right, and dest registers may be the same: specifically, the left == dest, or right == dest, or left == right == dest cases.
We add scratch register to fix this.

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::compareIntegerVector):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::addSIMDRelOp):
(JSC::Wasm::AirIRGenerator64::addConstant):

Canonical link: <a href="https://commits.webkit.org/257835@main">https://commits.webkit.org/257835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61c71b360d4c3e334cb5aa8c5de372d0f77a46cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109505 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169740 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10230 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92600 "Failed to checkout and rebase branch from PR 7593") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107394 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105947 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/92600 "Failed to checkout and rebase branch from PR 7593") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/92600 "Failed to checkout and rebase branch from PR 7593") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90750 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3104 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86725 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/545 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3082 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29061 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9210 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43416 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89607 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4914 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20033 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2769 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->