### PR TITLE
Add size assert for Element

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -148,6 +148,13 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(Element);
 
+struct SameSizeAsElement : public ContainerNode {
+    QualifiedName tagName;
+    void* elementData;
+};
+
+static_assert(sizeof(Element) == sizeof(SameSizeAsElement), "Element should stay small");
+
 using namespace HTMLNames;
 using namespace XMLNames;
 
@@ -5139,6 +5146,26 @@ StylePropertyMapReadOnly* Element::computedStyleMap()
     auto map = ComputedStylePropertyMapReadOnly::create(*this);
     rareData.setComputedStyleMap(WTFMove(map));
     return rareData.computedStyleMap();
+}
+
+bool Element::hasDuplicateAttribute() const
+{
+    return hasRareData() ? elementRareData()->hasDuplicateAttribute() : false;
+}
+
+void Element::setHasDuplicateAttribute(bool hasDuplicateAttribute)
+{
+    ensureElementRareData().setHasDuplicateAttribute(hasDuplicateAttribute);
+}
+
+bool Element::displayContentsChanged() const
+{
+    return hasRareData() ? elementRareData()->displayContentsChanged() : false;
+}
+
+void Element::setDisplayContentsChanged(bool changed)
+{
+    ensureElementRareData().setDisplayContentsChanged(changed);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -696,8 +696,8 @@ public:
     String description() const override;
     String debugDescription() const override;
 
-    bool hasDuplicateAttribute() const { return m_hasDuplicateAttribute; };
-    void setHasDuplicateAttribute(bool hasDuplicateAttribute) { m_hasDuplicateAttribute = hasDuplicateAttribute; };
+    bool hasDuplicateAttribute() const;
+    void setHasDuplicateAttribute(bool);
 
     virtual void updateUserAgentShadowTree() { }
 
@@ -706,8 +706,8 @@ public:
     ExplicitlySetAttrElementsMap& explicitlySetAttrElementsMap();
     ExplicitlySetAttrElementsMap* explicitlySetAttrElementsMapIfExists() const;
 
-    bool displayContentsChanged() const { return m_displayContentsChanged; }
-    void setDisplayContentsChanged(bool changed = true) { m_displayContentsChanged = changed; }
+    bool displayContentsChanged() const;
+    void setDisplayContentsChanged(bool = true);
 
 protected:
     Element(const QualifiedName&, Document&, ConstructionType);
@@ -831,11 +831,6 @@ private:
 
     QualifiedName m_tagName;
     RefPtr<ElementData> m_elementData;
-
-    // FIXME: these flags should move somewhere else and then we should have a static assert on
-    // Element size and ideally stick to that size.
-    bool m_hasDuplicateAttribute { false };
-    bool m_displayContentsChanged { false };
 };
 
 inline void Element::setSavedLayerScrollPosition(const IntPoint& position)

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -119,6 +119,12 @@ public:
 
     ExplicitlySetAttrElementsMap& explicitlySetAttrElementsMap() { return m_explicitlySetAttrElementsMap; }
 
+    bool hasDuplicateAttribute() const { return m_hasDuplicateAttribute; };
+    void setHasDuplicateAttribute(bool hasDuplicateAttribute) { m_hasDuplicateAttribute = hasDuplicateAttribute; };
+
+    bool displayContentsChanged() const { return m_displayContentsChanged; }
+    void setDisplayContentsChanged(bool changed) { m_displayContentsChanged = changed; }
+
 #if DUMP_NODE_STATISTICS
     OptionSet<UseType> useTypes() const
     {

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -325,9 +325,11 @@ protected:
     // Used by ElementRareData. Defined here for better packing in 64-bit.
     int m_unusualTabIndex { 0 };
     unsigned short m_childIndex { 0 };
+    bool m_hasDuplicateAttribute : 1 { false };
+    bool m_displayContentsChanged : 1 { false };
 
 private:
-    bool m_isElementRareData;
+    bool m_isElementRareData : 1;
 
     std::unique_ptr<NodeListsNodeData> m_nodeLists;
     std::unique_ptr<NodeMutationObserverData> m_mutationObserverData;


### PR DESCRIPTION
#### 80db98e4cb00b296185031cc4ccdb4e902982180
<pre>
Add size assert for Element
<a href="https://bugs.webkit.org/show_bug.cgi?id=249295">https://bugs.webkit.org/show_bug.cgi?id=249295</a>

Reviewed by Antti Koivisto.

To keep Element a reasonable size move two existing flags
to rare data and add a static_assert to verify that
Element does not grow in the future.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::hasDuplicateAttribute const):
(WebCore::Element::setHasDuplicateAttribute):
(WebCore::Element::displayContentsChanged const):
(WebCore::Element::setDisplayContentsChanged):
* Source/WebCore/dom/Element.h:
(WebCore::Element::hasDuplicateAttribute const): Deleted.
(WebCore::Element::setHasDuplicateAttribute): Deleted.
(WebCore::Element::displayContentsChanged const): Deleted.
(WebCore::Element::setDisplayContentsChanged): Deleted.
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::hasDuplicateAttribute const):
(WebCore::ElementRareData::setHasDuplicateAttribute):
(WebCore::ElementRareData::displayContentsChanged const):
(WebCore::ElementRareData::setDisplayContentsChanged):
* Source/WebCore/dom/NodeRareData.h:

Canonical link: <a href="https://commits.webkit.org/258238@main">https://commits.webkit.org/258238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8406a2536d48cd97a890f87ed0f6a686fdf44d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109536 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169769 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10277 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92630 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107425 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34454 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89694 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22443 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77398 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/close-quickly (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3135 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23959 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3113 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9241 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43447 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5670 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4945 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->