### PR TITLE
Make sure computed values for 'baseline-shift' CSS property have 'px' unit for lengths

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt
@@ -11,8 +11,8 @@ PASS Can set 'baseline-shift' to a percent: -3.14%
 PASS Can set 'baseline-shift' to a percent: 3.14%
 PASS Can set 'baseline-shift' to a percent: calc(0% + 0%)
 PASS Can set 'baseline-shift' to a length: 0px
-FAIL Can set 'baseline-shift' to a length: -3.14em assert_equals: unit expected "px" but got "em"
-FAIL Can set 'baseline-shift' to a length: 3.14cm assert_equals: unit expected "px" but got "cm"
+PASS Can set 'baseline-shift' to a length: -3.14em
+PASS Can set 'baseline-shift' to a length: 3.14cm
 PASS Can set 'baseline-shift' to a length: calc(0px + 0em)
 PASS Setting 'baseline-shift' to a time: 0s throws TypeError
 PASS Setting 'baseline-shift' to a time: -3.14ms throws TypeError

--- a/Source/WebCore/css/SVGCSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/SVGCSSComputedStyleDeclaration.cpp
@@ -154,8 +154,12 @@ RefPtr<CSSValue> ComputedStyleExtractor::svgPropertyValue(CSSPropertyID property
             return CSSPrimitiveValue::createIdentifier(CSSValueSuper);
         case BaselineShift::Sub:
             return CSSPrimitiveValue::createIdentifier(CSSValueSub);
-        case BaselineShift::Length:
-            return svgStyle.baselineShiftValue().toCSSPrimitiveValue(m_element.get());
+        case BaselineShift::Length: {
+            auto computedValue = svgStyle.baselineShiftValue().toCSSPrimitiveValue(m_element.get());
+            if (computedValue->isLength() && computedValue->primitiveType() != CSSUnitType::CSS_PX)
+                return CSSPrimitiveValue::create(computedValue->doubleValue(CSSUnitType::CSS_PX), CSSUnitType::CSS_PX);
+            return computedValue;
+        }
         }
         ASSERT_NOT_REACHED();
         return nullptr;


### PR DESCRIPTION
#### c08063e923437d16d256cb71e2ce10faf33e04d6
<pre>
Make sure computed values for &apos;baseline-shift&apos; CSS property have &apos;px&apos; unit for lengths
<a href="https://bugs.webkit.org/show_bug.cgi?id=249318">https://bugs.webkit.org/show_bug.cgi?id=249318</a>

Reviewed by Simon Fraser.

Make sure computed values for &apos;baseline-shift&apos; CSS property have &apos;px&apos; unit for lengths.
This is similar to what we do for other types of CSS properties. However, this SVG CSS
property would previously only compute to &apos;px&apos; when applied to a SVGElement.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt:
* Source/WebCore/css/SVGCSSComputedStyleDeclaration.cpp:
(WebCore::ComputedStyleExtractor::svgPropertyValue):

Canonical link: <a href="https://commits.webkit.org/257928@main">https://commits.webkit.org/257928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4498fc427dcdfb7dc8e5a137b001800c13a79eec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109569 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169801 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10315 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92663 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107456 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106021 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7806 "Found 1 new test failure: media/audioSession/ios/audioSessionState-getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91083 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34482 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77444 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3165 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23992 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3146 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43481 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4975 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2826 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->