### PR TITLE
[JSC] Fix AVX functions more

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -1761,6 +1761,7 @@ public:
 
     void divDouble(FPRegisterID src, FPRegisterID dest)
     {
+        // dest = dest / src
         // https://www.felixcloutier.com/x86/divsd
         // VEX.LIG.F2.0F.WIG 5E /r VDIVSD xmm1, xmm2, xmm3/m64
         // B   NA   ModRM:reg (w)   VEX.vvvv (r)   ModRM:r/m (r)   NA
@@ -1772,6 +1773,7 @@ public:
 
     void divDouble(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
     {
+        // dest = op1 / op2
         // B := A / B is invalid.
         ASSERT(op1 == dest || op2 != dest);
         if (supportsAVX())
@@ -1784,6 +1786,7 @@ public:
 
     void divDouble(Address src, FPRegisterID dest)
     {
+        // dest = dest / src
         if (supportsAVX())
             m_assembler.vdivsd_mrr(src.offset, src.base, dest, dest);
         else
@@ -1813,6 +1816,7 @@ public:
 
     void subDouble(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
     {
+        // dest = op1 - op2
         if (supportsAVX())
             m_assembler.vsubsd_rrr(op2, op1, dest);
         else {
@@ -1825,6 +1829,7 @@ public:
 
     void subDouble(FPRegisterID op1, Address op2, FPRegisterID dest)
     {
+        // dest = op1 - op2
         if (supportsAVX())
             m_assembler.vsubsd_mrr(op2.offset, op2.base, op1, dest);
         else {
@@ -1835,6 +1840,7 @@ public:
 
     void subDouble(FPRegisterID op1, BaseIndex op2, FPRegisterID dest)
     {
+        // dest = op1 - op2
         if (supportsAVX())
             m_assembler.vsubsd_mrr(op2.offset, op2.base, op2.index, op2.scale, op1, dest);
         else {

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -337,7 +337,7 @@ x86: MulFloat U:F:32, UD:F:32
     Tmp, Tmp
     Addr, Tmp
 
-arm: DivDouble U:F:64, U:F:32, D:F:64
+arm: DivDouble U:F:64, U:F:64, D:F:64
     Tmp, Tmp, Tmp
 
 x86: DivDouble U:F:64, UD:F:64

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -21501,13 +21501,18 @@ IGNORE_CLANG_WARNINGS_END
     {
         PatchpointValue* result = m_out.patchpoint(Void);
         result->effects.writesLocalState = true;
-        result->append(value, ValueRep::reg(GPRInfo::regT0));
         Type valueType = value->type();
+        if (valueType == Double)
+            result->append(value, ValueRep::reg(FPRInfo::fpRegT0));
+        else
+            result->append(value, ValueRep::reg(GPRInfo::regT0));
         result->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams&) {
             AllowMacroScratchRegisterUsage allowScratch(jit);
 
             jit.probeDebug([=] (Probe::Context& context) {
-                if (valueType == Int32)
+                if (valueType == Double)
+                    dataLogLn(prefix, context.fpr<double>(FPRInfo::fpRegT0));
+                else if (valueType == Int32)
                     dataLogLn(prefix, context.gpr<int32_t>(GPRInfo::regT0));
                 else
                     dataLogLn(prefix, context.gpr<JSValue>(GPRInfo::regT0));


### PR DESCRIPTION
#### 1d13b6a54e05bcac8de9fade78527d04035ef802
<pre>
[JSC] Fix AVX functions more
<a href="https://bugs.webkit.org/show_bug.cgi?id=249291">https://bugs.webkit.org/show_bug.cgi?id=249291</a>
rdar://103340763

Reviewed by Michael Saboff.

This patch fixes more AVX functions (vdivsd_mrr etc.) so that
we can now pass all JSC tests with AVX enabled.
We also fixes AirOpcode.opcodes&apos;s DivDouble definition, but
since we do not lower from MoveDouble to MoveFloat, this fix
does not affect on the result, but anyway, this is a bug fix.

* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h:
(JSC::MacroAssemblerX86Common::divDouble):
(JSC::MacroAssemblerX86Common::subDouble):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::vpinsrb_i8mrr):
(JSC::X86Assembler::vpinsrb_i8rrr):
(JSC::X86Assembler::vpinsrw_i8mrr):
(JSC::X86Assembler::vpinsrd_i8mrr):
(JSC::X86Assembler::vpinsrq_i8mrr):
(JSC::X86Assembler::vdivsd_rrr):
(JSC::X86Assembler::vdivsd_mrr):
(JSC::X86Assembler::vdivss_mrr):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/257863@main">https://commits.webkit.org/257863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e519fe7919ab2f5947d144c375f333dde5b11fb0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109521 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169754 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10259 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107410 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34442 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22430 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90766 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3120 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23946 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86744 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/561 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3098 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29067 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43434 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89624 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4930 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20039 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2782 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->