### PR TITLE
REGRESSION (256459@main): data-type="number" is broken in libxslt

### DIFF
--- a/Source/WebCore/xml/XSLTUnicodeSort.cpp
+++ b/Source/WebCore/xml/XSLTUnicodeSort.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2007, 2008, 2009 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,18 +72,19 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts, in
 #ifdef XSLT_REFACTORED
     xsltStyleItemSortPtr comp;
 #else
-    const xsltStylePreComp* comp;
+    xsltStylePreCompPtr comp;
 #endif
     xmlXPathObjectPtr *resultsTab[XSLT_MAX_SORT];
     xmlXPathObjectPtr *results = NULL, *res;
     xmlNodeSetPtr list = NULL;
+    int descending, number, desc, numb;
     int len = 0;
     int i, j, incr;
     int tst;
     int depth;
     xmlNodePtr node;
     xmlXPathObjectPtr tmp;    
-    int number[XSLT_MAX_SORT], desc[XSLT_MAX_SORT];
+    int tempstype[XSLT_MAX_SORT], temporder[XSLT_MAX_SORT];
 
     if ((ctxt == NULL) || (sorts == NULL) || (nbsorts <= 0) ||
         (nbsorts >= XSLT_MAX_SORT))
@@ -100,44 +101,41 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts, in
 
     for (j = 0; j < nbsorts; j++) {
         comp = static_cast<xsltStylePreComp*>(sorts[j]->psvi);
+        tempstype[j] = 0;
         if ((comp->stype == NULL) && (comp->has_stype != 0)) {
-            xmlChar* stype =
+            comp->stype =
                 xsltEvalAttrValueTemplate(ctxt, sorts[j], (const xmlChar *) "data-type", XSLT_NAMESPACE);
-            number[j] = 0;
-            if (stype) {
-                if (xmlStrEqual(stype, reinterpret_cast<const xmlChar*>("text"))) {
-                    // number[j] already zero.
-                } else if (xmlStrEqual(stype, reinterpret_cast<const xmlChar*>("number")))
-                    number[j] = 1;
+            if (comp->stype != NULL) {
+                tempstype[j] = 1;
+                if (xmlStrEqual(comp->stype, (const xmlChar *) "text"))
+                    comp->number = 0;
+                else if (xmlStrEqual(comp->stype, (const xmlChar *) "number"))
+                    comp->number = 1;
                 else {
                     xsltTransformError(ctxt, NULL, sorts[j],
                           "xsltDoSortFunction: no support for data-type = %s\n",
-                          stype);
+                                     comp->stype);
+                    comp->number = 0; /* use default */
                 }
-                xmlFree(stype);
             }
-        } else {
-            number[j] = comp->number;
         }
+        temporder[j] = 0;
         if ((comp->order == NULL) && (comp->has_order != 0)) {
-            xmlChar* order = xsltEvalAttrValueTemplate(ctxt, sorts[j],
-                                                       reinterpret_cast<const xmlChar*>("order"),
-                                                       XSLT_NAMESPACE);
-            desc[j] = 0;
-            if (order) {
-                if (xmlStrEqual(order, reinterpret_cast<const xmlChar*>("ascending"))) {
-                    // desc[j] already zero.
-                } else if (xmlStrEqual(order, reinterpret_cast<const xmlChar*>("descending")))
-                    desc[j] = 1;
+            comp->order = xsltEvalAttrValueTemplate(ctxt, sorts[j], (const xmlChar *) "order", XSLT_NAMESPACE);
+            if (comp->order != NULL) {
+                temporder[j] = 1;
+                if (xmlStrEqual(comp->order, (const xmlChar *) "ascending"))
+                    comp->descending = 0;
+                else if (xmlStrEqual(comp->order,
+                                     (const xmlChar *) "descending"))
+                    comp->descending = 1;
                 else {
                     xsltTransformError(ctxt, NULL, sorts[j],
                              "xsltDoSortFunction: invalid value %s for order\n",
-                             order);
+                                     comp->order);
+                    comp->descending = 0; /* use default */
                 }
-                xmlFree(order);
             }
-        } else {
-            desc[j] = comp->descending;
         }
     }
 
@@ -150,6 +148,8 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts, in
     results = resultsTab[0];
 
     comp = static_cast<xsltStylePreComp*>(sorts[0]->psvi);
+    descending = comp->descending;
+    number = comp->number;
     if (results == NULL)
         return;
 
@@ -170,7 +170,7 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts, in
                 if (results[j] == NULL)
                     tst = 1;
                 else {
-                    if (number[0]) {
+                    if (number) {
                         /* We make NaN smaller than number in accordance
                            with XSLT spec */
                         if (xmlXPathIsNaN(results[j]->floatval)) {
@@ -189,7 +189,7 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts, in
                         else tst = -1;
                     } else
                         tst = collator.collateUTF8(reinterpret_cast<const char*>(results[j]->stringval), reinterpret_cast<const char*>(results[j + incr]->stringval));
-                    if (desc[0])
+                    if (descending)
                         tst = -tst;
                 }
                 if (tst == 0) {
@@ -203,6 +203,8 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts, in
                         comp = static_cast<xsltStylePreComp*>(sorts[depth]->psvi);
                         if (comp == NULL)
                             break;
+                        desc = comp->descending;
+                        numb = comp->number;
 
                         /*
                          * Compute the result of the next level for the
@@ -218,7 +220,7 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts, in
                             if (res[j+incr] != NULL)
                                 tst = 1;
                         } else {
-                            if (number[depth]) {
+                            if (numb) {
                                 /* We make NaN smaller than number in
                                    accordance with XSLT spec */
                                 if (xmlXPathIsNaN(res[j]->floatval)) {
@@ -239,7 +241,7 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts, in
                                 else tst = -1;
                             } else
                                 tst = collator.collateUTF8(reinterpret_cast<const char*>(res[j]->stringval), reinterpret_cast<const char*>(res[j + incr]->stringval));
-                            if (desc[depth])
+                            if (desc)
                                 tst = -tst;
                         }
 
@@ -283,6 +285,16 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts, in
 
     for (j = 0; j < nbsorts; j++) {
         comp = static_cast<xsltStylePreComp*>(sorts[j]->psvi);
+        if (tempstype[j] == 1) {
+            /* The data-type needs to be recomputed each time */
+            xmlFree((void *)(comp->stype));
+            comp->stype = NULL;
+        }
+        if (temporder[j] == 1) {
+            /* The order needs to be recomputed each time */
+            xmlFree((void *)(comp->order));
+            comp->order = NULL;
+        }
         if (resultsTab[j] != NULL) {
             for (i = 0;i < len;i++)
                 xmlXPathFreeObject(resultsTab[j][i]);


### PR DESCRIPTION
#### d62c575193bd1c1239b45a34bea8ceb408391237
<pre>
REGRESSION (256459@main): data-type=&quot;number&quot; is broken in libxslt
<a href="https://bugs.webkit.org/show_bug.cgi?id=249321">https://bugs.webkit.org/show_bug.cgi?id=249321</a>
&lt;rdar://103360797&gt;

Unreviewed revert of 256459@main.

* Source/WebCore/xml/XSLTUnicodeSort.cpp:
(WebCore::xsltUnicodeSortFunction):

Canonical link: <a href="https://commits.webkit.org/257866@main">https://commits.webkit.org/257866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb6fc76f46b653b776281141c848595550a0b7ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100248 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109572 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169804 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10318 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92666 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107459 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106024 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34483 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3168 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3149 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43487 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4978 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2783 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->