### PR TITLE
[@property] Allow CSS-wide keywords in registered custom properties

### DIFF
--- a/LayoutTests/css-custom-properties-api/inline-expected.txt
+++ b/LayoutTests/css-custom-properties-api/inline-expected.txt
@@ -6,10 +6,10 @@ PASS CSS.registerProperty
 PASS Formerly valid values are still readable from inline styles but are computed as the unset value
 PASS Values not matching the registered type can't be set
 PASS Values can be removed from inline styles
-FAIL Stylesheets can be modified by CSSOM assert_equals: expected "0px" but got "20px"
-FAIL Valid values can be set on inline styles assert_equals: expected "inherit" but got "30em"
-FAIL Var values are accepted assert_equals: expected "calc(var(--b) + 10px)" but got "30em"
-FAIL Var values are accepted without validation assert_equals: expected "calc(var(--b) + 15px)" but got "30em"
-FAIL Var values are accepted without validation, even when it is obvious they will not parse assert_equals: expected "calc(var(--b) 15px)" but got "30em"
-FAIL Var values are accepted without validation, even when it is obvious they will not parse (typed) assert_equals: expected "calc(var(--registered) 15px)" but got "30em"
+PASS Stylesheets can be modified by CSSOM
+PASS Valid values can be set on inline styles
+FAIL Var values are accepted assert_equals: expected "calc(var(--b) + 10px)" but got "inherit"
+FAIL Var values are accepted without validation assert_equals: expected "calc(var(--b) + 15px)" but got "inherit"
+FAIL Var values are accepted without validation, even when it is obvious they will not parse assert_equals: expected "calc(var(--b) 15px)" but got "inherit"
+FAIL Var values are accepted without validation, even when it is obvious they will not parse (typed) assert_equals: expected "calc(var(--registered) 15px)" but got "inherit"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
@@ -119,11 +119,11 @@ PASS syntax:'<length>|INHERIT', initialValue:'10px' is invalid
 PASS syntax:'<percentage>|unsEt', initialValue:'2%' is invalid
 PASS syntax:'<color>|REVert', initialValue:'red' is invalid
 PASS syntax:'<integer>|deFAUlt', initialValue:'1' is invalid
-FAIL syntax:'*', initialValue:'initial' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
-FAIL syntax:'*', initialValue:'inherit' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
-FAIL syntax:'*', initialValue:'unset' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
-FAIL syntax:'*', initialValue:'revert' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
-FAIL syntax:'*', initialValue:'revert-layer' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
+PASS syntax:'*', initialValue:'initial' is invalid
+PASS syntax:'*', initialValue:'inherit' is invalid
+PASS syntax:'*', initialValue:'unset' is invalid
+PASS syntax:'*', initialValue:'revert' is invalid
+PASS syntax:'*', initialValue:'revert-layer' is invalid
 FAIL syntax:'*', initialValue:'default' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
 PASS syntax:'<custom-ident>', initialValue:'initial' is invalid
 PASS syntax:'<custom-ident>', initialValue:'inherit' is invalid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-cssom-expected.txt
@@ -5,5 +5,5 @@ FAIL Formerly valid values are still readable from inline styles but are compute
 FAIL Values not matching the registered type can still be set assert_equals: expected "hi" but got ""
 PASS Values can be removed from inline styles
 FAIL Stylesheets can be modified by CSSOM assert_equals: expected "0px" but got "10px"
-FAIL Valid values can be set on inline styles assert_equals: expected "inherit" but got "pink"
+PASS Valid values can be set on inline styles
 

--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -127,4 +127,18 @@ Vector<CSSParserToken> CSSCustomPropertyValue::tokens() const
     return result;
 }
 
+bool CSSCustomPropertyValue::containsCSSWideKeyword() const
+{
+    return WTF::switchOn(m_value, [&](const CSSValueID& valueID) {
+        return WebCore::isCSSWideKeyword(valueID);
+    }, [&](const Ref<CSSVariableData>& value) {
+        auto range = CSSParserTokenRange { value->tokens() };
+        range.consumeWhitespace();
+        auto token = range.consumeIncludingWhitespace();
+        return range.atEnd() && token.type() == IdentToken && WebCore::isCSSWideKeyword(token.id());
+    }, [&](auto&) {
+        return false;
+    });
+}
+
 }

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -97,6 +97,7 @@ public:
     bool isResolved() const { return !std::holds_alternative<Ref<CSSVariableReferenceValue>>(m_value); }
     bool isUnset() const { return std::holds_alternative<CSSValueID>(m_value) && std::get<CSSValueID>(m_value) == CSSValueUnset; }
     bool isInvalid() const { return std::holds_alternative<CSSValueID>(m_value) && std::get<CSSValueID>(m_value) == CSSValueInvalid; }
+    bool containsCSSWideKeyword() const;
 
     const VariantValue& value() const { return m_value; }
 

--- a/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
+++ b/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
@@ -74,6 +74,9 @@ ExceptionOr<void> DOMCSSRegisterCustomProperty::registerProperty(Document& docum
 
         if (!initialValue || !initialValue->isResolved())
             return Exception { SyntaxError, "The given initial value does not parse for the given syntax."_s };
+
+        if (initialValue->containsCSSWideKeyword())
+            return Exception { SyntaxError, "The intitial value cannot be a CSS-wide keyword."_s };
     }
 
     CSSRegisteredCustomProperty property { AtomString { descriptor.name }, *syntax, descriptor.inherits, WTFMove(initialValue) };

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -87,6 +87,8 @@ public:
             ++m_first;
     }
 
+    CSSParserTokenRange consumeAll() { return { std::exchange(m_first, m_last), m_last }; }
+
     String serialize() const;
 
     const CSSParserToken* begin() const { return m_first; }

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -4306,11 +4306,7 @@ static RefPtr<CSSValue> consumeCustomPaint(CSSParserTokenRange& args)
     if (!args.atEnd())
         args.consume();
 
-    auto argumentList = CSSVariableData::create(args);
-
-    while (!args.atEnd())
-        args.consume();
-
+    auto argumentList = CSSVariableData::create(args.consumeAll());
     return CSSPaintImageValue::create(name, WTFMove(argumentList));
 }
 #endif


### PR DESCRIPTION
#### b957d5f5e295f6a8c8557b75c73ac2ab424f6b6d
<pre>
[@property] Allow CSS-wide keywords in registered custom properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=249305">https://bugs.webkit.org/show_bug.cgi?id=249305</a>
&lt;rdar://problem/103357146&gt;

Reviewed by Alan Baradlay.

CSS-wide keywords (initial, inherit, unset, revert, revert-layer) should be allowed whatever the syntax is.

* LayoutTests/css-custom-properties-api/inline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-cssom-expected.txt:
* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::containsCSSWideKeyword const):

Find if this value contains a CSS-wide keyword, including the &quot;*&quot; case where we just have tokens.

* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp:
(WebCore::DOMCSSRegisterCustomProperty::registerProperty):

CSS-wide keywords are not allowed as the initial value though.

* Source/WebCore/css/parser/CSSParserTokenRange.h:
(WebCore::CSSParserTokenRange::consumeAll):

Add a helper to avoid silly consume loops.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeCustomPropertyValueWithSyntax):
(WebCore::CSSPropertyParser::collectParsedCustomPropertyValueDependencies):
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue):

Canonical link: <a href="https://commits.webkit.org/257873@main">https://commits.webkit.org/257873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94a645d05f9415c4939f200bfdc877bee519bfca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109586 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10333 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107473 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106038 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34496 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3183 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24007 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3164 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43497 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5408 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4992 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->