### PR TITLE
[@property] Rename CSSPropertySyntax to CSSCustomPropertySyntax

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -854,6 +854,7 @@ css/calc/CSSCalcPrimitiveValueNode.cpp
 css/calc/CSSCalcSymbolTable.cpp
 css/calc/CSSCalcValue.cpp
 css/parser/CSSAtRuleID.cpp
+css/parser/CSSCustomPropertySyntax.cpp
 css/parser/CSSParser.cpp
 css/parser/CSSParserContext.cpp
 css/parser/CSSParserFastPaths.cpp
@@ -868,7 +869,6 @@ css/parser/CSSPropertyParserHelpers.cpp
 css/parser/CSSPropertyParserWorkerSafe.cpp
 css/parser/CSSSelectorParser.cpp
 css/parser/CSSSupportsParser.cpp
-css/parser/CSSPropertySyntax.cpp
 css/parser/CSSTokenizer.cpp
 css/parser/CSSTokenizerInputStream.cpp
 css/parser/CSSVariableParser.cpp

--- a/Source/WebCore/css/CSSRegisteredCustomProperty.cpp
+++ b/Source/WebCore/css/CSSRegisteredCustomProperty.cpp
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-CSSRegisteredCustomProperty::CSSRegisteredCustomProperty(const AtomString& name, const CSSPropertySyntax& syntax, bool inherits, RefPtr<CSSCustomPropertyValue>&& initialValue)
+CSSRegisteredCustomProperty::CSSRegisteredCustomProperty(const AtomString& name, const CSSCustomPropertySyntax& syntax, bool inherits, RefPtr<CSSCustomPropertyValue>&& initialValue)
     : name(name)
     , syntax(syntax)
     , inherits(inherits)

--- a/Source/WebCore/css/CSSRegisteredCustomProperty.h
+++ b/Source/WebCore/css/CSSRegisteredCustomProperty.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "CSSPropertySyntax.h"
+#include "CSSCustomPropertySyntax.h"
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
@@ -36,10 +36,10 @@ struct CSSRegisteredCustomProperty {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     const AtomString name;
-    const CSSPropertySyntax syntax;
+    const CSSCustomPropertySyntax syntax;
     const bool inherits;
 
-    CSSRegisteredCustomProperty(const AtomString& name, const CSSPropertySyntax&, bool inherits, RefPtr<CSSCustomPropertyValue>&& initialValue);
+    CSSRegisteredCustomProperty(const AtomString& name, const CSSCustomPropertySyntax&, bool inherits, RefPtr<CSSCustomPropertyValue>&& initialValue);
 
     const CSSCustomPropertyValue* initialValue() const { return m_initialValue.get(); }
     RefPtr<CSSCustomPropertyValue> initialValueCopy() const;

--- a/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
+++ b/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
@@ -46,7 +46,7 @@ ExceptionOr<void> DOMCSSRegisterCustomProperty::registerProperty(Document& docum
     if (!isCustomPropertyName(descriptor.name))
         return Exception { SyntaxError, "The name of this property is not a custom property name."_s };
 
-    auto syntax = CSSPropertySyntax::parse(descriptor.syntax);
+    auto syntax = CSSCustomPropertySyntax::parse(descriptor.syntax);
     if (!syntax)
         return Exception { SyntaxError, "Invalid property syntax definition."_s };
 

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -1422,7 +1422,7 @@ bool MutableStyleProperties::setCustomProperty(const Document* document, const S
     auto propertyNameAtom = AtomString { propertyName };
     auto* registered = document ? document->registeredCSSCustomProperties().get(propertyNameAtom) : nullptr;
 
-    auto& syntax = registered ? registered->syntax : CSSPropertySyntax::universal();
+    auto& syntax = registered ? registered->syntax : CSSCustomPropertySyntax::universal();
 
     CSSTokenizer tokenizer(value);
     if (!CSSPropertyParser::canParseTypedCustomPropertyValue(syntax, tokenizer.tokenRange(), parserContext))

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
@@ -23,7 +23,7 @@
  */
 
 #include "config.h"
-#include "CSSPropertySyntax.h"
+#include "CSSCustomPropertySyntax.h"
 
 #include "CSSParserIdioms.h"
 #include "CSSTokenizer.h"
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 template<typename CharacterType>
-auto CSSPropertySyntax::parseComponent(StringParsingBuffer<CharacterType> buffer) -> std::optional<Component>
+auto CSSCustomPropertySyntax::parseComponent(StringParsingBuffer<CharacterType> buffer) -> std::optional<Component>
 {
     auto consumeMultiplier = [&] {
         if (skipExactly(buffer, '+'))
@@ -88,10 +88,10 @@ auto CSSPropertySyntax::parseComponent(StringParsingBuffer<CharacterType> buffer
     return Component { Type::CustomIdent, multiplier, ident };
 }
 
-std::optional<CSSPropertySyntax> CSSPropertySyntax::parse(StringView syntax)
+std::optional<CSSCustomPropertySyntax> CSSCustomPropertySyntax::parse(StringView syntax)
 {
     // The format doesn't quite parse with CSSTokenizer.
-    return readCharactersForParsing(syntax, [&](auto buffer) -> std::optional<CSSPropertySyntax> {
+    return readCharactersForParsing(syntax, [&](auto buffer) -> std::optional<CSSCustomPropertySyntax> {
         skipWhile<isCSSSpace>(buffer);
 
         if (skipExactly(buffer, '*')) {
@@ -122,11 +122,11 @@ std::optional<CSSPropertySyntax> CSSPropertySyntax::parse(StringView syntax)
         if (definition.isEmpty())
             return { };
 
-        return CSSPropertySyntax { definition };
+        return CSSCustomPropertySyntax { definition };
     });
 }
 
-auto CSSPropertySyntax::typeForTypeName(StringView dataTypeName) -> Type
+auto CSSCustomPropertySyntax::typeForTypeName(StringView dataTypeName) -> Type
 {
     if (dataTypeName == "length"_s)
         return Type::Length;

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.h
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-struct CSSPropertySyntax {
+struct CSSCustomPropertySyntax {
     enum class Type : uint8_t {
         Length,
         LengthPercentage,
@@ -64,8 +64,8 @@ struct CSSPropertySyntax {
 
     bool isUniversal() const { return definition.isEmpty(); }
 
-    static std::optional<CSSPropertySyntax> parse(StringView);
-    static CSSPropertySyntax universal() { return { }; }
+    static std::optional<CSSCustomPropertySyntax> parse(StringView);
+    static CSSCustomPropertySyntax universal() { return { }; }
 
 private:
     template<typename CharacterType> static std::optional<Component> parseComponent(StringParsingBuffer<CharacterType>);

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -229,7 +229,7 @@ RefPtr<CSSValue> CSSParser::parseValueWithVariableReferences(CSSPropertyID propI
 
     auto& name = downcast<CSSCustomPropertyValue>(value).name();
     auto* registered = builderState.document().registeredCSSCustomProperties().get(name);
-    auto& syntax = registered ? registered->syntax : CSSPropertySyntax::universal();
+    auto& syntax = registered ? registered->syntax : CSSCustomPropertySyntax::universal();
     auto resolvedData = valueWithReferences.resolveVariableReferences(builderState);
     if (!resolvedData)
         return nullptr;

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -22,10 +22,10 @@
 
 #pragma once
 
+#include "CSSCustomPropertySyntax.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParserHelpers.h"
 #include "CSSPropertyParserWorkerSafe.h"
-#include "CSSPropertySyntax.h"
 #include "StyleRuleType.h"
 #include <wtf/text/StringView.h>
 
@@ -51,9 +51,9 @@ public:
 
     // Parses a non-shorthand CSS property
     static RefPtr<CSSValue> parseSingleValue(CSSPropertyID, const CSSParserTokenRange&, const CSSParserContext&);
-    static bool canParseTypedCustomPropertyValue(const CSSPropertySyntax&, const CSSParserTokenRange&, const CSSParserContext&);
-    static RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const CSSPropertySyntax&, const CSSParserTokenRange&, Style::BuilderState&, const CSSParserContext&);
-    static void collectParsedCustomPropertyValueDependencies(const CSSPropertySyntax&, bool isRoot, HashSet<CSSPropertyID>& dependencies, const CSSParserTokenRange&, const CSSParserContext&);
+    static bool canParseTypedCustomPropertyValue(const CSSCustomPropertySyntax&, const CSSParserTokenRange&, const CSSParserContext&);
+    static RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const CSSCustomPropertySyntax&, const CSSParserTokenRange&, Style::BuilderState&, const CSSParserContext&);
+    static void collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax&, bool isRoot, HashSet<CSSPropertyID>& dependencies, const CSSParserTokenRange&, const CSSParserContext&);
 
     static RefPtr<CSSValue> parseCounterStyleDescriptor(CSSPropertyID, CSSParserTokenRange&, const CSSParserContext&);
 
@@ -64,10 +64,10 @@ private:
     bool parseValueStart(CSSPropertyID, bool important);
     bool consumeCSSWideKeyword(CSSPropertyID, bool important);
     RefPtr<CSSValue> parseSingleValue(CSSPropertyID, CSSPropertyID = CSSPropertyInvalid);
-    std::pair<RefPtr<CSSValue>, CSSPropertySyntax::Type> consumeCustomPropertyValueWithSyntax(const CSSPropertySyntax&);
-    bool canParseTypedCustomPropertyValue(const CSSPropertySyntax&);
-    RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const CSSPropertySyntax&, Style::BuilderState&);
-    void collectParsedCustomPropertyValueDependencies(const CSSPropertySyntax&, bool isInitial, HashSet<CSSPropertyID>& dependencies);
+    std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> consumeCustomPropertyValueWithSyntax(const CSSCustomPropertySyntax&);
+    bool canParseTypedCustomPropertyValue(const CSSCustomPropertySyntax&);
+    RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const CSSCustomPropertySyntax&, Style::BuilderState&);
+    void collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax&, bool isInitial, HashSet<CSSPropertyID>& dependencies);
 
     bool inQuirksMode() const { return m_context.mode == HTMLQuirksMode; }
 


### PR DESCRIPTION
#### 30fcb6f7b33f0db82e5a2999fa33cab17bd7ce0b
<pre>
[@property] Rename CSSPropertySyntax to CSSCustomPropertySyntax
<a href="https://bugs.webkit.org/show_bug.cgi?id=249302">https://bugs.webkit.org/show_bug.cgi?id=249302</a>
rdar://103351996

Reviewed by Antoine Quint.

...so it doesn&apos;t collide with the upcoming CSSPropertySyntax enum value in the CSSPropertyID enum (which should be an enum class).

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSRegisteredCustomProperty.cpp:
(WebCore::CSSRegisteredCustomProperty::CSSRegisteredCustomProperty):
* Source/WebCore/css/CSSRegisteredCustomProperty.h:
* Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp:
(WebCore::DOMCSSRegisterCustomProperty::registerProperty):
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::MutableStyleProperties::setCustomProperty):
* Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp: Renamed from Source/WebCore/css/parser/CSSPropertySyntax.cpp.
(WebCore::CSSCustomPropertySyntax::parseComponent):
(WebCore::CSSCustomPropertySyntax::parse):
(WebCore::CSSCustomPropertySyntax::typeForTypeName):
* Source/WebCore/css/parser/CSSCustomPropertySyntax.h: Renamed from Source/WebCore/css/parser/CSSPropertySyntax.h.
(WebCore::CSSCustomPropertySyntax::isUniversal const):
(WebCore::CSSCustomPropertySyntax::universal):
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parseValueWithVariableReferences):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::canParseTypedCustomPropertyValue):
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue):
(WebCore::CSSPropertyParser::collectParsedCustomPropertyValueDependencies):
(WebCore::CSSPropertyParser::consumeCustomPropertyValueWithSyntax):
* Source/WebCore/css/parser/CSSPropertyParser.h:

Canonical link: <a href="https://commits.webkit.org/257852@main">https://commits.webkit.org/257852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36ce2506659357755b2e9a7bd5dbd5394f69190b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109535 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169768 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10276 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92629 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107424 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105984 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91046 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3134 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23957 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3112 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43445 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5391 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4944 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->