### PR TITLE
Update isMasonryRows/Columns to areMasonryRows/Columns

### DIFF
--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -698,8 +698,7 @@ static GridArea insertIntoGrid(Grid& grid, RenderBox& child, const GridArea& are
     return clamped;
 }
 
-// TODO: Update name of functions to 'areMasonryRows'.
-bool RenderGrid::isMasonryRows() const
+bool RenderGrid::areMasonryRows() const
 {
     return style().gridMasonryRows();
 }
@@ -707,9 +706,9 @@ bool RenderGrid::isMasonryRows() const
 // Masonry Spec Section 2
 // "If masonry is specified for both grid-template-columns and grid-template-rows, then the used value for grid-template-columns is none,
 // and thus the inline axis will be the grid axis."
-bool RenderGrid::isMasonryColumns() const
+bool RenderGrid::areMasonryColumns() const
 {
-    return !isMasonryRows() && style().gridMasonryColumns();
+    return !areMasonryRows() && style().gridMasonryColumns();
 }
 
 // Masonry Spec Section 2.3.1 repeat(auto-fit)
@@ -719,7 +718,7 @@ AutoRepeatType RenderGrid::autoRepeatColumnsType() const
 {
     auto autoRepeatColumns = style().gridAutoRepeatColumnsType();
 
-    if (isMasonryRows() && autoRepeatColumns == AutoRepeatType::Fit)
+    if (areMasonryRows() && autoRepeatColumns == AutoRepeatType::Fit)
         return AutoRepeatType::Fill;
 
     return autoRepeatColumns;
@@ -729,7 +728,7 @@ AutoRepeatType RenderGrid::autoRepeatRowsType() const
 {
     auto autoRepeatRow = style().gridAutoRepeatRowsType();
 
-    if (isMasonryColumns() && autoRepeatRow == AutoRepeatType::Fit)
+    if (areMasonryColumns() && autoRepeatRow == AutoRepeatType::Fit)
         return AutoRepeatType::Fill;
 
     return autoRepeatRow;
@@ -766,9 +765,9 @@ void RenderGrid::placeItemsOnGrid(std::optional<LayoutUnit> availableLogicalWidt
 
         // Grid items should use the grid area sizes instead of the containing block (grid container)
         // sizes, we initialize the overrides here if needed to ensure it.
-        if (!child->hasOverridingContainingBlockContentLogicalWidth() && !isMasonryColumns())
+        if (!child->hasOverridingContainingBlockContentLogicalWidth() && !areMasonryColumns())
             child->setOverridingContainingBlockContentLogicalWidth(LayoutUnit());
-        if (!child->hasOverridingContainingBlockContentLogicalHeight() && !isMasonryRows())
+        if (!child->hasOverridingContainingBlockContentLogicalHeight() && !areMasonryRows())
             child->setOverridingContainingBlockContentLogicalHeight(std::nullopt);
 
         GridArea area = currentGrid().gridItemArea(*child);
@@ -818,9 +817,9 @@ void RenderGrid::placeItemsOnGrid(std::optional<LayoutUnit> availableLogicalWidt
         m_masonryLayout.performMasonryPlacement(gridAxisTracksBeforeAutoPlacement, masonryAxisDirection);
     };
 
-    if (isMasonryRows())
+    if (areMasonryRows())
         performMasonryPlacement(ForRows);
-    else if (isMasonryColumns())
+    else if (areMasonryColumns())
         performMasonryPlacement(ForColumns);
     else
         performAutoPlacement();
@@ -1203,9 +1202,9 @@ void RenderGrid::layoutPositionedObject(RenderBox& child, bool relayoutChildren,
 LayoutUnit RenderGrid::gridAreaBreadthForChildIncludingAlignmentOffsets(const RenderBox& child, GridTrackSizingDirection direction) const
 {
     if (direction == ForRows) {
-        if (isMasonryRows())
+        if (areMasonryRows())
             return isHorizontalWritingMode() ? child.height() + child.verticalMarginExtent() : child.width() + child.horizontalMarginExtent();
-    } else if (isMasonryColumns())
+    } else if (areMasonryColumns())
         return isHorizontalWritingMode() ? child.width() + child.horizontalMarginExtent() : child.height() + child.verticalMarginExtent();
 
     // We need the cached value when available because Content Distribution alignment properties
@@ -1735,7 +1734,7 @@ LayoutUnit RenderGrid::columnAxisOffsetForChild(const RenderBox& child) const
     gridAreaPositionForChild(child, ForRows, startOfRow, endOfRow);
     LayoutUnit startPosition = startOfRow + marginBeforeForChild(child);
     LayoutUnit columnAxisChildSize = GridLayoutFunctions::isOrthogonalChild(*this, child) ? child.logicalWidth() + child.marginLogicalWidth() : child.logicalHeight() + child.marginLogicalHeight();
-    LayoutUnit masonryOffset = isMasonryRows() ? m_masonryLayout.offsetForChild(child) : 0_lu;
+    LayoutUnit masonryOffset = areMasonryRows() ? m_masonryLayout.offsetForChild(child) : 0_lu;
     auto overflow = alignSelfForChild(child).overflow();
         LayoutUnit offsetFromStartPosition = computeOverflowAlignmentOffset(overflow, endOfRow - startOfRow, columnAxisChildSize);
     if (hasAutoMarginsInColumnAxis(child))
@@ -1760,7 +1759,7 @@ LayoutUnit RenderGrid::rowAxisOffsetForChild(const RenderBox& child) const
     LayoutUnit endOfColumn;
     gridAreaPositionForChild(child, ForColumns, startOfColumn, endOfColumn);
     LayoutUnit startPosition = startOfColumn + marginStartForChild(child);
-    LayoutUnit masonryOffset = isMasonryColumns() ? m_masonryLayout.offsetForChild(child) : 0_lu;
+    LayoutUnit masonryOffset = areMasonryColumns() ? m_masonryLayout.offsetForChild(child) : 0_lu;
     if (hasAutoMarginsInRowAxis(child))
         return startPosition;
     GridAxisPosition axisPosition = rowAxisPositionForChild(child);

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -235,8 +235,8 @@ private:
 
     bool computeGridPositionsForOutOfFlowChild(const RenderBox&, GridTrackSizingDirection, int&, bool&, int&, bool&) const;
 
-    bool isMasonryRows() const;
-    bool isMasonryColumns() const;
+    bool areMasonryRows() const;
+    bool areMasonryColumns() const;
     AutoRepeatType autoRepeatColumnsType() const;
     AutoRepeatType autoRepeatRowsType() const;
 


### PR DESCRIPTION
#### b9b7b85430bcf1fa938d28113a67d179da852fad
<pre>
Update isMasonryRows/Columns to areMasonryRows/Columns
<a href="https://bugs.webkit.org/show_bug.cgi?id=249325">https://bugs.webkit.org/show_bug.cgi?id=249325</a>

Reviewed by Brent Fulgham.

Update the function names isMasonryRows/Columns.

* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::areMasonryRows const):
(WebCore::RenderGrid::areMasonryColumns const):
(WebCore::RenderGrid::autoRepeatColumnsType const):
(WebCore::RenderGrid::autoRepeatRowsType const):
(WebCore::RenderGrid::placeItemsOnGrid):
(WebCore::RenderGrid::gridAreaBreadthForChildIncludingAlignmentOffsets const):
(WebCore::RenderGrid::columnAxisOffsetForChild const):
(WebCore::RenderGrid::rowAxisOffsetForChild const):
(WebCore::RenderGrid::isMasonryRows const): Deleted.
(WebCore::RenderGrid::isMasonryColumns const): Deleted.
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/257888@main">https://commits.webkit.org/257888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5550bdc65afe983194e3ed3749ac642a63840855

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109583 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169811 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10330 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92676 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107470 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91093 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34498 "Found 1 new test failure: media/video-as-img-output-pts.html (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22483 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3180 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24002 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3161 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43492 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5421 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4989 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->