### PR TITLE
Port the various FetchOptions to the new IPC serialization format

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1093,6 +1093,11 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/EmptyFrameLoaderClient.h
     loader/EphemeralNonce.h
     loader/FetchOptions.h
+    loader/FetchOptionsCache.h
+    loader/FetchOptionsCredentials.h
+    loader/FetchOptionsDestination.h
+    loader/FetchOptionsMode.h
+    loader/FetchOptionsRedirect.h
     loader/FontLoadRequest.h
     loader/FormState.h
     loader/FormSubmission.h

--- a/Source/WebCore/Modules/fetch/FetchHeaders.h
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.h
@@ -38,16 +38,17 @@ namespace WebCore {
 
 class ScriptExecutionContext;
 
+enum class FetchHeadersGuard : uint8_t {
+    None,
+    Immutable,
+    Request,
+    RequestNoCors,
+    Response
+};
+
 class FetchHeaders : public RefCounted<FetchHeaders> {
 public:
-    enum class Guard {
-        None,
-        Immutable,
-        Request,
-        RequestNoCors,
-        Response
-    };
-
+    using Guard = FetchHeadersGuard;
     using Init = std::variant<Vector<Vector<String>>, Vector<KeyValuePair<String, String>>>;
     static ExceptionOr<Ref<FetchHeaders>> create(std::optional<Init>&&);
 
@@ -118,17 +119,6 @@ inline void FetchHeaders::setGuard(Guard guard)
 } // namespace WebCore
 
 namespace WTF {
-
-template<> struct EnumTraits<WebCore::FetchHeaders::Guard> {
-    using values = EnumValues<
-    WebCore::FetchHeaders::Guard,
-    WebCore::FetchHeaders::Guard::None,
-    WebCore::FetchHeaders::Guard::Immutable,
-    WebCore::FetchHeaders::Guard::Request,
-    WebCore::FetchHeaders::Guard::RequestNoCors,
-    WebCore::FetchHeaders::Guard::Response
-    >;
-};
 
 template<> struct EnumTraitsForPersistence<WebCore::FetchHeaders::Guard> {
     using values = EnumValues<

--- a/Source/WebCore/loader/FetchOptions.h
+++ b/Source/WebCore/loader/FetchOptions.h
@@ -28,6 +28,11 @@
 
 #pragma once
 
+#include "FetchOptionsCache.h"
+#include "FetchOptionsCredentials.h"
+#include "FetchOptionsDestination.h"
+#include "FetchOptionsMode.h"
+#include "FetchOptionsRedirect.h"
 #include "ProcessQualified.h"
 #include "ReferrerPolicy.h"
 #include "ScriptExecutionContextIdentifier.h"
@@ -37,11 +42,11 @@
 namespace WebCore {
 
 struct FetchOptions {
-    enum class Destination : uint8_t { EmptyString, Audio, Audioworklet, Document, Embed, Font, Image, Iframe, Manifest, Model, Object, Paintworklet, Report, Script, Serviceworker, Sharedworker, Style, Track, Video, Worker, Xslt };
-    enum class Mode : uint8_t { Navigate, SameOrigin, NoCors, Cors };
-    enum class Credentials : uint8_t { Omit, SameOrigin, Include };
-    enum class Cache : uint8_t { Default, NoStore, Reload, NoCache, ForceCache, OnlyIfCached };
-    enum class Redirect : uint8_t { Follow, Error, Manual };
+    using Destination = FetchOptionsDestination;
+    using Mode = FetchOptionsMode;
+    using Credentials = FetchOptionsCredentials;
+    using Cache = FetchOptionsCache;
+    using Redirect = FetchOptionsRedirect;
 
     FetchOptions() = default;
     FetchOptions(Destination, Mode, Credentials, Cache, Redirect, ReferrerPolicy, String&&, bool, std::optional<ScriptExecutionContextIdentifier>);
@@ -50,8 +55,6 @@ struct FetchOptions {
 
     template<class Encoder> void encodePersistent(Encoder&) const;
     template<class Decoder> static WARN_UNUSED_RETURN bool decodePersistent(Decoder&, FetchOptions&);
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<FetchOptions> decode(Decoder&);
 
     Destination destination { Destination::EmptyString };
     Mode mode { Mode::NoCors };
@@ -185,73 +188,6 @@ template<> struct EnumTraitsForPersistence<WebCore::FetchOptions::Redirect> {
     >;
 };
 
-template<> struct EnumTraits<WebCore::FetchOptions::Destination> {
-    using values = EnumValues<
-        WebCore::FetchOptions::Destination,
-        WebCore::FetchOptions::Destination::EmptyString,
-        WebCore::FetchOptions::Destination::Audio,
-        WebCore::FetchOptions::Destination::Audioworklet,
-        WebCore::FetchOptions::Destination::Document,
-        WebCore::FetchOptions::Destination::Embed,
-        WebCore::FetchOptions::Destination::Font,
-        WebCore::FetchOptions::Destination::Image,
-        WebCore::FetchOptions::Destination::Iframe,
-        WebCore::FetchOptions::Destination::Manifest,
-        WebCore::FetchOptions::Destination::Model,
-        WebCore::FetchOptions::Destination::Object,
-        WebCore::FetchOptions::Destination::Paintworklet,
-        WebCore::FetchOptions::Destination::Report,
-        WebCore::FetchOptions::Destination::Script,
-        WebCore::FetchOptions::Destination::Serviceworker,
-        WebCore::FetchOptions::Destination::Sharedworker,
-        WebCore::FetchOptions::Destination::Style,
-        WebCore::FetchOptions::Destination::Track,
-        WebCore::FetchOptions::Destination::Video,
-        WebCore::FetchOptions::Destination::Worker,
-        WebCore::FetchOptions::Destination::Xslt
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FetchOptions::Mode> {
-    using values = EnumValues<
-        WebCore::FetchOptions::Mode,
-        WebCore::FetchOptions::Mode::Navigate,
-        WebCore::FetchOptions::Mode::SameOrigin,
-        WebCore::FetchOptions::Mode::NoCors,
-        WebCore::FetchOptions::Mode::Cors
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FetchOptions::Credentials> {
-    using values = EnumValues<
-        WebCore::FetchOptions::Credentials,
-        WebCore::FetchOptions::Credentials::Omit,
-        WebCore::FetchOptions::Credentials::SameOrigin,
-        WebCore::FetchOptions::Credentials::Include
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FetchOptions::Cache> {
-    using values = EnumValues<
-        WebCore::FetchOptions::Cache,
-        WebCore::FetchOptions::Cache::Default,
-        WebCore::FetchOptions::Cache::NoStore,
-        WebCore::FetchOptions::Cache::Reload,
-        WebCore::FetchOptions::Cache::NoCache,
-        WebCore::FetchOptions::Cache::ForceCache,
-        WebCore::FetchOptions::Cache::OnlyIfCached
-    >;
-};
-
-template<> struct EnumTraits<WebCore::FetchOptions::Redirect> {
-    using values = EnumValues<
-        WebCore::FetchOptions::Redirect,
-        WebCore::FetchOptions::Redirect::Follow,
-        WebCore::FetchOptions::Redirect::Error,
-        WebCore::FetchOptions::Redirect::Manual
-    >;
-};
-
 }
 
 namespace WebCore {
@@ -323,29 +259,6 @@ inline bool FetchOptions::decodePersistent(Decoder& decoder, FetchOptions& optio
     options.keepAlive = *keepAlive;
 
     return true;
-}
-
-template<class Encoder>
-inline void FetchOptions::encode(Encoder& encoder) const
-{
-    encodePersistent(encoder);
-    encoder << clientIdentifier;
-}
-
-template<class Decoder>
-inline std::optional<FetchOptions> FetchOptions::decode(Decoder& decoder)
-{
-    FetchOptions options;
-    if (!decodePersistent(decoder, options))
-        return std::nullopt;
-
-    std::optional<std::optional<ScriptExecutionContextIdentifier>> clientIdentifier;
-    decoder >> clientIdentifier;
-    if (!clientIdentifier)
-        return std::nullopt;
-    options.clientIdentifier = WTFMove(clientIdentifier.value());
-
-    return options;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/FetchOptionsCache.h
+++ b/Source/WebCore/loader/FetchOptionsCache.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+    
+enum class FetchOptionsCache : uint8_t { Default, NoStore, Reload, NoCache, ForceCache, OnlyIfCached };
+    
+} // namespace WebCore

--- a/Source/WebCore/loader/FetchOptionsCredentials.h
+++ b/Source/WebCore/loader/FetchOptionsCredentials.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+    
+enum class FetchOptionsCredentials : uint8_t { Omit, SameOrigin, Include };
+    
+} // namespace WebCore

--- a/Source/WebCore/loader/FetchOptionsDestination.h
+++ b/Source/WebCore/loader/FetchOptionsDestination.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+    
+enum class FetchOptionsDestination : uint8_t { EmptyString, Audio, Audioworklet, Document, Embed, Font, Image, Iframe, Manifest, Model, Object, Paintworklet, Report, Script, Serviceworker, Sharedworker, Style, Track, Video, Worker, Xslt };
+    
+} // namespace WebCore

--- a/Source/WebCore/loader/FetchOptionsMode.h
+++ b/Source/WebCore/loader/FetchOptionsMode.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+    
+enum class FetchOptionsMode : uint8_t { Navigate, SameOrigin, NoCors, Cors };
+
+} // namespace WebCore

--- a/Source/WebCore/loader/FetchOptionsRedirect.h
+++ b/Source/WebCore/loader/FetchOptionsRedirect.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+    
+enum class FetchOptionsRedirect : uint8_t { Follow, Error, Manual };
+
+} // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2258,3 +2258,75 @@ enum class WebCore::ReferrerPolicy : uint8_t {
     StrictOriginWhenCrossOrigin,
     UnsafeUrl,
 };
+
+enum class WebCore::FetchOptionsDestination : uint8_t {
+    EmptyString,
+    Audio,
+    Audioworklet,
+    Document,
+    Embed,
+    Font,
+    Image,
+    Iframe,
+    Manifest,
+    Model,
+    Object,
+    Paintworklet,
+    Report,
+    Script,
+    Serviceworker,
+    Sharedworker,
+    Style,
+    Track,
+    Video,
+    Worker,
+    Xslt
+};
+
+enum class WebCore::FetchOptionsMode : uint8_t {
+    Navigate,
+    SameOrigin,
+    NoCors,
+    Cors
+};
+
+enum class WebCore::FetchOptionsCredentials : uint8_t {
+    Omit,
+    SameOrigin,
+    Include
+};
+
+enum class WebCore::FetchOptionsCache : uint8_t {
+    Default,
+    NoStore,
+    Reload,
+    NoCache,
+    ForceCache,
+    OnlyIfCached
+};
+
+enum class WebCore::FetchOptionsRedirect : uint8_t {
+    Follow,
+    Error,
+    Manual
+};
+
+struct WebCore::FetchOptions {
+    WebCore::FetchOptionsDestination destination;
+    WebCore::FetchOptionsMode mode;
+    WebCore::FetchOptionsCredentials credentials;
+    WebCore::FetchOptionsCache cache;
+    WebCore::FetchOptionsRedirect redirect;
+    WebCore::ReferrerPolicy referrerPolicy;
+    String integrity;
+    bool keepAlive;
+    std::optional<WebCore::ScriptExecutionContextIdentifier> clientIdentifier;
+}
+
+enum class WebCore::FetchHeadersGuard : uint8_t {
+    None,
+    Immutable,
+    Request,
+    RequestNoCors,
+    Response
+};

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in
@@ -26,7 +26,7 @@ messages -> WebSWClientConnection {
     # When possible, these messages can be implemented directly by WebCore::SWServer::Connection
     JobRejectedInServer(WebCore::ServiceWorkerJobIdentifier jobDataIdentifier, struct WebCore::ExceptionData exception)
     RegistrationJobResolvedInServer(WebCore::ServiceWorkerJobIdentifier jobDataIdentifier, struct WebCore::ServiceWorkerRegistrationData registration, enum:bool WebCore::ShouldNotifyWhenResolved shouldNotifyWhenResolved)
-    StartScriptFetchForServer(WebCore::ServiceWorkerJobIdentifier jobDataIdentifier, WebCore::ServiceWorkerRegistrationKey registrationKey, WebCore::FetchOptions::Cache cachePolicy)
+    StartScriptFetchForServer(WebCore::ServiceWorkerJobIdentifier jobDataIdentifier, WebCore::ServiceWorkerRegistrationKey registrationKey, enum:uint8_t WebCore::FetchOptions::Cache cachePolicy)
     UpdateRegistrationState(WebCore::ServiceWorkerRegistrationIdentifier identifier, enum:uint8_t WebCore::ServiceWorkerRegistrationState state, std::optional<WebCore::ServiceWorkerData> serviceWorkerIdentifier)
     UpdateWorkerState(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, enum:uint8_t WebCore::ServiceWorkerState state)
     FireUpdateFoundEvent(WebCore::ServiceWorkerRegistrationIdentifier identifier)


### PR DESCRIPTION
#### df928f2f3d5af2580922ca6b2584f0b611b85643
<pre>
Port the various FetchOptions to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=249311">https://bugs.webkit.org/show_bug.cgi?id=249311</a>
rdar://103355724

Reviewed by Alex Christensen.

This change includes ports for:
    - FetchOptionsDestination
    - FetchOptionsMode
    - FetchOptionsCredentials
    - FetchOptionsCache
    - FetchOptionsRedirect
    - FetchOptions
    - FetchHeadersGuard

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/fetch/FetchHeaders.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/FetchOptions.h:
(WebCore::FetchOptions::encode const): Deleted.
(WebCore::FetchOptions::decode): Deleted.
* Source/WebCore/loader/FetchOptionsCache.h: Added.
* Source/WebCore/loader/FetchOptionsCredentials.h: Added.
* Source/WebCore/loader/FetchOptionsDestination.h: Added.
* Source/WebCore/loader/FetchOptionsMode.h: Added.
* Source/WebCore/loader/FetchOptionsRedirect.h: Added.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in:

Canonical link: <a href="https://commits.webkit.org/257941@main">https://commits.webkit.org/257941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/908e6be47c287bdcd77a5b2985915d5eb84dba71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109719 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169965 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/131 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92806 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107597 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7930 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34581 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22588 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3304 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24107 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3295 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9416 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43597 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5112 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2836 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->