### PR TITLE
Add margin-trim to CSS parser.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/inheritance-expected.txt
@@ -11,8 +11,8 @@ PASS Property margin-right has initial value 0px
 PASS Property margin-right does not inherit
 PASS Property margin-top has initial value 0px
 PASS Property margin-top does not inherit
-FAIL Property margin-trim has initial value none assert_true: margin-trim doesn't seem to be supported in the computed style expected true got false
-FAIL Property margin-trim does not inherit assert_true: expected true got false
+PASS Property margin-trim has initial value none
+PASS Property margin-trim does not inherit
 PASS Property padding-bottom has initial value 0px
 PASS Property padding-bottom does not inherit
 PASS Property padding-left has initial value 0px

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/parsing/margin-trim-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/parsing/margin-trim-computed-expected.txt
@@ -1,0 +1,18 @@
+
+PASS Property margin-trim value 'none'
+PASS Property margin-trim value 'block'
+PASS Property margin-trim value 'inline'
+PASS Property margin-trim value 'block-start block-end'
+PASS Property margin-trim value 'inline-start inline-end'
+PASS Property margin-trim value 'block-start'
+PASS Property margin-trim value 'block-end'
+PASS Property margin-trim value 'inline-start'
+PASS Property margin-trim value 'inline-end'
+PASS Property margin-trim value 'block-start inline-start'
+PASS Property margin-trim value 'inline-start block-start'
+PASS Property margin-trim value 'inline-end block-start'
+PASS Property margin-trim value 'inline-end block-end'
+PASS Property margin-trim value 'block-start block-end inline-start'
+PASS Property margin-trim value 'inline-start block-start inline-end block-end'
+PASS Property margin-trim value 'inline-start inline-end block-start'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/parsing/margin-trim-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/parsing/margin-trim-computed.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS margin-trim computed style</title>
+<link rel="help" href="https://www.w3.org/TR/css-box-4/#margin-trim">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="Test the computed values for margin-trim">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("margin-trim", "none");
+test_computed_value("margin-trim", "block");
+test_computed_value("margin-trim", "inline");
+test_computed_value("margin-trim", "block-start block-end", "block");
+test_computed_value("margin-trim", "inline-start inline-end", "inline");
+test_computed_value("margin-trim", "block-start");
+test_computed_value("margin-trim", "block-end");
+test_computed_value("margin-trim", "inline-start");
+test_computed_value("margin-trim", "inline-end");
+test_computed_value("margin-trim", "block-start inline-start");
+test_computed_value("margin-trim", "inline-start block-start", "block-start inline-start");
+test_computed_value("margin-trim", "inline-end block-start", "block-start inline-end");
+test_computed_value("margin-trim", "inline-end block-end", "block-end inline-end");
+test_computed_value("margin-trim", "block-start block-end inline-start", "block-start inline-start block-end");
+test_computed_value("margin-trim", "inline-start block-start inline-end block-end", "block-start inline-start block-end inline-end");
+test_computed_value("margin-trim", "inline-start inline-end block-start", "block-start inline-start inline-end");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/parsing/margin-trim-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/parsing/margin-trim-expected.txt
@@ -1,0 +1,26 @@
+
+PASS e.style['margin-trim'] = "none" should set the property value
+PASS e.style['margin-trim'] = "block" should set the property value
+PASS e.style['margin-trim'] = "inline" should set the property value
+PASS e.style['margin-trim'] = "block-start" should set the property value
+PASS e.style['margin-trim'] = "block-end" should set the property value
+PASS e.style['margin-trim'] = "inline-start" should set the property value
+PASS e.style['margin-trim'] = "inline-end" should set the property value
+PASS e.style['margin-trim'] = "block-start block-end" should set the property value
+PASS e.style['margin-trim'] = "inline-start inline-end" should set the property value
+PASS e.style['margin-trim'] = "block-end block-start" should set the property value
+PASS e.style['margin-trim'] = "inline-end inline-start" should set the property value
+PASS e.style['margin-trim'] = "inline-start block-start" should set the property value
+PASS e.style['margin-trim'] = "inline-end block-start block-end" should set the property value
+PASS e.style['margin-trim'] = "block-start inline-start block-end inline-end" should set the property value
+PASS e.style['margin-trim'] = "inline-end block-end inline-start block-start" should set the property value
+PASS e.style['margin-trim'] = "block inline" should not set the property value
+PASS e.style['margin-trim'] = "block block" should not set the property value
+PASS e.style['margin-trim'] = "inline inline" should not set the property value
+PASS e.style['margin-trim'] = "block inline-start inline-end" should not set the property value
+PASS e.style['margin-trim'] = "block block-start block-end" should not set the property value
+PASS e.style['margin-trim'] = "block-start block-end block" should not set the property value
+PASS e.style['margin-trim'] = "block 10px" should not set the property value
+PASS e.style['margin-trim'] = "auto" should not set the property value
+PASS e.style['margin-trim'] = "left" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/parsing/margin-trim.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/parsing/margin-trim.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS margin-trim: property parsing</title>
+<link rel="help" href="https://www.w3.org/TR/css-box-4/#margin-trim">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="Test parsing for the margin-trim property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+// Individual values should get set
+test_valid_value("margin-trim", "none");
+test_valid_value("margin-trim", "block");
+test_valid_value("margin-trim", "inline");
+test_valid_value("margin-trim", "block-start");
+test_valid_value("margin-trim", "block-end");
+test_valid_value("margin-trim", "inline-start");
+test_valid_value("margin-trim", "inline-end");
+
+// Serialize values into either block or inline
+test_valid_value("margin-trim", "block-start block-end", "block");
+test_valid_value("margin-trim", "inline-start inline-end", "inline");
+test_valid_value("margin-trim", "block-end block-start", "block");
+test_valid_value("margin-trim", "inline-end inline-start", "inline");
+test_valid_value("margin-trim", "inline-start block-start");
+
+test_valid_value("margin-trim", "inline-end block-start block-end");
+test_valid_value("margin-trim", "block-start inline-start block-end inline-end");
+test_valid_value("margin-trim", "inline-end block-end inline-start block-start");
+
+test_invalid_value("margin-trim", "block inline");
+test_invalid_value("margin-trim", "block block");
+test_invalid_value("margin-trim", "inline inline");
+test_invalid_value("margin-trim", "block inline-start inline-end");
+test_invalid_value("margin-trim", "block block-start block-end");
+test_invalid_value("margin-trim", "block-start block-end block");
+test_invalid_value("margin-trim", "block 10px");
+test_invalid_value("margin-trim", "auto");
+test_invalid_value("margin-trim", "left");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -189,6 +189,7 @@ PASS margin-inline-start
 PASS margin-left
 PASS margin-right
 PASS margin-top
+PASS margin-trim
 PASS marker-end
 PASS marker-mid
 PASS marker-start

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -188,6 +188,7 @@ PASS margin-inline-start
 PASS margin-left
 PASS margin-right
 PASS margin-top
+PASS margin-trim
 PASS marker-end
 PASS marker-mid
 PASS marker-start

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -189,6 +189,7 @@ PASS margin-inline-start
 PASS margin-left
 PASS margin-right
 PASS margin-top
+PASS margin-trim
 PASS marker-end
 PASS marker-mid
 PASS marker-start

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -189,6 +189,7 @@ PASS margin-inline-start
 PASS margin-left
 PASS margin-right
 PASS margin-top
+PASS margin-trim
 PASS marker-end
 PASS marker-mid
 PASS marker-start

--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -394,6 +394,18 @@ CSSLeadingTrimEnabled:
     WebCore:
       default: false
 
+CSSMarginTrimEnabled:
+  type: bool
+  humanReadableName: "CSS margin-trim property"
+  humanReadableDescription: "Enable margin-trim CSS property"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSMotionPathEnabled:
   type: bool
   humanReadableName: "CSS Motion Path"

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3294,6 +3294,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new LengthPropertyWrapper(CSSPropertyMarginRight, &RenderStyle::marginRight, &RenderStyle::setMarginRight, { LengthPropertyWrapper::Flags::IsLengthPercentage }),
         new LengthPropertyWrapper(CSSPropertyMarginTop, &RenderStyle::marginTop, &RenderStyle::setMarginTop, { LengthPropertyWrapper::Flags::IsLengthPercentage }),
         new LengthPropertyWrapper(CSSPropertyMarginBottom, &RenderStyle::marginBottom, &RenderStyle::setMarginBottom, { LengthPropertyWrapper::Flags::IsLengthPercentage }),
+        new DiscretePropertyWrapper<OptionSet<MarginTrimType>>(CSSPropertyMarginTrim, &RenderStyle::marginTrim, &RenderStyle::setMarginTrim),
         new LengthPropertyWrapper(CSSPropertyPaddingLeft, &RenderStyle::paddingLeft, &RenderStyle::setPaddingLeft, { LengthPropertyWrapper::Flags::IsLengthPercentage, LengthPropertyWrapper::Flags::NegativeLengthsAreInvalid }),
         new LengthPropertyWrapper(CSSPropertyPaddingRight, &RenderStyle::paddingRight, &RenderStyle::setPaddingRight, { LengthPropertyWrapper::Flags::IsLengthPercentage, LengthPropertyWrapper::Flags::NegativeLengthsAreInvalid }),
         new LengthPropertyWrapper(CSSPropertyPaddingTop, &RenderStyle::paddingTop, &RenderStyle::setPaddingTop, { LengthPropertyWrapper::Flags::IsLengthPercentage, LengthPropertyWrapper::Flags::NegativeLengthsAreInvalid }),

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -3700,6 +3700,17 @@
                 "url": "https://www.w3.org/TR/CSS22/box.html#propdef-margin-top"
             }
         },
+        "margin-trim": {
+            "codegen-properties": {
+                "settings-flag": "cssMarginTrimEnabled",
+                "converter": "MarginTrim",
+                "custom-parser": true
+            },
+            "specification": {
+                "category": "css-box-4",
+                "url": "https://www.w3.org/TR/css-box-4/#margin-trim"
+            }
+        },
         "marker": {
             "inherited": true,
             "codegen-properties": {
@@ -8772,6 +8783,11 @@
             "shortname": "CSS Backgrounds and Borders",
             "longname": "CSS Backgrounds and Borders Module",
             "url": "https://www.w3.org/TR/css3-background/"
+        },
+        "css-box-4": {
+            "shortname": "CSS Box 4",
+            "longname": "CSS Box Model Module Level 4",
+            "url": "https://www.w3.org/TR/css-box-4/"
         },
         "css-break": {
             "shortname": "CSS Fragmentation",

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -379,8 +379,8 @@ distribute
 // none
 // left
 // right
-inline-start
-inline-end
+// inline-start
+// inline-end
 //
 // CSS_PROP_LIST_STYLE_POSITION:
 //
@@ -731,6 +731,14 @@ column-reverse
 // nowrap
 // wrap
 wrap-reverse
+
+// CSS_PROP_MARGIN_TRIM
+// block
+block-start
+block-end
+// inline
+inline-start
+inline-end
 
 // CSS_PROP_MARQUEE_DIRECTION
 forwards

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -240,6 +240,7 @@ RefPtr<CSSValue> consumeCounterReset(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeSize(CSSParserTokenRange&, CSSParserMode);
 RefPtr<CSSValue> consumeTextIndent(CSSParserTokenRange&, CSSParserMode);
 RefPtr<CSSValue> consumeMarginSide(CSSParserTokenRange&, CSSPropertyID currentShorthand, CSSParserMode);
+RefPtr<CSSValue> consumeMarginTrim(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeSide(CSSParserTokenRange&, CSSPropertyID currentShorthand, CSSParserMode);
 RefPtr<CSSValue> consumeClip(CSSParserTokenRange&, CSSParserMode);
 RefPtr<CSSValue> consumeTouchAction(CSSParserTokenRange&);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -401,6 +401,8 @@ public:
     LeadingTrim leadingTrim() const { return static_cast<LeadingTrim>(m_rareNonInheritedData->leadingTrim); }
     TextEdge textEdge() const;
 
+    OptionSet<MarginTrimType> marginTrim() const { return m_rareNonInheritedData->marginTrim; }
+
     const Length& wordSpacing() const;
     float letterSpacing() const;
 
@@ -1074,6 +1076,8 @@ public:
     void setLeadingTrim(LeadingTrim value) { SET_VAR(m_rareNonInheritedData, leadingTrim, static_cast<unsigned>(value)); }
     void setTextEdge(TextEdge);
 
+    void setMarginTrim(OptionSet<MarginTrimType> value) { SET_VAR(m_rareNonInheritedData, marginTrim, value); }
+
 #if ENABLE(TEXT_AUTOSIZING)
     void setSpecifiedLineHeight(Length&&);
 #endif
@@ -1684,6 +1688,7 @@ public:
     static Length initialOffset() { return Length(); }
     static Length initialRadius() { return Length(); }
     static Length initialMargin() { return Length(LengthType::Fixed); }
+    static OptionSet<MarginTrimType> initialMarginTrim() { return { }; }
     static Length initialPadding() { return Length(LengthType::Fixed); }
     static Length initialTextIndent() { return Length(LengthType::Fixed); }
     static LeadingTrim initialLeadingTrim() { return LeadingTrim::Normal; }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -675,6 +675,17 @@ TextStream& operator<<(TextStream& ts, ListStyleType styleType)
     return ts << nameLiteral(toCSSValueID(styleType)).characters();
 }
 
+TextStream& operator<<(TextStream& ts, MarginTrimType marginTrimType)
+{
+    switch (marginTrimType) {
+    case MarginTrimType::BlockStart: ts << "block-start"; break;
+    case MarginTrimType::BlockEnd: ts << "block-end"; break;
+    case MarginTrimType::InlineStart: ts << "inline-start"; break;
+    case MarginTrimType::InlineEnd: ts << "inline-end"; break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, MarqueeBehavior marqueeBehavior)
 {
     switch (marqueeBehavior) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -788,6 +788,13 @@ enum class LeadingTrim : uint8_t {
     Both
 };
 
+enum class MarginTrimType : uint8_t {
+    BlockStart = 1 << 0,
+    BlockEnd = 1 << 1,
+    InlineStart = 1 << 2,
+    InlineEnd = 1 << 3
+};
+
 enum class TextEdgeType : uint8_t {
     Leading,
     Text,
@@ -1303,6 +1310,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, LineBreak);
 WTF::TextStream& operator<<(WTF::TextStream&, LineSnap);
 WTF::TextStream& operator<<(WTF::TextStream&, ListStylePosition);
 WTF::TextStream& operator<<(WTF::TextStream&, ListStyleType);
+WTF::TextStream& operator<<(WTF::TextStream&, MarginTrimType);
 WTF::TextStream& operator<<(WTF::TextStream&, MarqueeBehavior);
 WTF::TextStream& operator<<(WTF::TextStream&, MarqueeDirection);
 WTF::TextStream& operator<<(WTF::TextStream&, MaskMode);

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -87,6 +87,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , translate(RenderStyle::initialTranslate())
     , offsetPath(RenderStyle::initialOffsetPath())
     , touchActions(RenderStyle::initialTouchActions())
+    , marginTrim(RenderStyle::initialMarginTrim())
     , pageSizeType(PAGE_SIZE_AUTO)
     , transformStyle3D(static_cast<unsigned>(RenderStyle::initialTransformStyle3D()))
     , transformStyleForcedToFlat(false)
@@ -199,6 +200,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , translate(o.translate)
     , offsetPath(o.offsetPath)
     , touchActions(o.touchActions)
+    , marginTrim(o.marginTrim)
     , pageSizeType(o.pageSizeType)
     , transformStyle3D(o.transformStyle3D)
     , transformStyleForcedToFlat(o.transformStyleForcedToFlat)
@@ -359,7 +361,8 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && offsetAnchor == o.offsetAnchor
         && offsetRotate == o.offsetRotate
         && overflowAnchor == o.overflowAnchor
-        && leadingTrim == o.leadingTrim;
+        && leadingTrim == o.leadingTrim
+        && marginTrim == o.marginTrim;
 }
 
 bool StyleRareNonInheritedData::contentDataEquivalent(const StyleRareNonInheritedData& other) const

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -202,6 +202,8 @@ public:
 
     OptionSet<TouchAction> touchActions;
 
+    OptionSet<MarginTrimType> marginTrim;
+
     unsigned pageSizeType : 2; // PageSizeType
     unsigned transformStyle3D : 2; // TransformStyle3D
     unsigned transformStyleForcedToFlat : 1; // The used value for transform-style is forced to flat by a grouping property.


### PR DESCRIPTION
#### e603e43fbb226e2dd51867afc86e6c0a879c800e
<pre>
Add margin-trim to CSS parser.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249205">https://bugs.webkit.org/show_bug.cgi?id=249205</a>
rdar://103285644

Reviewed by Tim Nguyen.

Creates a feature flag for the margin-trim CSS property and also
adds it to the CSS parser behind this flag. When the flag is enabled the
property can be set according to the grammar in the spec.

This property has the following grammar:
none | block | inline | [ block-start || inline-start || block-end || inline-end ]

Spec reference: <a href="https://www.w3.org/TR/css-box-4/#margin-trim">https://www.w3.org/TR/css-box-4/#margin-trim</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/parsing/margin-trim-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/parsing/margin-trim-computed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/parsing/margin-trim-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/parsing/margin-trim.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/css/parser/CSSParserContext.cpp:
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeMarginTrim):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::marginTrim const):
(WebCore::RenderStyle::setMarginTrim):
(WebCore::RenderStyle::initialMarginTrim):
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertMarginTrim):

Canonical link: <a href="https://commits.webkit.org/257960@main">https://commits.webkit.org/257960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e43d22f400b9a161e2c72ca063c85562864e7a37

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109800 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170047 "Hash e43d22f4 for PR 7626 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104436 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10516 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92867 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107633 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91227 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22616 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90985 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3340 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24135 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87006 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/801 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3332 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29123 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43625 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89888 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5454 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5147 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20094 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->