### PR TITLE
Warn web developers if a WebCodecsVideoFrame is destroyed without close being called

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6166,6 +6166,9 @@ imported/w3c/web-platform-tests/workers/modules/shared-worker-import-data-url.wi
 imported/w3c/web-platform-tests/workers/modules/shared-worker-options-credentials.html [ Skip ]
 imported/w3c/web-platform-tests/xhr/send-after-setting-document-domain.htm [ Skip ]
 
+imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageBitmap.any.html [ DumpJSConsoleLogInStdErr ]
+
 # Needs non-zero line gap in 'Arial'
 fast/text/text-edge-no-half-leading-simple.html [ Skip ]
 fast/text/text-edge-no-half-leading-with-line-height-simple.html [ Skip ]

--- a/LayoutTests/http/wpt/webcodecs/webcodecs-gc.html
+++ b/LayoutTests/http/wpt/webcodecs/webcodecs-gc.html
@@ -40,6 +40,7 @@ async function createChunks(encoderConfig) {
   const h = encoderConfig.height;
   const frame = makeOffscreenCanvas(w, h);
   encoder.encode(frame, { keyFrame: true });
+  frame.close();
 
   const timer = setInterval(() => gc(), 100); 
   await encoder.flush();

--- a/LayoutTests/http/wpt/webcodecs/webcodecs-message-gc-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/webcodecs-message-gc-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+
+PASS VP8 codec GC without calling VideoFrame.close
+

--- a/LayoutTests/http/wpt/webcodecs/webcodecs-message-gc.html
+++ b/LayoutTests/http/wpt/webcodecs/webcodecs-message-gc.html
@@ -3,6 +3,7 @@
 <header>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
+<script src="../resources/gc.js"></script>
 </header>
 <body>
 <script>
@@ -15,30 +16,17 @@ function makeOffscreenCanvas(width, height) {
   return new VideoFrame(canvas, { timestamp: 1 });
 }
 
-async function doEncodeDecode(encoderConfig)
-{
-  let resolve, reject;
-  const promise = new Promise((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
+let chunks = [];
+let config;
 
-  const decoder = new VideoDecoder({
-    output(frame) {
-      resolve(frame);
-    },
-    error(e) {
-      reject(e.message);
-    }
-  });
-
+async function createChunks(encoderConfig) {
+  chunks = [];
   const encoderInit = {
     output(chunk, metadata) {
-      let config = metadata.decoderConfig;
-      if (config) {
-        decoder.configure(config);
+      if (metadata.decoderConfig) {
+        config = metadata.decoderConfig;
       }
-      decoder.decode(chunk);
+      chunks.push(chunk);
     },
     error(e) {
       reject(e.message);
@@ -54,12 +42,44 @@ async function doEncodeDecode(encoderConfig)
   encoder.encode(frame, { keyFrame: true });
   frame.close();
 
+  const timer = setInterval(() => gc(), 100); 
   await encoder.flush();
-  await decoder.flush();
-  encoder.close();
-  decoder.close();
+  clearInterval(timer);
+}
 
-  return promise;
+async function doEncodeDecode(encoderConfig)
+{
+  await createChunks(encoderConfig);
+
+  let resolve, reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  const decoder = new VideoDecoder({
+    // here, we do not do anything with the frame provided to output, so we will not call close.
+    output() {
+      resolve();
+    },
+    error(e) {
+      reject(e.message);
+    }
+  });
+
+  decoder.configure(config);
+
+  for (let chunk of chunks)
+    decoder.decode(chunk);
+
+  const timer = setInterval(() => gc(), 100); 
+  await decoder.flush();
+
+  await promise;
+
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  clearInterval(timer);
 }
 
 function doTest(codec, title)
@@ -71,16 +91,11 @@ function doTest(codec, title)
   config.framerate = 30;
 
   promise_test(async t => {
-    const frame = await doEncodeDecode(config);
-    t.add_cleanup(() => frame.close());
- 
-    assert_not_equals(frame.colorSpace.primaries, null, "primaries");
+    return doEncodeDecode(config);
   }, title);
 }
 
-doTest('vp8', "VP8 decoded frame color space");
-doTest('vp09.00.10.08', "VP9 decoded frame color space");
-doTest('avc1.42001E', "H.264 decoded frame color space");
+doTest('vp8', "VP8 codec GC without calling VideoFrame.close");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.js
@@ -89,6 +89,7 @@ promise_test(async t => {
   for (let i = 0; i < frames_to_encode; i++) {
     var frame = createFrame(original_w, original_h, next_ts++);
     encoder.encode(frame, {});
+    frame.close();
   }
 
   params.width = new_w;
@@ -102,6 +103,7 @@ promise_test(async t => {
   for (let i = 0; i < frames_to_encode; i++) {
     var frame = createFrame(new_w, new_h, next_ts++);
     encoder.encode(frame, {});
+    frame.close();
   }
 
   await encoder.flush();

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.js
@@ -63,6 +63,10 @@ promise_test(async t => {
 
   let frame1 = createFrame(640, 480, 0);
   let frame2 = createFrame(640, 480, 33333);
+  t.add_cleanup(() => {
+    frame1.close();
+    frame2.close();
+  });
 
   encoder.encode(frame1);
   encoder.encode(frame2);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -159,7 +159,7 @@ ExceptionOr<void> WebCodecsVideoDecoder::configure(ScriptExecutionContext& conte
             init.duration = decodedResult.duration;
             init.colorSpace = decodedResult.frame->colorSpace();
 
-            auto videoFrame = WebCodecsVideoFrame::create(WTFMove(decodedResult.frame), WTFMove(init));
+            auto videoFrame = WebCodecsVideoFrame::create(*scriptExecutionContext(), WTFMove(decodedResult.frame), WTFMove(init));
             m_output->handleEvent(WTFMove(videoFrame));
         }, WTFMove(postTaskCallback));
     });

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -49,17 +49,26 @@
 
 namespace WebCore {
 
-WebCodecsVideoFrame::WebCodecsVideoFrame()
+WebCodecsVideoFrame::WebCodecsVideoFrame(ScriptExecutionContext& context)
+    : ContextDestructionObserver(&context)
 {
 }
 
-WebCodecsVideoFrame::WebCodecsVideoFrame(WebCodecsVideoFrameData&& data)
-    : m_data(WTFMove(data))
+WebCodecsVideoFrame::WebCodecsVideoFrame(ScriptExecutionContext& context, WebCodecsVideoFrameData&& data)
+    : ContextDestructionObserver(&context)
+    , m_data(WTFMove(data))
 {
 }
 
 WebCodecsVideoFrame::~WebCodecsVideoFrame()
 {
+    if (m_isDetached)
+        return;
+    if (auto* context = scriptExecutionContext()) {
+        context->postTask([](auto& context) {
+            context.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "A VideoFrame was destroyed without having been closed explicitly"_s);
+        });
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#check-the-usability-of-the-image-argument
@@ -110,7 +119,7 @@ static std::optional<Exception> checkImageUsability(const WebCodecsVideoFrame::C
     });
 }
 
-ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(CanvasImageSource&& source, Init&& init)
+ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutionContext& context, CanvasImageSource&& source, Init&& init)
 {
     if (auto exception = checkImageUsability(source))
         return WTFMove(*exception);
@@ -124,7 +133,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(CanvasImageSou
         if (!image)
             return Exception { InvalidStateError,  "Image element has no video frame"_s };
 
-        return initializeFrameWithResourceAndSize(image.releaseNonNull(), WTFMove(init));
+        return initializeFrameWithResourceAndSize(context, image.releaseNonNull(), WTFMove(init));
     },
     [&] (RefPtr<CSSStyleImageValue>& cssImage) -> ExceptionOr<Ref<WebCodecsVideoFrame>> {
         if (!init.timestamp)
@@ -134,14 +143,14 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(CanvasImageSou
         if (!image)
             return Exception { InvalidStateError,  "CSS Image has no video frame"_s };
 
-        return initializeFrameWithResourceAndSize(image.releaseNonNull(), WTFMove(init));
+        return initializeFrameWithResourceAndSize(context, image.releaseNonNull(), WTFMove(init));
     },
 #if ENABLE(VIDEO)
     [&] (RefPtr<HTMLVideoElement>& video) -> ExceptionOr<Ref<WebCodecsVideoFrame>> {
         RefPtr<VideoFrame> videoFrame = video->player() ? video->player()->videoFrameForCurrentTime() : nullptr;
         if (!videoFrame)
             return Exception { InvalidStateError,  "Video element has no video frame"_s };
-        return initializeFrameFromOtherFrame(videoFrame.releaseNonNull(), WTFMove(init));
+        return initializeFrameFromOtherFrame(context, videoFrame.releaseNonNull(), WTFMove(init));
     },
 #endif
     [&] (RefPtr<HTMLCanvasElement>& canvas) -> ExceptionOr<Ref<WebCodecsVideoFrame>> {
@@ -154,7 +163,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(CanvasImageSou
         auto videoFrame = canvas->toVideoFrame();
         if (!videoFrame)
             return Exception { InvalidStateError,  "Canvas has no frame"_s };
-        return initializeFrameFromOtherFrame(videoFrame.releaseNonNull(), WTFMove(init));
+        return initializeFrameFromOtherFrame(context, videoFrame.releaseNonNull(), WTFMove(init));
     },
 #if ENABLE(OFFSCREEN_CANVAS)
     [&] (RefPtr<OffscreenCanvas>& canvas) -> ExceptionOr<Ref<WebCodecsVideoFrame>> {
@@ -168,7 +177,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(CanvasImageSou
         if (!imageBuffer)
             return Exception { InvalidStateError,  "Input canvas has no image buffer"_s };
 
-        return create(*imageBuffer, { static_cast<int>(canvas->width()), static_cast<int>(canvas->height()) }, WTFMove(init));
+        return create(context, *imageBuffer, { static_cast<int>(canvas->width()), static_cast<int>(canvas->height()) }, WTFMove(init));
     },
 #endif // ENABLE(OFFSCREEN_CANVAS)
     [&] (RefPtr<ImageBitmap>& image) -> ExceptionOr<Ref<WebCodecsVideoFrame>> {
@@ -182,11 +191,11 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(CanvasImageSou
         if (!imageBuffer)
             return Exception { InvalidStateError,  "Input image has no image buffer"_s };
 
-        return create(*imageBuffer, { static_cast<int>(image->width()), static_cast<int>(image->height()) }, WTFMove(init));
+        return create(context, *imageBuffer, { static_cast<int>(image->width()), static_cast<int>(image->height()) }, WTFMove(init));
     });
 }
 
-ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ImageBuffer& buffer, IntSize size, WebCodecsVideoFrame::Init&& init)
+ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutionContext& context, ImageBuffer& buffer, IntSize size, WebCodecsVideoFrame::Init&& init)
 {
     PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, DestinationColorSpace::SRGB() };
     IntRect region { IntPoint::zero(), size };
@@ -202,18 +211,18 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ImageBuffer& b
     if (!videoFrame)
         return Exception { InvalidStateError,  "Unable to create frame from buffer"_s };
 
-    return WebCodecsVideoFrame::initializeFrameFromOtherFrame(videoFrame.releaseNonNull(), WTFMove(init));
+    return WebCodecsVideoFrame::initializeFrameFromOtherFrame(context, videoFrame.releaseNonNull(), WTFMove(init));
 }
 
-ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(Ref<WebCodecsVideoFrame>&& initFrame, Init&& init)
+ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutionContext& context, Ref<WebCodecsVideoFrame>&& initFrame, Init&& init)
 {
     if (initFrame->isDetached())
         return Exception { InvalidStateError,  "VideoFrame is detached"_s };
-    return initializeFrameFromOtherFrame(WTFMove(initFrame), WTFMove(init));
+    return initializeFrameFromOtherFrame(context, WTFMove(initFrame), WTFMove(init));
 }
 
 // https://w3c.github.io/webcodecs/#dom-videoframe-videoframe-data-init
-ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(BufferSource&& data, BufferInit&& init)
+ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutionContext& context, BufferSource&& data, BufferInit&& init)
 {
     if (!isValidVideoFrameBufferInit(init))
         return Exception { TypeError, "buffer init is not valid"_s };
@@ -256,14 +265,14 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(BufferSource&&
     if (!videoFrame)
         return Exception { TypeError, "Unable to create internal resource from data"_s };
     
-    return WebCodecsVideoFrame::create(videoFrame.releaseNonNull(), WTFMove(init));
+    return WebCodecsVideoFrame::create(context, videoFrame.releaseNonNull(), WTFMove(init));
 }
 
-Ref<WebCodecsVideoFrame> WebCodecsVideoFrame::create(Ref<VideoFrame>&& videoFrame, BufferInit&& init)
+Ref<WebCodecsVideoFrame> WebCodecsVideoFrame::create(ScriptExecutionContext& context, Ref<VideoFrame>&& videoFrame, BufferInit&& init)
 {
     ASSERT(isValidVideoFrameBufferInit(init));
 
-    auto result = adoptRef(*new WebCodecsVideoFrame);
+    auto result = adoptRef(*new WebCodecsVideoFrame(context));
     result->m_data.internalFrame = WTFMove(videoFrame);
     result->m_data.format = init.format;
 
@@ -312,7 +321,7 @@ static VideoPixelFormat computeVideoPixelFormat(VideoPixelFormat baseFormat, boo
 }
 
 // https://w3c.github.io/webcodecs/#videoframe-initialize-frame-from-other-frame
-ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOtherFrame(Ref<WebCodecsVideoFrame>&& videoFrame, Init&& init)
+ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOtherFrame(ScriptExecutionContext& context, Ref<WebCodecsVideoFrame>&& videoFrame, Init&& init)
 {
     auto codedWidth = videoFrame->m_data.codedWidth;
     auto codedHeight = videoFrame->m_data.codedHeight;
@@ -320,7 +329,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOt
     if (!validateVideoFrameInit(init, codedWidth, codedHeight, format))
         return Exception { TypeError,  "VideoFrameInit is not valid"_s };
 
-    auto result = adoptRef(*new WebCodecsVideoFrame);
+    auto result = adoptRef(*new WebCodecsVideoFrame(context));
     result->m_data.internalFrame = videoFrame->m_data.internalFrame;
     if (videoFrame->m_data.format)
         result->m_data.format = format;
@@ -336,7 +345,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOt
     return result;
 }
 
-ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOtherFrame(Ref<VideoFrame>&& internalVideoFrame, Init&& init)
+ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOtherFrame(ScriptExecutionContext& context, Ref<VideoFrame>&& internalVideoFrame, Init&& init)
 {
     auto codedWidth = internalVideoFrame->presentationSize().width();
     auto codedHeight = internalVideoFrame->presentationSize().height();
@@ -344,7 +353,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOt
     if (!validateVideoFrameInit(init, codedWidth, codedHeight, format))
         return Exception { TypeError,  "VideoFrameInit is not valid"_s };
 
-    auto result = adoptRef(*new WebCodecsVideoFrame);
+    auto result = adoptRef(*new WebCodecsVideoFrame(context));
     result->m_data.internalFrame = WTFMove(internalVideoFrame);
     result->m_data.format = format;
     result->m_data.codedWidth = codedWidth;
@@ -360,7 +369,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOt
 }
 
 // https://w3c.github.io/webcodecs/#videoframe-initialize-frame-with-resource-and-size
-ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameWithResourceAndSize(Ref<NativeImage>&& image, Init&& init)
+ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameWithResourceAndSize(ScriptExecutionContext& context, Ref<NativeImage>&& image, Init&& init)
 {
     auto internalVideoFrame = VideoFrame::fromNativeImage(image.get());
     if (!internalVideoFrame)
@@ -372,7 +381,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameWithRe
     if (!validateVideoFrameInit(init, codedWidth, codedHeight, format))
         return Exception { TypeError,  "VideoFrameInit is not valid"_s };
 
-    auto result = adoptRef(*new WebCodecsVideoFrame);
+    auto result = adoptRef(*new WebCodecsVideoFrame(context));
     result->m_data.internalFrame = WTFMove(internalVideoFrame);
     result->m_data.format = format;
     result->m_data.codedWidth = codedWidth;
@@ -435,12 +444,12 @@ void WebCodecsVideoFrame::copyTo(BufferSource&& source, CopyToOptions&& options,
     });
 }
 
-ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::clone()
+ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::clone(ScriptExecutionContext& context)
 {
     if (isDetached())
         return Exception { InvalidStateError,  "VideoFrame is detached"_s };
 
-    auto clone = adoptRef(*new WebCodecsVideoFrame(WebCodecsVideoFrameData { m_data }));
+    auto clone = adoptRef(*new WebCodecsVideoFrame(context, WebCodecsVideoFrameData { m_data }));
 
     clone->m_colorSpace = colorSpace();
     clone->m_codedRect = codedRect();

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include "ContextDestructionObserver.h"
 #include "DOMRectReadOnly.h"
 #include "JSDOMPromiseDeferred.h"
 #include "PlaneLayout.h"
@@ -47,7 +48,7 @@ class NativeImage;
 class OffscreenCanvas;
 class VideoColorSpace;
 
-class WebCodecsVideoFrame : public RefCounted<WebCodecsVideoFrame> {
+class WebCodecsVideoFrame : public RefCounted<WebCodecsVideoFrame>, public ContextDestructionObserver {
 public:
     ~WebCodecsVideoFrame();
 
@@ -89,12 +90,12 @@ public:
         std::optional<VideoColorSpaceInit> colorSpace;
     };
 
-    static ExceptionOr<Ref<WebCodecsVideoFrame>> create(CanvasImageSource&&, Init&&);
-    static ExceptionOr<Ref<WebCodecsVideoFrame>> create(Ref<WebCodecsVideoFrame>&&, Init&&);
-    static ExceptionOr<Ref<WebCodecsVideoFrame>> create(BufferSource&&, BufferInit&&);
-    static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ImageBuffer&, IntSize, Init&&);
-    static Ref<WebCodecsVideoFrame> create(Ref<VideoFrame>&&, BufferInit&&);
-    static Ref<WebCodecsVideoFrame> create(WebCodecsVideoFrameData&& data) { return adoptRef(*new WebCodecsVideoFrame(WTFMove(data))); }
+    static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, CanvasImageSource&&, Init&&);
+    static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, Ref<WebCodecsVideoFrame>&&, Init&&);
+    static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, BufferSource&&, BufferInit&&);
+    static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, ImageBuffer&, IntSize, Init&&);
+    static Ref<WebCodecsVideoFrame> create(ScriptExecutionContext&, Ref<VideoFrame>&&, BufferInit&&);
+    static Ref<WebCodecsVideoFrame> create(ScriptExecutionContext& context, WebCodecsVideoFrameData&& data) { return adoptRef(*new WebCodecsVideoFrame(context, WTFMove(data))); }
 
     std::optional<VideoPixelFormat> format() const { return m_data.format; }
     size_t codedWidth() const { return m_data.codedWidth; }
@@ -117,7 +118,7 @@ public:
 
     using CopyToPromise = DOMPromiseDeferred<IDLSequence<IDLDictionary<PlaneLayout>>>;
     void copyTo(BufferSource&&, CopyToOptions&&, CopyToPromise&&);
-    ExceptionOr<Ref<WebCodecsVideoFrame>> clone();
+    ExceptionOr<Ref<WebCodecsVideoFrame>> clone(ScriptExecutionContext&);
     void close();
 
     bool isDetached() const { return m_isDetached; }
@@ -132,12 +133,12 @@ public:
     size_t memoryCost() const { return m_data.memoryCost(); }
 
 private:
-    WebCodecsVideoFrame();
-    explicit WebCodecsVideoFrame(WebCodecsVideoFrameData&&);
+    explicit WebCodecsVideoFrame(ScriptExecutionContext&);
+    WebCodecsVideoFrame(ScriptExecutionContext&, WebCodecsVideoFrameData&&);
 
-    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameFromOtherFrame(Ref<WebCodecsVideoFrame>&&, Init&&);
-    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameFromOtherFrame(Ref<VideoFrame>&&, Init&&);
-    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameWithResourceAndSize(Ref<NativeImage>&&, Init&&);
+    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameFromOtherFrame(ScriptExecutionContext&, Ref<WebCodecsVideoFrame>&&, Init&&);
+    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameFromOtherFrame(ScriptExecutionContext&, Ref<VideoFrame>&&, Init&&);
+    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameWithResourceAndSize(ScriptExecutionContext&, Ref<NativeImage>&&, Init&&);
 
     WebCodecsVideoFrameData m_data;
     mutable RefPtr<VideoColorSpace> m_colorSpace;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
@@ -42,9 +42,9 @@ typedef (HTMLImageElement or HTMLCanvasElement or ImageBitmap
     InterfaceName=VideoFrame,
     ReportExtraMemoryCost,
 ] interface WebCodecsVideoFrame {
-    constructor(CanvasImageSource image, optional VideoFrameInit init = {});
-    constructor(WebCodecsVideoFrame image, optional VideoFrameInit init = {});
-    constructor([AllowShared] BufferSource data, VideoFrameBufferInit init);
+    [CallWith=CurrentScriptExecutionContext] constructor(CanvasImageSource image, optional VideoFrameInit init = {});
+    [CallWith=CurrentScriptExecutionContext] constructor(WebCodecsVideoFrame image, optional VideoFrameInit init = {});
+    [CallWith=CurrentScriptExecutionContext] constructor([AllowShared] BufferSource data, VideoFrameBufferInit init);
 
     readonly attribute VideoPixelFormat? format;
     readonly attribute unsigned long codedWidth;
@@ -59,7 +59,7 @@ typedef (HTMLImageElement or HTMLCanvasElement or ImageBitmap
 
     unsigned long allocationSize(optional VideoFrameCopyToOptions options = {});
     Promise<sequence<PlaneLayout>> copyTo([AllowShared] BufferSource destination, optional VideoFrameCopyToOptions options = {});
-    WebCodecsVideoFrame clone();
+    [CallWith=CurrentScriptExecutionContext] WebCodecsVideoFrame clone();
     undefined close();
 };
 

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -3583,7 +3583,7 @@ private:
         }
 
         if (!m_videoFrames[index])
-            m_videoFrames[index] = WebCodecsVideoFrame::create(WTFMove(m_serializedVideoFrames.at(index)));
+            m_videoFrames[index] = WebCodecsVideoFrame::create(*executionContext(m_lexicalGlobalObject), WTFMove(m_serializedVideoFrames.at(index)));
 
         return getJSValue(m_videoFrames[index].get());
     }


### PR DESCRIPTION
#### cc57182c3c1340406032846854f75b175f46f6ed
<pre>
Warn web developers if a WebCodecsVideoFrame is destroyed without close being called
<a href="https://bugs.webkit.org/show_bug.cgi?id=247728">https://bugs.webkit.org/show_bug.cgi?id=247728</a>
rdar://problem/102188812

Reviewed by Eric Carlson.

Make WebCodecsVideoFrame be a ContextDestructionObserver so that we can post a task to add a warning message from WebCodecsVideoFrame destructor if the WebCodecsVideoFrame is not detached.

* LayoutTests/TestExpectations:
* LayoutTests/http/wpt/webcodecs/webcodecs-gc.html:
* LayoutTests/http/wpt/webcodecs/webcodecs-message-gc-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/webcodecs-message-gc.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.js:
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.js:
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.js:
(testImageBitmapToAndFromVideoFrame):
(promise_test):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::configure):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::WebCodecsVideoFrame):
(WebCore::WebCodecsVideoFrame::~WebCodecsVideoFrame):
(WebCore::WebCodecsVideoFrame::create):
(WebCore::WebCodecsVideoFrame::initializeFrameFromOtherFrame):
(WebCore::WebCodecsVideoFrame::initializeFrameWithResourceAndSize):
(WebCore::WebCodecsVideoFrame::clone):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h:
(WebCore::WebCodecsVideoFrame::create):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readWebCodecsVideoFrame):

Canonical link: <a href="https://commits.webkit.org/257914@main">https://commits.webkit.org/257914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c85f109cf37952460a99f1262663673581dbe3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100383 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109699 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169938 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/99 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92787 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107577 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34568 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22572 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3286 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24091 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3278 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43581 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5435 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5094 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->