### PR TITLE
[iOS] Scrolling after element focus does not avoid input views when OOP keyboard is enabled

### DIFF
--- a/LayoutTests/fast/forms/ios/scroll-after-tapping-on-input-with-software-keyboard-expected.txt
+++ b/LayoutTests/fast/forms/ios/scroll-after-tapping-on-input-with-software-keyboard-expected.txt
@@ -1,0 +1,10 @@
+Tests scrolling to reveal a text input on tap. To manually test, tap the input below without a hardware keyboard connected; the input field should be centered in the visible viewport.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS scrollY is >= 400
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/scroll-after-tapping-on-input-with-software-keyboard.html
+++ b/LayoutTests/fast/forms/ios/scroll-after-tapping-on-input-with-software-keyboard.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="initial-scale=1, width=device-width">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    height: 2000px;
+    margin: 0;
+}
+
+input {
+    position: absolute;
+    top: 90vh;
+    left: calc(50vw - 100px);
+    width: 200px;
+    font-size: 18px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Tests scrolling to reveal a text input on tap. To manually test, tap the input below without a hardware keyboard connected; the input field should be centered in the visible viewport.");
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.setHardwareKeyboardAttached(false);
+
+    const input = document.querySelector("input");
+    await UIHelper.activateElementAndWaitForInputSession(input);
+
+    shouldBeGreaterThanOrEqual("scrollY", "400");
+
+    input.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<input placeholder="Tap me" />
+</body>
+</html>

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -469,6 +469,7 @@ UIProcess/ios/GestureRecognizerConsistencyEnforcer.mm
 UIProcess/ios/InputViewUpdateDeferrer.mm
 UIProcess/ios/PageClientImplIOS.mm
 UIProcess/ios/ProcessStateMonitor.mm
+UIProcess/ios/RevealFocusedElementDeferrer.mm
 UIProcess/ios/SmartMagnificationController.mm
 UIProcess/ios/TextCheckerIOS.mm
 UIProcess/ios/ViewGestureControllerIOS.mm

--- a/Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.h
+++ b/Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(IOS_FAMILY)
+
+#import <wtf/EnumTraits.h>
+#import <wtf/OptionSet.h>
+#import <wtf/RefCounted.h>
+#import <wtf/WeakObjCPtr.h>
+
+@class WKContentView;
+
+namespace WebKit {
+
+enum class RevealFocusedElementDeferralReason : uint8_t {
+    EditorState = 1 << 0,
+    KeyboardWillShow = 1 << 1,
+    KeyboardDidShow = 1 << 2,
+};
+
+class RevealFocusedElementDeferrer final : public RefCounted<RevealFocusedElementDeferrer> {
+public:
+    static Ref<RevealFocusedElementDeferrer> create(WKContentView *, OptionSet<RevealFocusedElementDeferralReason>);
+    void fulfill(RevealFocusedElementDeferralReason);
+
+private:
+    RevealFocusedElementDeferrer(WKContentView *, OptionSet<RevealFocusedElementDeferralReason>);
+
+    WeakObjCPtr<WKContentView> m_view;
+    OptionSet<RevealFocusedElementDeferralReason> m_reasons;
+};
+
+} // namespace WebKit
+
+namespace WTF {
+
+template<> struct EnumTraits<WebKit::RevealFocusedElementDeferralReason> {
+    using values = EnumValues<
+        WebKit::RevealFocusedElementDeferralReason,
+        WebKit::RevealFocusedElementDeferralReason::EditorState,
+        WebKit::RevealFocusedElementDeferralReason::KeyboardWillShow,
+        WebKit::RevealFocusedElementDeferralReason::KeyboardDidShow
+    >;
+};
+
+} // namespace WTF
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.mm
+++ b/Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.mm
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "RevealFocusedElementDeferrer.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "WKContentViewInteraction.h"
+
+namespace WebKit {
+
+RevealFocusedElementDeferrer::RevealFocusedElementDeferrer(WKContentView *view, OptionSet<RevealFocusedElementDeferralReason> reasons)
+    : m_view(view)
+    , m_reasons(reasons)
+{
+    ASSERT(!m_reasons.isEmpty());
+}
+
+Ref<RevealFocusedElementDeferrer> RevealFocusedElementDeferrer::create(WKContentView *view, OptionSet<RevealFocusedElementDeferralReason> reasons)
+{
+    return adoptRef(*new RevealFocusedElementDeferrer(view, reasons));
+}
+
+void RevealFocusedElementDeferrer::fulfill(RevealFocusedElementDeferralReason reason)
+{
+    m_reasons.remove(reason);
+    if (!m_reasons.isEmpty())
+        return;
+
+    Ref protectedThis = *this;
+    [std::exchange(m_view, nil) _zoomToRevealFocusedElement];
+}
+
+} // namespace WebKit
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -37,6 +37,7 @@
 #import "ImageAnalysisUtilities.h"
 #import "InteractionInformationAtPosition.h"
 #import "PasteboardAccessIntent.h"
+#import "RevealFocusedElementDeferrer.h"
 #import "SyntheticEditingCommandType.h"
 #import "TextCheckingController.h"
 #import "TransactionID.h"
@@ -266,7 +267,7 @@ struct ImageAnalysisContextMenuActionData {
     RetainPtr<UIMenu> machineReadableCodeMenu;
 };
 
-}
+} // namespace WebKit
 
 @class WKFocusedElementInfo;
 @protocol UIMenuBuilder;
@@ -434,6 +435,8 @@ struct ImageAnalysisContextMenuActionData {
     WeakObjCPtr<WKDataListSuggestionsControl> _dataListSuggestionsControl;
 #endif
 
+    RefPtr<WebKit::RevealFocusedElementDeferrer> _revealFocusedElementDeferrer;
+
     BOOL _isEditable;
     BOOL _showingTextStyleOptions;
     BOOL _hasValidPositionInformation;
@@ -472,8 +475,7 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _isRelinquishingFirstResponderToFocusedElement;
     BOOL _unsuppressSoftwareKeyboardAfterNextAutocorrectionContextUpdate;
     BOOL _isUnsuppressingSoftwareKeyboardUsingLastAutocorrectionContext;
-    BOOL _waitingForKeyboardToStartAnimatingInAfterElementFocus;
-    BOOL _shouldZoomToFocusRectAfterShowingKeyboard;
+    BOOL _waitingForKeyboardAppearanceAnimationToStart;
     BOOL _isHidingKeyboard;
     BOOL _isPreparingEditMenu;
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1164,7 +1164,7 @@ static WKDragSessionContext *ensureLocalDragSessionContext(id <UIDragSession> se
         _interactionViewsContainerView = nil;
     }
 
-    _waitingForKeyboardToStartAnimatingInAfterElementFocus = NO;
+    _waitingForKeyboardAppearanceAnimationToStart = NO;
     _lastInsertedCharacterToOverrideCharacterBeforeSelection = std::nullopt;
 
     [_touchEventGestureRecognizer setDelegate:nil];
@@ -1241,7 +1241,7 @@ static WKDragSessionContext *ensureLocalDragSessionContext(id <UIDragSession> se
     _pointerInteraction = nil;
 #endif
 
-    [self resetShouldZoomToFocusRectAfterShowingKeyboard];
+    _revealFocusedElementDeferrer = nullptr;
 
 #if HAVE(PENCILKIT_TEXT_INPUT)
     [self cleanUpScribbleInteraction];
@@ -2404,23 +2404,14 @@ static NSValue *nsSizeForTapHighlightBorderRadius(WebCore::IntSize borderRadius,
 
 - (void)_keyboardWillShow
 {
-    _waitingForKeyboardToStartAnimatingInAfterElementFocus = NO;
+    _waitingForKeyboardAppearanceAnimationToStart = NO;
+
+    if (_revealFocusedElementDeferrer)
+        _revealFocusedElementDeferrer->fulfill(WebKit::RevealFocusedElementDeferralReason::KeyboardWillShow);
 }
 
 - (void)_keyboardDidShow
 {
-    [self _zoomToFocusRectAfterShowingKeyboardIfNeeded];
-
-#if USE(UICONTEXTMENU)
-    [_fileUploadPanel repositionContextMenuIfNeeded];
-#endif
-}
-
-- (void)_zoomToFocusRectAfterShowingKeyboardIfNeeded
-{
-    if (!_shouldZoomToFocusRectAfterShowingKeyboard)
-        return;
-
     // FIXME: This deferred call to -_zoomToRevealFocusedElement works around the fact that Mail compose
     // disables automatic content inset adjustment using the keyboard height, and instead has logic to
     // explicitly set WKScrollView's contentScrollInset after receiving UIKeyboardDidShowNotification.
@@ -2428,23 +2419,28 @@ static NSValue *nsSizeForTapHighlightBorderRadius(WebCore::IntSize borderRadius,
     // Mail, we won't take the keyboard height into account when scrolling.
     // Mitigate this by deferring the call to -_zoomToRevealFocusedElement in this case until after the
     // keyboard has finished animating. We can revert this once rdar://87733414 is fixed.
-    [self resetShouldZoomToFocusRectAfterShowingKeyboard];
-    [self performSelector:@selector(_zoomToRevealFocusedElement) withObject:nil afterDelay:0];
+    RunLoop::main().dispatch([weakSelf = WeakObjCPtr<WKContentView>(self)] {
+        auto strongSelf = weakSelf.get();
+        if (!strongSelf || !strongSelf->_revealFocusedElementDeferrer)
+            return;
+
+        strongSelf->_revealFocusedElementDeferrer->fulfill(WebKit::RevealFocusedElementDeferralReason::KeyboardDidShow);
+    });
+
+#if USE(UICONTEXTMENU)
+    [_fileUploadPanel repositionContextMenuIfNeeded];
+#endif
 }
 
 - (void)_zoomToRevealFocusedElement
 {
+    _revealFocusedElementDeferrer = nullptr;
+
     if (_focusedElementInformation.preventScroll)
         return;
 
     if (_suppressSelectionAssistantReasons || _activeTextInteractionCount)
         return;
-
-    if (!self._scroller.firstResponderKeyboardAvoidanceEnabled
-        && (_page->isKeyboardAnimatingIn() || _waitingForKeyboardToStartAnimatingInAfterElementFocus)) {
-        _shouldZoomToFocusRectAfterShowingKeyboard = YES;
-        return;
-    }
 
     // In case user scaling is force enabled, do not use that scaling when zooming in with an input field.
     // Zooming above the page's default scale factor should only happen when the user performs it.
@@ -2455,12 +2451,6 @@ static NSValue *nsSizeForTapHighlightBorderRadius(WebCore::IntSize borderRadius,
         maximumScale:_focusedElementInformation.maximumScaleFactorIgnoringAlwaysScalable
         allowScaling:_focusedElementInformation.allowsUserScalingIgnoringAlwaysScalable && WebKit::currentUserInterfaceIdiomIsSmallScreen()
         forceScroll:[self requiresAccessoryView]];
-}
-
-- (void)resetShouldZoomToFocusRectAfterShowingKeyboard
-{
-    _shouldZoomToFocusRectAfterShowingKeyboard = NO;
-    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(_zoomToRevealFocusedElement) object:nil];
 }
 
 - (UIView *)inputView
@@ -7043,7 +7033,7 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
     }
 
     _inputPeripheral = createInputPeripheralWithView(_focusedElementInformation.elementType, self);
-    _waitingForKeyboardToStartAnimatingInAfterElementFocus = requiresKeyboard;
+    _waitingForKeyboardAppearanceAnimationToStart = requiresKeyboard && !_isChangingFocus;
 
 #if HAVE(PEPPER_UI_CORE)
     [self addFocusedFormControlOverlay];
@@ -7066,9 +7056,17 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
     // For elements that have selectable content (e.g. text field) we need to wait for the web process to send an up-to-date
     // selection rect before we can zoom and reveal the selection. Non-selectable elements (e.g. <select>) can be zoomed
     // immediately because they have no selection to reveal.
-    if (requiresKeyboard)
+    if (requiresKeyboard) {
+        _revealFocusedElementDeferrer = WebKit::RevealFocusedElementDeferrer::create(self, [&] {
+            OptionSet reasons { WebKit::RevealFocusedElementDeferralReason::EditorState };
+            if (!self._scroller.firstResponderKeyboardAvoidanceEnabled)
+                reasons.add(WebKit::RevealFocusedElementDeferralReason::KeyboardDidShow);
+            else if (_waitingForKeyboardAppearanceAnimationToStart)
+                reasons.add(WebKit::RevealFocusedElementDeferralReason::KeyboardWillShow);
+            return reasons;
+        }());
         _page->setWaitingForPostLayoutEditorStateUpdateAfterFocusingElement(true);
-    else
+    } else
         [self _zoomToRevealFocusedElement];
 
     [self _updateAccessory];
@@ -7114,9 +7112,8 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
     _focusRequiresStrongPasswordAssistance = NO;
     _autocorrectionContextNeedsUpdate = YES;
     _additionalContextForStrongPasswordAssistance = nil;
-    _waitingForKeyboardToStartAnimatingInAfterElementFocus = NO;
-
-    [self resetShouldZoomToFocusRectAfterShowingKeyboard];
+    _waitingForKeyboardAppearanceAnimationToStart = NO;
+    _revealFocusedElementDeferrer = nullptr;
 
     // When defocusing an editable element reset a seen keydown before calling -_hideKeyboard so that we
     // re-evaluate whether we still need a keyboard when UIKit calls us back in -_requiresKeyboardWhenFirstResponder.
@@ -7255,8 +7252,8 @@ static BOOL allPasteboardItemOriginsMatchOrigin(UIPasteboard *pasteboard, const 
 
     // FIXME: If the initial writing direction just changed, we should wait until we get the next post-layout editor state
     // before zooming to reveal the selection rect.
-    if (mayContainSelectableText(_focusedElementInformation.elementType))
-        [self _zoomToRevealFocusedElement];
+    if (_revealFocusedElementDeferrer)
+        _revealFocusedElementDeferrer->fulfill(WebKit::RevealFocusedElementDeferralReason::EditorState);
 
     _treatAsContentEditableUntilNextEditorStateUpdate = NO;
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2427,6 +2427,7 @@
 		F496A4311F58A272004C1757 /* DragDropInteractionState.h in Headers */ = {isa = PBXBuildFile; fileRef = F496A42F1F58A272004C1757 /* DragDropInteractionState.h */; };
 		F4974E76265ECBBC00B49B8C /* WKRevealItemPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = F446EDEF265EB2B00031DA8F /* WKRevealItemPresenter.h */; };
 		F4975CF22624B80A003C626E /* WKQuickLookPreviewController.h in Headers */ = {isa = PBXBuildFile; fileRef = F4975CF12624B80A003C626E /* WKQuickLookPreviewController.h */; };
+		F499BAA32947C1A4001241D6 /* RevealFocusedElementDeferrer.h in Headers */ = {isa = PBXBuildFile; fileRef = F499BAA12947C1A4001241D6 /* RevealFocusedElementDeferrer.h */; };
 		F4A7B1C128E4DDC30042C75A /* ShareableBitmapHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = F4A7B1C028E4DDC30042C75A /* ShareableBitmapHandle.h */; };
 		F4BA33F225757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BA33F025757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h */; };
 		F4BE0D7727AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BE0D7627AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h */; };
@@ -7586,6 +7587,8 @@
 		F496A4301F58A272004C1757 /* DragDropInteractionState.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = DragDropInteractionState.mm; path = ios/DragDropInteractionState.mm; sourceTree = "<group>"; };
 		F4975CF12624B80A003C626E /* WKQuickLookPreviewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKQuickLookPreviewController.h; sourceTree = "<group>"; };
 		F4975CF32624B918003C626E /* WKQuickLookPreviewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKQuickLookPreviewController.mm; sourceTree = "<group>"; };
+		F499BAA12947C1A4001241D6 /* RevealFocusedElementDeferrer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RevealFocusedElementDeferrer.h; path = ios/RevealFocusedElementDeferrer.h; sourceTree = "<group>"; };
+		F499BAA22947C1A4001241D6 /* RevealFocusedElementDeferrer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = RevealFocusedElementDeferrer.mm; path = ios/RevealFocusedElementDeferrer.mm; sourceTree = "<group>"; };
 		F4A318A7291EFCF600F7A903 /* RemoteMediaPlayerState.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RemoteMediaPlayerState.serialization.in; sourceTree = "<group>"; };
 		F4A7B1C028E4DDC30042C75A /* ShareableBitmapHandle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShareableBitmapHandle.h; sourceTree = "<group>"; };
 		F4A7B1C228E4FB050042C75A /* ShareableBitmapHandle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShareableBitmapHandle.cpp; sourceTree = "<group>"; };
@@ -9885,6 +9888,8 @@
 				0FCB4E3718BBE044000FCFC9 /* PageClientImplIOS.mm */,
 				93E05E3E282CD55D000B69EB /* ProcessStateMonitor.h */,
 				93E05E3F282CD55F000B69EB /* ProcessStateMonitor.mm */,
+				F499BAA12947C1A4001241D6 /* RevealFocusedElementDeferrer.h */,
+				F499BAA22947C1A4001241D6 /* RevealFocusedElementDeferrer.mm */,
 				2DAF06D418BD1A470081CEB1 /* SmartMagnificationController.h */,
 				2DAF06D818BD23BA0081CEB1 /* SmartMagnificationController.messages.in */,
 				2DAF06D518BD1A470081CEB1 /* SmartMagnificationController.mm */,
@@ -15255,6 +15260,7 @@
 				6BE969CD1E54E054008B7483 /* ResourceLoadStatisticsClassifier.h in Headers */,
 				6BE969CB1E54D4CF008B7483 /* ResourceLoadStatisticsClassifierCocoa.h in Headers */,
 				1A30066E1110F4F70031937C /* ResponsivenessTimer.h in Headers */,
+				F499BAA32947C1A4001241D6 /* RevealFocusedElementDeferrer.h in Headers */,
 				442E7BEB27B4586900C69AC1 /* RevealItem.h in Headers */,
 				410482CE1DDD324F00F006D0 /* RTCNetwork.h in Headers */,
 				46F38E8C2416E6730059375A /* RunningBoardServicesSPI.h in Headers */,


### PR DESCRIPTION
#### 3e5d99c2c3f855a3715de3ee90344b4b73337952
<pre>
[iOS] Scrolling after element focus does not avoid input views when OOP keyboard is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=249159">https://bugs.webkit.org/show_bug.cgi?id=249159</a>
rdar://88057475

Reviewed by Aditya Keerthi.

Scrolling to reveal the focused element is currently broken when OOP keyboard is enabled. This is
because OOP keyboard causes `UIKeyboardWillShowNotification` to be delivered to the app
asynchronously (after communicating with the input UI process), rather than dispatched immediately
under the call to `-reloadInputViews`. WebKit currently depends on the latter, since we expect the
keyboard&apos;s final geometry (after animation) to be set by the time the post-layout editor state
arrives in the UI process and we reveal the focused element using `-_zoomToRevealFocusedElement`.
However, since this geometry is sent through the &quot;KeyboardWillShow&quot; notification which (normally)
arrives after the editor state, we end up proceeding with `-_zoomToRevealFocusedElement` without
knowing the final keyboard geometry, so we end up only scrolling to keep the field centered within
the web view (ignoring the obscuring bounds of the software keyboard). In some cases (e.g. when
focusing an input field in some system views), this can cause focused input fields to be completely
obscured by the keyboard.

This is somewhat tricky to fix, since it&apos;s not guaranteed that the &quot;KeyboardWillShow&quot; notification
will always arrive after the editor state or vice versa. To complicate things further, in the Mail
compose case (i.e. when the web view&apos;s scroller has `-firstResponderKeyboardAvoidanceEnabled` set to
`NO`), we&apos;ll actually zoom to reveal the focused element only after `UIKeyboardDidShowNotification`
instead, since the keyboard geometry isn&apos;t available before the animation has finished (see
<a href="https://commits.webkit.org/246159@main">https://commits.webkit.org/246159@main</a> for more context). And of course, this fix also needs to
continue working with OOP keyboard disabled, where the &quot;KeyboardWillShow&quot; notification is dispatched
before we&apos;ve even begun waiting for the next editor state.

To handle all of the above scenarios, we add a helper class that encapsulates logic for deferring
calls to `-_zoomToRevealFocusedElement` after an element is focused. This helper class,
`WebKit::RevealFocusedElementDeferrer`, maintains a set of flags that enumerate the three distinct
reasons why we could be deferring this call: &quot;waiting for an editor state&quot;, &quot;waiting for a
`KeyboardWillShow` notification&quot;, and &quot;waiting for a `KeyboardDidShow` notification&quot;. As
`WKContentView` receives keyboard notification from UIKit or receives an editor state update from
the web process, it removes the appropriate deferral reasons from this helper object. Finally, when
there are no longer any deferral reasons, we call into `-_zoomToRevealFocusedElement` and clear out
the helper.

Test: fast/forms/ios/scroll-after-tapping-on-input-with-software-keyboard.html

* LayoutTests/fast/forms/ios/scroll-after-tapping-on-input-with-software-keyboard-expected.txt: Added.
* LayoutTests/fast/forms/ios/scroll-after-tapping-on-input-with-software-keyboard.html: Added.

Add a new layout test to exercise this scenario. All existing layout tests are actually insufficient
to cover the changes in this fix, since a test needs to:

-   Show the software keyboard (by default, layout tests run with the hardware keyboard connected).
-   Check that we scrolled the focused input into (roughly) the center of the visible viewport, not
    just onto the screen.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.h: Added.
* Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.mm: Added.
(WebKit::RevealFocusedElementDeferrer::RevealFocusedElementDeferrer):
(WebKit::RevealFocusedElementDeferrer::create):
(WebKit::RevealFocusedElementDeferrer::fulfill):

Add the new helper class. We protect the deferrer here since it expects its client (`WKContentView`)
to clear any references to itself when `-_zoomToRevealFocusedElement` is invoked.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpInteraction]):
(-[WKContentView _keyboardWillShow]):
(-[WKContentView _keyboardDidShow]):
(-[WKContentView _zoomToRevealFocusedElement]):
(-[WKContentView resetShouldZoomToFocusRectAfterShowingKeyboard]):
(-[WKContentView _elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:]):

Either call `-_zoomToRevealFocusedElement` immediately, or create a `RevealFocusedElementDeferrer`,
passing in deferral reasons as appropriate. See comments above for more details.

(-[WKContentView _elementDidBlur]):
(-[WKContentView _didUpdateEditorState]):
(-[WKContentView _zoomToFocusRectAfterShowingKeyboardIfNeeded]): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/257861@main">https://commits.webkit.org/257861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67d44a1139e6177d9c60b62530f340da28a98c34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109565 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10311 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92659 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106017 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3142 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9269 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2781 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->