### PR TITLE
macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS Queue Bringup

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -93,12 +93,12 @@
     { "name": "ews172", "platform": "mac-bigsur" },
     { "name": "ews173", "platform": "mac-bigsur" },
     { "name": "ews174", "platform": "mac-bigsur" },
-    { "name": "ews175", "platform": "mac-bigsur" },
-    { "name": "ews176", "platform": "mac-bigsur" },
-    { "name": "ews177", "platform": "mac-bigsur" },
-    { "name": "ews178", "platform": "mac-bigsur" },
-    { "name": "ews179", "platform": "mac-bigsur" },
-    { "name": "ews180", "platform": "mac-bigsur" },
+    { "name": "ews175", "platform": "mac-ventura" },
+    { "name": "ews176", "platform": "mac-ventura" },
+    { "name": "ews177", "platform": "mac-ventura" },
+    { "name": "ews178", "platform": "mac-ventura" },
+    { "name": "ews179", "platform": "mac-ventura" },
+    { "name": "ews180", "platform": "mac-ventura" },
     { "name": "ews181", "platform": "mac-bigsur" },
     { "name": "ews182", "platform": "mac-bigsur" },
     { "name": "ews183", "platform": "*" },
@@ -165,12 +165,12 @@
       "name": "macOS-AppleSilicon-Big-Sur-Debug-Build-EWS", "shortname": "mac-AS-debug", "icon": "buildOnly",
       "factory": "macOSBuildOnlyFactory", "platform": "mac-bigsur",
       "configuration": "debug", "architectures": ["arm64"],
-      "triggers": ["macos-applesilicon-big-sur-debug-wk2-tests-ews"],
+      "triggers": ["macos-applesilicon-ventura-debug-wk2-tests-ews"],
       "workernames": ["ews171", "ews172", "ews173", "ews174"]
     },
     {
-      "name": "macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS", "shortname": "mac-AS-debug-wk2", "icon": "testOnly",
-      "factory": "macOSWK2Factory", "platform": "mac-bigsur",
+      "name": "macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS", "shortname": "mac-AS-debug-wk2", "icon": "testOnly",
+      "factory": "macOSWK2Factory", "platform": "mac-ventura",
       "configuration": "debug", "architectures": ["arm64"],
       "triggered_by": ["macos-applesilicon-big-sur-debug-build-ews"],
       "workernames": ["ews138", "ews139", "ews140", "ews175", "ews176", "ews177", "ews178", "ews179", "ews180"]
@@ -404,8 +404,8 @@
       "builderNames": ["macOS-AppleSilicon-Big-Sur-Debug-Build-EWS"]
     },
     {
-      "type": "Triggerable", "name": "macos-applesilicon-big-sur-debug-wk2-tests-ews",
-      "builderNames": ["macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS"]
+      "type": "Triggerable", "name": "macos-applesilicon-ventura-debug-wk2-tests-ews",
+      "builderNames": ["macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS"]
     },
     {
       "type": "Triggerable", "name": "ios-16-sim-build-ews",

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -155,7 +155,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'kill-old-processes',
             'compile-webkit'
         ],
-        'macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS': [
+        'macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS': [
             'configure-build',
             'validate-change',
             'configuration',


### PR DESCRIPTION
#### e38ea9cb6f0e7453d21355414bef952c6d5bacc0
<pre>
macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS Queue Bringup
<a href="https://bugs.webkit.org/show_bug.cgi?id=249316">https://bugs.webkit.org/show_bug.cgi?id=249316</a>
rdar://101406098

Reviewed by Ryan Haddad.

macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS Queue Bringup

* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):

Canonical link: <a href="https://commits.webkit.org/257869@main">https://commits.webkit.org/257869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6550ce8991959f80029739d1a0712840ddc1b884

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109587 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10334 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106039 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3184 "Failed to checkout and rebase branch from PR 7620") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3165 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/99180 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9292 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5403 "Build was cancelled. Recent messages:Cleaned up git repository; Checked out pull request; Verified commit is squashed; Reviewed by Ryan Haddad; Validated commit message; Compiled WebKit (warnings); layout-tests (exception)") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2787 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->