### PR TITLE
[JSC] Expose error messages from ShadowRealms to outer realm

### DIFF
--- a/JSTests/stress/shadow-realm-evaluate.js
+++ b/JSTests/stress/shadow-realm-evaluate.js
@@ -67,7 +67,7 @@ function shouldThrow(func, errorType, assertionFn) {
       TypeError,
       (err) => {
           shouldBe($.globalObjectFor(err), globalThis);
-          shouldBe(String(err), "TypeError: Error encountered during evaluation");
+          shouldBe(String(err), "TypeError: secret");
       });
 }
 

--- a/Source/JavaScriptCore/runtime/Error.h
+++ b/Source/JavaScriptCore/runtime/Error.h
@@ -49,7 +49,6 @@ JSObject* createTypeError(JSGlobalObject*, const String&, ErrorInstance::SourceA
 JSObject* createNotEnoughArgumentsError(JSGlobalObject*, ErrorInstance::SourceAppender);
 JSObject* createURIError(JSGlobalObject*, const String&, ErrorInstance::SourceAppender);
 
-
 JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, const String&);
 JS_EXPORT_PRIVATE JSObject* createEvalError(JSGlobalObject*, const String&);
 JS_EXPORT_PRIVATE JSObject* createRangeError(JSGlobalObject*, const String&);
@@ -72,6 +71,14 @@ bool getLineColumnAndSource(VM&, Vector<StackFrame>* stackTrace, unsigned& line,
 bool addErrorInfo(VM&, Vector<StackFrame>*, JSObject*);
 JS_EXPORT_PRIVATE void addErrorInfo(JSGlobalObject*, JSObject*, bool);
 JSObject* addErrorInfo(VM&, JSObject* error, int line, const SourceCode&);
+
+// https://github.com/tc39/proposal-shadowrealm/pull/382
+//
+// When an crosses the ShadowRealm barrier, it is converted to a TypeError,
+// without invoking any observable operations. It attempts to maintain the
+// error message of the original error, if possible, and may include additional
+// information.
+JSObject* createTypeErrorCopy(JSGlobalObject*, JSValue error);
 
 // Methods to throw Errors.
 


### PR DESCRIPTION
#### ea7efa2f7f885f2dc5d0dea65d185fb9974cbf58
<pre>
[JSC] Expose error messages from ShadowRealms to outer realm
<a href="https://bugs.webkit.org/show_bug.cgi?id=249324">https://bugs.webkit.org/show_bug.cgi?id=249324</a>

Reviewed by Yusuke Suzuki.

This adds stuff from a yet unmerged spec change from <a href="https://github.com/tc39/proposal-shadowrealm/pull/382.">https://github.com/tc39/proposal-shadowrealm/pull/382.</a>

This particular implementation only concerns itself with converting a
primitive exception to a String and using that as the TypeError message,
or else accessing the own &quot;message&quot; property of an object and using
that, which is sufficient to inherit messages from a native Error.

A more robust approach could attempt to load &quot;message&quot; from the
prototype chain, and could incorporate some limited source information
from the source error into the new error message.

Canonical link: <a href="https://commits.webkit.org/258438@main">https://commits.webkit.org/258438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34f7f8eb91afcfb06f490e838661c2d8d986f988

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111307 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2035 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109061 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107755 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/92362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4702 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/25437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88537 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2309 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4792 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29448 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/exports-oom.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10868 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/44925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91451 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5789 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6541 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20442 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->