### PR TITLE
libpas build fix

### DIFF
--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -549,6 +549,8 @@
 		2B2A58992742D803005EE07C /* pas_probabilistic_guard_malloc_allocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B2A58972742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.h */; };
 		2B2A589A2742D803005EE07C /* pas_probabilistic_guard_malloc_allocator.c in Sources */ = {isa = PBXBuildFile; fileRef = 2B2A58982742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.c */; };
 		2B2A589C2742D815005EE07C /* PGMTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B2A589B2742D815005EE07C /* PGMTests.cpp */; };
+		2B2E2FD12949A41100F85C38 /* pas_malloc_stack_logging.c in Sources */ = {isa = PBXBuildFile; fileRef = 2B2E2FCF2949A41100F85C38 /* pas_malloc_stack_logging.c */; };
+		2B2E2FD22949A41100F85C38 /* pas_malloc_stack_logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B2E2FD02949A41100F85C38 /* pas_malloc_stack_logging.h */; };
 		2B6055E42805368B00C8BDAC /* BmallocTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B6055E32805368B00C8BDAC /* BmallocTests.cpp */; };
 		2C11E88E2728A783002162D0 /* bmalloc_type.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C11E88C2728A783002162D0 /* bmalloc_type.h */; };
 		2C11E88F2728A783002162D0 /* pas_simple_type.c in Sources */ = {isa = PBXBuildFile; fileRef = 2C11E88D2728A783002162D0 /* pas_simple_type.c */; };
@@ -1251,6 +1253,8 @@
 		2B2A58972742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_probabilistic_guard_malloc_allocator.h; sourceTree = "<group>"; };
 		2B2A58982742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_probabilistic_guard_malloc_allocator.c; sourceTree = "<group>"; };
 		2B2A589B2742D815005EE07C /* PGMTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PGMTests.cpp; sourceTree = "<group>"; };
+		2B2E2FCF2949A41100F85C38 /* pas_malloc_stack_logging.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_malloc_stack_logging.c; sourceTree = "<group>"; };
+		2B2E2FD02949A41100F85C38 /* pas_malloc_stack_logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_malloc_stack_logging.h; sourceTree = "<group>"; };
 		2B6055E32805368B00C8BDAC /* BmallocTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BmallocTests.cpp; sourceTree = "<group>"; };
 		2C11E88C2728A783002162D0 /* bmalloc_type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bmalloc_type.h; sourceTree = "<group>"; };
 		2C11E88D2728A783002162D0 /* pas_simple_type.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_simple_type.c; sourceTree = "<group>"; };
@@ -1750,6 +1754,8 @@
 				0FEA45BB236CD5AC00B5A375 /* pas_lock_free_read_ptr_ptr_hashtable.h */,
 				0F9E945623452262009FAFDD /* pas_log.c */,
 				0F9E945723452262009FAFDD /* pas_log.h */,
+				2B2E2FCF2949A41100F85C38 /* pas_malloc_stack_logging.c */,
+				2B2E2FD02949A41100F85C38 /* pas_malloc_stack_logging.h */,
 				0F037AF125AEA9190079B582 /* pas_medium_megapage_cache.c */,
 				0F037AF225AEA91A0079B582 /* pas_medium_megapage_cache.h */,
 				0FC6820021210B19003C6A13 /* pas_megapage_cache.c */,
@@ -2256,6 +2262,7 @@
 				0FE7EE2122960142004F4166 /* pas_lock.h in Headers */,
 				0FEA45BD236CD5AC00B5A375 /* pas_lock_free_read_ptr_ptr_hashtable.h in Headers */,
 				0F9E945923452262009FAFDD /* pas_log.h in Headers */,
+				2B2E2FD22949A41100F85C38 /* pas_malloc_stack_logging.h in Headers */,
 				0F037AF425AEA91A0079B582 /* pas_medium_megapage_cache.h in Headers */,
 				0FE7EE2222960142004F4166 /* pas_megapage_cache.h in Headers */,
 				0FD22CFC22CAF16400B21841 /* pas_min_heap.h in Headers */,
@@ -2774,6 +2781,7 @@
 				0F04C21F2460DB6F001D31F0 /* pas_lock.c in Sources */,
 				0FEA45BC236CD5AC00B5A375 /* pas_lock_free_read_ptr_ptr_hashtable.c in Sources */,
 				0F9E945823452262009FAFDD /* pas_log.c in Sources */,
+				2B2E2FD12949A41100F85C38 /* pas_malloc_stack_logging.c in Sources */,
 				0F037AF325AEA91A0079B582 /* pas_medium_megapage_cache.c in Sources */,
 				0FE7EDC822960142004F4166 /* pas_megapage_cache.c in Sources */,
 				0FD48B4B23A9ABB30026C46D /* pas_monotonic_time.c in Sources */,

--- a/Source/bmalloc/libpas/src/chaos/Chaos.cpp
+++ b/Source/bmalloc/libpas/src/chaos/Chaos.cpp
@@ -148,7 +148,7 @@ void threadMain(uintptr_t threadIndex)
         [&] (unique_ptr<Packet> packet) {
             Locker locker(globalPoolLock);
             globalPoolNumBytes += packet->numBytes;
-            globalPool.push_back(move(packet));
+            globalPool.push_back(std::move(packet));
         };
     
     auto takePacketFromGlobalPool =
@@ -158,8 +158,8 @@ void threadMain(uintptr_t threadIndex)
                 return unique_ptr<Packet>(nullptr);
             uintptr_t index =
                 uniform_int_distribution<uintptr_t>(0, globalPool.size() - 1)(randomGenerator);
-            unique_ptr<Packet> result = move(globalPool[index]);
-            globalPool[index] = move(globalPool.back());
+            unique_ptr<Packet> result = std::move(globalPool[index]);
+            globalPool[index] = std::move(globalPool.back());
             PAS_ASSERT(result->numBytes <= globalPoolNumBytes);
             globalPoolNumBytes -= result->numBytes;
             globalPool.pop_back();
@@ -228,7 +228,7 @@ void threadMain(uintptr_t threadIndex)
                 } else {
                     unique_ptr<Packet> packet = takePacketFromGlobalPool();
                     if (packet)
-                        localPool.push_back(move(packet));
+                        localPool.push_back(std::move(packet));
                 }
             } else
                 allocate();
@@ -236,11 +236,11 @@ void threadMain(uintptr_t threadIndex)
             if (localPool.size() > maxPacketsPerThread) {
                 uintptr_t index = 
                     uniform_int_distribution<uintptr_t>(0, localPool.size() - 1)(randomGenerator);
-                unique_ptr<Packet> result = move(localPool[index]);
+                unique_ptr<Packet> result = std::move(localPool[index]);
                 PAS_ASSERT(result);
                 localPool.erase(localPool.begin() + index);
                 if (!result->objects.empty())
-                    givePacketToGlobalPool(move(result));
+                    givePacketToGlobalPool(std::move(result));
             }
         };
 

--- a/Source/bmalloc/libpas/src/test/ThingyAndUtilityHeapAllocationTests.cpp
+++ b/Source/bmalloc/libpas/src/test/ThingyAndUtilityHeapAllocationTests.cpp
@@ -771,7 +771,7 @@ void testFreeListRefillSpans(unsigned prewarmObjectSize,
             objectsInThisSpan.push_back(ptr);
             actualNumberOfObjects++;
         }
-        objects.push_back(move(objectsInThisSpan));
+        objects.push_back(std::move(objectsInThisSpan));
     }
 
 #if PAS_ENABLE_TESTING


### PR DESCRIPTION
#### 9edeea7f6e68a167132183276c7aba8f795173d7
<pre>
libpas build fix
<a href="https://bugs.webkit.org/show_bug.cgi?id=249290">https://bugs.webkit.org/show_bug.cgi?id=249290</a>

Reviewed by Yusuke Suzuki.

Add malloc stack logging files to Xcode project.
Modify test cases include std:: when using move function.

* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/chaos/Chaos.cpp:
(std::threadMain):
* Source/bmalloc/libpas/src/test/ThingyAndUtilityHeapAllocationTests.cpp:
(std::testFreeListRefillSpans):

Canonical link: <a href="https://commits.webkit.org/257853@main">https://commits.webkit.org/257853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff24548597ee338787490414d3fba448842822c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100181 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109508 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169743 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10235 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92603 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107397 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7737 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34429 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22415 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90753 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3107 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23930 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86728 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/548 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3085 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29063 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9213 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43418 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89610 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5393 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4917 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20035 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->