### PR TITLE
Add more subtests to css/css-typed-om/the-stylepropertymap/properties WPT tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/accent-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/accent-color-expected.txt
@@ -6,17 +6,35 @@ PASS Can set 'accent-color' to CSS-wide keywords: revert
 PASS Can set 'accent-color' to var() references:  var(--A)
 PASS Can set 'accent-color' to the 'currentcolor' keyword: currentcolor
 FAIL Can set 'accent-color' to the 'auto' keyword: auto assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS Setting 'accent-color' to a length throws TypeError
-PASS Setting 'accent-color' to a percent throws TypeError
-PASS Setting 'accent-color' to a time throws TypeError
-PASS Setting 'accent-color' to an angle throws TypeError
-PASS Setting 'accent-color' to a flexible length throws TypeError
-PASS Setting 'accent-color' to a number throws TypeError
-PASS Setting 'accent-color' to a URL throws TypeError
-PASS Setting 'accent-color' to a transform throws TypeError
-FAIL 'accent-color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'accent-color' does not supported '#bbff00'
-PASS 'accent-color' does not supported 'rgb(255, 255, 128)'
-PASS 'accent-color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'accent-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'accent-color' to a length: 0px throws TypeError
+PASS Setting 'accent-color' to a length: -3.14em throws TypeError
+PASS Setting 'accent-color' to a length: 3.14cm throws TypeError
+PASS Setting 'accent-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'accent-color' to a percent: 0% throws TypeError
+PASS Setting 'accent-color' to a percent: -3.14% throws TypeError
+PASS Setting 'accent-color' to a percent: 3.14% throws TypeError
+PASS Setting 'accent-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'accent-color' to a time: 0s throws TypeError
+PASS Setting 'accent-color' to a time: -3.14ms throws TypeError
+PASS Setting 'accent-color' to a time: 3.14s throws TypeError
+PASS Setting 'accent-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'accent-color' to an angle: 0deg throws TypeError
+PASS Setting 'accent-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'accent-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'accent-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'accent-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'accent-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'accent-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'accent-color' to a number: 0 throws TypeError
+PASS Setting 'accent-color' to a number: -3.14 throws TypeError
+PASS Setting 'accent-color' to a number: 3.14 throws TypeError
+PASS Setting 'accent-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'accent-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'accent-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'accent-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'accent-color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'accent-color' does not support '#bbff00'
+PASS 'accent-color' does not support 'rgb(255, 255, 128)'
+PASS 'accent-color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'accent-color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline-expected.txt
@@ -15,12 +15,30 @@ FAIL Can set 'alignment-baseline' to the 'text-top' keyword: text-top Invalid va
 FAIL Can set 'alignment-baseline' to the 'bottom' keyword: bottom Invalid values
 FAIL Can set 'alignment-baseline' to the 'center' keyword: center Invalid values
 FAIL Can set 'alignment-baseline' to the 'top' keyword: top Invalid values
-PASS Setting 'alignment-baseline' to a length throws TypeError
-PASS Setting 'alignment-baseline' to a percent throws TypeError
-PASS Setting 'alignment-baseline' to a time throws TypeError
-PASS Setting 'alignment-baseline' to an angle throws TypeError
-PASS Setting 'alignment-baseline' to a flexible length throws TypeError
-PASS Setting 'alignment-baseline' to a number throws TypeError
-PASS Setting 'alignment-baseline' to a URL throws TypeError
-PASS Setting 'alignment-baseline' to a transform throws TypeError
+PASS Setting 'alignment-baseline' to a length: 0px throws TypeError
+PASS Setting 'alignment-baseline' to a length: -3.14em throws TypeError
+PASS Setting 'alignment-baseline' to a length: 3.14cm throws TypeError
+PASS Setting 'alignment-baseline' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'alignment-baseline' to a percent: 0% throws TypeError
+PASS Setting 'alignment-baseline' to a percent: -3.14% throws TypeError
+PASS Setting 'alignment-baseline' to a percent: 3.14% throws TypeError
+PASS Setting 'alignment-baseline' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'alignment-baseline' to a time: 0s throws TypeError
+PASS Setting 'alignment-baseline' to a time: -3.14ms throws TypeError
+PASS Setting 'alignment-baseline' to a time: 3.14s throws TypeError
+PASS Setting 'alignment-baseline' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'alignment-baseline' to an angle: 0deg throws TypeError
+PASS Setting 'alignment-baseline' to an angle: 3.14rad throws TypeError
+PASS Setting 'alignment-baseline' to an angle: -3.14deg throws TypeError
+PASS Setting 'alignment-baseline' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'alignment-baseline' to a flexible length: 0fr throws TypeError
+PASS Setting 'alignment-baseline' to a flexible length: 1fr throws TypeError
+PASS Setting 'alignment-baseline' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'alignment-baseline' to a number: 0 throws TypeError
+PASS Setting 'alignment-baseline' to a number: -3.14 throws TypeError
+PASS Setting 'alignment-baseline' to a number: 3.14 throws TypeError
+PASS Setting 'alignment-baseline' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'alignment-baseline' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'alignment-baseline' to a transform: perspective(10em) throws TypeError
+PASS Setting 'alignment-baseline' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/all-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/all-expected.txt
@@ -4,12 +4,30 @@ FAIL Can set 'all' to CSS-wide keywords: inherit assert_equals: expected "CSSKey
 FAIL Can set 'all' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'all' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'all' to var() references:  var(--A) assert_equals: expected 2 but got 1
-PASS Setting 'all' to a length throws TypeError
-PASS Setting 'all' to a percent throws TypeError
-PASS Setting 'all' to a time throws TypeError
-PASS Setting 'all' to an angle throws TypeError
-PASS Setting 'all' to a flexible length throws TypeError
-PASS Setting 'all' to a number throws TypeError
-PASS Setting 'all' to a URL throws TypeError
-PASS Setting 'all' to a transform throws TypeError
+PASS Setting 'all' to a length: 0px throws TypeError
+PASS Setting 'all' to a length: -3.14em throws TypeError
+PASS Setting 'all' to a length: 3.14cm throws TypeError
+PASS Setting 'all' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'all' to a percent: 0% throws TypeError
+PASS Setting 'all' to a percent: -3.14% throws TypeError
+PASS Setting 'all' to a percent: 3.14% throws TypeError
+PASS Setting 'all' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'all' to a time: 0s throws TypeError
+PASS Setting 'all' to a time: -3.14ms throws TypeError
+PASS Setting 'all' to a time: 3.14s throws TypeError
+PASS Setting 'all' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'all' to an angle: 0deg throws TypeError
+PASS Setting 'all' to an angle: 3.14rad throws TypeError
+PASS Setting 'all' to an angle: -3.14deg throws TypeError
+PASS Setting 'all' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'all' to a flexible length: 0fr throws TypeError
+PASS Setting 'all' to a flexible length: 1fr throws TypeError
+PASS Setting 'all' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'all' to a number: 0 throws TypeError
+PASS Setting 'all' to a number: -3.14 throws TypeError
+PASS Setting 'all' to a number: 3.14 throws TypeError
+PASS Setting 'all' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'all' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'all' to a transform: perspective(10em) throws TypeError
+PASS Setting 'all' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-end.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-end.tentative-expected.txt
@@ -8,11 +8,26 @@ FAIL Can set 'animation-delay-end' to a time: 0s Invalid property animation-dela
 FAIL Can set 'animation-delay-end' to a time: -3.14ms Invalid property animation-delay-end
 FAIL Can set 'animation-delay-end' to a time: 3.14s Invalid property animation-delay-end
 FAIL Can set 'animation-delay-end' to a time: calc(0s + 0ms) Invalid property animation-delay-end
-PASS Setting 'animation-delay-end' to a length throws TypeError
-PASS Setting 'animation-delay-end' to a percent throws TypeError
-PASS Setting 'animation-delay-end' to an angle throws TypeError
-PASS Setting 'animation-delay-end' to a flexible length throws TypeError
-PASS Setting 'animation-delay-end' to a number throws TypeError
-PASS Setting 'animation-delay-end' to a URL throws TypeError
-PASS Setting 'animation-delay-end' to a transform throws TypeError
+PASS Setting 'animation-delay-end' to a length: 0px throws TypeError
+PASS Setting 'animation-delay-end' to a length: -3.14em throws TypeError
+PASS Setting 'animation-delay-end' to a length: 3.14cm throws TypeError
+PASS Setting 'animation-delay-end' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'animation-delay-end' to a percent: 0% throws TypeError
+PASS Setting 'animation-delay-end' to a percent: -3.14% throws TypeError
+PASS Setting 'animation-delay-end' to a percent: 3.14% throws TypeError
+PASS Setting 'animation-delay-end' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'animation-delay-end' to an angle: 0deg throws TypeError
+PASS Setting 'animation-delay-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'animation-delay-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'animation-delay-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'animation-delay-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'animation-delay-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'animation-delay-end' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'animation-delay-end' to a number: 0 throws TypeError
+PASS Setting 'animation-delay-end' to a number: -3.14 throws TypeError
+PASS Setting 'animation-delay-end' to a number: 3.14 throws TypeError
+PASS Setting 'animation-delay-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'animation-delay-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'animation-delay-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'animation-delay-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-expected.txt
@@ -8,11 +8,26 @@ PASS Can set 'animation-delay' to a time: 0s
 PASS Can set 'animation-delay' to a time: -3.14ms
 PASS Can set 'animation-delay' to a time: 3.14s
 PASS Can set 'animation-delay' to a time: calc(0s + 0ms)
-PASS Setting 'animation-delay' to a length throws TypeError
-PASS Setting 'animation-delay' to a percent throws TypeError
-PASS Setting 'animation-delay' to an angle throws TypeError
-PASS Setting 'animation-delay' to a flexible length throws TypeError
-PASS Setting 'animation-delay' to a number throws TypeError
-PASS Setting 'animation-delay' to a URL throws TypeError
-PASS Setting 'animation-delay' to a transform throws TypeError
+PASS Setting 'animation-delay' to a length: 0px throws TypeError
+PASS Setting 'animation-delay' to a length: -3.14em throws TypeError
+PASS Setting 'animation-delay' to a length: 3.14cm throws TypeError
+PASS Setting 'animation-delay' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'animation-delay' to a percent: 0% throws TypeError
+PASS Setting 'animation-delay' to a percent: -3.14% throws TypeError
+PASS Setting 'animation-delay' to a percent: 3.14% throws TypeError
+PASS Setting 'animation-delay' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'animation-delay' to an angle: 0deg throws TypeError
+PASS Setting 'animation-delay' to an angle: 3.14rad throws TypeError
+PASS Setting 'animation-delay' to an angle: -3.14deg throws TypeError
+PASS Setting 'animation-delay' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'animation-delay' to a flexible length: 0fr throws TypeError
+PASS Setting 'animation-delay' to a flexible length: 1fr throws TypeError
+PASS Setting 'animation-delay' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'animation-delay' to a number: 0 throws TypeError
+PASS Setting 'animation-delay' to a number: -3.14 throws TypeError
+PASS Setting 'animation-delay' to a number: 3.14 throws TypeError
+PASS Setting 'animation-delay' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'animation-delay' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'animation-delay' to a transform: perspective(10em) throws TypeError
+PASS Setting 'animation-delay' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-start.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-start.tentative-expected.txt
@@ -8,11 +8,26 @@ FAIL Can set 'animation-delay-start' to a time: 0s Invalid property animation-de
 FAIL Can set 'animation-delay-start' to a time: -3.14ms Invalid property animation-delay-start
 FAIL Can set 'animation-delay-start' to a time: 3.14s Invalid property animation-delay-start
 FAIL Can set 'animation-delay-start' to a time: calc(0s + 0ms) Invalid property animation-delay-start
-PASS Setting 'animation-delay-start' to a length throws TypeError
-PASS Setting 'animation-delay-start' to a percent throws TypeError
-PASS Setting 'animation-delay-start' to an angle throws TypeError
-PASS Setting 'animation-delay-start' to a flexible length throws TypeError
-PASS Setting 'animation-delay-start' to a number throws TypeError
-PASS Setting 'animation-delay-start' to a URL throws TypeError
-PASS Setting 'animation-delay-start' to a transform throws TypeError
+PASS Setting 'animation-delay-start' to a length: 0px throws TypeError
+PASS Setting 'animation-delay-start' to a length: -3.14em throws TypeError
+PASS Setting 'animation-delay-start' to a length: 3.14cm throws TypeError
+PASS Setting 'animation-delay-start' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'animation-delay-start' to a percent: 0% throws TypeError
+PASS Setting 'animation-delay-start' to a percent: -3.14% throws TypeError
+PASS Setting 'animation-delay-start' to a percent: 3.14% throws TypeError
+PASS Setting 'animation-delay-start' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'animation-delay-start' to an angle: 0deg throws TypeError
+PASS Setting 'animation-delay-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'animation-delay-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'animation-delay-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'animation-delay-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'animation-delay-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'animation-delay-start' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'animation-delay-start' to a number: 0 throws TypeError
+PASS Setting 'animation-delay-start' to a number: -3.14 throws TypeError
+PASS Setting 'animation-delay-start' to a number: 3.14 throws TypeError
+PASS Setting 'animation-delay-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'animation-delay-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'animation-delay-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'animation-delay-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction-expected.txt
@@ -8,12 +8,30 @@ PASS Can set 'animation-direction' to the 'normal' keyword: normal
 PASS Can set 'animation-direction' to the 'reverse' keyword: reverse
 PASS Can set 'animation-direction' to the 'alternate-reverse' keyword: alternate-reverse
 PASS Can set 'animation-direction' to the 'alternate' keyword: alternate
-PASS Setting 'animation-direction' to a length throws TypeError
-PASS Setting 'animation-direction' to a percent throws TypeError
-PASS Setting 'animation-direction' to a time throws TypeError
-PASS Setting 'animation-direction' to an angle throws TypeError
-PASS Setting 'animation-direction' to a flexible length throws TypeError
-PASS Setting 'animation-direction' to a number throws TypeError
-PASS Setting 'animation-direction' to a URL throws TypeError
-PASS Setting 'animation-direction' to a transform throws TypeError
+PASS Setting 'animation-direction' to a length: 0px throws TypeError
+PASS Setting 'animation-direction' to a length: -3.14em throws TypeError
+PASS Setting 'animation-direction' to a length: 3.14cm throws TypeError
+PASS Setting 'animation-direction' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'animation-direction' to a percent: 0% throws TypeError
+PASS Setting 'animation-direction' to a percent: -3.14% throws TypeError
+PASS Setting 'animation-direction' to a percent: 3.14% throws TypeError
+PASS Setting 'animation-direction' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'animation-direction' to a time: 0s throws TypeError
+PASS Setting 'animation-direction' to a time: -3.14ms throws TypeError
+PASS Setting 'animation-direction' to a time: 3.14s throws TypeError
+PASS Setting 'animation-direction' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'animation-direction' to an angle: 0deg throws TypeError
+PASS Setting 'animation-direction' to an angle: 3.14rad throws TypeError
+PASS Setting 'animation-direction' to an angle: -3.14deg throws TypeError
+PASS Setting 'animation-direction' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'animation-direction' to a flexible length: 0fr throws TypeError
+PASS Setting 'animation-direction' to a flexible length: 1fr throws TypeError
+PASS Setting 'animation-direction' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'animation-direction' to a number: 0 throws TypeError
+PASS Setting 'animation-direction' to a number: -3.14 throws TypeError
+PASS Setting 'animation-direction' to a number: 3.14 throws TypeError
+PASS Setting 'animation-direction' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'animation-direction' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'animation-direction' to a transform: perspective(10em) throws TypeError
+PASS Setting 'animation-direction' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt
@@ -8,11 +8,26 @@ PASS Can set 'animation-duration' to a time: 0s
 FAIL Can set 'animation-duration' to a time: -3.14ms assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'animation-duration' to a time: 3.14s
 PASS Can set 'animation-duration' to a time: calc(0s + 0ms)
-PASS Setting 'animation-duration' to a length throws TypeError
-PASS Setting 'animation-duration' to a percent throws TypeError
-PASS Setting 'animation-duration' to an angle throws TypeError
-PASS Setting 'animation-duration' to a flexible length throws TypeError
-PASS Setting 'animation-duration' to a number throws TypeError
-PASS Setting 'animation-duration' to a URL throws TypeError
-PASS Setting 'animation-duration' to a transform throws TypeError
+PASS Setting 'animation-duration' to a length: 0px throws TypeError
+PASS Setting 'animation-duration' to a length: -3.14em throws TypeError
+PASS Setting 'animation-duration' to a length: 3.14cm throws TypeError
+PASS Setting 'animation-duration' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'animation-duration' to a percent: 0% throws TypeError
+PASS Setting 'animation-duration' to a percent: -3.14% throws TypeError
+PASS Setting 'animation-duration' to a percent: 3.14% throws TypeError
+PASS Setting 'animation-duration' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'animation-duration' to an angle: 0deg throws TypeError
+PASS Setting 'animation-duration' to an angle: 3.14rad throws TypeError
+PASS Setting 'animation-duration' to an angle: -3.14deg throws TypeError
+PASS Setting 'animation-duration' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'animation-duration' to a flexible length: 0fr throws TypeError
+PASS Setting 'animation-duration' to a flexible length: 1fr throws TypeError
+PASS Setting 'animation-duration' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'animation-duration' to a number: 0 throws TypeError
+PASS Setting 'animation-duration' to a number: -3.14 throws TypeError
+PASS Setting 'animation-duration' to a number: 3.14 throws TypeError
+PASS Setting 'animation-duration' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'animation-duration' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'animation-duration' to a transform: perspective(10em) throws TypeError
+PASS Setting 'animation-duration' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-expected.txt
@@ -1,4 +1,4 @@
 
-PASS 'animation' does not supported 'slidein 3s ease-in 1s infinite reverse both running'
-PASS 'animation' does not supported 'slidein .5s linear 1s infinite alternate'
+PASS 'animation' does not support 'slidein 3s ease-in 1s infinite reverse both running'
+PASS 'animation' does not support 'slidein .5s linear 1s infinite alternate'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode-expected.txt
@@ -8,12 +8,30 @@ PASS Can set 'animation-fill-mode' to the 'none' keyword: none
 PASS Can set 'animation-fill-mode' to the 'forwards' keyword: forwards
 PASS Can set 'animation-fill-mode' to the 'backwards' keyword: backwards
 PASS Can set 'animation-fill-mode' to the 'both' keyword: both
-PASS Setting 'animation-fill-mode' to a length throws TypeError
-PASS Setting 'animation-fill-mode' to a percent throws TypeError
-PASS Setting 'animation-fill-mode' to a time throws TypeError
-PASS Setting 'animation-fill-mode' to an angle throws TypeError
-PASS Setting 'animation-fill-mode' to a flexible length throws TypeError
-PASS Setting 'animation-fill-mode' to a number throws TypeError
-PASS Setting 'animation-fill-mode' to a URL throws TypeError
-PASS Setting 'animation-fill-mode' to a transform throws TypeError
+PASS Setting 'animation-fill-mode' to a length: 0px throws TypeError
+PASS Setting 'animation-fill-mode' to a length: -3.14em throws TypeError
+PASS Setting 'animation-fill-mode' to a length: 3.14cm throws TypeError
+PASS Setting 'animation-fill-mode' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'animation-fill-mode' to a percent: 0% throws TypeError
+PASS Setting 'animation-fill-mode' to a percent: -3.14% throws TypeError
+PASS Setting 'animation-fill-mode' to a percent: 3.14% throws TypeError
+PASS Setting 'animation-fill-mode' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'animation-fill-mode' to a time: 0s throws TypeError
+PASS Setting 'animation-fill-mode' to a time: -3.14ms throws TypeError
+PASS Setting 'animation-fill-mode' to a time: 3.14s throws TypeError
+PASS Setting 'animation-fill-mode' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'animation-fill-mode' to an angle: 0deg throws TypeError
+PASS Setting 'animation-fill-mode' to an angle: 3.14rad throws TypeError
+PASS Setting 'animation-fill-mode' to an angle: -3.14deg throws TypeError
+PASS Setting 'animation-fill-mode' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'animation-fill-mode' to a flexible length: 0fr throws TypeError
+PASS Setting 'animation-fill-mode' to a flexible length: 1fr throws TypeError
+PASS Setting 'animation-fill-mode' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'animation-fill-mode' to a number: 0 throws TypeError
+PASS Setting 'animation-fill-mode' to a number: -3.14 throws TypeError
+PASS Setting 'animation-fill-mode' to a number: 3.14 throws TypeError
+PASS Setting 'animation-fill-mode' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'animation-fill-mode' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'animation-fill-mode' to a transform: perspective(10em) throws TypeError
+PASS Setting 'animation-fill-mode' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt
@@ -9,11 +9,26 @@ PASS Can set 'animation-iteration-count' to a number: 0
 FAIL Can set 'animation-iteration-count' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'animation-iteration-count' to a number: 3.14
 PASS Can set 'animation-iteration-count' to a number: calc(2 + 3)
-PASS Setting 'animation-iteration-count' to a length throws TypeError
-PASS Setting 'animation-iteration-count' to a percent throws TypeError
-PASS Setting 'animation-iteration-count' to a time throws TypeError
-PASS Setting 'animation-iteration-count' to an angle throws TypeError
-PASS Setting 'animation-iteration-count' to a flexible length throws TypeError
-PASS Setting 'animation-iteration-count' to a URL throws TypeError
-PASS Setting 'animation-iteration-count' to a transform throws TypeError
+PASS Setting 'animation-iteration-count' to a length: 0px throws TypeError
+PASS Setting 'animation-iteration-count' to a length: -3.14em throws TypeError
+PASS Setting 'animation-iteration-count' to a length: 3.14cm throws TypeError
+PASS Setting 'animation-iteration-count' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'animation-iteration-count' to a percent: 0% throws TypeError
+PASS Setting 'animation-iteration-count' to a percent: -3.14% throws TypeError
+PASS Setting 'animation-iteration-count' to a percent: 3.14% throws TypeError
+PASS Setting 'animation-iteration-count' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'animation-iteration-count' to a time: 0s throws TypeError
+PASS Setting 'animation-iteration-count' to a time: -3.14ms throws TypeError
+PASS Setting 'animation-iteration-count' to a time: 3.14s throws TypeError
+PASS Setting 'animation-iteration-count' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'animation-iteration-count' to an angle: 0deg throws TypeError
+PASS Setting 'animation-iteration-count' to an angle: 3.14rad throws TypeError
+PASS Setting 'animation-iteration-count' to an angle: -3.14deg throws TypeError
+PASS Setting 'animation-iteration-count' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'animation-iteration-count' to a flexible length: 0fr throws TypeError
+PASS Setting 'animation-iteration-count' to a flexible length: 1fr throws TypeError
+PASS Setting 'animation-iteration-count' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'animation-iteration-count' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'animation-iteration-count' to a transform: perspective(10em) throws TypeError
+PASS Setting 'animation-iteration-count' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name-expected.txt
@@ -6,13 +6,31 @@ PASS Can set 'animation-name' to CSS-wide keywords: revert
 PASS Can set 'animation-name' to var() references:  var(--A)
 PASS Can set 'animation-name' to the 'none' keyword: none
 PASS Can set 'animation-name' to the 'custom-ident' keyword: custom-ident
-PASS Setting 'animation-name' to a length throws TypeError
-PASS Setting 'animation-name' to a percent throws TypeError
-PASS Setting 'animation-name' to a time throws TypeError
-PASS Setting 'animation-name' to an angle throws TypeError
-PASS Setting 'animation-name' to a flexible length throws TypeError
-PASS Setting 'animation-name' to a number throws TypeError
-PASS Setting 'animation-name' to a URL throws TypeError
-PASS Setting 'animation-name' to a transform throws TypeError
-FAIL 'animation-name' does not supported '"foo"' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'animation-name' to a length: 0px throws TypeError
+PASS Setting 'animation-name' to a length: -3.14em throws TypeError
+PASS Setting 'animation-name' to a length: 3.14cm throws TypeError
+PASS Setting 'animation-name' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'animation-name' to a percent: 0% throws TypeError
+PASS Setting 'animation-name' to a percent: -3.14% throws TypeError
+PASS Setting 'animation-name' to a percent: 3.14% throws TypeError
+PASS Setting 'animation-name' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'animation-name' to a time: 0s throws TypeError
+PASS Setting 'animation-name' to a time: -3.14ms throws TypeError
+PASS Setting 'animation-name' to a time: 3.14s throws TypeError
+PASS Setting 'animation-name' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'animation-name' to an angle: 0deg throws TypeError
+PASS Setting 'animation-name' to an angle: 3.14rad throws TypeError
+PASS Setting 'animation-name' to an angle: -3.14deg throws TypeError
+PASS Setting 'animation-name' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'animation-name' to a flexible length: 0fr throws TypeError
+PASS Setting 'animation-name' to a flexible length: 1fr throws TypeError
+PASS Setting 'animation-name' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'animation-name' to a number: 0 throws TypeError
+PASS Setting 'animation-name' to a number: -3.14 throws TypeError
+PASS Setting 'animation-name' to a number: 3.14 throws TypeError
+PASS Setting 'animation-name' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'animation-name' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'animation-name' to a transform: perspective(10em) throws TypeError
+PASS Setting 'animation-name' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'animation-name' does not support '"foo"' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-play-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-play-state-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'animation-play-state' to CSS-wide keywords: revert
 PASS Can set 'animation-play-state' to var() references:  var(--A)
 PASS Can set 'animation-play-state' to the 'running' keyword: running
 PASS Can set 'animation-play-state' to the 'paused' keyword: paused
-PASS Setting 'animation-play-state' to a length throws TypeError
-PASS Setting 'animation-play-state' to a percent throws TypeError
-PASS Setting 'animation-play-state' to a time throws TypeError
-PASS Setting 'animation-play-state' to an angle throws TypeError
-PASS Setting 'animation-play-state' to a flexible length throws TypeError
-PASS Setting 'animation-play-state' to a number throws TypeError
-PASS Setting 'animation-play-state' to a URL throws TypeError
-PASS Setting 'animation-play-state' to a transform throws TypeError
+PASS Setting 'animation-play-state' to a length: 0px throws TypeError
+PASS Setting 'animation-play-state' to a length: -3.14em throws TypeError
+PASS Setting 'animation-play-state' to a length: 3.14cm throws TypeError
+PASS Setting 'animation-play-state' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'animation-play-state' to a percent: 0% throws TypeError
+PASS Setting 'animation-play-state' to a percent: -3.14% throws TypeError
+PASS Setting 'animation-play-state' to a percent: 3.14% throws TypeError
+PASS Setting 'animation-play-state' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'animation-play-state' to a time: 0s throws TypeError
+PASS Setting 'animation-play-state' to a time: -3.14ms throws TypeError
+PASS Setting 'animation-play-state' to a time: 3.14s throws TypeError
+PASS Setting 'animation-play-state' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'animation-play-state' to an angle: 0deg throws TypeError
+PASS Setting 'animation-play-state' to an angle: 3.14rad throws TypeError
+PASS Setting 'animation-play-state' to an angle: -3.14deg throws TypeError
+PASS Setting 'animation-play-state' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'animation-play-state' to a flexible length: 0fr throws TypeError
+PASS Setting 'animation-play-state' to a flexible length: 1fr throws TypeError
+PASS Setting 'animation-play-state' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'animation-play-state' to a number: 0 throws TypeError
+PASS Setting 'animation-play-state' to a number: -3.14 throws TypeError
+PASS Setting 'animation-play-state' to a number: 3.14 throws TypeError
+PASS Setting 'animation-play-state' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'animation-play-state' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'animation-play-state' to a transform: perspective(10em) throws TypeError
+PASS Setting 'animation-play-state' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-timing-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-timing-function-expected.txt
@@ -11,14 +11,32 @@ PASS Can set 'animation-timing-function' to the 'ease-out' keyword: ease-out
 PASS Can set 'animation-timing-function' to the 'ease-in-out' keyword: ease-in-out
 PASS Can set 'animation-timing-function' to the 'step-start' keyword: step-start
 PASS Can set 'animation-timing-function' to the 'step-end' keyword: step-end
-PASS Setting 'animation-timing-function' to a length throws TypeError
-PASS Setting 'animation-timing-function' to a percent throws TypeError
-PASS Setting 'animation-timing-function' to a time throws TypeError
-PASS Setting 'animation-timing-function' to an angle throws TypeError
-PASS Setting 'animation-timing-function' to a flexible length throws TypeError
-PASS Setting 'animation-timing-function' to a number throws TypeError
-PASS Setting 'animation-timing-function' to a URL throws TypeError
-PASS Setting 'animation-timing-function' to a transform throws TypeError
-PASS 'animation-timing-function' does not supported 'cubic-bezier(0.1, 0.7, 1.0, 0.1)'
-PASS 'animation-timing-function' does not supported 'steps(4, end)'
+PASS Setting 'animation-timing-function' to a length: 0px throws TypeError
+PASS Setting 'animation-timing-function' to a length: -3.14em throws TypeError
+PASS Setting 'animation-timing-function' to a length: 3.14cm throws TypeError
+PASS Setting 'animation-timing-function' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'animation-timing-function' to a percent: 0% throws TypeError
+PASS Setting 'animation-timing-function' to a percent: -3.14% throws TypeError
+PASS Setting 'animation-timing-function' to a percent: 3.14% throws TypeError
+PASS Setting 'animation-timing-function' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'animation-timing-function' to a time: 0s throws TypeError
+PASS Setting 'animation-timing-function' to a time: -3.14ms throws TypeError
+PASS Setting 'animation-timing-function' to a time: 3.14s throws TypeError
+PASS Setting 'animation-timing-function' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'animation-timing-function' to an angle: 0deg throws TypeError
+PASS Setting 'animation-timing-function' to an angle: 3.14rad throws TypeError
+PASS Setting 'animation-timing-function' to an angle: -3.14deg throws TypeError
+PASS Setting 'animation-timing-function' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'animation-timing-function' to a flexible length: 0fr throws TypeError
+PASS Setting 'animation-timing-function' to a flexible length: 1fr throws TypeError
+PASS Setting 'animation-timing-function' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'animation-timing-function' to a number: 0 throws TypeError
+PASS Setting 'animation-timing-function' to a number: -3.14 throws TypeError
+PASS Setting 'animation-timing-function' to a number: 3.14 throws TypeError
+PASS Setting 'animation-timing-function' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'animation-timing-function' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'animation-timing-function' to a transform: perspective(10em) throws TypeError
+PASS Setting 'animation-timing-function' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'animation-timing-function' does not support 'cubic-bezier(0.1, 0.7, 1.0, 0.1)'
+PASS 'animation-timing-function' does not support 'steps(4, end)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backdrop-filter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backdrop-filter-expected.txt
@@ -5,14 +5,32 @@ FAIL Can set 'backdrop-filter' to CSS-wide keywords: unset Invalid property back
 FAIL Can set 'backdrop-filter' to CSS-wide keywords: revert Invalid property backdrop-filter
 FAIL Can set 'backdrop-filter' to var() references:  var(--A) Invalid property backdrop-filter
 FAIL Can set 'backdrop-filter' to the 'none' keyword: none Invalid property backdrop-filter
-PASS Setting 'backdrop-filter' to a length throws TypeError
-PASS Setting 'backdrop-filter' to a percent throws TypeError
-PASS Setting 'backdrop-filter' to a time throws TypeError
-PASS Setting 'backdrop-filter' to an angle throws TypeError
-PASS Setting 'backdrop-filter' to a flexible length throws TypeError
-PASS Setting 'backdrop-filter' to a number throws TypeError
-PASS Setting 'backdrop-filter' to a URL throws TypeError
-PASS Setting 'backdrop-filter' to a transform throws TypeError
-PASS 'filter' does not supported 'blur(2px)'
-FAIL 'filter' does not supported 'url(filters.svg) blur(4px) saturate(150%)' assert_equals: Unsupported value can be set on different element expected "url(\"filters.svg\") blur(4px) saturate(150%)" but got "url(\"filters.svg\")"
+PASS Setting 'backdrop-filter' to a length: 0px throws TypeError
+PASS Setting 'backdrop-filter' to a length: -3.14em throws TypeError
+PASS Setting 'backdrop-filter' to a length: 3.14cm throws TypeError
+PASS Setting 'backdrop-filter' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'backdrop-filter' to a percent: 0% throws TypeError
+PASS Setting 'backdrop-filter' to a percent: -3.14% throws TypeError
+PASS Setting 'backdrop-filter' to a percent: 3.14% throws TypeError
+PASS Setting 'backdrop-filter' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'backdrop-filter' to a time: 0s throws TypeError
+PASS Setting 'backdrop-filter' to a time: -3.14ms throws TypeError
+PASS Setting 'backdrop-filter' to a time: 3.14s throws TypeError
+PASS Setting 'backdrop-filter' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'backdrop-filter' to an angle: 0deg throws TypeError
+PASS Setting 'backdrop-filter' to an angle: 3.14rad throws TypeError
+PASS Setting 'backdrop-filter' to an angle: -3.14deg throws TypeError
+PASS Setting 'backdrop-filter' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'backdrop-filter' to a flexible length: 0fr throws TypeError
+PASS Setting 'backdrop-filter' to a flexible length: 1fr throws TypeError
+PASS Setting 'backdrop-filter' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'backdrop-filter' to a number: 0 throws TypeError
+PASS Setting 'backdrop-filter' to a number: -3.14 throws TypeError
+PASS Setting 'backdrop-filter' to a number: 3.14 throws TypeError
+PASS Setting 'backdrop-filter' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'backdrop-filter' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'backdrop-filter' to a transform: perspective(10em) throws TypeError
+PASS Setting 'backdrop-filter' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'filter' does not support 'blur(2px)'
+FAIL 'filter' does not support 'url(filters.svg) blur(4px) saturate(150%)' assert_equals: Unsupported value can be set on different element expected "url(\"filters.svg\") blur(4px) saturate(150%)" but got "url(\"filters.svg\")"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backface-visibility-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backface-visibility-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'backface-visibility' to CSS-wide keywords: revert
 PASS Can set 'backface-visibility' to var() references:  var(--A)
 PASS Can set 'backface-visibility' to the 'visible' keyword: visible
 PASS Can set 'backface-visibility' to the 'hidden' keyword: hidden
-PASS Setting 'backface-visibility' to a length throws TypeError
-PASS Setting 'backface-visibility' to a percent throws TypeError
-PASS Setting 'backface-visibility' to a time throws TypeError
-PASS Setting 'backface-visibility' to an angle throws TypeError
-PASS Setting 'backface-visibility' to a flexible length throws TypeError
-PASS Setting 'backface-visibility' to a number throws TypeError
-PASS Setting 'backface-visibility' to a URL throws TypeError
-PASS Setting 'backface-visibility' to a transform throws TypeError
+PASS Setting 'backface-visibility' to a length: 0px throws TypeError
+PASS Setting 'backface-visibility' to a length: -3.14em throws TypeError
+PASS Setting 'backface-visibility' to a length: 3.14cm throws TypeError
+PASS Setting 'backface-visibility' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'backface-visibility' to a percent: 0% throws TypeError
+PASS Setting 'backface-visibility' to a percent: -3.14% throws TypeError
+PASS Setting 'backface-visibility' to a percent: 3.14% throws TypeError
+PASS Setting 'backface-visibility' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'backface-visibility' to a time: 0s throws TypeError
+PASS Setting 'backface-visibility' to a time: -3.14ms throws TypeError
+PASS Setting 'backface-visibility' to a time: 3.14s throws TypeError
+PASS Setting 'backface-visibility' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'backface-visibility' to an angle: 0deg throws TypeError
+PASS Setting 'backface-visibility' to an angle: 3.14rad throws TypeError
+PASS Setting 'backface-visibility' to an angle: -3.14deg throws TypeError
+PASS Setting 'backface-visibility' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'backface-visibility' to a flexible length: 0fr throws TypeError
+PASS Setting 'backface-visibility' to a flexible length: 1fr throws TypeError
+PASS Setting 'backface-visibility' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'backface-visibility' to a number: 0 throws TypeError
+PASS Setting 'backface-visibility' to a number: -3.14 throws TypeError
+PASS Setting 'backface-visibility' to a number: 3.14 throws TypeError
+PASS Setting 'backface-visibility' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'backface-visibility' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'backface-visibility' to a transform: perspective(10em) throws TypeError
+PASS Setting 'backface-visibility' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-attachment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-attachment-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'background-attachment' to var() references:  var(--A)
 PASS Can set 'background-attachment' to the 'scroll' keyword: scroll
 PASS Can set 'background-attachment' to the 'fixed' keyword: fixed
 PASS Can set 'background-attachment' to the 'local' keyword: local
-PASS Setting 'background-attachment' to a length throws TypeError
-PASS Setting 'background-attachment' to a percent throws TypeError
-PASS Setting 'background-attachment' to a time throws TypeError
-PASS Setting 'background-attachment' to an angle throws TypeError
-PASS Setting 'background-attachment' to a flexible length throws TypeError
-PASS Setting 'background-attachment' to a number throws TypeError
-PASS Setting 'background-attachment' to a URL throws TypeError
-PASS Setting 'background-attachment' to a transform throws TypeError
+PASS Setting 'background-attachment' to a length: 0px throws TypeError
+PASS Setting 'background-attachment' to a length: -3.14em throws TypeError
+PASS Setting 'background-attachment' to a length: 3.14cm throws TypeError
+PASS Setting 'background-attachment' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'background-attachment' to a percent: 0% throws TypeError
+PASS Setting 'background-attachment' to a percent: -3.14% throws TypeError
+PASS Setting 'background-attachment' to a percent: 3.14% throws TypeError
+PASS Setting 'background-attachment' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'background-attachment' to a time: 0s throws TypeError
+PASS Setting 'background-attachment' to a time: -3.14ms throws TypeError
+PASS Setting 'background-attachment' to a time: 3.14s throws TypeError
+PASS Setting 'background-attachment' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'background-attachment' to an angle: 0deg throws TypeError
+PASS Setting 'background-attachment' to an angle: 3.14rad throws TypeError
+PASS Setting 'background-attachment' to an angle: -3.14deg throws TypeError
+PASS Setting 'background-attachment' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'background-attachment' to a flexible length: 0fr throws TypeError
+PASS Setting 'background-attachment' to a flexible length: 1fr throws TypeError
+PASS Setting 'background-attachment' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'background-attachment' to a number: 0 throws TypeError
+PASS Setting 'background-attachment' to a number: -3.14 throws TypeError
+PASS Setting 'background-attachment' to a number: 3.14 throws TypeError
+PASS Setting 'background-attachment' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'background-attachment' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'background-attachment' to a transform: perspective(10em) throws TypeError
+PASS Setting 'background-attachment' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-blend-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-blend-mode-expected.txt
@@ -20,12 +20,30 @@ PASS Can set 'background-blend-mode' to the 'hue' keyword: hue
 PASS Can set 'background-blend-mode' to the 'saturation' keyword: saturation
 PASS Can set 'background-blend-mode' to the 'color' keyword: color
 PASS Can set 'background-blend-mode' to the 'luminosity' keyword: luminosity
-PASS Setting 'background-blend-mode' to a length throws TypeError
-PASS Setting 'background-blend-mode' to a percent throws TypeError
-PASS Setting 'background-blend-mode' to a time throws TypeError
-PASS Setting 'background-blend-mode' to an angle throws TypeError
-PASS Setting 'background-blend-mode' to a flexible length throws TypeError
-PASS Setting 'background-blend-mode' to a number throws TypeError
-PASS Setting 'background-blend-mode' to a URL throws TypeError
-PASS Setting 'background-blend-mode' to a transform throws TypeError
+PASS Setting 'background-blend-mode' to a length: 0px throws TypeError
+PASS Setting 'background-blend-mode' to a length: -3.14em throws TypeError
+PASS Setting 'background-blend-mode' to a length: 3.14cm throws TypeError
+PASS Setting 'background-blend-mode' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'background-blend-mode' to a percent: 0% throws TypeError
+PASS Setting 'background-blend-mode' to a percent: -3.14% throws TypeError
+PASS Setting 'background-blend-mode' to a percent: 3.14% throws TypeError
+PASS Setting 'background-blend-mode' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'background-blend-mode' to a time: 0s throws TypeError
+PASS Setting 'background-blend-mode' to a time: -3.14ms throws TypeError
+PASS Setting 'background-blend-mode' to a time: 3.14s throws TypeError
+PASS Setting 'background-blend-mode' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'background-blend-mode' to an angle: 0deg throws TypeError
+PASS Setting 'background-blend-mode' to an angle: 3.14rad throws TypeError
+PASS Setting 'background-blend-mode' to an angle: -3.14deg throws TypeError
+PASS Setting 'background-blend-mode' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'background-blend-mode' to a flexible length: 0fr throws TypeError
+PASS Setting 'background-blend-mode' to a flexible length: 1fr throws TypeError
+PASS Setting 'background-blend-mode' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'background-blend-mode' to a number: 0 throws TypeError
+PASS Setting 'background-blend-mode' to a number: -3.14 throws TypeError
+PASS Setting 'background-blend-mode' to a number: 3.14 throws TypeError
+PASS Setting 'background-blend-mode' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'background-blend-mode' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'background-blend-mode' to a transform: perspective(10em) throws TypeError
+PASS Setting 'background-blend-mode' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-clip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-clip-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'background-clip' to var() references:  var(--A)
 PASS Can set 'background-clip' to the 'border-box' keyword: border-box
 PASS Can set 'background-clip' to the 'padding-box' keyword: padding-box
 PASS Can set 'background-clip' to the 'content-box' keyword: content-box
-PASS Setting 'background-clip' to a length throws TypeError
-PASS Setting 'background-clip' to a percent throws TypeError
-PASS Setting 'background-clip' to a time throws TypeError
-PASS Setting 'background-clip' to an angle throws TypeError
-PASS Setting 'background-clip' to a flexible length throws TypeError
-PASS Setting 'background-clip' to a number throws TypeError
-PASS Setting 'background-clip' to a URL throws TypeError
-PASS Setting 'background-clip' to a transform throws TypeError
+PASS Setting 'background-clip' to a length: 0px throws TypeError
+PASS Setting 'background-clip' to a length: -3.14em throws TypeError
+PASS Setting 'background-clip' to a length: 3.14cm throws TypeError
+PASS Setting 'background-clip' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'background-clip' to a percent: 0% throws TypeError
+PASS Setting 'background-clip' to a percent: -3.14% throws TypeError
+PASS Setting 'background-clip' to a percent: 3.14% throws TypeError
+PASS Setting 'background-clip' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'background-clip' to a time: 0s throws TypeError
+PASS Setting 'background-clip' to a time: -3.14ms throws TypeError
+PASS Setting 'background-clip' to a time: 3.14s throws TypeError
+PASS Setting 'background-clip' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'background-clip' to an angle: 0deg throws TypeError
+PASS Setting 'background-clip' to an angle: 3.14rad throws TypeError
+PASS Setting 'background-clip' to an angle: -3.14deg throws TypeError
+PASS Setting 'background-clip' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'background-clip' to a flexible length: 0fr throws TypeError
+PASS Setting 'background-clip' to a flexible length: 1fr throws TypeError
+PASS Setting 'background-clip' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'background-clip' to a number: 0 throws TypeError
+PASS Setting 'background-clip' to a number: -3.14 throws TypeError
+PASS Setting 'background-clip' to a number: 3.14 throws TypeError
+PASS Setting 'background-clip' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'background-clip' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'background-clip' to a transform: perspective(10em) throws TypeError
+PASS Setting 'background-clip' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-color-expected.txt
@@ -5,17 +5,35 @@ PASS Can set 'background-color' to CSS-wide keywords: unset
 PASS Can set 'background-color' to CSS-wide keywords: revert
 PASS Can set 'background-color' to var() references:  var(--A)
 PASS Can set 'background-color' to the 'currentcolor' keyword: currentcolor
-PASS Setting 'background-color' to a length throws TypeError
-PASS Setting 'background-color' to a percent throws TypeError
-PASS Setting 'background-color' to a time throws TypeError
-PASS Setting 'background-color' to an angle throws TypeError
-PASS Setting 'background-color' to a flexible length throws TypeError
-PASS Setting 'background-color' to a number throws TypeError
-PASS Setting 'background-color' to a URL throws TypeError
-PASS Setting 'background-color' to a transform throws TypeError
-FAIL 'background-color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'background-color' does not supported '#bbff00'
-PASS 'background-color' does not supported 'rgb(255, 255, 128)'
-PASS 'background-color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'background-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'background-color' to a length: 0px throws TypeError
+PASS Setting 'background-color' to a length: -3.14em throws TypeError
+PASS Setting 'background-color' to a length: 3.14cm throws TypeError
+PASS Setting 'background-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'background-color' to a percent: 0% throws TypeError
+PASS Setting 'background-color' to a percent: -3.14% throws TypeError
+PASS Setting 'background-color' to a percent: 3.14% throws TypeError
+PASS Setting 'background-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'background-color' to a time: 0s throws TypeError
+PASS Setting 'background-color' to a time: -3.14ms throws TypeError
+PASS Setting 'background-color' to a time: 3.14s throws TypeError
+PASS Setting 'background-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'background-color' to an angle: 0deg throws TypeError
+PASS Setting 'background-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'background-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'background-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'background-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'background-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'background-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'background-color' to a number: 0 throws TypeError
+PASS Setting 'background-color' to a number: -3.14 throws TypeError
+PASS Setting 'background-color' to a number: 3.14 throws TypeError
+PASS Setting 'background-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'background-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'background-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'background-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'background-color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'background-color' does not support '#bbff00'
+PASS 'background-color' does not support 'rgb(255, 255, 128)'
+PASS 'background-color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'background-color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-expected.txt
@@ -4,17 +4,35 @@ FAIL Can set 'background' to CSS-wide keywords: inherit assert_equals: expected 
 FAIL Can set 'background' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'background' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'background' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Setting 'background' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'background' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'background' to a time throws TypeError
-PASS Setting 'background' to an angle throws TypeError
-PASS Setting 'background' to a flexible length throws TypeError
-FAIL Setting 'background' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'background' to a URL throws TypeError
-PASS Setting 'background' to a transform throws TypeError
-PASS 'background' does not supported 'green'
-PASS 'background' does not supported 'content-box radial-gradient(crimson, skyblue)'
-PASS 'background' does not supported 'no-repeat url("http://foo.com")'
-PASS 'background' does not supported 'left 5% / 15% 60% repeat-x url("http://foo.com")'
-PASS 'background' does not supported 'center / contain no-repeat url("foo.com"), red'
+FAIL Setting 'background' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'background' to a length: -3.14em throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'background' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'background' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'background' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'background' to a percent: -3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'background' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'background' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'background' to a time: 0s throws TypeError
+PASS Setting 'background' to a time: -3.14ms throws TypeError
+PASS Setting 'background' to a time: 3.14s throws TypeError
+PASS Setting 'background' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'background' to an angle: 0deg throws TypeError
+PASS Setting 'background' to an angle: 3.14rad throws TypeError
+PASS Setting 'background' to an angle: -3.14deg throws TypeError
+PASS Setting 'background' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'background' to a flexible length: 0fr throws TypeError
+PASS Setting 'background' to a flexible length: 1fr throws TypeError
+PASS Setting 'background' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'background' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'background' to a number: -3.14 throws TypeError
+PASS Setting 'background' to a number: 3.14 throws TypeError
+PASS Setting 'background' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'background' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'background' to a transform: perspective(10em) throws TypeError
+PASS Setting 'background' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'background' does not support 'green'
+PASS 'background' does not support 'content-box radial-gradient(crimson, skyblue)'
+PASS 'background' does not support 'no-repeat url("http://foo.com")'
+PASS 'background' does not support 'left 5% / 15% 60% repeat-x url("http://foo.com")'
+PASS 'background' does not support 'center / contain no-repeat url("foo.com"), red'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-image-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'background-image' to CSS-wide keywords: revert
 PASS Can set 'background-image' to var() references:  var(--A)
 PASS Can set 'background-image' to the 'none' keyword: none
 PASS Can set 'background-image' to an image
-PASS Setting 'background-image' to a length throws TypeError
-PASS Setting 'background-image' to a percent throws TypeError
-PASS Setting 'background-image' to a time throws TypeError
-PASS Setting 'background-image' to an angle throws TypeError
-PASS Setting 'background-image' to a flexible length throws TypeError
-PASS Setting 'background-image' to a number throws TypeError
-PASS Setting 'background-image' to a URL throws TypeError
-PASS Setting 'background-image' to a transform throws TypeError
+PASS Setting 'background-image' to a length: 0px throws TypeError
+PASS Setting 'background-image' to a length: -3.14em throws TypeError
+PASS Setting 'background-image' to a length: 3.14cm throws TypeError
+PASS Setting 'background-image' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'background-image' to a percent: 0% throws TypeError
+PASS Setting 'background-image' to a percent: -3.14% throws TypeError
+PASS Setting 'background-image' to a percent: 3.14% throws TypeError
+PASS Setting 'background-image' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'background-image' to a time: 0s throws TypeError
+PASS Setting 'background-image' to a time: -3.14ms throws TypeError
+PASS Setting 'background-image' to a time: 3.14s throws TypeError
+PASS Setting 'background-image' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'background-image' to an angle: 0deg throws TypeError
+PASS Setting 'background-image' to an angle: 3.14rad throws TypeError
+PASS Setting 'background-image' to an angle: -3.14deg throws TypeError
+PASS Setting 'background-image' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'background-image' to a flexible length: 0fr throws TypeError
+PASS Setting 'background-image' to a flexible length: 1fr throws TypeError
+PASS Setting 'background-image' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'background-image' to a number: 0 throws TypeError
+PASS Setting 'background-image' to a number: -3.14 throws TypeError
+PASS Setting 'background-image' to a number: 3.14 throws TypeError
+PASS Setting 'background-image' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'background-image' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'background-image' to a transform: perspective(10em) throws TypeError
+PASS Setting 'background-image' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-origin-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'background-origin' to var() references:  var(--A)
 PASS Can set 'background-origin' to the 'border-box' keyword: border-box
 PASS Can set 'background-origin' to the 'padding-box' keyword: padding-box
 PASS Can set 'background-origin' to the 'content-box' keyword: content-box
-PASS Setting 'background-origin' to a length throws TypeError
-PASS Setting 'background-origin' to a percent throws TypeError
-PASS Setting 'background-origin' to a time throws TypeError
-PASS Setting 'background-origin' to an angle throws TypeError
-PASS Setting 'background-origin' to a flexible length throws TypeError
-PASS Setting 'background-origin' to a number throws TypeError
-PASS Setting 'background-origin' to a URL throws TypeError
-PASS Setting 'background-origin' to a transform throws TypeError
+PASS Setting 'background-origin' to a length: 0px throws TypeError
+PASS Setting 'background-origin' to a length: -3.14em throws TypeError
+PASS Setting 'background-origin' to a length: 3.14cm throws TypeError
+PASS Setting 'background-origin' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'background-origin' to a percent: 0% throws TypeError
+PASS Setting 'background-origin' to a percent: -3.14% throws TypeError
+PASS Setting 'background-origin' to a percent: 3.14% throws TypeError
+PASS Setting 'background-origin' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'background-origin' to a time: 0s throws TypeError
+PASS Setting 'background-origin' to a time: -3.14ms throws TypeError
+PASS Setting 'background-origin' to a time: 3.14s throws TypeError
+PASS Setting 'background-origin' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'background-origin' to an angle: 0deg throws TypeError
+PASS Setting 'background-origin' to an angle: 3.14rad throws TypeError
+PASS Setting 'background-origin' to an angle: -3.14deg throws TypeError
+PASS Setting 'background-origin' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'background-origin' to a flexible length: 0fr throws TypeError
+PASS Setting 'background-origin' to a flexible length: 1fr throws TypeError
+PASS Setting 'background-origin' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'background-origin' to a number: 0 throws TypeError
+PASS Setting 'background-origin' to a number: -3.14 throws TypeError
+PASS Setting 'background-origin' to a number: 3.14 throws TypeError
+PASS Setting 'background-origin' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'background-origin' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'background-origin' to a transform: perspective(10em) throws TypeError
+PASS Setting 'background-origin' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat-expected.txt
@@ -10,13 +10,31 @@ FAIL Can set 'background-position' to the 'repeat' keyword: repeat Bad value for
 FAIL Can set 'background-position' to the 'space' keyword: space Bad value for shorthand CSS property
 FAIL Can set 'background-position' to the 'round' keyword: round Bad value for shorthand CSS property
 FAIL Can set 'background-position' to the 'no-repeat' keyword: no-repeat Bad value for shorthand CSS property
-FAIL Setting 'background-position' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'background-position' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'background-position' to a time throws TypeError
-PASS Setting 'background-position' to an angle throws TypeError
-PASS Setting 'background-position' to a flexible length throws TypeError
-FAIL Setting 'background-position' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'background-position' to a URL throws TypeError
-PASS Setting 'background-position' to a transform throws TypeError
-FAIL 'background-position' does not supported 'space repeat' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL Setting 'background-position' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'background-position' to a length: -3.14em throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'background-position' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'background-position' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'background-position' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'background-position' to a percent: -3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'background-position' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'background-position' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'background-position' to a time: 0s throws TypeError
+PASS Setting 'background-position' to a time: -3.14ms throws TypeError
+PASS Setting 'background-position' to a time: 3.14s throws TypeError
+PASS Setting 'background-position' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'background-position' to an angle: 0deg throws TypeError
+PASS Setting 'background-position' to an angle: 3.14rad throws TypeError
+PASS Setting 'background-position' to an angle: -3.14deg throws TypeError
+PASS Setting 'background-position' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'background-position' to a flexible length: 0fr throws TypeError
+PASS Setting 'background-position' to a flexible length: 1fr throws TypeError
+PASS Setting 'background-position' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'background-position' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'background-position' to a number: -3.14 throws TypeError
+PASS Setting 'background-position' to a number: 3.14 throws TypeError
+PASS Setting 'background-position' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'background-position' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'background-position' to a transform: perspective(10em) throws TypeError
+PASS Setting 'background-position' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'background-position' does not support 'space repeat' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt
@@ -15,11 +15,23 @@ PASS Can set 'background-size' to a percent: calc(0% + 0%)
 PASS Can set 'background-size' to the 'auto' keyword: auto
 PASS Can set 'background-size' to the 'cover' keyword: cover
 PASS Can set 'background-size' to the 'contain' keyword: contain
-PASS Setting 'background-size' to a time throws TypeError
-PASS Setting 'background-size' to an angle throws TypeError
-PASS Setting 'background-size' to a flexible length throws TypeError
-FAIL Setting 'background-size' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'background-size' to a URL throws TypeError
-PASS Setting 'background-size' to a transform throws TypeError
-PASS 'background-size' does not supported '200px 100px'
+PASS Setting 'background-size' to a time: 0s throws TypeError
+PASS Setting 'background-size' to a time: -3.14ms throws TypeError
+PASS Setting 'background-size' to a time: 3.14s throws TypeError
+PASS Setting 'background-size' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'background-size' to an angle: 0deg throws TypeError
+PASS Setting 'background-size' to an angle: 3.14rad throws TypeError
+PASS Setting 'background-size' to an angle: -3.14deg throws TypeError
+PASS Setting 'background-size' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'background-size' to a flexible length: 0fr throws TypeError
+PASS Setting 'background-size' to a flexible length: 1fr throws TypeError
+PASS Setting 'background-size' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'background-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'background-size' to a number: -3.14 throws TypeError
+PASS Setting 'background-size' to a number: 3.14 throws TypeError
+PASS Setting 'background-size' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'background-size' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'background-size' to a transform: perspective(10em) throws TypeError
+PASS Setting 'background-size' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'background-size' does not support '200px 100px'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt
@@ -14,10 +14,22 @@ PASS Can set 'baseline-shift' to a length: 0px
 FAIL Can set 'baseline-shift' to a length: -3.14em assert_equals: unit expected "px" but got "em"
 FAIL Can set 'baseline-shift' to a length: 3.14cm assert_equals: unit expected "px" but got "cm"
 PASS Can set 'baseline-shift' to a length: calc(0px + 0em)
-PASS Setting 'baseline-shift' to a time throws TypeError
-PASS Setting 'baseline-shift' to an angle throws TypeError
-PASS Setting 'baseline-shift' to a flexible length throws TypeError
-FAIL Setting 'baseline-shift' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'baseline-shift' to a URL throws TypeError
-PASS Setting 'baseline-shift' to a transform throws TypeError
+PASS Setting 'baseline-shift' to a time: 0s throws TypeError
+PASS Setting 'baseline-shift' to a time: -3.14ms throws TypeError
+PASS Setting 'baseline-shift' to a time: 3.14s throws TypeError
+PASS Setting 'baseline-shift' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'baseline-shift' to an angle: 0deg throws TypeError
+PASS Setting 'baseline-shift' to an angle: 3.14rad throws TypeError
+PASS Setting 'baseline-shift' to an angle: -3.14deg throws TypeError
+PASS Setting 'baseline-shift' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'baseline-shift' to a flexible length: 0fr throws TypeError
+PASS Setting 'baseline-shift' to a flexible length: 1fr throws TypeError
+PASS Setting 'baseline-shift' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'baseline-shift' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'baseline-shift' to a number: -3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'baseline-shift' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'baseline-shift' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'baseline-shift' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'baseline-shift' to a transform: perspective(10em) throws TypeError
+PASS Setting 'baseline-shift' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt
@@ -13,12 +13,24 @@ PASS Can set 'block-size' to a length: 0px
 PASS Can set 'block-size' to a length: -3.14em
 PASS Can set 'block-size' to a length: 3.14cm
 PASS Can set 'block-size' to a length: calc(0px + 0em)
-PASS Setting 'block-size' to a time throws TypeError
-PASS Setting 'block-size' to an angle throws TypeError
-PASS Setting 'block-size' to a flexible length throws TypeError
-FAIL Setting 'block-size' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'block-size' to a URL throws TypeError
-PASS Setting 'block-size' to a transform throws TypeError
+PASS Setting 'block-size' to a time: 0s throws TypeError
+PASS Setting 'block-size' to a time: -3.14ms throws TypeError
+PASS Setting 'block-size' to a time: 3.14s throws TypeError
+PASS Setting 'block-size' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'block-size' to an angle: 0deg throws TypeError
+PASS Setting 'block-size' to an angle: 3.14rad throws TypeError
+PASS Setting 'block-size' to an angle: -3.14deg throws TypeError
+PASS Setting 'block-size' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'block-size' to a flexible length: 0fr throws TypeError
+PASS Setting 'block-size' to a flexible length: 1fr throws TypeError
+PASS Setting 'block-size' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'block-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'block-size' to a number: -3.14 throws TypeError
+PASS Setting 'block-size' to a number: 3.14 throws TypeError
+PASS Setting 'block-size' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'block-size' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'block-size' to a transform: perspective(10em) throws TypeError
+PASS Setting 'block-size' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'min-block-size' to CSS-wide keywords: initial
 PASS Can set 'min-block-size' to CSS-wide keywords: inherit
 PASS Can set 'min-block-size' to CSS-wide keywords: unset
@@ -32,12 +44,24 @@ PASS Can set 'min-block-size' to a length: 0px
 PASS Can set 'min-block-size' to a length: -3.14em
 PASS Can set 'min-block-size' to a length: 3.14cm
 PASS Can set 'min-block-size' to a length: calc(0px + 0em)
-PASS Setting 'min-block-size' to a time throws TypeError
-PASS Setting 'min-block-size' to an angle throws TypeError
-PASS Setting 'min-block-size' to a flexible length throws TypeError
-FAIL Setting 'min-block-size' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'min-block-size' to a URL throws TypeError
-PASS Setting 'min-block-size' to a transform throws TypeError
+PASS Setting 'min-block-size' to a time: 0s throws TypeError
+PASS Setting 'min-block-size' to a time: -3.14ms throws TypeError
+PASS Setting 'min-block-size' to a time: 3.14s throws TypeError
+PASS Setting 'min-block-size' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'min-block-size' to an angle: 0deg throws TypeError
+PASS Setting 'min-block-size' to an angle: 3.14rad throws TypeError
+PASS Setting 'min-block-size' to an angle: -3.14deg throws TypeError
+PASS Setting 'min-block-size' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'min-block-size' to a flexible length: 0fr throws TypeError
+PASS Setting 'min-block-size' to a flexible length: 1fr throws TypeError
+PASS Setting 'min-block-size' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'min-block-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'min-block-size' to a number: -3.14 throws TypeError
+PASS Setting 'min-block-size' to a number: 3.14 throws TypeError
+PASS Setting 'min-block-size' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'min-block-size' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'min-block-size' to a transform: perspective(10em) throws TypeError
+PASS Setting 'min-block-size' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'max-block-size' to CSS-wide keywords: initial
 PASS Can set 'max-block-size' to CSS-wide keywords: inherit
 PASS Can set 'max-block-size' to CSS-wide keywords: unset
@@ -52,10 +76,22 @@ PASS Can set 'max-block-size' to a length: 0px
 PASS Can set 'max-block-size' to a length: -3.14em
 PASS Can set 'max-block-size' to a length: 3.14cm
 PASS Can set 'max-block-size' to a length: calc(0px + 0em)
-PASS Setting 'max-block-size' to a time throws TypeError
-PASS Setting 'max-block-size' to an angle throws TypeError
-PASS Setting 'max-block-size' to a flexible length throws TypeError
-FAIL Setting 'max-block-size' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'max-block-size' to a URL throws TypeError
-PASS Setting 'max-block-size' to a transform throws TypeError
+PASS Setting 'max-block-size' to a time: 0s throws TypeError
+PASS Setting 'max-block-size' to a time: -3.14ms throws TypeError
+PASS Setting 'max-block-size' to a time: 3.14s throws TypeError
+PASS Setting 'max-block-size' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'max-block-size' to an angle: 0deg throws TypeError
+PASS Setting 'max-block-size' to an angle: 3.14rad throws TypeError
+PASS Setting 'max-block-size' to an angle: -3.14deg throws TypeError
+PASS Setting 'max-block-size' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'max-block-size' to a flexible length: 0fr throws TypeError
+PASS Setting 'max-block-size' to a flexible length: 1fr throws TypeError
+PASS Setting 'max-block-size' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'max-block-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'max-block-size' to a number: -3.14 throws TypeError
+PASS Setting 'max-block-size' to a number: 3.14 throws TypeError
+PASS Setting 'max-block-size' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'max-block-size' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'max-block-size' to a transform: perspective(10em) throws TypeError
+PASS Setting 'max-block-size' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-collapse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-collapse-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'border-collapse' to CSS-wide keywords: revert
 PASS Can set 'border-collapse' to var() references:  var(--A)
 PASS Can set 'border-collapse' to the 'separate' keyword: separate
 PASS Can set 'border-collapse' to the 'collapse' keyword: collapse
-PASS Setting 'border-collapse' to a length throws TypeError
-PASS Setting 'border-collapse' to a percent throws TypeError
-PASS Setting 'border-collapse' to a time throws TypeError
-PASS Setting 'border-collapse' to an angle throws TypeError
-PASS Setting 'border-collapse' to a flexible length throws TypeError
-PASS Setting 'border-collapse' to a number throws TypeError
-PASS Setting 'border-collapse' to a URL throws TypeError
-PASS Setting 'border-collapse' to a transform throws TypeError
+PASS Setting 'border-collapse' to a length: 0px throws TypeError
+PASS Setting 'border-collapse' to a length: -3.14em throws TypeError
+PASS Setting 'border-collapse' to a length: 3.14cm throws TypeError
+PASS Setting 'border-collapse' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-collapse' to a percent: 0% throws TypeError
+PASS Setting 'border-collapse' to a percent: -3.14% throws TypeError
+PASS Setting 'border-collapse' to a percent: 3.14% throws TypeError
+PASS Setting 'border-collapse' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-collapse' to a time: 0s throws TypeError
+PASS Setting 'border-collapse' to a time: -3.14ms throws TypeError
+PASS Setting 'border-collapse' to a time: 3.14s throws TypeError
+PASS Setting 'border-collapse' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-collapse' to an angle: 0deg throws TypeError
+PASS Setting 'border-collapse' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-collapse' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-collapse' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-collapse' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-collapse' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-collapse' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-collapse' to a number: 0 throws TypeError
+PASS Setting 'border-collapse' to a number: -3.14 throws TypeError
+PASS Setting 'border-collapse' to a number: 3.14 throws TypeError
+PASS Setting 'border-collapse' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-collapse' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-collapse' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-collapse' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-color-expected.txt
@@ -5,74 +5,146 @@ PASS Can set 'border-top-color' to CSS-wide keywords: unset
 PASS Can set 'border-top-color' to CSS-wide keywords: revert
 PASS Can set 'border-top-color' to var() references:  var(--A)
 PASS Can set 'border-top-color' to the 'currentcolor' keyword: currentcolor
-PASS Setting 'border-top-color' to a length throws TypeError
-PASS Setting 'border-top-color' to a percent throws TypeError
-PASS Setting 'border-top-color' to a time throws TypeError
-PASS Setting 'border-top-color' to an angle throws TypeError
-PASS Setting 'border-top-color' to a flexible length throws TypeError
-PASS Setting 'border-top-color' to a number throws TypeError
-PASS Setting 'border-top-color' to a URL throws TypeError
-PASS Setting 'border-top-color' to a transform throws TypeError
-FAIL 'border-top-color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'border-top-color' does not supported '#bbff00'
-PASS 'border-top-color' does not supported 'rgb(255, 255, 128)'
-PASS 'border-top-color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'border-top-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'border-top-color' to a length: 0px throws TypeError
+PASS Setting 'border-top-color' to a length: -3.14em throws TypeError
+PASS Setting 'border-top-color' to a length: 3.14cm throws TypeError
+PASS Setting 'border-top-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-top-color' to a percent: 0% throws TypeError
+PASS Setting 'border-top-color' to a percent: -3.14% throws TypeError
+PASS Setting 'border-top-color' to a percent: 3.14% throws TypeError
+PASS Setting 'border-top-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-top-color' to a time: 0s throws TypeError
+PASS Setting 'border-top-color' to a time: -3.14ms throws TypeError
+PASS Setting 'border-top-color' to a time: 3.14s throws TypeError
+PASS Setting 'border-top-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-top-color' to an angle: 0deg throws TypeError
+PASS Setting 'border-top-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-top-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-top-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-top-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-top-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-top-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-top-color' to a number: 0 throws TypeError
+PASS Setting 'border-top-color' to a number: -3.14 throws TypeError
+PASS Setting 'border-top-color' to a number: 3.14 throws TypeError
+PASS Setting 'border-top-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-top-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-top-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-top-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'border-top-color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'border-top-color' does not support '#bbff00'
+PASS 'border-top-color' does not support 'rgb(255, 255, 128)'
+PASS 'border-top-color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'border-top-color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 PASS Can set 'border-left-color' to CSS-wide keywords: initial
 PASS Can set 'border-left-color' to CSS-wide keywords: inherit
 PASS Can set 'border-left-color' to CSS-wide keywords: unset
 PASS Can set 'border-left-color' to CSS-wide keywords: revert
 PASS Can set 'border-left-color' to var() references:  var(--A)
 PASS Can set 'border-left-color' to the 'currentcolor' keyword: currentcolor
-PASS Setting 'border-left-color' to a length throws TypeError
-PASS Setting 'border-left-color' to a percent throws TypeError
-PASS Setting 'border-left-color' to a time throws TypeError
-PASS Setting 'border-left-color' to an angle throws TypeError
-PASS Setting 'border-left-color' to a flexible length throws TypeError
-PASS Setting 'border-left-color' to a number throws TypeError
-PASS Setting 'border-left-color' to a URL throws TypeError
-PASS Setting 'border-left-color' to a transform throws TypeError
-FAIL 'border-left-color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'border-left-color' does not supported '#bbff00'
-PASS 'border-left-color' does not supported 'rgb(255, 255, 128)'
-PASS 'border-left-color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'border-left-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'border-left-color' to a length: 0px throws TypeError
+PASS Setting 'border-left-color' to a length: -3.14em throws TypeError
+PASS Setting 'border-left-color' to a length: 3.14cm throws TypeError
+PASS Setting 'border-left-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-left-color' to a percent: 0% throws TypeError
+PASS Setting 'border-left-color' to a percent: -3.14% throws TypeError
+PASS Setting 'border-left-color' to a percent: 3.14% throws TypeError
+PASS Setting 'border-left-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-left-color' to a time: 0s throws TypeError
+PASS Setting 'border-left-color' to a time: -3.14ms throws TypeError
+PASS Setting 'border-left-color' to a time: 3.14s throws TypeError
+PASS Setting 'border-left-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-left-color' to an angle: 0deg throws TypeError
+PASS Setting 'border-left-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-left-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-left-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-left-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-left-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-left-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-left-color' to a number: 0 throws TypeError
+PASS Setting 'border-left-color' to a number: -3.14 throws TypeError
+PASS Setting 'border-left-color' to a number: 3.14 throws TypeError
+PASS Setting 'border-left-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-left-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-left-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-left-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'border-left-color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'border-left-color' does not support '#bbff00'
+PASS 'border-left-color' does not support 'rgb(255, 255, 128)'
+PASS 'border-left-color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'border-left-color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 PASS Can set 'border-right-color' to CSS-wide keywords: initial
 PASS Can set 'border-right-color' to CSS-wide keywords: inherit
 PASS Can set 'border-right-color' to CSS-wide keywords: unset
 PASS Can set 'border-right-color' to CSS-wide keywords: revert
 PASS Can set 'border-right-color' to var() references:  var(--A)
 PASS Can set 'border-right-color' to the 'currentcolor' keyword: currentcolor
-PASS Setting 'border-right-color' to a length throws TypeError
-PASS Setting 'border-right-color' to a percent throws TypeError
-PASS Setting 'border-right-color' to a time throws TypeError
-PASS Setting 'border-right-color' to an angle throws TypeError
-PASS Setting 'border-right-color' to a flexible length throws TypeError
-PASS Setting 'border-right-color' to a number throws TypeError
-PASS Setting 'border-right-color' to a URL throws TypeError
-PASS Setting 'border-right-color' to a transform throws TypeError
-FAIL 'border-right-color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'border-right-color' does not supported '#bbff00'
-PASS 'border-right-color' does not supported 'rgb(255, 255, 128)'
-PASS 'border-right-color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'border-right-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'border-right-color' to a length: 0px throws TypeError
+PASS Setting 'border-right-color' to a length: -3.14em throws TypeError
+PASS Setting 'border-right-color' to a length: 3.14cm throws TypeError
+PASS Setting 'border-right-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-right-color' to a percent: 0% throws TypeError
+PASS Setting 'border-right-color' to a percent: -3.14% throws TypeError
+PASS Setting 'border-right-color' to a percent: 3.14% throws TypeError
+PASS Setting 'border-right-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-right-color' to a time: 0s throws TypeError
+PASS Setting 'border-right-color' to a time: -3.14ms throws TypeError
+PASS Setting 'border-right-color' to a time: 3.14s throws TypeError
+PASS Setting 'border-right-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-right-color' to an angle: 0deg throws TypeError
+PASS Setting 'border-right-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-right-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-right-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-right-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-right-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-right-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-right-color' to a number: 0 throws TypeError
+PASS Setting 'border-right-color' to a number: -3.14 throws TypeError
+PASS Setting 'border-right-color' to a number: 3.14 throws TypeError
+PASS Setting 'border-right-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-right-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-right-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-right-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'border-right-color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'border-right-color' does not support '#bbff00'
+PASS 'border-right-color' does not support 'rgb(255, 255, 128)'
+PASS 'border-right-color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'border-right-color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 PASS Can set 'border-bottom-color' to CSS-wide keywords: initial
 PASS Can set 'border-bottom-color' to CSS-wide keywords: inherit
 PASS Can set 'border-bottom-color' to CSS-wide keywords: unset
 PASS Can set 'border-bottom-color' to CSS-wide keywords: revert
 PASS Can set 'border-bottom-color' to var() references:  var(--A)
 PASS Can set 'border-bottom-color' to the 'currentcolor' keyword: currentcolor
-PASS Setting 'border-bottom-color' to a length throws TypeError
-PASS Setting 'border-bottom-color' to a percent throws TypeError
-PASS Setting 'border-bottom-color' to a time throws TypeError
-PASS Setting 'border-bottom-color' to an angle throws TypeError
-PASS Setting 'border-bottom-color' to a flexible length throws TypeError
-PASS Setting 'border-bottom-color' to a number throws TypeError
-PASS Setting 'border-bottom-color' to a URL throws TypeError
-PASS Setting 'border-bottom-color' to a transform throws TypeError
-FAIL 'border-bottom-color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'border-bottom-color' does not supported '#bbff00'
-PASS 'border-bottom-color' does not supported 'rgb(255, 255, 128)'
-PASS 'border-bottom-color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'border-bottom-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'border-bottom-color' to a length: 0px throws TypeError
+PASS Setting 'border-bottom-color' to a length: -3.14em throws TypeError
+PASS Setting 'border-bottom-color' to a length: 3.14cm throws TypeError
+PASS Setting 'border-bottom-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-bottom-color' to a percent: 0% throws TypeError
+PASS Setting 'border-bottom-color' to a percent: -3.14% throws TypeError
+PASS Setting 'border-bottom-color' to a percent: 3.14% throws TypeError
+PASS Setting 'border-bottom-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-bottom-color' to a time: 0s throws TypeError
+PASS Setting 'border-bottom-color' to a time: -3.14ms throws TypeError
+PASS Setting 'border-bottom-color' to a time: 3.14s throws TypeError
+PASS Setting 'border-bottom-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-bottom-color' to an angle: 0deg throws TypeError
+PASS Setting 'border-bottom-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-bottom-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-bottom-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-bottom-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-bottom-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-bottom-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-bottom-color' to a number: 0 throws TypeError
+PASS Setting 'border-bottom-color' to a number: -3.14 throws TypeError
+PASS Setting 'border-bottom-color' to a number: 3.14 throws TypeError
+PASS Setting 'border-bottom-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-bottom-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-bottom-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-bottom-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'border-bottom-color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'border-bottom-color' does not support '#bbff00'
+PASS 'border-bottom-color' does not support 'rgb(255, 255, 128)'
+PASS 'border-bottom-color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'border-bottom-color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset-expected.txt
@@ -12,13 +12,25 @@ PASS Can set 'border-image-outset' to a number: 0
 FAIL Can set 'border-image-outset' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'border-image-outset' to a number: 3.14
 PASS Can set 'border-image-outset' to a number: calc(2 + 3)
-PASS Setting 'border-image-outset' to a percent throws TypeError
-PASS Setting 'border-image-outset' to a time throws TypeError
-PASS Setting 'border-image-outset' to an angle throws TypeError
-PASS Setting 'border-image-outset' to a flexible length throws TypeError
-PASS Setting 'border-image-outset' to a URL throws TypeError
-PASS Setting 'border-image-outset' to a transform throws TypeError
-PASS 'border-image-outset' does not supported '1 1.2'
-PASS 'border-image-outset' does not supported '30px 2 45px'
-PASS 'border-image-outset' does not supported '7px 12px 14px 5px'
+PASS Setting 'border-image-outset' to a percent: 0% throws TypeError
+PASS Setting 'border-image-outset' to a percent: -3.14% throws TypeError
+PASS Setting 'border-image-outset' to a percent: 3.14% throws TypeError
+PASS Setting 'border-image-outset' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-image-outset' to a time: 0s throws TypeError
+PASS Setting 'border-image-outset' to a time: -3.14ms throws TypeError
+PASS Setting 'border-image-outset' to a time: 3.14s throws TypeError
+PASS Setting 'border-image-outset' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-image-outset' to an angle: 0deg throws TypeError
+PASS Setting 'border-image-outset' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-image-outset' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-image-outset' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-image-outset' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-image-outset' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-image-outset' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-image-outset' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-image-outset' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-image-outset' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'border-image-outset' does not support '1 1.2'
+PASS 'border-image-outset' does not support '30px 2 45px'
+PASS 'border-image-outset' does not support '7px 12px 14px 5px'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat-expected.txt
@@ -8,14 +8,32 @@ PASS Can set 'border-image-repeat' to the 'stretch' keyword: stretch
 PASS Can set 'border-image-repeat' to the 'repeat' keyword: repeat
 PASS Can set 'border-image-repeat' to the 'round' keyword: round
 PASS Can set 'border-image-repeat' to the 'space' keyword: space
-PASS Setting 'border-image-repeat' to a length throws TypeError
-PASS Setting 'border-image-repeat' to a percent throws TypeError
-PASS Setting 'border-image-repeat' to a time throws TypeError
-PASS Setting 'border-image-repeat' to an angle throws TypeError
-PASS Setting 'border-image-repeat' to a flexible length throws TypeError
-PASS Setting 'border-image-repeat' to a number throws TypeError
-PASS Setting 'border-image-repeat' to a URL throws TypeError
-PASS Setting 'border-image-repeat' to a transform throws TypeError
-PASS 'border-image-repeat' does not supported 'stretch repeat'
-PASS 'border-image-repeat' does not supported 'round space'
+PASS Setting 'border-image-repeat' to a length: 0px throws TypeError
+PASS Setting 'border-image-repeat' to a length: -3.14em throws TypeError
+PASS Setting 'border-image-repeat' to a length: 3.14cm throws TypeError
+PASS Setting 'border-image-repeat' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-image-repeat' to a percent: 0% throws TypeError
+PASS Setting 'border-image-repeat' to a percent: -3.14% throws TypeError
+PASS Setting 'border-image-repeat' to a percent: 3.14% throws TypeError
+PASS Setting 'border-image-repeat' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-image-repeat' to a time: 0s throws TypeError
+PASS Setting 'border-image-repeat' to a time: -3.14ms throws TypeError
+PASS Setting 'border-image-repeat' to a time: 3.14s throws TypeError
+PASS Setting 'border-image-repeat' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-image-repeat' to an angle: 0deg throws TypeError
+PASS Setting 'border-image-repeat' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-image-repeat' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-image-repeat' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-image-repeat' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-image-repeat' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-image-repeat' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-image-repeat' to a number: 0 throws TypeError
+PASS Setting 'border-image-repeat' to a number: -3.14 throws TypeError
+PASS Setting 'border-image-repeat' to a number: 3.14 throws TypeError
+PASS Setting 'border-image-repeat' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-image-repeat' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-image-repeat' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-image-repeat' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'border-image-repeat' does not support 'stretch repeat'
+PASS 'border-image-repeat' does not support 'round space'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice-expected.txt
@@ -12,13 +12,25 @@ PASS Can set 'border-image-slice' to a percent: 0%
 FAIL Can set 'border-image-slice' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'border-image-slice' to a percent: 3.14%
 PASS Can set 'border-image-slice' to a percent: calc(0% + 0%)
-PASS Setting 'border-image-slice' to a length throws TypeError
-PASS Setting 'border-image-slice' to a time throws TypeError
-PASS Setting 'border-image-slice' to an angle throws TypeError
-PASS Setting 'border-image-slice' to a flexible length throws TypeError
-PASS Setting 'border-image-slice' to a URL throws TypeError
-PASS Setting 'border-image-slice' to a transform throws TypeError
-PASS 'border-image-slice' does not supported '30 fill'
-PASS 'border-image-slice' does not supported '30 40 50'
-PASS 'border-image-slice' does not supported '30 40 50 60 fill'
+PASS Setting 'border-image-slice' to a length: 0px throws TypeError
+PASS Setting 'border-image-slice' to a length: -3.14em throws TypeError
+PASS Setting 'border-image-slice' to a length: 3.14cm throws TypeError
+PASS Setting 'border-image-slice' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-image-slice' to a time: 0s throws TypeError
+PASS Setting 'border-image-slice' to a time: -3.14ms throws TypeError
+PASS Setting 'border-image-slice' to a time: 3.14s throws TypeError
+PASS Setting 'border-image-slice' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-image-slice' to an angle: 0deg throws TypeError
+PASS Setting 'border-image-slice' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-image-slice' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-image-slice' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-image-slice' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-image-slice' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-image-slice' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-image-slice' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-image-slice' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-image-slice' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'border-image-slice' does not support '30 fill'
+PASS 'border-image-slice' does not support '30 40 50'
+PASS 'border-image-slice' does not support '30 40 50 60 fill'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-source-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-source-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'border-image-source' to CSS-wide keywords: revert
 PASS Can set 'border-image-source' to var() references:  var(--A)
 PASS Can set 'border-image-source' to the 'none' keyword: none
 PASS Can set 'border-image-source' to an image
-PASS Setting 'border-image-source' to a length throws TypeError
-PASS Setting 'border-image-source' to a percent throws TypeError
-PASS Setting 'border-image-source' to a time throws TypeError
-PASS Setting 'border-image-source' to an angle throws TypeError
-PASS Setting 'border-image-source' to a flexible length throws TypeError
-PASS Setting 'border-image-source' to a number throws TypeError
-PASS Setting 'border-image-source' to a URL throws TypeError
-PASS Setting 'border-image-source' to a transform throws TypeError
+PASS Setting 'border-image-source' to a length: 0px throws TypeError
+PASS Setting 'border-image-source' to a length: -3.14em throws TypeError
+PASS Setting 'border-image-source' to a length: 3.14cm throws TypeError
+PASS Setting 'border-image-source' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-image-source' to a percent: 0% throws TypeError
+PASS Setting 'border-image-source' to a percent: -3.14% throws TypeError
+PASS Setting 'border-image-source' to a percent: 3.14% throws TypeError
+PASS Setting 'border-image-source' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-image-source' to a time: 0s throws TypeError
+PASS Setting 'border-image-source' to a time: -3.14ms throws TypeError
+PASS Setting 'border-image-source' to a time: 3.14s throws TypeError
+PASS Setting 'border-image-source' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-image-source' to an angle: 0deg throws TypeError
+PASS Setting 'border-image-source' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-image-source' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-image-source' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-image-source' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-image-source' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-image-source' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-image-source' to a number: 0 throws TypeError
+PASS Setting 'border-image-source' to a number: -3.14 throws TypeError
+PASS Setting 'border-image-source' to a number: 3.14 throws TypeError
+PASS Setting 'border-image-source' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-image-source' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-image-source' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-image-source' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width-expected.txt
@@ -17,12 +17,21 @@ FAIL Can set 'border-image-width' to a number: -3.14 assert_equals: expected "CS
 PASS Can set 'border-image-width' to a number: 3.14
 PASS Can set 'border-image-width' to a number: calc(2 + 3)
 PASS Can set 'border-image-width' to the 'auto' keyword: auto
-PASS Setting 'border-image-width' to a time throws TypeError
-PASS Setting 'border-image-width' to an angle throws TypeError
-PASS Setting 'border-image-width' to a flexible length throws TypeError
-PASS Setting 'border-image-width' to a URL throws TypeError
-PASS Setting 'border-image-width' to a transform throws TypeError
-PASS 'border-image-width' does not supported '2em 3em'
-PASS 'border-image-width' does not supported '5% 15% 10%'
-PASS 'border-image-width' does not supported '5% 2em 10% auto'
+PASS Setting 'border-image-width' to a time: 0s throws TypeError
+PASS Setting 'border-image-width' to a time: -3.14ms throws TypeError
+PASS Setting 'border-image-width' to a time: 3.14s throws TypeError
+PASS Setting 'border-image-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-image-width' to an angle: 0deg throws TypeError
+PASS Setting 'border-image-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-image-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-image-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-image-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-image-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-image-width' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-image-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-image-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-image-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'border-image-width' does not support '2em 3em'
+PASS 'border-image-width' does not support '5% 15% 10%'
+PASS 'border-image-width' does not support '5% 2em 10% auto'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt
@@ -12,12 +12,24 @@ PASS Can set 'border-top-left-radius' to a percent: 0%
 FAIL Can set 'border-top-left-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'border-top-left-radius' to a percent: 3.14%
 PASS Can set 'border-top-left-radius' to a percent: calc(0% + 0%)
-PASS Setting 'border-top-left-radius' to a time throws TypeError
-PASS Setting 'border-top-left-radius' to an angle throws TypeError
-PASS Setting 'border-top-left-radius' to a flexible length throws TypeError
-FAIL Setting 'border-top-left-radius' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-top-left-radius' to a URL throws TypeError
-PASS Setting 'border-top-left-radius' to a transform throws TypeError
+PASS Setting 'border-top-left-radius' to a time: 0s throws TypeError
+PASS Setting 'border-top-left-radius' to a time: -3.14ms throws TypeError
+PASS Setting 'border-top-left-radius' to a time: 3.14s throws TypeError
+PASS Setting 'border-top-left-radius' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-top-left-radius' to an angle: 0deg throws TypeError
+PASS Setting 'border-top-left-radius' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-top-left-radius' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-top-left-radius' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-top-left-radius' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-top-left-radius' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-top-left-radius' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-top-left-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-top-left-radius' to a number: -3.14 throws TypeError
+PASS Setting 'border-top-left-radius' to a number: 3.14 throws TypeError
+PASS Setting 'border-top-left-radius' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-top-left-radius' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-top-left-radius' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-top-left-radius' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-top-right-radius' to CSS-wide keywords: initial
 PASS Can set 'border-top-right-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-top-right-radius' to CSS-wide keywords: unset
@@ -31,12 +43,24 @@ PASS Can set 'border-top-right-radius' to a percent: 0%
 FAIL Can set 'border-top-right-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'border-top-right-radius' to a percent: 3.14%
 PASS Can set 'border-top-right-radius' to a percent: calc(0% + 0%)
-PASS Setting 'border-top-right-radius' to a time throws TypeError
-PASS Setting 'border-top-right-radius' to an angle throws TypeError
-PASS Setting 'border-top-right-radius' to a flexible length throws TypeError
-FAIL Setting 'border-top-right-radius' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-top-right-radius' to a URL throws TypeError
-PASS Setting 'border-top-right-radius' to a transform throws TypeError
+PASS Setting 'border-top-right-radius' to a time: 0s throws TypeError
+PASS Setting 'border-top-right-radius' to a time: -3.14ms throws TypeError
+PASS Setting 'border-top-right-radius' to a time: 3.14s throws TypeError
+PASS Setting 'border-top-right-radius' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-top-right-radius' to an angle: 0deg throws TypeError
+PASS Setting 'border-top-right-radius' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-top-right-radius' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-top-right-radius' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-top-right-radius' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-top-right-radius' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-top-right-radius' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-top-right-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-top-right-radius' to a number: -3.14 throws TypeError
+PASS Setting 'border-top-right-radius' to a number: 3.14 throws TypeError
+PASS Setting 'border-top-right-radius' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-top-right-radius' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-top-right-radius' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-top-right-radius' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-bottom-left-radius' to CSS-wide keywords: initial
 PASS Can set 'border-bottom-left-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-bottom-left-radius' to CSS-wide keywords: unset
@@ -50,12 +74,24 @@ PASS Can set 'border-bottom-left-radius' to a percent: 0%
 FAIL Can set 'border-bottom-left-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'border-bottom-left-radius' to a percent: 3.14%
 PASS Can set 'border-bottom-left-radius' to a percent: calc(0% + 0%)
-PASS Setting 'border-bottom-left-radius' to a time throws TypeError
-PASS Setting 'border-bottom-left-radius' to an angle throws TypeError
-PASS Setting 'border-bottom-left-radius' to a flexible length throws TypeError
-FAIL Setting 'border-bottom-left-radius' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-bottom-left-radius' to a URL throws TypeError
-PASS Setting 'border-bottom-left-radius' to a transform throws TypeError
+PASS Setting 'border-bottom-left-radius' to a time: 0s throws TypeError
+PASS Setting 'border-bottom-left-radius' to a time: -3.14ms throws TypeError
+PASS Setting 'border-bottom-left-radius' to a time: 3.14s throws TypeError
+PASS Setting 'border-bottom-left-radius' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-bottom-left-radius' to an angle: 0deg throws TypeError
+PASS Setting 'border-bottom-left-radius' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-bottom-left-radius' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-bottom-left-radius' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-bottom-left-radius' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-bottom-left-radius' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-bottom-left-radius' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-bottom-left-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-bottom-left-radius' to a number: -3.14 throws TypeError
+PASS Setting 'border-bottom-left-radius' to a number: 3.14 throws TypeError
+PASS Setting 'border-bottom-left-radius' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-bottom-left-radius' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-bottom-left-radius' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-bottom-left-radius' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-bottom-right-radius' to CSS-wide keywords: initial
 PASS Can set 'border-bottom-right-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-bottom-right-radius' to CSS-wide keywords: unset
@@ -69,14 +105,26 @@ PASS Can set 'border-bottom-right-radius' to a percent: 0%
 FAIL Can set 'border-bottom-right-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'border-bottom-right-radius' to a percent: 3.14%
 PASS Can set 'border-bottom-right-radius' to a percent: calc(0% + 0%)
-PASS Setting 'border-bottom-right-radius' to a time throws TypeError
-PASS Setting 'border-bottom-right-radius' to an angle throws TypeError
-PASS Setting 'border-bottom-right-radius' to a flexible length throws TypeError
-FAIL Setting 'border-bottom-right-radius' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-bottom-right-radius' to a URL throws TypeError
-PASS Setting 'border-bottom-right-radius' to a transform throws TypeError
-PASS 'border-radius' does not supported '30px'
-PASS 'border-radius' does not supported '25% 10%'
-PASS 'border-radius' does not supported '10% / 50%'
-PASS 'border-radius' does not supported '50% 20% / 10% 40%'
+PASS Setting 'border-bottom-right-radius' to a time: 0s throws TypeError
+PASS Setting 'border-bottom-right-radius' to a time: -3.14ms throws TypeError
+PASS Setting 'border-bottom-right-radius' to a time: 3.14s throws TypeError
+PASS Setting 'border-bottom-right-radius' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-bottom-right-radius' to an angle: 0deg throws TypeError
+PASS Setting 'border-bottom-right-radius' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-bottom-right-radius' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-bottom-right-radius' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-bottom-right-radius' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-bottom-right-radius' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-bottom-right-radius' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-bottom-right-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-bottom-right-radius' to a number: -3.14 throws TypeError
+PASS Setting 'border-bottom-right-radius' to a number: 3.14 throws TypeError
+PASS Setting 'border-bottom-right-radius' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-bottom-right-radius' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-bottom-right-radius' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-bottom-right-radius' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'border-radius' does not support '30px'
+PASS 'border-radius' does not support '25% 10%'
+PASS 'border-radius' does not support '10% / 50%'
+PASS 'border-radius' does not support '50% 20% / 10% 40%'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-style-expected.txt
@@ -6,14 +6,32 @@ PASS Can set 'border-top-style' to CSS-wide keywords: revert
 PASS Can set 'border-top-style' to var() references:  var(--A)
 PASS Can set 'border-top-style' to the 'none' keyword: none
 PASS Can set 'border-top-style' to the 'solid' keyword: solid
-PASS Setting 'border-top-style' to a length throws TypeError
-PASS Setting 'border-top-style' to a percent throws TypeError
-PASS Setting 'border-top-style' to a time throws TypeError
-PASS Setting 'border-top-style' to an angle throws TypeError
-PASS Setting 'border-top-style' to a flexible length throws TypeError
-PASS Setting 'border-top-style' to a number throws TypeError
-PASS Setting 'border-top-style' to a URL throws TypeError
-PASS Setting 'border-top-style' to a transform throws TypeError
+PASS Setting 'border-top-style' to a length: 0px throws TypeError
+PASS Setting 'border-top-style' to a length: -3.14em throws TypeError
+PASS Setting 'border-top-style' to a length: 3.14cm throws TypeError
+PASS Setting 'border-top-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-top-style' to a percent: 0% throws TypeError
+PASS Setting 'border-top-style' to a percent: -3.14% throws TypeError
+PASS Setting 'border-top-style' to a percent: 3.14% throws TypeError
+PASS Setting 'border-top-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-top-style' to a time: 0s throws TypeError
+PASS Setting 'border-top-style' to a time: -3.14ms throws TypeError
+PASS Setting 'border-top-style' to a time: 3.14s throws TypeError
+PASS Setting 'border-top-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-top-style' to an angle: 0deg throws TypeError
+PASS Setting 'border-top-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-top-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-top-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-top-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-top-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-top-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-top-style' to a number: 0 throws TypeError
+PASS Setting 'border-top-style' to a number: -3.14 throws TypeError
+PASS Setting 'border-top-style' to a number: 3.14 throws TypeError
+PASS Setting 'border-top-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-top-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-top-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-top-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-left-style' to CSS-wide keywords: initial
 PASS Can set 'border-left-style' to CSS-wide keywords: inherit
 PASS Can set 'border-left-style' to CSS-wide keywords: unset
@@ -21,14 +39,32 @@ PASS Can set 'border-left-style' to CSS-wide keywords: revert
 PASS Can set 'border-left-style' to var() references:  var(--A)
 PASS Can set 'border-left-style' to the 'none' keyword: none
 PASS Can set 'border-left-style' to the 'solid' keyword: solid
-PASS Setting 'border-left-style' to a length throws TypeError
-PASS Setting 'border-left-style' to a percent throws TypeError
-PASS Setting 'border-left-style' to a time throws TypeError
-PASS Setting 'border-left-style' to an angle throws TypeError
-PASS Setting 'border-left-style' to a flexible length throws TypeError
-PASS Setting 'border-left-style' to a number throws TypeError
-PASS Setting 'border-left-style' to a URL throws TypeError
-PASS Setting 'border-left-style' to a transform throws TypeError
+PASS Setting 'border-left-style' to a length: 0px throws TypeError
+PASS Setting 'border-left-style' to a length: -3.14em throws TypeError
+PASS Setting 'border-left-style' to a length: 3.14cm throws TypeError
+PASS Setting 'border-left-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-left-style' to a percent: 0% throws TypeError
+PASS Setting 'border-left-style' to a percent: -3.14% throws TypeError
+PASS Setting 'border-left-style' to a percent: 3.14% throws TypeError
+PASS Setting 'border-left-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-left-style' to a time: 0s throws TypeError
+PASS Setting 'border-left-style' to a time: -3.14ms throws TypeError
+PASS Setting 'border-left-style' to a time: 3.14s throws TypeError
+PASS Setting 'border-left-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-left-style' to an angle: 0deg throws TypeError
+PASS Setting 'border-left-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-left-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-left-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-left-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-left-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-left-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-left-style' to a number: 0 throws TypeError
+PASS Setting 'border-left-style' to a number: -3.14 throws TypeError
+PASS Setting 'border-left-style' to a number: 3.14 throws TypeError
+PASS Setting 'border-left-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-left-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-left-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-left-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-right-style' to CSS-wide keywords: initial
 PASS Can set 'border-right-style' to CSS-wide keywords: inherit
 PASS Can set 'border-right-style' to CSS-wide keywords: unset
@@ -36,14 +72,32 @@ PASS Can set 'border-right-style' to CSS-wide keywords: revert
 PASS Can set 'border-right-style' to var() references:  var(--A)
 PASS Can set 'border-right-style' to the 'none' keyword: none
 PASS Can set 'border-right-style' to the 'solid' keyword: solid
-PASS Setting 'border-right-style' to a length throws TypeError
-PASS Setting 'border-right-style' to a percent throws TypeError
-PASS Setting 'border-right-style' to a time throws TypeError
-PASS Setting 'border-right-style' to an angle throws TypeError
-PASS Setting 'border-right-style' to a flexible length throws TypeError
-PASS Setting 'border-right-style' to a number throws TypeError
-PASS Setting 'border-right-style' to a URL throws TypeError
-PASS Setting 'border-right-style' to a transform throws TypeError
+PASS Setting 'border-right-style' to a length: 0px throws TypeError
+PASS Setting 'border-right-style' to a length: -3.14em throws TypeError
+PASS Setting 'border-right-style' to a length: 3.14cm throws TypeError
+PASS Setting 'border-right-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-right-style' to a percent: 0% throws TypeError
+PASS Setting 'border-right-style' to a percent: -3.14% throws TypeError
+PASS Setting 'border-right-style' to a percent: 3.14% throws TypeError
+PASS Setting 'border-right-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-right-style' to a time: 0s throws TypeError
+PASS Setting 'border-right-style' to a time: -3.14ms throws TypeError
+PASS Setting 'border-right-style' to a time: 3.14s throws TypeError
+PASS Setting 'border-right-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-right-style' to an angle: 0deg throws TypeError
+PASS Setting 'border-right-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-right-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-right-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-right-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-right-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-right-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-right-style' to a number: 0 throws TypeError
+PASS Setting 'border-right-style' to a number: -3.14 throws TypeError
+PASS Setting 'border-right-style' to a number: 3.14 throws TypeError
+PASS Setting 'border-right-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-right-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-right-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-right-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-bottom-style' to CSS-wide keywords: initial
 PASS Can set 'border-bottom-style' to CSS-wide keywords: inherit
 PASS Can set 'border-bottom-style' to CSS-wide keywords: unset
@@ -51,12 +105,30 @@ PASS Can set 'border-bottom-style' to CSS-wide keywords: revert
 PASS Can set 'border-bottom-style' to var() references:  var(--A)
 PASS Can set 'border-bottom-style' to the 'none' keyword: none
 PASS Can set 'border-bottom-style' to the 'solid' keyword: solid
-PASS Setting 'border-bottom-style' to a length throws TypeError
-PASS Setting 'border-bottom-style' to a percent throws TypeError
-PASS Setting 'border-bottom-style' to a time throws TypeError
-PASS Setting 'border-bottom-style' to an angle throws TypeError
-PASS Setting 'border-bottom-style' to a flexible length throws TypeError
-PASS Setting 'border-bottom-style' to a number throws TypeError
-PASS Setting 'border-bottom-style' to a URL throws TypeError
-PASS Setting 'border-bottom-style' to a transform throws TypeError
+PASS Setting 'border-bottom-style' to a length: 0px throws TypeError
+PASS Setting 'border-bottom-style' to a length: -3.14em throws TypeError
+PASS Setting 'border-bottom-style' to a length: 3.14cm throws TypeError
+PASS Setting 'border-bottom-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-bottom-style' to a percent: 0% throws TypeError
+PASS Setting 'border-bottom-style' to a percent: -3.14% throws TypeError
+PASS Setting 'border-bottom-style' to a percent: 3.14% throws TypeError
+PASS Setting 'border-bottom-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-bottom-style' to a time: 0s throws TypeError
+PASS Setting 'border-bottom-style' to a time: -3.14ms throws TypeError
+PASS Setting 'border-bottom-style' to a time: 3.14s throws TypeError
+PASS Setting 'border-bottom-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-bottom-style' to an angle: 0deg throws TypeError
+PASS Setting 'border-bottom-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-bottom-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-bottom-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-bottom-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-bottom-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-bottom-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-bottom-style' to a number: 0 throws TypeError
+PASS Setting 'border-bottom-style' to a number: -3.14 throws TypeError
+PASS Setting 'border-bottom-style' to a number: 3.14 throws TypeError
+PASS Setting 'border-bottom-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-bottom-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-bottom-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-bottom-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt
@@ -11,13 +11,28 @@ PASS Can set 'border-top-width' to a length: 0px
 PASS Can set 'border-top-width' to a length: -3.14em
 PASS Can set 'border-top-width' to a length: 3.14cm
 PASS Can set 'border-top-width' to a length: calc(0px + 0em)
-PASS Setting 'border-top-width' to a percent throws TypeError
-PASS Setting 'border-top-width' to a time throws TypeError
-PASS Setting 'border-top-width' to an angle throws TypeError
-PASS Setting 'border-top-width' to a flexible length throws TypeError
-FAIL Setting 'border-top-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-top-width' to a URL throws TypeError
-PASS Setting 'border-top-width' to a transform throws TypeError
+PASS Setting 'border-top-width' to a percent: 0% throws TypeError
+PASS Setting 'border-top-width' to a percent: -3.14% throws TypeError
+PASS Setting 'border-top-width' to a percent: 3.14% throws TypeError
+PASS Setting 'border-top-width' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-top-width' to a time: 0s throws TypeError
+PASS Setting 'border-top-width' to a time: -3.14ms throws TypeError
+PASS Setting 'border-top-width' to a time: 3.14s throws TypeError
+PASS Setting 'border-top-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-top-width' to an angle: 0deg throws TypeError
+PASS Setting 'border-top-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-top-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-top-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-top-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-top-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-top-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-top-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-top-width' to a number: -3.14 throws TypeError
+PASS Setting 'border-top-width' to a number: 3.14 throws TypeError
+PASS Setting 'border-top-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-top-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-top-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-top-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-left-width' to CSS-wide keywords: initial
 PASS Can set 'border-left-width' to CSS-wide keywords: inherit
 PASS Can set 'border-left-width' to CSS-wide keywords: unset
@@ -30,13 +45,28 @@ PASS Can set 'border-left-width' to a length: 0px
 PASS Can set 'border-left-width' to a length: -3.14em
 PASS Can set 'border-left-width' to a length: 3.14cm
 PASS Can set 'border-left-width' to a length: calc(0px + 0em)
-PASS Setting 'border-left-width' to a percent throws TypeError
-PASS Setting 'border-left-width' to a time throws TypeError
-PASS Setting 'border-left-width' to an angle throws TypeError
-PASS Setting 'border-left-width' to a flexible length throws TypeError
-FAIL Setting 'border-left-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-left-width' to a URL throws TypeError
-PASS Setting 'border-left-width' to a transform throws TypeError
+PASS Setting 'border-left-width' to a percent: 0% throws TypeError
+PASS Setting 'border-left-width' to a percent: -3.14% throws TypeError
+PASS Setting 'border-left-width' to a percent: 3.14% throws TypeError
+PASS Setting 'border-left-width' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-left-width' to a time: 0s throws TypeError
+PASS Setting 'border-left-width' to a time: -3.14ms throws TypeError
+PASS Setting 'border-left-width' to a time: 3.14s throws TypeError
+PASS Setting 'border-left-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-left-width' to an angle: 0deg throws TypeError
+PASS Setting 'border-left-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-left-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-left-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-left-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-left-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-left-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-left-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-left-width' to a number: -3.14 throws TypeError
+PASS Setting 'border-left-width' to a number: 3.14 throws TypeError
+PASS Setting 'border-left-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-left-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-left-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-left-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-right-width' to CSS-wide keywords: initial
 PASS Can set 'border-right-width' to CSS-wide keywords: inherit
 PASS Can set 'border-right-width' to CSS-wide keywords: unset
@@ -49,13 +79,28 @@ PASS Can set 'border-right-width' to a length: 0px
 PASS Can set 'border-right-width' to a length: -3.14em
 PASS Can set 'border-right-width' to a length: 3.14cm
 PASS Can set 'border-right-width' to a length: calc(0px + 0em)
-PASS Setting 'border-right-width' to a percent throws TypeError
-PASS Setting 'border-right-width' to a time throws TypeError
-PASS Setting 'border-right-width' to an angle throws TypeError
-PASS Setting 'border-right-width' to a flexible length throws TypeError
-FAIL Setting 'border-right-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-right-width' to a URL throws TypeError
-PASS Setting 'border-right-width' to a transform throws TypeError
+PASS Setting 'border-right-width' to a percent: 0% throws TypeError
+PASS Setting 'border-right-width' to a percent: -3.14% throws TypeError
+PASS Setting 'border-right-width' to a percent: 3.14% throws TypeError
+PASS Setting 'border-right-width' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-right-width' to a time: 0s throws TypeError
+PASS Setting 'border-right-width' to a time: -3.14ms throws TypeError
+PASS Setting 'border-right-width' to a time: 3.14s throws TypeError
+PASS Setting 'border-right-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-right-width' to an angle: 0deg throws TypeError
+PASS Setting 'border-right-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-right-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-right-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-right-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-right-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-right-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-right-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-right-width' to a number: -3.14 throws TypeError
+PASS Setting 'border-right-width' to a number: 3.14 throws TypeError
+PASS Setting 'border-right-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-right-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-right-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-right-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-bottom-width' to CSS-wide keywords: initial
 PASS Can set 'border-bottom-width' to CSS-wide keywords: inherit
 PASS Can set 'border-bottom-width' to CSS-wide keywords: unset
@@ -68,11 +113,26 @@ PASS Can set 'border-bottom-width' to a length: 0px
 PASS Can set 'border-bottom-width' to a length: -3.14em
 PASS Can set 'border-bottom-width' to a length: 3.14cm
 PASS Can set 'border-bottom-width' to a length: calc(0px + 0em)
-PASS Setting 'border-bottom-width' to a percent throws TypeError
-PASS Setting 'border-bottom-width' to a time throws TypeError
-PASS Setting 'border-bottom-width' to an angle throws TypeError
-PASS Setting 'border-bottom-width' to a flexible length throws TypeError
-FAIL Setting 'border-bottom-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-bottom-width' to a URL throws TypeError
-PASS Setting 'border-bottom-width' to a transform throws TypeError
+PASS Setting 'border-bottom-width' to a percent: 0% throws TypeError
+PASS Setting 'border-bottom-width' to a percent: -3.14% throws TypeError
+PASS Setting 'border-bottom-width' to a percent: 3.14% throws TypeError
+PASS Setting 'border-bottom-width' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-bottom-width' to a time: 0s throws TypeError
+PASS Setting 'border-bottom-width' to a time: -3.14ms throws TypeError
+PASS Setting 'border-bottom-width' to a time: 3.14s throws TypeError
+PASS Setting 'border-bottom-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-bottom-width' to an angle: 0deg throws TypeError
+PASS Setting 'border-bottom-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-bottom-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-bottom-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-bottom-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-bottom-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-bottom-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-bottom-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-bottom-width' to a number: -3.14 throws TypeError
+PASS Setting 'border-bottom-width' to a number: 3.14 throws TypeError
+PASS Setting 'border-bottom-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-bottom-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-bottom-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-bottom-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/bottom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/bottom-expected.txt
@@ -13,10 +13,22 @@ PASS Can set 'bottom' to a length: 0px
 PASS Can set 'bottom' to a length: -3.14em
 PASS Can set 'bottom' to a length: 3.14cm
 PASS Can set 'bottom' to a length: calc(0px + 0em)
-PASS Setting 'bottom' to a time throws TypeError
-PASS Setting 'bottom' to an angle throws TypeError
-PASS Setting 'bottom' to a flexible length throws TypeError
-FAIL Setting 'bottom' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'bottom' to a URL throws TypeError
-PASS Setting 'bottom' to a transform throws TypeError
+PASS Setting 'bottom' to a time: 0s throws TypeError
+PASS Setting 'bottom' to a time: -3.14ms throws TypeError
+PASS Setting 'bottom' to a time: 3.14s throws TypeError
+PASS Setting 'bottom' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'bottom' to an angle: 0deg throws TypeError
+PASS Setting 'bottom' to an angle: 3.14rad throws TypeError
+PASS Setting 'bottom' to an angle: -3.14deg throws TypeError
+PASS Setting 'bottom' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'bottom' to a flexible length: 0fr throws TypeError
+PASS Setting 'bottom' to a flexible length: 1fr throws TypeError
+PASS Setting 'bottom' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'bottom' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'bottom' to a number: -3.14 throws TypeError
+PASS Setting 'bottom' to a number: 3.14 throws TypeError
+PASS Setting 'bottom' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'bottom' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'bottom' to a transform: perspective(10em) throws TypeError
+PASS Setting 'bottom' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-shadow-expected.txt
@@ -5,13 +5,31 @@ PASS Can set 'box-shadow' to CSS-wide keywords: unset
 PASS Can set 'box-shadow' to CSS-wide keywords: revert
 PASS Can set 'box-shadow' to var() references:  var(--A)
 PASS Can set 'box-shadow' to the 'none' keyword: none
-PASS Setting 'box-shadow' to a length throws TypeError
-PASS Setting 'box-shadow' to a percent throws TypeError
-PASS Setting 'box-shadow' to a time throws TypeError
-PASS Setting 'box-shadow' to an angle throws TypeError
-PASS Setting 'box-shadow' to a flexible length throws TypeError
-PASS Setting 'box-shadow' to a number throws TypeError
-PASS Setting 'box-shadow' to a URL throws TypeError
-PASS Setting 'box-shadow' to a transform throws TypeError
-PASS 'box-shadow' does not supported '10px 5px 5px red'
+PASS Setting 'box-shadow' to a length: 0px throws TypeError
+PASS Setting 'box-shadow' to a length: -3.14em throws TypeError
+PASS Setting 'box-shadow' to a length: 3.14cm throws TypeError
+PASS Setting 'box-shadow' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'box-shadow' to a percent: 0% throws TypeError
+PASS Setting 'box-shadow' to a percent: -3.14% throws TypeError
+PASS Setting 'box-shadow' to a percent: 3.14% throws TypeError
+PASS Setting 'box-shadow' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'box-shadow' to a time: 0s throws TypeError
+PASS Setting 'box-shadow' to a time: -3.14ms throws TypeError
+PASS Setting 'box-shadow' to a time: 3.14s throws TypeError
+PASS Setting 'box-shadow' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'box-shadow' to an angle: 0deg throws TypeError
+PASS Setting 'box-shadow' to an angle: 3.14rad throws TypeError
+PASS Setting 'box-shadow' to an angle: -3.14deg throws TypeError
+PASS Setting 'box-shadow' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'box-shadow' to a flexible length: 0fr throws TypeError
+PASS Setting 'box-shadow' to a flexible length: 1fr throws TypeError
+PASS Setting 'box-shadow' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'box-shadow' to a number: 0 throws TypeError
+PASS Setting 'box-shadow' to a number: -3.14 throws TypeError
+PASS Setting 'box-shadow' to a number: 3.14 throws TypeError
+PASS Setting 'box-shadow' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'box-shadow' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'box-shadow' to a transform: perspective(10em) throws TypeError
+PASS Setting 'box-shadow' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'box-shadow' does not support '10px 5px 5px red'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-sizing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-sizing-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'box-sizing' to CSS-wide keywords: revert
 PASS Can set 'box-sizing' to var() references:  var(--A)
 PASS Can set 'box-sizing' to the 'content-box' keyword: content-box
 PASS Can set 'box-sizing' to the 'border-box' keyword: border-box
-PASS Setting 'box-sizing' to a length throws TypeError
-PASS Setting 'box-sizing' to a percent throws TypeError
-PASS Setting 'box-sizing' to a time throws TypeError
-PASS Setting 'box-sizing' to an angle throws TypeError
-PASS Setting 'box-sizing' to a flexible length throws TypeError
-PASS Setting 'box-sizing' to a number throws TypeError
-PASS Setting 'box-sizing' to a URL throws TypeError
-PASS Setting 'box-sizing' to a transform throws TypeError
+PASS Setting 'box-sizing' to a length: 0px throws TypeError
+PASS Setting 'box-sizing' to a length: -3.14em throws TypeError
+PASS Setting 'box-sizing' to a length: 3.14cm throws TypeError
+PASS Setting 'box-sizing' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'box-sizing' to a percent: 0% throws TypeError
+PASS Setting 'box-sizing' to a percent: -3.14% throws TypeError
+PASS Setting 'box-sizing' to a percent: 3.14% throws TypeError
+PASS Setting 'box-sizing' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'box-sizing' to a time: 0s throws TypeError
+PASS Setting 'box-sizing' to a time: -3.14ms throws TypeError
+PASS Setting 'box-sizing' to a time: 3.14s throws TypeError
+PASS Setting 'box-sizing' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'box-sizing' to an angle: 0deg throws TypeError
+PASS Setting 'box-sizing' to an angle: 3.14rad throws TypeError
+PASS Setting 'box-sizing' to an angle: -3.14deg throws TypeError
+PASS Setting 'box-sizing' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'box-sizing' to a flexible length: 0fr throws TypeError
+PASS Setting 'box-sizing' to a flexible length: 1fr throws TypeError
+PASS Setting 'box-sizing' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'box-sizing' to a number: 0 throws TypeError
+PASS Setting 'box-sizing' to a number: -3.14 throws TypeError
+PASS Setting 'box-sizing' to a number: 3.14 throws TypeError
+PASS Setting 'box-sizing' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'box-sizing' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'box-sizing' to a transform: perspective(10em) throws TypeError
+PASS Setting 'box-sizing' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/break-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/break-expected.txt
@@ -16,14 +16,32 @@ PASS Can set 'break-after' to the 'recto' keyword: recto
 FAIL Can set 'break-after' to the 'region' keyword: region Invalid values
 PASS Can set 'break-after' to the 'right' keyword: right
 PASS Can set 'break-after' to the 'verso' keyword: verso
-PASS Setting 'break-after' to a length throws TypeError
-PASS Setting 'break-after' to a percent throws TypeError
-PASS Setting 'break-after' to a time throws TypeError
-PASS Setting 'break-after' to an angle throws TypeError
-PASS Setting 'break-after' to a flexible length throws TypeError
-PASS Setting 'break-after' to a number throws TypeError
-PASS Setting 'break-after' to a URL throws TypeError
-PASS Setting 'break-after' to a transform throws TypeError
+PASS Setting 'break-after' to a length: 0px throws TypeError
+PASS Setting 'break-after' to a length: -3.14em throws TypeError
+PASS Setting 'break-after' to a length: 3.14cm throws TypeError
+PASS Setting 'break-after' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'break-after' to a percent: 0% throws TypeError
+PASS Setting 'break-after' to a percent: -3.14% throws TypeError
+PASS Setting 'break-after' to a percent: 3.14% throws TypeError
+PASS Setting 'break-after' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'break-after' to a time: 0s throws TypeError
+PASS Setting 'break-after' to a time: -3.14ms throws TypeError
+PASS Setting 'break-after' to a time: 3.14s throws TypeError
+PASS Setting 'break-after' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'break-after' to an angle: 0deg throws TypeError
+PASS Setting 'break-after' to an angle: 3.14rad throws TypeError
+PASS Setting 'break-after' to an angle: -3.14deg throws TypeError
+PASS Setting 'break-after' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'break-after' to a flexible length: 0fr throws TypeError
+PASS Setting 'break-after' to a flexible length: 1fr throws TypeError
+PASS Setting 'break-after' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'break-after' to a number: 0 throws TypeError
+PASS Setting 'break-after' to a number: -3.14 throws TypeError
+PASS Setting 'break-after' to a number: 3.14 throws TypeError
+PASS Setting 'break-after' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'break-after' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'break-after' to a transform: perspective(10em) throws TypeError
+PASS Setting 'break-after' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'break-before' to CSS-wide keywords: initial
 PASS Can set 'break-before' to CSS-wide keywords: inherit
 PASS Can set 'break-before' to CSS-wide keywords: unset
@@ -41,14 +59,32 @@ PASS Can set 'break-before' to the 'recto' keyword: recto
 FAIL Can set 'break-before' to the 'region' keyword: region Invalid values
 PASS Can set 'break-before' to the 'right' keyword: right
 PASS Can set 'break-before' to the 'verso' keyword: verso
-PASS Setting 'break-before' to a length throws TypeError
-PASS Setting 'break-before' to a percent throws TypeError
-PASS Setting 'break-before' to a time throws TypeError
-PASS Setting 'break-before' to an angle throws TypeError
-PASS Setting 'break-before' to a flexible length throws TypeError
-PASS Setting 'break-before' to a number throws TypeError
-PASS Setting 'break-before' to a URL throws TypeError
-PASS Setting 'break-before' to a transform throws TypeError
+PASS Setting 'break-before' to a length: 0px throws TypeError
+PASS Setting 'break-before' to a length: -3.14em throws TypeError
+PASS Setting 'break-before' to a length: 3.14cm throws TypeError
+PASS Setting 'break-before' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'break-before' to a percent: 0% throws TypeError
+PASS Setting 'break-before' to a percent: -3.14% throws TypeError
+PASS Setting 'break-before' to a percent: 3.14% throws TypeError
+PASS Setting 'break-before' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'break-before' to a time: 0s throws TypeError
+PASS Setting 'break-before' to a time: -3.14ms throws TypeError
+PASS Setting 'break-before' to a time: 3.14s throws TypeError
+PASS Setting 'break-before' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'break-before' to an angle: 0deg throws TypeError
+PASS Setting 'break-before' to an angle: 3.14rad throws TypeError
+PASS Setting 'break-before' to an angle: -3.14deg throws TypeError
+PASS Setting 'break-before' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'break-before' to a flexible length: 0fr throws TypeError
+PASS Setting 'break-before' to a flexible length: 1fr throws TypeError
+PASS Setting 'break-before' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'break-before' to a number: 0 throws TypeError
+PASS Setting 'break-before' to a number: -3.14 throws TypeError
+PASS Setting 'break-before' to a number: 3.14 throws TypeError
+PASS Setting 'break-before' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'break-before' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'break-before' to a transform: perspective(10em) throws TypeError
+PASS Setting 'break-before' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'break-inside' to CSS-wide keywords: initial
 PASS Can set 'break-inside' to CSS-wide keywords: inherit
 PASS Can set 'break-inside' to CSS-wide keywords: unset
@@ -59,12 +95,30 @@ PASS Can set 'break-inside' to the 'avoid' keyword: avoid
 PASS Can set 'break-inside' to the 'avoid-column' keyword: avoid-column
 PASS Can set 'break-inside' to the 'avoid-page' keyword: avoid-page
 FAIL Can set 'break-inside' to the 'avoid-region' keyword: avoid-region Invalid values
-PASS Setting 'break-inside' to a length throws TypeError
-PASS Setting 'break-inside' to a percent throws TypeError
-PASS Setting 'break-inside' to a time throws TypeError
-PASS Setting 'break-inside' to an angle throws TypeError
-PASS Setting 'break-inside' to a flexible length throws TypeError
-PASS Setting 'break-inside' to a number throws TypeError
-PASS Setting 'break-inside' to a URL throws TypeError
-PASS Setting 'break-inside' to a transform throws TypeError
+PASS Setting 'break-inside' to a length: 0px throws TypeError
+PASS Setting 'break-inside' to a length: -3.14em throws TypeError
+PASS Setting 'break-inside' to a length: 3.14cm throws TypeError
+PASS Setting 'break-inside' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'break-inside' to a percent: 0% throws TypeError
+PASS Setting 'break-inside' to a percent: -3.14% throws TypeError
+PASS Setting 'break-inside' to a percent: 3.14% throws TypeError
+PASS Setting 'break-inside' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'break-inside' to a time: 0s throws TypeError
+PASS Setting 'break-inside' to a time: -3.14ms throws TypeError
+PASS Setting 'break-inside' to a time: 3.14s throws TypeError
+PASS Setting 'break-inside' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'break-inside' to an angle: 0deg throws TypeError
+PASS Setting 'break-inside' to an angle: 3.14rad throws TypeError
+PASS Setting 'break-inside' to an angle: -3.14deg throws TypeError
+PASS Setting 'break-inside' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'break-inside' to a flexible length: 0fr throws TypeError
+PASS Setting 'break-inside' to a flexible length: 1fr throws TypeError
+PASS Setting 'break-inside' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'break-inside' to a number: 0 throws TypeError
+PASS Setting 'break-inside' to a number: -3.14 throws TypeError
+PASS Setting 'break-inside' to a number: 3.14 throws TypeError
+PASS Setting 'break-inside' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'break-inside' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'break-inside' to a transform: perspective(10em) throws TypeError
+PASS Setting 'break-inside' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caption-side-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caption-side-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'caption-side' to CSS-wide keywords: revert
 PASS Can set 'caption-side' to var() references:  var(--A)
 PASS Can set 'caption-side' to the 'top' keyword: top
 PASS Can set 'caption-side' to the 'bottom' keyword: bottom
-PASS Setting 'caption-side' to a length throws TypeError
-PASS Setting 'caption-side' to a percent throws TypeError
-PASS Setting 'caption-side' to a time throws TypeError
-PASS Setting 'caption-side' to an angle throws TypeError
-PASS Setting 'caption-side' to a flexible length throws TypeError
-PASS Setting 'caption-side' to a number throws TypeError
-PASS Setting 'caption-side' to a URL throws TypeError
-PASS Setting 'caption-side' to a transform throws TypeError
+PASS Setting 'caption-side' to a length: 0px throws TypeError
+PASS Setting 'caption-side' to a length: -3.14em throws TypeError
+PASS Setting 'caption-side' to a length: 3.14cm throws TypeError
+PASS Setting 'caption-side' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'caption-side' to a percent: 0% throws TypeError
+PASS Setting 'caption-side' to a percent: -3.14% throws TypeError
+PASS Setting 'caption-side' to a percent: 3.14% throws TypeError
+PASS Setting 'caption-side' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'caption-side' to a time: 0s throws TypeError
+PASS Setting 'caption-side' to a time: -3.14ms throws TypeError
+PASS Setting 'caption-side' to a time: 3.14s throws TypeError
+PASS Setting 'caption-side' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'caption-side' to an angle: 0deg throws TypeError
+PASS Setting 'caption-side' to an angle: 3.14rad throws TypeError
+PASS Setting 'caption-side' to an angle: -3.14deg throws TypeError
+PASS Setting 'caption-side' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'caption-side' to a flexible length: 0fr throws TypeError
+PASS Setting 'caption-side' to a flexible length: 1fr throws TypeError
+PASS Setting 'caption-side' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'caption-side' to a number: 0 throws TypeError
+PASS Setting 'caption-side' to a number: -3.14 throws TypeError
+PASS Setting 'caption-side' to a number: 3.14 throws TypeError
+PASS Setting 'caption-side' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'caption-side' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'caption-side' to a transform: perspective(10em) throws TypeError
+PASS Setting 'caption-side' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caret-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caret-color-expected.txt
@@ -6,17 +6,35 @@ PASS Can set 'caret-color' to CSS-wide keywords: revert
 PASS Can set 'caret-color' to var() references:  var(--A)
 PASS Can set 'caret-color' to the 'currentcolor' keyword: currentcolor
 PASS Can set 'caret-color' to the 'auto' keyword: auto
-PASS Setting 'caret-color' to a length throws TypeError
-PASS Setting 'caret-color' to a percent throws TypeError
-PASS Setting 'caret-color' to a time throws TypeError
-PASS Setting 'caret-color' to an angle throws TypeError
-PASS Setting 'caret-color' to a flexible length throws TypeError
-PASS Setting 'caret-color' to a number throws TypeError
-PASS Setting 'caret-color' to a URL throws TypeError
-PASS Setting 'caret-color' to a transform throws TypeError
-FAIL 'caret-color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'caret-color' does not supported '#bbff00'
-PASS 'caret-color' does not supported 'rgb(255, 255, 128)'
-PASS 'caret-color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'caret-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'caret-color' to a length: 0px throws TypeError
+PASS Setting 'caret-color' to a length: -3.14em throws TypeError
+PASS Setting 'caret-color' to a length: 3.14cm throws TypeError
+PASS Setting 'caret-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'caret-color' to a percent: 0% throws TypeError
+PASS Setting 'caret-color' to a percent: -3.14% throws TypeError
+PASS Setting 'caret-color' to a percent: 3.14% throws TypeError
+PASS Setting 'caret-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'caret-color' to a time: 0s throws TypeError
+PASS Setting 'caret-color' to a time: -3.14ms throws TypeError
+PASS Setting 'caret-color' to a time: 3.14s throws TypeError
+PASS Setting 'caret-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'caret-color' to an angle: 0deg throws TypeError
+PASS Setting 'caret-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'caret-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'caret-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'caret-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'caret-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'caret-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'caret-color' to a number: 0 throws TypeError
+PASS Setting 'caret-color' to a number: -3.14 throws TypeError
+PASS Setting 'caret-color' to a number: 3.14 throws TypeError
+PASS Setting 'caret-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'caret-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'caret-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'caret-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'caret-color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'caret-color' does not support '#bbff00'
+PASS 'caret-color' does not support 'rgb(255, 255, 128)'
+PASS 'caret-color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'caret-color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt
@@ -12,12 +12,24 @@ PASS Can set 'cx' to a length: 0px
 PASS Can set 'cx' to a length: -3.14em
 PASS Can set 'cx' to a length: 3.14cm
 PASS Can set 'cx' to a length: calc(0px + 0em)
-PASS Setting 'cx' to a time throws TypeError
-PASS Setting 'cx' to an angle throws TypeError
-PASS Setting 'cx' to a flexible length throws TypeError
-FAIL Setting 'cx' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'cx' to a URL throws TypeError
-PASS Setting 'cx' to a transform throws TypeError
+PASS Setting 'cx' to a time: 0s throws TypeError
+PASS Setting 'cx' to a time: -3.14ms throws TypeError
+PASS Setting 'cx' to a time: 3.14s throws TypeError
+PASS Setting 'cx' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'cx' to an angle: 0deg throws TypeError
+PASS Setting 'cx' to an angle: 3.14rad throws TypeError
+PASS Setting 'cx' to an angle: -3.14deg throws TypeError
+PASS Setting 'cx' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'cx' to a flexible length: 0fr throws TypeError
+PASS Setting 'cx' to a flexible length: 1fr throws TypeError
+PASS Setting 'cx' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'cx' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'cx' to a number: -3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'cx' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'cx' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'cx' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'cx' to a transform: perspective(10em) throws TypeError
+PASS Setting 'cx' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'cy' to CSS-wide keywords: initial
 PASS Can set 'cy' to CSS-wide keywords: inherit
 PASS Can set 'cy' to CSS-wide keywords: unset
@@ -31,10 +43,22 @@ PASS Can set 'cy' to a length: 0px
 PASS Can set 'cy' to a length: -3.14em
 PASS Can set 'cy' to a length: 3.14cm
 PASS Can set 'cy' to a length: calc(0px + 0em)
-PASS Setting 'cy' to a time throws TypeError
-PASS Setting 'cy' to an angle throws TypeError
-PASS Setting 'cy' to a flexible length throws TypeError
-FAIL Setting 'cy' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'cy' to a URL throws TypeError
-PASS Setting 'cy' to a transform throws TypeError
+PASS Setting 'cy' to a time: 0s throws TypeError
+PASS Setting 'cy' to a time: -3.14ms throws TypeError
+PASS Setting 'cy' to a time: 3.14s throws TypeError
+PASS Setting 'cy' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'cy' to an angle: 0deg throws TypeError
+PASS Setting 'cy' to an angle: 3.14rad throws TypeError
+PASS Setting 'cy' to an angle: -3.14deg throws TypeError
+PASS Setting 'cy' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'cy' to a flexible length: 0fr throws TypeError
+PASS Setting 'cy' to a flexible length: 1fr throws TypeError
+PASS Setting 'cy' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'cy' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'cy' to a number: -3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'cy' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'cy' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'cy' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'cy' to a transform: perspective(10em) throws TypeError
+PASS Setting 'cy' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clear-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clear-expected.txt
@@ -8,12 +8,30 @@ PASS Can set 'clear' to the 'none' keyword: none
 PASS Can set 'clear' to the 'left' keyword: left
 PASS Can set 'clear' to the 'right' keyword: right
 PASS Can set 'clear' to the 'both' keyword: both
-PASS Setting 'clear' to a length throws TypeError
-PASS Setting 'clear' to a percent throws TypeError
-PASS Setting 'clear' to a time throws TypeError
-PASS Setting 'clear' to an angle throws TypeError
-PASS Setting 'clear' to a flexible length throws TypeError
-PASS Setting 'clear' to a number throws TypeError
-PASS Setting 'clear' to a URL throws TypeError
-PASS Setting 'clear' to a transform throws TypeError
+PASS Setting 'clear' to a length: 0px throws TypeError
+PASS Setting 'clear' to a length: -3.14em throws TypeError
+PASS Setting 'clear' to a length: 3.14cm throws TypeError
+PASS Setting 'clear' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'clear' to a percent: 0% throws TypeError
+PASS Setting 'clear' to a percent: -3.14% throws TypeError
+PASS Setting 'clear' to a percent: 3.14% throws TypeError
+PASS Setting 'clear' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'clear' to a time: 0s throws TypeError
+PASS Setting 'clear' to a time: -3.14ms throws TypeError
+PASS Setting 'clear' to a time: 3.14s throws TypeError
+PASS Setting 'clear' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'clear' to an angle: 0deg throws TypeError
+PASS Setting 'clear' to an angle: 3.14rad throws TypeError
+PASS Setting 'clear' to an angle: -3.14deg throws TypeError
+PASS Setting 'clear' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'clear' to a flexible length: 0fr throws TypeError
+PASS Setting 'clear' to a flexible length: 1fr throws TypeError
+PASS Setting 'clear' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'clear' to a number: 0 throws TypeError
+PASS Setting 'clear' to a number: -3.14 throws TypeError
+PASS Setting 'clear' to a number: 3.14 throws TypeError
+PASS Setting 'clear' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'clear' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'clear' to a transform: perspective(10em) throws TypeError
+PASS Setting 'clear' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-expected.txt
@@ -5,13 +5,31 @@ PASS Can set 'clip' to CSS-wide keywords: unset
 PASS Can set 'clip' to CSS-wide keywords: revert
 PASS Can set 'clip' to var() references:  var(--A)
 PASS Can set 'clip' to the 'auto' keyword: auto
-PASS Setting 'clip' to a length throws TypeError
-PASS Setting 'clip' to a percent throws TypeError
-PASS Setting 'clip' to a time throws TypeError
-PASS Setting 'clip' to an angle throws TypeError
-PASS Setting 'clip' to a flexible length throws TypeError
-PASS Setting 'clip' to a number throws TypeError
-PASS Setting 'clip' to a URL throws TypeError
-PASS Setting 'clip' to a transform throws TypeError
-PASS 'clip' does not supported 'rect(0px, 1px, 2px, 3px)'
+PASS Setting 'clip' to a length: 0px throws TypeError
+PASS Setting 'clip' to a length: -3.14em throws TypeError
+PASS Setting 'clip' to a length: 3.14cm throws TypeError
+PASS Setting 'clip' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'clip' to a percent: 0% throws TypeError
+PASS Setting 'clip' to a percent: -3.14% throws TypeError
+PASS Setting 'clip' to a percent: 3.14% throws TypeError
+PASS Setting 'clip' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'clip' to a time: 0s throws TypeError
+PASS Setting 'clip' to a time: -3.14ms throws TypeError
+PASS Setting 'clip' to a time: 3.14s throws TypeError
+PASS Setting 'clip' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'clip' to an angle: 0deg throws TypeError
+PASS Setting 'clip' to an angle: 3.14rad throws TypeError
+PASS Setting 'clip' to an angle: -3.14deg throws TypeError
+PASS Setting 'clip' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'clip' to a flexible length: 0fr throws TypeError
+PASS Setting 'clip' to a flexible length: 1fr throws TypeError
+PASS Setting 'clip' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'clip' to a number: 0 throws TypeError
+PASS Setting 'clip' to a number: -3.14 throws TypeError
+PASS Setting 'clip' to a number: 3.14 throws TypeError
+PASS Setting 'clip' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'clip' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'clip' to a transform: perspective(10em) throws TypeError
+PASS Setting 'clip' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'clip' does not support 'rect(0px, 1px, 2px, 3px)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-path-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-path-expected.txt
@@ -12,12 +12,31 @@ PASS Can set 'clip-path' to the 'margin-box' keyword: margin-box
 PASS Can set 'clip-path' to the 'border-box' keyword: border-box
 PASS Can set 'clip-path' to the 'padding-box' keyword: padding-box
 PASS Can set 'clip-path' to the 'content-box' keyword: content-box
-PASS Setting 'clip-path' to a length throws TypeError
-PASS Setting 'clip-path' to a percent throws TypeError
-PASS Setting 'clip-path' to a time throws TypeError
-PASS Setting 'clip-path' to an angle throws TypeError
-PASS Setting 'clip-path' to a flexible length throws TypeError
-PASS Setting 'clip-path' to a number throws TypeError
-PASS Setting 'clip-path' to a transform throws TypeError
-FAIL 'clip' does not supported 'inset(22% 12% 15px 35px)' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS Setting 'clip-path' to a length: 0px throws TypeError
+PASS Setting 'clip-path' to a length: -3.14em throws TypeError
+PASS Setting 'clip-path' to a length: 3.14cm throws TypeError
+PASS Setting 'clip-path' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'clip-path' to a percent: 0% throws TypeError
+PASS Setting 'clip-path' to a percent: -3.14% throws TypeError
+PASS Setting 'clip-path' to a percent: 3.14% throws TypeError
+PASS Setting 'clip-path' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'clip-path' to a time: 0s throws TypeError
+PASS Setting 'clip-path' to a time: -3.14ms throws TypeError
+PASS Setting 'clip-path' to a time: 3.14s throws TypeError
+PASS Setting 'clip-path' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'clip-path' to an angle: 0deg throws TypeError
+PASS Setting 'clip-path' to an angle: 3.14rad throws TypeError
+PASS Setting 'clip-path' to an angle: -3.14deg throws TypeError
+PASS Setting 'clip-path' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'clip-path' to a flexible length: 0fr throws TypeError
+PASS Setting 'clip-path' to a flexible length: 1fr throws TypeError
+PASS Setting 'clip-path' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'clip-path' to a number: 0 throws TypeError
+PASS Setting 'clip-path' to a number: -3.14 throws TypeError
+PASS Setting 'clip-path' to a number: 3.14 throws TypeError
+PASS Setting 'clip-path' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'clip-path' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'clip-path' to a transform: perspective(10em) throws TypeError
+PASS Setting 'clip-path' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'clip' does not support 'inset(22% 12% 15px 35px)' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-rule-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'clip-rule' to CSS-wide keywords: revert
 PASS Can set 'clip-rule' to var() references:  var(--A)
 PASS Can set 'clip-rule' to the 'nonzero' keyword: nonzero
 PASS Can set 'clip-rule' to the 'evenodd' keyword: evenodd
-PASS Setting 'clip-rule' to a length throws TypeError
-PASS Setting 'clip-rule' to a percent throws TypeError
-PASS Setting 'clip-rule' to a time throws TypeError
-PASS Setting 'clip-rule' to an angle throws TypeError
-PASS Setting 'clip-rule' to a flexible length throws TypeError
-PASS Setting 'clip-rule' to a number throws TypeError
-PASS Setting 'clip-rule' to a URL throws TypeError
-PASS Setting 'clip-rule' to a transform throws TypeError
+PASS Setting 'clip-rule' to a length: 0px throws TypeError
+PASS Setting 'clip-rule' to a length: -3.14em throws TypeError
+PASS Setting 'clip-rule' to a length: 3.14cm throws TypeError
+PASS Setting 'clip-rule' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'clip-rule' to a percent: 0% throws TypeError
+PASS Setting 'clip-rule' to a percent: -3.14% throws TypeError
+PASS Setting 'clip-rule' to a percent: 3.14% throws TypeError
+PASS Setting 'clip-rule' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'clip-rule' to a time: 0s throws TypeError
+PASS Setting 'clip-rule' to a time: -3.14ms throws TypeError
+PASS Setting 'clip-rule' to a time: 3.14s throws TypeError
+PASS Setting 'clip-rule' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'clip-rule' to an angle: 0deg throws TypeError
+PASS Setting 'clip-rule' to an angle: 3.14rad throws TypeError
+PASS Setting 'clip-rule' to an angle: -3.14deg throws TypeError
+PASS Setting 'clip-rule' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'clip-rule' to a flexible length: 0fr throws TypeError
+PASS Setting 'clip-rule' to a flexible length: 1fr throws TypeError
+PASS Setting 'clip-rule' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'clip-rule' to a number: 0 throws TypeError
+PASS Setting 'clip-rule' to a number: -3.14 throws TypeError
+PASS Setting 'clip-rule' to a number: 3.14 throws TypeError
+PASS Setting 'clip-rule' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'clip-rule' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'clip-rule' to a transform: perspective(10em) throws TypeError
+PASS Setting 'clip-rule' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-expected.txt
@@ -5,17 +5,35 @@ PASS Can set 'color' to CSS-wide keywords: unset
 PASS Can set 'color' to CSS-wide keywords: revert
 PASS Can set 'color' to var() references:  var(--A)
 PASS Can set 'color' to the 'currentcolor' keyword: currentcolor
-PASS Setting 'color' to a length throws TypeError
-PASS Setting 'color' to a percent throws TypeError
-PASS Setting 'color' to a time throws TypeError
-PASS Setting 'color' to an angle throws TypeError
-PASS Setting 'color' to a flexible length throws TypeError
-PASS Setting 'color' to a number throws TypeError
-PASS Setting 'color' to a URL throws TypeError
-PASS Setting 'color' to a transform throws TypeError
-FAIL 'color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'color' does not supported '#bbff00'
-PASS 'color' does not supported 'rgb(255, 255, 128)'
-PASS 'color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'color' to a length: 0px throws TypeError
+PASS Setting 'color' to a length: -3.14em throws TypeError
+PASS Setting 'color' to a length: 3.14cm throws TypeError
+PASS Setting 'color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'color' to a percent: 0% throws TypeError
+PASS Setting 'color' to a percent: -3.14% throws TypeError
+PASS Setting 'color' to a percent: 3.14% throws TypeError
+PASS Setting 'color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'color' to a time: 0s throws TypeError
+PASS Setting 'color' to a time: -3.14ms throws TypeError
+PASS Setting 'color' to a time: 3.14s throws TypeError
+PASS Setting 'color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'color' to an angle: 0deg throws TypeError
+PASS Setting 'color' to an angle: 3.14rad throws TypeError
+PASS Setting 'color' to an angle: -3.14deg throws TypeError
+PASS Setting 'color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'color' to a flexible length: 0fr throws TypeError
+PASS Setting 'color' to a flexible length: 1fr throws TypeError
+PASS Setting 'color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'color' to a number: 0 throws TypeError
+PASS Setting 'color' to a number: -3.14 throws TypeError
+PASS Setting 'color' to a number: 3.14 throws TypeError
+PASS Setting 'color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'color' does not support '#bbff00'
+PASS 'color' does not support 'rgb(255, 255, 128)'
+PASS 'color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-interpolation-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'color-interpolation' to var() references:  var(--A)
 PASS Can set 'color-interpolation' to the 'auto' keyword: auto
 FAIL Can set 'color-interpolation' to the 'srgb' keyword: srgb assert_equals: expected "srgb" but got "sRGB"
 FAIL Can set 'color-interpolation' to the 'linearrgb' keyword: linearrgb assert_equals: expected "linearrgb" but got "linearRGB"
-PASS Setting 'color-interpolation' to a length throws TypeError
-PASS Setting 'color-interpolation' to a percent throws TypeError
-PASS Setting 'color-interpolation' to a time throws TypeError
-PASS Setting 'color-interpolation' to an angle throws TypeError
-PASS Setting 'color-interpolation' to a flexible length throws TypeError
-PASS Setting 'color-interpolation' to a number throws TypeError
-PASS Setting 'color-interpolation' to a URL throws TypeError
-PASS Setting 'color-interpolation' to a transform throws TypeError
+PASS Setting 'color-interpolation' to a length: 0px throws TypeError
+PASS Setting 'color-interpolation' to a length: -3.14em throws TypeError
+PASS Setting 'color-interpolation' to a length: 3.14cm throws TypeError
+PASS Setting 'color-interpolation' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'color-interpolation' to a percent: 0% throws TypeError
+PASS Setting 'color-interpolation' to a percent: -3.14% throws TypeError
+PASS Setting 'color-interpolation' to a percent: 3.14% throws TypeError
+PASS Setting 'color-interpolation' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'color-interpolation' to a time: 0s throws TypeError
+PASS Setting 'color-interpolation' to a time: -3.14ms throws TypeError
+PASS Setting 'color-interpolation' to a time: 3.14s throws TypeError
+PASS Setting 'color-interpolation' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'color-interpolation' to an angle: 0deg throws TypeError
+PASS Setting 'color-interpolation' to an angle: 3.14rad throws TypeError
+PASS Setting 'color-interpolation' to an angle: -3.14deg throws TypeError
+PASS Setting 'color-interpolation' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'color-interpolation' to a flexible length: 0fr throws TypeError
+PASS Setting 'color-interpolation' to a flexible length: 1fr throws TypeError
+PASS Setting 'color-interpolation' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'color-interpolation' to a number: 0 throws TypeError
+PASS Setting 'color-interpolation' to a number: -3.14 throws TypeError
+PASS Setting 'color-interpolation' to a number: 3.14 throws TypeError
+PASS Setting 'color-interpolation' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'color-interpolation' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'color-interpolation' to a transform: perspective(10em) throws TypeError
+PASS Setting 'color-interpolation' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-count-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-count-expected.txt
@@ -9,11 +9,26 @@ FAIL Can set 'column-count' to a number: 0 assert_approx_equals: expected 1 +/- 
 FAIL Can set 'column-count' to a number: -3.14 assert_approx_equals: expected 1 +/- 0.000001 but got 0
 PASS Can set 'column-count' to a number: 3.14
 PASS Can set 'column-count' to a number: calc(2 + 3)
-PASS Setting 'column-count' to a length throws TypeError
-PASS Setting 'column-count' to a percent throws TypeError
-PASS Setting 'column-count' to a time throws TypeError
-PASS Setting 'column-count' to an angle throws TypeError
-PASS Setting 'column-count' to a flexible length throws TypeError
-PASS Setting 'column-count' to a URL throws TypeError
-PASS Setting 'column-count' to a transform throws TypeError
+PASS Setting 'column-count' to a length: 0px throws TypeError
+PASS Setting 'column-count' to a length: -3.14em throws TypeError
+PASS Setting 'column-count' to a length: 3.14cm throws TypeError
+PASS Setting 'column-count' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'column-count' to a percent: 0% throws TypeError
+PASS Setting 'column-count' to a percent: -3.14% throws TypeError
+PASS Setting 'column-count' to a percent: 3.14% throws TypeError
+PASS Setting 'column-count' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'column-count' to a time: 0s throws TypeError
+PASS Setting 'column-count' to a time: -3.14ms throws TypeError
+PASS Setting 'column-count' to a time: 3.14s throws TypeError
+PASS Setting 'column-count' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'column-count' to an angle: 0deg throws TypeError
+PASS Setting 'column-count' to an angle: 3.14rad throws TypeError
+PASS Setting 'column-count' to an angle: -3.14deg throws TypeError
+PASS Setting 'column-count' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'column-count' to a flexible length: 0fr throws TypeError
+PASS Setting 'column-count' to a flexible length: 1fr throws TypeError
+PASS Setting 'column-count' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'column-count' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'column-count' to a transform: perspective(10em) throws TypeError
+PASS Setting 'column-count' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-color-expected.txt
@@ -5,17 +5,35 @@ PASS Can set 'column-rule-color' to CSS-wide keywords: unset
 PASS Can set 'column-rule-color' to CSS-wide keywords: revert
 PASS Can set 'column-rule-color' to var() references:  var(--A)
 PASS Can set 'column-rule-color' to the 'currentcolor' keyword: currentcolor
-PASS Setting 'column-rule-color' to a length throws TypeError
-PASS Setting 'column-rule-color' to a percent throws TypeError
-PASS Setting 'column-rule-color' to a time throws TypeError
-PASS Setting 'column-rule-color' to an angle throws TypeError
-PASS Setting 'column-rule-color' to a flexible length throws TypeError
-PASS Setting 'column-rule-color' to a number throws TypeError
-PASS Setting 'column-rule-color' to a URL throws TypeError
-PASS Setting 'column-rule-color' to a transform throws TypeError
-FAIL 'column-rule-color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'column-rule-color' does not supported '#bbff00'
-PASS 'column-rule-color' does not supported 'rgb(255, 255, 128)'
-PASS 'column-rule-color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'column-rule-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'column-rule-color' to a length: 0px throws TypeError
+PASS Setting 'column-rule-color' to a length: -3.14em throws TypeError
+PASS Setting 'column-rule-color' to a length: 3.14cm throws TypeError
+PASS Setting 'column-rule-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'column-rule-color' to a percent: 0% throws TypeError
+PASS Setting 'column-rule-color' to a percent: -3.14% throws TypeError
+PASS Setting 'column-rule-color' to a percent: 3.14% throws TypeError
+PASS Setting 'column-rule-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'column-rule-color' to a time: 0s throws TypeError
+PASS Setting 'column-rule-color' to a time: -3.14ms throws TypeError
+PASS Setting 'column-rule-color' to a time: 3.14s throws TypeError
+PASS Setting 'column-rule-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'column-rule-color' to an angle: 0deg throws TypeError
+PASS Setting 'column-rule-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'column-rule-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'column-rule-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'column-rule-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'column-rule-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'column-rule-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'column-rule-color' to a number: 0 throws TypeError
+PASS Setting 'column-rule-color' to a number: -3.14 throws TypeError
+PASS Setting 'column-rule-color' to a number: 3.14 throws TypeError
+PASS Setting 'column-rule-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'column-rule-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'column-rule-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'column-rule-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'column-rule-color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'column-rule-color' does not support '#bbff00'
+PASS 'column-rule-color' does not support 'rgb(255, 255, 128)'
+PASS 'column-rule-color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'column-rule-color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-style-expected.txt
@@ -14,12 +14,30 @@ PASS Can set 'column-rule-style' to the 'groove' keyword: groove
 PASS Can set 'column-rule-style' to the 'ridge' keyword: ridge
 PASS Can set 'column-rule-style' to the 'inset' keyword: inset
 PASS Can set 'column-rule-style' to the 'outset' keyword: outset
-PASS Setting 'column-rule-style' to a length throws TypeError
-PASS Setting 'column-rule-style' to a percent throws TypeError
-PASS Setting 'column-rule-style' to a time throws TypeError
-PASS Setting 'column-rule-style' to an angle throws TypeError
-PASS Setting 'column-rule-style' to a flexible length throws TypeError
-PASS Setting 'column-rule-style' to a number throws TypeError
-PASS Setting 'column-rule-style' to a URL throws TypeError
-PASS Setting 'column-rule-style' to a transform throws TypeError
+PASS Setting 'column-rule-style' to a length: 0px throws TypeError
+PASS Setting 'column-rule-style' to a length: -3.14em throws TypeError
+PASS Setting 'column-rule-style' to a length: 3.14cm throws TypeError
+PASS Setting 'column-rule-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'column-rule-style' to a percent: 0% throws TypeError
+PASS Setting 'column-rule-style' to a percent: -3.14% throws TypeError
+PASS Setting 'column-rule-style' to a percent: 3.14% throws TypeError
+PASS Setting 'column-rule-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'column-rule-style' to a time: 0s throws TypeError
+PASS Setting 'column-rule-style' to a time: -3.14ms throws TypeError
+PASS Setting 'column-rule-style' to a time: 3.14s throws TypeError
+PASS Setting 'column-rule-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'column-rule-style' to an angle: 0deg throws TypeError
+PASS Setting 'column-rule-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'column-rule-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'column-rule-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'column-rule-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'column-rule-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'column-rule-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'column-rule-style' to a number: 0 throws TypeError
+PASS Setting 'column-rule-style' to a number: -3.14 throws TypeError
+PASS Setting 'column-rule-style' to a number: 3.14 throws TypeError
+PASS Setting 'column-rule-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'column-rule-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'column-rule-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'column-rule-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt
@@ -11,11 +11,26 @@ PASS Can set 'column-rule-width' to a length: 0px
 PASS Can set 'column-rule-width' to a length: -3.14em
 PASS Can set 'column-rule-width' to a length: 3.14cm
 PASS Can set 'column-rule-width' to a length: calc(0px + 0em)
-PASS Setting 'column-rule-width' to a percent throws TypeError
-PASS Setting 'column-rule-width' to a time throws TypeError
-PASS Setting 'column-rule-width' to an angle throws TypeError
-PASS Setting 'column-rule-width' to a flexible length throws TypeError
-FAIL Setting 'column-rule-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'column-rule-width' to a URL throws TypeError
-PASS Setting 'column-rule-width' to a transform throws TypeError
+PASS Setting 'column-rule-width' to a percent: 0% throws TypeError
+PASS Setting 'column-rule-width' to a percent: -3.14% throws TypeError
+PASS Setting 'column-rule-width' to a percent: 3.14% throws TypeError
+PASS Setting 'column-rule-width' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'column-rule-width' to a time: 0s throws TypeError
+PASS Setting 'column-rule-width' to a time: -3.14ms throws TypeError
+PASS Setting 'column-rule-width' to a time: 3.14s throws TypeError
+PASS Setting 'column-rule-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'column-rule-width' to an angle: 0deg throws TypeError
+PASS Setting 'column-rule-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'column-rule-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'column-rule-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'column-rule-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'column-rule-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'column-rule-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'column-rule-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'column-rule-width' to a number: -3.14 throws TypeError
+PASS Setting 'column-rule-width' to a number: 3.14 throws TypeError
+PASS Setting 'column-rule-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'column-rule-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'column-rule-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'column-rule-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-span-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-span-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'column-span' to CSS-wide keywords: revert
 PASS Can set 'column-span' to var() references:  var(--A)
 PASS Can set 'column-span' to the 'none' keyword: none
 PASS Can set 'column-span' to the 'all' keyword: all
-PASS Setting 'column-span' to a length throws TypeError
-PASS Setting 'column-span' to a percent throws TypeError
-PASS Setting 'column-span' to a time throws TypeError
-PASS Setting 'column-span' to an angle throws TypeError
-PASS Setting 'column-span' to a flexible length throws TypeError
-PASS Setting 'column-span' to a number throws TypeError
-PASS Setting 'column-span' to a URL throws TypeError
-PASS Setting 'column-span' to a transform throws TypeError
+PASS Setting 'column-span' to a length: 0px throws TypeError
+PASS Setting 'column-span' to a length: -3.14em throws TypeError
+PASS Setting 'column-span' to a length: 3.14cm throws TypeError
+PASS Setting 'column-span' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'column-span' to a percent: 0% throws TypeError
+PASS Setting 'column-span' to a percent: -3.14% throws TypeError
+PASS Setting 'column-span' to a percent: 3.14% throws TypeError
+PASS Setting 'column-span' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'column-span' to a time: 0s throws TypeError
+PASS Setting 'column-span' to a time: -3.14ms throws TypeError
+PASS Setting 'column-span' to a time: 3.14s throws TypeError
+PASS Setting 'column-span' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'column-span' to an angle: 0deg throws TypeError
+PASS Setting 'column-span' to an angle: 3.14rad throws TypeError
+PASS Setting 'column-span' to an angle: -3.14deg throws TypeError
+PASS Setting 'column-span' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'column-span' to a flexible length: 0fr throws TypeError
+PASS Setting 'column-span' to a flexible length: 1fr throws TypeError
+PASS Setting 'column-span' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'column-span' to a number: 0 throws TypeError
+PASS Setting 'column-span' to a number: -3.14 throws TypeError
+PASS Setting 'column-span' to a number: 3.14 throws TypeError
+PASS Setting 'column-span' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'column-span' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'column-span' to a transform: perspective(10em) throws TypeError
+PASS Setting 'column-span' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt
@@ -9,11 +9,26 @@ PASS Can set 'column-width' to a length: 0px
 PASS Can set 'column-width' to a length: -3.14em
 PASS Can set 'column-width' to a length: 3.14cm
 PASS Can set 'column-width' to a length: calc(0px + 0em)
-PASS Setting 'column-width' to a percent throws TypeError
-PASS Setting 'column-width' to a time throws TypeError
-PASS Setting 'column-width' to an angle throws TypeError
-PASS Setting 'column-width' to a flexible length throws TypeError
-FAIL Setting 'column-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'column-width' to a URL throws TypeError
-PASS Setting 'column-width' to a transform throws TypeError
+PASS Setting 'column-width' to a percent: 0% throws TypeError
+PASS Setting 'column-width' to a percent: -3.14% throws TypeError
+PASS Setting 'column-width' to a percent: 3.14% throws TypeError
+PASS Setting 'column-width' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'column-width' to a time: 0s throws TypeError
+PASS Setting 'column-width' to a time: -3.14ms throws TypeError
+PASS Setting 'column-width' to a time: 3.14s throws TypeError
+PASS Setting 'column-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'column-width' to an angle: 0deg throws TypeError
+PASS Setting 'column-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'column-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'column-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'column-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'column-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'column-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'column-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'column-width' to a number: -3.14 throws TypeError
+PASS Setting 'column-width' to a number: 3.14 throws TypeError
+PASS Setting 'column-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'column-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'column-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'column-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/contain-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/contain-expected.txt
@@ -12,14 +12,32 @@ PASS Can set 'contain' to the 'layout' keyword: layout
 PASS Can set 'contain' to the 'style' keyword: style
 PASS Can set 'contain' to the 'paint' keyword: paint
 PASS Can set 'contain' to the 'inline-size' keyword: inline-size
-PASS Setting 'contain' to a length throws TypeError
-PASS Setting 'contain' to a percent throws TypeError
-PASS Setting 'contain' to a time throws TypeError
-PASS Setting 'contain' to an angle throws TypeError
-PASS Setting 'contain' to a flexible length throws TypeError
-PASS Setting 'contain' to a number throws TypeError
-PASS Setting 'contain' to a URL throws TypeError
-PASS Setting 'contain' to a transform throws TypeError
-FAIL 'contain' does not supported 'size layout' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'contain' does not supported 'paint style layout size' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'contain' to a length: 0px throws TypeError
+PASS Setting 'contain' to a length: -3.14em throws TypeError
+PASS Setting 'contain' to a length: 3.14cm throws TypeError
+PASS Setting 'contain' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'contain' to a percent: 0% throws TypeError
+PASS Setting 'contain' to a percent: -3.14% throws TypeError
+PASS Setting 'contain' to a percent: 3.14% throws TypeError
+PASS Setting 'contain' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'contain' to a time: 0s throws TypeError
+PASS Setting 'contain' to a time: -3.14ms throws TypeError
+PASS Setting 'contain' to a time: 3.14s throws TypeError
+PASS Setting 'contain' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'contain' to an angle: 0deg throws TypeError
+PASS Setting 'contain' to an angle: 3.14rad throws TypeError
+PASS Setting 'contain' to an angle: -3.14deg throws TypeError
+PASS Setting 'contain' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'contain' to a flexible length: 0fr throws TypeError
+PASS Setting 'contain' to a flexible length: 1fr throws TypeError
+PASS Setting 'contain' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'contain' to a number: 0 throws TypeError
+PASS Setting 'contain' to a number: -3.14 throws TypeError
+PASS Setting 'contain' to a number: 3.14 throws TypeError
+PASS Setting 'contain' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'contain' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'contain' to a transform: perspective(10em) throws TypeError
+PASS Setting 'contain' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'contain' does not support 'size layout' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'contain' does not support 'paint style layout size' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt
@@ -6,13 +6,31 @@ PASS Can set 'container-name' to CSS-wide keywords: revert
 PASS Can set 'container-name' to var() references:  var(--A)
 PASS Can set 'container-name' to the 'none' keyword: none
 PASS Can set 'container-name' to the 'my-container' keyword: my-container
-PASS Setting 'container-name' to a length throws TypeError
-PASS Setting 'container-name' to a percent throws TypeError
-PASS Setting 'container-name' to a time throws TypeError
-PASS Setting 'container-name' to an angle throws TypeError
-PASS Setting 'container-name' to a flexible length throws TypeError
-PASS Setting 'container-name' to a number throws TypeError
-PASS Setting 'container-name' to a URL throws TypeError
-PASS Setting 'container-name' to a transform throws TypeError
-FAIL 'container-type' does not supported 'name1 name2' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS Setting 'container-name' to a length: 0px throws TypeError
+PASS Setting 'container-name' to a length: -3.14em throws TypeError
+PASS Setting 'container-name' to a length: 3.14cm throws TypeError
+PASS Setting 'container-name' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'container-name' to a percent: 0% throws TypeError
+PASS Setting 'container-name' to a percent: -3.14% throws TypeError
+PASS Setting 'container-name' to a percent: 3.14% throws TypeError
+PASS Setting 'container-name' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'container-name' to a time: 0s throws TypeError
+PASS Setting 'container-name' to a time: -3.14ms throws TypeError
+PASS Setting 'container-name' to a time: 3.14s throws TypeError
+PASS Setting 'container-name' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'container-name' to an angle: 0deg throws TypeError
+PASS Setting 'container-name' to an angle: 3.14rad throws TypeError
+PASS Setting 'container-name' to an angle: -3.14deg throws TypeError
+PASS Setting 'container-name' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'container-name' to a flexible length: 0fr throws TypeError
+PASS Setting 'container-name' to a flexible length: 1fr throws TypeError
+PASS Setting 'container-name' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'container-name' to a number: 0 throws TypeError
+PASS Setting 'container-name' to a number: -3.14 throws TypeError
+PASS Setting 'container-name' to a number: 3.14 throws TypeError
+PASS Setting 'container-name' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'container-name' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'container-name' to a transform: perspective(10em) throws TypeError
+PASS Setting 'container-name' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'container-type' does not support 'name1 name2' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-type-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'container-type' to var() references:  var(--A)
 PASS Can set 'container-type' to the 'normal' keyword: normal
 PASS Can set 'container-type' to the 'size' keyword: size
 PASS Can set 'container-type' to the 'inline-size' keyword: inline-size
-PASS Setting 'container-type' to a length throws TypeError
-PASS Setting 'container-type' to a percent throws TypeError
-PASS Setting 'container-type' to a time throws TypeError
-PASS Setting 'container-type' to an angle throws TypeError
-PASS Setting 'container-type' to a flexible length throws TypeError
-PASS Setting 'container-type' to a number throws TypeError
-PASS Setting 'container-type' to a URL throws TypeError
-PASS Setting 'container-type' to a transform throws TypeError
+PASS Setting 'container-type' to a length: 0px throws TypeError
+PASS Setting 'container-type' to a length: -3.14em throws TypeError
+PASS Setting 'container-type' to a length: 3.14cm throws TypeError
+PASS Setting 'container-type' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'container-type' to a percent: 0% throws TypeError
+PASS Setting 'container-type' to a percent: -3.14% throws TypeError
+PASS Setting 'container-type' to a percent: 3.14% throws TypeError
+PASS Setting 'container-type' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'container-type' to a time: 0s throws TypeError
+PASS Setting 'container-type' to a time: -3.14ms throws TypeError
+PASS Setting 'container-type' to a time: 3.14s throws TypeError
+PASS Setting 'container-type' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'container-type' to an angle: 0deg throws TypeError
+PASS Setting 'container-type' to an angle: 3.14rad throws TypeError
+PASS Setting 'container-type' to an angle: -3.14deg throws TypeError
+PASS Setting 'container-type' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'container-type' to a flexible length: 0fr throws TypeError
+PASS Setting 'container-type' to a flexible length: 1fr throws TypeError
+PASS Setting 'container-type' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'container-type' to a number: 0 throws TypeError
+PASS Setting 'container-type' to a number: -3.14 throws TypeError
+PASS Setting 'container-type' to a number: 3.14 throws TypeError
+PASS Setting 'container-type' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'container-type' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'container-type' to a transform: perspective(10em) throws TypeError
+PASS Setting 'container-type' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt
@@ -12,12 +12,24 @@ PASS Can set 'x' to a length: 0px
 PASS Can set 'x' to a length: -3.14em
 PASS Can set 'x' to a length: 3.14cm
 PASS Can set 'x' to a length: calc(0px + 0em)
-PASS Setting 'x' to a time throws TypeError
-PASS Setting 'x' to an angle throws TypeError
-PASS Setting 'x' to a flexible length throws TypeError
-FAIL Setting 'x' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'x' to a URL throws TypeError
-PASS Setting 'x' to a transform throws TypeError
+PASS Setting 'x' to a time: 0s throws TypeError
+PASS Setting 'x' to a time: -3.14ms throws TypeError
+PASS Setting 'x' to a time: 3.14s throws TypeError
+PASS Setting 'x' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'x' to an angle: 0deg throws TypeError
+PASS Setting 'x' to an angle: 3.14rad throws TypeError
+PASS Setting 'x' to an angle: -3.14deg throws TypeError
+PASS Setting 'x' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'x' to a flexible length: 0fr throws TypeError
+PASS Setting 'x' to a flexible length: 1fr throws TypeError
+PASS Setting 'x' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'x' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'x' to a number: -3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'x' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'x' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'x' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'x' to a transform: perspective(10em) throws TypeError
+PASS Setting 'x' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'y' to CSS-wide keywords: initial
 PASS Can set 'y' to CSS-wide keywords: inherit
 PASS Can set 'y' to CSS-wide keywords: unset
@@ -31,10 +43,22 @@ PASS Can set 'y' to a length: 0px
 PASS Can set 'y' to a length: -3.14em
 PASS Can set 'y' to a length: 3.14cm
 PASS Can set 'y' to a length: calc(0px + 0em)
-PASS Setting 'y' to a time throws TypeError
-PASS Setting 'y' to an angle throws TypeError
-PASS Setting 'y' to a flexible length throws TypeError
-FAIL Setting 'y' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'y' to a URL throws TypeError
-PASS Setting 'y' to a transform throws TypeError
+PASS Setting 'y' to a time: 0s throws TypeError
+PASS Setting 'y' to a time: -3.14ms throws TypeError
+PASS Setting 'y' to a time: 3.14s throws TypeError
+PASS Setting 'y' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'y' to an angle: 0deg throws TypeError
+PASS Setting 'y' to an angle: 3.14rad throws TypeError
+PASS Setting 'y' to an angle: -3.14deg throws TypeError
+PASS Setting 'y' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'y' to a flexible length: 0fr throws TypeError
+PASS Setting 'y' to a flexible length: 1fr throws TypeError
+PASS Setting 'y' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'y' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'y' to a number: -3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'y' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'y' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'y' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'y' to a transform: perspective(10em) throws TypeError
+PASS Setting 'y' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-increment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-increment-expected.txt
@@ -5,14 +5,32 @@ PASS Can set 'counter-increment' to CSS-wide keywords: unset
 PASS Can set 'counter-increment' to CSS-wide keywords: revert
 PASS Can set 'counter-increment' to var() references:  var(--A)
 PASS Can set 'counter-increment' to the 'none' keyword: none
-PASS Setting 'counter-increment' to a length throws TypeError
-PASS Setting 'counter-increment' to a percent throws TypeError
-PASS Setting 'counter-increment' to a time throws TypeError
-PASS Setting 'counter-increment' to an angle throws TypeError
-PASS Setting 'counter-increment' to a flexible length throws TypeError
-PASS Setting 'counter-increment' to a number throws TypeError
-PASS Setting 'counter-increment' to a URL throws TypeError
-PASS Setting 'counter-increment' to a transform throws TypeError
-PASS 'counter-increment' does not supported 'chapter'
-PASS 'counter-increment' does not supported 'chapter 3'
+PASS Setting 'counter-increment' to a length: 0px throws TypeError
+PASS Setting 'counter-increment' to a length: -3.14em throws TypeError
+PASS Setting 'counter-increment' to a length: 3.14cm throws TypeError
+PASS Setting 'counter-increment' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'counter-increment' to a percent: 0% throws TypeError
+PASS Setting 'counter-increment' to a percent: -3.14% throws TypeError
+PASS Setting 'counter-increment' to a percent: 3.14% throws TypeError
+PASS Setting 'counter-increment' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'counter-increment' to a time: 0s throws TypeError
+PASS Setting 'counter-increment' to a time: -3.14ms throws TypeError
+PASS Setting 'counter-increment' to a time: 3.14s throws TypeError
+PASS Setting 'counter-increment' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'counter-increment' to an angle: 0deg throws TypeError
+PASS Setting 'counter-increment' to an angle: 3.14rad throws TypeError
+PASS Setting 'counter-increment' to an angle: -3.14deg throws TypeError
+PASS Setting 'counter-increment' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'counter-increment' to a flexible length: 0fr throws TypeError
+PASS Setting 'counter-increment' to a flexible length: 1fr throws TypeError
+PASS Setting 'counter-increment' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'counter-increment' to a number: 0 throws TypeError
+PASS Setting 'counter-increment' to a number: -3.14 throws TypeError
+PASS Setting 'counter-increment' to a number: 3.14 throws TypeError
+PASS Setting 'counter-increment' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'counter-increment' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'counter-increment' to a transform: perspective(10em) throws TypeError
+PASS Setting 'counter-increment' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'counter-increment' does not support 'chapter'
+PASS 'counter-increment' does not support 'chapter 3'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-reset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-reset-expected.txt
@@ -5,14 +5,32 @@ PASS Can set 'counter-reset' to CSS-wide keywords: unset
 PASS Can set 'counter-reset' to CSS-wide keywords: revert
 PASS Can set 'counter-reset' to var() references:  var(--A)
 PASS Can set 'counter-reset' to the 'none' keyword: none
-PASS Setting 'counter-reset' to a length throws TypeError
-PASS Setting 'counter-reset' to a percent throws TypeError
-PASS Setting 'counter-reset' to a time throws TypeError
-PASS Setting 'counter-reset' to an angle throws TypeError
-PASS Setting 'counter-reset' to a flexible length throws TypeError
-PASS Setting 'counter-reset' to a number throws TypeError
-PASS Setting 'counter-reset' to a URL throws TypeError
-PASS Setting 'counter-reset' to a transform throws TypeError
-PASS 'counter-reset' does not supported 'chapter'
-PASS 'counter-reset' does not supported 'chapter 3'
+PASS Setting 'counter-reset' to a length: 0px throws TypeError
+PASS Setting 'counter-reset' to a length: -3.14em throws TypeError
+PASS Setting 'counter-reset' to a length: 3.14cm throws TypeError
+PASS Setting 'counter-reset' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'counter-reset' to a percent: 0% throws TypeError
+PASS Setting 'counter-reset' to a percent: -3.14% throws TypeError
+PASS Setting 'counter-reset' to a percent: 3.14% throws TypeError
+PASS Setting 'counter-reset' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'counter-reset' to a time: 0s throws TypeError
+PASS Setting 'counter-reset' to a time: -3.14ms throws TypeError
+PASS Setting 'counter-reset' to a time: 3.14s throws TypeError
+PASS Setting 'counter-reset' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'counter-reset' to an angle: 0deg throws TypeError
+PASS Setting 'counter-reset' to an angle: 3.14rad throws TypeError
+PASS Setting 'counter-reset' to an angle: -3.14deg throws TypeError
+PASS Setting 'counter-reset' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'counter-reset' to a flexible length: 0fr throws TypeError
+PASS Setting 'counter-reset' to a flexible length: 1fr throws TypeError
+PASS Setting 'counter-reset' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'counter-reset' to a number: 0 throws TypeError
+PASS Setting 'counter-reset' to a number: -3.14 throws TypeError
+PASS Setting 'counter-reset' to a number: 3.14 throws TypeError
+PASS Setting 'counter-reset' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'counter-reset' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'counter-reset' to a transform: perspective(10em) throws TypeError
+PASS Setting 'counter-reset' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'counter-reset' does not support 'chapter'
+PASS 'counter-reset' does not support 'chapter 3'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-set-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-set-expected.txt
@@ -5,14 +5,32 @@ FAIL Can set 'counter-set' to CSS-wide keywords: unset Invalid property counter-
 FAIL Can set 'counter-set' to CSS-wide keywords: revert Invalid property counter-set
 FAIL Can set 'counter-set' to var() references:  var(--A) Invalid property counter-set
 FAIL Can set 'counter-set' to the 'none' keyword: none Invalid property counter-set
-PASS Setting 'counter-set' to a length throws TypeError
-PASS Setting 'counter-set' to a percent throws TypeError
-PASS Setting 'counter-set' to a time throws TypeError
-PASS Setting 'counter-set' to an angle throws TypeError
-PASS Setting 'counter-set' to a flexible length throws TypeError
-PASS Setting 'counter-set' to a number throws TypeError
-PASS Setting 'counter-set' to a URL throws TypeError
-PASS Setting 'counter-set' to a transform throws TypeError
-FAIL 'counter-set' does not supported 'chapter' Invalid property counter-set
-FAIL 'counter-set' does not supported 'chapter 3' Invalid property counter-set
+PASS Setting 'counter-set' to a length: 0px throws TypeError
+PASS Setting 'counter-set' to a length: -3.14em throws TypeError
+PASS Setting 'counter-set' to a length: 3.14cm throws TypeError
+PASS Setting 'counter-set' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'counter-set' to a percent: 0% throws TypeError
+PASS Setting 'counter-set' to a percent: -3.14% throws TypeError
+PASS Setting 'counter-set' to a percent: 3.14% throws TypeError
+PASS Setting 'counter-set' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'counter-set' to a time: 0s throws TypeError
+PASS Setting 'counter-set' to a time: -3.14ms throws TypeError
+PASS Setting 'counter-set' to a time: 3.14s throws TypeError
+PASS Setting 'counter-set' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'counter-set' to an angle: 0deg throws TypeError
+PASS Setting 'counter-set' to an angle: 3.14rad throws TypeError
+PASS Setting 'counter-set' to an angle: -3.14deg throws TypeError
+PASS Setting 'counter-set' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'counter-set' to a flexible length: 0fr throws TypeError
+PASS Setting 'counter-set' to a flexible length: 1fr throws TypeError
+PASS Setting 'counter-set' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'counter-set' to a number: 0 throws TypeError
+PASS Setting 'counter-set' to a number: -3.14 throws TypeError
+PASS Setting 'counter-set' to a number: 3.14 throws TypeError
+PASS Setting 'counter-set' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'counter-set' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'counter-set' to a transform: perspective(10em) throws TypeError
+PASS Setting 'counter-set' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'counter-set' does not support 'chapter' Invalid property counter-set
+FAIL 'counter-set' does not support 'chapter 3' Invalid property counter-set
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/cursor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/cursor-expected.txt
@@ -40,14 +40,32 @@ PASS Can set 'cursor' to the 'row-resize' keyword: row-resize
 PASS Can set 'cursor' to the 'all-scroll' keyword: all-scroll
 PASS Can set 'cursor' to the 'zoom-in' keyword: zoom-in
 PASS Can set 'cursor' to the 'zoom-out' keyword: zoom-out
-PASS Setting 'cursor' to a length throws TypeError
-PASS Setting 'cursor' to a percent throws TypeError
-PASS Setting 'cursor' to a time throws TypeError
-PASS Setting 'cursor' to an angle throws TypeError
-PASS Setting 'cursor' to a flexible length throws TypeError
-PASS Setting 'cursor' to a number throws TypeError
-PASS Setting 'cursor' to a URL throws TypeError
-PASS Setting 'cursor' to a transform throws TypeError
-FAIL 'cursor' does not supported 'url(hand.cur), pointer' Invalid values
-FAIL 'cursor' does not supported 'url(cursor1.png) 4 12, auto' Invalid values
+PASS Setting 'cursor' to a length: 0px throws TypeError
+PASS Setting 'cursor' to a length: -3.14em throws TypeError
+PASS Setting 'cursor' to a length: 3.14cm throws TypeError
+PASS Setting 'cursor' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'cursor' to a percent: 0% throws TypeError
+PASS Setting 'cursor' to a percent: -3.14% throws TypeError
+PASS Setting 'cursor' to a percent: 3.14% throws TypeError
+PASS Setting 'cursor' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'cursor' to a time: 0s throws TypeError
+PASS Setting 'cursor' to a time: -3.14ms throws TypeError
+PASS Setting 'cursor' to a time: 3.14s throws TypeError
+PASS Setting 'cursor' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'cursor' to an angle: 0deg throws TypeError
+PASS Setting 'cursor' to an angle: 3.14rad throws TypeError
+PASS Setting 'cursor' to an angle: -3.14deg throws TypeError
+PASS Setting 'cursor' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'cursor' to a flexible length: 0fr throws TypeError
+PASS Setting 'cursor' to a flexible length: 1fr throws TypeError
+PASS Setting 'cursor' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'cursor' to a number: 0 throws TypeError
+PASS Setting 'cursor' to a number: -3.14 throws TypeError
+PASS Setting 'cursor' to a number: 3.14 throws TypeError
+PASS Setting 'cursor' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'cursor' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'cursor' to a transform: perspective(10em) throws TypeError
+PASS Setting 'cursor' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'cursor' does not support 'url(hand.cur), pointer' Invalid values
+FAIL 'cursor' does not support 'url(cursor1.png) 4 12, auto' Invalid values
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/d-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/d-expected.txt
@@ -5,13 +5,31 @@ FAIL Can set 'd' to CSS-wide keywords: unset Invalid property d
 FAIL Can set 'd' to CSS-wide keywords: revert Invalid property d
 FAIL Can set 'd' to var() references:  var(--A) Invalid property d
 FAIL Can set 'd' to the 'none' keyword: none Invalid property d
-PASS Setting 'd' to a length throws TypeError
-PASS Setting 'd' to a percent throws TypeError
-PASS Setting 'd' to a time throws TypeError
-PASS Setting 'd' to an angle throws TypeError
-PASS Setting 'd' to a flexible length throws TypeError
-PASS Setting 'd' to a number throws TypeError
-PASS Setting 'd' to a URL throws TypeError
-PASS Setting 'd' to a transform throws TypeError
-FAIL 'd' does not supported 'path("M 100 100 L 300 100 L 200 300 Z")' Invalid property d
+PASS Setting 'd' to a length: 0px throws TypeError
+PASS Setting 'd' to a length: -3.14em throws TypeError
+PASS Setting 'd' to a length: 3.14cm throws TypeError
+PASS Setting 'd' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'd' to a percent: 0% throws TypeError
+PASS Setting 'd' to a percent: -3.14% throws TypeError
+PASS Setting 'd' to a percent: 3.14% throws TypeError
+PASS Setting 'd' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'd' to a time: 0s throws TypeError
+PASS Setting 'd' to a time: -3.14ms throws TypeError
+PASS Setting 'd' to a time: 3.14s throws TypeError
+PASS Setting 'd' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'd' to an angle: 0deg throws TypeError
+PASS Setting 'd' to an angle: 3.14rad throws TypeError
+PASS Setting 'd' to an angle: -3.14deg throws TypeError
+PASS Setting 'd' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'd' to a flexible length: 0fr throws TypeError
+PASS Setting 'd' to a flexible length: 1fr throws TypeError
+PASS Setting 'd' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'd' to a number: 0 throws TypeError
+PASS Setting 'd' to a number: -3.14 throws TypeError
+PASS Setting 'd' to a number: 3.14 throws TypeError
+PASS Setting 'd' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'd' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'd' to a transform: perspective(10em) throws TypeError
+PASS Setting 'd' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'd' does not support 'path("M 100 100 L 300 100 L 200 300 Z")' Invalid property d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/direction-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'direction' to CSS-wide keywords: revert
 PASS Can set 'direction' to var() references:  var(--A)
 PASS Can set 'direction' to the 'ltr' keyword: ltr
 PASS Can set 'direction' to the 'rtl' keyword: rtl
-PASS Setting 'direction' to a length throws TypeError
-PASS Setting 'direction' to a percent throws TypeError
-PASS Setting 'direction' to a time throws TypeError
-PASS Setting 'direction' to an angle throws TypeError
-PASS Setting 'direction' to a flexible length throws TypeError
-PASS Setting 'direction' to a number throws TypeError
-PASS Setting 'direction' to a URL throws TypeError
-PASS Setting 'direction' to a transform throws TypeError
+PASS Setting 'direction' to a length: 0px throws TypeError
+PASS Setting 'direction' to a length: -3.14em throws TypeError
+PASS Setting 'direction' to a length: 3.14cm throws TypeError
+PASS Setting 'direction' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'direction' to a percent: 0% throws TypeError
+PASS Setting 'direction' to a percent: -3.14% throws TypeError
+PASS Setting 'direction' to a percent: 3.14% throws TypeError
+PASS Setting 'direction' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'direction' to a time: 0s throws TypeError
+PASS Setting 'direction' to a time: -3.14ms throws TypeError
+PASS Setting 'direction' to a time: 3.14s throws TypeError
+PASS Setting 'direction' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'direction' to an angle: 0deg throws TypeError
+PASS Setting 'direction' to an angle: 3.14rad throws TypeError
+PASS Setting 'direction' to an angle: -3.14deg throws TypeError
+PASS Setting 'direction' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'direction' to a flexible length: 0fr throws TypeError
+PASS Setting 'direction' to a flexible length: 1fr throws TypeError
+PASS Setting 'direction' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'direction' to a number: 0 throws TypeError
+PASS Setting 'direction' to a number: -3.14 throws TypeError
+PASS Setting 'direction' to a number: 3.14 throws TypeError
+PASS Setting 'direction' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'direction' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'direction' to a transform: perspective(10em) throws TypeError
+PASS Setting 'direction' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/display-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/display-expected.txt
@@ -25,16 +25,34 @@ PASS Can set 'display' to the 'inline-block' keyword: inline-block
 PASS Can set 'display' to the 'inline-table' keyword: inline-table
 PASS Can set 'display' to the 'inline-flex' keyword: inline-flex
 PASS Can set 'display' to the 'inline-grid' keyword: inline-grid
-PASS Setting 'display' to a length throws TypeError
-PASS Setting 'display' to a percent throws TypeError
-PASS Setting 'display' to a time throws TypeError
-PASS Setting 'display' to an angle throws TypeError
-PASS Setting 'display' to a flexible length throws TypeError
-PASS Setting 'display' to a number throws TypeError
-PASS Setting 'display' to a URL throws TypeError
-PASS Setting 'display' to a transform throws TypeError
-FAIL 'display' does not supported 'block math' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'display' does not supported 'math block' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'display' does not supported 'inline math' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'display' does not supported 'math inline' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS Setting 'display' to a length: 0px throws TypeError
+PASS Setting 'display' to a length: -3.14em throws TypeError
+PASS Setting 'display' to a length: 3.14cm throws TypeError
+PASS Setting 'display' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'display' to a percent: 0% throws TypeError
+PASS Setting 'display' to a percent: -3.14% throws TypeError
+PASS Setting 'display' to a percent: 3.14% throws TypeError
+PASS Setting 'display' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'display' to a time: 0s throws TypeError
+PASS Setting 'display' to a time: -3.14ms throws TypeError
+PASS Setting 'display' to a time: 3.14s throws TypeError
+PASS Setting 'display' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'display' to an angle: 0deg throws TypeError
+PASS Setting 'display' to an angle: 3.14rad throws TypeError
+PASS Setting 'display' to an angle: -3.14deg throws TypeError
+PASS Setting 'display' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'display' to a flexible length: 0fr throws TypeError
+PASS Setting 'display' to a flexible length: 1fr throws TypeError
+PASS Setting 'display' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'display' to a number: 0 throws TypeError
+PASS Setting 'display' to a number: -3.14 throws TypeError
+PASS Setting 'display' to a number: 3.14 throws TypeError
+PASS Setting 'display' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'display' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'display' to a transform: perspective(10em) throws TypeError
+PASS Setting 'display' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'display' does not support 'block math' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'display' does not support 'math block' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'display' does not support 'inline math' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'display' does not support 'math inline' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/dominant-baseline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/dominant-baseline-expected.txt
@@ -13,12 +13,30 @@ PASS Can set 'dominant-baseline' to the 'central' keyword: central
 PASS Can set 'dominant-baseline' to the 'mathematical' keyword: mathematical
 PASS Can set 'dominant-baseline' to the 'hanging' keyword: hanging
 FAIL Can set 'dominant-baseline' to the 'text-top' keyword: text-top Invalid values
-PASS Setting 'dominant-baseline' to a length throws TypeError
-PASS Setting 'dominant-baseline' to a percent throws TypeError
-PASS Setting 'dominant-baseline' to a time throws TypeError
-PASS Setting 'dominant-baseline' to an angle throws TypeError
-PASS Setting 'dominant-baseline' to a flexible length throws TypeError
-PASS Setting 'dominant-baseline' to a number throws TypeError
-PASS Setting 'dominant-baseline' to a URL throws TypeError
-PASS Setting 'dominant-baseline' to a transform throws TypeError
+PASS Setting 'dominant-baseline' to a length: 0px throws TypeError
+PASS Setting 'dominant-baseline' to a length: -3.14em throws TypeError
+PASS Setting 'dominant-baseline' to a length: 3.14cm throws TypeError
+PASS Setting 'dominant-baseline' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'dominant-baseline' to a percent: 0% throws TypeError
+PASS Setting 'dominant-baseline' to a percent: -3.14% throws TypeError
+PASS Setting 'dominant-baseline' to a percent: 3.14% throws TypeError
+PASS Setting 'dominant-baseline' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'dominant-baseline' to a time: 0s throws TypeError
+PASS Setting 'dominant-baseline' to a time: -3.14ms throws TypeError
+PASS Setting 'dominant-baseline' to a time: 3.14s throws TypeError
+PASS Setting 'dominant-baseline' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'dominant-baseline' to an angle: 0deg throws TypeError
+PASS Setting 'dominant-baseline' to an angle: 3.14rad throws TypeError
+PASS Setting 'dominant-baseline' to an angle: -3.14deg throws TypeError
+PASS Setting 'dominant-baseline' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'dominant-baseline' to a flexible length: 0fr throws TypeError
+PASS Setting 'dominant-baseline' to a flexible length: 1fr throws TypeError
+PASS Setting 'dominant-baseline' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'dominant-baseline' to a number: 0 throws TypeError
+PASS Setting 'dominant-baseline' to a number: -3.14 throws TypeError
+PASS Setting 'dominant-baseline' to a number: 3.14 throws TypeError
+PASS Setting 'dominant-baseline' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'dominant-baseline' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'dominant-baseline' to a transform: perspective(10em) throws TypeError
+PASS Setting 'dominant-baseline' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/empty-cells-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/empty-cells-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'empty-cells' to CSS-wide keywords: revert
 PASS Can set 'empty-cells' to var() references:  var(--A)
 PASS Can set 'empty-cells' to the 'show' keyword: show
 PASS Can set 'empty-cells' to the 'hide' keyword: hide
-PASS Setting 'empty-cells' to a length throws TypeError
-PASS Setting 'empty-cells' to a percent throws TypeError
-PASS Setting 'empty-cells' to a time throws TypeError
-PASS Setting 'empty-cells' to an angle throws TypeError
-PASS Setting 'empty-cells' to a flexible length throws TypeError
-PASS Setting 'empty-cells' to a number throws TypeError
-PASS Setting 'empty-cells' to a URL throws TypeError
-PASS Setting 'empty-cells' to a transform throws TypeError
+PASS Setting 'empty-cells' to a length: 0px throws TypeError
+PASS Setting 'empty-cells' to a length: -3.14em throws TypeError
+PASS Setting 'empty-cells' to a length: 3.14cm throws TypeError
+PASS Setting 'empty-cells' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'empty-cells' to a percent: 0% throws TypeError
+PASS Setting 'empty-cells' to a percent: -3.14% throws TypeError
+PASS Setting 'empty-cells' to a percent: 3.14% throws TypeError
+PASS Setting 'empty-cells' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'empty-cells' to a time: 0s throws TypeError
+PASS Setting 'empty-cells' to a time: -3.14ms throws TypeError
+PASS Setting 'empty-cells' to a time: 3.14s throws TypeError
+PASS Setting 'empty-cells' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'empty-cells' to an angle: 0deg throws TypeError
+PASS Setting 'empty-cells' to an angle: 3.14rad throws TypeError
+PASS Setting 'empty-cells' to an angle: -3.14deg throws TypeError
+PASS Setting 'empty-cells' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'empty-cells' to a flexible length: 0fr throws TypeError
+PASS Setting 'empty-cells' to a flexible length: 1fr throws TypeError
+PASS Setting 'empty-cells' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'empty-cells' to a number: 0 throws TypeError
+PASS Setting 'empty-cells' to a number: -3.14 throws TypeError
+PASS Setting 'empty-cells' to a number: 3.14 throws TypeError
+PASS Setting 'empty-cells' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'empty-cells' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'empty-cells' to a transform: perspective(10em) throws TypeError
+PASS Setting 'empty-cells' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-color-expected.txt
@@ -5,17 +5,35 @@ FAIL Can set 'fill-color' to CSS-wide keywords: unset Invalid property fill-colo
 FAIL Can set 'fill-color' to CSS-wide keywords: revert Invalid property fill-color
 FAIL Can set 'fill-color' to var() references:  var(--A) Invalid property fill-color
 FAIL Can set 'fill-color' to the 'currentcolor' keyword: currentcolor Invalid property fill-color
-PASS Setting 'fill-color' to a length throws TypeError
-PASS Setting 'fill-color' to a percent throws TypeError
-PASS Setting 'fill-color' to a time throws TypeError
-PASS Setting 'fill-color' to an angle throws TypeError
-PASS Setting 'fill-color' to a flexible length throws TypeError
-PASS Setting 'fill-color' to a number throws TypeError
-PASS Setting 'fill-color' to a URL throws TypeError
-PASS Setting 'fill-color' to a transform throws TypeError
-FAIL 'fill-color' does not supported 'red' Invalid property fill-color
-FAIL 'fill-color' does not supported '#bbff00' Invalid property fill-color
-FAIL 'fill-color' does not supported 'rgb(255, 255, 128)' Invalid property fill-color
-FAIL 'fill-color' does not supported 'hsl(50, 33%, 25%)' Invalid property fill-color
-FAIL 'fill-color' does not supported 'transparent' Invalid property fill-color
+PASS Setting 'fill-color' to a length: 0px throws TypeError
+PASS Setting 'fill-color' to a length: -3.14em throws TypeError
+PASS Setting 'fill-color' to a length: 3.14cm throws TypeError
+PASS Setting 'fill-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'fill-color' to a percent: 0% throws TypeError
+PASS Setting 'fill-color' to a percent: -3.14% throws TypeError
+PASS Setting 'fill-color' to a percent: 3.14% throws TypeError
+PASS Setting 'fill-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'fill-color' to a time: 0s throws TypeError
+PASS Setting 'fill-color' to a time: -3.14ms throws TypeError
+PASS Setting 'fill-color' to a time: 3.14s throws TypeError
+PASS Setting 'fill-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'fill-color' to an angle: 0deg throws TypeError
+PASS Setting 'fill-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'fill-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'fill-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'fill-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'fill-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'fill-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'fill-color' to a number: 0 throws TypeError
+PASS Setting 'fill-color' to a number: -3.14 throws TypeError
+PASS Setting 'fill-color' to a number: 3.14 throws TypeError
+PASS Setting 'fill-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'fill-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'fill-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'fill-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'fill-color' does not support 'red' Invalid property fill-color
+FAIL 'fill-color' does not support '#bbff00' Invalid property fill-color
+FAIL 'fill-color' does not support 'rgb(255, 255, 128)' Invalid property fill-color
+FAIL 'fill-color' does not support 'hsl(50, 33%, 25%)' Invalid property fill-color
+FAIL 'fill-color' does not support 'transparent' Invalid property fill-color
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL 'fill' does not supported 'black' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'fill' does not supported 'red gray' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'fill' does not support 'black' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'fill' does not support 'red gray' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity-expected.txt
@@ -8,11 +8,26 @@ PASS Can set 'fill-opacity' to a number: 0
 PASS Can set 'fill-opacity' to a number: -3.14
 PASS Can set 'fill-opacity' to a number: 3.14
 PASS Can set 'fill-opacity' to a number: calc(2 + 3)
-PASS Setting 'fill-opacity' to a length throws TypeError
-FAIL Setting 'fill-opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'fill-opacity' to a time throws TypeError
-PASS Setting 'fill-opacity' to an angle throws TypeError
-PASS Setting 'fill-opacity' to a flexible length throws TypeError
-PASS Setting 'fill-opacity' to a URL throws TypeError
-PASS Setting 'fill-opacity' to a transform throws TypeError
+PASS Setting 'fill-opacity' to a length: 0px throws TypeError
+PASS Setting 'fill-opacity' to a length: -3.14em throws TypeError
+PASS Setting 'fill-opacity' to a length: 3.14cm throws TypeError
+PASS Setting 'fill-opacity' to a length: calc(0px + 0em) throws TypeError
+FAIL Setting 'fill-opacity' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'fill-opacity' to a percent: -3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'fill-opacity' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'fill-opacity' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'fill-opacity' to a time: 0s throws TypeError
+PASS Setting 'fill-opacity' to a time: -3.14ms throws TypeError
+PASS Setting 'fill-opacity' to a time: 3.14s throws TypeError
+PASS Setting 'fill-opacity' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'fill-opacity' to an angle: 0deg throws TypeError
+PASS Setting 'fill-opacity' to an angle: 3.14rad throws TypeError
+PASS Setting 'fill-opacity' to an angle: -3.14deg throws TypeError
+PASS Setting 'fill-opacity' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'fill-opacity' to a flexible length: 0fr throws TypeError
+PASS Setting 'fill-opacity' to a flexible length: 1fr throws TypeError
+PASS Setting 'fill-opacity' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'fill-opacity' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'fill-opacity' to a transform: perspective(10em) throws TypeError
+PASS Setting 'fill-opacity' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-rule-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'fill-rule' to CSS-wide keywords: revert
 PASS Can set 'fill-rule' to var() references:  var(--A)
 PASS Can set 'fill-rule' to the 'nonzero' keyword: nonzero
 PASS Can set 'fill-rule' to the 'evenodd' keyword: evenodd
-PASS Setting 'fill-rule' to a length throws TypeError
-PASS Setting 'fill-rule' to a percent throws TypeError
-PASS Setting 'fill-rule' to a time throws TypeError
-PASS Setting 'fill-rule' to an angle throws TypeError
-PASS Setting 'fill-rule' to a flexible length throws TypeError
-PASS Setting 'fill-rule' to a number throws TypeError
-PASS Setting 'fill-rule' to a URL throws TypeError
-PASS Setting 'fill-rule' to a transform throws TypeError
+PASS Setting 'fill-rule' to a length: 0px throws TypeError
+PASS Setting 'fill-rule' to a length: -3.14em throws TypeError
+PASS Setting 'fill-rule' to a length: 3.14cm throws TypeError
+PASS Setting 'fill-rule' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'fill-rule' to a percent: 0% throws TypeError
+PASS Setting 'fill-rule' to a percent: -3.14% throws TypeError
+PASS Setting 'fill-rule' to a percent: 3.14% throws TypeError
+PASS Setting 'fill-rule' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'fill-rule' to a time: 0s throws TypeError
+PASS Setting 'fill-rule' to a time: -3.14ms throws TypeError
+PASS Setting 'fill-rule' to a time: 3.14s throws TypeError
+PASS Setting 'fill-rule' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'fill-rule' to an angle: 0deg throws TypeError
+PASS Setting 'fill-rule' to an angle: 3.14rad throws TypeError
+PASS Setting 'fill-rule' to an angle: -3.14deg throws TypeError
+PASS Setting 'fill-rule' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'fill-rule' to a flexible length: 0fr throws TypeError
+PASS Setting 'fill-rule' to a flexible length: 1fr throws TypeError
+PASS Setting 'fill-rule' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'fill-rule' to a number: 0 throws TypeError
+PASS Setting 'fill-rule' to a number: -3.14 throws TypeError
+PASS Setting 'fill-rule' to a number: 3.14 throws TypeError
+PASS Setting 'fill-rule' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'fill-rule' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'fill-rule' to a transform: perspective(10em) throws TypeError
+PASS Setting 'fill-rule' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/filter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/filter-expected.txt
@@ -5,14 +5,32 @@ PASS Can set 'filter' to CSS-wide keywords: unset
 PASS Can set 'filter' to CSS-wide keywords: revert
 PASS Can set 'filter' to var() references:  var(--A)
 PASS Can set 'filter' to the 'none' keyword: none
-PASS Setting 'filter' to a length throws TypeError
-PASS Setting 'filter' to a percent throws TypeError
-PASS Setting 'filter' to a time throws TypeError
-PASS Setting 'filter' to an angle throws TypeError
-PASS Setting 'filter' to a flexible length throws TypeError
-PASS Setting 'filter' to a number throws TypeError
-PASS Setting 'filter' to a URL throws TypeError
-PASS Setting 'filter' to a transform throws TypeError
-PASS 'filter' does not supported 'blur(2px)'
-FAIL 'filter' does not supported 'url(filters.svg) blur(4px) saturate(150%)' assert_equals: Unsupported value can be set on different element expected "url(\"filters.svg\") blur(4px) saturate(150%)" but got "url(\"filters.svg\")"
+PASS Setting 'filter' to a length: 0px throws TypeError
+PASS Setting 'filter' to a length: -3.14em throws TypeError
+PASS Setting 'filter' to a length: 3.14cm throws TypeError
+PASS Setting 'filter' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'filter' to a percent: 0% throws TypeError
+PASS Setting 'filter' to a percent: -3.14% throws TypeError
+PASS Setting 'filter' to a percent: 3.14% throws TypeError
+PASS Setting 'filter' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'filter' to a time: 0s throws TypeError
+PASS Setting 'filter' to a time: -3.14ms throws TypeError
+PASS Setting 'filter' to a time: 3.14s throws TypeError
+PASS Setting 'filter' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'filter' to an angle: 0deg throws TypeError
+PASS Setting 'filter' to an angle: 3.14rad throws TypeError
+PASS Setting 'filter' to an angle: -3.14deg throws TypeError
+PASS Setting 'filter' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'filter' to a flexible length: 0fr throws TypeError
+PASS Setting 'filter' to a flexible length: 1fr throws TypeError
+PASS Setting 'filter' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'filter' to a number: 0 throws TypeError
+PASS Setting 'filter' to a number: -3.14 throws TypeError
+PASS Setting 'filter' to a number: 3.14 throws TypeError
+PASS Setting 'filter' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'filter' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'filter' to a transform: perspective(10em) throws TypeError
+PASS Setting 'filter' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'filter' does not support 'blur(2px)'
+FAIL 'filter' does not support 'url(filters.svg) blur(4px) saturate(150%)' assert_equals: Unsupported value can be set on different element expected "url(\"filters.svg\") blur(4px) saturate(150%)" but got "url(\"filters.svg\")"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt
@@ -17,10 +17,22 @@ PASS Can set 'flex-basis' to a percent: 0%
 FAIL Can set 'flex-basis' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'flex-basis' to a percent: 3.14%
 PASS Can set 'flex-basis' to a percent: calc(0% + 0%)
-PASS Setting 'flex-basis' to a time throws TypeError
-PASS Setting 'flex-basis' to an angle throws TypeError
-PASS Setting 'flex-basis' to a flexible length throws TypeError
-FAIL Setting 'flex-basis' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'flex-basis' to a URL throws TypeError
-PASS Setting 'flex-basis' to a transform throws TypeError
+PASS Setting 'flex-basis' to a time: 0s throws TypeError
+PASS Setting 'flex-basis' to a time: -3.14ms throws TypeError
+PASS Setting 'flex-basis' to a time: 3.14s throws TypeError
+PASS Setting 'flex-basis' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'flex-basis' to an angle: 0deg throws TypeError
+PASS Setting 'flex-basis' to an angle: 3.14rad throws TypeError
+PASS Setting 'flex-basis' to an angle: -3.14deg throws TypeError
+PASS Setting 'flex-basis' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'flex-basis' to a flexible length: 0fr throws TypeError
+PASS Setting 'flex-basis' to a flexible length: 1fr throws TypeError
+PASS Setting 'flex-basis' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'flex-basis' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'flex-basis' to a number: -3.14 throws TypeError
+PASS Setting 'flex-basis' to a number: 3.14 throws TypeError
+PASS Setting 'flex-basis' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'flex-basis' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'flex-basis' to a transform: perspective(10em) throws TypeError
+PASS Setting 'flex-basis' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-direction-expected.txt
@@ -8,12 +8,30 @@ PASS Can set 'flex-direction' to the 'row' keyword: row
 PASS Can set 'flex-direction' to the 'row-reverse' keyword: row-reverse
 PASS Can set 'flex-direction' to the 'column' keyword: column
 PASS Can set 'flex-direction' to the 'column-reverse' keyword: column-reverse
-PASS Setting 'flex-direction' to a length throws TypeError
-PASS Setting 'flex-direction' to a percent throws TypeError
-PASS Setting 'flex-direction' to a time throws TypeError
-PASS Setting 'flex-direction' to an angle throws TypeError
-PASS Setting 'flex-direction' to a flexible length throws TypeError
-PASS Setting 'flex-direction' to a number throws TypeError
-PASS Setting 'flex-direction' to a URL throws TypeError
-PASS Setting 'flex-direction' to a transform throws TypeError
+PASS Setting 'flex-direction' to a length: 0px throws TypeError
+PASS Setting 'flex-direction' to a length: -3.14em throws TypeError
+PASS Setting 'flex-direction' to a length: 3.14cm throws TypeError
+PASS Setting 'flex-direction' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'flex-direction' to a percent: 0% throws TypeError
+PASS Setting 'flex-direction' to a percent: -3.14% throws TypeError
+PASS Setting 'flex-direction' to a percent: 3.14% throws TypeError
+PASS Setting 'flex-direction' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'flex-direction' to a time: 0s throws TypeError
+PASS Setting 'flex-direction' to a time: -3.14ms throws TypeError
+PASS Setting 'flex-direction' to a time: 3.14s throws TypeError
+PASS Setting 'flex-direction' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'flex-direction' to an angle: 0deg throws TypeError
+PASS Setting 'flex-direction' to an angle: 3.14rad throws TypeError
+PASS Setting 'flex-direction' to an angle: -3.14deg throws TypeError
+PASS Setting 'flex-direction' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'flex-direction' to a flexible length: 0fr throws TypeError
+PASS Setting 'flex-direction' to a flexible length: 1fr throws TypeError
+PASS Setting 'flex-direction' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'flex-direction' to a number: 0 throws TypeError
+PASS Setting 'flex-direction' to a number: -3.14 throws TypeError
+PASS Setting 'flex-direction' to a number: 3.14 throws TypeError
+PASS Setting 'flex-direction' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'flex-direction' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'flex-direction' to a transform: perspective(10em) throws TypeError
+PASS Setting 'flex-direction' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-expected.txt
@@ -1,6 +1,6 @@
 
-PASS 'flex' does not supported 'auto'
-PASS 'flex' does not supported '2'
-PASS 'flex' does not supported '1 30px'
-PASS 'flex' does not supported '2 2 10%'
+PASS 'flex' does not support 'auto'
+PASS 'flex' does not support '2'
+PASS 'flex' does not support '1 30px'
+PASS 'flex' does not support '2 2 10%'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-flow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-flow-expected.txt
@@ -1,5 +1,5 @@
 
-PASS 'flex-flow' does not supported 'row'
-PASS 'flex-flow' does not supported 'column wrap'
-PASS 'flex-flow' does not supported 'row-reverse wrap-reverse'
+PASS 'flex-flow' does not support 'row'
+PASS 'flex-flow' does not support 'column wrap'
+PASS 'flex-flow' does not support 'row-reverse wrap-reverse'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt
@@ -8,11 +8,26 @@ PASS Can set 'flex-grow' to a number: 0
 FAIL Can set 'flex-grow' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'flex-grow' to a number: 3.14
 PASS Can set 'flex-grow' to a number: calc(2 + 3)
-PASS Setting 'flex-grow' to a length throws TypeError
-PASS Setting 'flex-grow' to a percent throws TypeError
-PASS Setting 'flex-grow' to a time throws TypeError
-PASS Setting 'flex-grow' to an angle throws TypeError
-PASS Setting 'flex-grow' to a flexible length throws TypeError
-PASS Setting 'flex-grow' to a URL throws TypeError
-PASS Setting 'flex-grow' to a transform throws TypeError
+PASS Setting 'flex-grow' to a length: 0px throws TypeError
+PASS Setting 'flex-grow' to a length: -3.14em throws TypeError
+PASS Setting 'flex-grow' to a length: 3.14cm throws TypeError
+PASS Setting 'flex-grow' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'flex-grow' to a percent: 0% throws TypeError
+PASS Setting 'flex-grow' to a percent: -3.14% throws TypeError
+PASS Setting 'flex-grow' to a percent: 3.14% throws TypeError
+PASS Setting 'flex-grow' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'flex-grow' to a time: 0s throws TypeError
+PASS Setting 'flex-grow' to a time: -3.14ms throws TypeError
+PASS Setting 'flex-grow' to a time: 3.14s throws TypeError
+PASS Setting 'flex-grow' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'flex-grow' to an angle: 0deg throws TypeError
+PASS Setting 'flex-grow' to an angle: 3.14rad throws TypeError
+PASS Setting 'flex-grow' to an angle: -3.14deg throws TypeError
+PASS Setting 'flex-grow' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'flex-grow' to a flexible length: 0fr throws TypeError
+PASS Setting 'flex-grow' to a flexible length: 1fr throws TypeError
+PASS Setting 'flex-grow' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'flex-grow' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'flex-grow' to a transform: perspective(10em) throws TypeError
+PASS Setting 'flex-grow' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt
@@ -8,11 +8,26 @@ PASS Can set 'flex-shrink' to a number: 0
 FAIL Can set 'flex-shrink' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'flex-shrink' to a number: 3.14
 PASS Can set 'flex-shrink' to a number: calc(2 + 3)
-PASS Setting 'flex-shrink' to a length throws TypeError
-PASS Setting 'flex-shrink' to a percent throws TypeError
-PASS Setting 'flex-shrink' to a time throws TypeError
-PASS Setting 'flex-shrink' to an angle throws TypeError
-PASS Setting 'flex-shrink' to a flexible length throws TypeError
-PASS Setting 'flex-shrink' to a URL throws TypeError
-PASS Setting 'flex-shrink' to a transform throws TypeError
+PASS Setting 'flex-shrink' to a length: 0px throws TypeError
+PASS Setting 'flex-shrink' to a length: -3.14em throws TypeError
+PASS Setting 'flex-shrink' to a length: 3.14cm throws TypeError
+PASS Setting 'flex-shrink' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'flex-shrink' to a percent: 0% throws TypeError
+PASS Setting 'flex-shrink' to a percent: -3.14% throws TypeError
+PASS Setting 'flex-shrink' to a percent: 3.14% throws TypeError
+PASS Setting 'flex-shrink' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'flex-shrink' to a time: 0s throws TypeError
+PASS Setting 'flex-shrink' to a time: -3.14ms throws TypeError
+PASS Setting 'flex-shrink' to a time: 3.14s throws TypeError
+PASS Setting 'flex-shrink' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'flex-shrink' to an angle: 0deg throws TypeError
+PASS Setting 'flex-shrink' to an angle: 3.14rad throws TypeError
+PASS Setting 'flex-shrink' to an angle: -3.14deg throws TypeError
+PASS Setting 'flex-shrink' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'flex-shrink' to a flexible length: 0fr throws TypeError
+PASS Setting 'flex-shrink' to a flexible length: 1fr throws TypeError
+PASS Setting 'flex-shrink' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'flex-shrink' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'flex-shrink' to a transform: perspective(10em) throws TypeError
+PASS Setting 'flex-shrink' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-wrap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-wrap-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'flex-wrap' to var() references:  var(--A)
 PASS Can set 'flex-wrap' to the 'nowrap' keyword: nowrap
 PASS Can set 'flex-wrap' to the 'wrap' keyword: wrap
 PASS Can set 'flex-wrap' to the 'wrap-reverse' keyword: wrap-reverse
-PASS Setting 'flex-wrap' to a length throws TypeError
-PASS Setting 'flex-wrap' to a percent throws TypeError
-PASS Setting 'flex-wrap' to a time throws TypeError
-PASS Setting 'flex-wrap' to an angle throws TypeError
-PASS Setting 'flex-wrap' to a flexible length throws TypeError
-PASS Setting 'flex-wrap' to a number throws TypeError
-PASS Setting 'flex-wrap' to a URL throws TypeError
-PASS Setting 'flex-wrap' to a transform throws TypeError
+PASS Setting 'flex-wrap' to a length: 0px throws TypeError
+PASS Setting 'flex-wrap' to a length: -3.14em throws TypeError
+PASS Setting 'flex-wrap' to a length: 3.14cm throws TypeError
+PASS Setting 'flex-wrap' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'flex-wrap' to a percent: 0% throws TypeError
+PASS Setting 'flex-wrap' to a percent: -3.14% throws TypeError
+PASS Setting 'flex-wrap' to a percent: 3.14% throws TypeError
+PASS Setting 'flex-wrap' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'flex-wrap' to a time: 0s throws TypeError
+PASS Setting 'flex-wrap' to a time: -3.14ms throws TypeError
+PASS Setting 'flex-wrap' to a time: 3.14s throws TypeError
+PASS Setting 'flex-wrap' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'flex-wrap' to an angle: 0deg throws TypeError
+PASS Setting 'flex-wrap' to an angle: 3.14rad throws TypeError
+PASS Setting 'flex-wrap' to an angle: -3.14deg throws TypeError
+PASS Setting 'flex-wrap' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'flex-wrap' to a flexible length: 0fr throws TypeError
+PASS Setting 'flex-wrap' to a flexible length: 1fr throws TypeError
+PASS Setting 'flex-wrap' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'flex-wrap' to a number: 0 throws TypeError
+PASS Setting 'flex-wrap' to a number: -3.14 throws TypeError
+PASS Setting 'flex-wrap' to a number: 3.14 throws TypeError
+PASS Setting 'flex-wrap' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'flex-wrap' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'flex-wrap' to a transform: perspective(10em) throws TypeError
+PASS Setting 'flex-wrap' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/float-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/float-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'float' to var() references:  var(--A)
 PASS Can set 'float' to the 'left' keyword: left
 PASS Can set 'float' to the 'right' keyword: right
 PASS Can set 'float' to the 'none' keyword: none
-PASS Setting 'float' to a length throws TypeError
-PASS Setting 'float' to a percent throws TypeError
-PASS Setting 'float' to a time throws TypeError
-PASS Setting 'float' to an angle throws TypeError
-PASS Setting 'float' to a flexible length throws TypeError
-PASS Setting 'float' to a number throws TypeError
-PASS Setting 'float' to a URL throws TypeError
-PASS Setting 'float' to a transform throws TypeError
+PASS Setting 'float' to a length: 0px throws TypeError
+PASS Setting 'float' to a length: -3.14em throws TypeError
+PASS Setting 'float' to a length: 3.14cm throws TypeError
+PASS Setting 'float' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'float' to a percent: 0% throws TypeError
+PASS Setting 'float' to a percent: -3.14% throws TypeError
+PASS Setting 'float' to a percent: 3.14% throws TypeError
+PASS Setting 'float' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'float' to a time: 0s throws TypeError
+PASS Setting 'float' to a time: -3.14ms throws TypeError
+PASS Setting 'float' to a time: 3.14s throws TypeError
+PASS Setting 'float' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'float' to an angle: 0deg throws TypeError
+PASS Setting 'float' to an angle: 3.14rad throws TypeError
+PASS Setting 'float' to an angle: -3.14deg throws TypeError
+PASS Setting 'float' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'float' to a flexible length: 0fr throws TypeError
+PASS Setting 'float' to a flexible length: 1fr throws TypeError
+PASS Setting 'float' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'float' to a number: 0 throws TypeError
+PASS Setting 'float' to a number: -3.14 throws TypeError
+PASS Setting 'float' to a number: 3.14 throws TypeError
+PASS Setting 'float' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'float' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'float' to a transform: perspective(10em) throws TypeError
+PASS Setting 'float' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-color-expected.txt
@@ -5,17 +5,35 @@ PASS Can set 'flood-color' to CSS-wide keywords: unset
 PASS Can set 'flood-color' to CSS-wide keywords: revert
 PASS Can set 'flood-color' to var() references:  var(--A)
 PASS Can set 'flood-color' to the 'currentcolor' keyword: currentcolor
-PASS Setting 'flood-color' to a length throws TypeError
-PASS Setting 'flood-color' to a percent throws TypeError
-PASS Setting 'flood-color' to a time throws TypeError
-PASS Setting 'flood-color' to an angle throws TypeError
-PASS Setting 'flood-color' to a flexible length throws TypeError
-PASS Setting 'flood-color' to a number throws TypeError
-PASS Setting 'flood-color' to a URL throws TypeError
-PASS Setting 'flood-color' to a transform throws TypeError
-FAIL 'flood-color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'flood-color' does not supported '#bbff00'
-PASS 'flood-color' does not supported 'rgb(255, 255, 128)'
-PASS 'flood-color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'flood-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'flood-color' to a length: 0px throws TypeError
+PASS Setting 'flood-color' to a length: -3.14em throws TypeError
+PASS Setting 'flood-color' to a length: 3.14cm throws TypeError
+PASS Setting 'flood-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'flood-color' to a percent: 0% throws TypeError
+PASS Setting 'flood-color' to a percent: -3.14% throws TypeError
+PASS Setting 'flood-color' to a percent: 3.14% throws TypeError
+PASS Setting 'flood-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'flood-color' to a time: 0s throws TypeError
+PASS Setting 'flood-color' to a time: -3.14ms throws TypeError
+PASS Setting 'flood-color' to a time: 3.14s throws TypeError
+PASS Setting 'flood-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'flood-color' to an angle: 0deg throws TypeError
+PASS Setting 'flood-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'flood-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'flood-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'flood-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'flood-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'flood-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'flood-color' to a number: 0 throws TypeError
+PASS Setting 'flood-color' to a number: -3.14 throws TypeError
+PASS Setting 'flood-color' to a number: 3.14 throws TypeError
+PASS Setting 'flood-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'flood-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'flood-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'flood-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'flood-color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'flood-color' does not support '#bbff00'
+PASS 'flood-color' does not support 'rgb(255, 255, 128)'
+PASS 'flood-color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'flood-color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity-expected.txt
@@ -8,11 +8,26 @@ PASS Can set 'flood-opacity' to a number: 0
 PASS Can set 'flood-opacity' to a number: -3.14
 PASS Can set 'flood-opacity' to a number: 3.14
 PASS Can set 'flood-opacity' to a number: calc(2 + 3)
-PASS Setting 'flood-opacity' to a length throws TypeError
-FAIL Setting 'flood-opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'flood-opacity' to a time throws TypeError
-PASS Setting 'flood-opacity' to an angle throws TypeError
-PASS Setting 'flood-opacity' to a flexible length throws TypeError
-PASS Setting 'flood-opacity' to a URL throws TypeError
-PASS Setting 'flood-opacity' to a transform throws TypeError
+PASS Setting 'flood-opacity' to a length: 0px throws TypeError
+PASS Setting 'flood-opacity' to a length: -3.14em throws TypeError
+PASS Setting 'flood-opacity' to a length: 3.14cm throws TypeError
+PASS Setting 'flood-opacity' to a length: calc(0px + 0em) throws TypeError
+FAIL Setting 'flood-opacity' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'flood-opacity' to a percent: -3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'flood-opacity' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'flood-opacity' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'flood-opacity' to a time: 0s throws TypeError
+PASS Setting 'flood-opacity' to a time: -3.14ms throws TypeError
+PASS Setting 'flood-opacity' to a time: 3.14s throws TypeError
+PASS Setting 'flood-opacity' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'flood-opacity' to an angle: 0deg throws TypeError
+PASS Setting 'flood-opacity' to an angle: 3.14rad throws TypeError
+PASS Setting 'flood-opacity' to an angle: -3.14deg throws TypeError
+PASS Setting 'flood-opacity' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'flood-opacity' to a flexible length: 0fr throws TypeError
+PASS Setting 'flood-opacity' to a flexible length: 1fr throws TypeError
+PASS Setting 'flood-opacity' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'flood-opacity' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'flood-opacity' to a transform: perspective(10em) throws TypeError
+PASS Setting 'flood-opacity' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-expected.txt
@@ -1,7 +1,7 @@
 
-PASS 'font' does not supported '1.2em "Fira Sans", sans-serif'
-PASS 'font' does not supported 'italic 1.2em "Fira Sans", serif'
-PASS 'font' does not supported 'italic small-caps bold 16px/2 cursive'
-PASS 'font' does not supported 'small-caps bold 24px/1 sans-serif'
-PASS 'font' does not supported 'caption'
+PASS 'font' does not support '1.2em "Fira Sans", sans-serif'
+PASS 'font' does not support 'italic 1.2em "Fira Sans", serif'
+PASS 'font' does not support 'italic small-caps bold 16px/2 cursive'
+PASS 'font' does not support 'small-caps bold 24px/1 sans-serif'
+PASS 'font' does not support 'caption'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-family-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-family-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL 'font-family' does not supported 'Georgia' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'font-family' does not supported '"Gill Sans"' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'font-family' does not supported 'sans-serif' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'font-family' does not support 'Georgia' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'font-family' does not support '"Gill Sans"' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'font-family' does not support 'sans-serif' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-feature-settings-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-feature-settings-expected.txt
@@ -5,14 +5,32 @@ PASS Can set 'font-feature-settings' to CSS-wide keywords: unset
 PASS Can set 'font-feature-settings' to CSS-wide keywords: revert
 PASS Can set 'font-feature-settings' to var() references:  var(--A)
 PASS Can set 'font-feature-settings' to the 'normal' keyword: normal
-PASS Setting 'font-feature-settings' to a length throws TypeError
-PASS Setting 'font-feature-settings' to a percent throws TypeError
-PASS Setting 'font-feature-settings' to a time throws TypeError
-PASS Setting 'font-feature-settings' to an angle throws TypeError
-PASS Setting 'font-feature-settings' to a flexible length throws TypeError
-PASS Setting 'font-feature-settings' to a number throws TypeError
-PASS Setting 'font-feature-settings' to a URL throws TypeError
-PASS Setting 'font-feature-settings' to a transform throws TypeError
-PASS 'font-feature-settings' does not supported '"dlig" 1'
-PASS 'font-feature-settings' does not supported '"smcp" on'
+PASS Setting 'font-feature-settings' to a length: 0px throws TypeError
+PASS Setting 'font-feature-settings' to a length: -3.14em throws TypeError
+PASS Setting 'font-feature-settings' to a length: 3.14cm throws TypeError
+PASS Setting 'font-feature-settings' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-feature-settings' to a percent: 0% throws TypeError
+PASS Setting 'font-feature-settings' to a percent: -3.14% throws TypeError
+PASS Setting 'font-feature-settings' to a percent: 3.14% throws TypeError
+PASS Setting 'font-feature-settings' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-feature-settings' to a time: 0s throws TypeError
+PASS Setting 'font-feature-settings' to a time: -3.14ms throws TypeError
+PASS Setting 'font-feature-settings' to a time: 3.14s throws TypeError
+PASS Setting 'font-feature-settings' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-feature-settings' to an angle: 0deg throws TypeError
+PASS Setting 'font-feature-settings' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-feature-settings' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-feature-settings' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-feature-settings' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-feature-settings' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-feature-settings' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-feature-settings' to a number: 0 throws TypeError
+PASS Setting 'font-feature-settings' to a number: -3.14 throws TypeError
+PASS Setting 'font-feature-settings' to a number: 3.14 throws TypeError
+PASS Setting 'font-feature-settings' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-feature-settings' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-feature-settings' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-feature-settings' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'font-feature-settings' does not support '"dlig" 1'
+PASS 'font-feature-settings' does not support '"smcp" on'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-kerning-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-kerning-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'font-kerning' to var() references:  var(--A)
 PASS Can set 'font-kerning' to the 'auto' keyword: auto
 PASS Can set 'font-kerning' to the 'normal' keyword: normal
 PASS Can set 'font-kerning' to the 'none' keyword: none
-PASS Setting 'font-kerning' to a length throws TypeError
-PASS Setting 'font-kerning' to a percent throws TypeError
-PASS Setting 'font-kerning' to a time throws TypeError
-PASS Setting 'font-kerning' to an angle throws TypeError
-PASS Setting 'font-kerning' to a flexible length throws TypeError
-PASS Setting 'font-kerning' to a number throws TypeError
-PASS Setting 'font-kerning' to a URL throws TypeError
-PASS Setting 'font-kerning' to a transform throws TypeError
+PASS Setting 'font-kerning' to a length: 0px throws TypeError
+PASS Setting 'font-kerning' to a length: -3.14em throws TypeError
+PASS Setting 'font-kerning' to a length: 3.14cm throws TypeError
+PASS Setting 'font-kerning' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-kerning' to a percent: 0% throws TypeError
+PASS Setting 'font-kerning' to a percent: -3.14% throws TypeError
+PASS Setting 'font-kerning' to a percent: 3.14% throws TypeError
+PASS Setting 'font-kerning' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-kerning' to a time: 0s throws TypeError
+PASS Setting 'font-kerning' to a time: -3.14ms throws TypeError
+PASS Setting 'font-kerning' to a time: 3.14s throws TypeError
+PASS Setting 'font-kerning' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-kerning' to an angle: 0deg throws TypeError
+PASS Setting 'font-kerning' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-kerning' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-kerning' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-kerning' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-kerning' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-kerning' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-kerning' to a number: 0 throws TypeError
+PASS Setting 'font-kerning' to a number: -3.14 throws TypeError
+PASS Setting 'font-kerning' to a number: 3.14 throws TypeError
+PASS Setting 'font-kerning' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-kerning' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-kerning' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-kerning' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-language-override-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-language-override-expected.txt
@@ -5,13 +5,31 @@ FAIL Can set 'font-language-override' to CSS-wide keywords: unset Invalid proper
 FAIL Can set 'font-language-override' to CSS-wide keywords: revert Invalid property font-language-override
 FAIL Can set 'font-language-override' to var() references:  var(--A) Invalid property font-language-override
 FAIL Can set 'font-language-override' to the 'normal' keyword: normal Invalid property font-language-override
-PASS Setting 'font-language-override' to a length throws TypeError
-PASS Setting 'font-language-override' to a percent throws TypeError
-PASS Setting 'font-language-override' to a time throws TypeError
-PASS Setting 'font-language-override' to an angle throws TypeError
-PASS Setting 'font-language-override' to a flexible length throws TypeError
-PASS Setting 'font-language-override' to a number throws TypeError
-PASS Setting 'font-language-override' to a URL throws TypeError
-PASS Setting 'font-language-override' to a transform throws TypeError
-FAIL 'font-language-override' does not supported '"SRB"' Invalid property font-language-override
+PASS Setting 'font-language-override' to a length: 0px throws TypeError
+PASS Setting 'font-language-override' to a length: -3.14em throws TypeError
+PASS Setting 'font-language-override' to a length: 3.14cm throws TypeError
+PASS Setting 'font-language-override' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-language-override' to a percent: 0% throws TypeError
+PASS Setting 'font-language-override' to a percent: -3.14% throws TypeError
+PASS Setting 'font-language-override' to a percent: 3.14% throws TypeError
+PASS Setting 'font-language-override' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-language-override' to a time: 0s throws TypeError
+PASS Setting 'font-language-override' to a time: -3.14ms throws TypeError
+PASS Setting 'font-language-override' to a time: 3.14s throws TypeError
+PASS Setting 'font-language-override' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-language-override' to an angle: 0deg throws TypeError
+PASS Setting 'font-language-override' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-language-override' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-language-override' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-language-override' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-language-override' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-language-override' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-language-override' to a number: 0 throws TypeError
+PASS Setting 'font-language-override' to a number: -3.14 throws TypeError
+PASS Setting 'font-language-override' to a number: 3.14 throws TypeError
+PASS Setting 'font-language-override' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-language-override' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-language-override' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-language-override' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'font-language-override' does not support '"SRB"' Invalid property font-language-override
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-optical-sizing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-optical-sizing-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'font-optical-sizing' to CSS-wide keywords: revert
 PASS Can set 'font-optical-sizing' to var() references:  var(--A)
 PASS Can set 'font-optical-sizing' to the 'auto' keyword: auto
 PASS Can set 'font-optical-sizing' to the 'none' keyword: none
-PASS Setting 'font-optical-sizing' to a length throws TypeError
-PASS Setting 'font-optical-sizing' to a percent throws TypeError
-PASS Setting 'font-optical-sizing' to a time throws TypeError
-PASS Setting 'font-optical-sizing' to an angle throws TypeError
-PASS Setting 'font-optical-sizing' to a flexible length throws TypeError
-PASS Setting 'font-optical-sizing' to a number throws TypeError
-PASS Setting 'font-optical-sizing' to a URL throws TypeError
-PASS Setting 'font-optical-sizing' to a transform throws TypeError
+PASS Setting 'font-optical-sizing' to a length: 0px throws TypeError
+PASS Setting 'font-optical-sizing' to a length: -3.14em throws TypeError
+PASS Setting 'font-optical-sizing' to a length: 3.14cm throws TypeError
+PASS Setting 'font-optical-sizing' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-optical-sizing' to a percent: 0% throws TypeError
+PASS Setting 'font-optical-sizing' to a percent: -3.14% throws TypeError
+PASS Setting 'font-optical-sizing' to a percent: 3.14% throws TypeError
+PASS Setting 'font-optical-sizing' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-optical-sizing' to a time: 0s throws TypeError
+PASS Setting 'font-optical-sizing' to a time: -3.14ms throws TypeError
+PASS Setting 'font-optical-sizing' to a time: 3.14s throws TypeError
+PASS Setting 'font-optical-sizing' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-optical-sizing' to an angle: 0deg throws TypeError
+PASS Setting 'font-optical-sizing' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-optical-sizing' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-optical-sizing' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-optical-sizing' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-optical-sizing' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-optical-sizing' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-optical-sizing' to a number: 0 throws TypeError
+PASS Setting 'font-optical-sizing' to a number: -3.14 throws TypeError
+PASS Setting 'font-optical-sizing' to a number: 3.14 throws TypeError
+PASS Setting 'font-optical-sizing' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-optical-sizing' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-optical-sizing' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-optical-sizing' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-palette-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-palette-expected.txt
@@ -7,13 +7,31 @@ PASS Can set 'font-palette' to var() references:  var(--A)
 PASS Can set 'font-palette' to the 'normal' keyword: normal
 PASS Can set 'font-palette' to the 'light' keyword: light
 PASS Can set 'font-palette' to the 'dark' keyword: dark
-PASS Setting 'font-palette' to a length throws TypeError
-PASS Setting 'font-palette' to a percent throws TypeError
-PASS Setting 'font-palette' to a time throws TypeError
-PASS Setting 'font-palette' to an angle throws TypeError
-PASS Setting 'font-palette' to a flexible length throws TypeError
-PASS Setting 'font-palette' to a number throws TypeError
-PASS Setting 'font-palette' to a URL throws TypeError
-PASS Setting 'font-palette' to a transform throws TypeError
-FAIL 'font-palette' does not supported 'Augusta' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS Setting 'font-palette' to a length: 0px throws TypeError
+PASS Setting 'font-palette' to a length: -3.14em throws TypeError
+PASS Setting 'font-palette' to a length: 3.14cm throws TypeError
+PASS Setting 'font-palette' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-palette' to a percent: 0% throws TypeError
+PASS Setting 'font-palette' to a percent: -3.14% throws TypeError
+PASS Setting 'font-palette' to a percent: 3.14% throws TypeError
+PASS Setting 'font-palette' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-palette' to a time: 0s throws TypeError
+PASS Setting 'font-palette' to a time: -3.14ms throws TypeError
+PASS Setting 'font-palette' to a time: 3.14s throws TypeError
+PASS Setting 'font-palette' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-palette' to an angle: 0deg throws TypeError
+PASS Setting 'font-palette' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-palette' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-palette' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-palette' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-palette' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-palette' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-palette' to a number: 0 throws TypeError
+PASS Setting 'font-palette' to a number: -3.14 throws TypeError
+PASS Setting 'font-palette' to a number: 3.14 throws TypeError
+PASS Setting 'font-palette' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-palette' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-palette' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-palette' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'font-palette' does not support 'Augusta' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-presentation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-presentation-expected.txt
@@ -7,12 +7,30 @@ FAIL Can set 'font-presentation' to var() references:  var(--A) Invalid property
 FAIL Can set 'font-presentation' to the 'auto' keyword: auto Invalid property font-presentation
 FAIL Can set 'font-presentation' to the 'text' keyword: text Invalid property font-presentation
 FAIL Can set 'font-presentation' to the 'emoji' keyword: emoji Invalid property font-presentation
-PASS Setting 'font-presentation' to a length throws TypeError
-PASS Setting 'font-presentation' to a percent throws TypeError
-PASS Setting 'font-presentation' to a time throws TypeError
-PASS Setting 'font-presentation' to an angle throws TypeError
-PASS Setting 'font-presentation' to a flexible length throws TypeError
-PASS Setting 'font-presentation' to a number throws TypeError
-PASS Setting 'font-presentation' to a URL throws TypeError
-PASS Setting 'font-presentation' to a transform throws TypeError
+PASS Setting 'font-presentation' to a length: 0px throws TypeError
+PASS Setting 'font-presentation' to a length: -3.14em throws TypeError
+PASS Setting 'font-presentation' to a length: 3.14cm throws TypeError
+PASS Setting 'font-presentation' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-presentation' to a percent: 0% throws TypeError
+PASS Setting 'font-presentation' to a percent: -3.14% throws TypeError
+PASS Setting 'font-presentation' to a percent: 3.14% throws TypeError
+PASS Setting 'font-presentation' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-presentation' to a time: 0s throws TypeError
+PASS Setting 'font-presentation' to a time: -3.14ms throws TypeError
+PASS Setting 'font-presentation' to a time: 3.14s throws TypeError
+PASS Setting 'font-presentation' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-presentation' to an angle: 0deg throws TypeError
+PASS Setting 'font-presentation' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-presentation' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-presentation' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-presentation' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-presentation' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-presentation' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-presentation' to a number: 0 throws TypeError
+PASS Setting 'font-presentation' to a number: -3.14 throws TypeError
+PASS Setting 'font-presentation' to a number: 3.14 throws TypeError
+PASS Setting 'font-presentation' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-presentation' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-presentation' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-presentation' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt
@@ -9,11 +9,26 @@ PASS Can set 'font-size-adjust' to a number: 0
 FAIL Can set 'font-size-adjust' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'font-size-adjust' to a number: 3.14
 PASS Can set 'font-size-adjust' to a number: calc(2 + 3)
-PASS Setting 'font-size-adjust' to a length throws TypeError
-PASS Setting 'font-size-adjust' to a percent throws TypeError
-PASS Setting 'font-size-adjust' to a time throws TypeError
-PASS Setting 'font-size-adjust' to an angle throws TypeError
-PASS Setting 'font-size-adjust' to a flexible length throws TypeError
-PASS Setting 'font-size-adjust' to a URL throws TypeError
-PASS Setting 'font-size-adjust' to a transform throws TypeError
+PASS Setting 'font-size-adjust' to a length: 0px throws TypeError
+PASS Setting 'font-size-adjust' to a length: -3.14em throws TypeError
+PASS Setting 'font-size-adjust' to a length: 3.14cm throws TypeError
+PASS Setting 'font-size-adjust' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-size-adjust' to a percent: 0% throws TypeError
+PASS Setting 'font-size-adjust' to a percent: -3.14% throws TypeError
+PASS Setting 'font-size-adjust' to a percent: 3.14% throws TypeError
+PASS Setting 'font-size-adjust' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-size-adjust' to a time: 0s throws TypeError
+PASS Setting 'font-size-adjust' to a time: -3.14ms throws TypeError
+PASS Setting 'font-size-adjust' to a time: 3.14s throws TypeError
+PASS Setting 'font-size-adjust' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-size-adjust' to an angle: 0deg throws TypeError
+PASS Setting 'font-size-adjust' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-size-adjust' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-size-adjust' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-size-adjust' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-size-adjust' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-size-adjust' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-size-adjust' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-size-adjust' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-size-adjust' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt
@@ -21,12 +21,24 @@ PASS Can set 'font-size' to a percent: 0%
 PASS Can set 'font-size' to a percent: -3.14%
 PASS Can set 'font-size' to a percent: 3.14%
 PASS Can set 'font-size' to a percent: calc(0% + 0%)
-PASS Setting 'font-size' to a time throws TypeError
-PASS Setting 'font-size' to an angle throws TypeError
-PASS Setting 'font-size' to a flexible length throws TypeError
-FAIL Setting 'font-size' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'font-size' to a URL throws TypeError
-PASS Setting 'font-size' to a transform throws TypeError
+PASS Setting 'font-size' to a time: 0s throws TypeError
+PASS Setting 'font-size' to a time: -3.14ms throws TypeError
+PASS Setting 'font-size' to a time: 3.14s throws TypeError
+PASS Setting 'font-size' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-size' to an angle: 0deg throws TypeError
+PASS Setting 'font-size' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-size' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-size' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-size' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-size' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-size' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'font-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'font-size' to a number: -3.14 throws TypeError
+PASS Setting 'font-size' to a number: 3.14 throws TypeError
+PASS Setting 'font-size' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-size' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-size' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-size' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'font-min-size' to CSS-wide keywords: initial Invalid property font-min-size
 FAIL Can set 'font-min-size' to CSS-wide keywords: inherit Invalid property font-min-size
 FAIL Can set 'font-min-size' to CSS-wide keywords: unset Invalid property font-min-size
@@ -49,12 +61,24 @@ FAIL Can set 'font-min-size' to a percent: 0% Invalid property font-min-size
 FAIL Can set 'font-min-size' to a percent: -3.14% Invalid property font-min-size
 FAIL Can set 'font-min-size' to a percent: 3.14% Invalid property font-min-size
 FAIL Can set 'font-min-size' to a percent: calc(0% + 0%) Invalid property font-min-size
-PASS Setting 'font-min-size' to a time throws TypeError
-PASS Setting 'font-min-size' to an angle throws TypeError
-PASS Setting 'font-min-size' to a flexible length throws TypeError
-PASS Setting 'font-min-size' to a number throws TypeError
-PASS Setting 'font-min-size' to a URL throws TypeError
-PASS Setting 'font-min-size' to a transform throws TypeError
+PASS Setting 'font-min-size' to a time: 0s throws TypeError
+PASS Setting 'font-min-size' to a time: -3.14ms throws TypeError
+PASS Setting 'font-min-size' to a time: 3.14s throws TypeError
+PASS Setting 'font-min-size' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-min-size' to an angle: 0deg throws TypeError
+PASS Setting 'font-min-size' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-min-size' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-min-size' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-min-size' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-min-size' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-min-size' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-min-size' to a number: 0 throws TypeError
+PASS Setting 'font-min-size' to a number: -3.14 throws TypeError
+PASS Setting 'font-min-size' to a number: 3.14 throws TypeError
+PASS Setting 'font-min-size' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-min-size' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-min-size' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-min-size' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'font-max-size' to CSS-wide keywords: initial Invalid property font-max-size
 FAIL Can set 'font-max-size' to CSS-wide keywords: inherit Invalid property font-max-size
 FAIL Can set 'font-max-size' to CSS-wide keywords: unset Invalid property font-max-size
@@ -78,10 +102,22 @@ FAIL Can set 'font-max-size' to a percent: 0% Invalid property font-max-size
 FAIL Can set 'font-max-size' to a percent: -3.14% Invalid property font-max-size
 FAIL Can set 'font-max-size' to a percent: 3.14% Invalid property font-max-size
 FAIL Can set 'font-max-size' to a percent: calc(0% + 0%) Invalid property font-max-size
-PASS Setting 'font-max-size' to a time throws TypeError
-PASS Setting 'font-max-size' to an angle throws TypeError
-PASS Setting 'font-max-size' to a flexible length throws TypeError
-PASS Setting 'font-max-size' to a number throws TypeError
-PASS Setting 'font-max-size' to a URL throws TypeError
-PASS Setting 'font-max-size' to a transform throws TypeError
+PASS Setting 'font-max-size' to a time: 0s throws TypeError
+PASS Setting 'font-max-size' to a time: -3.14ms throws TypeError
+PASS Setting 'font-max-size' to a time: 3.14s throws TypeError
+PASS Setting 'font-max-size' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-max-size' to an angle: 0deg throws TypeError
+PASS Setting 'font-max-size' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-max-size' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-max-size' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-max-size' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-max-size' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-max-size' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-max-size' to a number: 0 throws TypeError
+PASS Setting 'font-max-size' to a number: -3.14 throws TypeError
+PASS Setting 'font-max-size' to a number: 3.14 throws TypeError
+PASS Setting 'font-max-size' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-max-size' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-max-size' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-max-size' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt
@@ -17,11 +17,26 @@ PASS Can set 'font-stretch' to a percent: 0%
 FAIL Can set 'font-stretch' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 FAIL Can set 'font-stretch' to a percent: 3.14% assert_approx_equals: expected 3.14 +/- 0.000001 but got 3
 PASS Can set 'font-stretch' to a percent: calc(0% + 0%)
-PASS Setting 'font-stretch' to a length throws TypeError
-PASS Setting 'font-stretch' to a time throws TypeError
-PASS Setting 'font-stretch' to an angle throws TypeError
-PASS Setting 'font-stretch' to a flexible length throws TypeError
-PASS Setting 'font-stretch' to a number throws TypeError
-PASS Setting 'font-stretch' to a URL throws TypeError
-PASS Setting 'font-stretch' to a transform throws TypeError
+PASS Setting 'font-stretch' to a length: 0px throws TypeError
+PASS Setting 'font-stretch' to a length: -3.14em throws TypeError
+PASS Setting 'font-stretch' to a length: 3.14cm throws TypeError
+PASS Setting 'font-stretch' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-stretch' to a time: 0s throws TypeError
+PASS Setting 'font-stretch' to a time: -3.14ms throws TypeError
+PASS Setting 'font-stretch' to a time: 3.14s throws TypeError
+PASS Setting 'font-stretch' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-stretch' to an angle: 0deg throws TypeError
+PASS Setting 'font-stretch' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-stretch' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-stretch' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-stretch' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-stretch' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-stretch' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-stretch' to a number: 0 throws TypeError
+PASS Setting 'font-stretch' to a number: -3.14 throws TypeError
+PASS Setting 'font-stretch' to a number: 3.14 throws TypeError
+PASS Setting 'font-stretch' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-stretch' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-stretch' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-stretch' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-style-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'font-style' to var() references:  var(--A)
 PASS Can set 'font-style' to the 'normal' keyword: normal
 PASS Can set 'font-style' to the 'italic' keyword: italic
 PASS Can set 'font-style' to the 'oblique' keyword: oblique
-PASS Setting 'font-style' to a length throws TypeError
-PASS Setting 'font-style' to a percent throws TypeError
-PASS Setting 'font-style' to a time throws TypeError
-PASS Setting 'font-style' to an angle throws TypeError
-PASS Setting 'font-style' to a flexible length throws TypeError
-PASS Setting 'font-style' to a number throws TypeError
-PASS Setting 'font-style' to a URL throws TypeError
-PASS Setting 'font-style' to a transform throws TypeError
+PASS Setting 'font-style' to a length: 0px throws TypeError
+PASS Setting 'font-style' to a length: -3.14em throws TypeError
+PASS Setting 'font-style' to a length: 3.14cm throws TypeError
+PASS Setting 'font-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-style' to a percent: 0% throws TypeError
+PASS Setting 'font-style' to a percent: -3.14% throws TypeError
+PASS Setting 'font-style' to a percent: 3.14% throws TypeError
+PASS Setting 'font-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-style' to a time: 0s throws TypeError
+PASS Setting 'font-style' to a time: -3.14ms throws TypeError
+PASS Setting 'font-style' to a time: 3.14s throws TypeError
+PASS Setting 'font-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-style' to an angle: 0deg throws TypeError
+PASS Setting 'font-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-style' to a number: 0 throws TypeError
+PASS Setting 'font-style' to a number: -3.14 throws TypeError
+PASS Setting 'font-style' to a number: 3.14 throws TypeError
+PASS Setting 'font-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-synthesis-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-synthesis-expected.txt
@@ -6,14 +6,32 @@ PASS Can set 'font-synthesis-weight' to CSS-wide keywords: revert
 PASS Can set 'font-synthesis-weight' to var() references:  var(--A)
 PASS Can set 'font-synthesis-weight' to the 'auto' keyword: auto
 PASS Can set 'font-synthesis-weight' to the 'none' keyword: none
-PASS Setting 'font-synthesis-weight' to a length throws TypeError
-PASS Setting 'font-synthesis-weight' to a percent throws TypeError
-PASS Setting 'font-synthesis-weight' to a time throws TypeError
-PASS Setting 'font-synthesis-weight' to an angle throws TypeError
-PASS Setting 'font-synthesis-weight' to a flexible length throws TypeError
-PASS Setting 'font-synthesis-weight' to a number throws TypeError
-PASS Setting 'font-synthesis-weight' to a URL throws TypeError
-PASS Setting 'font-synthesis-weight' to a transform throws TypeError
+PASS Setting 'font-synthesis-weight' to a length: 0px throws TypeError
+PASS Setting 'font-synthesis-weight' to a length: -3.14em throws TypeError
+PASS Setting 'font-synthesis-weight' to a length: 3.14cm throws TypeError
+PASS Setting 'font-synthesis-weight' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-synthesis-weight' to a percent: 0% throws TypeError
+PASS Setting 'font-synthesis-weight' to a percent: -3.14% throws TypeError
+PASS Setting 'font-synthesis-weight' to a percent: 3.14% throws TypeError
+PASS Setting 'font-synthesis-weight' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-synthesis-weight' to a time: 0s throws TypeError
+PASS Setting 'font-synthesis-weight' to a time: -3.14ms throws TypeError
+PASS Setting 'font-synthesis-weight' to a time: 3.14s throws TypeError
+PASS Setting 'font-synthesis-weight' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-synthesis-weight' to an angle: 0deg throws TypeError
+PASS Setting 'font-synthesis-weight' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-synthesis-weight' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-synthesis-weight' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-synthesis-weight' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-synthesis-weight' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-synthesis-weight' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-synthesis-weight' to a number: 0 throws TypeError
+PASS Setting 'font-synthesis-weight' to a number: -3.14 throws TypeError
+PASS Setting 'font-synthesis-weight' to a number: 3.14 throws TypeError
+PASS Setting 'font-synthesis-weight' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-synthesis-weight' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-synthesis-weight' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-synthesis-weight' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'font-synthesis-style' to CSS-wide keywords: initial
 PASS Can set 'font-synthesis-style' to CSS-wide keywords: inherit
 PASS Can set 'font-synthesis-style' to CSS-wide keywords: unset
@@ -21,14 +39,32 @@ PASS Can set 'font-synthesis-style' to CSS-wide keywords: revert
 PASS Can set 'font-synthesis-style' to var() references:  var(--A)
 PASS Can set 'font-synthesis-style' to the 'auto' keyword: auto
 PASS Can set 'font-synthesis-style' to the 'none' keyword: none
-PASS Setting 'font-synthesis-style' to a length throws TypeError
-PASS Setting 'font-synthesis-style' to a percent throws TypeError
-PASS Setting 'font-synthesis-style' to a time throws TypeError
-PASS Setting 'font-synthesis-style' to an angle throws TypeError
-PASS Setting 'font-synthesis-style' to a flexible length throws TypeError
-PASS Setting 'font-synthesis-style' to a number throws TypeError
-PASS Setting 'font-synthesis-style' to a URL throws TypeError
-PASS Setting 'font-synthesis-style' to a transform throws TypeError
+PASS Setting 'font-synthesis-style' to a length: 0px throws TypeError
+PASS Setting 'font-synthesis-style' to a length: -3.14em throws TypeError
+PASS Setting 'font-synthesis-style' to a length: 3.14cm throws TypeError
+PASS Setting 'font-synthesis-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-synthesis-style' to a percent: 0% throws TypeError
+PASS Setting 'font-synthesis-style' to a percent: -3.14% throws TypeError
+PASS Setting 'font-synthesis-style' to a percent: 3.14% throws TypeError
+PASS Setting 'font-synthesis-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-synthesis-style' to a time: 0s throws TypeError
+PASS Setting 'font-synthesis-style' to a time: -3.14ms throws TypeError
+PASS Setting 'font-synthesis-style' to a time: 3.14s throws TypeError
+PASS Setting 'font-synthesis-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-synthesis-style' to an angle: 0deg throws TypeError
+PASS Setting 'font-synthesis-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-synthesis-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-synthesis-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-synthesis-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-synthesis-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-synthesis-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-synthesis-style' to a number: 0 throws TypeError
+PASS Setting 'font-synthesis-style' to a number: -3.14 throws TypeError
+PASS Setting 'font-synthesis-style' to a number: 3.14 throws TypeError
+PASS Setting 'font-synthesis-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-synthesis-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-synthesis-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-synthesis-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'font-synthesis-small-caps' to CSS-wide keywords: initial
 PASS Can set 'font-synthesis-small-caps' to CSS-wide keywords: inherit
 PASS Can set 'font-synthesis-small-caps' to CSS-wide keywords: unset
@@ -36,15 +72,33 @@ PASS Can set 'font-synthesis-small-caps' to CSS-wide keywords: revert
 PASS Can set 'font-synthesis-small-caps' to var() references:  var(--A)
 PASS Can set 'font-synthesis-small-caps' to the 'auto' keyword: auto
 PASS Can set 'font-synthesis-small-caps' to the 'none' keyword: none
-PASS Setting 'font-synthesis-small-caps' to a length throws TypeError
-PASS Setting 'font-synthesis-small-caps' to a percent throws TypeError
-PASS Setting 'font-synthesis-small-caps' to a time throws TypeError
-PASS Setting 'font-synthesis-small-caps' to an angle throws TypeError
-PASS Setting 'font-synthesis-small-caps' to a flexible length throws TypeError
-PASS Setting 'font-synthesis-small-caps' to a number throws TypeError
-PASS Setting 'font-synthesis-small-caps' to a URL throws TypeError
-PASS Setting 'font-synthesis-small-caps' to a transform throws TypeError
-PASS 'font-synthesis' does not supported 'weight style'
-PASS 'font-synthesis' does not supported 'style small-caps'
-PASS 'font-synthesis' does not supported 'small-caps weight style'
+PASS Setting 'font-synthesis-small-caps' to a length: 0px throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a length: -3.14em throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a length: 3.14cm throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a percent: 0% throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a percent: -3.14% throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a percent: 3.14% throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a time: 0s throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a time: -3.14ms throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a time: 3.14s throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-synthesis-small-caps' to an angle: 0deg throws TypeError
+PASS Setting 'font-synthesis-small-caps' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-synthesis-small-caps' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-synthesis-small-caps' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a number: 0 throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a number: -3.14 throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a number: 3.14 throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-synthesis-small-caps' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'font-synthesis' does not support 'weight style'
+PASS 'font-synthesis' does not support 'style small-caps'
+PASS 'font-synthesis' does not support 'small-caps weight style'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-alternates-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-alternates-expected.txt
@@ -6,19 +6,37 @@ PASS Can set 'font-variant-alternates' to CSS-wide keywords: revert
 PASS Can set 'font-variant-alternates' to var() references:  var(--A)
 PASS Can set 'font-variant-alternates' to the 'normal' keyword: normal
 FAIL Can set 'font-variant-alternates' to the 'historical-forms' keyword: historical-forms assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-PASS Setting 'font-variant-alternates' to a length throws TypeError
-PASS Setting 'font-variant-alternates' to a percent throws TypeError
-PASS Setting 'font-variant-alternates' to a time throws TypeError
-PASS Setting 'font-variant-alternates' to an angle throws TypeError
-PASS Setting 'font-variant-alternates' to a flexible length throws TypeError
-PASS Setting 'font-variant-alternates' to a number throws TypeError
-PASS Setting 'font-variant-alternates' to a URL throws TypeError
-PASS Setting 'font-variant-alternates' to a transform throws TypeError
-PASS 'font-variant-alternates' does not supported 'stylistic(foo)'
-PASS 'font-variant-alternates' does not supported 'styleset(foo)'
-PASS 'font-variant-alternates' does not supported 'character-variant(foo)'
-PASS 'font-variant-alternates' does not supported 'swash(foo)'
-PASS 'font-variant-alternates' does not supported 'ornaments(foo)'
-PASS 'font-variant-alternates' does not supported 'annotation(foo)'
-PASS 'font-variant-alternates' does not supported 'swash(foo) annotation(foo2)'
+PASS Setting 'font-variant-alternates' to a length: 0px throws TypeError
+PASS Setting 'font-variant-alternates' to a length: -3.14em throws TypeError
+PASS Setting 'font-variant-alternates' to a length: 3.14cm throws TypeError
+PASS Setting 'font-variant-alternates' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-variant-alternates' to a percent: 0% throws TypeError
+PASS Setting 'font-variant-alternates' to a percent: -3.14% throws TypeError
+PASS Setting 'font-variant-alternates' to a percent: 3.14% throws TypeError
+PASS Setting 'font-variant-alternates' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-variant-alternates' to a time: 0s throws TypeError
+PASS Setting 'font-variant-alternates' to a time: -3.14ms throws TypeError
+PASS Setting 'font-variant-alternates' to a time: 3.14s throws TypeError
+PASS Setting 'font-variant-alternates' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-variant-alternates' to an angle: 0deg throws TypeError
+PASS Setting 'font-variant-alternates' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-variant-alternates' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-variant-alternates' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-variant-alternates' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-variant-alternates' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-variant-alternates' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-variant-alternates' to a number: 0 throws TypeError
+PASS Setting 'font-variant-alternates' to a number: -3.14 throws TypeError
+PASS Setting 'font-variant-alternates' to a number: 3.14 throws TypeError
+PASS Setting 'font-variant-alternates' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-variant-alternates' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-variant-alternates' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-variant-alternates' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'font-variant-alternates' does not support 'stylistic(foo)'
+PASS 'font-variant-alternates' does not support 'styleset(foo)'
+PASS 'font-variant-alternates' does not support 'character-variant(foo)'
+PASS 'font-variant-alternates' does not support 'swash(foo)'
+PASS 'font-variant-alternates' does not support 'ornaments(foo)'
+PASS 'font-variant-alternates' does not support 'annotation(foo)'
+PASS 'font-variant-alternates' does not support 'swash(foo) annotation(foo2)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-caps-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-caps-expected.txt
@@ -11,12 +11,30 @@ PASS Can set 'font-variant-caps' to the 'petite-caps' keyword: petite-caps
 PASS Can set 'font-variant-caps' to the 'all-petite-caps' keyword: all-petite-caps
 PASS Can set 'font-variant-caps' to the 'unicase' keyword: unicase
 PASS Can set 'font-variant-caps' to the 'titling-caps' keyword: titling-caps
-PASS Setting 'font-variant-caps' to a length throws TypeError
-PASS Setting 'font-variant-caps' to a percent throws TypeError
-PASS Setting 'font-variant-caps' to a time throws TypeError
-PASS Setting 'font-variant-caps' to an angle throws TypeError
-PASS Setting 'font-variant-caps' to a flexible length throws TypeError
-PASS Setting 'font-variant-caps' to a number throws TypeError
-PASS Setting 'font-variant-caps' to a URL throws TypeError
-PASS Setting 'font-variant-caps' to a transform throws TypeError
+PASS Setting 'font-variant-caps' to a length: 0px throws TypeError
+PASS Setting 'font-variant-caps' to a length: -3.14em throws TypeError
+PASS Setting 'font-variant-caps' to a length: 3.14cm throws TypeError
+PASS Setting 'font-variant-caps' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-variant-caps' to a percent: 0% throws TypeError
+PASS Setting 'font-variant-caps' to a percent: -3.14% throws TypeError
+PASS Setting 'font-variant-caps' to a percent: 3.14% throws TypeError
+PASS Setting 'font-variant-caps' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-variant-caps' to a time: 0s throws TypeError
+PASS Setting 'font-variant-caps' to a time: -3.14ms throws TypeError
+PASS Setting 'font-variant-caps' to a time: 3.14s throws TypeError
+PASS Setting 'font-variant-caps' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-variant-caps' to an angle: 0deg throws TypeError
+PASS Setting 'font-variant-caps' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-variant-caps' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-variant-caps' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-variant-caps' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-variant-caps' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-variant-caps' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-variant-caps' to a number: 0 throws TypeError
+PASS Setting 'font-variant-caps' to a number: -3.14 throws TypeError
+PASS Setting 'font-variant-caps' to a number: 3.14 throws TypeError
+PASS Setting 'font-variant-caps' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-variant-caps' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-variant-caps' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-variant-caps' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-east-asian-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-east-asian-expected.txt
@@ -14,14 +14,32 @@ PASS Can set 'font-variant-east-asian' to the 'traditional' keyword: traditional
 PASS Can set 'font-variant-east-asian' to the 'full-width' keyword: full-width
 PASS Can set 'font-variant-east-asian' to the 'proportional-width' keyword: proportional-width
 PASS Can set 'font-variant-east-asian' to the 'ruby' keyword: ruby
-PASS Setting 'font-variant-east-asian' to a length throws TypeError
-PASS Setting 'font-variant-east-asian' to a percent throws TypeError
-PASS Setting 'font-variant-east-asian' to a time throws TypeError
-PASS Setting 'font-variant-east-asian' to an angle throws TypeError
-PASS Setting 'font-variant-east-asian' to a flexible length throws TypeError
-PASS Setting 'font-variant-east-asian' to a number throws TypeError
-PASS Setting 'font-variant-east-asian' to a URL throws TypeError
-PASS Setting 'font-variant-east-asian' to a transform throws TypeError
-FAIL 'font-variant-east-asian' does not supported 'jis78 full-width' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'font-variant-east-asian' does not supported 'traditional proportional-width ruby' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'font-variant-east-asian' to a length: 0px throws TypeError
+PASS Setting 'font-variant-east-asian' to a length: -3.14em throws TypeError
+PASS Setting 'font-variant-east-asian' to a length: 3.14cm throws TypeError
+PASS Setting 'font-variant-east-asian' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-variant-east-asian' to a percent: 0% throws TypeError
+PASS Setting 'font-variant-east-asian' to a percent: -3.14% throws TypeError
+PASS Setting 'font-variant-east-asian' to a percent: 3.14% throws TypeError
+PASS Setting 'font-variant-east-asian' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-variant-east-asian' to a time: 0s throws TypeError
+PASS Setting 'font-variant-east-asian' to a time: -3.14ms throws TypeError
+PASS Setting 'font-variant-east-asian' to a time: 3.14s throws TypeError
+PASS Setting 'font-variant-east-asian' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-variant-east-asian' to an angle: 0deg throws TypeError
+PASS Setting 'font-variant-east-asian' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-variant-east-asian' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-variant-east-asian' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-variant-east-asian' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-variant-east-asian' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-variant-east-asian' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-variant-east-asian' to a number: 0 throws TypeError
+PASS Setting 'font-variant-east-asian' to a number: -3.14 throws TypeError
+PASS Setting 'font-variant-east-asian' to a number: 3.14 throws TypeError
+PASS Setting 'font-variant-east-asian' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-variant-east-asian' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-variant-east-asian' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-variant-east-asian' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'font-variant-east-asian' does not support 'jis78 full-width' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'font-variant-east-asian' does not support 'traditional proportional-width ruby' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-emoji-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-emoji-expected.txt
@@ -7,12 +7,30 @@ FAIL Can set 'font-variant-emoji' to var() references:  var(--A) Invalid propert
 FAIL Can set 'font-variant-emoji' to the 'auto' keyword: auto Invalid property font-variant-emoji
 FAIL Can set 'font-variant-emoji' to the 'text' keyword: text Invalid property font-variant-emoji
 FAIL Can set 'font-variant-emoji' to the 'emoji' keyword: emoji Invalid property font-variant-emoji
-PASS Setting 'font-variant-emoji' to a length throws TypeError
-PASS Setting 'font-variant-emoji' to a percent throws TypeError
-PASS Setting 'font-variant-emoji' to a time throws TypeError
-PASS Setting 'font-variant-emoji' to an angle throws TypeError
-PASS Setting 'font-variant-emoji' to a flexible length throws TypeError
-PASS Setting 'font-variant-emoji' to a number throws TypeError
-PASS Setting 'font-variant-emoji' to a URL throws TypeError
-PASS Setting 'font-variant-emoji' to a transform throws TypeError
+PASS Setting 'font-variant-emoji' to a length: 0px throws TypeError
+PASS Setting 'font-variant-emoji' to a length: -3.14em throws TypeError
+PASS Setting 'font-variant-emoji' to a length: 3.14cm throws TypeError
+PASS Setting 'font-variant-emoji' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-variant-emoji' to a percent: 0% throws TypeError
+PASS Setting 'font-variant-emoji' to a percent: -3.14% throws TypeError
+PASS Setting 'font-variant-emoji' to a percent: 3.14% throws TypeError
+PASS Setting 'font-variant-emoji' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-variant-emoji' to a time: 0s throws TypeError
+PASS Setting 'font-variant-emoji' to a time: -3.14ms throws TypeError
+PASS Setting 'font-variant-emoji' to a time: 3.14s throws TypeError
+PASS Setting 'font-variant-emoji' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-variant-emoji' to an angle: 0deg throws TypeError
+PASS Setting 'font-variant-emoji' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-variant-emoji' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-variant-emoji' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-variant-emoji' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-variant-emoji' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-variant-emoji' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-variant-emoji' to a number: 0 throws TypeError
+PASS Setting 'font-variant-emoji' to a number: -3.14 throws TypeError
+PASS Setting 'font-variant-emoji' to a number: 3.14 throws TypeError
+PASS Setting 'font-variant-emoji' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-variant-emoji' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-variant-emoji' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-variant-emoji' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-expected.txt
@@ -1,6 +1,6 @@
 
-PASS 'font-variant' does not supported 'normal'
-PASS 'font-variant' does not supported 'no-common-ligatures proportional-nums'
-PASS 'font-variant' does not supported 'common-ligatures tabular-nums'
-PASS 'font-variant' does not supported 'small-caps slashed-zero'
+PASS 'font-variant' does not support 'normal'
+PASS 'font-variant' does not support 'no-common-ligatures proportional-nums'
+PASS 'font-variant' does not support 'common-ligatures tabular-nums'
+PASS 'font-variant' does not support 'small-caps slashed-zero'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-ligatures-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-ligatures-expected.txt
@@ -14,14 +14,32 @@ PASS Can set 'font-variant-ligatures' to the 'historical-ligatures' keyword: his
 PASS Can set 'font-variant-ligatures' to the 'no-historical-ligatures' keyword: no-historical-ligatures
 PASS Can set 'font-variant-ligatures' to the 'contextual' keyword: contextual
 PASS Can set 'font-variant-ligatures' to the 'no-contextual' keyword: no-contextual
-PASS Setting 'font-variant-ligatures' to a length throws TypeError
-PASS Setting 'font-variant-ligatures' to a percent throws TypeError
-PASS Setting 'font-variant-ligatures' to a time throws TypeError
-PASS Setting 'font-variant-ligatures' to an angle throws TypeError
-PASS Setting 'font-variant-ligatures' to a flexible length throws TypeError
-PASS Setting 'font-variant-ligatures' to a number throws TypeError
-PASS Setting 'font-variant-ligatures' to a URL throws TypeError
-PASS Setting 'font-variant-ligatures' to a transform throws TypeError
-FAIL 'font-variant-ligatures' does not supported 'common-ligatures contextual' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'font-variant-ligatures' does not supported 'no-common-ligatures discretionary-ligatures no-historical-ligatures no-contextual' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'font-variant-ligatures' to a length: 0px throws TypeError
+PASS Setting 'font-variant-ligatures' to a length: -3.14em throws TypeError
+PASS Setting 'font-variant-ligatures' to a length: 3.14cm throws TypeError
+PASS Setting 'font-variant-ligatures' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-variant-ligatures' to a percent: 0% throws TypeError
+PASS Setting 'font-variant-ligatures' to a percent: -3.14% throws TypeError
+PASS Setting 'font-variant-ligatures' to a percent: 3.14% throws TypeError
+PASS Setting 'font-variant-ligatures' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-variant-ligatures' to a time: 0s throws TypeError
+PASS Setting 'font-variant-ligatures' to a time: -3.14ms throws TypeError
+PASS Setting 'font-variant-ligatures' to a time: 3.14s throws TypeError
+PASS Setting 'font-variant-ligatures' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-variant-ligatures' to an angle: 0deg throws TypeError
+PASS Setting 'font-variant-ligatures' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-variant-ligatures' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-variant-ligatures' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-variant-ligatures' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-variant-ligatures' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-variant-ligatures' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-variant-ligatures' to a number: 0 throws TypeError
+PASS Setting 'font-variant-ligatures' to a number: -3.14 throws TypeError
+PASS Setting 'font-variant-ligatures' to a number: 3.14 throws TypeError
+PASS Setting 'font-variant-ligatures' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-variant-ligatures' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-variant-ligatures' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-variant-ligatures' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'font-variant-ligatures' does not support 'common-ligatures contextual' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'font-variant-ligatures' does not support 'no-common-ligatures discretionary-ligatures no-historical-ligatures no-contextual' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-numeric-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-numeric-expected.txt
@@ -13,14 +13,32 @@ PASS Can set 'font-variant-numeric' to the 'diagonal-fractions' keyword: diagona
 PASS Can set 'font-variant-numeric' to the 'stacked-fractions' keyword: stacked-fractions
 PASS Can set 'font-variant-numeric' to the 'ordinal' keyword: ordinal
 PASS Can set 'font-variant-numeric' to the 'slashed-zero' keyword: slashed-zero
-PASS Setting 'font-variant-numeric' to a length throws TypeError
-PASS Setting 'font-variant-numeric' to a percent throws TypeError
-PASS Setting 'font-variant-numeric' to a time throws TypeError
-PASS Setting 'font-variant-numeric' to an angle throws TypeError
-PASS Setting 'font-variant-numeric' to a flexible length throws TypeError
-PASS Setting 'font-variant-numeric' to a number throws TypeError
-PASS Setting 'font-variant-numeric' to a URL throws TypeError
-PASS Setting 'font-variant-numeric' to a transform throws TypeError
-FAIL 'font-variant-numeric' does not supported 'lining-nums ordinal' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'font-variant-numeric' does not supported 'oldstyle-nums tabular-nums stacked-fractions ordinal slashed-zero' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'font-variant-numeric' to a length: 0px throws TypeError
+PASS Setting 'font-variant-numeric' to a length: -3.14em throws TypeError
+PASS Setting 'font-variant-numeric' to a length: 3.14cm throws TypeError
+PASS Setting 'font-variant-numeric' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-variant-numeric' to a percent: 0% throws TypeError
+PASS Setting 'font-variant-numeric' to a percent: -3.14% throws TypeError
+PASS Setting 'font-variant-numeric' to a percent: 3.14% throws TypeError
+PASS Setting 'font-variant-numeric' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-variant-numeric' to a time: 0s throws TypeError
+PASS Setting 'font-variant-numeric' to a time: -3.14ms throws TypeError
+PASS Setting 'font-variant-numeric' to a time: 3.14s throws TypeError
+PASS Setting 'font-variant-numeric' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-variant-numeric' to an angle: 0deg throws TypeError
+PASS Setting 'font-variant-numeric' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-variant-numeric' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-variant-numeric' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-variant-numeric' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-variant-numeric' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-variant-numeric' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-variant-numeric' to a number: 0 throws TypeError
+PASS Setting 'font-variant-numeric' to a number: -3.14 throws TypeError
+PASS Setting 'font-variant-numeric' to a number: 3.14 throws TypeError
+PASS Setting 'font-variant-numeric' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-variant-numeric' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-variant-numeric' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-variant-numeric' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'font-variant-numeric' does not support 'lining-nums ordinal' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'font-variant-numeric' does not support 'oldstyle-nums tabular-nums stacked-fractions ordinal slashed-zero' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variation-settings-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variation-settings-expected.txt
@@ -5,13 +5,31 @@ PASS Can set 'font-variation-settings' to CSS-wide keywords: unset
 PASS Can set 'font-variation-settings' to CSS-wide keywords: revert
 PASS Can set 'font-variation-settings' to var() references:  var(--A)
 PASS Can set 'font-variation-settings' to the 'normal' keyword: normal
-PASS Setting 'font-variation-settings' to a length throws TypeError
-PASS Setting 'font-variation-settings' to a percent throws TypeError
-PASS Setting 'font-variation-settings' to a time throws TypeError
-PASS Setting 'font-variation-settings' to an angle throws TypeError
-PASS Setting 'font-variation-settings' to a flexible length throws TypeError
-PASS Setting 'font-variation-settings' to a number throws TypeError
-PASS Setting 'font-variation-settings' to a URL throws TypeError
-PASS Setting 'font-variation-settings' to a transform throws TypeError
-PASS 'font-variation-settings' does not supported '"XHGT" 0.7'
+PASS Setting 'font-variation-settings' to a length: 0px throws TypeError
+PASS Setting 'font-variation-settings' to a length: -3.14em throws TypeError
+PASS Setting 'font-variation-settings' to a length: 3.14cm throws TypeError
+PASS Setting 'font-variation-settings' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-variation-settings' to a percent: 0% throws TypeError
+PASS Setting 'font-variation-settings' to a percent: -3.14% throws TypeError
+PASS Setting 'font-variation-settings' to a percent: 3.14% throws TypeError
+PASS Setting 'font-variation-settings' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-variation-settings' to a time: 0s throws TypeError
+PASS Setting 'font-variation-settings' to a time: -3.14ms throws TypeError
+PASS Setting 'font-variation-settings' to a time: 3.14s throws TypeError
+PASS Setting 'font-variation-settings' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-variation-settings' to an angle: 0deg throws TypeError
+PASS Setting 'font-variation-settings' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-variation-settings' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-variation-settings' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-variation-settings' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-variation-settings' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-variation-settings' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-variation-settings' to a number: 0 throws TypeError
+PASS Setting 'font-variation-settings' to a number: -3.14 throws TypeError
+PASS Setting 'font-variation-settings' to a number: 3.14 throws TypeError
+PASS Setting 'font-variation-settings' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'font-variation-settings' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-variation-settings' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-variation-settings' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'font-variation-settings' does not support '"XHGT" 0.7'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt
@@ -12,11 +12,26 @@ FAIL Can set 'font-weight' to a number: 0 assert_equals: expected "CSSUnitValue"
 FAIL Can set 'font-weight' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 FAIL Can set 'font-weight' to a number: 3.14 assert_approx_equals: expected 3.14 +/- 0.000001 but got 3
 PASS Can set 'font-weight' to a number: calc(2 + 3)
-PASS Setting 'font-weight' to a length throws TypeError
-PASS Setting 'font-weight' to a percent throws TypeError
-PASS Setting 'font-weight' to a time throws TypeError
-PASS Setting 'font-weight' to an angle throws TypeError
-PASS Setting 'font-weight' to a flexible length throws TypeError
-PASS Setting 'font-weight' to a URL throws TypeError
-PASS Setting 'font-weight' to a transform throws TypeError
+PASS Setting 'font-weight' to a length: 0px throws TypeError
+PASS Setting 'font-weight' to a length: -3.14em throws TypeError
+PASS Setting 'font-weight' to a length: 3.14cm throws TypeError
+PASS Setting 'font-weight' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'font-weight' to a percent: 0% throws TypeError
+PASS Setting 'font-weight' to a percent: -3.14% throws TypeError
+PASS Setting 'font-weight' to a percent: 3.14% throws TypeError
+PASS Setting 'font-weight' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'font-weight' to a time: 0s throws TypeError
+PASS Setting 'font-weight' to a time: -3.14ms throws TypeError
+PASS Setting 'font-weight' to a time: 3.14s throws TypeError
+PASS Setting 'font-weight' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'font-weight' to an angle: 0deg throws TypeError
+PASS Setting 'font-weight' to an angle: 3.14rad throws TypeError
+PASS Setting 'font-weight' to an angle: -3.14deg throws TypeError
+PASS Setting 'font-weight' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'font-weight' to a flexible length: 0fr throws TypeError
+PASS Setting 'font-weight' to a flexible length: 1fr throws TypeError
+PASS Setting 'font-weight' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'font-weight' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'font-weight' to a transform: perspective(10em) throws TypeError
+PASS Setting 'font-weight' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt
@@ -13,12 +13,24 @@ PASS Can set 'column-gap' to a percent: 0%
 FAIL Can set 'column-gap' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'column-gap' to a percent: 3.14%
 PASS Can set 'column-gap' to a percent: calc(0% + 0%)
-PASS Setting 'column-gap' to a time throws TypeError
-PASS Setting 'column-gap' to an angle throws TypeError
-PASS Setting 'column-gap' to a flexible length throws TypeError
-FAIL Setting 'column-gap' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'column-gap' to a URL throws TypeError
-PASS Setting 'column-gap' to a transform throws TypeError
+PASS Setting 'column-gap' to a time: 0s throws TypeError
+PASS Setting 'column-gap' to a time: -3.14ms throws TypeError
+PASS Setting 'column-gap' to a time: 3.14s throws TypeError
+PASS Setting 'column-gap' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'column-gap' to an angle: 0deg throws TypeError
+PASS Setting 'column-gap' to an angle: 3.14rad throws TypeError
+PASS Setting 'column-gap' to an angle: -3.14deg throws TypeError
+PASS Setting 'column-gap' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'column-gap' to a flexible length: 0fr throws TypeError
+PASS Setting 'column-gap' to a flexible length: 1fr throws TypeError
+PASS Setting 'column-gap' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'column-gap' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'column-gap' to a number: -3.14 throws TypeError
+PASS Setting 'column-gap' to a number: 3.14 throws TypeError
+PASS Setting 'column-gap' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'column-gap' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'column-gap' to a transform: perspective(10em) throws TypeError
+PASS Setting 'column-gap' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'row-gap' to CSS-wide keywords: initial
 PASS Can set 'row-gap' to CSS-wide keywords: inherit
 PASS Can set 'row-gap' to CSS-wide keywords: unset
@@ -33,10 +45,22 @@ PASS Can set 'row-gap' to a percent: 0%
 FAIL Can set 'row-gap' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'row-gap' to a percent: 3.14%
 PASS Can set 'row-gap' to a percent: calc(0% + 0%)
-PASS Setting 'row-gap' to a time throws TypeError
-PASS Setting 'row-gap' to an angle throws TypeError
-PASS Setting 'row-gap' to a flexible length throws TypeError
-FAIL Setting 'row-gap' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'row-gap' to a URL throws TypeError
-PASS Setting 'row-gap' to a transform throws TypeError
+PASS Setting 'row-gap' to a time: 0s throws TypeError
+PASS Setting 'row-gap' to a time: -3.14ms throws TypeError
+PASS Setting 'row-gap' to a time: 3.14s throws TypeError
+PASS Setting 'row-gap' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'row-gap' to an angle: 0deg throws TypeError
+PASS Setting 'row-gap' to an angle: 3.14rad throws TypeError
+PASS Setting 'row-gap' to an angle: -3.14deg throws TypeError
+PASS Setting 'row-gap' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'row-gap' to a flexible length: 0fr throws TypeError
+PASS Setting 'row-gap' to a flexible length: 1fr throws TypeError
+PASS Setting 'row-gap' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'row-gap' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'row-gap' to a number: -3.14 throws TypeError
+PASS Setting 'row-gap' to a number: 3.14 throws TypeError
+PASS Setting 'row-gap' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'row-gap' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'row-gap' to a transform: perspective(10em) throws TypeError
+PASS Setting 'row-gap' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-area-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-area-expected.txt
@@ -1,9 +1,9 @@
 
-PASS 'grid-area' does not supported 'a'
-PASS 'grid-area' does not supported 'a / a'
-PASS 'grid-area' does not supported 'auto'
-PASS 'grid-area' does not supported 'auto / auto'
-PASS 'grid-area' does not supported '2 / 1 / 2'
-PASS 'grid-area' does not supported 'span 3'
-PASS 'grid-area' does not supported '2 span / a span'
+PASS 'grid-area' does not support 'a'
+PASS 'grid-area' does not support 'a / a'
+PASS 'grid-area' does not support 'auto'
+PASS 'grid-area' does not support 'auto / auto'
+PASS 'grid-area' does not support '2 / 1 / 2'
+PASS 'grid-area' does not support 'span 3'
+PASS 'grid-area' does not support '2 span / a span'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
@@ -18,13 +18,23 @@ PASS Can set 'grid-auto-columns' to a percent: calc(0% + 0%)
 PASS Can set 'grid-auto-columns' to a flexible length: 0fr
 PASS Can set 'grid-auto-columns' to a flexible length: 1fr
 FAIL Can set 'grid-auto-columns' to a flexible length: -3.14fr Invalid values
-PASS Setting 'grid-auto-columns' to a time throws TypeError
-PASS Setting 'grid-auto-columns' to an angle throws TypeError
-FAIL Setting 'grid-auto-columns' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'grid-auto-columns' to a URL throws TypeError
-PASS Setting 'grid-auto-columns' to a transform throws TypeError
-PASS 'grid-auto-columns' does not supported 'minmax(100px, auto)'
-PASS 'grid-auto-columns' does not supported 'fit-content(400px)'
+PASS Setting 'grid-auto-columns' to a time: 0s throws TypeError
+PASS Setting 'grid-auto-columns' to a time: -3.14ms throws TypeError
+PASS Setting 'grid-auto-columns' to a time: 3.14s throws TypeError
+PASS Setting 'grid-auto-columns' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'grid-auto-columns' to an angle: 0deg throws TypeError
+PASS Setting 'grid-auto-columns' to an angle: 3.14rad throws TypeError
+PASS Setting 'grid-auto-columns' to an angle: -3.14deg throws TypeError
+PASS Setting 'grid-auto-columns' to an angle: calc(0rad + 0deg) throws TypeError
+FAIL Setting 'grid-auto-columns' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-auto-columns' to a number: -3.14 throws TypeError
+PASS Setting 'grid-auto-columns' to a number: 3.14 throws TypeError
+PASS Setting 'grid-auto-columns' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'grid-auto-columns' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'grid-auto-columns' to a transform: perspective(10em) throws TypeError
+PASS Setting 'grid-auto-columns' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'grid-auto-columns' does not support 'minmax(100px, auto)'
+PASS 'grid-auto-columns' does not support 'fit-content(400px)'
 PASS Can set 'grid-auto-rows' to CSS-wide keywords: initial
 PASS Can set 'grid-auto-rows' to CSS-wide keywords: inherit
 PASS Can set 'grid-auto-rows' to CSS-wide keywords: unset
@@ -44,11 +54,21 @@ PASS Can set 'grid-auto-rows' to a percent: calc(0% + 0%)
 PASS Can set 'grid-auto-rows' to a flexible length: 0fr
 PASS Can set 'grid-auto-rows' to a flexible length: 1fr
 FAIL Can set 'grid-auto-rows' to a flexible length: -3.14fr Invalid values
-PASS Setting 'grid-auto-rows' to a time throws TypeError
-PASS Setting 'grid-auto-rows' to an angle throws TypeError
-FAIL Setting 'grid-auto-rows' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'grid-auto-rows' to a URL throws TypeError
-PASS Setting 'grid-auto-rows' to a transform throws TypeError
-PASS 'grid-auto-rows' does not supported 'minmax(100px, auto)'
-PASS 'grid-auto-rows' does not supported 'fit-content(400px)'
+PASS Setting 'grid-auto-rows' to a time: 0s throws TypeError
+PASS Setting 'grid-auto-rows' to a time: -3.14ms throws TypeError
+PASS Setting 'grid-auto-rows' to a time: 3.14s throws TypeError
+PASS Setting 'grid-auto-rows' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'grid-auto-rows' to an angle: 0deg throws TypeError
+PASS Setting 'grid-auto-rows' to an angle: 3.14rad throws TypeError
+PASS Setting 'grid-auto-rows' to an angle: -3.14deg throws TypeError
+PASS Setting 'grid-auto-rows' to an angle: calc(0rad + 0deg) throws TypeError
+FAIL Setting 'grid-auto-rows' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-auto-rows' to a number: -3.14 throws TypeError
+PASS Setting 'grid-auto-rows' to a number: 3.14 throws TypeError
+PASS Setting 'grid-auto-rows' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'grid-auto-rows' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'grid-auto-rows' to a transform: perspective(10em) throws TypeError
+PASS Setting 'grid-auto-rows' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'grid-auto-rows' does not support 'minmax(100px, auto)'
+PASS 'grid-auto-rows' does not support 'fit-content(400px)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-flow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-flow-expected.txt
@@ -6,13 +6,31 @@ PASS Can set 'grid-auto-flow' to CSS-wide keywords: revert
 PASS Can set 'grid-auto-flow' to var() references:  var(--A)
 PASS Can set 'grid-auto-flow' to the 'row' keyword: row
 PASS Can set 'grid-auto-flow' to the 'column' keyword: column
-PASS Setting 'grid-auto-flow' to a length throws TypeError
-PASS Setting 'grid-auto-flow' to a percent throws TypeError
-PASS Setting 'grid-auto-flow' to a time throws TypeError
-PASS Setting 'grid-auto-flow' to an angle throws TypeError
-PASS Setting 'grid-auto-flow' to a flexible length throws TypeError
-PASS Setting 'grid-auto-flow' to a number throws TypeError
-PASS Setting 'grid-auto-flow' to a URL throws TypeError
-PASS Setting 'grid-auto-flow' to a transform throws TypeError
-FAIL 'grid-auto-flow' does not supported 'column dense' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'grid-auto-flow' to a length: 0px throws TypeError
+PASS Setting 'grid-auto-flow' to a length: -3.14em throws TypeError
+PASS Setting 'grid-auto-flow' to a length: 3.14cm throws TypeError
+PASS Setting 'grid-auto-flow' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'grid-auto-flow' to a percent: 0% throws TypeError
+PASS Setting 'grid-auto-flow' to a percent: -3.14% throws TypeError
+PASS Setting 'grid-auto-flow' to a percent: 3.14% throws TypeError
+PASS Setting 'grid-auto-flow' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'grid-auto-flow' to a time: 0s throws TypeError
+PASS Setting 'grid-auto-flow' to a time: -3.14ms throws TypeError
+PASS Setting 'grid-auto-flow' to a time: 3.14s throws TypeError
+PASS Setting 'grid-auto-flow' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'grid-auto-flow' to an angle: 0deg throws TypeError
+PASS Setting 'grid-auto-flow' to an angle: 3.14rad throws TypeError
+PASS Setting 'grid-auto-flow' to an angle: -3.14deg throws TypeError
+PASS Setting 'grid-auto-flow' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'grid-auto-flow' to a flexible length: 0fr throws TypeError
+PASS Setting 'grid-auto-flow' to a flexible length: 1fr throws TypeError
+PASS Setting 'grid-auto-flow' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'grid-auto-flow' to a number: 0 throws TypeError
+PASS Setting 'grid-auto-flow' to a number: -3.14 throws TypeError
+PASS Setting 'grid-auto-flow' to a number: 3.14 throws TypeError
+PASS Setting 'grid-auto-flow' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'grid-auto-flow' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'grid-auto-flow' to a transform: perspective(10em) throws TypeError
+PASS Setting 'grid-auto-flow' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'grid-auto-flow' does not support 'column dense' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-expected.txt
@@ -1,5 +1,5 @@
 
-PASS 'grid' does not supported 'auto-flow / 1fr 1fr 1fr'
-PASS 'grid' does not supported 'auto-flow dense / 40px 40px 1fr'
-PASS 'grid' does not supported 'repeat(3, 80px) / auto-flow'
+PASS 'grid' does not support 'auto-flow / 1fr 1fr 1fr'
+PASS 'grid' does not support 'auto-flow dense / 40px 40px 1fr'
+PASS 'grid' does not support 'repeat(3, 80px) / auto-flow'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-gap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-gap-expected.txt
@@ -1,7 +1,7 @@
 
-PASS 'grid-gap' does not supported '20px'
-PASS 'grid-gap' does not supported '16%'
-PASS 'grid-gap' does not supported '20px 10px'
-PASS 'grid-gap' does not supported '15% 100%'
-PASS 'grid-gap' does not supported '21px 82%'
+PASS 'grid-gap' does not support '20px'
+PASS 'grid-gap' does not support '16%'
+PASS 'grid-gap' does not support '20px 10px'
+PASS 'grid-gap' does not support '15% 100%'
+PASS 'grid-gap' does not support '21px 82%'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt
@@ -5,66 +5,138 @@ PASS Can set 'grid-row-start' to CSS-wide keywords: unset
 PASS Can set 'grid-row-start' to CSS-wide keywords: revert
 PASS Can set 'grid-row-start' to var() references:  var(--A)
 PASS Can set 'grid-row-start' to the 'auto' keyword: auto
-PASS Setting 'grid-row-start' to a length throws TypeError
-PASS Setting 'grid-row-start' to a percent throws TypeError
-PASS Setting 'grid-row-start' to a time throws TypeError
-PASS Setting 'grid-row-start' to an angle throws TypeError
-PASS Setting 'grid-row-start' to a flexible length throws TypeError
-FAIL Setting 'grid-row-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'grid-row-start' to a URL throws TypeError
-PASS Setting 'grid-row-start' to a transform throws TypeError
-PASS 'grid-row-start' does not supported '3'
-FAIL 'grid-row-start' does not supported 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'grid-row-start' does not supported '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'grid-row-start' to a length: 0px throws TypeError
+PASS Setting 'grid-row-start' to a length: -3.14em throws TypeError
+PASS Setting 'grid-row-start' to a length: 3.14cm throws TypeError
+PASS Setting 'grid-row-start' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'grid-row-start' to a percent: 0% throws TypeError
+PASS Setting 'grid-row-start' to a percent: -3.14% throws TypeError
+PASS Setting 'grid-row-start' to a percent: 3.14% throws TypeError
+PASS Setting 'grid-row-start' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'grid-row-start' to a time: 0s throws TypeError
+PASS Setting 'grid-row-start' to a time: -3.14ms throws TypeError
+PASS Setting 'grid-row-start' to a time: 3.14s throws TypeError
+PASS Setting 'grid-row-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'grid-row-start' to an angle: 0deg throws TypeError
+PASS Setting 'grid-row-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'grid-row-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'grid-row-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'grid-row-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'grid-row-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'grid-row-start' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'grid-row-start' to a number: 0 throws TypeError
+PASS Setting 'grid-row-start' to a number: -3.14 throws TypeError
+PASS Setting 'grid-row-start' to a number: 3.14 throws TypeError
+FAIL Setting 'grid-row-start' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-row-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'grid-row-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'grid-row-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'grid-row-start' does not support '3'
+FAIL 'grid-row-start' does not support 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'grid-row-start' does not support '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 PASS Can set 'grid-row-end' to CSS-wide keywords: initial
 PASS Can set 'grid-row-end' to CSS-wide keywords: inherit
 PASS Can set 'grid-row-end' to CSS-wide keywords: unset
 PASS Can set 'grid-row-end' to CSS-wide keywords: revert
 PASS Can set 'grid-row-end' to var() references:  var(--A)
 PASS Can set 'grid-row-end' to the 'auto' keyword: auto
-PASS Setting 'grid-row-end' to a length throws TypeError
-PASS Setting 'grid-row-end' to a percent throws TypeError
-PASS Setting 'grid-row-end' to a time throws TypeError
-PASS Setting 'grid-row-end' to an angle throws TypeError
-PASS Setting 'grid-row-end' to a flexible length throws TypeError
-FAIL Setting 'grid-row-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'grid-row-end' to a URL throws TypeError
-PASS Setting 'grid-row-end' to a transform throws TypeError
-PASS 'grid-row-end' does not supported '3'
-FAIL 'grid-row-end' does not supported 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'grid-row-end' does not supported '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'grid-row-end' to a length: 0px throws TypeError
+PASS Setting 'grid-row-end' to a length: -3.14em throws TypeError
+PASS Setting 'grid-row-end' to a length: 3.14cm throws TypeError
+PASS Setting 'grid-row-end' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'grid-row-end' to a percent: 0% throws TypeError
+PASS Setting 'grid-row-end' to a percent: -3.14% throws TypeError
+PASS Setting 'grid-row-end' to a percent: 3.14% throws TypeError
+PASS Setting 'grid-row-end' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'grid-row-end' to a time: 0s throws TypeError
+PASS Setting 'grid-row-end' to a time: -3.14ms throws TypeError
+PASS Setting 'grid-row-end' to a time: 3.14s throws TypeError
+PASS Setting 'grid-row-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'grid-row-end' to an angle: 0deg throws TypeError
+PASS Setting 'grid-row-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'grid-row-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'grid-row-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'grid-row-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'grid-row-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'grid-row-end' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'grid-row-end' to a number: 0 throws TypeError
+PASS Setting 'grid-row-end' to a number: -3.14 throws TypeError
+PASS Setting 'grid-row-end' to a number: 3.14 throws TypeError
+FAIL Setting 'grid-row-end' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-row-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'grid-row-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'grid-row-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'grid-row-end' does not support '3'
+FAIL 'grid-row-end' does not support 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'grid-row-end' does not support '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 PASS Can set 'grid-column-start' to CSS-wide keywords: initial
 PASS Can set 'grid-column-start' to CSS-wide keywords: inherit
 PASS Can set 'grid-column-start' to CSS-wide keywords: unset
 PASS Can set 'grid-column-start' to CSS-wide keywords: revert
 PASS Can set 'grid-column-start' to var() references:  var(--A)
 PASS Can set 'grid-column-start' to the 'auto' keyword: auto
-PASS Setting 'grid-column-start' to a length throws TypeError
-PASS Setting 'grid-column-start' to a percent throws TypeError
-PASS Setting 'grid-column-start' to a time throws TypeError
-PASS Setting 'grid-column-start' to an angle throws TypeError
-PASS Setting 'grid-column-start' to a flexible length throws TypeError
-FAIL Setting 'grid-column-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'grid-column-start' to a URL throws TypeError
-PASS Setting 'grid-column-start' to a transform throws TypeError
-PASS 'grid-column-start' does not supported '3'
-FAIL 'grid-column-start' does not supported 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'grid-column-start' does not supported '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'grid-column-start' to a length: 0px throws TypeError
+PASS Setting 'grid-column-start' to a length: -3.14em throws TypeError
+PASS Setting 'grid-column-start' to a length: 3.14cm throws TypeError
+PASS Setting 'grid-column-start' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'grid-column-start' to a percent: 0% throws TypeError
+PASS Setting 'grid-column-start' to a percent: -3.14% throws TypeError
+PASS Setting 'grid-column-start' to a percent: 3.14% throws TypeError
+PASS Setting 'grid-column-start' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'grid-column-start' to a time: 0s throws TypeError
+PASS Setting 'grid-column-start' to a time: -3.14ms throws TypeError
+PASS Setting 'grid-column-start' to a time: 3.14s throws TypeError
+PASS Setting 'grid-column-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'grid-column-start' to an angle: 0deg throws TypeError
+PASS Setting 'grid-column-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'grid-column-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'grid-column-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'grid-column-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'grid-column-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'grid-column-start' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'grid-column-start' to a number: 0 throws TypeError
+PASS Setting 'grid-column-start' to a number: -3.14 throws TypeError
+PASS Setting 'grid-column-start' to a number: 3.14 throws TypeError
+FAIL Setting 'grid-column-start' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-column-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'grid-column-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'grid-column-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'grid-column-start' does not support '3'
+FAIL 'grid-column-start' does not support 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'grid-column-start' does not support '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 PASS Can set 'grid-column-end' to CSS-wide keywords: initial
 PASS Can set 'grid-column-end' to CSS-wide keywords: inherit
 PASS Can set 'grid-column-end' to CSS-wide keywords: unset
 PASS Can set 'grid-column-end' to CSS-wide keywords: revert
 PASS Can set 'grid-column-end' to var() references:  var(--A)
 PASS Can set 'grid-column-end' to the 'auto' keyword: auto
-PASS Setting 'grid-column-end' to a length throws TypeError
-PASS Setting 'grid-column-end' to a percent throws TypeError
-PASS Setting 'grid-column-end' to a time throws TypeError
-PASS Setting 'grid-column-end' to an angle throws TypeError
-PASS Setting 'grid-column-end' to a flexible length throws TypeError
-FAIL Setting 'grid-column-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'grid-column-end' to a URL throws TypeError
-PASS Setting 'grid-column-end' to a transform throws TypeError
-PASS 'grid-column-end' does not supported '3'
-FAIL 'grid-column-end' does not supported 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'grid-column-end' does not supported '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'grid-column-end' to a length: 0px throws TypeError
+PASS Setting 'grid-column-end' to a length: -3.14em throws TypeError
+PASS Setting 'grid-column-end' to a length: 3.14cm throws TypeError
+PASS Setting 'grid-column-end' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'grid-column-end' to a percent: 0% throws TypeError
+PASS Setting 'grid-column-end' to a percent: -3.14% throws TypeError
+PASS Setting 'grid-column-end' to a percent: 3.14% throws TypeError
+PASS Setting 'grid-column-end' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'grid-column-end' to a time: 0s throws TypeError
+PASS Setting 'grid-column-end' to a time: -3.14ms throws TypeError
+PASS Setting 'grid-column-end' to a time: 3.14s throws TypeError
+PASS Setting 'grid-column-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'grid-column-end' to an angle: 0deg throws TypeError
+PASS Setting 'grid-column-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'grid-column-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'grid-column-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'grid-column-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'grid-column-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'grid-column-end' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'grid-column-end' to a number: 0 throws TypeError
+PASS Setting 'grid-column-end' to a number: -3.14 throws TypeError
+PASS Setting 'grid-column-end' to a number: 3.14 throws TypeError
+FAIL Setting 'grid-column-end' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-column-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'grid-column-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'grid-column-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'grid-column-end' does not support '3'
+FAIL 'grid-column-end' does not support 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'grid-column-end' does not support '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-areas-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-areas-expected.txt
@@ -5,14 +5,32 @@ PASS Can set 'grid-template-areas' to CSS-wide keywords: unset
 PASS Can set 'grid-template-areas' to CSS-wide keywords: revert
 PASS Can set 'grid-template-areas' to var() references:  var(--A)
 PASS Can set 'grid-template-areas' to the 'none' keyword: none
-PASS Setting 'grid-template-areas' to a length throws TypeError
-PASS Setting 'grid-template-areas' to a percent throws TypeError
-PASS Setting 'grid-template-areas' to a time throws TypeError
-PASS Setting 'grid-template-areas' to an angle throws TypeError
-PASS Setting 'grid-template-areas' to a flexible length throws TypeError
-PASS Setting 'grid-template-areas' to a number throws TypeError
-PASS Setting 'grid-template-areas' to a URL throws TypeError
-PASS Setting 'grid-template-areas' to a transform throws TypeError
-PASS 'grid-template-areas' does not supported '"a a a"'
-PASS 'grid-template-areas' does not supported '"a a a" "b b b"'
+PASS Setting 'grid-template-areas' to a length: 0px throws TypeError
+PASS Setting 'grid-template-areas' to a length: -3.14em throws TypeError
+PASS Setting 'grid-template-areas' to a length: 3.14cm throws TypeError
+PASS Setting 'grid-template-areas' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'grid-template-areas' to a percent: 0% throws TypeError
+PASS Setting 'grid-template-areas' to a percent: -3.14% throws TypeError
+PASS Setting 'grid-template-areas' to a percent: 3.14% throws TypeError
+PASS Setting 'grid-template-areas' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'grid-template-areas' to a time: 0s throws TypeError
+PASS Setting 'grid-template-areas' to a time: -3.14ms throws TypeError
+PASS Setting 'grid-template-areas' to a time: 3.14s throws TypeError
+PASS Setting 'grid-template-areas' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'grid-template-areas' to an angle: 0deg throws TypeError
+PASS Setting 'grid-template-areas' to an angle: 3.14rad throws TypeError
+PASS Setting 'grid-template-areas' to an angle: -3.14deg throws TypeError
+PASS Setting 'grid-template-areas' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'grid-template-areas' to a flexible length: 0fr throws TypeError
+PASS Setting 'grid-template-areas' to a flexible length: 1fr throws TypeError
+PASS Setting 'grid-template-areas' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'grid-template-areas' to a number: 0 throws TypeError
+PASS Setting 'grid-template-areas' to a number: -3.14 throws TypeError
+PASS Setting 'grid-template-areas' to a number: 3.14 throws TypeError
+PASS Setting 'grid-template-areas' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'grid-template-areas' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'grid-template-areas' to a transform: perspective(10em) throws TypeError
+PASS Setting 'grid-template-areas' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'grid-template-areas' does not support '"a a a"'
+PASS 'grid-template-areas' does not support '"a a a" "b b b"'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt
@@ -5,30 +5,66 @@ PASS Can set 'grid-template-columns' to CSS-wide keywords: unset
 PASS Can set 'grid-template-columns' to CSS-wide keywords: revert
 PASS Can set 'grid-template-columns' to var() references:  var(--A)
 PASS Can set 'grid-template-columns' to the 'none' keyword: none
-FAIL Setting 'grid-template-columns' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'grid-template-columns' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'grid-template-columns' to a time throws TypeError
-PASS Setting 'grid-template-columns' to an angle throws TypeError
-FAIL Setting 'grid-template-columns' to a flexible length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'grid-template-columns' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'grid-template-columns' to a URL throws TypeError
-PASS Setting 'grid-template-columns' to a transform throws TypeError
-FAIL 'grid-template-columns' does not supported '[linename1] 100px [linename2 linename3]' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'grid-template-columns' does not supported '200px repeat(auto-fill, 100px) 300px' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+FAIL Setting 'grid-template-columns' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-template-columns' to a length: -3.14em throws TypeError
+FAIL Setting 'grid-template-columns' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'grid-template-columns' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'grid-template-columns' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-template-columns' to a percent: -3.14% throws TypeError
+FAIL Setting 'grid-template-columns' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'grid-template-columns' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-template-columns' to a time: 0s throws TypeError
+PASS Setting 'grid-template-columns' to a time: -3.14ms throws TypeError
+PASS Setting 'grid-template-columns' to a time: 3.14s throws TypeError
+PASS Setting 'grid-template-columns' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'grid-template-columns' to an angle: 0deg throws TypeError
+PASS Setting 'grid-template-columns' to an angle: 3.14rad throws TypeError
+PASS Setting 'grid-template-columns' to an angle: -3.14deg throws TypeError
+PASS Setting 'grid-template-columns' to an angle: calc(0rad + 0deg) throws TypeError
+FAIL Setting 'grid-template-columns' to a flexible length: 0fr throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'grid-template-columns' to a flexible length: 1fr throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-template-columns' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'grid-template-columns' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-template-columns' to a number: -3.14 throws TypeError
+PASS Setting 'grid-template-columns' to a number: 3.14 throws TypeError
+PASS Setting 'grid-template-columns' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'grid-template-columns' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'grid-template-columns' to a transform: perspective(10em) throws TypeError
+PASS Setting 'grid-template-columns' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'grid-template-columns' does not support '[linename1] 100px [linename2 linename3]' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'grid-template-columns' does not support '200px repeat(auto-fill, 100px) 300px' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
 PASS Can set 'grid-template-rows' to CSS-wide keywords: initial
 PASS Can set 'grid-template-rows' to CSS-wide keywords: inherit
 PASS Can set 'grid-template-rows' to CSS-wide keywords: unset
 PASS Can set 'grid-template-rows' to CSS-wide keywords: revert
 PASS Can set 'grid-template-rows' to var() references:  var(--A)
 PASS Can set 'grid-template-rows' to the 'none' keyword: none
-FAIL Setting 'grid-template-rows' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'grid-template-rows' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'grid-template-rows' to a time throws TypeError
-PASS Setting 'grid-template-rows' to an angle throws TypeError
-FAIL Setting 'grid-template-rows' to a flexible length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'grid-template-rows' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'grid-template-rows' to a URL throws TypeError
-PASS Setting 'grid-template-rows' to a transform throws TypeError
-FAIL 'grid-template-rows' does not supported '[linename1] 100px [linename2 linename3]' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'grid-template-rows' does not supported '200px repeat(auto-fill, 100px) 300px' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+FAIL Setting 'grid-template-rows' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-template-rows' to a length: -3.14em throws TypeError
+FAIL Setting 'grid-template-rows' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'grid-template-rows' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'grid-template-rows' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-template-rows' to a percent: -3.14% throws TypeError
+FAIL Setting 'grid-template-rows' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'grid-template-rows' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-template-rows' to a time: 0s throws TypeError
+PASS Setting 'grid-template-rows' to a time: -3.14ms throws TypeError
+PASS Setting 'grid-template-rows' to a time: 3.14s throws TypeError
+PASS Setting 'grid-template-rows' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'grid-template-rows' to an angle: 0deg throws TypeError
+PASS Setting 'grid-template-rows' to an angle: 3.14rad throws TypeError
+PASS Setting 'grid-template-rows' to an angle: -3.14deg throws TypeError
+PASS Setting 'grid-template-rows' to an angle: calc(0rad + 0deg) throws TypeError
+FAIL Setting 'grid-template-rows' to a flexible length: 0fr throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'grid-template-rows' to a flexible length: 1fr throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-template-rows' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'grid-template-rows' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-template-rows' to a number: -3.14 throws TypeError
+PASS Setting 'grid-template-rows' to a number: 3.14 throws TypeError
+PASS Setting 'grid-template-rows' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'grid-template-rows' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'grid-template-rows' to a transform: perspective(10em) throws TypeError
+PASS Setting 'grid-template-rows' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'grid-template-rows' does not support '[linename1] 100px [linename2 linename3]' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'grid-template-rows' does not support '200px repeat(auto-fill, 100px) 300px' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-expected.txt
@@ -1,8 +1,8 @@
 
-PASS 'grid-template' does not supported 'none'
-PASS 'grid-template' does not supported '100px 1fr / 50px 1fr'
-PASS 'grid-template' does not supported '[linename] 100px / [columnname1] 30% [columname2] 70%'
-PASS 'grid-template' does not supported 'fit-content(100px) / fit-content(40%)'
-PASS 'grid-template' does not supported '"a a a" "b b b"'
-PASS 'grid-template' does not supported '[header-top] "a a a" [header-bottom] [main-top] "b b b" 1fr [main-bottom] / auto 1fr auto'
+PASS 'grid-template' does not support 'none'
+PASS 'grid-template' does not support '100px 1fr / 50px 1fr'
+PASS 'grid-template' does not support '[linename] 100px / [columnname1] 30% [columname2] 70%'
+PASS 'grid-template' does not support 'fit-content(100px) / fit-content(40%)'
+PASS 'grid-template' does not support '"a a a" "b b b"'
+PASS 'grid-template' does not support '[header-top] "a a a" [header-bottom] [main-top] "b b b" 1fr [main-bottom] / auto 1fr auto'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt
@@ -13,12 +13,24 @@ PASS Can set 'height' to a length: 0px
 PASS Can set 'height' to a length: -3.14em
 PASS Can set 'height' to a length: 3.14cm
 PASS Can set 'height' to a length: calc(0px + 0em)
-PASS Setting 'height' to a time throws TypeError
-PASS Setting 'height' to an angle throws TypeError
-PASS Setting 'height' to a flexible length throws TypeError
-FAIL Setting 'height' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'height' to a URL throws TypeError
-PASS Setting 'height' to a transform throws TypeError
+PASS Setting 'height' to a time: 0s throws TypeError
+PASS Setting 'height' to a time: -3.14ms throws TypeError
+PASS Setting 'height' to a time: 3.14s throws TypeError
+PASS Setting 'height' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'height' to an angle: 0deg throws TypeError
+PASS Setting 'height' to an angle: 3.14rad throws TypeError
+PASS Setting 'height' to an angle: -3.14deg throws TypeError
+PASS Setting 'height' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'height' to a flexible length: 0fr throws TypeError
+PASS Setting 'height' to a flexible length: 1fr throws TypeError
+PASS Setting 'height' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'height' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'height' to a number: -3.14 throws TypeError
+PASS Setting 'height' to a number: 3.14 throws TypeError
+PASS Setting 'height' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'height' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'height' to a transform: perspective(10em) throws TypeError
+PASS Setting 'height' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'min-height' to CSS-wide keywords: initial
 PASS Can set 'min-height' to CSS-wide keywords: inherit
 PASS Can set 'min-height' to CSS-wide keywords: unset
@@ -32,12 +44,24 @@ PASS Can set 'min-height' to a length: 0px
 PASS Can set 'min-height' to a length: -3.14em
 PASS Can set 'min-height' to a length: 3.14cm
 PASS Can set 'min-height' to a length: calc(0px + 0em)
-PASS Setting 'min-height' to a time throws TypeError
-PASS Setting 'min-height' to an angle throws TypeError
-PASS Setting 'min-height' to a flexible length throws TypeError
-FAIL Setting 'min-height' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'min-height' to a URL throws TypeError
-PASS Setting 'min-height' to a transform throws TypeError
+PASS Setting 'min-height' to a time: 0s throws TypeError
+PASS Setting 'min-height' to a time: -3.14ms throws TypeError
+PASS Setting 'min-height' to a time: 3.14s throws TypeError
+PASS Setting 'min-height' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'min-height' to an angle: 0deg throws TypeError
+PASS Setting 'min-height' to an angle: 3.14rad throws TypeError
+PASS Setting 'min-height' to an angle: -3.14deg throws TypeError
+PASS Setting 'min-height' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'min-height' to a flexible length: 0fr throws TypeError
+PASS Setting 'min-height' to a flexible length: 1fr throws TypeError
+PASS Setting 'min-height' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'min-height' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'min-height' to a number: -3.14 throws TypeError
+PASS Setting 'min-height' to a number: 3.14 throws TypeError
+PASS Setting 'min-height' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'min-height' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'min-height' to a transform: perspective(10em) throws TypeError
+PASS Setting 'min-height' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'max-height' to CSS-wide keywords: initial
 PASS Can set 'max-height' to CSS-wide keywords: inherit
 PASS Can set 'max-height' to CSS-wide keywords: unset
@@ -52,10 +76,22 @@ PASS Can set 'max-height' to a length: 0px
 PASS Can set 'max-height' to a length: -3.14em
 PASS Can set 'max-height' to a length: 3.14cm
 PASS Can set 'max-height' to a length: calc(0px + 0em)
-PASS Setting 'max-height' to a time throws TypeError
-PASS Setting 'max-height' to an angle throws TypeError
-PASS Setting 'max-height' to a flexible length throws TypeError
-FAIL Setting 'max-height' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'max-height' to a URL throws TypeError
-PASS Setting 'max-height' to a transform throws TypeError
+PASS Setting 'max-height' to a time: 0s throws TypeError
+PASS Setting 'max-height' to a time: -3.14ms throws TypeError
+PASS Setting 'max-height' to a time: 3.14s throws TypeError
+PASS Setting 'max-height' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'max-height' to an angle: 0deg throws TypeError
+PASS Setting 'max-height' to an angle: 3.14rad throws TypeError
+PASS Setting 'max-height' to an angle: -3.14deg throws TypeError
+PASS Setting 'max-height' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'max-height' to a flexible length: 0fr throws TypeError
+PASS Setting 'max-height' to a flexible length: 1fr throws TypeError
+PASS Setting 'max-height' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'max-height' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'max-height' to a number: -3.14 throws TypeError
+PASS Setting 'max-height' to a number: 3.14 throws TypeError
+PASS Setting 'max-height' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'max-height' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'max-height' to a transform: perspective(10em) throws TypeError
+PASS Setting 'max-height' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/hyphens-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/hyphens-expected.txt
@@ -7,12 +7,30 @@ FAIL Can set 'hyphens' to var() references:  var(--A) Invalid property hyphens
 FAIL Can set 'hyphens' to the 'none' keyword: none Invalid property hyphens
 FAIL Can set 'hyphens' to the 'manual' keyword: manual Invalid property hyphens
 FAIL Can set 'hyphens' to the 'auto' keyword: auto Invalid property hyphens
-PASS Setting 'hyphens' to a length throws TypeError
-PASS Setting 'hyphens' to a percent throws TypeError
-PASS Setting 'hyphens' to a time throws TypeError
-PASS Setting 'hyphens' to an angle throws TypeError
-PASS Setting 'hyphens' to a flexible length throws TypeError
-PASS Setting 'hyphens' to a number throws TypeError
-PASS Setting 'hyphens' to a URL throws TypeError
-PASS Setting 'hyphens' to a transform throws TypeError
+PASS Setting 'hyphens' to a length: 0px throws TypeError
+PASS Setting 'hyphens' to a length: -3.14em throws TypeError
+PASS Setting 'hyphens' to a length: 3.14cm throws TypeError
+PASS Setting 'hyphens' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'hyphens' to a percent: 0% throws TypeError
+PASS Setting 'hyphens' to a percent: -3.14% throws TypeError
+PASS Setting 'hyphens' to a percent: 3.14% throws TypeError
+PASS Setting 'hyphens' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'hyphens' to a time: 0s throws TypeError
+PASS Setting 'hyphens' to a time: -3.14ms throws TypeError
+PASS Setting 'hyphens' to a time: 3.14s throws TypeError
+PASS Setting 'hyphens' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'hyphens' to an angle: 0deg throws TypeError
+PASS Setting 'hyphens' to an angle: 3.14rad throws TypeError
+PASS Setting 'hyphens' to an angle: -3.14deg throws TypeError
+PASS Setting 'hyphens' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'hyphens' to a flexible length: 0fr throws TypeError
+PASS Setting 'hyphens' to a flexible length: 1fr throws TypeError
+PASS Setting 'hyphens' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'hyphens' to a number: 0 throws TypeError
+PASS Setting 'hyphens' to a number: -3.14 throws TypeError
+PASS Setting 'hyphens' to a number: 3.14 throws TypeError
+PASS Setting 'hyphens' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'hyphens' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'hyphens' to a transform: perspective(10em) throws TypeError
+PASS Setting 'hyphens' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering-expected.txt
@@ -9,12 +9,30 @@ FAIL Can set 'image-rendering' to the 'smooth' keyword: smooth Invalid values
 FAIL Can set 'image-rendering' to the 'high-quality' keyword: high-quality Invalid values
 PASS Can set 'image-rendering' to the 'crisp-edges' keyword: crisp-edges
 PASS Can set 'image-rendering' to the 'pixelated' keyword: pixelated
-PASS Setting 'image-rendering' to a length throws TypeError
-PASS Setting 'image-rendering' to a percent throws TypeError
-PASS Setting 'image-rendering' to a time throws TypeError
-PASS Setting 'image-rendering' to an angle throws TypeError
-PASS Setting 'image-rendering' to a flexible length throws TypeError
-PASS Setting 'image-rendering' to a number throws TypeError
-PASS Setting 'image-rendering' to a URL throws TypeError
-PASS Setting 'image-rendering' to a transform throws TypeError
+PASS Setting 'image-rendering' to a length: 0px throws TypeError
+PASS Setting 'image-rendering' to a length: -3.14em throws TypeError
+PASS Setting 'image-rendering' to a length: 3.14cm throws TypeError
+PASS Setting 'image-rendering' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'image-rendering' to a percent: 0% throws TypeError
+PASS Setting 'image-rendering' to a percent: -3.14% throws TypeError
+PASS Setting 'image-rendering' to a percent: 3.14% throws TypeError
+PASS Setting 'image-rendering' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'image-rendering' to a time: 0s throws TypeError
+PASS Setting 'image-rendering' to a time: -3.14ms throws TypeError
+PASS Setting 'image-rendering' to a time: 3.14s throws TypeError
+PASS Setting 'image-rendering' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'image-rendering' to an angle: 0deg throws TypeError
+PASS Setting 'image-rendering' to an angle: 3.14rad throws TypeError
+PASS Setting 'image-rendering' to an angle: -3.14deg throws TypeError
+PASS Setting 'image-rendering' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'image-rendering' to a flexible length: 0fr throws TypeError
+PASS Setting 'image-rendering' to a flexible length: 1fr throws TypeError
+PASS Setting 'image-rendering' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'image-rendering' to a number: 0 throws TypeError
+PASS Setting 'image-rendering' to a number: -3.14 throws TypeError
+PASS Setting 'image-rendering' to a number: 3.14 throws TypeError
+PASS Setting 'image-rendering' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'image-rendering' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'image-rendering' to a transform: perspective(10em) throws TypeError
+PASS Setting 'image-rendering' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt
@@ -13,12 +13,24 @@ PASS Can set 'inline-size' to a length: 0px
 PASS Can set 'inline-size' to a length: -3.14em
 PASS Can set 'inline-size' to a length: 3.14cm
 PASS Can set 'inline-size' to a length: calc(0px + 0em)
-PASS Setting 'inline-size' to a time throws TypeError
-PASS Setting 'inline-size' to an angle throws TypeError
-PASS Setting 'inline-size' to a flexible length throws TypeError
-FAIL Setting 'inline-size' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'inline-size' to a URL throws TypeError
-PASS Setting 'inline-size' to a transform throws TypeError
+PASS Setting 'inline-size' to a time: 0s throws TypeError
+PASS Setting 'inline-size' to a time: -3.14ms throws TypeError
+PASS Setting 'inline-size' to a time: 3.14s throws TypeError
+PASS Setting 'inline-size' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'inline-size' to an angle: 0deg throws TypeError
+PASS Setting 'inline-size' to an angle: 3.14rad throws TypeError
+PASS Setting 'inline-size' to an angle: -3.14deg throws TypeError
+PASS Setting 'inline-size' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'inline-size' to a flexible length: 0fr throws TypeError
+PASS Setting 'inline-size' to a flexible length: 1fr throws TypeError
+PASS Setting 'inline-size' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'inline-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'inline-size' to a number: -3.14 throws TypeError
+PASS Setting 'inline-size' to a number: 3.14 throws TypeError
+PASS Setting 'inline-size' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'inline-size' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'inline-size' to a transform: perspective(10em) throws TypeError
+PASS Setting 'inline-size' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'min-inline-size' to CSS-wide keywords: initial
 PASS Can set 'min-inline-size' to CSS-wide keywords: inherit
 PASS Can set 'min-inline-size' to CSS-wide keywords: unset
@@ -32,12 +44,24 @@ PASS Can set 'min-inline-size' to a length: 0px
 PASS Can set 'min-inline-size' to a length: -3.14em
 PASS Can set 'min-inline-size' to a length: 3.14cm
 PASS Can set 'min-inline-size' to a length: calc(0px + 0em)
-PASS Setting 'min-inline-size' to a time throws TypeError
-PASS Setting 'min-inline-size' to an angle throws TypeError
-PASS Setting 'min-inline-size' to a flexible length throws TypeError
-FAIL Setting 'min-inline-size' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'min-inline-size' to a URL throws TypeError
-PASS Setting 'min-inline-size' to a transform throws TypeError
+PASS Setting 'min-inline-size' to a time: 0s throws TypeError
+PASS Setting 'min-inline-size' to a time: -3.14ms throws TypeError
+PASS Setting 'min-inline-size' to a time: 3.14s throws TypeError
+PASS Setting 'min-inline-size' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'min-inline-size' to an angle: 0deg throws TypeError
+PASS Setting 'min-inline-size' to an angle: 3.14rad throws TypeError
+PASS Setting 'min-inline-size' to an angle: -3.14deg throws TypeError
+PASS Setting 'min-inline-size' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'min-inline-size' to a flexible length: 0fr throws TypeError
+PASS Setting 'min-inline-size' to a flexible length: 1fr throws TypeError
+PASS Setting 'min-inline-size' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'min-inline-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'min-inline-size' to a number: -3.14 throws TypeError
+PASS Setting 'min-inline-size' to a number: 3.14 throws TypeError
+PASS Setting 'min-inline-size' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'min-inline-size' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'min-inline-size' to a transform: perspective(10em) throws TypeError
+PASS Setting 'min-inline-size' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'max-inline-size' to CSS-wide keywords: initial
 PASS Can set 'max-inline-size' to CSS-wide keywords: inherit
 PASS Can set 'max-inline-size' to CSS-wide keywords: unset
@@ -52,10 +76,22 @@ PASS Can set 'max-inline-size' to a length: 0px
 PASS Can set 'max-inline-size' to a length: -3.14em
 PASS Can set 'max-inline-size' to a length: 3.14cm
 PASS Can set 'max-inline-size' to a length: calc(0px + 0em)
-PASS Setting 'max-inline-size' to a time throws TypeError
-PASS Setting 'max-inline-size' to an angle throws TypeError
-PASS Setting 'max-inline-size' to a flexible length throws TypeError
-FAIL Setting 'max-inline-size' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'max-inline-size' to a URL throws TypeError
-PASS Setting 'max-inline-size' to a transform throws TypeError
+PASS Setting 'max-inline-size' to a time: 0s throws TypeError
+PASS Setting 'max-inline-size' to a time: -3.14ms throws TypeError
+PASS Setting 'max-inline-size' to a time: 3.14s throws TypeError
+PASS Setting 'max-inline-size' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'max-inline-size' to an angle: 0deg throws TypeError
+PASS Setting 'max-inline-size' to an angle: 3.14rad throws TypeError
+PASS Setting 'max-inline-size' to an angle: -3.14deg throws TypeError
+PASS Setting 'max-inline-size' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'max-inline-size' to a flexible length: 0fr throws TypeError
+PASS Setting 'max-inline-size' to a flexible length: 1fr throws TypeError
+PASS Setting 'max-inline-size' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'max-inline-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'max-inline-size' to a number: -3.14 throws TypeError
+PASS Setting 'max-inline-size' to a number: 3.14 throws TypeError
+PASS Setting 'max-inline-size' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'max-inline-size' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'max-inline-size' to a transform: perspective(10em) throws TypeError
+PASS Setting 'max-inline-size' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/isolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/isolation-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'isolation' to CSS-wide keywords: revert
 PASS Can set 'isolation' to var() references:  var(--A)
 PASS Can set 'isolation' to the 'auto' keyword: auto
 PASS Can set 'isolation' to the 'isolate' keyword: isolate
-PASS Setting 'isolation' to a length throws TypeError
-PASS Setting 'isolation' to a percent throws TypeError
-PASS Setting 'isolation' to a time throws TypeError
-PASS Setting 'isolation' to an angle throws TypeError
-PASS Setting 'isolation' to a flexible length throws TypeError
-PASS Setting 'isolation' to a number throws TypeError
-PASS Setting 'isolation' to a URL throws TypeError
-PASS Setting 'isolation' to a transform throws TypeError
+PASS Setting 'isolation' to a length: 0px throws TypeError
+PASS Setting 'isolation' to a length: -3.14em throws TypeError
+PASS Setting 'isolation' to a length: 3.14cm throws TypeError
+PASS Setting 'isolation' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'isolation' to a percent: 0% throws TypeError
+PASS Setting 'isolation' to a percent: -3.14% throws TypeError
+PASS Setting 'isolation' to a percent: 3.14% throws TypeError
+PASS Setting 'isolation' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'isolation' to a time: 0s throws TypeError
+PASS Setting 'isolation' to a time: -3.14ms throws TypeError
+PASS Setting 'isolation' to a time: 3.14s throws TypeError
+PASS Setting 'isolation' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'isolation' to an angle: 0deg throws TypeError
+PASS Setting 'isolation' to an angle: 3.14rad throws TypeError
+PASS Setting 'isolation' to an angle: -3.14deg throws TypeError
+PASS Setting 'isolation' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'isolation' to a flexible length: 0fr throws TypeError
+PASS Setting 'isolation' to a flexible length: 1fr throws TypeError
+PASS Setting 'isolation' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'isolation' to a number: 0 throws TypeError
+PASS Setting 'isolation' to a number: -3.14 throws TypeError
+PASS Setting 'isolation' to a number: 3.14 throws TypeError
+PASS Setting 'isolation' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'isolation' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'isolation' to a transform: perspective(10em) throws TypeError
+PASS Setting 'isolation' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/left-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/left-expected.txt
@@ -13,10 +13,22 @@ PASS Can set 'left' to a length: 0px
 PASS Can set 'left' to a length: -3.14em
 PASS Can set 'left' to a length: 3.14cm
 PASS Can set 'left' to a length: calc(0px + 0em)
-PASS Setting 'left' to a time throws TypeError
-PASS Setting 'left' to an angle throws TypeError
-PASS Setting 'left' to a flexible length throws TypeError
-FAIL Setting 'left' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'left' to a URL throws TypeError
-PASS Setting 'left' to a transform throws TypeError
+PASS Setting 'left' to a time: 0s throws TypeError
+PASS Setting 'left' to a time: -3.14ms throws TypeError
+PASS Setting 'left' to a time: 3.14s throws TypeError
+PASS Setting 'left' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'left' to an angle: 0deg throws TypeError
+PASS Setting 'left' to an angle: 3.14rad throws TypeError
+PASS Setting 'left' to an angle: -3.14deg throws TypeError
+PASS Setting 'left' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'left' to a flexible length: 0fr throws TypeError
+PASS Setting 'left' to a flexible length: 1fr throws TypeError
+PASS Setting 'left' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'left' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'left' to a number: -3.14 throws TypeError
+PASS Setting 'left' to a number: 3.14 throws TypeError
+PASS Setting 'left' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'left' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'left' to a transform: perspective(10em) throws TypeError
+PASS Setting 'left' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt
@@ -9,11 +9,26 @@ FAIL Can set 'letter-spacing' to a length: 0px assert_equals: expected "CSSUnitV
 PASS Can set 'letter-spacing' to a length: -3.14em
 PASS Can set 'letter-spacing' to a length: 3.14cm
 FAIL Can set 'letter-spacing' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSKeywordValue]"
-PASS Setting 'letter-spacing' to a percent throws TypeError
-PASS Setting 'letter-spacing' to a time throws TypeError
-PASS Setting 'letter-spacing' to an angle throws TypeError
-PASS Setting 'letter-spacing' to a flexible length throws TypeError
-FAIL Setting 'letter-spacing' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'letter-spacing' to a URL throws TypeError
-PASS Setting 'letter-spacing' to a transform throws TypeError
+PASS Setting 'letter-spacing' to a percent: 0% throws TypeError
+PASS Setting 'letter-spacing' to a percent: -3.14% throws TypeError
+PASS Setting 'letter-spacing' to a percent: 3.14% throws TypeError
+PASS Setting 'letter-spacing' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'letter-spacing' to a time: 0s throws TypeError
+PASS Setting 'letter-spacing' to a time: -3.14ms throws TypeError
+PASS Setting 'letter-spacing' to a time: 3.14s throws TypeError
+PASS Setting 'letter-spacing' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'letter-spacing' to an angle: 0deg throws TypeError
+PASS Setting 'letter-spacing' to an angle: 3.14rad throws TypeError
+PASS Setting 'letter-spacing' to an angle: -3.14deg throws TypeError
+PASS Setting 'letter-spacing' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'letter-spacing' to a flexible length: 0fr throws TypeError
+PASS Setting 'letter-spacing' to a flexible length: 1fr throws TypeError
+PASS Setting 'letter-spacing' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'letter-spacing' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'letter-spacing' to a number: -3.14 throws TypeError
+PASS Setting 'letter-spacing' to a number: 3.14 throws TypeError
+PASS Setting 'letter-spacing' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'letter-spacing' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'letter-spacing' to a transform: perspective(10em) throws TypeError
+PASS Setting 'letter-spacing' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/lighting-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/lighting-color-expected.txt
@@ -5,17 +5,35 @@ PASS Can set 'lighting-color' to CSS-wide keywords: unset
 PASS Can set 'lighting-color' to CSS-wide keywords: revert
 PASS Can set 'lighting-color' to var() references:  var(--A)
 PASS Can set 'lighting-color' to the 'currentcolor' keyword: currentcolor
-PASS Setting 'lighting-color' to a length throws TypeError
-PASS Setting 'lighting-color' to a percent throws TypeError
-PASS Setting 'lighting-color' to a time throws TypeError
-PASS Setting 'lighting-color' to an angle throws TypeError
-PASS Setting 'lighting-color' to a flexible length throws TypeError
-PASS Setting 'lighting-color' to a number throws TypeError
-PASS Setting 'lighting-color' to a URL throws TypeError
-PASS Setting 'lighting-color' to a transform throws TypeError
-FAIL 'lighting-color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'lighting-color' does not supported '#bbff00'
-PASS 'lighting-color' does not supported 'rgb(255, 255, 128)'
-PASS 'lighting-color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'lighting-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'lighting-color' to a length: 0px throws TypeError
+PASS Setting 'lighting-color' to a length: -3.14em throws TypeError
+PASS Setting 'lighting-color' to a length: 3.14cm throws TypeError
+PASS Setting 'lighting-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'lighting-color' to a percent: 0% throws TypeError
+PASS Setting 'lighting-color' to a percent: -3.14% throws TypeError
+PASS Setting 'lighting-color' to a percent: 3.14% throws TypeError
+PASS Setting 'lighting-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'lighting-color' to a time: 0s throws TypeError
+PASS Setting 'lighting-color' to a time: -3.14ms throws TypeError
+PASS Setting 'lighting-color' to a time: 3.14s throws TypeError
+PASS Setting 'lighting-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'lighting-color' to an angle: 0deg throws TypeError
+PASS Setting 'lighting-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'lighting-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'lighting-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'lighting-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'lighting-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'lighting-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'lighting-color' to a number: 0 throws TypeError
+PASS Setting 'lighting-color' to a number: -3.14 throws TypeError
+PASS Setting 'lighting-color' to a number: 3.14 throws TypeError
+PASS Setting 'lighting-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'lighting-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'lighting-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'lighting-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'lighting-color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'lighting-color' does not support '#bbff00'
+PASS 'lighting-color' does not support 'rgb(255, 255, 128)'
+PASS 'lighting-color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'lighting-color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-break-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-break-expected.txt
@@ -9,12 +9,30 @@ PASS Can set 'line-break' to the 'loose' keyword: loose
 PASS Can set 'line-break' to the 'normal' keyword: normal
 PASS Can set 'line-break' to the 'strict' keyword: strict
 PASS Can set 'line-break' to the 'anywhere' keyword: anywhere
-PASS Setting 'line-break' to a length throws TypeError
-PASS Setting 'line-break' to a percent throws TypeError
-PASS Setting 'line-break' to a time throws TypeError
-PASS Setting 'line-break' to an angle throws TypeError
-PASS Setting 'line-break' to a flexible length throws TypeError
-PASS Setting 'line-break' to a number throws TypeError
-PASS Setting 'line-break' to a URL throws TypeError
-PASS Setting 'line-break' to a transform throws TypeError
+PASS Setting 'line-break' to a length: 0px throws TypeError
+PASS Setting 'line-break' to a length: -3.14em throws TypeError
+PASS Setting 'line-break' to a length: 3.14cm throws TypeError
+PASS Setting 'line-break' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'line-break' to a percent: 0% throws TypeError
+PASS Setting 'line-break' to a percent: -3.14% throws TypeError
+PASS Setting 'line-break' to a percent: 3.14% throws TypeError
+PASS Setting 'line-break' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'line-break' to a time: 0s throws TypeError
+PASS Setting 'line-break' to a time: -3.14ms throws TypeError
+PASS Setting 'line-break' to a time: 3.14s throws TypeError
+PASS Setting 'line-break' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'line-break' to an angle: 0deg throws TypeError
+PASS Setting 'line-break' to an angle: 3.14rad throws TypeError
+PASS Setting 'line-break' to an angle: -3.14deg throws TypeError
+PASS Setting 'line-break' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'line-break' to a flexible length: 0fr throws TypeError
+PASS Setting 'line-break' to a flexible length: 1fr throws TypeError
+PASS Setting 'line-break' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'line-break' to a number: 0 throws TypeError
+PASS Setting 'line-break' to a number: -3.14 throws TypeError
+PASS Setting 'line-break' to a number: 3.14 throws TypeError
+PASS Setting 'line-break' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'line-break' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'line-break' to a transform: perspective(10em) throws TypeError
+PASS Setting 'line-break' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-expected.txt
@@ -17,9 +17,18 @@ PASS Can set 'line-height' to a percent: 0%
 PASS Can set 'line-height' to a percent: -3.14%
 PASS Can set 'line-height' to a percent: 3.14%
 PASS Can set 'line-height' to a percent: calc(0% + 0%)
-PASS Setting 'line-height' to a time throws TypeError
-PASS Setting 'line-height' to an angle throws TypeError
-PASS Setting 'line-height' to a flexible length throws TypeError
-PASS Setting 'line-height' to a URL throws TypeError
-PASS Setting 'line-height' to a transform throws TypeError
+PASS Setting 'line-height' to a time: 0s throws TypeError
+PASS Setting 'line-height' to a time: -3.14ms throws TypeError
+PASS Setting 'line-height' to a time: 3.14s throws TypeError
+PASS Setting 'line-height' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'line-height' to an angle: 0deg throws TypeError
+PASS Setting 'line-height' to an angle: 3.14rad throws TypeError
+PASS Setting 'line-height' to an angle: -3.14deg throws TypeError
+PASS Setting 'line-height' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'line-height' to a flexible length: 0fr throws TypeError
+PASS Setting 'line-height' to a flexible length: 1fr throws TypeError
+PASS Setting 'line-height' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'line-height' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'line-height' to a transform: perspective(10em) throws TypeError
+PASS Setting 'line-height' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-step-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-step-expected.txt
@@ -8,11 +8,26 @@ FAIL Can set 'line-height-step' to a length: 0px Invalid property line-height-st
 FAIL Can set 'line-height-step' to a length: -3.14em Invalid property line-height-step
 FAIL Can set 'line-height-step' to a length: 3.14cm Invalid property line-height-step
 FAIL Can set 'line-height-step' to a length: calc(0px + 0em) Invalid property line-height-step
-PASS Setting 'line-height-step' to a percent throws TypeError
-PASS Setting 'line-height-step' to a time throws TypeError
-PASS Setting 'line-height-step' to an angle throws TypeError
-PASS Setting 'line-height-step' to a flexible length throws TypeError
-PASS Setting 'line-height-step' to a number throws TypeError
-PASS Setting 'line-height-step' to a URL throws TypeError
-PASS Setting 'line-height-step' to a transform throws TypeError
+PASS Setting 'line-height-step' to a percent: 0% throws TypeError
+PASS Setting 'line-height-step' to a percent: -3.14% throws TypeError
+PASS Setting 'line-height-step' to a percent: 3.14% throws TypeError
+PASS Setting 'line-height-step' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'line-height-step' to a time: 0s throws TypeError
+PASS Setting 'line-height-step' to a time: -3.14ms throws TypeError
+PASS Setting 'line-height-step' to a time: 3.14s throws TypeError
+PASS Setting 'line-height-step' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'line-height-step' to an angle: 0deg throws TypeError
+PASS Setting 'line-height-step' to an angle: 3.14rad throws TypeError
+PASS Setting 'line-height-step' to an angle: -3.14deg throws TypeError
+PASS Setting 'line-height-step' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'line-height-step' to a flexible length: 0fr throws TypeError
+PASS Setting 'line-height-step' to a flexible length: 1fr throws TypeError
+PASS Setting 'line-height-step' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'line-height-step' to a number: 0 throws TypeError
+PASS Setting 'line-height-step' to a number: -3.14 throws TypeError
+PASS Setting 'line-height-step' to a number: 3.14 throws TypeError
+PASS Setting 'line-height-step' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'line-height-step' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'line-height-step' to a transform: perspective(10em) throws TypeError
+PASS Setting 'line-height-step' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-image-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'list-style-image' to CSS-wide keywords: revert
 PASS Can set 'list-style-image' to var() references:  var(--A)
 PASS Can set 'list-style-image' to the 'none' keyword: none
 PASS Can set 'list-style-image' to an image
-PASS Setting 'list-style-image' to a length throws TypeError
-PASS Setting 'list-style-image' to a percent throws TypeError
-PASS Setting 'list-style-image' to a time throws TypeError
-PASS Setting 'list-style-image' to an angle throws TypeError
-PASS Setting 'list-style-image' to a flexible length throws TypeError
-PASS Setting 'list-style-image' to a number throws TypeError
-PASS Setting 'list-style-image' to a URL throws TypeError
-PASS Setting 'list-style-image' to a transform throws TypeError
+PASS Setting 'list-style-image' to a length: 0px throws TypeError
+PASS Setting 'list-style-image' to a length: -3.14em throws TypeError
+PASS Setting 'list-style-image' to a length: 3.14cm throws TypeError
+PASS Setting 'list-style-image' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'list-style-image' to a percent: 0% throws TypeError
+PASS Setting 'list-style-image' to a percent: -3.14% throws TypeError
+PASS Setting 'list-style-image' to a percent: 3.14% throws TypeError
+PASS Setting 'list-style-image' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'list-style-image' to a time: 0s throws TypeError
+PASS Setting 'list-style-image' to a time: -3.14ms throws TypeError
+PASS Setting 'list-style-image' to a time: 3.14s throws TypeError
+PASS Setting 'list-style-image' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'list-style-image' to an angle: 0deg throws TypeError
+PASS Setting 'list-style-image' to an angle: 3.14rad throws TypeError
+PASS Setting 'list-style-image' to an angle: -3.14deg throws TypeError
+PASS Setting 'list-style-image' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'list-style-image' to a flexible length: 0fr throws TypeError
+PASS Setting 'list-style-image' to a flexible length: 1fr throws TypeError
+PASS Setting 'list-style-image' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'list-style-image' to a number: 0 throws TypeError
+PASS Setting 'list-style-image' to a number: -3.14 throws TypeError
+PASS Setting 'list-style-image' to a number: 3.14 throws TypeError
+PASS Setting 'list-style-image' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'list-style-image' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'list-style-image' to a transform: perspective(10em) throws TypeError
+PASS Setting 'list-style-image' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-position-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'list-style-position' to CSS-wide keywords: revert
 PASS Can set 'list-style-position' to var() references:  var(--A)
 PASS Can set 'list-style-position' to the 'inside' keyword: inside
 PASS Can set 'list-style-position' to the 'outside' keyword: outside
-PASS Setting 'list-style-position' to a length throws TypeError
-PASS Setting 'list-style-position' to a percent throws TypeError
-PASS Setting 'list-style-position' to a time throws TypeError
-PASS Setting 'list-style-position' to an angle throws TypeError
-PASS Setting 'list-style-position' to a flexible length throws TypeError
-PASS Setting 'list-style-position' to a number throws TypeError
-PASS Setting 'list-style-position' to a URL throws TypeError
-PASS Setting 'list-style-position' to a transform throws TypeError
+PASS Setting 'list-style-position' to a length: 0px throws TypeError
+PASS Setting 'list-style-position' to a length: -3.14em throws TypeError
+PASS Setting 'list-style-position' to a length: 3.14cm throws TypeError
+PASS Setting 'list-style-position' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'list-style-position' to a percent: 0% throws TypeError
+PASS Setting 'list-style-position' to a percent: -3.14% throws TypeError
+PASS Setting 'list-style-position' to a percent: 3.14% throws TypeError
+PASS Setting 'list-style-position' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'list-style-position' to a time: 0s throws TypeError
+PASS Setting 'list-style-position' to a time: -3.14ms throws TypeError
+PASS Setting 'list-style-position' to a time: 3.14s throws TypeError
+PASS Setting 'list-style-position' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'list-style-position' to an angle: 0deg throws TypeError
+PASS Setting 'list-style-position' to an angle: 3.14rad throws TypeError
+PASS Setting 'list-style-position' to an angle: -3.14deg throws TypeError
+PASS Setting 'list-style-position' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'list-style-position' to a flexible length: 0fr throws TypeError
+PASS Setting 'list-style-position' to a flexible length: 1fr throws TypeError
+PASS Setting 'list-style-position' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'list-style-position' to a number: 0 throws TypeError
+PASS Setting 'list-style-position' to a number: -3.14 throws TypeError
+PASS Setting 'list-style-position' to a number: 3.14 throws TypeError
+PASS Setting 'list-style-position' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'list-style-position' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'list-style-position' to a transform: perspective(10em) throws TypeError
+PASS Setting 'list-style-position' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-type-expected.txt
@@ -6,14 +6,32 @@ PASS Can set 'list-style-type' to CSS-wide keywords: revert
 PASS Can set 'list-style-type' to var() references:  var(--A)
 PASS Can set 'list-style-type' to the 'none' keyword: none
 FAIL Can set 'list-style-type' to the 'custom-ident' keyword: custom-ident Invalid values
-PASS Setting 'list-style-type' to a length throws TypeError
-PASS Setting 'list-style-type' to a percent throws TypeError
-PASS Setting 'list-style-type' to a time throws TypeError
-PASS Setting 'list-style-type' to an angle throws TypeError
-PASS Setting 'list-style-type' to a flexible length throws TypeError
-PASS Setting 'list-style-type' to a number throws TypeError
-PASS Setting 'list-style-type' to a URL throws TypeError
-PASS Setting 'list-style-type' to a transform throws TypeError
-FAIL 'list-style-type' does not supported '"Note: "' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'list-style-type' does not supported 'symbols("*" "A" "B" "C")' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS Setting 'list-style-type' to a length: 0px throws TypeError
+PASS Setting 'list-style-type' to a length: -3.14em throws TypeError
+PASS Setting 'list-style-type' to a length: 3.14cm throws TypeError
+PASS Setting 'list-style-type' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'list-style-type' to a percent: 0% throws TypeError
+PASS Setting 'list-style-type' to a percent: -3.14% throws TypeError
+PASS Setting 'list-style-type' to a percent: 3.14% throws TypeError
+PASS Setting 'list-style-type' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'list-style-type' to a time: 0s throws TypeError
+PASS Setting 'list-style-type' to a time: -3.14ms throws TypeError
+PASS Setting 'list-style-type' to a time: 3.14s throws TypeError
+PASS Setting 'list-style-type' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'list-style-type' to an angle: 0deg throws TypeError
+PASS Setting 'list-style-type' to an angle: 3.14rad throws TypeError
+PASS Setting 'list-style-type' to an angle: -3.14deg throws TypeError
+PASS Setting 'list-style-type' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'list-style-type' to a flexible length: 0fr throws TypeError
+PASS Setting 'list-style-type' to a flexible length: 1fr throws TypeError
+PASS Setting 'list-style-type' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'list-style-type' to a number: 0 throws TypeError
+PASS Setting 'list-style-type' to a number: -3.14 throws TypeError
+PASS Setting 'list-style-type' to a number: 3.14 throws TypeError
+PASS Setting 'list-style-type' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'list-style-type' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'list-style-type' to a transform: perspective(10em) throws TypeError
+PASS Setting 'list-style-type' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'list-style-type' does not support '"Note: "' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'list-style-type' does not support 'symbols("*" "A" "B" "C")' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
@@ -12,12 +12,24 @@ PASS Can set 'margin-block-start' to a length: 0px
 PASS Can set 'margin-block-start' to a length: -3.14em
 PASS Can set 'margin-block-start' to a length: 3.14cm
 PASS Can set 'margin-block-start' to a length: calc(0px + 0em)
-PASS Setting 'margin-block-start' to a time throws TypeError
-PASS Setting 'margin-block-start' to an angle throws TypeError
-PASS Setting 'margin-block-start' to a flexible length throws TypeError
-FAIL Setting 'margin-block-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'margin-block-start' to a URL throws TypeError
-PASS Setting 'margin-block-start' to a transform throws TypeError
+PASS Setting 'margin-block-start' to a time: 0s throws TypeError
+PASS Setting 'margin-block-start' to a time: -3.14ms throws TypeError
+PASS Setting 'margin-block-start' to a time: 3.14s throws TypeError
+PASS Setting 'margin-block-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'margin-block-start' to an angle: 0deg throws TypeError
+PASS Setting 'margin-block-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'margin-block-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'margin-block-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'margin-block-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'margin-block-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'margin-block-start' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'margin-block-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-block-start' to a number: -3.14 throws TypeError
+PASS Setting 'margin-block-start' to a number: 3.14 throws TypeError
+PASS Setting 'margin-block-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'margin-block-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'margin-block-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'margin-block-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'margin-block-end' to CSS-wide keywords: initial
 PASS Can set 'margin-block-end' to CSS-wide keywords: inherit
 PASS Can set 'margin-block-end' to CSS-wide keywords: unset
@@ -31,12 +43,24 @@ PASS Can set 'margin-block-end' to a length: 0px
 PASS Can set 'margin-block-end' to a length: -3.14em
 PASS Can set 'margin-block-end' to a length: 3.14cm
 PASS Can set 'margin-block-end' to a length: calc(0px + 0em)
-PASS Setting 'margin-block-end' to a time throws TypeError
-PASS Setting 'margin-block-end' to an angle throws TypeError
-PASS Setting 'margin-block-end' to a flexible length throws TypeError
-FAIL Setting 'margin-block-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'margin-block-end' to a URL throws TypeError
-PASS Setting 'margin-block-end' to a transform throws TypeError
+PASS Setting 'margin-block-end' to a time: 0s throws TypeError
+PASS Setting 'margin-block-end' to a time: -3.14ms throws TypeError
+PASS Setting 'margin-block-end' to a time: 3.14s throws TypeError
+PASS Setting 'margin-block-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'margin-block-end' to an angle: 0deg throws TypeError
+PASS Setting 'margin-block-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'margin-block-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'margin-block-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'margin-block-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'margin-block-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'margin-block-end' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'margin-block-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-block-end' to a number: -3.14 throws TypeError
+PASS Setting 'margin-block-end' to a number: 3.14 throws TypeError
+PASS Setting 'margin-block-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'margin-block-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'margin-block-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'margin-block-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'margin-inline-start' to CSS-wide keywords: initial
 PASS Can set 'margin-inline-start' to CSS-wide keywords: inherit
 PASS Can set 'margin-inline-start' to CSS-wide keywords: unset
@@ -50,12 +74,24 @@ PASS Can set 'margin-inline-start' to a length: 0px
 PASS Can set 'margin-inline-start' to a length: -3.14em
 PASS Can set 'margin-inline-start' to a length: 3.14cm
 PASS Can set 'margin-inline-start' to a length: calc(0px + 0em)
-PASS Setting 'margin-inline-start' to a time throws TypeError
-PASS Setting 'margin-inline-start' to an angle throws TypeError
-PASS Setting 'margin-inline-start' to a flexible length throws TypeError
-FAIL Setting 'margin-inline-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'margin-inline-start' to a URL throws TypeError
-PASS Setting 'margin-inline-start' to a transform throws TypeError
+PASS Setting 'margin-inline-start' to a time: 0s throws TypeError
+PASS Setting 'margin-inline-start' to a time: -3.14ms throws TypeError
+PASS Setting 'margin-inline-start' to a time: 3.14s throws TypeError
+PASS Setting 'margin-inline-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'margin-inline-start' to an angle: 0deg throws TypeError
+PASS Setting 'margin-inline-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'margin-inline-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'margin-inline-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'margin-inline-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'margin-inline-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'margin-inline-start' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'margin-inline-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-inline-start' to a number: -3.14 throws TypeError
+PASS Setting 'margin-inline-start' to a number: 3.14 throws TypeError
+PASS Setting 'margin-inline-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'margin-inline-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'margin-inline-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'margin-inline-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'margin-inline-end' to CSS-wide keywords: initial
 PASS Can set 'margin-inline-end' to CSS-wide keywords: inherit
 PASS Can set 'margin-inline-end' to CSS-wide keywords: unset
@@ -69,12 +105,24 @@ PASS Can set 'margin-inline-end' to a length: 0px
 PASS Can set 'margin-inline-end' to a length: -3.14em
 PASS Can set 'margin-inline-end' to a length: 3.14cm
 PASS Can set 'margin-inline-end' to a length: calc(0px + 0em)
-PASS Setting 'margin-inline-end' to a time throws TypeError
-PASS Setting 'margin-inline-end' to an angle throws TypeError
-PASS Setting 'margin-inline-end' to a flexible length throws TypeError
-FAIL Setting 'margin-inline-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'margin-inline-end' to a URL throws TypeError
-PASS Setting 'margin-inline-end' to a transform throws TypeError
+PASS Setting 'margin-inline-end' to a time: 0s throws TypeError
+PASS Setting 'margin-inline-end' to a time: -3.14ms throws TypeError
+PASS Setting 'margin-inline-end' to a time: 3.14s throws TypeError
+PASS Setting 'margin-inline-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'margin-inline-end' to an angle: 0deg throws TypeError
+PASS Setting 'margin-inline-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'margin-inline-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'margin-inline-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'margin-inline-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'margin-inline-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'margin-inline-end' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'margin-inline-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-inline-end' to a number: -3.14 throws TypeError
+PASS Setting 'margin-inline-end' to a number: 3.14 throws TypeError
+PASS Setting 'margin-inline-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'margin-inline-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'margin-inline-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'margin-inline-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'margin-block' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'margin-block' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'margin-block' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
@@ -88,12 +136,24 @@ FAIL Can set 'margin-block' to a length: 0px assert_equals: expected "CSSUnitVal
 FAIL Can set 'margin-block' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'margin-block' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'margin-block' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-PASS Setting 'margin-block' to a time throws TypeError
-PASS Setting 'margin-block' to an angle throws TypeError
-PASS Setting 'margin-block' to a flexible length throws TypeError
-FAIL Setting 'margin-block' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'margin-block' to a URL throws TypeError
-PASS Setting 'margin-block' to a transform throws TypeError
+PASS Setting 'margin-block' to a time: 0s throws TypeError
+PASS Setting 'margin-block' to a time: -3.14ms throws TypeError
+PASS Setting 'margin-block' to a time: 3.14s throws TypeError
+PASS Setting 'margin-block' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'margin-block' to an angle: 0deg throws TypeError
+PASS Setting 'margin-block' to an angle: 3.14rad throws TypeError
+PASS Setting 'margin-block' to an angle: -3.14deg throws TypeError
+PASS Setting 'margin-block' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'margin-block' to a flexible length: 0fr throws TypeError
+PASS Setting 'margin-block' to a flexible length: 1fr throws TypeError
+PASS Setting 'margin-block' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'margin-block' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-block' to a number: -3.14 throws TypeError
+PASS Setting 'margin-block' to a number: 3.14 throws TypeError
+PASS Setting 'margin-block' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'margin-block' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'margin-block' to a transform: perspective(10em) throws TypeError
+PASS Setting 'margin-block' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'margin-inline' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'margin-inline' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'margin-inline' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
@@ -107,12 +167,24 @@ FAIL Can set 'margin-inline' to a length: 0px assert_equals: expected "CSSUnitVa
 FAIL Can set 'margin-inline' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'margin-inline' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'margin-inline' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-PASS Setting 'margin-inline' to a time throws TypeError
-PASS Setting 'margin-inline' to an angle throws TypeError
-PASS Setting 'margin-inline' to a flexible length throws TypeError
-FAIL Setting 'margin-inline' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'margin-inline' to a URL throws TypeError
-PASS Setting 'margin-inline' to a transform throws TypeError
+PASS Setting 'margin-inline' to a time: 0s throws TypeError
+PASS Setting 'margin-inline' to a time: -3.14ms throws TypeError
+PASS Setting 'margin-inline' to a time: 3.14s throws TypeError
+PASS Setting 'margin-inline' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'margin-inline' to an angle: 0deg throws TypeError
+PASS Setting 'margin-inline' to an angle: 3.14rad throws TypeError
+PASS Setting 'margin-inline' to an angle: -3.14deg throws TypeError
+PASS Setting 'margin-inline' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'margin-inline' to a flexible length: 0fr throws TypeError
+PASS Setting 'margin-inline' to a flexible length: 1fr throws TypeError
+PASS Setting 'margin-inline' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'margin-inline' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-inline' to a number: -3.14 throws TypeError
+PASS Setting 'margin-inline' to a number: 3.14 throws TypeError
+PASS Setting 'margin-inline' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'margin-inline' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'margin-inline' to a transform: perspective(10em) throws TypeError
+PASS Setting 'margin-inline' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'inset-block-start' to CSS-wide keywords: initial
 PASS Can set 'inset-block-start' to CSS-wide keywords: inherit
 PASS Can set 'inset-block-start' to CSS-wide keywords: unset
@@ -126,12 +198,24 @@ PASS Can set 'inset-block-start' to a length: 0px
 PASS Can set 'inset-block-start' to a length: -3.14em
 PASS Can set 'inset-block-start' to a length: 3.14cm
 PASS Can set 'inset-block-start' to a length: calc(0px + 0em)
-PASS Setting 'inset-block-start' to a time throws TypeError
-PASS Setting 'inset-block-start' to an angle throws TypeError
-PASS Setting 'inset-block-start' to a flexible length throws TypeError
-FAIL Setting 'inset-block-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'inset-block-start' to a URL throws TypeError
-PASS Setting 'inset-block-start' to a transform throws TypeError
+PASS Setting 'inset-block-start' to a time: 0s throws TypeError
+PASS Setting 'inset-block-start' to a time: -3.14ms throws TypeError
+PASS Setting 'inset-block-start' to a time: 3.14s throws TypeError
+PASS Setting 'inset-block-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'inset-block-start' to an angle: 0deg throws TypeError
+PASS Setting 'inset-block-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'inset-block-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'inset-block-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'inset-block-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'inset-block-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'inset-block-start' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'inset-block-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'inset-block-start' to a number: -3.14 throws TypeError
+PASS Setting 'inset-block-start' to a number: 3.14 throws TypeError
+PASS Setting 'inset-block-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'inset-block-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'inset-block-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'inset-block-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'inset-block-end' to CSS-wide keywords: initial
 PASS Can set 'inset-block-end' to CSS-wide keywords: inherit
 PASS Can set 'inset-block-end' to CSS-wide keywords: unset
@@ -145,12 +229,24 @@ PASS Can set 'inset-block-end' to a length: 0px
 PASS Can set 'inset-block-end' to a length: -3.14em
 PASS Can set 'inset-block-end' to a length: 3.14cm
 PASS Can set 'inset-block-end' to a length: calc(0px + 0em)
-PASS Setting 'inset-block-end' to a time throws TypeError
-PASS Setting 'inset-block-end' to an angle throws TypeError
-PASS Setting 'inset-block-end' to a flexible length throws TypeError
-FAIL Setting 'inset-block-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'inset-block-end' to a URL throws TypeError
-PASS Setting 'inset-block-end' to a transform throws TypeError
+PASS Setting 'inset-block-end' to a time: 0s throws TypeError
+PASS Setting 'inset-block-end' to a time: -3.14ms throws TypeError
+PASS Setting 'inset-block-end' to a time: 3.14s throws TypeError
+PASS Setting 'inset-block-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'inset-block-end' to an angle: 0deg throws TypeError
+PASS Setting 'inset-block-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'inset-block-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'inset-block-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'inset-block-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'inset-block-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'inset-block-end' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'inset-block-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'inset-block-end' to a number: -3.14 throws TypeError
+PASS Setting 'inset-block-end' to a number: 3.14 throws TypeError
+PASS Setting 'inset-block-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'inset-block-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'inset-block-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'inset-block-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'inset-inline-start' to CSS-wide keywords: initial
 PASS Can set 'inset-inline-start' to CSS-wide keywords: inherit
 PASS Can set 'inset-inline-start' to CSS-wide keywords: unset
@@ -164,12 +260,24 @@ PASS Can set 'inset-inline-start' to a length: 0px
 PASS Can set 'inset-inline-start' to a length: -3.14em
 PASS Can set 'inset-inline-start' to a length: 3.14cm
 PASS Can set 'inset-inline-start' to a length: calc(0px + 0em)
-PASS Setting 'inset-inline-start' to a time throws TypeError
-PASS Setting 'inset-inline-start' to an angle throws TypeError
-PASS Setting 'inset-inline-start' to a flexible length throws TypeError
-FAIL Setting 'inset-inline-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'inset-inline-start' to a URL throws TypeError
-PASS Setting 'inset-inline-start' to a transform throws TypeError
+PASS Setting 'inset-inline-start' to a time: 0s throws TypeError
+PASS Setting 'inset-inline-start' to a time: -3.14ms throws TypeError
+PASS Setting 'inset-inline-start' to a time: 3.14s throws TypeError
+PASS Setting 'inset-inline-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'inset-inline-start' to an angle: 0deg throws TypeError
+PASS Setting 'inset-inline-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'inset-inline-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'inset-inline-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'inset-inline-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'inset-inline-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'inset-inline-start' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'inset-inline-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'inset-inline-start' to a number: -3.14 throws TypeError
+PASS Setting 'inset-inline-start' to a number: 3.14 throws TypeError
+PASS Setting 'inset-inline-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'inset-inline-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'inset-inline-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'inset-inline-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'inset-inline-end' to CSS-wide keywords: initial
 PASS Can set 'inset-inline-end' to CSS-wide keywords: inherit
 PASS Can set 'inset-inline-end' to CSS-wide keywords: unset
@@ -183,12 +291,24 @@ PASS Can set 'inset-inline-end' to a length: 0px
 PASS Can set 'inset-inline-end' to a length: -3.14em
 PASS Can set 'inset-inline-end' to a length: 3.14cm
 PASS Can set 'inset-inline-end' to a length: calc(0px + 0em)
-PASS Setting 'inset-inline-end' to a time throws TypeError
-PASS Setting 'inset-inline-end' to an angle throws TypeError
-PASS Setting 'inset-inline-end' to a flexible length throws TypeError
-FAIL Setting 'inset-inline-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'inset-inline-end' to a URL throws TypeError
-PASS Setting 'inset-inline-end' to a transform throws TypeError
+PASS Setting 'inset-inline-end' to a time: 0s throws TypeError
+PASS Setting 'inset-inline-end' to a time: -3.14ms throws TypeError
+PASS Setting 'inset-inline-end' to a time: 3.14s throws TypeError
+PASS Setting 'inset-inline-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'inset-inline-end' to an angle: 0deg throws TypeError
+PASS Setting 'inset-inline-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'inset-inline-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'inset-inline-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'inset-inline-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'inset-inline-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'inset-inline-end' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'inset-inline-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'inset-inline-end' to a number: -3.14 throws TypeError
+PASS Setting 'inset-inline-end' to a number: 3.14 throws TypeError
+PASS Setting 'inset-inline-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'inset-inline-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'inset-inline-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'inset-inline-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'inset-block' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'inset-block' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'inset-block' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
@@ -202,12 +322,24 @@ FAIL Can set 'inset-block' to a length: 0px assert_equals: expected "CSSUnitValu
 FAIL Can set 'inset-block' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'inset-block' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'inset-block' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-PASS Setting 'inset-block' to a time throws TypeError
-PASS Setting 'inset-block' to an angle throws TypeError
-PASS Setting 'inset-block' to a flexible length throws TypeError
-FAIL Setting 'inset-block' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'inset-block' to a URL throws TypeError
-PASS Setting 'inset-block' to a transform throws TypeError
+PASS Setting 'inset-block' to a time: 0s throws TypeError
+PASS Setting 'inset-block' to a time: -3.14ms throws TypeError
+PASS Setting 'inset-block' to a time: 3.14s throws TypeError
+PASS Setting 'inset-block' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'inset-block' to an angle: 0deg throws TypeError
+PASS Setting 'inset-block' to an angle: 3.14rad throws TypeError
+PASS Setting 'inset-block' to an angle: -3.14deg throws TypeError
+PASS Setting 'inset-block' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'inset-block' to a flexible length: 0fr throws TypeError
+PASS Setting 'inset-block' to a flexible length: 1fr throws TypeError
+PASS Setting 'inset-block' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'inset-block' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'inset-block' to a number: -3.14 throws TypeError
+PASS Setting 'inset-block' to a number: 3.14 throws TypeError
+PASS Setting 'inset-block' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'inset-block' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'inset-block' to a transform: perspective(10em) throws TypeError
+PASS Setting 'inset-block' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'inset-inline' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'inset-inline' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'inset-inline' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
@@ -221,12 +353,24 @@ FAIL Can set 'inset-inline' to a length: 0px assert_equals: expected "CSSUnitVal
 FAIL Can set 'inset-inline' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'inset-inline' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'inset-inline' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-PASS Setting 'inset-inline' to a time throws TypeError
-PASS Setting 'inset-inline' to an angle throws TypeError
-PASS Setting 'inset-inline' to a flexible length throws TypeError
-FAIL Setting 'inset-inline' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'inset-inline' to a URL throws TypeError
-PASS Setting 'inset-inline' to a transform throws TypeError
+PASS Setting 'inset-inline' to a time: 0s throws TypeError
+PASS Setting 'inset-inline' to a time: -3.14ms throws TypeError
+PASS Setting 'inset-inline' to a time: 3.14s throws TypeError
+PASS Setting 'inset-inline' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'inset-inline' to an angle: 0deg throws TypeError
+PASS Setting 'inset-inline' to an angle: 3.14rad throws TypeError
+PASS Setting 'inset-inline' to an angle: -3.14deg throws TypeError
+PASS Setting 'inset-inline' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'inset-inline' to a flexible length: 0fr throws TypeError
+PASS Setting 'inset-inline' to a flexible length: 1fr throws TypeError
+PASS Setting 'inset-inline' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'inset-inline' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'inset-inline' to a number: -3.14 throws TypeError
+PASS Setting 'inset-inline' to a number: 3.14 throws TypeError
+PASS Setting 'inset-inline' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'inset-inline' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'inset-inline' to a transform: perspective(10em) throws TypeError
+PASS Setting 'inset-inline' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'padding-block-start' to CSS-wide keywords: initial
 PASS Can set 'padding-block-start' to CSS-wide keywords: inherit
 PASS Can set 'padding-block-start' to CSS-wide keywords: unset
@@ -240,12 +384,24 @@ PASS Can set 'padding-block-start' to a length: 0px
 FAIL Can set 'padding-block-start' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'padding-block-start' to a length: 3.14cm
 PASS Can set 'padding-block-start' to a length: calc(0px + 0em)
-PASS Setting 'padding-block-start' to a time throws TypeError
-PASS Setting 'padding-block-start' to an angle throws TypeError
-PASS Setting 'padding-block-start' to a flexible length throws TypeError
-FAIL Setting 'padding-block-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-block-start' to a URL throws TypeError
-PASS Setting 'padding-block-start' to a transform throws TypeError
+PASS Setting 'padding-block-start' to a time: 0s throws TypeError
+PASS Setting 'padding-block-start' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-block-start' to a time: 3.14s throws TypeError
+PASS Setting 'padding-block-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-block-start' to an angle: 0deg throws TypeError
+PASS Setting 'padding-block-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-block-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-block-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-block-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-block-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-block-start' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-block-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-block-start' to a number: -3.14 throws TypeError
+PASS Setting 'padding-block-start' to a number: 3.14 throws TypeError
+PASS Setting 'padding-block-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-block-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-block-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-block-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'padding-block-end' to CSS-wide keywords: initial
 PASS Can set 'padding-block-end' to CSS-wide keywords: inherit
 PASS Can set 'padding-block-end' to CSS-wide keywords: unset
@@ -259,12 +415,24 @@ PASS Can set 'padding-block-end' to a length: 0px
 FAIL Can set 'padding-block-end' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'padding-block-end' to a length: 3.14cm
 PASS Can set 'padding-block-end' to a length: calc(0px + 0em)
-PASS Setting 'padding-block-end' to a time throws TypeError
-PASS Setting 'padding-block-end' to an angle throws TypeError
-PASS Setting 'padding-block-end' to a flexible length throws TypeError
-FAIL Setting 'padding-block-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-block-end' to a URL throws TypeError
-PASS Setting 'padding-block-end' to a transform throws TypeError
+PASS Setting 'padding-block-end' to a time: 0s throws TypeError
+PASS Setting 'padding-block-end' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-block-end' to a time: 3.14s throws TypeError
+PASS Setting 'padding-block-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-block-end' to an angle: 0deg throws TypeError
+PASS Setting 'padding-block-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-block-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-block-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-block-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-block-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-block-end' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-block-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-block-end' to a number: -3.14 throws TypeError
+PASS Setting 'padding-block-end' to a number: 3.14 throws TypeError
+PASS Setting 'padding-block-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-block-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-block-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-block-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'padding-inline-start' to CSS-wide keywords: initial
 PASS Can set 'padding-inline-start' to CSS-wide keywords: inherit
 PASS Can set 'padding-inline-start' to CSS-wide keywords: unset
@@ -278,12 +446,24 @@ PASS Can set 'padding-inline-start' to a length: 0px
 FAIL Can set 'padding-inline-start' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'padding-inline-start' to a length: 3.14cm
 PASS Can set 'padding-inline-start' to a length: calc(0px + 0em)
-PASS Setting 'padding-inline-start' to a time throws TypeError
-PASS Setting 'padding-inline-start' to an angle throws TypeError
-PASS Setting 'padding-inline-start' to a flexible length throws TypeError
-FAIL Setting 'padding-inline-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-inline-start' to a URL throws TypeError
-PASS Setting 'padding-inline-start' to a transform throws TypeError
+PASS Setting 'padding-inline-start' to a time: 0s throws TypeError
+PASS Setting 'padding-inline-start' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-inline-start' to a time: 3.14s throws TypeError
+PASS Setting 'padding-inline-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-inline-start' to an angle: 0deg throws TypeError
+PASS Setting 'padding-inline-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-inline-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-inline-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-inline-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-inline-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-inline-start' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-inline-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-inline-start' to a number: -3.14 throws TypeError
+PASS Setting 'padding-inline-start' to a number: 3.14 throws TypeError
+PASS Setting 'padding-inline-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-inline-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-inline-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-inline-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'padding-inline-end' to CSS-wide keywords: initial
 PASS Can set 'padding-inline-end' to CSS-wide keywords: inherit
 PASS Can set 'padding-inline-end' to CSS-wide keywords: unset
@@ -297,12 +477,24 @@ PASS Can set 'padding-inline-end' to a length: 0px
 FAIL Can set 'padding-inline-end' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'padding-inline-end' to a length: 3.14cm
 PASS Can set 'padding-inline-end' to a length: calc(0px + 0em)
-PASS Setting 'padding-inline-end' to a time throws TypeError
-PASS Setting 'padding-inline-end' to an angle throws TypeError
-PASS Setting 'padding-inline-end' to a flexible length throws TypeError
-FAIL Setting 'padding-inline-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-inline-end' to a URL throws TypeError
-PASS Setting 'padding-inline-end' to a transform throws TypeError
+PASS Setting 'padding-inline-end' to a time: 0s throws TypeError
+PASS Setting 'padding-inline-end' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-inline-end' to a time: 3.14s throws TypeError
+PASS Setting 'padding-inline-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-inline-end' to an angle: 0deg throws TypeError
+PASS Setting 'padding-inline-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-inline-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-inline-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-inline-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-inline-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-inline-end' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-inline-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-inline-end' to a number: -3.14 throws TypeError
+PASS Setting 'padding-inline-end' to a number: 3.14 throws TypeError
+PASS Setting 'padding-inline-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-inline-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-inline-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-inline-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'padding-block' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'padding-block' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'padding-block' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
@@ -316,12 +508,24 @@ FAIL Can set 'padding-block' to a length: 0px assert_equals: expected "CSSUnitVa
 FAIL Can set 'padding-block' to a length: -3.14em Bad value for shorthand CSS property
 FAIL Can set 'padding-block' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'padding-block' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-PASS Setting 'padding-block' to a time throws TypeError
-PASS Setting 'padding-block' to an angle throws TypeError
-PASS Setting 'padding-block' to a flexible length throws TypeError
-FAIL Setting 'padding-block' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-block' to a URL throws TypeError
-PASS Setting 'padding-block' to a transform throws TypeError
+PASS Setting 'padding-block' to a time: 0s throws TypeError
+PASS Setting 'padding-block' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-block' to a time: 3.14s throws TypeError
+PASS Setting 'padding-block' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-block' to an angle: 0deg throws TypeError
+PASS Setting 'padding-block' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-block' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-block' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-block' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-block' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-block' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-block' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-block' to a number: -3.14 throws TypeError
+PASS Setting 'padding-block' to a number: 3.14 throws TypeError
+PASS Setting 'padding-block' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-block' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-block' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-block' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'padding-inline' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'padding-inline' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'padding-inline' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
@@ -335,26 +539,56 @@ FAIL Can set 'padding-inline' to a length: 0px assert_equals: expected "CSSUnitV
 FAIL Can set 'padding-inline' to a length: -3.14em Bad value for shorthand CSS property
 FAIL Can set 'padding-inline' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'padding-inline' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-PASS Setting 'padding-inline' to a time throws TypeError
-PASS Setting 'padding-inline' to an angle throws TypeError
-PASS Setting 'padding-inline' to a flexible length throws TypeError
-FAIL Setting 'padding-inline' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-inline' to a URL throws TypeError
-PASS Setting 'padding-inline' to a transform throws TypeError
+PASS Setting 'padding-inline' to a time: 0s throws TypeError
+PASS Setting 'padding-inline' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-inline' to a time: 3.14s throws TypeError
+PASS Setting 'padding-inline' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-inline' to an angle: 0deg throws TypeError
+PASS Setting 'padding-inline' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-inline' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-inline' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-inline' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-inline' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-inline' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-inline' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-inline' to a number: -3.14 throws TypeError
+PASS Setting 'padding-inline' to a number: 3.14 throws TypeError
+PASS Setting 'padding-inline' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-inline' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-inline' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-inline' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'border-block-start' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-start' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-start' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-start' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
 FAIL Can set 'border-block-start' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Setting 'border-block-start' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-block-start' to a percent throws TypeError
-PASS Setting 'border-block-start' to a time throws TypeError
-PASS Setting 'border-block-start' to an angle throws TypeError
-PASS Setting 'border-block-start' to a flexible length throws TypeError
-FAIL Setting 'border-block-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-block-start' to a URL throws TypeError
-PASS Setting 'border-block-start' to a transform throws TypeError
+FAIL Setting 'border-block-start' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-block-start' to a length: -3.14em throws TypeError
+FAIL Setting 'border-block-start' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'border-block-start' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-block-start' to a percent: 0% throws TypeError
+PASS Setting 'border-block-start' to a percent: -3.14% throws TypeError
+PASS Setting 'border-block-start' to a percent: 3.14% throws TypeError
+PASS Setting 'border-block-start' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-block-start' to a time: 0s throws TypeError
+PASS Setting 'border-block-start' to a time: -3.14ms throws TypeError
+PASS Setting 'border-block-start' to a time: 3.14s throws TypeError
+PASS Setting 'border-block-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-block-start' to an angle: 0deg throws TypeError
+PASS Setting 'border-block-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-block-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-block-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-block-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-block-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-block-start' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-block-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-block-start' to a number: -3.14 throws TypeError
+PASS Setting 'border-block-start' to a number: 3.14 throws TypeError
+PASS Setting 'border-block-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-block-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-block-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-block-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-block-start-width' to CSS-wide keywords: initial
 PASS Can set 'border-block-start-width' to CSS-wide keywords: inherit
 PASS Can set 'border-block-start-width' to CSS-wide keywords: unset
@@ -367,27 +601,60 @@ PASS Can set 'border-block-start-width' to a length: 0px
 FAIL Can set 'border-block-start-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'border-block-start-width' to a length: 3.14cm
 PASS Can set 'border-block-start-width' to a length: calc(0px + 0em)
-PASS Setting 'border-block-start-width' to a percent throws TypeError
-PASS Setting 'border-block-start-width' to a time throws TypeError
-PASS Setting 'border-block-start-width' to an angle throws TypeError
-PASS Setting 'border-block-start-width' to a flexible length throws TypeError
-FAIL Setting 'border-block-start-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-block-start-width' to a URL throws TypeError
-PASS Setting 'border-block-start-width' to a transform throws TypeError
+PASS Setting 'border-block-start-width' to a percent: 0% throws TypeError
+PASS Setting 'border-block-start-width' to a percent: -3.14% throws TypeError
+PASS Setting 'border-block-start-width' to a percent: 3.14% throws TypeError
+PASS Setting 'border-block-start-width' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-block-start-width' to a time: 0s throws TypeError
+PASS Setting 'border-block-start-width' to a time: -3.14ms throws TypeError
+PASS Setting 'border-block-start-width' to a time: 3.14s throws TypeError
+PASS Setting 'border-block-start-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-block-start-width' to an angle: 0deg throws TypeError
+PASS Setting 'border-block-start-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-block-start-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-block-start-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-block-start-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-block-start-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-block-start-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-block-start-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-block-start-width' to a number: -3.14 throws TypeError
+PASS Setting 'border-block-start-width' to a number: 3.14 throws TypeError
+PASS Setting 'border-block-start-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-block-start-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-block-start-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-block-start-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-block-start-color' to CSS-wide keywords: initial
 PASS Can set 'border-block-start-color' to CSS-wide keywords: inherit
 PASS Can set 'border-block-start-color' to CSS-wide keywords: unset
 PASS Can set 'border-block-start-color' to CSS-wide keywords: revert
 PASS Can set 'border-block-start-color' to var() references:  var(--A)
 FAIL Can set 'border-block-start-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-PASS Setting 'border-block-start-color' to a length throws TypeError
-PASS Setting 'border-block-start-color' to a percent throws TypeError
-PASS Setting 'border-block-start-color' to a time throws TypeError
-PASS Setting 'border-block-start-color' to an angle throws TypeError
-PASS Setting 'border-block-start-color' to a flexible length throws TypeError
-PASS Setting 'border-block-start-color' to a number throws TypeError
-PASS Setting 'border-block-start-color' to a URL throws TypeError
-PASS Setting 'border-block-start-color' to a transform throws TypeError
+PASS Setting 'border-block-start-color' to a length: 0px throws TypeError
+PASS Setting 'border-block-start-color' to a length: -3.14em throws TypeError
+PASS Setting 'border-block-start-color' to a length: 3.14cm throws TypeError
+PASS Setting 'border-block-start-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-block-start-color' to a percent: 0% throws TypeError
+PASS Setting 'border-block-start-color' to a percent: -3.14% throws TypeError
+PASS Setting 'border-block-start-color' to a percent: 3.14% throws TypeError
+PASS Setting 'border-block-start-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-block-start-color' to a time: 0s throws TypeError
+PASS Setting 'border-block-start-color' to a time: -3.14ms throws TypeError
+PASS Setting 'border-block-start-color' to a time: 3.14s throws TypeError
+PASS Setting 'border-block-start-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-block-start-color' to an angle: 0deg throws TypeError
+PASS Setting 'border-block-start-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-block-start-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-block-start-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-block-start-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-block-start-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-block-start-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-block-start-color' to a number: 0 throws TypeError
+PASS Setting 'border-block-start-color' to a number: -3.14 throws TypeError
+PASS Setting 'border-block-start-color' to a number: 3.14 throws TypeError
+PASS Setting 'border-block-start-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-block-start-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-block-start-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-block-start-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-block-start-style' to CSS-wide keywords: initial
 PASS Can set 'border-block-start-style' to CSS-wide keywords: inherit
 PASS Can set 'border-block-start-style' to CSS-wide keywords: unset
@@ -395,28 +662,64 @@ PASS Can set 'border-block-start-style' to CSS-wide keywords: revert
 PASS Can set 'border-block-start-style' to var() references:  var(--A)
 PASS Can set 'border-block-start-style' to the 'none' keyword: none
 PASS Can set 'border-block-start-style' to the 'solid' keyword: solid
-PASS Setting 'border-block-start-style' to a length throws TypeError
-PASS Setting 'border-block-start-style' to a percent throws TypeError
-PASS Setting 'border-block-start-style' to a time throws TypeError
-PASS Setting 'border-block-start-style' to an angle throws TypeError
-PASS Setting 'border-block-start-style' to a flexible length throws TypeError
-PASS Setting 'border-block-start-style' to a number throws TypeError
-PASS Setting 'border-block-start-style' to a URL throws TypeError
-PASS Setting 'border-block-start-style' to a transform throws TypeError
+PASS Setting 'border-block-start-style' to a length: 0px throws TypeError
+PASS Setting 'border-block-start-style' to a length: -3.14em throws TypeError
+PASS Setting 'border-block-start-style' to a length: 3.14cm throws TypeError
+PASS Setting 'border-block-start-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-block-start-style' to a percent: 0% throws TypeError
+PASS Setting 'border-block-start-style' to a percent: -3.14% throws TypeError
+PASS Setting 'border-block-start-style' to a percent: 3.14% throws TypeError
+PASS Setting 'border-block-start-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-block-start-style' to a time: 0s throws TypeError
+PASS Setting 'border-block-start-style' to a time: -3.14ms throws TypeError
+PASS Setting 'border-block-start-style' to a time: 3.14s throws TypeError
+PASS Setting 'border-block-start-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-block-start-style' to an angle: 0deg throws TypeError
+PASS Setting 'border-block-start-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-block-start-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-block-start-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-block-start-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-block-start-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-block-start-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-block-start-style' to a number: 0 throws TypeError
+PASS Setting 'border-block-start-style' to a number: -3.14 throws TypeError
+PASS Setting 'border-block-start-style' to a number: 3.14 throws TypeError
+PASS Setting 'border-block-start-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-block-start-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-block-start-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-block-start-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'border-block-end' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-end' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-end' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-end' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
 FAIL Can set 'border-block-end' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Setting 'border-block-end' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-block-end' to a percent throws TypeError
-PASS Setting 'border-block-end' to a time throws TypeError
-PASS Setting 'border-block-end' to an angle throws TypeError
-PASS Setting 'border-block-end' to a flexible length throws TypeError
-FAIL Setting 'border-block-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-block-end' to a URL throws TypeError
-PASS Setting 'border-block-end' to a transform throws TypeError
+FAIL Setting 'border-block-end' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-block-end' to a length: -3.14em throws TypeError
+FAIL Setting 'border-block-end' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'border-block-end' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-block-end' to a percent: 0% throws TypeError
+PASS Setting 'border-block-end' to a percent: -3.14% throws TypeError
+PASS Setting 'border-block-end' to a percent: 3.14% throws TypeError
+PASS Setting 'border-block-end' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-block-end' to a time: 0s throws TypeError
+PASS Setting 'border-block-end' to a time: -3.14ms throws TypeError
+PASS Setting 'border-block-end' to a time: 3.14s throws TypeError
+PASS Setting 'border-block-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-block-end' to an angle: 0deg throws TypeError
+PASS Setting 'border-block-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-block-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-block-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-block-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-block-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-block-end' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-block-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-block-end' to a number: -3.14 throws TypeError
+PASS Setting 'border-block-end' to a number: 3.14 throws TypeError
+PASS Setting 'border-block-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-block-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-block-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-block-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-block-end-width' to CSS-wide keywords: initial
 PASS Can set 'border-block-end-width' to CSS-wide keywords: inherit
 PASS Can set 'border-block-end-width' to CSS-wide keywords: unset
@@ -429,27 +732,60 @@ PASS Can set 'border-block-end-width' to a length: 0px
 FAIL Can set 'border-block-end-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'border-block-end-width' to a length: 3.14cm
 PASS Can set 'border-block-end-width' to a length: calc(0px + 0em)
-PASS Setting 'border-block-end-width' to a percent throws TypeError
-PASS Setting 'border-block-end-width' to a time throws TypeError
-PASS Setting 'border-block-end-width' to an angle throws TypeError
-PASS Setting 'border-block-end-width' to a flexible length throws TypeError
-FAIL Setting 'border-block-end-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-block-end-width' to a URL throws TypeError
-PASS Setting 'border-block-end-width' to a transform throws TypeError
+PASS Setting 'border-block-end-width' to a percent: 0% throws TypeError
+PASS Setting 'border-block-end-width' to a percent: -3.14% throws TypeError
+PASS Setting 'border-block-end-width' to a percent: 3.14% throws TypeError
+PASS Setting 'border-block-end-width' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-block-end-width' to a time: 0s throws TypeError
+PASS Setting 'border-block-end-width' to a time: -3.14ms throws TypeError
+PASS Setting 'border-block-end-width' to a time: 3.14s throws TypeError
+PASS Setting 'border-block-end-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-block-end-width' to an angle: 0deg throws TypeError
+PASS Setting 'border-block-end-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-block-end-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-block-end-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-block-end-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-block-end-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-block-end-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-block-end-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-block-end-width' to a number: -3.14 throws TypeError
+PASS Setting 'border-block-end-width' to a number: 3.14 throws TypeError
+PASS Setting 'border-block-end-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-block-end-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-block-end-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-block-end-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-block-end-color' to CSS-wide keywords: initial
 PASS Can set 'border-block-end-color' to CSS-wide keywords: inherit
 PASS Can set 'border-block-end-color' to CSS-wide keywords: unset
 PASS Can set 'border-block-end-color' to CSS-wide keywords: revert
 PASS Can set 'border-block-end-color' to var() references:  var(--A)
 FAIL Can set 'border-block-end-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-PASS Setting 'border-block-end-color' to a length throws TypeError
-PASS Setting 'border-block-end-color' to a percent throws TypeError
-PASS Setting 'border-block-end-color' to a time throws TypeError
-PASS Setting 'border-block-end-color' to an angle throws TypeError
-PASS Setting 'border-block-end-color' to a flexible length throws TypeError
-PASS Setting 'border-block-end-color' to a number throws TypeError
-PASS Setting 'border-block-end-color' to a URL throws TypeError
-PASS Setting 'border-block-end-color' to a transform throws TypeError
+PASS Setting 'border-block-end-color' to a length: 0px throws TypeError
+PASS Setting 'border-block-end-color' to a length: -3.14em throws TypeError
+PASS Setting 'border-block-end-color' to a length: 3.14cm throws TypeError
+PASS Setting 'border-block-end-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-block-end-color' to a percent: 0% throws TypeError
+PASS Setting 'border-block-end-color' to a percent: -3.14% throws TypeError
+PASS Setting 'border-block-end-color' to a percent: 3.14% throws TypeError
+PASS Setting 'border-block-end-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-block-end-color' to a time: 0s throws TypeError
+PASS Setting 'border-block-end-color' to a time: -3.14ms throws TypeError
+PASS Setting 'border-block-end-color' to a time: 3.14s throws TypeError
+PASS Setting 'border-block-end-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-block-end-color' to an angle: 0deg throws TypeError
+PASS Setting 'border-block-end-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-block-end-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-block-end-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-block-end-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-block-end-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-block-end-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-block-end-color' to a number: 0 throws TypeError
+PASS Setting 'border-block-end-color' to a number: -3.14 throws TypeError
+PASS Setting 'border-block-end-color' to a number: 3.14 throws TypeError
+PASS Setting 'border-block-end-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-block-end-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-block-end-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-block-end-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-block-end-style' to CSS-wide keywords: initial
 PASS Can set 'border-block-end-style' to CSS-wide keywords: inherit
 PASS Can set 'border-block-end-style' to CSS-wide keywords: unset
@@ -457,28 +793,64 @@ PASS Can set 'border-block-end-style' to CSS-wide keywords: revert
 PASS Can set 'border-block-end-style' to var() references:  var(--A)
 PASS Can set 'border-block-end-style' to the 'none' keyword: none
 PASS Can set 'border-block-end-style' to the 'solid' keyword: solid
-PASS Setting 'border-block-end-style' to a length throws TypeError
-PASS Setting 'border-block-end-style' to a percent throws TypeError
-PASS Setting 'border-block-end-style' to a time throws TypeError
-PASS Setting 'border-block-end-style' to an angle throws TypeError
-PASS Setting 'border-block-end-style' to a flexible length throws TypeError
-PASS Setting 'border-block-end-style' to a number throws TypeError
-PASS Setting 'border-block-end-style' to a URL throws TypeError
-PASS Setting 'border-block-end-style' to a transform throws TypeError
+PASS Setting 'border-block-end-style' to a length: 0px throws TypeError
+PASS Setting 'border-block-end-style' to a length: -3.14em throws TypeError
+PASS Setting 'border-block-end-style' to a length: 3.14cm throws TypeError
+PASS Setting 'border-block-end-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-block-end-style' to a percent: 0% throws TypeError
+PASS Setting 'border-block-end-style' to a percent: -3.14% throws TypeError
+PASS Setting 'border-block-end-style' to a percent: 3.14% throws TypeError
+PASS Setting 'border-block-end-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-block-end-style' to a time: 0s throws TypeError
+PASS Setting 'border-block-end-style' to a time: -3.14ms throws TypeError
+PASS Setting 'border-block-end-style' to a time: 3.14s throws TypeError
+PASS Setting 'border-block-end-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-block-end-style' to an angle: 0deg throws TypeError
+PASS Setting 'border-block-end-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-block-end-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-block-end-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-block-end-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-block-end-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-block-end-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-block-end-style' to a number: 0 throws TypeError
+PASS Setting 'border-block-end-style' to a number: -3.14 throws TypeError
+PASS Setting 'border-block-end-style' to a number: 3.14 throws TypeError
+PASS Setting 'border-block-end-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-block-end-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-block-end-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-block-end-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'border-inline-start' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-start' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-start' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-start' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-start' to var() references:  var(--A) assert_equals: expected 2 but got 1
 FAIL Can set 'border-inline-start' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Setting 'border-inline-start' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-inline-start' to a percent throws TypeError
-PASS Setting 'border-inline-start' to a time throws TypeError
-PASS Setting 'border-inline-start' to an angle throws TypeError
-PASS Setting 'border-inline-start' to a flexible length throws TypeError
-FAIL Setting 'border-inline-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-inline-start' to a URL throws TypeError
-PASS Setting 'border-inline-start' to a transform throws TypeError
+FAIL Setting 'border-inline-start' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-inline-start' to a length: -3.14em throws TypeError
+FAIL Setting 'border-inline-start' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'border-inline-start' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-inline-start' to a percent: 0% throws TypeError
+PASS Setting 'border-inline-start' to a percent: -3.14% throws TypeError
+PASS Setting 'border-inline-start' to a percent: 3.14% throws TypeError
+PASS Setting 'border-inline-start' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-inline-start' to a time: 0s throws TypeError
+PASS Setting 'border-inline-start' to a time: -3.14ms throws TypeError
+PASS Setting 'border-inline-start' to a time: 3.14s throws TypeError
+PASS Setting 'border-inline-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-inline-start' to an angle: 0deg throws TypeError
+PASS Setting 'border-inline-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-inline-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-inline-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-inline-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-inline-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-inline-start' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-inline-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-inline-start' to a number: -3.14 throws TypeError
+PASS Setting 'border-inline-start' to a number: 3.14 throws TypeError
+PASS Setting 'border-inline-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-inline-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-inline-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-inline-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-inline-start-width' to CSS-wide keywords: initial
 PASS Can set 'border-inline-start-width' to CSS-wide keywords: inherit
 PASS Can set 'border-inline-start-width' to CSS-wide keywords: unset
@@ -491,27 +863,60 @@ PASS Can set 'border-inline-start-width' to a length: 0px
 FAIL Can set 'border-inline-start-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'border-inline-start-width' to a length: 3.14cm
 PASS Can set 'border-inline-start-width' to a length: calc(0px + 0em)
-PASS Setting 'border-inline-start-width' to a percent throws TypeError
-PASS Setting 'border-inline-start-width' to a time throws TypeError
-PASS Setting 'border-inline-start-width' to an angle throws TypeError
-PASS Setting 'border-inline-start-width' to a flexible length throws TypeError
-FAIL Setting 'border-inline-start-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-inline-start-width' to a URL throws TypeError
-PASS Setting 'border-inline-start-width' to a transform throws TypeError
+PASS Setting 'border-inline-start-width' to a percent: 0% throws TypeError
+PASS Setting 'border-inline-start-width' to a percent: -3.14% throws TypeError
+PASS Setting 'border-inline-start-width' to a percent: 3.14% throws TypeError
+PASS Setting 'border-inline-start-width' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-inline-start-width' to a time: 0s throws TypeError
+PASS Setting 'border-inline-start-width' to a time: -3.14ms throws TypeError
+PASS Setting 'border-inline-start-width' to a time: 3.14s throws TypeError
+PASS Setting 'border-inline-start-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-inline-start-width' to an angle: 0deg throws TypeError
+PASS Setting 'border-inline-start-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-inline-start-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-inline-start-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-inline-start-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-inline-start-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-inline-start-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-inline-start-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-inline-start-width' to a number: -3.14 throws TypeError
+PASS Setting 'border-inline-start-width' to a number: 3.14 throws TypeError
+PASS Setting 'border-inline-start-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-inline-start-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-inline-start-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-inline-start-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-inline-start-color' to CSS-wide keywords: initial
 PASS Can set 'border-inline-start-color' to CSS-wide keywords: inherit
 PASS Can set 'border-inline-start-color' to CSS-wide keywords: unset
 PASS Can set 'border-inline-start-color' to CSS-wide keywords: revert
 PASS Can set 'border-inline-start-color' to var() references:  var(--A)
 FAIL Can set 'border-inline-start-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-PASS Setting 'border-inline-start-color' to a length throws TypeError
-PASS Setting 'border-inline-start-color' to a percent throws TypeError
-PASS Setting 'border-inline-start-color' to a time throws TypeError
-PASS Setting 'border-inline-start-color' to an angle throws TypeError
-PASS Setting 'border-inline-start-color' to a flexible length throws TypeError
-PASS Setting 'border-inline-start-color' to a number throws TypeError
-PASS Setting 'border-inline-start-color' to a URL throws TypeError
-PASS Setting 'border-inline-start-color' to a transform throws TypeError
+PASS Setting 'border-inline-start-color' to a length: 0px throws TypeError
+PASS Setting 'border-inline-start-color' to a length: -3.14em throws TypeError
+PASS Setting 'border-inline-start-color' to a length: 3.14cm throws TypeError
+PASS Setting 'border-inline-start-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-inline-start-color' to a percent: 0% throws TypeError
+PASS Setting 'border-inline-start-color' to a percent: -3.14% throws TypeError
+PASS Setting 'border-inline-start-color' to a percent: 3.14% throws TypeError
+PASS Setting 'border-inline-start-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-inline-start-color' to a time: 0s throws TypeError
+PASS Setting 'border-inline-start-color' to a time: -3.14ms throws TypeError
+PASS Setting 'border-inline-start-color' to a time: 3.14s throws TypeError
+PASS Setting 'border-inline-start-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-inline-start-color' to an angle: 0deg throws TypeError
+PASS Setting 'border-inline-start-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-inline-start-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-inline-start-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-inline-start-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-inline-start-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-inline-start-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-inline-start-color' to a number: 0 throws TypeError
+PASS Setting 'border-inline-start-color' to a number: -3.14 throws TypeError
+PASS Setting 'border-inline-start-color' to a number: 3.14 throws TypeError
+PASS Setting 'border-inline-start-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-inline-start-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-inline-start-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-inline-start-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-inline-start-style' to CSS-wide keywords: initial
 PASS Can set 'border-inline-start-style' to CSS-wide keywords: inherit
 PASS Can set 'border-inline-start-style' to CSS-wide keywords: unset
@@ -519,28 +924,64 @@ PASS Can set 'border-inline-start-style' to CSS-wide keywords: revert
 PASS Can set 'border-inline-start-style' to var() references:  var(--A)
 PASS Can set 'border-inline-start-style' to the 'none' keyword: none
 PASS Can set 'border-inline-start-style' to the 'solid' keyword: solid
-PASS Setting 'border-inline-start-style' to a length throws TypeError
-PASS Setting 'border-inline-start-style' to a percent throws TypeError
-PASS Setting 'border-inline-start-style' to a time throws TypeError
-PASS Setting 'border-inline-start-style' to an angle throws TypeError
-PASS Setting 'border-inline-start-style' to a flexible length throws TypeError
-PASS Setting 'border-inline-start-style' to a number throws TypeError
-PASS Setting 'border-inline-start-style' to a URL throws TypeError
-PASS Setting 'border-inline-start-style' to a transform throws TypeError
+PASS Setting 'border-inline-start-style' to a length: 0px throws TypeError
+PASS Setting 'border-inline-start-style' to a length: -3.14em throws TypeError
+PASS Setting 'border-inline-start-style' to a length: 3.14cm throws TypeError
+PASS Setting 'border-inline-start-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-inline-start-style' to a percent: 0% throws TypeError
+PASS Setting 'border-inline-start-style' to a percent: -3.14% throws TypeError
+PASS Setting 'border-inline-start-style' to a percent: 3.14% throws TypeError
+PASS Setting 'border-inline-start-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-inline-start-style' to a time: 0s throws TypeError
+PASS Setting 'border-inline-start-style' to a time: -3.14ms throws TypeError
+PASS Setting 'border-inline-start-style' to a time: 3.14s throws TypeError
+PASS Setting 'border-inline-start-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-inline-start-style' to an angle: 0deg throws TypeError
+PASS Setting 'border-inline-start-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-inline-start-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-inline-start-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-inline-start-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-inline-start-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-inline-start-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-inline-start-style' to a number: 0 throws TypeError
+PASS Setting 'border-inline-start-style' to a number: -3.14 throws TypeError
+PASS Setting 'border-inline-start-style' to a number: 3.14 throws TypeError
+PASS Setting 'border-inline-start-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-inline-start-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-inline-start-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-inline-start-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'border-inline-end' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-end' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-end' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-end' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-end' to var() references:  var(--A) assert_equals: expected 2 but got 1
 FAIL Can set 'border-inline-end' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Setting 'border-inline-end' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-inline-end' to a percent throws TypeError
-PASS Setting 'border-inline-end' to a time throws TypeError
-PASS Setting 'border-inline-end' to an angle throws TypeError
-PASS Setting 'border-inline-end' to a flexible length throws TypeError
-FAIL Setting 'border-inline-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-inline-end' to a URL throws TypeError
-PASS Setting 'border-inline-end' to a transform throws TypeError
+FAIL Setting 'border-inline-end' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-inline-end' to a length: -3.14em throws TypeError
+FAIL Setting 'border-inline-end' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'border-inline-end' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-inline-end' to a percent: 0% throws TypeError
+PASS Setting 'border-inline-end' to a percent: -3.14% throws TypeError
+PASS Setting 'border-inline-end' to a percent: 3.14% throws TypeError
+PASS Setting 'border-inline-end' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-inline-end' to a time: 0s throws TypeError
+PASS Setting 'border-inline-end' to a time: -3.14ms throws TypeError
+PASS Setting 'border-inline-end' to a time: 3.14s throws TypeError
+PASS Setting 'border-inline-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-inline-end' to an angle: 0deg throws TypeError
+PASS Setting 'border-inline-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-inline-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-inline-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-inline-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-inline-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-inline-end' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-inline-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-inline-end' to a number: -3.14 throws TypeError
+PASS Setting 'border-inline-end' to a number: 3.14 throws TypeError
+PASS Setting 'border-inline-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-inline-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-inline-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-inline-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-inline-end-width' to CSS-wide keywords: initial
 PASS Can set 'border-inline-end-width' to CSS-wide keywords: inherit
 PASS Can set 'border-inline-end-width' to CSS-wide keywords: unset
@@ -553,27 +994,60 @@ PASS Can set 'border-inline-end-width' to a length: 0px
 FAIL Can set 'border-inline-end-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'border-inline-end-width' to a length: 3.14cm
 PASS Can set 'border-inline-end-width' to a length: calc(0px + 0em)
-PASS Setting 'border-inline-end-width' to a percent throws TypeError
-PASS Setting 'border-inline-end-width' to a time throws TypeError
-PASS Setting 'border-inline-end-width' to an angle throws TypeError
-PASS Setting 'border-inline-end-width' to a flexible length throws TypeError
-FAIL Setting 'border-inline-end-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-inline-end-width' to a URL throws TypeError
-PASS Setting 'border-inline-end-width' to a transform throws TypeError
+PASS Setting 'border-inline-end-width' to a percent: 0% throws TypeError
+PASS Setting 'border-inline-end-width' to a percent: -3.14% throws TypeError
+PASS Setting 'border-inline-end-width' to a percent: 3.14% throws TypeError
+PASS Setting 'border-inline-end-width' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-inline-end-width' to a time: 0s throws TypeError
+PASS Setting 'border-inline-end-width' to a time: -3.14ms throws TypeError
+PASS Setting 'border-inline-end-width' to a time: 3.14s throws TypeError
+PASS Setting 'border-inline-end-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-inline-end-width' to an angle: 0deg throws TypeError
+PASS Setting 'border-inline-end-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-inline-end-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-inline-end-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-inline-end-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-inline-end-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-inline-end-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-inline-end-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-inline-end-width' to a number: -3.14 throws TypeError
+PASS Setting 'border-inline-end-width' to a number: 3.14 throws TypeError
+PASS Setting 'border-inline-end-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-inline-end-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-inline-end-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-inline-end-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-inline-end-color' to CSS-wide keywords: initial
 PASS Can set 'border-inline-end-color' to CSS-wide keywords: inherit
 PASS Can set 'border-inline-end-color' to CSS-wide keywords: unset
 PASS Can set 'border-inline-end-color' to CSS-wide keywords: revert
 PASS Can set 'border-inline-end-color' to var() references:  var(--A)
 FAIL Can set 'border-inline-end-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-PASS Setting 'border-inline-end-color' to a length throws TypeError
-PASS Setting 'border-inline-end-color' to a percent throws TypeError
-PASS Setting 'border-inline-end-color' to a time throws TypeError
-PASS Setting 'border-inline-end-color' to an angle throws TypeError
-PASS Setting 'border-inline-end-color' to a flexible length throws TypeError
-PASS Setting 'border-inline-end-color' to a number throws TypeError
-PASS Setting 'border-inline-end-color' to a URL throws TypeError
-PASS Setting 'border-inline-end-color' to a transform throws TypeError
+PASS Setting 'border-inline-end-color' to a length: 0px throws TypeError
+PASS Setting 'border-inline-end-color' to a length: -3.14em throws TypeError
+PASS Setting 'border-inline-end-color' to a length: 3.14cm throws TypeError
+PASS Setting 'border-inline-end-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-inline-end-color' to a percent: 0% throws TypeError
+PASS Setting 'border-inline-end-color' to a percent: -3.14% throws TypeError
+PASS Setting 'border-inline-end-color' to a percent: 3.14% throws TypeError
+PASS Setting 'border-inline-end-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-inline-end-color' to a time: 0s throws TypeError
+PASS Setting 'border-inline-end-color' to a time: -3.14ms throws TypeError
+PASS Setting 'border-inline-end-color' to a time: 3.14s throws TypeError
+PASS Setting 'border-inline-end-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-inline-end-color' to an angle: 0deg throws TypeError
+PASS Setting 'border-inline-end-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-inline-end-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-inline-end-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-inline-end-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-inline-end-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-inline-end-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-inline-end-color' to a number: 0 throws TypeError
+PASS Setting 'border-inline-end-color' to a number: -3.14 throws TypeError
+PASS Setting 'border-inline-end-color' to a number: 3.14 throws TypeError
+PASS Setting 'border-inline-end-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-inline-end-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-inline-end-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-inline-end-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-inline-end-style' to CSS-wide keywords: initial
 PASS Can set 'border-inline-end-style' to CSS-wide keywords: inherit
 PASS Can set 'border-inline-end-style' to CSS-wide keywords: unset
@@ -581,28 +1055,64 @@ PASS Can set 'border-inline-end-style' to CSS-wide keywords: revert
 PASS Can set 'border-inline-end-style' to var() references:  var(--A)
 PASS Can set 'border-inline-end-style' to the 'none' keyword: none
 PASS Can set 'border-inline-end-style' to the 'solid' keyword: solid
-PASS Setting 'border-inline-end-style' to a length throws TypeError
-PASS Setting 'border-inline-end-style' to a percent throws TypeError
-PASS Setting 'border-inline-end-style' to a time throws TypeError
-PASS Setting 'border-inline-end-style' to an angle throws TypeError
-PASS Setting 'border-inline-end-style' to a flexible length throws TypeError
-PASS Setting 'border-inline-end-style' to a number throws TypeError
-PASS Setting 'border-inline-end-style' to a URL throws TypeError
-PASS Setting 'border-inline-end-style' to a transform throws TypeError
+PASS Setting 'border-inline-end-style' to a length: 0px throws TypeError
+PASS Setting 'border-inline-end-style' to a length: -3.14em throws TypeError
+PASS Setting 'border-inline-end-style' to a length: 3.14cm throws TypeError
+PASS Setting 'border-inline-end-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-inline-end-style' to a percent: 0% throws TypeError
+PASS Setting 'border-inline-end-style' to a percent: -3.14% throws TypeError
+PASS Setting 'border-inline-end-style' to a percent: 3.14% throws TypeError
+PASS Setting 'border-inline-end-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-inline-end-style' to a time: 0s throws TypeError
+PASS Setting 'border-inline-end-style' to a time: -3.14ms throws TypeError
+PASS Setting 'border-inline-end-style' to a time: 3.14s throws TypeError
+PASS Setting 'border-inline-end-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-inline-end-style' to an angle: 0deg throws TypeError
+PASS Setting 'border-inline-end-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-inline-end-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-inline-end-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-inline-end-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-inline-end-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-inline-end-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-inline-end-style' to a number: 0 throws TypeError
+PASS Setting 'border-inline-end-style' to a number: -3.14 throws TypeError
+PASS Setting 'border-inline-end-style' to a number: 3.14 throws TypeError
+PASS Setting 'border-inline-end-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-inline-end-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-inline-end-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-inline-end-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'border-block' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block' to var() references:  var(--A) assert_equals: expected 2 but got 1
 FAIL Can set 'border-block' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Setting 'border-block' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-block' to a percent throws TypeError
-PASS Setting 'border-block' to a time throws TypeError
-PASS Setting 'border-block' to an angle throws TypeError
-PASS Setting 'border-block' to a flexible length throws TypeError
-FAIL Setting 'border-block' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-block' to a URL throws TypeError
-PASS Setting 'border-block' to a transform throws TypeError
+FAIL Setting 'border-block' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-block' to a length: -3.14em throws TypeError
+FAIL Setting 'border-block' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'border-block' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-block' to a percent: 0% throws TypeError
+PASS Setting 'border-block' to a percent: -3.14% throws TypeError
+PASS Setting 'border-block' to a percent: 3.14% throws TypeError
+PASS Setting 'border-block' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-block' to a time: 0s throws TypeError
+PASS Setting 'border-block' to a time: -3.14ms throws TypeError
+PASS Setting 'border-block' to a time: 3.14s throws TypeError
+PASS Setting 'border-block' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-block' to an angle: 0deg throws TypeError
+PASS Setting 'border-block' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-block' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-block' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-block' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-block' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-block' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-block' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-block' to a number: -3.14 throws TypeError
+PASS Setting 'border-block' to a number: 3.14 throws TypeError
+PASS Setting 'border-block' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-block' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-block' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-block' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'border-block-width' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-width' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-width' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
@@ -615,27 +1125,60 @@ FAIL Can set 'border-block-width' to a length: 0px assert_equals: expected "CSSU
 FAIL Can set 'border-block-width' to a length: -3.14em Bad value for shorthand CSS property
 FAIL Can set 'border-block-width' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-width' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-PASS Setting 'border-block-width' to a percent throws TypeError
-PASS Setting 'border-block-width' to a time throws TypeError
-PASS Setting 'border-block-width' to an angle throws TypeError
-PASS Setting 'border-block-width' to a flexible length throws TypeError
-FAIL Setting 'border-block-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-block-width' to a URL throws TypeError
-PASS Setting 'border-block-width' to a transform throws TypeError
+PASS Setting 'border-block-width' to a percent: 0% throws TypeError
+PASS Setting 'border-block-width' to a percent: -3.14% throws TypeError
+PASS Setting 'border-block-width' to a percent: 3.14% throws TypeError
+PASS Setting 'border-block-width' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-block-width' to a time: 0s throws TypeError
+PASS Setting 'border-block-width' to a time: -3.14ms throws TypeError
+PASS Setting 'border-block-width' to a time: 3.14s throws TypeError
+PASS Setting 'border-block-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-block-width' to an angle: 0deg throws TypeError
+PASS Setting 'border-block-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-block-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-block-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-block-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-block-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-block-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-block-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-block-width' to a number: -3.14 throws TypeError
+PASS Setting 'border-block-width' to a number: 3.14 throws TypeError
+PASS Setting 'border-block-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-block-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-block-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-block-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'border-block-color' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-color' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-color' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-color' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
 FAIL Can set 'border-block-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-PASS Setting 'border-block-color' to a length throws TypeError
-PASS Setting 'border-block-color' to a percent throws TypeError
-PASS Setting 'border-block-color' to a time throws TypeError
-PASS Setting 'border-block-color' to an angle throws TypeError
-PASS Setting 'border-block-color' to a flexible length throws TypeError
-PASS Setting 'border-block-color' to a number throws TypeError
-PASS Setting 'border-block-color' to a URL throws TypeError
-PASS Setting 'border-block-color' to a transform throws TypeError
+PASS Setting 'border-block-color' to a length: 0px throws TypeError
+PASS Setting 'border-block-color' to a length: -3.14em throws TypeError
+PASS Setting 'border-block-color' to a length: 3.14cm throws TypeError
+PASS Setting 'border-block-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-block-color' to a percent: 0% throws TypeError
+PASS Setting 'border-block-color' to a percent: -3.14% throws TypeError
+PASS Setting 'border-block-color' to a percent: 3.14% throws TypeError
+PASS Setting 'border-block-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-block-color' to a time: 0s throws TypeError
+PASS Setting 'border-block-color' to a time: -3.14ms throws TypeError
+PASS Setting 'border-block-color' to a time: 3.14s throws TypeError
+PASS Setting 'border-block-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-block-color' to an angle: 0deg throws TypeError
+PASS Setting 'border-block-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-block-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-block-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-block-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-block-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-block-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-block-color' to a number: 0 throws TypeError
+PASS Setting 'border-block-color' to a number: -3.14 throws TypeError
+PASS Setting 'border-block-color' to a number: 3.14 throws TypeError
+PASS Setting 'border-block-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-block-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-block-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-block-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'border-block-style' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-style' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-style' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
@@ -643,28 +1186,64 @@ FAIL Can set 'border-block-style' to CSS-wide keywords: revert assert_equals: ex
 FAIL Can set 'border-block-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
 FAIL Can set 'border-block-style' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-style' to the 'solid' keyword: solid assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-PASS Setting 'border-block-style' to a length throws TypeError
-PASS Setting 'border-block-style' to a percent throws TypeError
-PASS Setting 'border-block-style' to a time throws TypeError
-PASS Setting 'border-block-style' to an angle throws TypeError
-PASS Setting 'border-block-style' to a flexible length throws TypeError
-PASS Setting 'border-block-style' to a number throws TypeError
-PASS Setting 'border-block-style' to a URL throws TypeError
-PASS Setting 'border-block-style' to a transform throws TypeError
+PASS Setting 'border-block-style' to a length: 0px throws TypeError
+PASS Setting 'border-block-style' to a length: -3.14em throws TypeError
+PASS Setting 'border-block-style' to a length: 3.14cm throws TypeError
+PASS Setting 'border-block-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-block-style' to a percent: 0% throws TypeError
+PASS Setting 'border-block-style' to a percent: -3.14% throws TypeError
+PASS Setting 'border-block-style' to a percent: 3.14% throws TypeError
+PASS Setting 'border-block-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-block-style' to a time: 0s throws TypeError
+PASS Setting 'border-block-style' to a time: -3.14ms throws TypeError
+PASS Setting 'border-block-style' to a time: 3.14s throws TypeError
+PASS Setting 'border-block-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-block-style' to an angle: 0deg throws TypeError
+PASS Setting 'border-block-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-block-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-block-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-block-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-block-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-block-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-block-style' to a number: 0 throws TypeError
+PASS Setting 'border-block-style' to a number: -3.14 throws TypeError
+PASS Setting 'border-block-style' to a number: 3.14 throws TypeError
+PASS Setting 'border-block-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-block-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-block-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-block-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'border-inline' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline' to var() references:  var(--A) assert_equals: expected 2 but got 1
 FAIL Can set 'border-inline' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Setting 'border-inline' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-inline' to a percent throws TypeError
-PASS Setting 'border-inline' to a time throws TypeError
-PASS Setting 'border-inline' to an angle throws TypeError
-PASS Setting 'border-inline' to a flexible length throws TypeError
-FAIL Setting 'border-inline' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-inline' to a URL throws TypeError
-PASS Setting 'border-inline' to a transform throws TypeError
+FAIL Setting 'border-inline' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-inline' to a length: -3.14em throws TypeError
+FAIL Setting 'border-inline' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'border-inline' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-inline' to a percent: 0% throws TypeError
+PASS Setting 'border-inline' to a percent: -3.14% throws TypeError
+PASS Setting 'border-inline' to a percent: 3.14% throws TypeError
+PASS Setting 'border-inline' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-inline' to a time: 0s throws TypeError
+PASS Setting 'border-inline' to a time: -3.14ms throws TypeError
+PASS Setting 'border-inline' to a time: 3.14s throws TypeError
+PASS Setting 'border-inline' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-inline' to an angle: 0deg throws TypeError
+PASS Setting 'border-inline' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-inline' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-inline' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-inline' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-inline' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-inline' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-inline' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-inline' to a number: -3.14 throws TypeError
+PASS Setting 'border-inline' to a number: 3.14 throws TypeError
+PASS Setting 'border-inline' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-inline' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-inline' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-inline' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'border-inline-width' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-width' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-width' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
@@ -677,27 +1256,60 @@ FAIL Can set 'border-inline-width' to a length: 0px assert_equals: expected "CSS
 FAIL Can set 'border-inline-width' to a length: -3.14em Bad value for shorthand CSS property
 FAIL Can set 'border-inline-width' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-width' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-PASS Setting 'border-inline-width' to a percent throws TypeError
-PASS Setting 'border-inline-width' to a time throws TypeError
-PASS Setting 'border-inline-width' to an angle throws TypeError
-PASS Setting 'border-inline-width' to a flexible length throws TypeError
-FAIL Setting 'border-inline-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-inline-width' to a URL throws TypeError
-PASS Setting 'border-inline-width' to a transform throws TypeError
+PASS Setting 'border-inline-width' to a percent: 0% throws TypeError
+PASS Setting 'border-inline-width' to a percent: -3.14% throws TypeError
+PASS Setting 'border-inline-width' to a percent: 3.14% throws TypeError
+PASS Setting 'border-inline-width' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-inline-width' to a time: 0s throws TypeError
+PASS Setting 'border-inline-width' to a time: -3.14ms throws TypeError
+PASS Setting 'border-inline-width' to a time: 3.14s throws TypeError
+PASS Setting 'border-inline-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-inline-width' to an angle: 0deg throws TypeError
+PASS Setting 'border-inline-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-inline-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-inline-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-inline-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-inline-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-inline-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-inline-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-inline-width' to a number: -3.14 throws TypeError
+PASS Setting 'border-inline-width' to a number: 3.14 throws TypeError
+PASS Setting 'border-inline-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-inline-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-inline-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-inline-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'border-inline-color' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-color' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-color' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-color' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-color' to var() references:  var(--A) assert_equals: expected 2 but got 1
 FAIL Can set 'border-inline-color' to the 'currentcolor' keyword: currentcolor assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-PASS Setting 'border-inline-color' to a length throws TypeError
-PASS Setting 'border-inline-color' to a percent throws TypeError
-PASS Setting 'border-inline-color' to a time throws TypeError
-PASS Setting 'border-inline-color' to an angle throws TypeError
-PASS Setting 'border-inline-color' to a flexible length throws TypeError
-PASS Setting 'border-inline-color' to a number throws TypeError
-PASS Setting 'border-inline-color' to a URL throws TypeError
-PASS Setting 'border-inline-color' to a transform throws TypeError
+PASS Setting 'border-inline-color' to a length: 0px throws TypeError
+PASS Setting 'border-inline-color' to a length: -3.14em throws TypeError
+PASS Setting 'border-inline-color' to a length: 3.14cm throws TypeError
+PASS Setting 'border-inline-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-inline-color' to a percent: 0% throws TypeError
+PASS Setting 'border-inline-color' to a percent: -3.14% throws TypeError
+PASS Setting 'border-inline-color' to a percent: 3.14% throws TypeError
+PASS Setting 'border-inline-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-inline-color' to a time: 0s throws TypeError
+PASS Setting 'border-inline-color' to a time: -3.14ms throws TypeError
+PASS Setting 'border-inline-color' to a time: 3.14s throws TypeError
+PASS Setting 'border-inline-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-inline-color' to an angle: 0deg throws TypeError
+PASS Setting 'border-inline-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-inline-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-inline-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-inline-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-inline-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-inline-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-inline-color' to a number: 0 throws TypeError
+PASS Setting 'border-inline-color' to a number: -3.14 throws TypeError
+PASS Setting 'border-inline-color' to a number: 3.14 throws TypeError
+PASS Setting 'border-inline-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-inline-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-inline-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-inline-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'border-inline-style' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-style' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-style' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
@@ -705,14 +1317,32 @@ FAIL Can set 'border-inline-style' to CSS-wide keywords: revert assert_equals: e
 FAIL Can set 'border-inline-style' to var() references:  var(--A) assert_equals: expected 2 but got 1
 FAIL Can set 'border-inline-style' to the 'none' keyword: none assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-style' to the 'solid' keyword: solid assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-PASS Setting 'border-inline-style' to a length throws TypeError
-PASS Setting 'border-inline-style' to a percent throws TypeError
-PASS Setting 'border-inline-style' to a time throws TypeError
-PASS Setting 'border-inline-style' to an angle throws TypeError
-PASS Setting 'border-inline-style' to a flexible length throws TypeError
-PASS Setting 'border-inline-style' to a number throws TypeError
-PASS Setting 'border-inline-style' to a URL throws TypeError
-PASS Setting 'border-inline-style' to a transform throws TypeError
+PASS Setting 'border-inline-style' to a length: 0px throws TypeError
+PASS Setting 'border-inline-style' to a length: -3.14em throws TypeError
+PASS Setting 'border-inline-style' to a length: 3.14cm throws TypeError
+PASS Setting 'border-inline-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'border-inline-style' to a percent: 0% throws TypeError
+PASS Setting 'border-inline-style' to a percent: -3.14% throws TypeError
+PASS Setting 'border-inline-style' to a percent: 3.14% throws TypeError
+PASS Setting 'border-inline-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'border-inline-style' to a time: 0s throws TypeError
+PASS Setting 'border-inline-style' to a time: -3.14ms throws TypeError
+PASS Setting 'border-inline-style' to a time: 3.14s throws TypeError
+PASS Setting 'border-inline-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-inline-style' to an angle: 0deg throws TypeError
+PASS Setting 'border-inline-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-inline-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-inline-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-inline-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-inline-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-inline-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'border-inline-style' to a number: 0 throws TypeError
+PASS Setting 'border-inline-style' to a number: -3.14 throws TypeError
+PASS Setting 'border-inline-style' to a number: 3.14 throws TypeError
+PASS Setting 'border-inline-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-inline-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-inline-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-inline-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-start-start-radius' to CSS-wide keywords: initial
 PASS Can set 'border-start-start-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-start-start-radius' to CSS-wide keywords: unset
@@ -726,12 +1356,24 @@ FAIL Can set 'border-start-start-radius' to a length: 0px assert_equals: expecte
 FAIL Can set 'border-start-start-radius' to a length: -3.14em Invalid values
 FAIL Can set 'border-start-start-radius' to a length: 3.14cm assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
 FAIL Can set 'border-start-start-radius' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
-PASS Setting 'border-start-start-radius' to a time throws TypeError
-PASS Setting 'border-start-start-radius' to an angle throws TypeError
-PASS Setting 'border-start-start-radius' to a flexible length throws TypeError
-FAIL Setting 'border-start-start-radius' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-start-start-radius' to a URL throws TypeError
-PASS Setting 'border-start-start-radius' to a transform throws TypeError
+PASS Setting 'border-start-start-radius' to a time: 0s throws TypeError
+PASS Setting 'border-start-start-radius' to a time: -3.14ms throws TypeError
+PASS Setting 'border-start-start-radius' to a time: 3.14s throws TypeError
+PASS Setting 'border-start-start-radius' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-start-start-radius' to an angle: 0deg throws TypeError
+PASS Setting 'border-start-start-radius' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-start-start-radius' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-start-start-radius' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-start-start-radius' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-start-start-radius' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-start-start-radius' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-start-start-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-start-start-radius' to a number: -3.14 throws TypeError
+PASS Setting 'border-start-start-radius' to a number: 3.14 throws TypeError
+PASS Setting 'border-start-start-radius' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-start-start-radius' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-start-start-radius' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-start-start-radius' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-start-end-radius' to CSS-wide keywords: initial
 PASS Can set 'border-start-end-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-start-end-radius' to CSS-wide keywords: unset
@@ -745,12 +1387,24 @@ FAIL Can set 'border-start-end-radius' to a length: 0px assert_equals: expected 
 FAIL Can set 'border-start-end-radius' to a length: -3.14em Invalid values
 FAIL Can set 'border-start-end-radius' to a length: 3.14cm assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
 FAIL Can set 'border-start-end-radius' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
-PASS Setting 'border-start-end-radius' to a time throws TypeError
-PASS Setting 'border-start-end-radius' to an angle throws TypeError
-PASS Setting 'border-start-end-radius' to a flexible length throws TypeError
-FAIL Setting 'border-start-end-radius' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-start-end-radius' to a URL throws TypeError
-PASS Setting 'border-start-end-radius' to a transform throws TypeError
+PASS Setting 'border-start-end-radius' to a time: 0s throws TypeError
+PASS Setting 'border-start-end-radius' to a time: -3.14ms throws TypeError
+PASS Setting 'border-start-end-radius' to a time: 3.14s throws TypeError
+PASS Setting 'border-start-end-radius' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-start-end-radius' to an angle: 0deg throws TypeError
+PASS Setting 'border-start-end-radius' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-start-end-radius' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-start-end-radius' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-start-end-radius' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-start-end-radius' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-start-end-radius' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-start-end-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-start-end-radius' to a number: -3.14 throws TypeError
+PASS Setting 'border-start-end-radius' to a number: 3.14 throws TypeError
+PASS Setting 'border-start-end-radius' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-start-end-radius' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-start-end-radius' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-start-end-radius' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-end-start-radius' to CSS-wide keywords: initial
 PASS Can set 'border-end-start-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-end-start-radius' to CSS-wide keywords: unset
@@ -764,12 +1418,24 @@ FAIL Can set 'border-end-start-radius' to a length: 0px assert_equals: expected 
 FAIL Can set 'border-end-start-radius' to a length: -3.14em Invalid values
 FAIL Can set 'border-end-start-radius' to a length: 3.14cm assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
 FAIL Can set 'border-end-start-radius' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
-PASS Setting 'border-end-start-radius' to a time throws TypeError
-PASS Setting 'border-end-start-radius' to an angle throws TypeError
-PASS Setting 'border-end-start-radius' to a flexible length throws TypeError
-FAIL Setting 'border-end-start-radius' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-end-start-radius' to a URL throws TypeError
-PASS Setting 'border-end-start-radius' to a transform throws TypeError
+PASS Setting 'border-end-start-radius' to a time: 0s throws TypeError
+PASS Setting 'border-end-start-radius' to a time: -3.14ms throws TypeError
+PASS Setting 'border-end-start-radius' to a time: 3.14s throws TypeError
+PASS Setting 'border-end-start-radius' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-end-start-radius' to an angle: 0deg throws TypeError
+PASS Setting 'border-end-start-radius' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-end-start-radius' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-end-start-radius' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-end-start-radius' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-end-start-radius' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-end-start-radius' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-end-start-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-end-start-radius' to a number: -3.14 throws TypeError
+PASS Setting 'border-end-start-radius' to a number: 3.14 throws TypeError
+PASS Setting 'border-end-start-radius' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-end-start-radius' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-end-start-radius' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-end-start-radius' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'border-end-end-radius' to CSS-wide keywords: initial
 PASS Can set 'border-end-end-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-end-end-radius' to CSS-wide keywords: unset
@@ -783,10 +1449,22 @@ FAIL Can set 'border-end-end-radius' to a length: 0px assert_equals: expected "C
 FAIL Can set 'border-end-end-radius' to a length: -3.14em Invalid values
 FAIL Can set 'border-end-end-radius' to a length: 3.14cm assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
 FAIL Can set 'border-end-end-radius' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
-PASS Setting 'border-end-end-radius' to a time throws TypeError
-PASS Setting 'border-end-end-radius' to an angle throws TypeError
-PASS Setting 'border-end-end-radius' to a flexible length throws TypeError
-FAIL Setting 'border-end-end-radius' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'border-end-end-radius' to a URL throws TypeError
-PASS Setting 'border-end-end-radius' to a transform throws TypeError
+PASS Setting 'border-end-end-radius' to a time: 0s throws TypeError
+PASS Setting 'border-end-end-radius' to a time: -3.14ms throws TypeError
+PASS Setting 'border-end-end-radius' to a time: 3.14s throws TypeError
+PASS Setting 'border-end-end-radius' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'border-end-end-radius' to an angle: 0deg throws TypeError
+PASS Setting 'border-end-end-radius' to an angle: 3.14rad throws TypeError
+PASS Setting 'border-end-end-radius' to an angle: -3.14deg throws TypeError
+PASS Setting 'border-end-end-radius' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'border-end-end-radius' to a flexible length: 0fr throws TypeError
+PASS Setting 'border-end-end-radius' to a flexible length: 1fr throws TypeError
+PASS Setting 'border-end-end-radius' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'border-end-end-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-end-end-radius' to a number: -3.14 throws TypeError
+PASS Setting 'border-end-end-radius' to a number: 3.14 throws TypeError
+PASS Setting 'border-end-end-radius' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'border-end-end-radius' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'border-end-end-radius' to a transform: perspective(10em) throws TypeError
+PASS Setting 'border-end-end-radius' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/margin-expected.txt
@@ -13,12 +13,24 @@ PASS Can set 'margin-top' to a length: 0px
 PASS Can set 'margin-top' to a length: -3.14em
 PASS Can set 'margin-top' to a length: 3.14cm
 PASS Can set 'margin-top' to a length: calc(0px + 0em)
-PASS Setting 'margin-top' to a time throws TypeError
-PASS Setting 'margin-top' to an angle throws TypeError
-PASS Setting 'margin-top' to a flexible length throws TypeError
-FAIL Setting 'margin-top' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'margin-top' to a URL throws TypeError
-PASS Setting 'margin-top' to a transform throws TypeError
+PASS Setting 'margin-top' to a time: 0s throws TypeError
+PASS Setting 'margin-top' to a time: -3.14ms throws TypeError
+PASS Setting 'margin-top' to a time: 3.14s throws TypeError
+PASS Setting 'margin-top' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'margin-top' to an angle: 0deg throws TypeError
+PASS Setting 'margin-top' to an angle: 3.14rad throws TypeError
+PASS Setting 'margin-top' to an angle: -3.14deg throws TypeError
+PASS Setting 'margin-top' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'margin-top' to a flexible length: 0fr throws TypeError
+PASS Setting 'margin-top' to a flexible length: 1fr throws TypeError
+PASS Setting 'margin-top' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'margin-top' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-top' to a number: -3.14 throws TypeError
+PASS Setting 'margin-top' to a number: 3.14 throws TypeError
+PASS Setting 'margin-top' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'margin-top' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'margin-top' to a transform: perspective(10em) throws TypeError
+PASS Setting 'margin-top' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'margin-left' to CSS-wide keywords: initial
 PASS Can set 'margin-left' to CSS-wide keywords: inherit
 PASS Can set 'margin-left' to CSS-wide keywords: unset
@@ -33,12 +45,24 @@ PASS Can set 'margin-left' to a length: 0px
 PASS Can set 'margin-left' to a length: -3.14em
 PASS Can set 'margin-left' to a length: 3.14cm
 PASS Can set 'margin-left' to a length: calc(0px + 0em)
-PASS Setting 'margin-left' to a time throws TypeError
-PASS Setting 'margin-left' to an angle throws TypeError
-PASS Setting 'margin-left' to a flexible length throws TypeError
-FAIL Setting 'margin-left' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'margin-left' to a URL throws TypeError
-PASS Setting 'margin-left' to a transform throws TypeError
+PASS Setting 'margin-left' to a time: 0s throws TypeError
+PASS Setting 'margin-left' to a time: -3.14ms throws TypeError
+PASS Setting 'margin-left' to a time: 3.14s throws TypeError
+PASS Setting 'margin-left' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'margin-left' to an angle: 0deg throws TypeError
+PASS Setting 'margin-left' to an angle: 3.14rad throws TypeError
+PASS Setting 'margin-left' to an angle: -3.14deg throws TypeError
+PASS Setting 'margin-left' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'margin-left' to a flexible length: 0fr throws TypeError
+PASS Setting 'margin-left' to a flexible length: 1fr throws TypeError
+PASS Setting 'margin-left' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'margin-left' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-left' to a number: -3.14 throws TypeError
+PASS Setting 'margin-left' to a number: 3.14 throws TypeError
+PASS Setting 'margin-left' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'margin-left' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'margin-left' to a transform: perspective(10em) throws TypeError
+PASS Setting 'margin-left' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'margin-right' to CSS-wide keywords: initial
 PASS Can set 'margin-right' to CSS-wide keywords: inherit
 PASS Can set 'margin-right' to CSS-wide keywords: unset
@@ -53,12 +77,24 @@ PASS Can set 'margin-right' to a length: 0px
 PASS Can set 'margin-right' to a length: -3.14em
 PASS Can set 'margin-right' to a length: 3.14cm
 PASS Can set 'margin-right' to a length: calc(0px + 0em)
-PASS Setting 'margin-right' to a time throws TypeError
-PASS Setting 'margin-right' to an angle throws TypeError
-PASS Setting 'margin-right' to a flexible length throws TypeError
-FAIL Setting 'margin-right' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'margin-right' to a URL throws TypeError
-PASS Setting 'margin-right' to a transform throws TypeError
+PASS Setting 'margin-right' to a time: 0s throws TypeError
+PASS Setting 'margin-right' to a time: -3.14ms throws TypeError
+PASS Setting 'margin-right' to a time: 3.14s throws TypeError
+PASS Setting 'margin-right' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'margin-right' to an angle: 0deg throws TypeError
+PASS Setting 'margin-right' to an angle: 3.14rad throws TypeError
+PASS Setting 'margin-right' to an angle: -3.14deg throws TypeError
+PASS Setting 'margin-right' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'margin-right' to a flexible length: 0fr throws TypeError
+PASS Setting 'margin-right' to a flexible length: 1fr throws TypeError
+PASS Setting 'margin-right' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'margin-right' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-right' to a number: -3.14 throws TypeError
+PASS Setting 'margin-right' to a number: 3.14 throws TypeError
+PASS Setting 'margin-right' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'margin-right' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'margin-right' to a transform: perspective(10em) throws TypeError
+PASS Setting 'margin-right' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'margin-bottom' to CSS-wide keywords: initial
 PASS Can set 'margin-bottom' to CSS-wide keywords: inherit
 PASS Can set 'margin-bottom' to CSS-wide keywords: unset
@@ -73,25 +109,55 @@ PASS Can set 'margin-bottom' to a length: 0px
 PASS Can set 'margin-bottom' to a length: -3.14em
 PASS Can set 'margin-bottom' to a length: 3.14cm
 PASS Can set 'margin-bottom' to a length: calc(0px + 0em)
-PASS Setting 'margin-bottom' to a time throws TypeError
-PASS Setting 'margin-bottom' to an angle throws TypeError
-PASS Setting 'margin-bottom' to a flexible length throws TypeError
-FAIL Setting 'margin-bottom' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'margin-bottom' to a URL throws TypeError
-PASS Setting 'margin-bottom' to a transform throws TypeError
+PASS Setting 'margin-bottom' to a time: 0s throws TypeError
+PASS Setting 'margin-bottom' to a time: -3.14ms throws TypeError
+PASS Setting 'margin-bottom' to a time: 3.14s throws TypeError
+PASS Setting 'margin-bottom' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'margin-bottom' to an angle: 0deg throws TypeError
+PASS Setting 'margin-bottom' to an angle: 3.14rad throws TypeError
+PASS Setting 'margin-bottom' to an angle: -3.14deg throws TypeError
+PASS Setting 'margin-bottom' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'margin-bottom' to a flexible length: 0fr throws TypeError
+PASS Setting 'margin-bottom' to a flexible length: 1fr throws TypeError
+PASS Setting 'margin-bottom' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'margin-bottom' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-bottom' to a number: -3.14 throws TypeError
+PASS Setting 'margin-bottom' to a number: 3.14 throws TypeError
+PASS Setting 'margin-bottom' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'margin-bottom' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'margin-bottom' to a transform: perspective(10em) throws TypeError
+PASS Setting 'margin-bottom' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'margin' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'margin' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'margin' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'margin' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'margin' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Setting 'margin' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'margin' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'margin' to a time throws TypeError
-PASS Setting 'margin' to an angle throws TypeError
-PASS Setting 'margin' to a flexible length throws TypeError
-FAIL Setting 'margin' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'margin' to a URL throws TypeError
-PASS Setting 'margin' to a transform throws TypeError
-PASS 'margin' does not supported '1px'
-PASS 'margin' does not supported '1px 2px 3px 4px'
+FAIL Setting 'margin' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'margin' to a length: -3.14em throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'margin' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'margin' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'margin' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'margin' to a percent: -3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'margin' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'margin' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin' to a time: 0s throws TypeError
+PASS Setting 'margin' to a time: -3.14ms throws TypeError
+PASS Setting 'margin' to a time: 3.14s throws TypeError
+PASS Setting 'margin' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'margin' to an angle: 0deg throws TypeError
+PASS Setting 'margin' to an angle: 3.14rad throws TypeError
+PASS Setting 'margin' to an angle: -3.14deg throws TypeError
+PASS Setting 'margin' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'margin' to a flexible length: 0fr throws TypeError
+PASS Setting 'margin' to a flexible length: 1fr throws TypeError
+PASS Setting 'margin' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'margin' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin' to a number: -3.14 throws TypeError
+PASS Setting 'margin' to a number: 3.14 throws TypeError
+PASS Setting 'margin' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'margin' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'margin' to a transform: perspective(10em) throws TypeError
+PASS Setting 'margin' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'margin' does not support '1px'
+PASS 'margin' does not support '1px 2px 3px 4px'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/marker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/marker-expected.txt
@@ -1,43 +1,100 @@
 
-PASS 'marker' does not supported 'none'
-PASS 'marker' does not supported 'url(#m1)'
+PASS 'marker' does not support 'none'
+PASS 'marker' does not support 'url(#m1)'
 PASS Can set 'marker-start' to CSS-wide keywords: initial
 PASS Can set 'marker-start' to CSS-wide keywords: inherit
 PASS Can set 'marker-start' to CSS-wide keywords: unset
 PASS Can set 'marker-start' to CSS-wide keywords: revert
 PASS Can set 'marker-start' to var() references:  var(--A)
 PASS Can set 'marker-start' to the 'none' keyword: none
-PASS Setting 'marker-start' to a length throws TypeError
-PASS Setting 'marker-start' to a percent throws TypeError
-PASS Setting 'marker-start' to a time throws TypeError
-PASS Setting 'marker-start' to an angle throws TypeError
-PASS Setting 'marker-start' to a flexible length throws TypeError
-PASS Setting 'marker-start' to a number throws TypeError
-PASS Setting 'marker-start' to a transform throws TypeError
+PASS Setting 'marker-start' to a length: 0px throws TypeError
+PASS Setting 'marker-start' to a length: -3.14em throws TypeError
+PASS Setting 'marker-start' to a length: 3.14cm throws TypeError
+PASS Setting 'marker-start' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'marker-start' to a percent: 0% throws TypeError
+PASS Setting 'marker-start' to a percent: -3.14% throws TypeError
+PASS Setting 'marker-start' to a percent: 3.14% throws TypeError
+PASS Setting 'marker-start' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'marker-start' to a time: 0s throws TypeError
+PASS Setting 'marker-start' to a time: -3.14ms throws TypeError
+PASS Setting 'marker-start' to a time: 3.14s throws TypeError
+PASS Setting 'marker-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'marker-start' to an angle: 0deg throws TypeError
+PASS Setting 'marker-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'marker-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'marker-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'marker-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'marker-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'marker-start' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'marker-start' to a number: 0 throws TypeError
+PASS Setting 'marker-start' to a number: -3.14 throws TypeError
+PASS Setting 'marker-start' to a number: 3.14 throws TypeError
+PASS Setting 'marker-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'marker-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'marker-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'marker-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'marker-mid' to CSS-wide keywords: initial
 PASS Can set 'marker-mid' to CSS-wide keywords: inherit
 PASS Can set 'marker-mid' to CSS-wide keywords: unset
 PASS Can set 'marker-mid' to CSS-wide keywords: revert
 PASS Can set 'marker-mid' to var() references:  var(--A)
 PASS Can set 'marker-mid' to the 'none' keyword: none
-PASS Setting 'marker-mid' to a length throws TypeError
-PASS Setting 'marker-mid' to a percent throws TypeError
-PASS Setting 'marker-mid' to a time throws TypeError
-PASS Setting 'marker-mid' to an angle throws TypeError
-PASS Setting 'marker-mid' to a flexible length throws TypeError
-PASS Setting 'marker-mid' to a number throws TypeError
-PASS Setting 'marker-mid' to a transform throws TypeError
+PASS Setting 'marker-mid' to a length: 0px throws TypeError
+PASS Setting 'marker-mid' to a length: -3.14em throws TypeError
+PASS Setting 'marker-mid' to a length: 3.14cm throws TypeError
+PASS Setting 'marker-mid' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'marker-mid' to a percent: 0% throws TypeError
+PASS Setting 'marker-mid' to a percent: -3.14% throws TypeError
+PASS Setting 'marker-mid' to a percent: 3.14% throws TypeError
+PASS Setting 'marker-mid' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'marker-mid' to a time: 0s throws TypeError
+PASS Setting 'marker-mid' to a time: -3.14ms throws TypeError
+PASS Setting 'marker-mid' to a time: 3.14s throws TypeError
+PASS Setting 'marker-mid' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'marker-mid' to an angle: 0deg throws TypeError
+PASS Setting 'marker-mid' to an angle: 3.14rad throws TypeError
+PASS Setting 'marker-mid' to an angle: -3.14deg throws TypeError
+PASS Setting 'marker-mid' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'marker-mid' to a flexible length: 0fr throws TypeError
+PASS Setting 'marker-mid' to a flexible length: 1fr throws TypeError
+PASS Setting 'marker-mid' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'marker-mid' to a number: 0 throws TypeError
+PASS Setting 'marker-mid' to a number: -3.14 throws TypeError
+PASS Setting 'marker-mid' to a number: 3.14 throws TypeError
+PASS Setting 'marker-mid' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'marker-mid' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'marker-mid' to a transform: perspective(10em) throws TypeError
+PASS Setting 'marker-mid' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'marker-end' to CSS-wide keywords: initial
 PASS Can set 'marker-end' to CSS-wide keywords: inherit
 PASS Can set 'marker-end' to CSS-wide keywords: unset
 PASS Can set 'marker-end' to CSS-wide keywords: revert
 PASS Can set 'marker-end' to var() references:  var(--A)
 PASS Can set 'marker-end' to the 'none' keyword: none
-PASS Setting 'marker-end' to a length throws TypeError
-PASS Setting 'marker-end' to a percent throws TypeError
-PASS Setting 'marker-end' to a time throws TypeError
-PASS Setting 'marker-end' to an angle throws TypeError
-PASS Setting 'marker-end' to a flexible length throws TypeError
-PASS Setting 'marker-end' to a number throws TypeError
-PASS Setting 'marker-end' to a transform throws TypeError
+PASS Setting 'marker-end' to a length: 0px throws TypeError
+PASS Setting 'marker-end' to a length: -3.14em throws TypeError
+PASS Setting 'marker-end' to a length: 3.14cm throws TypeError
+PASS Setting 'marker-end' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'marker-end' to a percent: 0% throws TypeError
+PASS Setting 'marker-end' to a percent: -3.14% throws TypeError
+PASS Setting 'marker-end' to a percent: 3.14% throws TypeError
+PASS Setting 'marker-end' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'marker-end' to a time: 0s throws TypeError
+PASS Setting 'marker-end' to a time: -3.14ms throws TypeError
+PASS Setting 'marker-end' to a time: 3.14s throws TypeError
+PASS Setting 'marker-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'marker-end' to an angle: 0deg throws TypeError
+PASS Setting 'marker-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'marker-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'marker-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'marker-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'marker-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'marker-end' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'marker-end' to a number: 0 throws TypeError
+PASS Setting 'marker-end' to a number: -3.14 throws TypeError
+PASS Setting 'marker-end' to a number: 3.14 throws TypeError
+PASS Setting 'marker-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'marker-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'marker-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'marker-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-expected.txt
@@ -1,4 +1,4 @@
 
-PASS 'mask' does not supported 'none'
-PASS 'mask' does not supported 'url(mask.png)'
+PASS 'mask' does not support 'none'
+PASS 'mask' does not support 'url(mask.png)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-image-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'mask-image' to CSS-wide keywords: revert
 PASS Can set 'mask-image' to var() references:  var(--A)
 PASS Can set 'mask-image' to the 'none' keyword: none
 PASS Can set 'mask-image' to an image
-PASS Setting 'mask-image' to a length throws TypeError
-PASS Setting 'mask-image' to a percent throws TypeError
-PASS Setting 'mask-image' to a time throws TypeError
-PASS Setting 'mask-image' to an angle throws TypeError
-PASS Setting 'mask-image' to a flexible length throws TypeError
-PASS Setting 'mask-image' to a number throws TypeError
-PASS Setting 'mask-image' to a URL throws TypeError
-PASS Setting 'mask-image' to a transform throws TypeError
+PASS Setting 'mask-image' to a length: 0px throws TypeError
+PASS Setting 'mask-image' to a length: -3.14em throws TypeError
+PASS Setting 'mask-image' to a length: 3.14cm throws TypeError
+PASS Setting 'mask-image' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'mask-image' to a percent: 0% throws TypeError
+PASS Setting 'mask-image' to a percent: -3.14% throws TypeError
+PASS Setting 'mask-image' to a percent: 3.14% throws TypeError
+PASS Setting 'mask-image' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'mask-image' to a time: 0s throws TypeError
+PASS Setting 'mask-image' to a time: -3.14ms throws TypeError
+PASS Setting 'mask-image' to a time: 3.14s throws TypeError
+PASS Setting 'mask-image' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'mask-image' to an angle: 0deg throws TypeError
+PASS Setting 'mask-image' to an angle: 3.14rad throws TypeError
+PASS Setting 'mask-image' to an angle: -3.14deg throws TypeError
+PASS Setting 'mask-image' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'mask-image' to a flexible length: 0fr throws TypeError
+PASS Setting 'mask-image' to a flexible length: 1fr throws TypeError
+PASS Setting 'mask-image' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'mask-image' to a number: 0 throws TypeError
+PASS Setting 'mask-image' to a number: -3.14 throws TypeError
+PASS Setting 'mask-image' to a number: 3.14 throws TypeError
+PASS Setting 'mask-image' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'mask-image' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'mask-image' to a transform: perspective(10em) throws TypeError
+PASS Setting 'mask-image' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-type-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'mask-type' to CSS-wide keywords: revert
 PASS Can set 'mask-type' to var() references:  var(--A)
 PASS Can set 'mask-type' to the 'luminance' keyword: luminance
 PASS Can set 'mask-type' to the 'alpha' keyword: alpha
-PASS Setting 'mask-type' to a length throws TypeError
-PASS Setting 'mask-type' to a percent throws TypeError
-PASS Setting 'mask-type' to a time throws TypeError
-PASS Setting 'mask-type' to an angle throws TypeError
-PASS Setting 'mask-type' to a flexible length throws TypeError
-PASS Setting 'mask-type' to a number throws TypeError
-PASS Setting 'mask-type' to a URL throws TypeError
-PASS Setting 'mask-type' to a transform throws TypeError
+PASS Setting 'mask-type' to a length: 0px throws TypeError
+PASS Setting 'mask-type' to a length: -3.14em throws TypeError
+PASS Setting 'mask-type' to a length: 3.14cm throws TypeError
+PASS Setting 'mask-type' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'mask-type' to a percent: 0% throws TypeError
+PASS Setting 'mask-type' to a percent: -3.14% throws TypeError
+PASS Setting 'mask-type' to a percent: 3.14% throws TypeError
+PASS Setting 'mask-type' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'mask-type' to a time: 0s throws TypeError
+PASS Setting 'mask-type' to a time: -3.14ms throws TypeError
+PASS Setting 'mask-type' to a time: 3.14s throws TypeError
+PASS Setting 'mask-type' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'mask-type' to an angle: 0deg throws TypeError
+PASS Setting 'mask-type' to an angle: 3.14rad throws TypeError
+PASS Setting 'mask-type' to an angle: -3.14deg throws TypeError
+PASS Setting 'mask-type' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'mask-type' to a flexible length: 0fr throws TypeError
+PASS Setting 'mask-type' to a flexible length: 1fr throws TypeError
+PASS Setting 'mask-type' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'mask-type' to a number: 0 throws TypeError
+PASS Setting 'mask-type' to a number: -3.14 throws TypeError
+PASS Setting 'mask-type' to a number: 3.14 throws TypeError
+PASS Setting 'mask-type' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'mask-type' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'mask-type' to a transform: perspective(10em) throws TypeError
+PASS Setting 'mask-type' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mix-blend-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mix-blend-mode-expected.txt
@@ -20,12 +20,30 @@ PASS Can set 'mix-blend-mode' to the 'hue' keyword: hue
 PASS Can set 'mix-blend-mode' to the 'saturation' keyword: saturation
 PASS Can set 'mix-blend-mode' to the 'color' keyword: color
 PASS Can set 'mix-blend-mode' to the 'luminosity' keyword: luminosity
-PASS Setting 'mix-blend-mode' to a length throws TypeError
-PASS Setting 'mix-blend-mode' to a percent throws TypeError
-PASS Setting 'mix-blend-mode' to a time throws TypeError
-PASS Setting 'mix-blend-mode' to an angle throws TypeError
-PASS Setting 'mix-blend-mode' to a flexible length throws TypeError
-PASS Setting 'mix-blend-mode' to a number throws TypeError
-PASS Setting 'mix-blend-mode' to a URL throws TypeError
-PASS Setting 'mix-blend-mode' to a transform throws TypeError
+PASS Setting 'mix-blend-mode' to a length: 0px throws TypeError
+PASS Setting 'mix-blend-mode' to a length: -3.14em throws TypeError
+PASS Setting 'mix-blend-mode' to a length: 3.14cm throws TypeError
+PASS Setting 'mix-blend-mode' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'mix-blend-mode' to a percent: 0% throws TypeError
+PASS Setting 'mix-blend-mode' to a percent: -3.14% throws TypeError
+PASS Setting 'mix-blend-mode' to a percent: 3.14% throws TypeError
+PASS Setting 'mix-blend-mode' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'mix-blend-mode' to a time: 0s throws TypeError
+PASS Setting 'mix-blend-mode' to a time: -3.14ms throws TypeError
+PASS Setting 'mix-blend-mode' to a time: 3.14s throws TypeError
+PASS Setting 'mix-blend-mode' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'mix-blend-mode' to an angle: 0deg throws TypeError
+PASS Setting 'mix-blend-mode' to an angle: 3.14rad throws TypeError
+PASS Setting 'mix-blend-mode' to an angle: -3.14deg throws TypeError
+PASS Setting 'mix-blend-mode' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'mix-blend-mode' to a flexible length: 0fr throws TypeError
+PASS Setting 'mix-blend-mode' to a flexible length: 1fr throws TypeError
+PASS Setting 'mix-blend-mode' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'mix-blend-mode' to a number: 0 throws TypeError
+PASS Setting 'mix-blend-mode' to a number: -3.14 throws TypeError
+PASS Setting 'mix-blend-mode' to a number: 3.14 throws TypeError
+PASS Setting 'mix-blend-mode' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'mix-blend-mode' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'mix-blend-mode' to a transform: perspective(10em) throws TypeError
+PASS Setting 'mix-blend-mode' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-fit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-fit-expected.txt
@@ -9,12 +9,30 @@ PASS Can set 'object-fit' to the 'contain' keyword: contain
 PASS Can set 'object-fit' to the 'cover' keyword: cover
 PASS Can set 'object-fit' to the 'none' keyword: none
 PASS Can set 'object-fit' to the 'scale-down' keyword: scale-down
-PASS Setting 'object-fit' to a length throws TypeError
-PASS Setting 'object-fit' to a percent throws TypeError
-PASS Setting 'object-fit' to a time throws TypeError
-PASS Setting 'object-fit' to an angle throws TypeError
-PASS Setting 'object-fit' to a flexible length throws TypeError
-PASS Setting 'object-fit' to a number throws TypeError
-PASS Setting 'object-fit' to a URL throws TypeError
-PASS Setting 'object-fit' to a transform throws TypeError
+PASS Setting 'object-fit' to a length: 0px throws TypeError
+PASS Setting 'object-fit' to a length: -3.14em throws TypeError
+PASS Setting 'object-fit' to a length: 3.14cm throws TypeError
+PASS Setting 'object-fit' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'object-fit' to a percent: 0% throws TypeError
+PASS Setting 'object-fit' to a percent: -3.14% throws TypeError
+PASS Setting 'object-fit' to a percent: 3.14% throws TypeError
+PASS Setting 'object-fit' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'object-fit' to a time: 0s throws TypeError
+PASS Setting 'object-fit' to a time: -3.14ms throws TypeError
+PASS Setting 'object-fit' to a time: 3.14s throws TypeError
+PASS Setting 'object-fit' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'object-fit' to an angle: 0deg throws TypeError
+PASS Setting 'object-fit' to an angle: 3.14rad throws TypeError
+PASS Setting 'object-fit' to an angle: -3.14deg throws TypeError
+PASS Setting 'object-fit' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'object-fit' to a flexible length: 0fr throws TypeError
+PASS Setting 'object-fit' to a flexible length: 1fr throws TypeError
+PASS Setting 'object-fit' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'object-fit' to a number: 0 throws TypeError
+PASS Setting 'object-fit' to a number: -3.14 throws TypeError
+PASS Setting 'object-fit' to a number: 3.14 throws TypeError
+PASS Setting 'object-fit' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'object-fit' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'object-fit' to a transform: perspective(10em) throws TypeError
+PASS Setting 'object-fit' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-distance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-distance-expected.txt
@@ -12,10 +12,22 @@ PASS Can set 'offset-distance' to a percent: 0%
 PASS Can set 'offset-distance' to a percent: -3.14%
 PASS Can set 'offset-distance' to a percent: 3.14%
 PASS Can set 'offset-distance' to a percent: calc(0% + 0%)
-PASS Setting 'offset-distance' to a time throws TypeError
-PASS Setting 'offset-distance' to an angle throws TypeError
-PASS Setting 'offset-distance' to a flexible length throws TypeError
-FAIL Setting 'offset-distance' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'offset-distance' to a URL throws TypeError
-PASS Setting 'offset-distance' to a transform throws TypeError
+PASS Setting 'offset-distance' to a time: 0s throws TypeError
+PASS Setting 'offset-distance' to a time: -3.14ms throws TypeError
+PASS Setting 'offset-distance' to a time: 3.14s throws TypeError
+PASS Setting 'offset-distance' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'offset-distance' to an angle: 0deg throws TypeError
+PASS Setting 'offset-distance' to an angle: 3.14rad throws TypeError
+PASS Setting 'offset-distance' to an angle: -3.14deg throws TypeError
+PASS Setting 'offset-distance' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'offset-distance' to a flexible length: 0fr throws TypeError
+PASS Setting 'offset-distance' to a flexible length: 1fr throws TypeError
+PASS Setting 'offset-distance' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'offset-distance' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'offset-distance' to a number: -3.14 throws TypeError
+PASS Setting 'offset-distance' to a number: 3.14 throws TypeError
+PASS Setting 'offset-distance' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'offset-distance' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'offset-distance' to a transform: perspective(10em) throws TypeError
+PASS Setting 'offset-distance' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-expected.txt
@@ -1,8 +1,8 @@
 
-PASS 'offset' does not supported 'auto'
-PASS 'offset' does not supported '10px 30px'
-PASS 'offset' does not supported 'none'
-PASS 'offset' does not supported 'ray(45deg closest-side)'
-PASS 'offset' does not supported 'path("M 100 100 L 300 100 L 200 300 z")'
-PASS 'offset' does not supported 'ray(45deg closest-side) / 40px 20px'
+PASS 'offset' does not support 'auto'
+PASS 'offset' does not support '10px 30px'
+PASS 'offset' does not support 'none'
+PASS 'offset' does not support 'ray(45deg closest-side)'
+PASS 'offset' does not support 'path("M 100 100 L 300 100 L 200 300 z")'
+PASS 'offset' does not support 'ray(45deg closest-side) / 40px 20px'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-path-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-path-expected.txt
@@ -5,14 +5,32 @@ PASS Can set 'offset-path' to CSS-wide keywords: unset
 PASS Can set 'offset-path' to CSS-wide keywords: revert
 PASS Can set 'offset-path' to var() references:  var(--A)
 PASS Can set 'offset-path' to the 'none' keyword: none
-PASS Setting 'offset-path' to a length throws TypeError
-PASS Setting 'offset-path' to a percent throws TypeError
-PASS Setting 'offset-path' to a time throws TypeError
-PASS Setting 'offset-path' to an angle throws TypeError
-PASS Setting 'offset-path' to a flexible length throws TypeError
-PASS Setting 'offset-path' to a number throws TypeError
-PASS Setting 'offset-path' to a URL throws TypeError
-PASS Setting 'offset-path' to a transform throws TypeError
-PASS 'offset-path' does not supported 'ray(45deg closest-side)'
-PASS 'offset-path' does not supported 'path("M 100 100 L 300 100 L 200 300 Z")'
+PASS Setting 'offset-path' to a length: 0px throws TypeError
+PASS Setting 'offset-path' to a length: -3.14em throws TypeError
+PASS Setting 'offset-path' to a length: 3.14cm throws TypeError
+PASS Setting 'offset-path' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'offset-path' to a percent: 0% throws TypeError
+PASS Setting 'offset-path' to a percent: -3.14% throws TypeError
+PASS Setting 'offset-path' to a percent: 3.14% throws TypeError
+PASS Setting 'offset-path' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'offset-path' to a time: 0s throws TypeError
+PASS Setting 'offset-path' to a time: -3.14ms throws TypeError
+PASS Setting 'offset-path' to a time: 3.14s throws TypeError
+PASS Setting 'offset-path' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'offset-path' to an angle: 0deg throws TypeError
+PASS Setting 'offset-path' to an angle: 3.14rad throws TypeError
+PASS Setting 'offset-path' to an angle: -3.14deg throws TypeError
+PASS Setting 'offset-path' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'offset-path' to a flexible length: 0fr throws TypeError
+PASS Setting 'offset-path' to a flexible length: 1fr throws TypeError
+PASS Setting 'offset-path' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'offset-path' to a number: 0 throws TypeError
+PASS Setting 'offset-path' to a number: -3.14 throws TypeError
+PASS Setting 'offset-path' to a number: 3.14 throws TypeError
+PASS Setting 'offset-path' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'offset-path' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'offset-path' to a transform: perspective(10em) throws TypeError
+PASS Setting 'offset-path' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'offset-path' does not support 'ray(45deg closest-side)'
+PASS 'offset-path' does not support 'path("M 100 100 L 300 100 L 200 300 Z")'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-rotate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-rotate-expected.txt
@@ -10,13 +10,28 @@ PASS Can set 'offset-rotate' to an angle: 0deg
 PASS Can set 'offset-rotate' to an angle: 3.14rad
 PASS Can set 'offset-rotate' to an angle: -3.14deg
 PASS Can set 'offset-rotate' to an angle: calc(0rad + 0deg)
-PASS Setting 'offset-rotate' to a length throws TypeError
-PASS Setting 'offset-rotate' to a percent throws TypeError
-PASS Setting 'offset-rotate' to a time throws TypeError
-PASS Setting 'offset-rotate' to a flexible length throws TypeError
-PASS Setting 'offset-rotate' to a number throws TypeError
-PASS Setting 'offset-rotate' to a URL throws TypeError
-PASS Setting 'offset-rotate' to a transform throws TypeError
-PASS 'offset-rotate' does not supported 'auto 90deg'
-PASS 'offset-rotate' does not supported 'reverse -90deg'
+PASS Setting 'offset-rotate' to a length: 0px throws TypeError
+PASS Setting 'offset-rotate' to a length: -3.14em throws TypeError
+PASS Setting 'offset-rotate' to a length: 3.14cm throws TypeError
+PASS Setting 'offset-rotate' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'offset-rotate' to a percent: 0% throws TypeError
+PASS Setting 'offset-rotate' to a percent: -3.14% throws TypeError
+PASS Setting 'offset-rotate' to a percent: 3.14% throws TypeError
+PASS Setting 'offset-rotate' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'offset-rotate' to a time: 0s throws TypeError
+PASS Setting 'offset-rotate' to a time: -3.14ms throws TypeError
+PASS Setting 'offset-rotate' to a time: 3.14s throws TypeError
+PASS Setting 'offset-rotate' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'offset-rotate' to a flexible length: 0fr throws TypeError
+PASS Setting 'offset-rotate' to a flexible length: 1fr throws TypeError
+PASS Setting 'offset-rotate' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'offset-rotate' to a number: 0 throws TypeError
+PASS Setting 'offset-rotate' to a number: -3.14 throws TypeError
+PASS Setting 'offset-rotate' to a number: 3.14 throws TypeError
+PASS Setting 'offset-rotate' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'offset-rotate' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'offset-rotate' to a transform: perspective(10em) throws TypeError
+PASS Setting 'offset-rotate' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'offset-rotate' does not support 'auto 90deg'
+PASS 'offset-rotate' does not support 'reverse -90deg'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity-expected.txt
@@ -8,11 +8,26 @@ PASS Can set 'opacity' to a number: 0
 PASS Can set 'opacity' to a number: -3.14
 PASS Can set 'opacity' to a number: 3.14
 PASS Can set 'opacity' to a number: calc(2 + 3)
-PASS Setting 'opacity' to a length throws TypeError
-FAIL Setting 'opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'opacity' to a time throws TypeError
-PASS Setting 'opacity' to an angle throws TypeError
-PASS Setting 'opacity' to a flexible length throws TypeError
-PASS Setting 'opacity' to a URL throws TypeError
-PASS Setting 'opacity' to a transform throws TypeError
+PASS Setting 'opacity' to a length: 0px throws TypeError
+PASS Setting 'opacity' to a length: -3.14em throws TypeError
+PASS Setting 'opacity' to a length: 3.14cm throws TypeError
+PASS Setting 'opacity' to a length: calc(0px + 0em) throws TypeError
+FAIL Setting 'opacity' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'opacity' to a percent: -3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'opacity' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'opacity' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'opacity' to a time: 0s throws TypeError
+PASS Setting 'opacity' to a time: -3.14ms throws TypeError
+PASS Setting 'opacity' to a time: 3.14s throws TypeError
+PASS Setting 'opacity' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'opacity' to an angle: 0deg throws TypeError
+PASS Setting 'opacity' to an angle: 3.14rad throws TypeError
+PASS Setting 'opacity' to an angle: -3.14deg throws TypeError
+PASS Setting 'opacity' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'opacity' to a flexible length: 0fr throws TypeError
+PASS Setting 'opacity' to a flexible length: 1fr throws TypeError
+PASS Setting 'opacity' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'opacity' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'opacity' to a transform: perspective(10em) throws TypeError
+PASS Setting 'opacity' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt
@@ -8,11 +8,26 @@ FAIL Can set 'order' to a number: 0 assert_equals: expected "CSSUnitValue" but g
 FAIL Can set 'order' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'order' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'order' to a number: calc(2 + 3) assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-PASS Setting 'order' to a length throws TypeError
-PASS Setting 'order' to a percent throws TypeError
-PASS Setting 'order' to a time throws TypeError
-PASS Setting 'order' to an angle throws TypeError
-PASS Setting 'order' to a flexible length throws TypeError
-PASS Setting 'order' to a URL throws TypeError
-PASS Setting 'order' to a transform throws TypeError
+PASS Setting 'order' to a length: 0px throws TypeError
+PASS Setting 'order' to a length: -3.14em throws TypeError
+PASS Setting 'order' to a length: 3.14cm throws TypeError
+PASS Setting 'order' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'order' to a percent: 0% throws TypeError
+PASS Setting 'order' to a percent: -3.14% throws TypeError
+PASS Setting 'order' to a percent: 3.14% throws TypeError
+PASS Setting 'order' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'order' to a time: 0s throws TypeError
+PASS Setting 'order' to a time: -3.14ms throws TypeError
+PASS Setting 'order' to a time: 3.14s throws TypeError
+PASS Setting 'order' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'order' to an angle: 0deg throws TypeError
+PASS Setting 'order' to an angle: 3.14rad throws TypeError
+PASS Setting 'order' to an angle: -3.14deg throws TypeError
+PASS Setting 'order' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'order' to a flexible length: 0fr throws TypeError
+PASS Setting 'order' to a flexible length: 1fr throws TypeError
+PASS Setting 'order' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'order' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'order' to a transform: perspective(10em) throws TypeError
+PASS Setting 'order' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt
@@ -8,11 +8,26 @@ FAIL Can set 'orphans' to a number: 0 assert_equals: expected "CSSUnitValue" but
 FAIL Can set 'orphans' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'orphans' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'orphans' to a number: calc(2 + 3) assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-PASS Setting 'orphans' to a length throws TypeError
-PASS Setting 'orphans' to a percent throws TypeError
-PASS Setting 'orphans' to a time throws TypeError
-PASS Setting 'orphans' to an angle throws TypeError
-PASS Setting 'orphans' to a flexible length throws TypeError
-PASS Setting 'orphans' to a URL throws TypeError
-PASS Setting 'orphans' to a transform throws TypeError
+PASS Setting 'orphans' to a length: 0px throws TypeError
+PASS Setting 'orphans' to a length: -3.14em throws TypeError
+PASS Setting 'orphans' to a length: 3.14cm throws TypeError
+PASS Setting 'orphans' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'orphans' to a percent: 0% throws TypeError
+PASS Setting 'orphans' to a percent: -3.14% throws TypeError
+PASS Setting 'orphans' to a percent: 3.14% throws TypeError
+PASS Setting 'orphans' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'orphans' to a time: 0s throws TypeError
+PASS Setting 'orphans' to a time: -3.14ms throws TypeError
+PASS Setting 'orphans' to a time: 3.14s throws TypeError
+PASS Setting 'orphans' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'orphans' to an angle: 0deg throws TypeError
+PASS Setting 'orphans' to an angle: 3.14rad throws TypeError
+PASS Setting 'orphans' to an angle: -3.14deg throws TypeError
+PASS Setting 'orphans' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'orphans' to a flexible length: 0fr throws TypeError
+PASS Setting 'orphans' to a flexible length: 1fr throws TypeError
+PASS Setting 'orphans' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'orphans' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'orphans' to a transform: perspective(10em) throws TypeError
+PASS Setting 'orphans' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-color-expected.txt
@@ -5,17 +5,35 @@ PASS Can set 'outline-color' to CSS-wide keywords: unset
 PASS Can set 'outline-color' to CSS-wide keywords: revert
 PASS Can set 'outline-color' to var() references:  var(--A)
 PASS Can set 'outline-color' to the 'currentcolor' keyword: currentcolor
-PASS Setting 'outline-color' to a length throws TypeError
-PASS Setting 'outline-color' to a percent throws TypeError
-PASS Setting 'outline-color' to a time throws TypeError
-PASS Setting 'outline-color' to an angle throws TypeError
-PASS Setting 'outline-color' to a flexible length throws TypeError
-PASS Setting 'outline-color' to a number throws TypeError
-PASS Setting 'outline-color' to a URL throws TypeError
-PASS Setting 'outline-color' to a transform throws TypeError
-FAIL 'outline-color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'outline-color' does not supported '#bbff00'
-PASS 'outline-color' does not supported 'rgb(255, 255, 128)'
-PASS 'outline-color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'outline-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'outline-color' to a length: 0px throws TypeError
+PASS Setting 'outline-color' to a length: -3.14em throws TypeError
+PASS Setting 'outline-color' to a length: 3.14cm throws TypeError
+PASS Setting 'outline-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'outline-color' to a percent: 0% throws TypeError
+PASS Setting 'outline-color' to a percent: -3.14% throws TypeError
+PASS Setting 'outline-color' to a percent: 3.14% throws TypeError
+PASS Setting 'outline-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'outline-color' to a time: 0s throws TypeError
+PASS Setting 'outline-color' to a time: -3.14ms throws TypeError
+PASS Setting 'outline-color' to a time: 3.14s throws TypeError
+PASS Setting 'outline-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'outline-color' to an angle: 0deg throws TypeError
+PASS Setting 'outline-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'outline-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'outline-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'outline-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'outline-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'outline-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'outline-color' to a number: 0 throws TypeError
+PASS Setting 'outline-color' to a number: -3.14 throws TypeError
+PASS Setting 'outline-color' to a number: 3.14 throws TypeError
+PASS Setting 'outline-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'outline-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'outline-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'outline-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'outline-color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'outline-color' does not support '#bbff00'
+PASS 'outline-color' does not support 'rgb(255, 255, 128)'
+PASS 'outline-color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'outline-color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-offset-expected.txt
@@ -8,11 +8,26 @@ PASS Can set 'outline-offset' to a length: 0px
 PASS Can set 'outline-offset' to a length: -3.14em
 PASS Can set 'outline-offset' to a length: 3.14cm
 PASS Can set 'outline-offset' to a length: calc(0px + 0em)
-PASS Setting 'outline-offset' to a percent throws TypeError
-PASS Setting 'outline-offset' to a time throws TypeError
-PASS Setting 'outline-offset' to an angle throws TypeError
-PASS Setting 'outline-offset' to a flexible length throws TypeError
-FAIL Setting 'outline-offset' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'outline-offset' to a URL throws TypeError
-PASS Setting 'outline-offset' to a transform throws TypeError
+PASS Setting 'outline-offset' to a percent: 0% throws TypeError
+PASS Setting 'outline-offset' to a percent: -3.14% throws TypeError
+PASS Setting 'outline-offset' to a percent: 3.14% throws TypeError
+PASS Setting 'outline-offset' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'outline-offset' to a time: 0s throws TypeError
+PASS Setting 'outline-offset' to a time: -3.14ms throws TypeError
+PASS Setting 'outline-offset' to a time: 3.14s throws TypeError
+PASS Setting 'outline-offset' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'outline-offset' to an angle: 0deg throws TypeError
+PASS Setting 'outline-offset' to an angle: 3.14rad throws TypeError
+PASS Setting 'outline-offset' to an angle: -3.14deg throws TypeError
+PASS Setting 'outline-offset' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'outline-offset' to a flexible length: 0fr throws TypeError
+PASS Setting 'outline-offset' to a flexible length: 1fr throws TypeError
+PASS Setting 'outline-offset' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'outline-offset' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'outline-offset' to a number: -3.14 throws TypeError
+PASS Setting 'outline-offset' to a number: 3.14 throws TypeError
+PASS Setting 'outline-offset' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'outline-offset' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'outline-offset' to a transform: perspective(10em) throws TypeError
+PASS Setting 'outline-offset' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-style-expected.txt
@@ -14,12 +14,30 @@ PASS Can set 'outline-style' to the 'groove' keyword: groove
 PASS Can set 'outline-style' to the 'ridge' keyword: ridge
 PASS Can set 'outline-style' to the 'inset' keyword: inset
 PASS Can set 'outline-style' to the 'outset' keyword: outset
-PASS Setting 'outline-style' to a length throws TypeError
-PASS Setting 'outline-style' to a percent throws TypeError
-PASS Setting 'outline-style' to a time throws TypeError
-PASS Setting 'outline-style' to an angle throws TypeError
-PASS Setting 'outline-style' to a flexible length throws TypeError
-PASS Setting 'outline-style' to a number throws TypeError
-PASS Setting 'outline-style' to a URL throws TypeError
-PASS Setting 'outline-style' to a transform throws TypeError
+PASS Setting 'outline-style' to a length: 0px throws TypeError
+PASS Setting 'outline-style' to a length: -3.14em throws TypeError
+PASS Setting 'outline-style' to a length: 3.14cm throws TypeError
+PASS Setting 'outline-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'outline-style' to a percent: 0% throws TypeError
+PASS Setting 'outline-style' to a percent: -3.14% throws TypeError
+PASS Setting 'outline-style' to a percent: 3.14% throws TypeError
+PASS Setting 'outline-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'outline-style' to a time: 0s throws TypeError
+PASS Setting 'outline-style' to a time: -3.14ms throws TypeError
+PASS Setting 'outline-style' to a time: 3.14s throws TypeError
+PASS Setting 'outline-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'outline-style' to an angle: 0deg throws TypeError
+PASS Setting 'outline-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'outline-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'outline-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'outline-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'outline-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'outline-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'outline-style' to a number: 0 throws TypeError
+PASS Setting 'outline-style' to a number: -3.14 throws TypeError
+PASS Setting 'outline-style' to a number: 3.14 throws TypeError
+PASS Setting 'outline-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'outline-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'outline-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'outline-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt
@@ -11,11 +11,26 @@ PASS Can set 'outline-width' to a length: 0px
 PASS Can set 'outline-width' to a length: -3.14em
 PASS Can set 'outline-width' to a length: 3.14cm
 PASS Can set 'outline-width' to a length: calc(0px + 0em)
-PASS Setting 'outline-width' to a percent throws TypeError
-PASS Setting 'outline-width' to a time throws TypeError
-PASS Setting 'outline-width' to an angle throws TypeError
-PASS Setting 'outline-width' to a flexible length throws TypeError
-FAIL Setting 'outline-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'outline-width' to a URL throws TypeError
-PASS Setting 'outline-width' to a transform throws TypeError
+PASS Setting 'outline-width' to a percent: 0% throws TypeError
+PASS Setting 'outline-width' to a percent: -3.14% throws TypeError
+PASS Setting 'outline-width' to a percent: 3.14% throws TypeError
+PASS Setting 'outline-width' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'outline-width' to a time: 0s throws TypeError
+PASS Setting 'outline-width' to a time: -3.14ms throws TypeError
+PASS Setting 'outline-width' to a time: 3.14s throws TypeError
+PASS Setting 'outline-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'outline-width' to an angle: 0deg throws TypeError
+PASS Setting 'outline-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'outline-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'outline-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'outline-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'outline-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'outline-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'outline-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'outline-width' to a number: -3.14 throws TypeError
+PASS Setting 'outline-width' to a number: 3.14 throws TypeError
+PASS Setting 'outline-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'outline-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'outline-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'outline-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-anchor-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'overflow-anchor' to CSS-wide keywords: revert
 PASS Can set 'overflow-anchor' to var() references:  var(--A)
 PASS Can set 'overflow-anchor' to the 'auto' keyword: auto
 PASS Can set 'overflow-anchor' to the 'none' keyword: none
-PASS Setting 'overflow-anchor' to a length throws TypeError
-PASS Setting 'overflow-anchor' to a percent throws TypeError
-PASS Setting 'overflow-anchor' to a time throws TypeError
-PASS Setting 'overflow-anchor' to an angle throws TypeError
-PASS Setting 'overflow-anchor' to a flexible length throws TypeError
-PASS Setting 'overflow-anchor' to a number throws TypeError
-PASS Setting 'overflow-anchor' to a URL throws TypeError
-PASS Setting 'overflow-anchor' to a transform throws TypeError
+PASS Setting 'overflow-anchor' to a length: 0px throws TypeError
+PASS Setting 'overflow-anchor' to a length: -3.14em throws TypeError
+PASS Setting 'overflow-anchor' to a length: 3.14cm throws TypeError
+PASS Setting 'overflow-anchor' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'overflow-anchor' to a percent: 0% throws TypeError
+PASS Setting 'overflow-anchor' to a percent: -3.14% throws TypeError
+PASS Setting 'overflow-anchor' to a percent: 3.14% throws TypeError
+PASS Setting 'overflow-anchor' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'overflow-anchor' to a time: 0s throws TypeError
+PASS Setting 'overflow-anchor' to a time: -3.14ms throws TypeError
+PASS Setting 'overflow-anchor' to a time: 3.14s throws TypeError
+PASS Setting 'overflow-anchor' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'overflow-anchor' to an angle: 0deg throws TypeError
+PASS Setting 'overflow-anchor' to an angle: 3.14rad throws TypeError
+PASS Setting 'overflow-anchor' to an angle: -3.14deg throws TypeError
+PASS Setting 'overflow-anchor' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'overflow-anchor' to a flexible length: 0fr throws TypeError
+PASS Setting 'overflow-anchor' to a flexible length: 1fr throws TypeError
+PASS Setting 'overflow-anchor' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'overflow-anchor' to a number: 0 throws TypeError
+PASS Setting 'overflow-anchor' to a number: -3.14 throws TypeError
+PASS Setting 'overflow-anchor' to a number: 3.14 throws TypeError
+PASS Setting 'overflow-anchor' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'overflow-anchor' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'overflow-anchor' to a transform: perspective(10em) throws TypeError
+PASS Setting 'overflow-anchor' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-clip-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-clip-margin-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL 'overflow-clip-margin' does not supported 'border-box' Invalid property overflow-clip-margin
-FAIL 'overflow-clip-margin' does not supported 'content-box' Invalid property overflow-clip-margin
-FAIL 'overflow-clip-margin' does not supported 'padding-box' Invalid property overflow-clip-margin
-FAIL 'overflow-clip-margin' does not supported 'padding-box 10px' Invalid property overflow-clip-margin
-FAIL 'overflow-clip-margin' does not supported '10px content-box' Invalid property overflow-clip-margin
-FAIL 'overflow-clip-margin' does not supported '0px' Invalid property overflow-clip-margin
-FAIL 'overflow-clip-margin' does not supported '10px' Invalid property overflow-clip-margin
+FAIL 'overflow-clip-margin' does not support 'border-box' Invalid property overflow-clip-margin
+FAIL 'overflow-clip-margin' does not support 'content-box' Invalid property overflow-clip-margin
+FAIL 'overflow-clip-margin' does not support 'padding-box' Invalid property overflow-clip-margin
+FAIL 'overflow-clip-margin' does not support 'padding-box 10px' Invalid property overflow-clip-margin
+FAIL 'overflow-clip-margin' does not support '10px content-box' Invalid property overflow-clip-margin
+FAIL 'overflow-clip-margin' does not support '0px' Invalid property overflow-clip-margin
+FAIL 'overflow-clip-margin' does not support '10px' Invalid property overflow-clip-margin
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-expected.txt
@@ -9,14 +9,32 @@ PASS Can set 'overflow-x' to the 'hidden' keyword: hidden
 PASS Can set 'overflow-x' to the 'clip' keyword: clip
 PASS Can set 'overflow-x' to the 'scroll' keyword: scroll
 PASS Can set 'overflow-x' to the 'auto' keyword: auto
-PASS Setting 'overflow-x' to a length throws TypeError
-PASS Setting 'overflow-x' to a percent throws TypeError
-PASS Setting 'overflow-x' to a time throws TypeError
-PASS Setting 'overflow-x' to an angle throws TypeError
-PASS Setting 'overflow-x' to a flexible length throws TypeError
-PASS Setting 'overflow-x' to a number throws TypeError
-PASS Setting 'overflow-x' to a URL throws TypeError
-PASS Setting 'overflow-x' to a transform throws TypeError
+PASS Setting 'overflow-x' to a length: 0px throws TypeError
+PASS Setting 'overflow-x' to a length: -3.14em throws TypeError
+PASS Setting 'overflow-x' to a length: 3.14cm throws TypeError
+PASS Setting 'overflow-x' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'overflow-x' to a percent: 0% throws TypeError
+PASS Setting 'overflow-x' to a percent: -3.14% throws TypeError
+PASS Setting 'overflow-x' to a percent: 3.14% throws TypeError
+PASS Setting 'overflow-x' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'overflow-x' to a time: 0s throws TypeError
+PASS Setting 'overflow-x' to a time: -3.14ms throws TypeError
+PASS Setting 'overflow-x' to a time: 3.14s throws TypeError
+PASS Setting 'overflow-x' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'overflow-x' to an angle: 0deg throws TypeError
+PASS Setting 'overflow-x' to an angle: 3.14rad throws TypeError
+PASS Setting 'overflow-x' to an angle: -3.14deg throws TypeError
+PASS Setting 'overflow-x' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'overflow-x' to a flexible length: 0fr throws TypeError
+PASS Setting 'overflow-x' to a flexible length: 1fr throws TypeError
+PASS Setting 'overflow-x' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'overflow-x' to a number: 0 throws TypeError
+PASS Setting 'overflow-x' to a number: -3.14 throws TypeError
+PASS Setting 'overflow-x' to a number: 3.14 throws TypeError
+PASS Setting 'overflow-x' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'overflow-x' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'overflow-x' to a transform: perspective(10em) throws TypeError
+PASS Setting 'overflow-x' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'overflow-y' to CSS-wide keywords: initial
 PASS Can set 'overflow-y' to CSS-wide keywords: inherit
 PASS Can set 'overflow-y' to CSS-wide keywords: unset
@@ -27,12 +45,30 @@ PASS Can set 'overflow-y' to the 'hidden' keyword: hidden
 PASS Can set 'overflow-y' to the 'clip' keyword: clip
 PASS Can set 'overflow-y' to the 'scroll' keyword: scroll
 PASS Can set 'overflow-y' to the 'auto' keyword: auto
-PASS Setting 'overflow-y' to a length throws TypeError
-PASS Setting 'overflow-y' to a percent throws TypeError
-PASS Setting 'overflow-y' to a time throws TypeError
-PASS Setting 'overflow-y' to an angle throws TypeError
-PASS Setting 'overflow-y' to a flexible length throws TypeError
-PASS Setting 'overflow-y' to a number throws TypeError
-PASS Setting 'overflow-y' to a URL throws TypeError
-PASS Setting 'overflow-y' to a transform throws TypeError
+PASS Setting 'overflow-y' to a length: 0px throws TypeError
+PASS Setting 'overflow-y' to a length: -3.14em throws TypeError
+PASS Setting 'overflow-y' to a length: 3.14cm throws TypeError
+PASS Setting 'overflow-y' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'overflow-y' to a percent: 0% throws TypeError
+PASS Setting 'overflow-y' to a percent: -3.14% throws TypeError
+PASS Setting 'overflow-y' to a percent: 3.14% throws TypeError
+PASS Setting 'overflow-y' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'overflow-y' to a time: 0s throws TypeError
+PASS Setting 'overflow-y' to a time: -3.14ms throws TypeError
+PASS Setting 'overflow-y' to a time: 3.14s throws TypeError
+PASS Setting 'overflow-y' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'overflow-y' to an angle: 0deg throws TypeError
+PASS Setting 'overflow-y' to an angle: 3.14rad throws TypeError
+PASS Setting 'overflow-y' to an angle: -3.14deg throws TypeError
+PASS Setting 'overflow-y' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'overflow-y' to a flexible length: 0fr throws TypeError
+PASS Setting 'overflow-y' to a flexible length: 1fr throws TypeError
+PASS Setting 'overflow-y' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'overflow-y' to a number: 0 throws TypeError
+PASS Setting 'overflow-y' to a number: -3.14 throws TypeError
+PASS Setting 'overflow-y' to a number: 3.14 throws TypeError
+PASS Setting 'overflow-y' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'overflow-y' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'overflow-y' to a transform: perspective(10em) throws TypeError
+PASS Setting 'overflow-y' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-wrap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-wrap-expected.txt
@@ -7,13 +7,31 @@ PASS Can set 'overflow-wrap' to var() references:  var(--A)
 PASS Can set 'overflow-wrap' to the 'normal' keyword: normal
 PASS Can set 'overflow-wrap' to the 'break-word' keyword: break-word
 FAIL Can set 'overflow-wrap' to the 'break-spaces' keyword: break-spaces Invalid values
-PASS Setting 'overflow-wrap' to a length throws TypeError
-PASS Setting 'overflow-wrap' to a percent throws TypeError
-PASS Setting 'overflow-wrap' to a time throws TypeError
-PASS Setting 'overflow-wrap' to an angle throws TypeError
-PASS Setting 'overflow-wrap' to a flexible length throws TypeError
-PASS Setting 'overflow-wrap' to a number throws TypeError
-PASS Setting 'overflow-wrap' to a URL throws TypeError
-PASS Setting 'overflow-wrap' to a transform throws TypeError
-FAIL 'overflow-wrap' does not supported 'break-overflow break-spaces' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS Setting 'overflow-wrap' to a length: 0px throws TypeError
+PASS Setting 'overflow-wrap' to a length: -3.14em throws TypeError
+PASS Setting 'overflow-wrap' to a length: 3.14cm throws TypeError
+PASS Setting 'overflow-wrap' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'overflow-wrap' to a percent: 0% throws TypeError
+PASS Setting 'overflow-wrap' to a percent: -3.14% throws TypeError
+PASS Setting 'overflow-wrap' to a percent: 3.14% throws TypeError
+PASS Setting 'overflow-wrap' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'overflow-wrap' to a time: 0s throws TypeError
+PASS Setting 'overflow-wrap' to a time: -3.14ms throws TypeError
+PASS Setting 'overflow-wrap' to a time: 3.14s throws TypeError
+PASS Setting 'overflow-wrap' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'overflow-wrap' to an angle: 0deg throws TypeError
+PASS Setting 'overflow-wrap' to an angle: 3.14rad throws TypeError
+PASS Setting 'overflow-wrap' to an angle: -3.14deg throws TypeError
+PASS Setting 'overflow-wrap' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'overflow-wrap' to a flexible length: 0fr throws TypeError
+PASS Setting 'overflow-wrap' to a flexible length: 1fr throws TypeError
+PASS Setting 'overflow-wrap' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'overflow-wrap' to a number: 0 throws TypeError
+PASS Setting 'overflow-wrap' to a number: -3.14 throws TypeError
+PASS Setting 'overflow-wrap' to a number: 3.14 throws TypeError
+PASS Setting 'overflow-wrap' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'overflow-wrap' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'overflow-wrap' to a transform: perspective(10em) throws TypeError
+PASS Setting 'overflow-wrap' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'overflow-wrap' does not support 'break-overflow break-spaces' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overscroll-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overscroll-behavior-expected.txt
@@ -7,14 +7,32 @@ PASS Can set 'overscroll-behavior-x' to var() references:  var(--A)
 PASS Can set 'overscroll-behavior-x' to the 'contain' keyword: contain
 PASS Can set 'overscroll-behavior-x' to the 'none' keyword: none
 PASS Can set 'overscroll-behavior-x' to the 'auto' keyword: auto
-PASS Setting 'overscroll-behavior-x' to a length throws TypeError
-PASS Setting 'overscroll-behavior-x' to a percent throws TypeError
-PASS Setting 'overscroll-behavior-x' to a time throws TypeError
-PASS Setting 'overscroll-behavior-x' to an angle throws TypeError
-PASS Setting 'overscroll-behavior-x' to a flexible length throws TypeError
-PASS Setting 'overscroll-behavior-x' to a number throws TypeError
-PASS Setting 'overscroll-behavior-x' to a URL throws TypeError
-PASS Setting 'overscroll-behavior-x' to a transform throws TypeError
+PASS Setting 'overscroll-behavior-x' to a length: 0px throws TypeError
+PASS Setting 'overscroll-behavior-x' to a length: -3.14em throws TypeError
+PASS Setting 'overscroll-behavior-x' to a length: 3.14cm throws TypeError
+PASS Setting 'overscroll-behavior-x' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'overscroll-behavior-x' to a percent: 0% throws TypeError
+PASS Setting 'overscroll-behavior-x' to a percent: -3.14% throws TypeError
+PASS Setting 'overscroll-behavior-x' to a percent: 3.14% throws TypeError
+PASS Setting 'overscroll-behavior-x' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'overscroll-behavior-x' to a time: 0s throws TypeError
+PASS Setting 'overscroll-behavior-x' to a time: -3.14ms throws TypeError
+PASS Setting 'overscroll-behavior-x' to a time: 3.14s throws TypeError
+PASS Setting 'overscroll-behavior-x' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'overscroll-behavior-x' to an angle: 0deg throws TypeError
+PASS Setting 'overscroll-behavior-x' to an angle: 3.14rad throws TypeError
+PASS Setting 'overscroll-behavior-x' to an angle: -3.14deg throws TypeError
+PASS Setting 'overscroll-behavior-x' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'overscroll-behavior-x' to a flexible length: 0fr throws TypeError
+PASS Setting 'overscroll-behavior-x' to a flexible length: 1fr throws TypeError
+PASS Setting 'overscroll-behavior-x' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'overscroll-behavior-x' to a number: 0 throws TypeError
+PASS Setting 'overscroll-behavior-x' to a number: -3.14 throws TypeError
+PASS Setting 'overscroll-behavior-x' to a number: 3.14 throws TypeError
+PASS Setting 'overscroll-behavior-x' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'overscroll-behavior-x' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'overscroll-behavior-x' to a transform: perspective(10em) throws TypeError
+PASS Setting 'overscroll-behavior-x' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'overscroll-behavior-y' to CSS-wide keywords: initial
 PASS Can set 'overscroll-behavior-y' to CSS-wide keywords: inherit
 PASS Can set 'overscroll-behavior-y' to CSS-wide keywords: unset
@@ -23,12 +41,30 @@ PASS Can set 'overscroll-behavior-y' to var() references:  var(--A)
 PASS Can set 'overscroll-behavior-y' to the 'contain' keyword: contain
 PASS Can set 'overscroll-behavior-y' to the 'none' keyword: none
 PASS Can set 'overscroll-behavior-y' to the 'auto' keyword: auto
-PASS Setting 'overscroll-behavior-y' to a length throws TypeError
-PASS Setting 'overscroll-behavior-y' to a percent throws TypeError
-PASS Setting 'overscroll-behavior-y' to a time throws TypeError
-PASS Setting 'overscroll-behavior-y' to an angle throws TypeError
-PASS Setting 'overscroll-behavior-y' to a flexible length throws TypeError
-PASS Setting 'overscroll-behavior-y' to a number throws TypeError
-PASS Setting 'overscroll-behavior-y' to a URL throws TypeError
-PASS Setting 'overscroll-behavior-y' to a transform throws TypeError
+PASS Setting 'overscroll-behavior-y' to a length: 0px throws TypeError
+PASS Setting 'overscroll-behavior-y' to a length: -3.14em throws TypeError
+PASS Setting 'overscroll-behavior-y' to a length: 3.14cm throws TypeError
+PASS Setting 'overscroll-behavior-y' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'overscroll-behavior-y' to a percent: 0% throws TypeError
+PASS Setting 'overscroll-behavior-y' to a percent: -3.14% throws TypeError
+PASS Setting 'overscroll-behavior-y' to a percent: 3.14% throws TypeError
+PASS Setting 'overscroll-behavior-y' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'overscroll-behavior-y' to a time: 0s throws TypeError
+PASS Setting 'overscroll-behavior-y' to a time: -3.14ms throws TypeError
+PASS Setting 'overscroll-behavior-y' to a time: 3.14s throws TypeError
+PASS Setting 'overscroll-behavior-y' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'overscroll-behavior-y' to an angle: 0deg throws TypeError
+PASS Setting 'overscroll-behavior-y' to an angle: 3.14rad throws TypeError
+PASS Setting 'overscroll-behavior-y' to an angle: -3.14deg throws TypeError
+PASS Setting 'overscroll-behavior-y' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'overscroll-behavior-y' to a flexible length: 0fr throws TypeError
+PASS Setting 'overscroll-behavior-y' to a flexible length: 1fr throws TypeError
+PASS Setting 'overscroll-behavior-y' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'overscroll-behavior-y' to a number: 0 throws TypeError
+PASS Setting 'overscroll-behavior-y' to a number: -3.14 throws TypeError
+PASS Setting 'overscroll-behavior-y' to a number: 3.14 throws TypeError
+PASS Setting 'overscroll-behavior-y' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'overscroll-behavior-y' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'overscroll-behavior-y' to a transform: perspective(10em) throws TypeError
+PASS Setting 'overscroll-behavior-y' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt
@@ -12,12 +12,24 @@ PASS Can set 'padding-top' to a length: 0px
 PASS Can set 'padding-top' to a length: -3.14em
 PASS Can set 'padding-top' to a length: 3.14cm
 PASS Can set 'padding-top' to a length: calc(0px + 0em)
-PASS Setting 'padding-top' to a time throws TypeError
-PASS Setting 'padding-top' to an angle throws TypeError
-PASS Setting 'padding-top' to a flexible length throws TypeError
-FAIL Setting 'padding-top' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-top' to a URL throws TypeError
-PASS Setting 'padding-top' to a transform throws TypeError
+PASS Setting 'padding-top' to a time: 0s throws TypeError
+PASS Setting 'padding-top' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-top' to a time: 3.14s throws TypeError
+PASS Setting 'padding-top' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-top' to an angle: 0deg throws TypeError
+PASS Setting 'padding-top' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-top' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-top' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-top' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-top' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-top' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-top' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-top' to a number: -3.14 throws TypeError
+PASS Setting 'padding-top' to a number: 3.14 throws TypeError
+PASS Setting 'padding-top' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-top' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-top' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-top' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'padding-left' to CSS-wide keywords: initial
 PASS Can set 'padding-left' to CSS-wide keywords: inherit
 PASS Can set 'padding-left' to CSS-wide keywords: unset
@@ -31,12 +43,24 @@ PASS Can set 'padding-left' to a length: 0px
 PASS Can set 'padding-left' to a length: -3.14em
 PASS Can set 'padding-left' to a length: 3.14cm
 PASS Can set 'padding-left' to a length: calc(0px + 0em)
-PASS Setting 'padding-left' to a time throws TypeError
-PASS Setting 'padding-left' to an angle throws TypeError
-PASS Setting 'padding-left' to a flexible length throws TypeError
-FAIL Setting 'padding-left' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-left' to a URL throws TypeError
-PASS Setting 'padding-left' to a transform throws TypeError
+PASS Setting 'padding-left' to a time: 0s throws TypeError
+PASS Setting 'padding-left' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-left' to a time: 3.14s throws TypeError
+PASS Setting 'padding-left' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-left' to an angle: 0deg throws TypeError
+PASS Setting 'padding-left' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-left' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-left' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-left' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-left' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-left' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-left' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-left' to a number: -3.14 throws TypeError
+PASS Setting 'padding-left' to a number: 3.14 throws TypeError
+PASS Setting 'padding-left' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-left' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-left' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-left' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'padding-right' to CSS-wide keywords: initial
 PASS Can set 'padding-right' to CSS-wide keywords: inherit
 PASS Can set 'padding-right' to CSS-wide keywords: unset
@@ -50,12 +74,24 @@ PASS Can set 'padding-right' to a length: 0px
 PASS Can set 'padding-right' to a length: -3.14em
 PASS Can set 'padding-right' to a length: 3.14cm
 PASS Can set 'padding-right' to a length: calc(0px + 0em)
-PASS Setting 'padding-right' to a time throws TypeError
-PASS Setting 'padding-right' to an angle throws TypeError
-PASS Setting 'padding-right' to a flexible length throws TypeError
-FAIL Setting 'padding-right' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-right' to a URL throws TypeError
-PASS Setting 'padding-right' to a transform throws TypeError
+PASS Setting 'padding-right' to a time: 0s throws TypeError
+PASS Setting 'padding-right' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-right' to a time: 3.14s throws TypeError
+PASS Setting 'padding-right' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-right' to an angle: 0deg throws TypeError
+PASS Setting 'padding-right' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-right' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-right' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-right' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-right' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-right' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-right' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-right' to a number: -3.14 throws TypeError
+PASS Setting 'padding-right' to a number: 3.14 throws TypeError
+PASS Setting 'padding-right' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-right' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-right' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-right' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'padding-bottom' to CSS-wide keywords: initial
 PASS Can set 'padding-bottom' to CSS-wide keywords: inherit
 PASS Can set 'padding-bottom' to CSS-wide keywords: unset
@@ -69,10 +105,22 @@ PASS Can set 'padding-bottom' to a length: 0px
 PASS Can set 'padding-bottom' to a length: -3.14em
 PASS Can set 'padding-bottom' to a length: 3.14cm
 PASS Can set 'padding-bottom' to a length: calc(0px + 0em)
-PASS Setting 'padding-bottom' to a time throws TypeError
-PASS Setting 'padding-bottom' to an angle throws TypeError
-PASS Setting 'padding-bottom' to a flexible length throws TypeError
-FAIL Setting 'padding-bottom' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-bottom' to a URL throws TypeError
-PASS Setting 'padding-bottom' to a transform throws TypeError
+PASS Setting 'padding-bottom' to a time: 0s throws TypeError
+PASS Setting 'padding-bottom' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-bottom' to a time: 3.14s throws TypeError
+PASS Setting 'padding-bottom' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-bottom' to an angle: 0deg throws TypeError
+PASS Setting 'padding-bottom' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-bottom' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-bottom' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-bottom' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-bottom' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-bottom' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-bottom' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-bottom' to a number: -3.14 throws TypeError
+PASS Setting 'padding-bottom' to a number: 3.14 throws TypeError
+PASS Setting 'padding-bottom' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-bottom' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-bottom' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-bottom' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt
@@ -6,12 +6,30 @@ FAIL Can set 'page' to CSS-wide keywords: revert assert_not_equals: Computed val
 FAIL Can set 'page' to var() references:  var(--A) assert_not_equals: Computed value must not be null got disallowed value null
 FAIL Can set 'page' to the 'auto' keyword: auto assert_not_equals: Computed value must not be null got disallowed value null
 FAIL Can set 'page' to the 'custom-ident' keyword: custom-ident assert_not_equals: Computed value must not be null got disallowed value null
-PASS Setting 'page' to a length throws TypeError
-PASS Setting 'page' to a percent throws TypeError
-PASS Setting 'page' to a time throws TypeError
-PASS Setting 'page' to an angle throws TypeError
-PASS Setting 'page' to a flexible length throws TypeError
-PASS Setting 'page' to a number throws TypeError
-PASS Setting 'page' to a URL throws TypeError
-PASS Setting 'page' to a transform throws TypeError
+PASS Setting 'page' to a length: 0px throws TypeError
+PASS Setting 'page' to a length: -3.14em throws TypeError
+PASS Setting 'page' to a length: 3.14cm throws TypeError
+PASS Setting 'page' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'page' to a percent: 0% throws TypeError
+PASS Setting 'page' to a percent: -3.14% throws TypeError
+PASS Setting 'page' to a percent: 3.14% throws TypeError
+PASS Setting 'page' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'page' to a time: 0s throws TypeError
+PASS Setting 'page' to a time: -3.14ms throws TypeError
+PASS Setting 'page' to a time: 3.14s throws TypeError
+PASS Setting 'page' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'page' to an angle: 0deg throws TypeError
+PASS Setting 'page' to an angle: 3.14rad throws TypeError
+PASS Setting 'page' to an angle: -3.14deg throws TypeError
+PASS Setting 'page' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'page' to a flexible length: 0fr throws TypeError
+PASS Setting 'page' to a flexible length: 1fr throws TypeError
+PASS Setting 'page' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'page' to a number: 0 throws TypeError
+PASS Setting 'page' to a number: -3.14 throws TypeError
+PASS Setting 'page' to a number: 3.14 throws TypeError
+PASS Setting 'page' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'page' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'page' to a transform: perspective(10em) throws TypeError
+PASS Setting 'page' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/paint-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/paint-order-expected.txt
@@ -8,14 +8,32 @@ PASS Can set 'paint-order' to the 'normal' keyword: normal
 PASS Can set 'paint-order' to the 'fill' keyword: fill
 PASS Can set 'paint-order' to the 'stroke' keyword: stroke
 PASS Can set 'paint-order' to the 'markers' keyword: markers
-PASS Setting 'paint-order' to a length throws TypeError
-PASS Setting 'paint-order' to a percent throws TypeError
-PASS Setting 'paint-order' to a time throws TypeError
-PASS Setting 'paint-order' to an angle throws TypeError
-PASS Setting 'paint-order' to a flexible length throws TypeError
-PASS Setting 'paint-order' to a number throws TypeError
-PASS Setting 'paint-order' to a URL throws TypeError
-PASS Setting 'paint-order' to a transform throws TypeError
-FAIL 'paint-order' does not supported 'fill stroke' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'paint-order' does not supported 'markers fill stroke' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'paint-order' to a length: 0px throws TypeError
+PASS Setting 'paint-order' to a length: -3.14em throws TypeError
+PASS Setting 'paint-order' to a length: 3.14cm throws TypeError
+PASS Setting 'paint-order' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'paint-order' to a percent: 0% throws TypeError
+PASS Setting 'paint-order' to a percent: -3.14% throws TypeError
+PASS Setting 'paint-order' to a percent: 3.14% throws TypeError
+PASS Setting 'paint-order' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'paint-order' to a time: 0s throws TypeError
+PASS Setting 'paint-order' to a time: -3.14ms throws TypeError
+PASS Setting 'paint-order' to a time: 3.14s throws TypeError
+PASS Setting 'paint-order' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'paint-order' to an angle: 0deg throws TypeError
+PASS Setting 'paint-order' to an angle: 3.14rad throws TypeError
+PASS Setting 'paint-order' to an angle: -3.14deg throws TypeError
+PASS Setting 'paint-order' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'paint-order' to a flexible length: 0fr throws TypeError
+PASS Setting 'paint-order' to a flexible length: 1fr throws TypeError
+PASS Setting 'paint-order' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'paint-order' to a number: 0 throws TypeError
+PASS Setting 'paint-order' to a number: -3.14 throws TypeError
+PASS Setting 'paint-order' to a number: 3.14 throws TypeError
+PASS Setting 'paint-order' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'paint-order' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'paint-order' to a transform: perspective(10em) throws TypeError
+PASS Setting 'paint-order' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'paint-order' does not support 'fill stroke' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'paint-order' does not support 'markers fill stroke' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt
@@ -9,11 +9,26 @@ PASS Can set 'perspective' to a length: 0px
 PASS Can set 'perspective' to a length: -3.14em
 PASS Can set 'perspective' to a length: 3.14cm
 PASS Can set 'perspective' to a length: calc(0px + 0em)
-PASS Setting 'perspective' to a percent throws TypeError
-PASS Setting 'perspective' to a time throws TypeError
-PASS Setting 'perspective' to an angle throws TypeError
-PASS Setting 'perspective' to a flexible length throws TypeError
-FAIL Setting 'perspective' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'perspective' to a URL throws TypeError
-PASS Setting 'perspective' to a transform throws TypeError
+PASS Setting 'perspective' to a percent: 0% throws TypeError
+PASS Setting 'perspective' to a percent: -3.14% throws TypeError
+PASS Setting 'perspective' to a percent: 3.14% throws TypeError
+PASS Setting 'perspective' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'perspective' to a time: 0s throws TypeError
+PASS Setting 'perspective' to a time: -3.14ms throws TypeError
+PASS Setting 'perspective' to a time: 3.14s throws TypeError
+PASS Setting 'perspective' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'perspective' to an angle: 0deg throws TypeError
+PASS Setting 'perspective' to an angle: 3.14rad throws TypeError
+PASS Setting 'perspective' to an angle: -3.14deg throws TypeError
+PASS Setting 'perspective' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'perspective' to a flexible length: 0fr throws TypeError
+PASS Setting 'perspective' to a flexible length: 1fr throws TypeError
+PASS Setting 'perspective' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'perspective' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'perspective' to a number: -3.14 throws TypeError
+PASS Setting 'perspective' to a number: 3.14 throws TypeError
+PASS Setting 'perspective' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'perspective' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'perspective' to a transform: perspective(10em) throws TypeError
+PASS Setting 'perspective' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/pointer-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/pointer-events-expected.txt
@@ -14,12 +14,30 @@ PASS Can set 'pointer-events' to the 'fill' keyword: fill
 PASS Can set 'pointer-events' to the 'stroke' keyword: stroke
 PASS Can set 'pointer-events' to the 'all' keyword: all
 PASS Can set 'pointer-events' to the 'none' keyword: none
-PASS Setting 'pointer-events' to a length throws TypeError
-PASS Setting 'pointer-events' to a percent throws TypeError
-PASS Setting 'pointer-events' to a time throws TypeError
-PASS Setting 'pointer-events' to an angle throws TypeError
-PASS Setting 'pointer-events' to a flexible length throws TypeError
-PASS Setting 'pointer-events' to a number throws TypeError
-PASS Setting 'pointer-events' to a URL throws TypeError
-PASS Setting 'pointer-events' to a transform throws TypeError
+PASS Setting 'pointer-events' to a length: 0px throws TypeError
+PASS Setting 'pointer-events' to a length: -3.14em throws TypeError
+PASS Setting 'pointer-events' to a length: 3.14cm throws TypeError
+PASS Setting 'pointer-events' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'pointer-events' to a percent: 0% throws TypeError
+PASS Setting 'pointer-events' to a percent: -3.14% throws TypeError
+PASS Setting 'pointer-events' to a percent: 3.14% throws TypeError
+PASS Setting 'pointer-events' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'pointer-events' to a time: 0s throws TypeError
+PASS Setting 'pointer-events' to a time: -3.14ms throws TypeError
+PASS Setting 'pointer-events' to a time: 3.14s throws TypeError
+PASS Setting 'pointer-events' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'pointer-events' to an angle: 0deg throws TypeError
+PASS Setting 'pointer-events' to an angle: 3.14rad throws TypeError
+PASS Setting 'pointer-events' to an angle: -3.14deg throws TypeError
+PASS Setting 'pointer-events' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'pointer-events' to a flexible length: 0fr throws TypeError
+PASS Setting 'pointer-events' to a flexible length: 1fr throws TypeError
+PASS Setting 'pointer-events' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'pointer-events' to a number: 0 throws TypeError
+PASS Setting 'pointer-events' to a number: -3.14 throws TypeError
+PASS Setting 'pointer-events' to a number: 3.14 throws TypeError
+PASS Setting 'pointer-events' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'pointer-events' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'pointer-events' to a transform: perspective(10em) throws TypeError
+PASS Setting 'pointer-events' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/position-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'position' to CSS-wide keywords: revert
 PASS Can set 'position' to var() references:  var(--A)
 PASS Can set 'position' to the 'relative' keyword: relative
 PASS Can set 'position' to the 'absolute' keyword: absolute
-PASS Setting 'position' to a length throws TypeError
-PASS Setting 'position' to a percent throws TypeError
-PASS Setting 'position' to a time throws TypeError
-PASS Setting 'position' to an angle throws TypeError
-PASS Setting 'position' to a flexible length throws TypeError
-PASS Setting 'position' to a number throws TypeError
-PASS Setting 'position' to a URL throws TypeError
-PASS Setting 'position' to a transform throws TypeError
+PASS Setting 'position' to a length: 0px throws TypeError
+PASS Setting 'position' to a length: -3.14em throws TypeError
+PASS Setting 'position' to a length: 3.14cm throws TypeError
+PASS Setting 'position' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'position' to a percent: 0% throws TypeError
+PASS Setting 'position' to a percent: -3.14% throws TypeError
+PASS Setting 'position' to a percent: 3.14% throws TypeError
+PASS Setting 'position' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'position' to a time: 0s throws TypeError
+PASS Setting 'position' to a time: -3.14ms throws TypeError
+PASS Setting 'position' to a time: 3.14s throws TypeError
+PASS Setting 'position' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'position' to an angle: 0deg throws TypeError
+PASS Setting 'position' to an angle: 3.14rad throws TypeError
+PASS Setting 'position' to an angle: -3.14deg throws TypeError
+PASS Setting 'position' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'position' to a flexible length: 0fr throws TypeError
+PASS Setting 'position' to a flexible length: 1fr throws TypeError
+PASS Setting 'position' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'position' to a number: 0 throws TypeError
+PASS Setting 'position' to a number: -3.14 throws TypeError
+PASS Setting 'position' to a number: 3.14 throws TypeError
+PASS Setting 'position' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'position' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'position' to a transform: perspective(10em) throws TypeError
+PASS Setting 'position' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/quotes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/quotes-expected.txt
@@ -5,13 +5,31 @@ PASS Can set 'quotes' to CSS-wide keywords: unset
 PASS Can set 'quotes' to CSS-wide keywords: revert
 PASS Can set 'quotes' to var() references:  var(--A)
 PASS Can set 'quotes' to the 'none' keyword: none
-PASS Setting 'quotes' to a length throws TypeError
-PASS Setting 'quotes' to a percent throws TypeError
-PASS Setting 'quotes' to a time throws TypeError
-PASS Setting 'quotes' to an angle throws TypeError
-PASS Setting 'quotes' to a flexible length throws TypeError
-PASS Setting 'quotes' to a number throws TypeError
-PASS Setting 'quotes' to a URL throws TypeError
-PASS Setting 'quotes' to a transform throws TypeError
-FAIL 'quotes' does not supported '"<<" ">>" "<" ">"' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'quotes' to a length: 0px throws TypeError
+PASS Setting 'quotes' to a length: -3.14em throws TypeError
+PASS Setting 'quotes' to a length: 3.14cm throws TypeError
+PASS Setting 'quotes' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'quotes' to a percent: 0% throws TypeError
+PASS Setting 'quotes' to a percent: -3.14% throws TypeError
+PASS Setting 'quotes' to a percent: 3.14% throws TypeError
+PASS Setting 'quotes' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'quotes' to a time: 0s throws TypeError
+PASS Setting 'quotes' to a time: -3.14ms throws TypeError
+PASS Setting 'quotes' to a time: 3.14s throws TypeError
+PASS Setting 'quotes' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'quotes' to an angle: 0deg throws TypeError
+PASS Setting 'quotes' to an angle: 3.14rad throws TypeError
+PASS Setting 'quotes' to an angle: -3.14deg throws TypeError
+PASS Setting 'quotes' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'quotes' to a flexible length: 0fr throws TypeError
+PASS Setting 'quotes' to a flexible length: 1fr throws TypeError
+PASS Setting 'quotes' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'quotes' to a number: 0 throws TypeError
+PASS Setting 'quotes' to a number: -3.14 throws TypeError
+PASS Setting 'quotes' to a number: 3.14 throws TypeError
+PASS Setting 'quotes' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'quotes' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'quotes' to a transform: perspective(10em) throws TypeError
+PASS Setting 'quotes' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'quotes' does not support '"<<" ">>" "<" ">"' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt
@@ -12,12 +12,24 @@ PASS Can set 'r' to a length: 0px
 PASS Can set 'r' to a length: -3.14em
 PASS Can set 'r' to a length: 3.14cm
 PASS Can set 'r' to a length: calc(0px + 0em)
-PASS Setting 'r' to a time throws TypeError
-PASS Setting 'r' to an angle throws TypeError
-PASS Setting 'r' to a flexible length throws TypeError
-FAIL Setting 'r' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'r' to a URL throws TypeError
-PASS Setting 'r' to a transform throws TypeError
+PASS Setting 'r' to a time: 0s throws TypeError
+PASS Setting 'r' to a time: -3.14ms throws TypeError
+PASS Setting 'r' to a time: 3.14s throws TypeError
+PASS Setting 'r' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'r' to an angle: 0deg throws TypeError
+PASS Setting 'r' to an angle: 3.14rad throws TypeError
+PASS Setting 'r' to an angle: -3.14deg throws TypeError
+PASS Setting 'r' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'r' to a flexible length: 0fr throws TypeError
+PASS Setting 'r' to a flexible length: 1fr throws TypeError
+PASS Setting 'r' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'r' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'r' to a number: -3.14 throws TypeError
+PASS Setting 'r' to a number: 3.14 throws TypeError
+PASS Setting 'r' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'r' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'r' to a transform: perspective(10em) throws TypeError
+PASS Setting 'r' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'rx' to CSS-wide keywords: initial
 PASS Can set 'rx' to CSS-wide keywords: inherit
 PASS Can set 'rx' to CSS-wide keywords: unset
@@ -32,12 +44,24 @@ PASS Can set 'rx' to a length: 0px
 PASS Can set 'rx' to a length: -3.14em
 PASS Can set 'rx' to a length: 3.14cm
 PASS Can set 'rx' to a length: calc(0px + 0em)
-PASS Setting 'rx' to a time throws TypeError
-PASS Setting 'rx' to an angle throws TypeError
-PASS Setting 'rx' to a flexible length throws TypeError
-FAIL Setting 'rx' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'rx' to a URL throws TypeError
-PASS Setting 'rx' to a transform throws TypeError
+PASS Setting 'rx' to a time: 0s throws TypeError
+PASS Setting 'rx' to a time: -3.14ms throws TypeError
+PASS Setting 'rx' to a time: 3.14s throws TypeError
+PASS Setting 'rx' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'rx' to an angle: 0deg throws TypeError
+PASS Setting 'rx' to an angle: 3.14rad throws TypeError
+PASS Setting 'rx' to an angle: -3.14deg throws TypeError
+PASS Setting 'rx' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'rx' to a flexible length: 0fr throws TypeError
+PASS Setting 'rx' to a flexible length: 1fr throws TypeError
+PASS Setting 'rx' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'rx' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'rx' to a number: -3.14 throws TypeError
+PASS Setting 'rx' to a number: 3.14 throws TypeError
+PASS Setting 'rx' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'rx' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'rx' to a transform: perspective(10em) throws TypeError
+PASS Setting 'rx' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'ry' to CSS-wide keywords: initial
 PASS Can set 'ry' to CSS-wide keywords: inherit
 PASS Can set 'ry' to CSS-wide keywords: unset
@@ -52,10 +76,22 @@ PASS Can set 'ry' to a length: 0px
 PASS Can set 'ry' to a length: -3.14em
 PASS Can set 'ry' to a length: 3.14cm
 PASS Can set 'ry' to a length: calc(0px + 0em)
-PASS Setting 'ry' to a time throws TypeError
-PASS Setting 'ry' to an angle throws TypeError
-PASS Setting 'ry' to a flexible length throws TypeError
-FAIL Setting 'ry' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'ry' to a URL throws TypeError
-PASS Setting 'ry' to a transform throws TypeError
+PASS Setting 'ry' to a time: 0s throws TypeError
+PASS Setting 'ry' to a time: -3.14ms throws TypeError
+PASS Setting 'ry' to a time: 3.14s throws TypeError
+PASS Setting 'ry' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'ry' to an angle: 0deg throws TypeError
+PASS Setting 'ry' to an angle: 3.14rad throws TypeError
+PASS Setting 'ry' to an angle: -3.14deg throws TypeError
+PASS Setting 'ry' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'ry' to a flexible length: 0fr throws TypeError
+PASS Setting 'ry' to a flexible length: 1fr throws TypeError
+PASS Setting 'ry' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'ry' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'ry' to a number: -3.14 throws TypeError
+PASS Setting 'ry' to a number: 3.14 throws TypeError
+PASS Setting 'ry' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'ry' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'ry' to a transform: perspective(10em) throws TypeError
+PASS Setting 'ry' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resize-expected.txt
@@ -8,12 +8,30 @@ PASS Can set 'resize' to the 'none' keyword: none
 PASS Can set 'resize' to the 'both' keyword: both
 PASS Can set 'resize' to the 'horizontal' keyword: horizontal
 PASS Can set 'resize' to the 'vertical' keyword: vertical
-PASS Setting 'resize' to a length throws TypeError
-PASS Setting 'resize' to a percent throws TypeError
-PASS Setting 'resize' to a time throws TypeError
-PASS Setting 'resize' to an angle throws TypeError
-PASS Setting 'resize' to a flexible length throws TypeError
-PASS Setting 'resize' to a number throws TypeError
-PASS Setting 'resize' to a URL throws TypeError
-PASS Setting 'resize' to a transform throws TypeError
+PASS Setting 'resize' to a length: 0px throws TypeError
+PASS Setting 'resize' to a length: -3.14em throws TypeError
+PASS Setting 'resize' to a length: 3.14cm throws TypeError
+PASS Setting 'resize' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'resize' to a percent: 0% throws TypeError
+PASS Setting 'resize' to a percent: -3.14% throws TypeError
+PASS Setting 'resize' to a percent: 3.14% throws TypeError
+PASS Setting 'resize' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'resize' to a time: 0s throws TypeError
+PASS Setting 'resize' to a time: -3.14ms throws TypeError
+PASS Setting 'resize' to a time: 3.14s throws TypeError
+PASS Setting 'resize' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'resize' to an angle: 0deg throws TypeError
+PASS Setting 'resize' to an angle: 3.14rad throws TypeError
+PASS Setting 'resize' to an angle: -3.14deg throws TypeError
+PASS Setting 'resize' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'resize' to a flexible length: 0fr throws TypeError
+PASS Setting 'resize' to a flexible length: 1fr throws TypeError
+PASS Setting 'resize' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'resize' to a number: 0 throws TypeError
+PASS Setting 'resize' to a number: -3.14 throws TypeError
+PASS Setting 'resize' to a number: 3.14 throws TypeError
+PASS Setting 'resize' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'resize' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'resize' to a transform: perspective(10em) throws TypeError
+PASS Setting 'resize' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resources/testsuite.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resources/testsuite.js
@@ -349,12 +349,12 @@ function testIsImageValidForProperty(propertyName) {
 
 // Test that styleMap.set throws for invalid values
 function testPropertyInvalid(propertyName, examples, description) {
-  test(t => {
-    let styleMap = createInlineStyleMap(t);
-    for (const example of examples) {
+  for (const example of examples) {
+    test(t => {
+      let styleMap = createInlineStyleMap(t);
       assert_throws_js(TypeError, () => styleMap.set(propertyName, example.input));
-    }
-  }, `Setting '${propertyName}' to ${description} throws TypeError`);
+    }, `Setting '${propertyName}' to ${description}: ${example.input} throws TypeError`);
+  }
 }
 
 // Test that styleMap.get/.set roundtrips correctly for unsupported values.
@@ -378,7 +378,7 @@ function testUnsupportedValue(propertyName, cssText) {
     assert_style_value_equals(resultAll[0], result,
       `getAll() with single unsupported value returns single-item list ` +
       `with same result as get()`);
-  }, `'${propertyName}' does not supported '${cssText}'`);
+  }, `'${propertyName}' does not support '${cssText}'`);
 }
 
 function createKeywordExample(keyword) {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/right-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/right-expected.txt
@@ -13,10 +13,22 @@ PASS Can set 'right' to a length: 0px
 PASS Can set 'right' to a length: -3.14em
 PASS Can set 'right' to a length: 3.14cm
 PASS Can set 'right' to a length: calc(0px + 0em)
-PASS Setting 'right' to a time throws TypeError
-PASS Setting 'right' to an angle throws TypeError
-PASS Setting 'right' to a flexible length throws TypeError
-FAIL Setting 'right' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'right' to a URL throws TypeError
-PASS Setting 'right' to a transform throws TypeError
+PASS Setting 'right' to a time: 0s throws TypeError
+PASS Setting 'right' to a time: -3.14ms throws TypeError
+PASS Setting 'right' to a time: 3.14s throws TypeError
+PASS Setting 'right' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'right' to an angle: 0deg throws TypeError
+PASS Setting 'right' to an angle: 3.14rad throws TypeError
+PASS Setting 'right' to an angle: -3.14deg throws TypeError
+PASS Setting 'right' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'right' to a flexible length: 0fr throws TypeError
+PASS Setting 'right' to a flexible length: 1fr throws TypeError
+PASS Setting 'right' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'right' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'right' to a number: -3.14 throws TypeError
+PASS Setting 'right' to a number: 3.14 throws TypeError
+PASS Setting 'right' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'right' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'right' to a transform: perspective(10em) throws TypeError
+PASS Setting 'right' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-behavior-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'scroll-behavior' to CSS-wide keywords: revert
 PASS Can set 'scroll-behavior' to var() references:  var(--A)
 PASS Can set 'scroll-behavior' to the 'auto' keyword: auto
 PASS Can set 'scroll-behavior' to the 'smooth' keyword: smooth
-PASS Setting 'scroll-behavior' to a length throws TypeError
-PASS Setting 'scroll-behavior' to a percent throws TypeError
-PASS Setting 'scroll-behavior' to a time throws TypeError
-PASS Setting 'scroll-behavior' to an angle throws TypeError
-PASS Setting 'scroll-behavior' to a flexible length throws TypeError
-PASS Setting 'scroll-behavior' to a number throws TypeError
-PASS Setting 'scroll-behavior' to a URL throws TypeError
-PASS Setting 'scroll-behavior' to a transform throws TypeError
+PASS Setting 'scroll-behavior' to a length: 0px throws TypeError
+PASS Setting 'scroll-behavior' to a length: -3.14em throws TypeError
+PASS Setting 'scroll-behavior' to a length: 3.14cm throws TypeError
+PASS Setting 'scroll-behavior' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'scroll-behavior' to a percent: 0% throws TypeError
+PASS Setting 'scroll-behavior' to a percent: -3.14% throws TypeError
+PASS Setting 'scroll-behavior' to a percent: 3.14% throws TypeError
+PASS Setting 'scroll-behavior' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scroll-behavior' to a time: 0s throws TypeError
+PASS Setting 'scroll-behavior' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-behavior' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-behavior' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-behavior' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-behavior' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-behavior' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-behavior' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-behavior' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-behavior' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-behavior' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'scroll-behavior' to a number: 0 throws TypeError
+PASS Setting 'scroll-behavior' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-behavior' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-behavior' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-behavior' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-behavior' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-behavior' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-margin-expected.txt
@@ -8,13 +8,28 @@ PASS Can set 'scroll-margin-top' to a length: 0px
 PASS Can set 'scroll-margin-top' to a length: -3.14em
 PASS Can set 'scroll-margin-top' to a length: 3.14cm
 PASS Can set 'scroll-margin-top' to a length: calc(0px + 0em)
-PASS Setting 'scroll-margin-top' to a percent throws TypeError
-PASS Setting 'scroll-margin-top' to a time throws TypeError
-PASS Setting 'scroll-margin-top' to an angle throws TypeError
-PASS Setting 'scroll-margin-top' to a flexible length throws TypeError
-FAIL Setting 'scroll-margin-top' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-margin-top' to a URL throws TypeError
-PASS Setting 'scroll-margin-top' to a transform throws TypeError
+PASS Setting 'scroll-margin-top' to a percent: 0% throws TypeError
+PASS Setting 'scroll-margin-top' to a percent: -3.14% throws TypeError
+PASS Setting 'scroll-margin-top' to a percent: 3.14% throws TypeError
+PASS Setting 'scroll-margin-top' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scroll-margin-top' to a time: 0s throws TypeError
+PASS Setting 'scroll-margin-top' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-margin-top' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-margin-top' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-margin-top' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-margin-top' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-margin-top' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-margin-top' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-margin-top' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-margin-top' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-margin-top' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-margin-top' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-top' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-margin-top' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-margin-top' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-margin-top' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-margin-top' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-margin-top' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'scroll-margin-left' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-left' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-left' to CSS-wide keywords: unset
@@ -24,13 +39,28 @@ PASS Can set 'scroll-margin-left' to a length: 0px
 PASS Can set 'scroll-margin-left' to a length: -3.14em
 PASS Can set 'scroll-margin-left' to a length: 3.14cm
 PASS Can set 'scroll-margin-left' to a length: calc(0px + 0em)
-PASS Setting 'scroll-margin-left' to a percent throws TypeError
-PASS Setting 'scroll-margin-left' to a time throws TypeError
-PASS Setting 'scroll-margin-left' to an angle throws TypeError
-PASS Setting 'scroll-margin-left' to a flexible length throws TypeError
-FAIL Setting 'scroll-margin-left' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-margin-left' to a URL throws TypeError
-PASS Setting 'scroll-margin-left' to a transform throws TypeError
+PASS Setting 'scroll-margin-left' to a percent: 0% throws TypeError
+PASS Setting 'scroll-margin-left' to a percent: -3.14% throws TypeError
+PASS Setting 'scroll-margin-left' to a percent: 3.14% throws TypeError
+PASS Setting 'scroll-margin-left' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scroll-margin-left' to a time: 0s throws TypeError
+PASS Setting 'scroll-margin-left' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-margin-left' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-margin-left' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-margin-left' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-margin-left' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-margin-left' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-margin-left' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-margin-left' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-margin-left' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-margin-left' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-margin-left' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-left' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-margin-left' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-margin-left' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-margin-left' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-margin-left' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-margin-left' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'scroll-margin-right' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-right' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-right' to CSS-wide keywords: unset
@@ -40,13 +70,28 @@ PASS Can set 'scroll-margin-right' to a length: 0px
 PASS Can set 'scroll-margin-right' to a length: -3.14em
 PASS Can set 'scroll-margin-right' to a length: 3.14cm
 PASS Can set 'scroll-margin-right' to a length: calc(0px + 0em)
-PASS Setting 'scroll-margin-right' to a percent throws TypeError
-PASS Setting 'scroll-margin-right' to a time throws TypeError
-PASS Setting 'scroll-margin-right' to an angle throws TypeError
-PASS Setting 'scroll-margin-right' to a flexible length throws TypeError
-FAIL Setting 'scroll-margin-right' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-margin-right' to a URL throws TypeError
-PASS Setting 'scroll-margin-right' to a transform throws TypeError
+PASS Setting 'scroll-margin-right' to a percent: 0% throws TypeError
+PASS Setting 'scroll-margin-right' to a percent: -3.14% throws TypeError
+PASS Setting 'scroll-margin-right' to a percent: 3.14% throws TypeError
+PASS Setting 'scroll-margin-right' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scroll-margin-right' to a time: 0s throws TypeError
+PASS Setting 'scroll-margin-right' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-margin-right' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-margin-right' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-margin-right' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-margin-right' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-margin-right' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-margin-right' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-margin-right' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-margin-right' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-margin-right' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-margin-right' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-right' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-margin-right' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-margin-right' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-margin-right' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-margin-right' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-margin-right' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'scroll-margin-bottom' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-bottom' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-bottom' to CSS-wide keywords: unset
@@ -56,13 +101,28 @@ PASS Can set 'scroll-margin-bottom' to a length: 0px
 PASS Can set 'scroll-margin-bottom' to a length: -3.14em
 PASS Can set 'scroll-margin-bottom' to a length: 3.14cm
 PASS Can set 'scroll-margin-bottom' to a length: calc(0px + 0em)
-PASS Setting 'scroll-margin-bottom' to a percent throws TypeError
-PASS Setting 'scroll-margin-bottom' to a time throws TypeError
-PASS Setting 'scroll-margin-bottom' to an angle throws TypeError
-PASS Setting 'scroll-margin-bottom' to a flexible length throws TypeError
-FAIL Setting 'scroll-margin-bottom' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-margin-bottom' to a URL throws TypeError
-PASS Setting 'scroll-margin-bottom' to a transform throws TypeError
+PASS Setting 'scroll-margin-bottom' to a percent: 0% throws TypeError
+PASS Setting 'scroll-margin-bottom' to a percent: -3.14% throws TypeError
+PASS Setting 'scroll-margin-bottom' to a percent: 3.14% throws TypeError
+PASS Setting 'scroll-margin-bottom' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scroll-margin-bottom' to a time: 0s throws TypeError
+PASS Setting 'scroll-margin-bottom' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-margin-bottom' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-margin-bottom' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-margin-bottom' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-margin-bottom' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-margin-bottom' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-margin-bottom' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-margin-bottom' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-margin-bottom' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-margin-bottom' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-margin-bottom' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-bottom' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-margin-bottom' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-margin-bottom' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-margin-bottom' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-margin-bottom' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-margin-bottom' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'scroll-margin-inline-start' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-inline-start' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-inline-start' to CSS-wide keywords: unset
@@ -72,13 +132,28 @@ PASS Can set 'scroll-margin-inline-start' to a length: 0px
 PASS Can set 'scroll-margin-inline-start' to a length: -3.14em
 PASS Can set 'scroll-margin-inline-start' to a length: 3.14cm
 PASS Can set 'scroll-margin-inline-start' to a length: calc(0px + 0em)
-PASS Setting 'scroll-margin-inline-start' to a percent throws TypeError
-PASS Setting 'scroll-margin-inline-start' to a time throws TypeError
-PASS Setting 'scroll-margin-inline-start' to an angle throws TypeError
-PASS Setting 'scroll-margin-inline-start' to a flexible length throws TypeError
-FAIL Setting 'scroll-margin-inline-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-margin-inline-start' to a URL throws TypeError
-PASS Setting 'scroll-margin-inline-start' to a transform throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a percent: 0% throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a percent: -3.14% throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a percent: 3.14% throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a time: 0s throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-margin-inline-start' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-margin-inline-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-margin-inline-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-margin-inline-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-margin-inline-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-inline-start' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-margin-inline-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'scroll-margin-block-start' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-block-start' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-block-start' to CSS-wide keywords: unset
@@ -88,13 +163,28 @@ PASS Can set 'scroll-margin-block-start' to a length: 0px
 PASS Can set 'scroll-margin-block-start' to a length: -3.14em
 PASS Can set 'scroll-margin-block-start' to a length: 3.14cm
 PASS Can set 'scroll-margin-block-start' to a length: calc(0px + 0em)
-PASS Setting 'scroll-margin-block-start' to a percent throws TypeError
-PASS Setting 'scroll-margin-block-start' to a time throws TypeError
-PASS Setting 'scroll-margin-block-start' to an angle throws TypeError
-PASS Setting 'scroll-margin-block-start' to a flexible length throws TypeError
-FAIL Setting 'scroll-margin-block-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-margin-block-start' to a URL throws TypeError
-PASS Setting 'scroll-margin-block-start' to a transform throws TypeError
+PASS Setting 'scroll-margin-block-start' to a percent: 0% throws TypeError
+PASS Setting 'scroll-margin-block-start' to a percent: -3.14% throws TypeError
+PASS Setting 'scroll-margin-block-start' to a percent: 3.14% throws TypeError
+PASS Setting 'scroll-margin-block-start' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scroll-margin-block-start' to a time: 0s throws TypeError
+PASS Setting 'scroll-margin-block-start' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-margin-block-start' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-margin-block-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-margin-block-start' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-margin-block-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-margin-block-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-margin-block-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-margin-block-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-margin-block-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-margin-block-start' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-margin-block-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-block-start' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-margin-block-start' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-margin-block-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-margin-block-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-margin-block-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-margin-block-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'scroll-margin-inline-end' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-inline-end' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-inline-end' to CSS-wide keywords: unset
@@ -104,13 +194,28 @@ PASS Can set 'scroll-margin-inline-end' to a length: 0px
 PASS Can set 'scroll-margin-inline-end' to a length: -3.14em
 PASS Can set 'scroll-margin-inline-end' to a length: 3.14cm
 PASS Can set 'scroll-margin-inline-end' to a length: calc(0px + 0em)
-PASS Setting 'scroll-margin-inline-end' to a percent throws TypeError
-PASS Setting 'scroll-margin-inline-end' to a time throws TypeError
-PASS Setting 'scroll-margin-inline-end' to an angle throws TypeError
-PASS Setting 'scroll-margin-inline-end' to a flexible length throws TypeError
-FAIL Setting 'scroll-margin-inline-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-margin-inline-end' to a URL throws TypeError
-PASS Setting 'scroll-margin-inline-end' to a transform throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a percent: 0% throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a percent: -3.14% throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a percent: 3.14% throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a time: 0s throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-margin-inline-end' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-margin-inline-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-margin-inline-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-margin-inline-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-margin-inline-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-inline-end' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-margin-inline-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'scroll-margin-block-end' to CSS-wide keywords: initial
 PASS Can set 'scroll-margin-block-end' to CSS-wide keywords: inherit
 PASS Can set 'scroll-margin-block-end' to CSS-wide keywords: unset
@@ -120,15 +225,30 @@ PASS Can set 'scroll-margin-block-end' to a length: 0px
 PASS Can set 'scroll-margin-block-end' to a length: -3.14em
 PASS Can set 'scroll-margin-block-end' to a length: 3.14cm
 PASS Can set 'scroll-margin-block-end' to a length: calc(0px + 0em)
-PASS Setting 'scroll-margin-block-end' to a percent throws TypeError
-PASS Setting 'scroll-margin-block-end' to a time throws TypeError
-PASS Setting 'scroll-margin-block-end' to an angle throws TypeError
-PASS Setting 'scroll-margin-block-end' to a flexible length throws TypeError
-FAIL Setting 'scroll-margin-block-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-margin-block-end' to a URL throws TypeError
-PASS Setting 'scroll-margin-block-end' to a transform throws TypeError
-PASS 'scroll-margin' does not supported '0px'
-PASS 'scroll-margin' does not supported '1px 2px'
-PASS 'scroll-margin' does not supported '3px 4px 5px'
-PASS 'scroll-margin' does not supported '6px 7px 8px 9px'
+PASS Setting 'scroll-margin-block-end' to a percent: 0% throws TypeError
+PASS Setting 'scroll-margin-block-end' to a percent: -3.14% throws TypeError
+PASS Setting 'scroll-margin-block-end' to a percent: 3.14% throws TypeError
+PASS Setting 'scroll-margin-block-end' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scroll-margin-block-end' to a time: 0s throws TypeError
+PASS Setting 'scroll-margin-block-end' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-margin-block-end' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-margin-block-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-margin-block-end' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-margin-block-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-margin-block-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-margin-block-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-margin-block-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-margin-block-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-margin-block-end' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-margin-block-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-block-end' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-margin-block-end' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-margin-block-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-margin-block-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-margin-block-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-margin-block-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'scroll-margin' does not support '0px'
+PASS 'scroll-margin' does not support '1px 2px'
+PASS 'scroll-margin' does not support '3px 4px 5px'
+PASS 'scroll-margin' does not support '6px 7px 8px 9px'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt
@@ -12,12 +12,24 @@ PASS Can set 'scroll-padding-top' to a length: 0px
 FAIL Can set 'scroll-padding-top' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-top' to a length: 3.14cm
 PASS Can set 'scroll-padding-top' to a length: calc(0px + 0em)
-PASS Setting 'scroll-padding-top' to a time throws TypeError
-PASS Setting 'scroll-padding-top' to an angle throws TypeError
-PASS Setting 'scroll-padding-top' to a flexible length throws TypeError
-FAIL Setting 'scroll-padding-top' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-padding-top' to a URL throws TypeError
-PASS Setting 'scroll-padding-top' to a transform throws TypeError
+PASS Setting 'scroll-padding-top' to a time: 0s throws TypeError
+PASS Setting 'scroll-padding-top' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-padding-top' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-padding-top' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-padding-top' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-padding-top' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-padding-top' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-padding-top' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-padding-top' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-padding-top' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-padding-top' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-padding-top' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-top' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-padding-top' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-padding-top' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-padding-top' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-padding-top' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-padding-top' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'scroll-padding-left' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-left' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-left' to CSS-wide keywords: unset
@@ -31,12 +43,24 @@ PASS Can set 'scroll-padding-left' to a length: 0px
 FAIL Can set 'scroll-padding-left' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-left' to a length: 3.14cm
 PASS Can set 'scroll-padding-left' to a length: calc(0px + 0em)
-PASS Setting 'scroll-padding-left' to a time throws TypeError
-PASS Setting 'scroll-padding-left' to an angle throws TypeError
-PASS Setting 'scroll-padding-left' to a flexible length throws TypeError
-FAIL Setting 'scroll-padding-left' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-padding-left' to a URL throws TypeError
-PASS Setting 'scroll-padding-left' to a transform throws TypeError
+PASS Setting 'scroll-padding-left' to a time: 0s throws TypeError
+PASS Setting 'scroll-padding-left' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-padding-left' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-padding-left' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-padding-left' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-padding-left' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-padding-left' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-padding-left' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-padding-left' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-padding-left' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-padding-left' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-padding-left' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-left' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-padding-left' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-padding-left' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-padding-left' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-padding-left' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-padding-left' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'scroll-padding-right' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-right' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-right' to CSS-wide keywords: unset
@@ -50,12 +74,24 @@ PASS Can set 'scroll-padding-right' to a length: 0px
 FAIL Can set 'scroll-padding-right' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-right' to a length: 3.14cm
 PASS Can set 'scroll-padding-right' to a length: calc(0px + 0em)
-PASS Setting 'scroll-padding-right' to a time throws TypeError
-PASS Setting 'scroll-padding-right' to an angle throws TypeError
-PASS Setting 'scroll-padding-right' to a flexible length throws TypeError
-FAIL Setting 'scroll-padding-right' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-padding-right' to a URL throws TypeError
-PASS Setting 'scroll-padding-right' to a transform throws TypeError
+PASS Setting 'scroll-padding-right' to a time: 0s throws TypeError
+PASS Setting 'scroll-padding-right' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-padding-right' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-padding-right' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-padding-right' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-padding-right' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-padding-right' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-padding-right' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-padding-right' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-padding-right' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-padding-right' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-padding-right' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-right' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-padding-right' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-padding-right' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-padding-right' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-padding-right' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-padding-right' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: unset
@@ -69,12 +105,24 @@ PASS Can set 'scroll-padding-bottom' to a length: 0px
 FAIL Can set 'scroll-padding-bottom' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-bottom' to a length: 3.14cm
 PASS Can set 'scroll-padding-bottom' to a length: calc(0px + 0em)
-PASS Setting 'scroll-padding-bottom' to a time throws TypeError
-PASS Setting 'scroll-padding-bottom' to an angle throws TypeError
-PASS Setting 'scroll-padding-bottom' to a flexible length throws TypeError
-FAIL Setting 'scroll-padding-bottom' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-padding-bottom' to a URL throws TypeError
-PASS Setting 'scroll-padding-bottom' to a transform throws TypeError
+PASS Setting 'scroll-padding-bottom' to a time: 0s throws TypeError
+PASS Setting 'scroll-padding-bottom' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-padding-bottom' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-padding-bottom' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-padding-bottom' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-padding-bottom' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-padding-bottom' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-padding-bottom' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-padding-bottom' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-padding-bottom' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-padding-bottom' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-padding-bottom' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-bottom' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-padding-bottom' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-padding-bottom' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-padding-bottom' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-padding-bottom' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-padding-bottom' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: unset
@@ -88,12 +136,24 @@ PASS Can set 'scroll-padding-inline-start' to a length: 0px
 FAIL Can set 'scroll-padding-inline-start' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-inline-start' to a length: 3.14cm
 PASS Can set 'scroll-padding-inline-start' to a length: calc(0px + 0em)
-PASS Setting 'scroll-padding-inline-start' to a time throws TypeError
-PASS Setting 'scroll-padding-inline-start' to an angle throws TypeError
-PASS Setting 'scroll-padding-inline-start' to a flexible length throws TypeError
-FAIL Setting 'scroll-padding-inline-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-padding-inline-start' to a URL throws TypeError
-PASS Setting 'scroll-padding-inline-start' to a transform throws TypeError
+PASS Setting 'scroll-padding-inline-start' to a time: 0s throws TypeError
+PASS Setting 'scroll-padding-inline-start' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-padding-inline-start' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-padding-inline-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-padding-inline-start' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-padding-inline-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-padding-inline-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-padding-inline-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-padding-inline-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-padding-inline-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-padding-inline-start' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-padding-inline-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-inline-start' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-padding-inline-start' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-padding-inline-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-padding-inline-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-padding-inline-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-padding-inline-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: unset
@@ -107,12 +167,24 @@ PASS Can set 'scroll-padding-block-start' to a length: 0px
 FAIL Can set 'scroll-padding-block-start' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-block-start' to a length: 3.14cm
 PASS Can set 'scroll-padding-block-start' to a length: calc(0px + 0em)
-PASS Setting 'scroll-padding-block-start' to a time throws TypeError
-PASS Setting 'scroll-padding-block-start' to an angle throws TypeError
-PASS Setting 'scroll-padding-block-start' to a flexible length throws TypeError
-FAIL Setting 'scroll-padding-block-start' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-padding-block-start' to a URL throws TypeError
-PASS Setting 'scroll-padding-block-start' to a transform throws TypeError
+PASS Setting 'scroll-padding-block-start' to a time: 0s throws TypeError
+PASS Setting 'scroll-padding-block-start' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-padding-block-start' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-padding-block-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-padding-block-start' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-padding-block-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-padding-block-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-padding-block-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-padding-block-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-padding-block-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-padding-block-start' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-padding-block-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-block-start' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-padding-block-start' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-padding-block-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-padding-block-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-padding-block-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-padding-block-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: unset
@@ -126,12 +198,24 @@ PASS Can set 'scroll-padding-inline-end' to a length: 0px
 FAIL Can set 'scroll-padding-inline-end' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-inline-end' to a length: 3.14cm
 PASS Can set 'scroll-padding-inline-end' to a length: calc(0px + 0em)
-PASS Setting 'scroll-padding-inline-end' to a time throws TypeError
-PASS Setting 'scroll-padding-inline-end' to an angle throws TypeError
-PASS Setting 'scroll-padding-inline-end' to a flexible length throws TypeError
-FAIL Setting 'scroll-padding-inline-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-padding-inline-end' to a URL throws TypeError
-PASS Setting 'scroll-padding-inline-end' to a transform throws TypeError
+PASS Setting 'scroll-padding-inline-end' to a time: 0s throws TypeError
+PASS Setting 'scroll-padding-inline-end' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-padding-inline-end' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-padding-inline-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-padding-inline-end' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-padding-inline-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-padding-inline-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-padding-inline-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-padding-inline-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-padding-inline-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-padding-inline-end' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-padding-inline-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-inline-end' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-padding-inline-end' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-padding-inline-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-padding-inline-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-padding-inline-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-padding-inline-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: initial
 PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: inherit
 PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: unset
@@ -145,14 +229,26 @@ PASS Can set 'scroll-padding-block-end' to a length: 0px
 FAIL Can set 'scroll-padding-block-end' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'scroll-padding-block-end' to a length: 3.14cm
 PASS Can set 'scroll-padding-block-end' to a length: calc(0px + 0em)
-PASS Setting 'scroll-padding-block-end' to a time throws TypeError
-PASS Setting 'scroll-padding-block-end' to an angle throws TypeError
-PASS Setting 'scroll-padding-block-end' to a flexible length throws TypeError
-FAIL Setting 'scroll-padding-block-end' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'scroll-padding-block-end' to a URL throws TypeError
-PASS Setting 'scroll-padding-block-end' to a transform throws TypeError
-PASS 'scroll-padding' does not supported '0%'
-PASS 'scroll-padding' does not supported '1px 2px'
-PASS 'scroll-padding' does not supported '3% 4px 5%'
-PASS 'scroll-padding' does not supported '6px 7% 8% 9px'
+PASS Setting 'scroll-padding-block-end' to a time: 0s throws TypeError
+PASS Setting 'scroll-padding-block-end' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-padding-block-end' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-padding-block-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-padding-block-end' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-padding-block-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-padding-block-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-padding-block-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-padding-block-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-padding-block-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-padding-block-end' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'scroll-padding-block-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-block-end' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-padding-block-end' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-padding-block-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-padding-block-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-padding-block-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-padding-block-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'scroll-padding' does not support '0%'
+PASS 'scroll-padding' does not support '1px 2px'
+PASS 'scroll-padding' does not support '3% 4px 5%'
+PASS 'scroll-padding' does not support '6px 7% 8% 9px'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-align-expected.txt
@@ -8,14 +8,32 @@ FAIL Can set 'scroll-snap-align' to the 'none' keyword: none assert_class_string
 FAIL Can set 'scroll-snap-align' to the 'start' keyword: start assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 FAIL Can set 'scroll-snap-align' to the 'end' keyword: end assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 FAIL Can set 'scroll-snap-align' to the 'center' keyword: center assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS Setting 'scroll-snap-align' to a length throws TypeError
-PASS Setting 'scroll-snap-align' to a percent throws TypeError
-PASS Setting 'scroll-snap-align' to a time throws TypeError
-PASS Setting 'scroll-snap-align' to an angle throws TypeError
-PASS Setting 'scroll-snap-align' to a flexible length throws TypeError
-PASS Setting 'scroll-snap-align' to a number throws TypeError
-PASS Setting 'scroll-snap-align' to a URL throws TypeError
-PASS Setting 'scroll-snap-align' to a transform throws TypeError
-FAIL 'scroll-snap-align' does not supported 'none center' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'scroll-snap-align' does not supported 'end start' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'scroll-snap-align' to a length: 0px throws TypeError
+PASS Setting 'scroll-snap-align' to a length: -3.14em throws TypeError
+PASS Setting 'scroll-snap-align' to a length: 3.14cm throws TypeError
+PASS Setting 'scroll-snap-align' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'scroll-snap-align' to a percent: 0% throws TypeError
+PASS Setting 'scroll-snap-align' to a percent: -3.14% throws TypeError
+PASS Setting 'scroll-snap-align' to a percent: 3.14% throws TypeError
+PASS Setting 'scroll-snap-align' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scroll-snap-align' to a time: 0s throws TypeError
+PASS Setting 'scroll-snap-align' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-snap-align' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-snap-align' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-snap-align' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-snap-align' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-snap-align' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-snap-align' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-snap-align' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-snap-align' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-snap-align' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'scroll-snap-align' to a number: 0 throws TypeError
+PASS Setting 'scroll-snap-align' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-snap-align' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-snap-align' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-snap-align' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-snap-align' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-snap-align' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'scroll-snap-align' does not support 'none center' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'scroll-snap-align' does not support 'end start' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-stop-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-stop-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'scroll-snap-stop' to CSS-wide keywords: revert
 PASS Can set 'scroll-snap-stop' to var() references:  var(--A)
 PASS Can set 'scroll-snap-stop' to the 'normal' keyword: normal
 PASS Can set 'scroll-snap-stop' to the 'always' keyword: always
-PASS Setting 'scroll-snap-stop' to a length throws TypeError
-PASS Setting 'scroll-snap-stop' to a percent throws TypeError
-PASS Setting 'scroll-snap-stop' to a time throws TypeError
-PASS Setting 'scroll-snap-stop' to an angle throws TypeError
-PASS Setting 'scroll-snap-stop' to a flexible length throws TypeError
-PASS Setting 'scroll-snap-stop' to a number throws TypeError
-PASS Setting 'scroll-snap-stop' to a URL throws TypeError
-PASS Setting 'scroll-snap-stop' to a transform throws TypeError
+PASS Setting 'scroll-snap-stop' to a length: 0px throws TypeError
+PASS Setting 'scroll-snap-stop' to a length: -3.14em throws TypeError
+PASS Setting 'scroll-snap-stop' to a length: 3.14cm throws TypeError
+PASS Setting 'scroll-snap-stop' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'scroll-snap-stop' to a percent: 0% throws TypeError
+PASS Setting 'scroll-snap-stop' to a percent: -3.14% throws TypeError
+PASS Setting 'scroll-snap-stop' to a percent: 3.14% throws TypeError
+PASS Setting 'scroll-snap-stop' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scroll-snap-stop' to a time: 0s throws TypeError
+PASS Setting 'scroll-snap-stop' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-snap-stop' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-snap-stop' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-snap-stop' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-snap-stop' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-snap-stop' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-snap-stop' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-snap-stop' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-snap-stop' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-snap-stop' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'scroll-snap-stop' to a number: 0 throws TypeError
+PASS Setting 'scroll-snap-stop' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-snap-stop' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-snap-stop' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-snap-stop' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-snap-stop' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-snap-stop' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-type-expected.txt
@@ -10,14 +10,32 @@ PASS Can set 'scroll-snap-type' to the 'y' keyword: y
 PASS Can set 'scroll-snap-type' to the 'block' keyword: block
 PASS Can set 'scroll-snap-type' to the 'inline' keyword: inline
 PASS Can set 'scroll-snap-type' to the 'both' keyword: both
-PASS Setting 'scroll-snap-type' to a length throws TypeError
-PASS Setting 'scroll-snap-type' to a percent throws TypeError
-PASS Setting 'scroll-snap-type' to a time throws TypeError
-PASS Setting 'scroll-snap-type' to an angle throws TypeError
-PASS Setting 'scroll-snap-type' to a flexible length throws TypeError
-PASS Setting 'scroll-snap-type' to a number throws TypeError
-PASS Setting 'scroll-snap-type' to a URL throws TypeError
-PASS Setting 'scroll-snap-type' to a transform throws TypeError
-FAIL 'scroll-snap-type' does not supported 'x mandatory' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'scroll-snap-type' does not supported 'inline proximity' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'scroll-snap-type' to a length: 0px throws TypeError
+PASS Setting 'scroll-snap-type' to a length: -3.14em throws TypeError
+PASS Setting 'scroll-snap-type' to a length: 3.14cm throws TypeError
+PASS Setting 'scroll-snap-type' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'scroll-snap-type' to a percent: 0% throws TypeError
+PASS Setting 'scroll-snap-type' to a percent: -3.14% throws TypeError
+PASS Setting 'scroll-snap-type' to a percent: 3.14% throws TypeError
+PASS Setting 'scroll-snap-type' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scroll-snap-type' to a time: 0s throws TypeError
+PASS Setting 'scroll-snap-type' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-snap-type' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-snap-type' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-snap-type' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-snap-type' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-snap-type' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-snap-type' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-snap-type' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-snap-type' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-snap-type' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'scroll-snap-type' to a number: 0 throws TypeError
+PASS Setting 'scroll-snap-type' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-snap-type' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-snap-type' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-snap-type' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-snap-type' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-snap-type' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'scroll-snap-type' does not support 'x mandatory' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'scroll-snap-type' does not support 'inline proximity' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-gutter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-gutter-expected.txt
@@ -6,13 +6,31 @@ FAIL Can set 'scrollbar-gutter' to CSS-wide keywords: revert Invalid property sc
 FAIL Can set 'scrollbar-gutter' to var() references:  var(--A) Invalid property scrollbar-gutter
 FAIL Can set 'scrollbar-gutter' to the 'auto' keyword: auto Invalid property scrollbar-gutter
 FAIL Can set 'scrollbar-gutter' to the 'stable' keyword: stable Invalid property scrollbar-gutter
-PASS Setting 'scrollbar-gutter' to a length throws TypeError
-PASS Setting 'scrollbar-gutter' to a percent throws TypeError
-PASS Setting 'scrollbar-gutter' to a time throws TypeError
-PASS Setting 'scrollbar-gutter' to an angle throws TypeError
-PASS Setting 'scrollbar-gutter' to a flexible length throws TypeError
-PASS Setting 'scrollbar-gutter' to a number throws TypeError
-PASS Setting 'scrollbar-gutter' to a URL throws TypeError
-PASS Setting 'scrollbar-gutter' to a transform throws TypeError
-FAIL 'scrollbar-gutter' does not supported 'stable both-edges' Invalid property scrollbar-gutter
+PASS Setting 'scrollbar-gutter' to a length: 0px throws TypeError
+PASS Setting 'scrollbar-gutter' to a length: -3.14em throws TypeError
+PASS Setting 'scrollbar-gutter' to a length: 3.14cm throws TypeError
+PASS Setting 'scrollbar-gutter' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'scrollbar-gutter' to a percent: 0% throws TypeError
+PASS Setting 'scrollbar-gutter' to a percent: -3.14% throws TypeError
+PASS Setting 'scrollbar-gutter' to a percent: 3.14% throws TypeError
+PASS Setting 'scrollbar-gutter' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scrollbar-gutter' to a time: 0s throws TypeError
+PASS Setting 'scrollbar-gutter' to a time: -3.14ms throws TypeError
+PASS Setting 'scrollbar-gutter' to a time: 3.14s throws TypeError
+PASS Setting 'scrollbar-gutter' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scrollbar-gutter' to an angle: 0deg throws TypeError
+PASS Setting 'scrollbar-gutter' to an angle: 3.14rad throws TypeError
+PASS Setting 'scrollbar-gutter' to an angle: -3.14deg throws TypeError
+PASS Setting 'scrollbar-gutter' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scrollbar-gutter' to a flexible length: 0fr throws TypeError
+PASS Setting 'scrollbar-gutter' to a flexible length: 1fr throws TypeError
+PASS Setting 'scrollbar-gutter' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'scrollbar-gutter' to a number: 0 throws TypeError
+PASS Setting 'scrollbar-gutter' to a number: -3.14 throws TypeError
+PASS Setting 'scrollbar-gutter' to a number: 3.14 throws TypeError
+PASS Setting 'scrollbar-gutter' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scrollbar-gutter' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scrollbar-gutter' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scrollbar-gutter' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'scrollbar-gutter' does not support 'stable both-edges' Invalid property scrollbar-gutter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-width-expected.txt
@@ -7,12 +7,30 @@ FAIL Can set 'scrollbar-width' to var() references:  var(--A) Invalid property s
 FAIL Can set 'scrollbar-width' to the 'auto' keyword: auto Invalid property scrollbar-width
 FAIL Can set 'scrollbar-width' to the 'thin' keyword: thin Invalid property scrollbar-width
 FAIL Can set 'scrollbar-width' to the 'none' keyword: none Invalid property scrollbar-width
-PASS Setting 'scrollbar-width' to a length throws TypeError
-PASS Setting 'scrollbar-width' to a percent throws TypeError
-PASS Setting 'scrollbar-width' to a time throws TypeError
-PASS Setting 'scrollbar-width' to an angle throws TypeError
-PASS Setting 'scrollbar-width' to a flexible length throws TypeError
-PASS Setting 'scrollbar-width' to a number throws TypeError
-PASS Setting 'scrollbar-width' to a URL throws TypeError
-PASS Setting 'scrollbar-width' to a transform throws TypeError
+PASS Setting 'scrollbar-width' to a length: 0px throws TypeError
+PASS Setting 'scrollbar-width' to a length: -3.14em throws TypeError
+PASS Setting 'scrollbar-width' to a length: 3.14cm throws TypeError
+PASS Setting 'scrollbar-width' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'scrollbar-width' to a percent: 0% throws TypeError
+PASS Setting 'scrollbar-width' to a percent: -3.14% throws TypeError
+PASS Setting 'scrollbar-width' to a percent: 3.14% throws TypeError
+PASS Setting 'scrollbar-width' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scrollbar-width' to a time: 0s throws TypeError
+PASS Setting 'scrollbar-width' to a time: -3.14ms throws TypeError
+PASS Setting 'scrollbar-width' to a time: 3.14s throws TypeError
+PASS Setting 'scrollbar-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scrollbar-width' to an angle: 0deg throws TypeError
+PASS Setting 'scrollbar-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'scrollbar-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'scrollbar-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scrollbar-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'scrollbar-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'scrollbar-width' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'scrollbar-width' to a number: 0 throws TypeError
+PASS Setting 'scrollbar-width' to a number: -3.14 throws TypeError
+PASS Setting 'scrollbar-width' to a number: 3.14 throws TypeError
+PASS Setting 'scrollbar-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scrollbar-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scrollbar-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scrollbar-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-image-threshold-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-image-threshold-expected.txt
@@ -8,11 +8,26 @@ PASS Can set 'shape-image-threshold' to a number: 0
 PASS Can set 'shape-image-threshold' to a number: -3.14
 PASS Can set 'shape-image-threshold' to a number: 3.14
 PASS Can set 'shape-image-threshold' to a number: calc(2 + 3)
-PASS Setting 'shape-image-threshold' to a length throws TypeError
-PASS Setting 'shape-image-threshold' to a percent throws TypeError
-PASS Setting 'shape-image-threshold' to a time throws TypeError
-PASS Setting 'shape-image-threshold' to an angle throws TypeError
-PASS Setting 'shape-image-threshold' to a flexible length throws TypeError
-PASS Setting 'shape-image-threshold' to a URL throws TypeError
-PASS Setting 'shape-image-threshold' to a transform throws TypeError
+PASS Setting 'shape-image-threshold' to a length: 0px throws TypeError
+PASS Setting 'shape-image-threshold' to a length: -3.14em throws TypeError
+PASS Setting 'shape-image-threshold' to a length: 3.14cm throws TypeError
+PASS Setting 'shape-image-threshold' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'shape-image-threshold' to a percent: 0% throws TypeError
+PASS Setting 'shape-image-threshold' to a percent: -3.14% throws TypeError
+PASS Setting 'shape-image-threshold' to a percent: 3.14% throws TypeError
+PASS Setting 'shape-image-threshold' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'shape-image-threshold' to a time: 0s throws TypeError
+PASS Setting 'shape-image-threshold' to a time: -3.14ms throws TypeError
+PASS Setting 'shape-image-threshold' to a time: 3.14s throws TypeError
+PASS Setting 'shape-image-threshold' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'shape-image-threshold' to an angle: 0deg throws TypeError
+PASS Setting 'shape-image-threshold' to an angle: 3.14rad throws TypeError
+PASS Setting 'shape-image-threshold' to an angle: -3.14deg throws TypeError
+PASS Setting 'shape-image-threshold' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'shape-image-threshold' to a flexible length: 0fr throws TypeError
+PASS Setting 'shape-image-threshold' to a flexible length: 1fr throws TypeError
+PASS Setting 'shape-image-threshold' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'shape-image-threshold' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'shape-image-threshold' to a transform: perspective(10em) throws TypeError
+PASS Setting 'shape-image-threshold' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt
@@ -12,10 +12,22 @@ PASS Can set 'shape-margin' to a percent: 0%
 FAIL Can set 'shape-margin' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'shape-margin' to a percent: 3.14%
 PASS Can set 'shape-margin' to a percent: calc(0% + 0%)
-PASS Setting 'shape-margin' to a time throws TypeError
-PASS Setting 'shape-margin' to an angle throws TypeError
-PASS Setting 'shape-margin' to a flexible length throws TypeError
-FAIL Setting 'shape-margin' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'shape-margin' to a URL throws TypeError
-PASS Setting 'shape-margin' to a transform throws TypeError
+PASS Setting 'shape-margin' to a time: 0s throws TypeError
+PASS Setting 'shape-margin' to a time: -3.14ms throws TypeError
+PASS Setting 'shape-margin' to a time: 3.14s throws TypeError
+PASS Setting 'shape-margin' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'shape-margin' to an angle: 0deg throws TypeError
+PASS Setting 'shape-margin' to an angle: 3.14rad throws TypeError
+PASS Setting 'shape-margin' to an angle: -3.14deg throws TypeError
+PASS Setting 'shape-margin' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'shape-margin' to a flexible length: 0fr throws TypeError
+PASS Setting 'shape-margin' to a flexible length: 1fr throws TypeError
+PASS Setting 'shape-margin' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'shape-margin' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'shape-margin' to a number: -3.14 throws TypeError
+PASS Setting 'shape-margin' to a number: 3.14 throws TypeError
+PASS Setting 'shape-margin' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'shape-margin' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'shape-margin' to a transform: perspective(10em) throws TypeError
+PASS Setting 'shape-margin' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-outside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-outside-expected.txt
@@ -10,16 +10,34 @@ PASS Can set 'shape-outside' to the 'border-box' keyword: border-box
 PASS Can set 'shape-outside' to the 'padding-box' keyword: padding-box
 PASS Can set 'shape-outside' to the 'content-box' keyword: content-box
 PASS Can set 'shape-outside' to an image
-PASS Setting 'shape-outside' to a length throws TypeError
-PASS Setting 'shape-outside' to a percent throws TypeError
-PASS Setting 'shape-outside' to a time throws TypeError
-PASS Setting 'shape-outside' to an angle throws TypeError
-PASS Setting 'shape-outside' to a flexible length throws TypeError
-PASS Setting 'shape-outside' to a number throws TypeError
-PASS Setting 'shape-outside' to a URL throws TypeError
-PASS Setting 'shape-outside' to a transform throws TypeError
-PASS 'shape-outside' does not supported 'inset(22% 12% 15px 35px)'
-PASS 'shape-outside' does not supported 'circle(6rem at 12rem 6rem)'
-PASS 'shape-outside' does not supported 'ellipse(115px 55px at 50% 40%)'
-PASS 'shape-outside' does not supported 'polygon(50% 20%, 90% 80%, 10% 80%)'
+PASS Setting 'shape-outside' to a length: 0px throws TypeError
+PASS Setting 'shape-outside' to a length: -3.14em throws TypeError
+PASS Setting 'shape-outside' to a length: 3.14cm throws TypeError
+PASS Setting 'shape-outside' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'shape-outside' to a percent: 0% throws TypeError
+PASS Setting 'shape-outside' to a percent: -3.14% throws TypeError
+PASS Setting 'shape-outside' to a percent: 3.14% throws TypeError
+PASS Setting 'shape-outside' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'shape-outside' to a time: 0s throws TypeError
+PASS Setting 'shape-outside' to a time: -3.14ms throws TypeError
+PASS Setting 'shape-outside' to a time: 3.14s throws TypeError
+PASS Setting 'shape-outside' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'shape-outside' to an angle: 0deg throws TypeError
+PASS Setting 'shape-outside' to an angle: 3.14rad throws TypeError
+PASS Setting 'shape-outside' to an angle: -3.14deg throws TypeError
+PASS Setting 'shape-outside' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'shape-outside' to a flexible length: 0fr throws TypeError
+PASS Setting 'shape-outside' to a flexible length: 1fr throws TypeError
+PASS Setting 'shape-outside' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'shape-outside' to a number: 0 throws TypeError
+PASS Setting 'shape-outside' to a number: -3.14 throws TypeError
+PASS Setting 'shape-outside' to a number: 3.14 throws TypeError
+PASS Setting 'shape-outside' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'shape-outside' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'shape-outside' to a transform: perspective(10em) throws TypeError
+PASS Setting 'shape-outside' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'shape-outside' does not support 'inset(22% 12% 15px 35px)'
+PASS 'shape-outside' does not support 'circle(6rem at 12rem 6rem)'
+PASS 'shape-outside' does not support 'ellipse(115px 55px at 50% 40%)'
+PASS 'shape-outside' does not support 'polygon(50% 20%, 90% 80%, 10% 80%)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-rendering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-rendering-expected.txt
@@ -8,12 +8,30 @@ PASS Can set 'shape-rendering' to the 'auto' keyword: auto
 FAIL Can set 'shape-rendering' to the 'optimizespeed' keyword: optimizespeed assert_equals: expected "optimizespeed" but got "optimizeSpeed"
 PASS Can set 'shape-rendering' to the 'crispedges' keyword: crispedges
 FAIL Can set 'shape-rendering' to the 'geometricprecision' keyword: geometricprecision assert_equals: expected "geometricprecision" but got "geometricPrecision"
-PASS Setting 'shape-rendering' to a length throws TypeError
-PASS Setting 'shape-rendering' to a percent throws TypeError
-PASS Setting 'shape-rendering' to a time throws TypeError
-PASS Setting 'shape-rendering' to an angle throws TypeError
-PASS Setting 'shape-rendering' to a flexible length throws TypeError
-PASS Setting 'shape-rendering' to a number throws TypeError
-PASS Setting 'shape-rendering' to a URL throws TypeError
-PASS Setting 'shape-rendering' to a transform throws TypeError
+PASS Setting 'shape-rendering' to a length: 0px throws TypeError
+PASS Setting 'shape-rendering' to a length: -3.14em throws TypeError
+PASS Setting 'shape-rendering' to a length: 3.14cm throws TypeError
+PASS Setting 'shape-rendering' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'shape-rendering' to a percent: 0% throws TypeError
+PASS Setting 'shape-rendering' to a percent: -3.14% throws TypeError
+PASS Setting 'shape-rendering' to a percent: 3.14% throws TypeError
+PASS Setting 'shape-rendering' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'shape-rendering' to a time: 0s throws TypeError
+PASS Setting 'shape-rendering' to a time: -3.14ms throws TypeError
+PASS Setting 'shape-rendering' to a time: 3.14s throws TypeError
+PASS Setting 'shape-rendering' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'shape-rendering' to an angle: 0deg throws TypeError
+PASS Setting 'shape-rendering' to an angle: 3.14rad throws TypeError
+PASS Setting 'shape-rendering' to an angle: -3.14deg throws TypeError
+PASS Setting 'shape-rendering' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'shape-rendering' to a flexible length: 0fr throws TypeError
+PASS Setting 'shape-rendering' to a flexible length: 1fr throws TypeError
+PASS Setting 'shape-rendering' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'shape-rendering' to a number: 0 throws TypeError
+PASS Setting 'shape-rendering' to a number: -3.14 throws TypeError
+PASS Setting 'shape-rendering' to a number: 3.14 throws TypeError
+PASS Setting 'shape-rendering' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'shape-rendering' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'shape-rendering' to a transform: perspective(10em) throws TypeError
+PASS Setting 'shape-rendering' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/speak-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/speak-expected.txt
@@ -7,12 +7,30 @@ FAIL Can set 'speak' to var() references:  var(--A) Invalid property speak
 FAIL Can set 'speak' to the 'auto' keyword: auto Invalid property speak
 FAIL Can set 'speak' to the 'never' keyword: never Invalid property speak
 FAIL Can set 'speak' to the 'always' keyword: always Invalid property speak
-PASS Setting 'speak' to a length throws TypeError
-PASS Setting 'speak' to a percent throws TypeError
-PASS Setting 'speak' to a time throws TypeError
-PASS Setting 'speak' to an angle throws TypeError
-PASS Setting 'speak' to a flexible length throws TypeError
-PASS Setting 'speak' to a number throws TypeError
-PASS Setting 'speak' to a URL throws TypeError
-PASS Setting 'speak' to a transform throws TypeError
+PASS Setting 'speak' to a length: 0px throws TypeError
+PASS Setting 'speak' to a length: -3.14em throws TypeError
+PASS Setting 'speak' to a length: 3.14cm throws TypeError
+PASS Setting 'speak' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'speak' to a percent: 0% throws TypeError
+PASS Setting 'speak' to a percent: -3.14% throws TypeError
+PASS Setting 'speak' to a percent: 3.14% throws TypeError
+PASS Setting 'speak' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'speak' to a time: 0s throws TypeError
+PASS Setting 'speak' to a time: -3.14ms throws TypeError
+PASS Setting 'speak' to a time: 3.14s throws TypeError
+PASS Setting 'speak' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'speak' to an angle: 0deg throws TypeError
+PASS Setting 'speak' to an angle: 3.14rad throws TypeError
+PASS Setting 'speak' to an angle: -3.14deg throws TypeError
+PASS Setting 'speak' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'speak' to a flexible length: 0fr throws TypeError
+PASS Setting 'speak' to a flexible length: 1fr throws TypeError
+PASS Setting 'speak' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'speak' to a number: 0 throws TypeError
+PASS Setting 'speak' to a number: -3.14 throws TypeError
+PASS Setting 'speak' to a number: 3.14 throws TypeError
+PASS Setting 'speak' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'speak' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'speak' to a transform: perspective(10em) throws TypeError
+PASS Setting 'speak' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-color-expected.txt
@@ -5,17 +5,35 @@ PASS Can set 'stop-color' to CSS-wide keywords: unset
 PASS Can set 'stop-color' to CSS-wide keywords: revert
 PASS Can set 'stop-color' to var() references:  var(--A)
 PASS Can set 'stop-color' to the 'currentcolor' keyword: currentcolor
-PASS Setting 'stop-color' to a length throws TypeError
-PASS Setting 'stop-color' to a percent throws TypeError
-PASS Setting 'stop-color' to a time throws TypeError
-PASS Setting 'stop-color' to an angle throws TypeError
-PASS Setting 'stop-color' to a flexible length throws TypeError
-PASS Setting 'stop-color' to a number throws TypeError
-PASS Setting 'stop-color' to a URL throws TypeError
-PASS Setting 'stop-color' to a transform throws TypeError
-FAIL 'stop-color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'stop-color' does not supported '#bbff00'
-PASS 'stop-color' does not supported 'rgb(255, 255, 128)'
-PASS 'stop-color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'stop-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'stop-color' to a length: 0px throws TypeError
+PASS Setting 'stop-color' to a length: -3.14em throws TypeError
+PASS Setting 'stop-color' to a length: 3.14cm throws TypeError
+PASS Setting 'stop-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'stop-color' to a percent: 0% throws TypeError
+PASS Setting 'stop-color' to a percent: -3.14% throws TypeError
+PASS Setting 'stop-color' to a percent: 3.14% throws TypeError
+PASS Setting 'stop-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'stop-color' to a time: 0s throws TypeError
+PASS Setting 'stop-color' to a time: -3.14ms throws TypeError
+PASS Setting 'stop-color' to a time: 3.14s throws TypeError
+PASS Setting 'stop-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'stop-color' to an angle: 0deg throws TypeError
+PASS Setting 'stop-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'stop-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'stop-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'stop-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'stop-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'stop-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'stop-color' to a number: 0 throws TypeError
+PASS Setting 'stop-color' to a number: -3.14 throws TypeError
+PASS Setting 'stop-color' to a number: 3.14 throws TypeError
+PASS Setting 'stop-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'stop-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'stop-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'stop-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'stop-color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'stop-color' does not support '#bbff00'
+PASS 'stop-color' does not support 'rgb(255, 255, 128)'
+PASS 'stop-color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'stop-color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity-expected.txt
@@ -8,11 +8,26 @@ PASS Can set 'stop-opacity' to a number: 0
 PASS Can set 'stop-opacity' to a number: -3.14
 PASS Can set 'stop-opacity' to a number: 3.14
 PASS Can set 'stop-opacity' to a number: calc(2 + 3)
-PASS Setting 'stop-opacity' to a length throws TypeError
-FAIL Setting 'stop-opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'stop-opacity' to a time throws TypeError
-PASS Setting 'stop-opacity' to an angle throws TypeError
-PASS Setting 'stop-opacity' to a flexible length throws TypeError
-PASS Setting 'stop-opacity' to a URL throws TypeError
-PASS Setting 'stop-opacity' to a transform throws TypeError
+PASS Setting 'stop-opacity' to a length: 0px throws TypeError
+PASS Setting 'stop-opacity' to a length: -3.14em throws TypeError
+PASS Setting 'stop-opacity' to a length: 3.14cm throws TypeError
+PASS Setting 'stop-opacity' to a length: calc(0px + 0em) throws TypeError
+FAIL Setting 'stop-opacity' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stop-opacity' to a percent: -3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stop-opacity' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stop-opacity' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'stop-opacity' to a time: 0s throws TypeError
+PASS Setting 'stop-opacity' to a time: -3.14ms throws TypeError
+PASS Setting 'stop-opacity' to a time: 3.14s throws TypeError
+PASS Setting 'stop-opacity' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'stop-opacity' to an angle: 0deg throws TypeError
+PASS Setting 'stop-opacity' to an angle: 3.14rad throws TypeError
+PASS Setting 'stop-opacity' to an angle: -3.14deg throws TypeError
+PASS Setting 'stop-opacity' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'stop-opacity' to a flexible length: 0fr throws TypeError
+PASS Setting 'stop-opacity' to a flexible length: 1fr throws TypeError
+PASS Setting 'stop-opacity' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'stop-opacity' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'stop-opacity' to a transform: perspective(10em) throws TypeError
+PASS Setting 'stop-opacity' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt
@@ -5,13 +5,31 @@ PASS Can set 'stroke-dasharray' to CSS-wide keywords: unset
 PASS Can set 'stroke-dasharray' to CSS-wide keywords: revert
 PASS Can set 'stroke-dasharray' to var() references:  var(--A)
 PASS Can set 'stroke-dasharray' to the 'none' keyword: none
-FAIL Setting 'stroke-dasharray' to a length throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stroke-dasharray' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'stroke-dasharray' to a time throws TypeError
-PASS Setting 'stroke-dasharray' to an angle throws TypeError
-PASS Setting 'stroke-dasharray' to a flexible length throws TypeError
-FAIL Setting 'stroke-dasharray' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'stroke-dasharray' to a URL throws TypeError
-PASS Setting 'stroke-dasharray' to a transform throws TypeError
-FAIL 'stroke-dasharray' does not supported '5% 1em 2%' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+FAIL Setting 'stroke-dasharray' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'stroke-dasharray' to a length: -3.14em throws TypeError
+FAIL Setting 'stroke-dasharray' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stroke-dasharray' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stroke-dasharray' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'stroke-dasharray' to a percent: -3.14% throws TypeError
+FAIL Setting 'stroke-dasharray' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stroke-dasharray' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'stroke-dasharray' to a time: 0s throws TypeError
+PASS Setting 'stroke-dasharray' to a time: -3.14ms throws TypeError
+PASS Setting 'stroke-dasharray' to a time: 3.14s throws TypeError
+PASS Setting 'stroke-dasharray' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'stroke-dasharray' to an angle: 0deg throws TypeError
+PASS Setting 'stroke-dasharray' to an angle: 3.14rad throws TypeError
+PASS Setting 'stroke-dasharray' to an angle: -3.14deg throws TypeError
+PASS Setting 'stroke-dasharray' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'stroke-dasharray' to a flexible length: 0fr throws TypeError
+PASS Setting 'stroke-dasharray' to a flexible length: 1fr throws TypeError
+PASS Setting 'stroke-dasharray' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'stroke-dasharray' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'stroke-dasharray' to a number: -3.14 throws TypeError
+FAIL Setting 'stroke-dasharray' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stroke-dasharray' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'stroke-dasharray' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'stroke-dasharray' to a transform: perspective(10em) throws TypeError
+PASS Setting 'stroke-dasharray' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'stroke-dasharray' does not support '5% 1em 2%' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset-expected.txt
@@ -12,10 +12,22 @@ PASS Can set 'stroke-dashoffset' to a percent: 0%
 PASS Can set 'stroke-dashoffset' to a percent: -3.14%
 PASS Can set 'stroke-dashoffset' to a percent: 3.14%
 PASS Can set 'stroke-dashoffset' to a percent: calc(0% + 0%)
-PASS Setting 'stroke-dashoffset' to a time throws TypeError
-PASS Setting 'stroke-dashoffset' to an angle throws TypeError
-PASS Setting 'stroke-dashoffset' to a flexible length throws TypeError
-FAIL Setting 'stroke-dashoffset' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'stroke-dashoffset' to a URL throws TypeError
-PASS Setting 'stroke-dashoffset' to a transform throws TypeError
+PASS Setting 'stroke-dashoffset' to a time: 0s throws TypeError
+PASS Setting 'stroke-dashoffset' to a time: -3.14ms throws TypeError
+PASS Setting 'stroke-dashoffset' to a time: 3.14s throws TypeError
+PASS Setting 'stroke-dashoffset' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'stroke-dashoffset' to an angle: 0deg throws TypeError
+PASS Setting 'stroke-dashoffset' to an angle: 3.14rad throws TypeError
+PASS Setting 'stroke-dashoffset' to an angle: -3.14deg throws TypeError
+PASS Setting 'stroke-dashoffset' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'stroke-dashoffset' to a flexible length: 0fr throws TypeError
+PASS Setting 'stroke-dashoffset' to a flexible length: 1fr throws TypeError
+PASS Setting 'stroke-dashoffset' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'stroke-dashoffset' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stroke-dashoffset' to a number: -3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stroke-dashoffset' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stroke-dashoffset' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'stroke-dashoffset' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'stroke-dashoffset' to a transform: perspective(10em) throws TypeError
+PASS Setting 'stroke-dashoffset' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL 'stroke' does not supported 'black' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'stroke' does not supported 'red gray' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'stroke' does not support 'black' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'stroke' does not support 'red gray' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linecap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linecap-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'stroke-linecap' to var() references:  var(--A)
 PASS Can set 'stroke-linecap' to the 'butt' keyword: butt
 PASS Can set 'stroke-linecap' to the 'round' keyword: round
 PASS Can set 'stroke-linecap' to the 'square' keyword: square
-PASS Setting 'stroke-linecap' to a length throws TypeError
-PASS Setting 'stroke-linecap' to a percent throws TypeError
-PASS Setting 'stroke-linecap' to a time throws TypeError
-PASS Setting 'stroke-linecap' to an angle throws TypeError
-PASS Setting 'stroke-linecap' to a flexible length throws TypeError
-PASS Setting 'stroke-linecap' to a number throws TypeError
-PASS Setting 'stroke-linecap' to a URL throws TypeError
-PASS Setting 'stroke-linecap' to a transform throws TypeError
+PASS Setting 'stroke-linecap' to a length: 0px throws TypeError
+PASS Setting 'stroke-linecap' to a length: -3.14em throws TypeError
+PASS Setting 'stroke-linecap' to a length: 3.14cm throws TypeError
+PASS Setting 'stroke-linecap' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'stroke-linecap' to a percent: 0% throws TypeError
+PASS Setting 'stroke-linecap' to a percent: -3.14% throws TypeError
+PASS Setting 'stroke-linecap' to a percent: 3.14% throws TypeError
+PASS Setting 'stroke-linecap' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'stroke-linecap' to a time: 0s throws TypeError
+PASS Setting 'stroke-linecap' to a time: -3.14ms throws TypeError
+PASS Setting 'stroke-linecap' to a time: 3.14s throws TypeError
+PASS Setting 'stroke-linecap' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'stroke-linecap' to an angle: 0deg throws TypeError
+PASS Setting 'stroke-linecap' to an angle: 3.14rad throws TypeError
+PASS Setting 'stroke-linecap' to an angle: -3.14deg throws TypeError
+PASS Setting 'stroke-linecap' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'stroke-linecap' to a flexible length: 0fr throws TypeError
+PASS Setting 'stroke-linecap' to a flexible length: 1fr throws TypeError
+PASS Setting 'stroke-linecap' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'stroke-linecap' to a number: 0 throws TypeError
+PASS Setting 'stroke-linecap' to a number: -3.14 throws TypeError
+PASS Setting 'stroke-linecap' to a number: 3.14 throws TypeError
+PASS Setting 'stroke-linecap' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'stroke-linecap' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'stroke-linecap' to a transform: perspective(10em) throws TypeError
+PASS Setting 'stroke-linecap' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linejoin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linejoin-expected.txt
@@ -10,14 +10,32 @@ PASS Can set 'stroke-linejoin' to the 'miter' keyword: miter
 PASS Can set 'stroke-linejoin' to the 'bevel' keyword: bevel
 PASS Can set 'stroke-linejoin' to the 'round' keyword: round
 FAIL Can set 'stroke-linejoin' to the 'stupid' keyword: stupid Invalid values
-PASS Setting 'stroke-linejoin' to a length throws TypeError
-PASS Setting 'stroke-linejoin' to a percent throws TypeError
-PASS Setting 'stroke-linejoin' to a time throws TypeError
-PASS Setting 'stroke-linejoin' to an angle throws TypeError
-PASS Setting 'stroke-linejoin' to a flexible length throws TypeError
-PASS Setting 'stroke-linejoin' to a number throws TypeError
-PASS Setting 'stroke-linejoin' to a URL throws TypeError
-PASS Setting 'stroke-linejoin' to a transform throws TypeError
-FAIL 'stroke-linejoin' does not supported 'crop bevel' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'stroke-linejoin' does not supported 'round arcs' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS Setting 'stroke-linejoin' to a length: 0px throws TypeError
+PASS Setting 'stroke-linejoin' to a length: -3.14em throws TypeError
+PASS Setting 'stroke-linejoin' to a length: 3.14cm throws TypeError
+PASS Setting 'stroke-linejoin' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'stroke-linejoin' to a percent: 0% throws TypeError
+PASS Setting 'stroke-linejoin' to a percent: -3.14% throws TypeError
+PASS Setting 'stroke-linejoin' to a percent: 3.14% throws TypeError
+PASS Setting 'stroke-linejoin' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'stroke-linejoin' to a time: 0s throws TypeError
+PASS Setting 'stroke-linejoin' to a time: -3.14ms throws TypeError
+PASS Setting 'stroke-linejoin' to a time: 3.14s throws TypeError
+PASS Setting 'stroke-linejoin' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'stroke-linejoin' to an angle: 0deg throws TypeError
+PASS Setting 'stroke-linejoin' to an angle: 3.14rad throws TypeError
+PASS Setting 'stroke-linejoin' to an angle: -3.14deg throws TypeError
+PASS Setting 'stroke-linejoin' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'stroke-linejoin' to a flexible length: 0fr throws TypeError
+PASS Setting 'stroke-linejoin' to a flexible length: 1fr throws TypeError
+PASS Setting 'stroke-linejoin' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'stroke-linejoin' to a number: 0 throws TypeError
+PASS Setting 'stroke-linejoin' to a number: -3.14 throws TypeError
+PASS Setting 'stroke-linejoin' to a number: 3.14 throws TypeError
+PASS Setting 'stroke-linejoin' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'stroke-linejoin' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'stroke-linejoin' to a transform: perspective(10em) throws TypeError
+PASS Setting 'stroke-linejoin' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'stroke-linejoin' does not support 'crop bevel' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'stroke-linejoin' does not support 'round arcs' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt
@@ -8,11 +8,26 @@ PASS Can set 'stroke-miterlimit' to a number: 0
 FAIL Can set 'stroke-miterlimit' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
 PASS Can set 'stroke-miterlimit' to a number: 3.14
 PASS Can set 'stroke-miterlimit' to a number: calc(2 + 3)
-PASS Setting 'stroke-miterlimit' to a length throws TypeError
-PASS Setting 'stroke-miterlimit' to a percent throws TypeError
-PASS Setting 'stroke-miterlimit' to a time throws TypeError
-PASS Setting 'stroke-miterlimit' to an angle throws TypeError
-PASS Setting 'stroke-miterlimit' to a flexible length throws TypeError
-PASS Setting 'stroke-miterlimit' to a URL throws TypeError
-PASS Setting 'stroke-miterlimit' to a transform throws TypeError
+PASS Setting 'stroke-miterlimit' to a length: 0px throws TypeError
+PASS Setting 'stroke-miterlimit' to a length: -3.14em throws TypeError
+PASS Setting 'stroke-miterlimit' to a length: 3.14cm throws TypeError
+PASS Setting 'stroke-miterlimit' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'stroke-miterlimit' to a percent: 0% throws TypeError
+PASS Setting 'stroke-miterlimit' to a percent: -3.14% throws TypeError
+PASS Setting 'stroke-miterlimit' to a percent: 3.14% throws TypeError
+PASS Setting 'stroke-miterlimit' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'stroke-miterlimit' to a time: 0s throws TypeError
+PASS Setting 'stroke-miterlimit' to a time: -3.14ms throws TypeError
+PASS Setting 'stroke-miterlimit' to a time: 3.14s throws TypeError
+PASS Setting 'stroke-miterlimit' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'stroke-miterlimit' to an angle: 0deg throws TypeError
+PASS Setting 'stroke-miterlimit' to an angle: 3.14rad throws TypeError
+PASS Setting 'stroke-miterlimit' to an angle: -3.14deg throws TypeError
+PASS Setting 'stroke-miterlimit' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'stroke-miterlimit' to a flexible length: 0fr throws TypeError
+PASS Setting 'stroke-miterlimit' to a flexible length: 1fr throws TypeError
+PASS Setting 'stroke-miterlimit' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'stroke-miterlimit' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'stroke-miterlimit' to a transform: perspective(10em) throws TypeError
+PASS Setting 'stroke-miterlimit' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity-expected.txt
@@ -8,11 +8,26 @@ PASS Can set 'stroke-opacity' to a number: 0
 PASS Can set 'stroke-opacity' to a number: -3.14
 PASS Can set 'stroke-opacity' to a number: 3.14
 PASS Can set 'stroke-opacity' to a number: calc(2 + 3)
-PASS Setting 'stroke-opacity' to a length throws TypeError
-FAIL Setting 'stroke-opacity' to a percent throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'stroke-opacity' to a time throws TypeError
-PASS Setting 'stroke-opacity' to an angle throws TypeError
-PASS Setting 'stroke-opacity' to a flexible length throws TypeError
-PASS Setting 'stroke-opacity' to a URL throws TypeError
-PASS Setting 'stroke-opacity' to a transform throws TypeError
+PASS Setting 'stroke-opacity' to a length: 0px throws TypeError
+PASS Setting 'stroke-opacity' to a length: -3.14em throws TypeError
+PASS Setting 'stroke-opacity' to a length: 3.14cm throws TypeError
+PASS Setting 'stroke-opacity' to a length: calc(0px + 0em) throws TypeError
+FAIL Setting 'stroke-opacity' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stroke-opacity' to a percent: -3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stroke-opacity' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stroke-opacity' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'stroke-opacity' to a time: 0s throws TypeError
+PASS Setting 'stroke-opacity' to a time: -3.14ms throws TypeError
+PASS Setting 'stroke-opacity' to a time: 3.14s throws TypeError
+PASS Setting 'stroke-opacity' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'stroke-opacity' to an angle: 0deg throws TypeError
+PASS Setting 'stroke-opacity' to an angle: 3.14rad throws TypeError
+PASS Setting 'stroke-opacity' to an angle: -3.14deg throws TypeError
+PASS Setting 'stroke-opacity' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'stroke-opacity' to a flexible length: 0fr throws TypeError
+PASS Setting 'stroke-opacity' to a flexible length: 1fr throws TypeError
+PASS Setting 'stroke-opacity' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'stroke-opacity' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'stroke-opacity' to a transform: perspective(10em) throws TypeError
+PASS Setting 'stroke-opacity' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt
@@ -12,10 +12,22 @@ PASS Can set 'stroke-width' to a percent: 0%
 FAIL Can set 'stroke-width' to a percent: -3.14% assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
 PASS Can set 'stroke-width' to a percent: 3.14%
 PASS Can set 'stroke-width' to a percent: calc(0% + 0%)
-PASS Setting 'stroke-width' to a time throws TypeError
-PASS Setting 'stroke-width' to an angle throws TypeError
-PASS Setting 'stroke-width' to a flexible length throws TypeError
-FAIL Setting 'stroke-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'stroke-width' to a URL throws TypeError
-PASS Setting 'stroke-width' to a transform throws TypeError
+PASS Setting 'stroke-width' to a time: 0s throws TypeError
+PASS Setting 'stroke-width' to a time: -3.14ms throws TypeError
+PASS Setting 'stroke-width' to a time: 3.14s throws TypeError
+PASS Setting 'stroke-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'stroke-width' to an angle: 0deg throws TypeError
+PASS Setting 'stroke-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'stroke-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'stroke-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'stroke-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'stroke-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'stroke-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'stroke-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stroke-width' to a number: -3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stroke-width' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+FAIL Setting 'stroke-width' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'stroke-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'stroke-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'stroke-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/tab-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/tab-size-expected.txt
@@ -12,10 +12,22 @@ PASS Can set 'tab-size' to a length: 0px
 PASS Can set 'tab-size' to a length: -3.14em
 PASS Can set 'tab-size' to a length: 3.14cm
 PASS Can set 'tab-size' to a length: calc(0px + 0em)
-PASS Setting 'tab-size' to a percent throws TypeError
-PASS Setting 'tab-size' to a time throws TypeError
-PASS Setting 'tab-size' to an angle throws TypeError
-PASS Setting 'tab-size' to a flexible length throws TypeError
-PASS Setting 'tab-size' to a URL throws TypeError
-PASS Setting 'tab-size' to a transform throws TypeError
+PASS Setting 'tab-size' to a percent: 0% throws TypeError
+PASS Setting 'tab-size' to a percent: -3.14% throws TypeError
+PASS Setting 'tab-size' to a percent: 3.14% throws TypeError
+PASS Setting 'tab-size' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'tab-size' to a time: 0s throws TypeError
+PASS Setting 'tab-size' to a time: -3.14ms throws TypeError
+PASS Setting 'tab-size' to a time: 3.14s throws TypeError
+PASS Setting 'tab-size' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'tab-size' to an angle: 0deg throws TypeError
+PASS Setting 'tab-size' to an angle: 3.14rad throws TypeError
+PASS Setting 'tab-size' to an angle: -3.14deg throws TypeError
+PASS Setting 'tab-size' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'tab-size' to a flexible length: 0fr throws TypeError
+PASS Setting 'tab-size' to a flexible length: 1fr throws TypeError
+PASS Setting 'tab-size' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'tab-size' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'tab-size' to a transform: perspective(10em) throws TypeError
+PASS Setting 'tab-size' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/table-layout-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/table-layout-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'table-layout' to CSS-wide keywords: revert
 PASS Can set 'table-layout' to var() references:  var(--A)
 PASS Can set 'table-layout' to the 'auto' keyword: auto
 PASS Can set 'table-layout' to the 'fixed' keyword: fixed
-PASS Setting 'table-layout' to a length throws TypeError
-PASS Setting 'table-layout' to a percent throws TypeError
-PASS Setting 'table-layout' to a time throws TypeError
-PASS Setting 'table-layout' to an angle throws TypeError
-PASS Setting 'table-layout' to a flexible length throws TypeError
-PASS Setting 'table-layout' to a number throws TypeError
-PASS Setting 'table-layout' to a URL throws TypeError
-PASS Setting 'table-layout' to a transform throws TypeError
+PASS Setting 'table-layout' to a length: 0px throws TypeError
+PASS Setting 'table-layout' to a length: -3.14em throws TypeError
+PASS Setting 'table-layout' to a length: 3.14cm throws TypeError
+PASS Setting 'table-layout' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'table-layout' to a percent: 0% throws TypeError
+PASS Setting 'table-layout' to a percent: -3.14% throws TypeError
+PASS Setting 'table-layout' to a percent: 3.14% throws TypeError
+PASS Setting 'table-layout' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'table-layout' to a time: 0s throws TypeError
+PASS Setting 'table-layout' to a time: -3.14ms throws TypeError
+PASS Setting 'table-layout' to a time: 3.14s throws TypeError
+PASS Setting 'table-layout' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'table-layout' to an angle: 0deg throws TypeError
+PASS Setting 'table-layout' to an angle: 3.14rad throws TypeError
+PASS Setting 'table-layout' to an angle: -3.14deg throws TypeError
+PASS Setting 'table-layout' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'table-layout' to a flexible length: 0fr throws TypeError
+PASS Setting 'table-layout' to a flexible length: 1fr throws TypeError
+PASS Setting 'table-layout' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'table-layout' to a number: 0 throws TypeError
+PASS Setting 'table-layout' to a number: -3.14 throws TypeError
+PASS Setting 'table-layout' to a number: 3.14 throws TypeError
+PASS Setting 'table-layout' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'table-layout' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'table-layout' to a transform: perspective(10em) throws TypeError
+PASS Setting 'table-layout' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'text-align' to CSS-wide keywords: revert
 PASS Can set 'text-align' to var() references:  var(--A)
 PASS Can set 'text-align' to the 'center' keyword: center
 PASS Can set 'text-align' to the 'justify' keyword: justify
-PASS Setting 'text-align' to a length throws TypeError
-PASS Setting 'text-align' to a percent throws TypeError
-PASS Setting 'text-align' to a time throws TypeError
-PASS Setting 'text-align' to an angle throws TypeError
-PASS Setting 'text-align' to a flexible length throws TypeError
-PASS Setting 'text-align' to a number throws TypeError
-PASS Setting 'text-align' to a URL throws TypeError
-PASS Setting 'text-align' to a transform throws TypeError
+PASS Setting 'text-align' to a length: 0px throws TypeError
+PASS Setting 'text-align' to a length: -3.14em throws TypeError
+PASS Setting 'text-align' to a length: 3.14cm throws TypeError
+PASS Setting 'text-align' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-align' to a percent: 0% throws TypeError
+PASS Setting 'text-align' to a percent: -3.14% throws TypeError
+PASS Setting 'text-align' to a percent: 3.14% throws TypeError
+PASS Setting 'text-align' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-align' to a time: 0s throws TypeError
+PASS Setting 'text-align' to a time: -3.14ms throws TypeError
+PASS Setting 'text-align' to a time: 3.14s throws TypeError
+PASS Setting 'text-align' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-align' to an angle: 0deg throws TypeError
+PASS Setting 'text-align' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-align' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-align' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-align' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-align' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-align' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-align' to a number: 0 throws TypeError
+PASS Setting 'text-align' to a number: -3.14 throws TypeError
+PASS Setting 'text-align' to a number: 3.14 throws TypeError
+PASS Setting 'text-align' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-align' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-align' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-align' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-last-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-last-expected.txt
@@ -11,12 +11,30 @@ PASS Can set 'text-align-last' to the 'left' keyword: left
 PASS Can set 'text-align-last' to the 'right' keyword: right
 PASS Can set 'text-align-last' to the 'center' keyword: center
 PASS Can set 'text-align-last' to the 'justify' keyword: justify
-PASS Setting 'text-align-last' to a length throws TypeError
-PASS Setting 'text-align-last' to a percent throws TypeError
-PASS Setting 'text-align-last' to a time throws TypeError
-PASS Setting 'text-align-last' to an angle throws TypeError
-PASS Setting 'text-align-last' to a flexible length throws TypeError
-PASS Setting 'text-align-last' to a number throws TypeError
-PASS Setting 'text-align-last' to a URL throws TypeError
-PASS Setting 'text-align-last' to a transform throws TypeError
+PASS Setting 'text-align-last' to a length: 0px throws TypeError
+PASS Setting 'text-align-last' to a length: -3.14em throws TypeError
+PASS Setting 'text-align-last' to a length: 3.14cm throws TypeError
+PASS Setting 'text-align-last' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-align-last' to a percent: 0% throws TypeError
+PASS Setting 'text-align-last' to a percent: -3.14% throws TypeError
+PASS Setting 'text-align-last' to a percent: 3.14% throws TypeError
+PASS Setting 'text-align-last' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-align-last' to a time: 0s throws TypeError
+PASS Setting 'text-align-last' to a time: -3.14ms throws TypeError
+PASS Setting 'text-align-last' to a time: 3.14s throws TypeError
+PASS Setting 'text-align-last' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-align-last' to an angle: 0deg throws TypeError
+PASS Setting 'text-align-last' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-align-last' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-align-last' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-align-last' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-align-last' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-align-last' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-align-last' to a number: 0 throws TypeError
+PASS Setting 'text-align-last' to a number: -3.14 throws TypeError
+PASS Setting 'text-align-last' to a number: 3.14 throws TypeError
+PASS Setting 'text-align-last' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-align-last' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-align-last' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-align-last' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-anchor-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'text-anchor' to var() references:  var(--A)
 PASS Can set 'text-anchor' to the 'start' keyword: start
 PASS Can set 'text-anchor' to the 'middle' keyword: middle
 PASS Can set 'text-anchor' to the 'end' keyword: end
-PASS Setting 'text-anchor' to a length throws TypeError
-PASS Setting 'text-anchor' to a percent throws TypeError
-PASS Setting 'text-anchor' to a time throws TypeError
-PASS Setting 'text-anchor' to an angle throws TypeError
-PASS Setting 'text-anchor' to a flexible length throws TypeError
-PASS Setting 'text-anchor' to a number throws TypeError
-PASS Setting 'text-anchor' to a URL throws TypeError
-PASS Setting 'text-anchor' to a transform throws TypeError
+PASS Setting 'text-anchor' to a length: 0px throws TypeError
+PASS Setting 'text-anchor' to a length: -3.14em throws TypeError
+PASS Setting 'text-anchor' to a length: 3.14cm throws TypeError
+PASS Setting 'text-anchor' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-anchor' to a percent: 0% throws TypeError
+PASS Setting 'text-anchor' to a percent: -3.14% throws TypeError
+PASS Setting 'text-anchor' to a percent: 3.14% throws TypeError
+PASS Setting 'text-anchor' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-anchor' to a time: 0s throws TypeError
+PASS Setting 'text-anchor' to a time: -3.14ms throws TypeError
+PASS Setting 'text-anchor' to a time: 3.14s throws TypeError
+PASS Setting 'text-anchor' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-anchor' to an angle: 0deg throws TypeError
+PASS Setting 'text-anchor' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-anchor' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-anchor' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-anchor' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-anchor' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-anchor' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-anchor' to a number: 0 throws TypeError
+PASS Setting 'text-anchor' to a number: -3.14 throws TypeError
+PASS Setting 'text-anchor' to a number: 3.14 throws TypeError
+PASS Setting 'text-anchor' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-anchor' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-anchor' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-anchor' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-combine-upright-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-combine-upright-expected.txt
@@ -6,13 +6,31 @@ PASS Can set 'text-combine-upright' to CSS-wide keywords: revert
 PASS Can set 'text-combine-upright' to var() references:  var(--A)
 PASS Can set 'text-combine-upright' to the 'none' keyword: none
 PASS Can set 'text-combine-upright' to the 'all' keyword: all
-PASS Setting 'text-combine-upright' to a length throws TypeError
-PASS Setting 'text-combine-upright' to a percent throws TypeError
-PASS Setting 'text-combine-upright' to a time throws TypeError
-PASS Setting 'text-combine-upright' to an angle throws TypeError
-PASS Setting 'text-combine-upright' to a flexible length throws TypeError
-PASS Setting 'text-combine-upright' to a number throws TypeError
-PASS Setting 'text-combine-upright' to a URL throws TypeError
-PASS Setting 'text-combine-upright' to a transform throws TypeError
-FAIL 'text-combine-upright' does not supported 'digits 3' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS Setting 'text-combine-upright' to a length: 0px throws TypeError
+PASS Setting 'text-combine-upright' to a length: -3.14em throws TypeError
+PASS Setting 'text-combine-upright' to a length: 3.14cm throws TypeError
+PASS Setting 'text-combine-upright' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-combine-upright' to a percent: 0% throws TypeError
+PASS Setting 'text-combine-upright' to a percent: -3.14% throws TypeError
+PASS Setting 'text-combine-upright' to a percent: 3.14% throws TypeError
+PASS Setting 'text-combine-upright' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-combine-upright' to a time: 0s throws TypeError
+PASS Setting 'text-combine-upright' to a time: -3.14ms throws TypeError
+PASS Setting 'text-combine-upright' to a time: 3.14s throws TypeError
+PASS Setting 'text-combine-upright' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-combine-upright' to an angle: 0deg throws TypeError
+PASS Setting 'text-combine-upright' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-combine-upright' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-combine-upright' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-combine-upright' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-combine-upright' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-combine-upright' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-combine-upright' to a number: 0 throws TypeError
+PASS Setting 'text-combine-upright' to a number: -3.14 throws TypeError
+PASS Setting 'text-combine-upright' to a number: 3.14 throws TypeError
+PASS Setting 'text-combine-upright' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-combine-upright' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-combine-upright' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-combine-upright' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'text-combine-upright' does not support 'digits 3' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-color-expected.txt
@@ -5,17 +5,35 @@ PASS Can set 'text-decoration-color' to CSS-wide keywords: unset
 PASS Can set 'text-decoration-color' to CSS-wide keywords: revert
 PASS Can set 'text-decoration-color' to var() references:  var(--A)
 PASS Can set 'text-decoration-color' to the 'currentcolor' keyword: currentcolor
-PASS Setting 'text-decoration-color' to a length throws TypeError
-PASS Setting 'text-decoration-color' to a percent throws TypeError
-PASS Setting 'text-decoration-color' to a time throws TypeError
-PASS Setting 'text-decoration-color' to an angle throws TypeError
-PASS Setting 'text-decoration-color' to a flexible length throws TypeError
-PASS Setting 'text-decoration-color' to a number throws TypeError
-PASS Setting 'text-decoration-color' to a URL throws TypeError
-PASS Setting 'text-decoration-color' to a transform throws TypeError
-FAIL 'text-decoration-color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'text-decoration-color' does not supported '#bbff00'
-PASS 'text-decoration-color' does not supported 'rgb(255, 255, 128)'
-PASS 'text-decoration-color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'text-decoration-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'text-decoration-color' to a length: 0px throws TypeError
+PASS Setting 'text-decoration-color' to a length: -3.14em throws TypeError
+PASS Setting 'text-decoration-color' to a length: 3.14cm throws TypeError
+PASS Setting 'text-decoration-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-decoration-color' to a percent: 0% throws TypeError
+PASS Setting 'text-decoration-color' to a percent: -3.14% throws TypeError
+PASS Setting 'text-decoration-color' to a percent: 3.14% throws TypeError
+PASS Setting 'text-decoration-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-decoration-color' to a time: 0s throws TypeError
+PASS Setting 'text-decoration-color' to a time: -3.14ms throws TypeError
+PASS Setting 'text-decoration-color' to a time: 3.14s throws TypeError
+PASS Setting 'text-decoration-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-decoration-color' to an angle: 0deg throws TypeError
+PASS Setting 'text-decoration-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-decoration-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-decoration-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-decoration-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-decoration-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-decoration-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-decoration-color' to a number: 0 throws TypeError
+PASS Setting 'text-decoration-color' to a number: -3.14 throws TypeError
+PASS Setting 'text-decoration-color' to a number: 3.14 throws TypeError
+PASS Setting 'text-decoration-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-decoration-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-decoration-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-decoration-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'text-decoration-color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'text-decoration-color' does not support '#bbff00'
+PASS 'text-decoration-color' does not support 'rgb(255, 255, 128)'
+PASS 'text-decoration-color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'text-decoration-color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-expected.txt
@@ -1,5 +1,5 @@
 
-PASS 'text-decoration' does not supported 'underline'
-FAIL 'text-decoration' does not supported 'underline dotted #ff3028' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'text-decoration' does not supported 'green wavy underline' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS 'text-decoration' does not support 'underline'
+FAIL 'text-decoration' does not support 'underline dotted #ff3028' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'text-decoration' does not support 'green wavy underline' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt
@@ -11,12 +11,30 @@ PASS Can set 'text-decoration-line' to the 'line-through' keyword: line-through
 FAIL Can set 'text-decoration-line' to the 'blink' keyword: blink assert_equals: expected "blink" but got "none"
 FAIL Can set 'text-decoration-line' to the 'spelling-error' keyword: spelling-error Invalid values
 FAIL Can set 'text-decoration-line' to the 'grammar-error' keyword: grammar-error Invalid values
-PASS Setting 'text-decoration-line' to a length throws TypeError
-PASS Setting 'text-decoration-line' to a percent throws TypeError
-PASS Setting 'text-decoration-line' to a time throws TypeError
-PASS Setting 'text-decoration-line' to an angle throws TypeError
-PASS Setting 'text-decoration-line' to a flexible length throws TypeError
-PASS Setting 'text-decoration-line' to a number throws TypeError
-PASS Setting 'text-decoration-line' to a URL throws TypeError
-PASS Setting 'text-decoration-line' to a transform throws TypeError
+PASS Setting 'text-decoration-line' to a length: 0px throws TypeError
+PASS Setting 'text-decoration-line' to a length: -3.14em throws TypeError
+PASS Setting 'text-decoration-line' to a length: 3.14cm throws TypeError
+PASS Setting 'text-decoration-line' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-decoration-line' to a percent: 0% throws TypeError
+PASS Setting 'text-decoration-line' to a percent: -3.14% throws TypeError
+PASS Setting 'text-decoration-line' to a percent: 3.14% throws TypeError
+PASS Setting 'text-decoration-line' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-decoration-line' to a time: 0s throws TypeError
+PASS Setting 'text-decoration-line' to a time: -3.14ms throws TypeError
+PASS Setting 'text-decoration-line' to a time: 3.14s throws TypeError
+PASS Setting 'text-decoration-line' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-decoration-line' to an angle: 0deg throws TypeError
+PASS Setting 'text-decoration-line' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-decoration-line' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-decoration-line' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-decoration-line' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-decoration-line' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-decoration-line' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-decoration-line' to a number: 0 throws TypeError
+PASS Setting 'text-decoration-line' to a number: -3.14 throws TypeError
+PASS Setting 'text-decoration-line' to a number: 3.14 throws TypeError
+PASS Setting 'text-decoration-line' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-decoration-line' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-decoration-line' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-decoration-line' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-expected.txt
@@ -9,15 +9,33 @@ FAIL Can set 'text-decoration-skip' to the 'objects' keyword: objects Bad value 
 FAIL Can set 'text-decoration-skip' to the 'edges' keyword: edges Bad value for shorthand CSS property
 FAIL Can set 'text-decoration-skip' to the 'box-decoration' keyword: box-decoration Bad value for shorthand CSS property
 FAIL Can set 'text-decoration-skip' to the 'spaces' keyword: spaces Bad value for shorthand CSS property
-PASS Setting 'text-decoration-skip' to a length throws TypeError
-PASS Setting 'text-decoration-skip' to a percent throws TypeError
-PASS Setting 'text-decoration-skip' to a time throws TypeError
-PASS Setting 'text-decoration-skip' to an angle throws TypeError
-PASS Setting 'text-decoration-skip' to a flexible length throws TypeError
-PASS Setting 'text-decoration-skip' to a number throws TypeError
-PASS Setting 'text-decoration-skip' to a URL throws TypeError
-PASS Setting 'text-decoration-skip' to a transform throws TypeError
-FAIL 'text-decoration-skip' does not supported 'objects spaces' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'text-decoration-skip' does not supported 'leading-spaces trailing-spaces' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'text-decoration-skip' does not supported 'objects edges box-decoration' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS Setting 'text-decoration-skip' to a length: 0px throws TypeError
+PASS Setting 'text-decoration-skip' to a length: -3.14em throws TypeError
+PASS Setting 'text-decoration-skip' to a length: 3.14cm throws TypeError
+PASS Setting 'text-decoration-skip' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-decoration-skip' to a percent: 0% throws TypeError
+PASS Setting 'text-decoration-skip' to a percent: -3.14% throws TypeError
+PASS Setting 'text-decoration-skip' to a percent: 3.14% throws TypeError
+PASS Setting 'text-decoration-skip' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-decoration-skip' to a time: 0s throws TypeError
+PASS Setting 'text-decoration-skip' to a time: -3.14ms throws TypeError
+PASS Setting 'text-decoration-skip' to a time: 3.14s throws TypeError
+PASS Setting 'text-decoration-skip' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-decoration-skip' to an angle: 0deg throws TypeError
+PASS Setting 'text-decoration-skip' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-decoration-skip' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-decoration-skip' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-decoration-skip' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-decoration-skip' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-decoration-skip' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-decoration-skip' to a number: 0 throws TypeError
+PASS Setting 'text-decoration-skip' to a number: -3.14 throws TypeError
+PASS Setting 'text-decoration-skip' to a number: 3.14 throws TypeError
+PASS Setting 'text-decoration-skip' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-decoration-skip' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-decoration-skip' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-decoration-skip' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'text-decoration-skip' does not support 'objects spaces' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'text-decoration-skip' does not support 'leading-spaces trailing-spaces' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'text-decoration-skip' does not support 'objects edges box-decoration' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-ink-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-ink-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'text-decoration-skip-ink' to CSS-wide keywords: revert
 PASS Can set 'text-decoration-skip-ink' to var() references:  var(--A)
 PASS Can set 'text-decoration-skip-ink' to the 'auto' keyword: auto
 PASS Can set 'text-decoration-skip-ink' to the 'none' keyword: none
-PASS Setting 'text-decoration-skip-ink' to a length throws TypeError
-PASS Setting 'text-decoration-skip-ink' to a percent throws TypeError
-PASS Setting 'text-decoration-skip-ink' to a time throws TypeError
-PASS Setting 'text-decoration-skip-ink' to an angle throws TypeError
-PASS Setting 'text-decoration-skip-ink' to a flexible length throws TypeError
-PASS Setting 'text-decoration-skip-ink' to a number throws TypeError
-PASS Setting 'text-decoration-skip-ink' to a URL throws TypeError
-PASS Setting 'text-decoration-skip-ink' to a transform throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a length: 0px throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a length: -3.14em throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a length: 3.14cm throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a percent: 0% throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a percent: -3.14% throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a percent: 3.14% throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a time: 0s throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a time: -3.14ms throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a time: 3.14s throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-decoration-skip-ink' to an angle: 0deg throws TypeError
+PASS Setting 'text-decoration-skip-ink' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-decoration-skip-ink' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-decoration-skip-ink' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a number: 0 throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a number: -3.14 throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a number: 3.14 throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-decoration-skip-ink' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-style-expected.txt
@@ -9,12 +9,30 @@ PASS Can set 'text-decoration-style' to the 'double' keyword: double
 PASS Can set 'text-decoration-style' to the 'dotted' keyword: dotted
 PASS Can set 'text-decoration-style' to the 'dashed' keyword: dashed
 PASS Can set 'text-decoration-style' to the 'wavy' keyword: wavy
-PASS Setting 'text-decoration-style' to a length throws TypeError
-PASS Setting 'text-decoration-style' to a percent throws TypeError
-PASS Setting 'text-decoration-style' to a time throws TypeError
-PASS Setting 'text-decoration-style' to an angle throws TypeError
-PASS Setting 'text-decoration-style' to a flexible length throws TypeError
-PASS Setting 'text-decoration-style' to a number throws TypeError
-PASS Setting 'text-decoration-style' to a URL throws TypeError
-PASS Setting 'text-decoration-style' to a transform throws TypeError
+PASS Setting 'text-decoration-style' to a length: 0px throws TypeError
+PASS Setting 'text-decoration-style' to a length: -3.14em throws TypeError
+PASS Setting 'text-decoration-style' to a length: 3.14cm throws TypeError
+PASS Setting 'text-decoration-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-decoration-style' to a percent: 0% throws TypeError
+PASS Setting 'text-decoration-style' to a percent: -3.14% throws TypeError
+PASS Setting 'text-decoration-style' to a percent: 3.14% throws TypeError
+PASS Setting 'text-decoration-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-decoration-style' to a time: 0s throws TypeError
+PASS Setting 'text-decoration-style' to a time: -3.14ms throws TypeError
+PASS Setting 'text-decoration-style' to a time: 3.14s throws TypeError
+PASS Setting 'text-decoration-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-decoration-style' to an angle: 0deg throws TypeError
+PASS Setting 'text-decoration-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-decoration-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-decoration-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-decoration-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-decoration-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-decoration-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-decoration-style' to a number: 0 throws TypeError
+PASS Setting 'text-decoration-style' to a number: -3.14 throws TypeError
+PASS Setting 'text-decoration-style' to a number: 3.14 throws TypeError
+PASS Setting 'text-decoration-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-decoration-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-decoration-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-decoration-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-thickness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-thickness-expected.txt
@@ -13,10 +13,22 @@ FAIL Can set 'text-decoration-thickness' to a percent: 0% Invalid values
 FAIL Can set 'text-decoration-thickness' to a percent: -3.14% Invalid values
 FAIL Can set 'text-decoration-thickness' to a percent: 3.14% Invalid values
 FAIL Can set 'text-decoration-thickness' to a percent: calc(0% + 0%) Invalid values
-PASS Setting 'text-decoration-thickness' to a time throws TypeError
-PASS Setting 'text-decoration-thickness' to an angle throws TypeError
-PASS Setting 'text-decoration-thickness' to a flexible length throws TypeError
-FAIL Setting 'text-decoration-thickness' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'text-decoration-thickness' to a URL throws TypeError
-PASS Setting 'text-decoration-thickness' to a transform throws TypeError
+PASS Setting 'text-decoration-thickness' to a time: 0s throws TypeError
+PASS Setting 'text-decoration-thickness' to a time: -3.14ms throws TypeError
+PASS Setting 'text-decoration-thickness' to a time: 3.14s throws TypeError
+PASS Setting 'text-decoration-thickness' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-decoration-thickness' to an angle: 0deg throws TypeError
+PASS Setting 'text-decoration-thickness' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-decoration-thickness' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-decoration-thickness' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-decoration-thickness' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-decoration-thickness' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-decoration-thickness' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'text-decoration-thickness' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'text-decoration-thickness' to a number: -3.14 throws TypeError
+PASS Setting 'text-decoration-thickness' to a number: 3.14 throws TypeError
+PASS Setting 'text-decoration-thickness' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-decoration-thickness' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-decoration-thickness' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-decoration-thickness' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-emphasis-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-emphasis-color-expected.txt
@@ -5,17 +5,35 @@ PASS Can set 'text-emphasis-color' to CSS-wide keywords: unset
 PASS Can set 'text-emphasis-color' to CSS-wide keywords: revert
 PASS Can set 'text-emphasis-color' to var() references:  var(--A)
 PASS Can set 'text-emphasis-color' to the 'currentcolor' keyword: currentcolor
-PASS Setting 'text-emphasis-color' to a length throws TypeError
-PASS Setting 'text-emphasis-color' to a percent throws TypeError
-PASS Setting 'text-emphasis-color' to a time throws TypeError
-PASS Setting 'text-emphasis-color' to an angle throws TypeError
-PASS Setting 'text-emphasis-color' to a flexible length throws TypeError
-PASS Setting 'text-emphasis-color' to a number throws TypeError
-PASS Setting 'text-emphasis-color' to a URL throws TypeError
-PASS Setting 'text-emphasis-color' to a transform throws TypeError
-FAIL 'text-emphasis-color' does not supported 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-PASS 'text-emphasis-color' does not supported '#bbff00'
-PASS 'text-emphasis-color' does not supported 'rgb(255, 255, 128)'
-PASS 'text-emphasis-color' does not supported 'hsl(50, 33%, 25%)'
-FAIL 'text-emphasis-color' does not supported 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'text-emphasis-color' to a length: 0px throws TypeError
+PASS Setting 'text-emphasis-color' to a length: -3.14em throws TypeError
+PASS Setting 'text-emphasis-color' to a length: 3.14cm throws TypeError
+PASS Setting 'text-emphasis-color' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-emphasis-color' to a percent: 0% throws TypeError
+PASS Setting 'text-emphasis-color' to a percent: -3.14% throws TypeError
+PASS Setting 'text-emphasis-color' to a percent: 3.14% throws TypeError
+PASS Setting 'text-emphasis-color' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-emphasis-color' to a time: 0s throws TypeError
+PASS Setting 'text-emphasis-color' to a time: -3.14ms throws TypeError
+PASS Setting 'text-emphasis-color' to a time: 3.14s throws TypeError
+PASS Setting 'text-emphasis-color' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-emphasis-color' to an angle: 0deg throws TypeError
+PASS Setting 'text-emphasis-color' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-emphasis-color' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-emphasis-color' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-emphasis-color' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-emphasis-color' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-emphasis-color' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-emphasis-color' to a number: 0 throws TypeError
+PASS Setting 'text-emphasis-color' to a number: -3.14 throws TypeError
+PASS Setting 'text-emphasis-color' to a number: 3.14 throws TypeError
+PASS Setting 'text-emphasis-color' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-emphasis-color' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-emphasis-color' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-emphasis-color' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'text-emphasis-color' does not support 'red' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'text-emphasis-color' does not support '#bbff00'
+PASS 'text-emphasis-color' does not support 'rgb(255, 255, 128)'
+PASS 'text-emphasis-color' does not support 'hsl(50, 33%, 25%)'
+FAIL 'text-emphasis-color' does not support 'transparent' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt
@@ -12,13 +12,25 @@ PASS Can set 'text-indent' to a percent: 0%
 PASS Can set 'text-indent' to a percent: -3.14%
 PASS Can set 'text-indent' to a percent: 3.14%
 PASS Can set 'text-indent' to a percent: calc(0% + 0%)
-PASS Setting 'text-indent' to a time throws TypeError
-PASS Setting 'text-indent' to an angle throws TypeError
-PASS Setting 'text-indent' to a flexible length throws TypeError
-FAIL Setting 'text-indent' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'text-indent' to a URL throws TypeError
-PASS Setting 'text-indent' to a transform throws TypeError
-FAIL 'text-indent' does not supported '5em each-line' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
-FAIL 'text-indent' does not supported '5em hanging' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
-FAIL 'text-indent' does not supported '5em hanging each-line' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+PASS Setting 'text-indent' to a time: 0s throws TypeError
+PASS Setting 'text-indent' to a time: -3.14ms throws TypeError
+PASS Setting 'text-indent' to a time: 3.14s throws TypeError
+PASS Setting 'text-indent' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-indent' to an angle: 0deg throws TypeError
+PASS Setting 'text-indent' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-indent' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-indent' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-indent' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-indent' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-indent' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'text-indent' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'text-indent' to a number: -3.14 throws TypeError
+PASS Setting 'text-indent' to a number: 3.14 throws TypeError
+PASS Setting 'text-indent' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-indent' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-indent' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-indent' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'text-indent' does not support '5em each-line' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+FAIL 'text-indent' does not support '5em hanging' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+FAIL 'text-indent' does not support '5em hanging each-line' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-justify-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-justify-expected.txt
@@ -8,12 +8,30 @@ PASS Can set 'text-justify' to the 'auto' keyword: auto
 PASS Can set 'text-justify' to the 'none' keyword: none
 PASS Can set 'text-justify' to the 'inter-word' keyword: inter-word
 PASS Can set 'text-justify' to the 'inter-character' keyword: inter-character
-PASS Setting 'text-justify' to a length throws TypeError
-PASS Setting 'text-justify' to a percent throws TypeError
-PASS Setting 'text-justify' to a time throws TypeError
-PASS Setting 'text-justify' to an angle throws TypeError
-PASS Setting 'text-justify' to a flexible length throws TypeError
-PASS Setting 'text-justify' to a number throws TypeError
-PASS Setting 'text-justify' to a URL throws TypeError
-PASS Setting 'text-justify' to a transform throws TypeError
+PASS Setting 'text-justify' to a length: 0px throws TypeError
+PASS Setting 'text-justify' to a length: -3.14em throws TypeError
+PASS Setting 'text-justify' to a length: 3.14cm throws TypeError
+PASS Setting 'text-justify' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-justify' to a percent: 0% throws TypeError
+PASS Setting 'text-justify' to a percent: -3.14% throws TypeError
+PASS Setting 'text-justify' to a percent: 3.14% throws TypeError
+PASS Setting 'text-justify' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-justify' to a time: 0s throws TypeError
+PASS Setting 'text-justify' to a time: -3.14ms throws TypeError
+PASS Setting 'text-justify' to a time: 3.14s throws TypeError
+PASS Setting 'text-justify' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-justify' to an angle: 0deg throws TypeError
+PASS Setting 'text-justify' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-justify' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-justify' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-justify' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-justify' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-justify' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-justify' to a number: 0 throws TypeError
+PASS Setting 'text-justify' to a number: -3.14 throws TypeError
+PASS Setting 'text-justify' to a number: 3.14 throws TypeError
+PASS Setting 'text-justify' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-justify' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-justify' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-justify' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-orientation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-orientation-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'text-orientation' to var() references:  var(--A)
 PASS Can set 'text-orientation' to the 'mixed' keyword: mixed
 PASS Can set 'text-orientation' to the 'upright' keyword: upright
 PASS Can set 'text-orientation' to the 'sideways' keyword: sideways
-PASS Setting 'text-orientation' to a length throws TypeError
-PASS Setting 'text-orientation' to a percent throws TypeError
-PASS Setting 'text-orientation' to a time throws TypeError
-PASS Setting 'text-orientation' to an angle throws TypeError
-PASS Setting 'text-orientation' to a flexible length throws TypeError
-PASS Setting 'text-orientation' to a number throws TypeError
-PASS Setting 'text-orientation' to a URL throws TypeError
-PASS Setting 'text-orientation' to a transform throws TypeError
+PASS Setting 'text-orientation' to a length: 0px throws TypeError
+PASS Setting 'text-orientation' to a length: -3.14em throws TypeError
+PASS Setting 'text-orientation' to a length: 3.14cm throws TypeError
+PASS Setting 'text-orientation' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-orientation' to a percent: 0% throws TypeError
+PASS Setting 'text-orientation' to a percent: -3.14% throws TypeError
+PASS Setting 'text-orientation' to a percent: 3.14% throws TypeError
+PASS Setting 'text-orientation' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-orientation' to a time: 0s throws TypeError
+PASS Setting 'text-orientation' to a time: -3.14ms throws TypeError
+PASS Setting 'text-orientation' to a time: 3.14s throws TypeError
+PASS Setting 'text-orientation' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-orientation' to an angle: 0deg throws TypeError
+PASS Setting 'text-orientation' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-orientation' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-orientation' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-orientation' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-orientation' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-orientation' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-orientation' to a number: 0 throws TypeError
+PASS Setting 'text-orientation' to a number: -3.14 throws TypeError
+PASS Setting 'text-orientation' to a number: 3.14 throws TypeError
+PASS Setting 'text-orientation' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-orientation' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-orientation' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-orientation' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-overflow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-overflow-expected.txt
@@ -7,15 +7,33 @@ PASS Can set 'text-overflow' to var() references:  var(--A)
 PASS Can set 'text-overflow' to the 'clip' keyword: clip
 PASS Can set 'text-overflow' to the 'ellipsis' keyword: ellipsis
 FAIL Can set 'text-overflow' to the 'fade' keyword: fade Invalid values
-PASS Setting 'text-overflow' to a length throws TypeError
-PASS Setting 'text-overflow' to a percent throws TypeError
-PASS Setting 'text-overflow' to a time throws TypeError
-PASS Setting 'text-overflow' to an angle throws TypeError
-PASS Setting 'text-overflow' to a flexible length throws TypeError
-PASS Setting 'text-overflow' to a number throws TypeError
-PASS Setting 'text-overflow' to a URL throws TypeError
-PASS Setting 'text-overflow' to a transform throws TypeError
-FAIL 'text-overflow' does not supported 'clip ellipsis' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'text-overflow' does not supported '"..."' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'text-overflow' does not supported 'fade(1px, 50%)' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS Setting 'text-overflow' to a length: 0px throws TypeError
+PASS Setting 'text-overflow' to a length: -3.14em throws TypeError
+PASS Setting 'text-overflow' to a length: 3.14cm throws TypeError
+PASS Setting 'text-overflow' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-overflow' to a percent: 0% throws TypeError
+PASS Setting 'text-overflow' to a percent: -3.14% throws TypeError
+PASS Setting 'text-overflow' to a percent: 3.14% throws TypeError
+PASS Setting 'text-overflow' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-overflow' to a time: 0s throws TypeError
+PASS Setting 'text-overflow' to a time: -3.14ms throws TypeError
+PASS Setting 'text-overflow' to a time: 3.14s throws TypeError
+PASS Setting 'text-overflow' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-overflow' to an angle: 0deg throws TypeError
+PASS Setting 'text-overflow' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-overflow' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-overflow' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-overflow' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-overflow' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-overflow' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-overflow' to a number: 0 throws TypeError
+PASS Setting 'text-overflow' to a number: -3.14 throws TypeError
+PASS Setting 'text-overflow' to a number: 3.14 throws TypeError
+PASS Setting 'text-overflow' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-overflow' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-overflow' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-overflow' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'text-overflow' does not support 'clip ellipsis' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'text-overflow' does not support '"..."' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'text-overflow' does not support 'fade(1px, 50%)' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-rendering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-rendering-expected.txt
@@ -8,12 +8,30 @@ PASS Can set 'text-rendering' to the 'auto' keyword: auto
 FAIL Can set 'text-rendering' to the 'optimizespeed' keyword: optimizespeed assert_equals: expected "optimizespeed" but got "optimizeSpeed"
 FAIL Can set 'text-rendering' to the 'optimizelegibility' keyword: optimizelegibility assert_equals: expected "optimizelegibility" but got "optimizeLegibility"
 FAIL Can set 'text-rendering' to the 'geometricprecision' keyword: geometricprecision assert_equals: expected "geometricprecision" but got "geometricPrecision"
-PASS Setting 'text-rendering' to a length throws TypeError
-PASS Setting 'text-rendering' to a percent throws TypeError
-PASS Setting 'text-rendering' to a time throws TypeError
-PASS Setting 'text-rendering' to an angle throws TypeError
-PASS Setting 'text-rendering' to a flexible length throws TypeError
-PASS Setting 'text-rendering' to a number throws TypeError
-PASS Setting 'text-rendering' to a URL throws TypeError
-PASS Setting 'text-rendering' to a transform throws TypeError
+PASS Setting 'text-rendering' to a length: 0px throws TypeError
+PASS Setting 'text-rendering' to a length: -3.14em throws TypeError
+PASS Setting 'text-rendering' to a length: 3.14cm throws TypeError
+PASS Setting 'text-rendering' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-rendering' to a percent: 0% throws TypeError
+PASS Setting 'text-rendering' to a percent: -3.14% throws TypeError
+PASS Setting 'text-rendering' to a percent: 3.14% throws TypeError
+PASS Setting 'text-rendering' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-rendering' to a time: 0s throws TypeError
+PASS Setting 'text-rendering' to a time: -3.14ms throws TypeError
+PASS Setting 'text-rendering' to a time: 3.14s throws TypeError
+PASS Setting 'text-rendering' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-rendering' to an angle: 0deg throws TypeError
+PASS Setting 'text-rendering' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-rendering' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-rendering' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-rendering' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-rendering' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-rendering' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-rendering' to a number: 0 throws TypeError
+PASS Setting 'text-rendering' to a number: -3.14 throws TypeError
+PASS Setting 'text-rendering' to a number: 3.14 throws TypeError
+PASS Setting 'text-rendering' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-rendering' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-rendering' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-rendering' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-shadow-expected.txt
@@ -5,14 +5,32 @@ PASS Can set 'text-shadow' to CSS-wide keywords: unset
 PASS Can set 'text-shadow' to CSS-wide keywords: revert
 PASS Can set 'text-shadow' to var() references:  var(--A)
 PASS Can set 'text-shadow' to the 'none' keyword: none
-PASS Setting 'text-shadow' to a length throws TypeError
-PASS Setting 'text-shadow' to a percent throws TypeError
-PASS Setting 'text-shadow' to a time throws TypeError
-PASS Setting 'text-shadow' to an angle throws TypeError
-PASS Setting 'text-shadow' to a flexible length throws TypeError
-PASS Setting 'text-shadow' to a number throws TypeError
-PASS Setting 'text-shadow' to a URL throws TypeError
-PASS Setting 'text-shadow' to a transform throws TypeError
-PASS 'text-shadow' does not supported '1px 1px 2px pink'
-FAIL 'text-shadow' does not supported '1px 1px 2px red, 0 0 1em blue, 0 0 0.2em blue' assert_equals: Unsupported value can be set on different element expected "red 1px 1px 2px, blue 0px 0px 1em, blue 0px 0px 0.2em" but got "red 1px 1px 2px"
+PASS Setting 'text-shadow' to a length: 0px throws TypeError
+PASS Setting 'text-shadow' to a length: -3.14em throws TypeError
+PASS Setting 'text-shadow' to a length: 3.14cm throws TypeError
+PASS Setting 'text-shadow' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-shadow' to a percent: 0% throws TypeError
+PASS Setting 'text-shadow' to a percent: -3.14% throws TypeError
+PASS Setting 'text-shadow' to a percent: 3.14% throws TypeError
+PASS Setting 'text-shadow' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-shadow' to a time: 0s throws TypeError
+PASS Setting 'text-shadow' to a time: -3.14ms throws TypeError
+PASS Setting 'text-shadow' to a time: 3.14s throws TypeError
+PASS Setting 'text-shadow' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-shadow' to an angle: 0deg throws TypeError
+PASS Setting 'text-shadow' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-shadow' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-shadow' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-shadow' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-shadow' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-shadow' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-shadow' to a number: 0 throws TypeError
+PASS Setting 'text-shadow' to a number: -3.14 throws TypeError
+PASS Setting 'text-shadow' to a number: 3.14 throws TypeError
+PASS Setting 'text-shadow' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-shadow' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-shadow' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-shadow' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'text-shadow' does not support '1px 1px 2px pink'
+FAIL 'text-shadow' does not support '1px 1px 2px red, 0 0 1em blue, 0 0 0.2em blue' assert_equals: Unsupported value can be set on different element expected "red 1px 1px 2px, blue 0px 0px 1em, blue 0px 0px 0.2em" but got "red 1px 1px 2px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-size-adjust-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-size-adjust-expected.txt
@@ -10,11 +10,26 @@ FAIL Can set 'text-size-adjust' to a percent: 0% Invalid property text-size-adju
 FAIL Can set 'text-size-adjust' to a percent: -3.14% Invalid property text-size-adjust
 FAIL Can set 'text-size-adjust' to a percent: 3.14% Invalid property text-size-adjust
 FAIL Can set 'text-size-adjust' to a percent: calc(0% + 0%) Invalid property text-size-adjust
-PASS Setting 'text-size-adjust' to a length throws TypeError
-PASS Setting 'text-size-adjust' to a time throws TypeError
-PASS Setting 'text-size-adjust' to an angle throws TypeError
-PASS Setting 'text-size-adjust' to a flexible length throws TypeError
-PASS Setting 'text-size-adjust' to a number throws TypeError
-PASS Setting 'text-size-adjust' to a URL throws TypeError
-PASS Setting 'text-size-adjust' to a transform throws TypeError
+PASS Setting 'text-size-adjust' to a length: 0px throws TypeError
+PASS Setting 'text-size-adjust' to a length: -3.14em throws TypeError
+PASS Setting 'text-size-adjust' to a length: 3.14cm throws TypeError
+PASS Setting 'text-size-adjust' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-size-adjust' to a time: 0s throws TypeError
+PASS Setting 'text-size-adjust' to a time: -3.14ms throws TypeError
+PASS Setting 'text-size-adjust' to a time: 3.14s throws TypeError
+PASS Setting 'text-size-adjust' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-size-adjust' to an angle: 0deg throws TypeError
+PASS Setting 'text-size-adjust' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-size-adjust' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-size-adjust' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-size-adjust' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-size-adjust' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-size-adjust' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-size-adjust' to a number: 0 throws TypeError
+PASS Setting 'text-size-adjust' to a number: -3.14 throws TypeError
+PASS Setting 'text-size-adjust' to a number: 3.14 throws TypeError
+PASS Setting 'text-size-adjust' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-size-adjust' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-size-adjust' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-size-adjust' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-transform-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-transform-expected.txt
@@ -9,12 +9,30 @@ PASS Can set 'text-transform' to the 'capitalize' keyword: capitalize
 PASS Can set 'text-transform' to the 'uppercase' keyword: uppercase
 PASS Can set 'text-transform' to the 'lowercase' keyword: lowercase
 FAIL Can set 'text-transform' to the 'full-width' keyword: full-width Invalid values
-PASS Setting 'text-transform' to a length throws TypeError
-PASS Setting 'text-transform' to a percent throws TypeError
-PASS Setting 'text-transform' to a time throws TypeError
-PASS Setting 'text-transform' to an angle throws TypeError
-PASS Setting 'text-transform' to a flexible length throws TypeError
-PASS Setting 'text-transform' to a number throws TypeError
-PASS Setting 'text-transform' to a URL throws TypeError
-PASS Setting 'text-transform' to a transform throws TypeError
+PASS Setting 'text-transform' to a length: 0px throws TypeError
+PASS Setting 'text-transform' to a length: -3.14em throws TypeError
+PASS Setting 'text-transform' to a length: 3.14cm throws TypeError
+PASS Setting 'text-transform' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-transform' to a percent: 0% throws TypeError
+PASS Setting 'text-transform' to a percent: -3.14% throws TypeError
+PASS Setting 'text-transform' to a percent: 3.14% throws TypeError
+PASS Setting 'text-transform' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-transform' to a time: 0s throws TypeError
+PASS Setting 'text-transform' to a time: -3.14ms throws TypeError
+PASS Setting 'text-transform' to a time: 3.14s throws TypeError
+PASS Setting 'text-transform' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-transform' to an angle: 0deg throws TypeError
+PASS Setting 'text-transform' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-transform' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-transform' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-transform' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-transform' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-transform' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-transform' to a number: 0 throws TypeError
+PASS Setting 'text-transform' to a number: -3.14 throws TypeError
+PASS Setting 'text-transform' to a number: 3.14 throws TypeError
+PASS Setting 'text-transform' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-transform' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-transform' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-transform' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt
@@ -13,10 +13,22 @@ FAIL Can set 'text-underline-offset' to a percent: 0% Invalid values
 FAIL Can set 'text-underline-offset' to a percent: -3.14% Invalid values
 FAIL Can set 'text-underline-offset' to a percent: 3.14% Invalid values
 FAIL Can set 'text-underline-offset' to a percent: calc(0% + 0%) Invalid values
-PASS Setting 'text-underline-offset' to a time throws TypeError
-PASS Setting 'text-underline-offset' to an angle throws TypeError
-PASS Setting 'text-underline-offset' to a flexible length throws TypeError
-FAIL Setting 'text-underline-offset' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'text-underline-offset' to a URL throws TypeError
-PASS Setting 'text-underline-offset' to a transform throws TypeError
+PASS Setting 'text-underline-offset' to a time: 0s throws TypeError
+PASS Setting 'text-underline-offset' to a time: -3.14ms throws TypeError
+PASS Setting 'text-underline-offset' to a time: 3.14s throws TypeError
+PASS Setting 'text-underline-offset' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-underline-offset' to an angle: 0deg throws TypeError
+PASS Setting 'text-underline-offset' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-underline-offset' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-underline-offset' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-underline-offset' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-underline-offset' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-underline-offset' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'text-underline-offset' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'text-underline-offset' to a number: -3.14 throws TypeError
+PASS Setting 'text-underline-offset' to a number: 3.14 throws TypeError
+PASS Setting 'text-underline-offset' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-underline-offset' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-underline-offset' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-underline-offset' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-position-expected.txt
@@ -8,14 +8,32 @@ PASS Can set 'text-underline-position' to the 'auto' keyword: auto
 PASS Can set 'text-underline-position' to the 'under' keyword: under
 FAIL Can set 'text-underline-position' to the 'left' keyword: left Invalid values
 FAIL Can set 'text-underline-position' to the 'right' keyword: right Invalid values
-PASS Setting 'text-underline-position' to a length throws TypeError
-PASS Setting 'text-underline-position' to a percent throws TypeError
-PASS Setting 'text-underline-position' to a time throws TypeError
-PASS Setting 'text-underline-position' to an angle throws TypeError
-PASS Setting 'text-underline-position' to a flexible length throws TypeError
-PASS Setting 'text-underline-position' to a number throws TypeError
-PASS Setting 'text-underline-position' to a URL throws TypeError
-PASS Setting 'text-underline-position' to a transform throws TypeError
-FAIL 'text-underline-position' does not supported 'under left' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'text-underline-position' does not supported 'right under' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS Setting 'text-underline-position' to a length: 0px throws TypeError
+PASS Setting 'text-underline-position' to a length: -3.14em throws TypeError
+PASS Setting 'text-underline-position' to a length: 3.14cm throws TypeError
+PASS Setting 'text-underline-position' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-underline-position' to a percent: 0% throws TypeError
+PASS Setting 'text-underline-position' to a percent: -3.14% throws TypeError
+PASS Setting 'text-underline-position' to a percent: 3.14% throws TypeError
+PASS Setting 'text-underline-position' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-underline-position' to a time: 0s throws TypeError
+PASS Setting 'text-underline-position' to a time: -3.14ms throws TypeError
+PASS Setting 'text-underline-position' to a time: 3.14s throws TypeError
+PASS Setting 'text-underline-position' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-underline-position' to an angle: 0deg throws TypeError
+PASS Setting 'text-underline-position' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-underline-position' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-underline-position' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-underline-position' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-underline-position' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-underline-position' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-underline-position' to a number: 0 throws TypeError
+PASS Setting 'text-underline-position' to a number: -3.14 throws TypeError
+PASS Setting 'text-underline-position' to a number: 3.14 throws TypeError
+PASS Setting 'text-underline-position' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-underline-position' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-underline-position' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-underline-position' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'text-underline-position' does not support 'under left' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'text-underline-position' does not support 'right under' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/top-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/top-expected.txt
@@ -13,10 +13,22 @@ PASS Can set 'top' to a length: 0px
 PASS Can set 'top' to a length: -3.14em
 PASS Can set 'top' to a length: 3.14cm
 PASS Can set 'top' to a length: calc(0px + 0em)
-PASS Setting 'top' to a time throws TypeError
-PASS Setting 'top' to an angle throws TypeError
-PASS Setting 'top' to a flexible length throws TypeError
-FAIL Setting 'top' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'top' to a URL throws TypeError
-PASS Setting 'top' to a transform throws TypeError
+PASS Setting 'top' to a time: 0s throws TypeError
+PASS Setting 'top' to a time: -3.14ms throws TypeError
+PASS Setting 'top' to a time: 3.14s throws TypeError
+PASS Setting 'top' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'top' to an angle: 0deg throws TypeError
+PASS Setting 'top' to an angle: 3.14rad throws TypeError
+PASS Setting 'top' to an angle: -3.14deg throws TypeError
+PASS Setting 'top' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'top' to a flexible length: 0fr throws TypeError
+PASS Setting 'top' to a flexible length: 1fr throws TypeError
+PASS Setting 'top' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'top' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'top' to a number: -3.14 throws TypeError
+PASS Setting 'top' to a number: 3.14 throws TypeError
+PASS Setting 'top' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'top' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'top' to a transform: perspective(10em) throws TypeError
+PASS Setting 'top' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/touch-action-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/touch-action-expected.txt
@@ -14,14 +14,32 @@ FAIL Can set 'touch-action' to the 'pan-up' keyword: pan-up Invalid values
 FAIL Can set 'touch-action' to the 'pan-down' keyword: pan-down Invalid values
 PASS Can set 'touch-action' to the 'pinch-zoom' keyword: pinch-zoom
 PASS Can set 'touch-action' to the 'manipulation' keyword: manipulation
-PASS Setting 'touch-action' to a length throws TypeError
-PASS Setting 'touch-action' to a percent throws TypeError
-PASS Setting 'touch-action' to a time throws TypeError
-PASS Setting 'touch-action' to an angle throws TypeError
-PASS Setting 'touch-action' to a flexible length throws TypeError
-PASS Setting 'touch-action' to a number throws TypeError
-PASS Setting 'touch-action' to a URL throws TypeError
-PASS Setting 'touch-action' to a transform throws TypeError
-FAIL 'touch-action' does not supported 'pan-x pan-down' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'touch-action' does not supported 'pan-down pinch-zoom pan-right' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS Setting 'touch-action' to a length: 0px throws TypeError
+PASS Setting 'touch-action' to a length: -3.14em throws TypeError
+PASS Setting 'touch-action' to a length: 3.14cm throws TypeError
+PASS Setting 'touch-action' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'touch-action' to a percent: 0% throws TypeError
+PASS Setting 'touch-action' to a percent: -3.14% throws TypeError
+PASS Setting 'touch-action' to a percent: 3.14% throws TypeError
+PASS Setting 'touch-action' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'touch-action' to a time: 0s throws TypeError
+PASS Setting 'touch-action' to a time: -3.14ms throws TypeError
+PASS Setting 'touch-action' to a time: 3.14s throws TypeError
+PASS Setting 'touch-action' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'touch-action' to an angle: 0deg throws TypeError
+PASS Setting 'touch-action' to an angle: 3.14rad throws TypeError
+PASS Setting 'touch-action' to an angle: -3.14deg throws TypeError
+PASS Setting 'touch-action' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'touch-action' to a flexible length: 0fr throws TypeError
+PASS Setting 'touch-action' to a flexible length: 1fr throws TypeError
+PASS Setting 'touch-action' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'touch-action' to a number: 0 throws TypeError
+PASS Setting 'touch-action' to a number: -3.14 throws TypeError
+PASS Setting 'touch-action' to a number: 3.14 throws TypeError
+PASS Setting 'touch-action' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'touch-action' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'touch-action' to a transform: perspective(10em) throws TypeError
+PASS Setting 'touch-action' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'touch-action' does not support 'pan-x pan-down' assert_not_equals: Unsupported value must not be null got disallowed value null
+FAIL 'touch-action' does not support 'pan-down pinch-zoom pan-right' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-box-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-box-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'transform-box' to var() references:  var(--A)
 PASS Can set 'transform-box' to the 'border-box' keyword: border-box
 PASS Can set 'transform-box' to the 'fill-box' keyword: fill-box
 PASS Can set 'transform-box' to the 'view-box' keyword: view-box
-PASS Setting 'transform-box' to a length throws TypeError
-PASS Setting 'transform-box' to a percent throws TypeError
-PASS Setting 'transform-box' to a time throws TypeError
-PASS Setting 'transform-box' to an angle throws TypeError
-PASS Setting 'transform-box' to a flexible length throws TypeError
-PASS Setting 'transform-box' to a number throws TypeError
-PASS Setting 'transform-box' to a URL throws TypeError
-PASS Setting 'transform-box' to a transform throws TypeError
+PASS Setting 'transform-box' to a length: 0px throws TypeError
+PASS Setting 'transform-box' to a length: -3.14em throws TypeError
+PASS Setting 'transform-box' to a length: 3.14cm throws TypeError
+PASS Setting 'transform-box' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'transform-box' to a percent: 0% throws TypeError
+PASS Setting 'transform-box' to a percent: -3.14% throws TypeError
+PASS Setting 'transform-box' to a percent: 3.14% throws TypeError
+PASS Setting 'transform-box' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'transform-box' to a time: 0s throws TypeError
+PASS Setting 'transform-box' to a time: -3.14ms throws TypeError
+PASS Setting 'transform-box' to a time: 3.14s throws TypeError
+PASS Setting 'transform-box' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'transform-box' to an angle: 0deg throws TypeError
+PASS Setting 'transform-box' to an angle: 3.14rad throws TypeError
+PASS Setting 'transform-box' to an angle: -3.14deg throws TypeError
+PASS Setting 'transform-box' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'transform-box' to a flexible length: 0fr throws TypeError
+PASS Setting 'transform-box' to a flexible length: 1fr throws TypeError
+PASS Setting 'transform-box' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'transform-box' to a number: 0 throws TypeError
+PASS Setting 'transform-box' to a number: -3.14 throws TypeError
+PASS Setting 'transform-box' to a number: 3.14 throws TypeError
+PASS Setting 'transform-box' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'transform-box' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'transform-box' to a transform: perspective(10em) throws TypeError
+PASS Setting 'transform-box' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-expected.txt
@@ -8,11 +8,27 @@ PASS Can set 'transform' to the 'none' keyword: none
 PASS Can set 'transform' to a transform: translate(50%, 50%)
 PASS Can set 'transform' to a transform: perspective(10em)
 FAIL Can set 'transform' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) assert_equals: expected "CSSSkewY" but got "CSSSkewX"
-PASS Setting 'transform' to a length throws TypeError
-PASS Setting 'transform' to a percent throws TypeError
-PASS Setting 'transform' to a time throws TypeError
-PASS Setting 'transform' to an angle throws TypeError
-PASS Setting 'transform' to a flexible length throws TypeError
-PASS Setting 'transform' to a number throws TypeError
-PASS Setting 'transform' to a URL throws TypeError
+PASS Setting 'transform' to a length: 0px throws TypeError
+PASS Setting 'transform' to a length: -3.14em throws TypeError
+PASS Setting 'transform' to a length: 3.14cm throws TypeError
+PASS Setting 'transform' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'transform' to a percent: 0% throws TypeError
+PASS Setting 'transform' to a percent: -3.14% throws TypeError
+PASS Setting 'transform' to a percent: 3.14% throws TypeError
+PASS Setting 'transform' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'transform' to a time: 0s throws TypeError
+PASS Setting 'transform' to a time: -3.14ms throws TypeError
+PASS Setting 'transform' to a time: 3.14s throws TypeError
+PASS Setting 'transform' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'transform' to an angle: 0deg throws TypeError
+PASS Setting 'transform' to an angle: 3.14rad throws TypeError
+PASS Setting 'transform' to an angle: -3.14deg throws TypeError
+PASS Setting 'transform' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'transform' to a flexible length: 0fr throws TypeError
+PASS Setting 'transform' to a flexible length: 1fr throws TypeError
+PASS Setting 'transform' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'transform' to a number: 0 throws TypeError
+PASS Setting 'transform' to a number: -3.14 throws TypeError
+PASS Setting 'transform' to a number: 3.14 throws TypeError
+PASS Setting 'transform' to a number: calc(2 + 3) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-style-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'transform-style' to var() references:  var(--A)
 FAIL Can set 'transform-style' to the 'auto' keyword: auto Invalid values
 PASS Can set 'transform-style' to the 'flat' keyword: flat
 PASS Can set 'transform-style' to the 'preserve-3d' keyword: preserve-3d
-PASS Setting 'transform-style' to a length throws TypeError
-PASS Setting 'transform-style' to a percent throws TypeError
-PASS Setting 'transform-style' to a time throws TypeError
-PASS Setting 'transform-style' to an angle throws TypeError
-PASS Setting 'transform-style' to a flexible length throws TypeError
-PASS Setting 'transform-style' to a number throws TypeError
-PASS Setting 'transform-style' to a URL throws TypeError
-PASS Setting 'transform-style' to a transform throws TypeError
+PASS Setting 'transform-style' to a length: 0px throws TypeError
+PASS Setting 'transform-style' to a length: -3.14em throws TypeError
+PASS Setting 'transform-style' to a length: 3.14cm throws TypeError
+PASS Setting 'transform-style' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'transform-style' to a percent: 0% throws TypeError
+PASS Setting 'transform-style' to a percent: -3.14% throws TypeError
+PASS Setting 'transform-style' to a percent: 3.14% throws TypeError
+PASS Setting 'transform-style' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'transform-style' to a time: 0s throws TypeError
+PASS Setting 'transform-style' to a time: -3.14ms throws TypeError
+PASS Setting 'transform-style' to a time: 3.14s throws TypeError
+PASS Setting 'transform-style' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'transform-style' to an angle: 0deg throws TypeError
+PASS Setting 'transform-style' to an angle: 3.14rad throws TypeError
+PASS Setting 'transform-style' to an angle: -3.14deg throws TypeError
+PASS Setting 'transform-style' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'transform-style' to a flexible length: 0fr throws TypeError
+PASS Setting 'transform-style' to a flexible length: 1fr throws TypeError
+PASS Setting 'transform-style' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'transform-style' to a number: 0 throws TypeError
+PASS Setting 'transform-style' to a number: -3.14 throws TypeError
+PASS Setting 'transform-style' to a number: 3.14 throws TypeError
+PASS Setting 'transform-style' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'transform-style' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'transform-style' to a transform: perspective(10em) throws TypeError
+PASS Setting 'transform-style' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-delay-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-delay-expected.txt
@@ -8,11 +8,26 @@ PASS Can set 'transition-delay' to a time: 0s
 PASS Can set 'transition-delay' to a time: -3.14ms
 PASS Can set 'transition-delay' to a time: 3.14s
 PASS Can set 'transition-delay' to a time: calc(0s + 0ms)
-PASS Setting 'transition-delay' to a length throws TypeError
-PASS Setting 'transition-delay' to a percent throws TypeError
-PASS Setting 'transition-delay' to an angle throws TypeError
-PASS Setting 'transition-delay' to a flexible length throws TypeError
-PASS Setting 'transition-delay' to a number throws TypeError
-PASS Setting 'transition-delay' to a URL throws TypeError
-PASS Setting 'transition-delay' to a transform throws TypeError
+PASS Setting 'transition-delay' to a length: 0px throws TypeError
+PASS Setting 'transition-delay' to a length: -3.14em throws TypeError
+PASS Setting 'transition-delay' to a length: 3.14cm throws TypeError
+PASS Setting 'transition-delay' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'transition-delay' to a percent: 0% throws TypeError
+PASS Setting 'transition-delay' to a percent: -3.14% throws TypeError
+PASS Setting 'transition-delay' to a percent: 3.14% throws TypeError
+PASS Setting 'transition-delay' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'transition-delay' to an angle: 0deg throws TypeError
+PASS Setting 'transition-delay' to an angle: 3.14rad throws TypeError
+PASS Setting 'transition-delay' to an angle: -3.14deg throws TypeError
+PASS Setting 'transition-delay' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'transition-delay' to a flexible length: 0fr throws TypeError
+PASS Setting 'transition-delay' to a flexible length: 1fr throws TypeError
+PASS Setting 'transition-delay' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'transition-delay' to a number: 0 throws TypeError
+PASS Setting 'transition-delay' to a number: -3.14 throws TypeError
+PASS Setting 'transition-delay' to a number: 3.14 throws TypeError
+PASS Setting 'transition-delay' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'transition-delay' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'transition-delay' to a transform: perspective(10em) throws TypeError
+PASS Setting 'transition-delay' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration-expected.txt
@@ -8,11 +8,26 @@ PASS Can set 'transition-duration' to a time: 0s
 FAIL Can set 'transition-duration' to a time: -3.14ms Invalid values
 PASS Can set 'transition-duration' to a time: 3.14s
 PASS Can set 'transition-duration' to a time: calc(0s + 0ms)
-PASS Setting 'transition-duration' to a length throws TypeError
-PASS Setting 'transition-duration' to a percent throws TypeError
-PASS Setting 'transition-duration' to an angle throws TypeError
-PASS Setting 'transition-duration' to a flexible length throws TypeError
-PASS Setting 'transition-duration' to a number throws TypeError
-PASS Setting 'transition-duration' to a URL throws TypeError
-PASS Setting 'transition-duration' to a transform throws TypeError
+PASS Setting 'transition-duration' to a length: 0px throws TypeError
+PASS Setting 'transition-duration' to a length: -3.14em throws TypeError
+PASS Setting 'transition-duration' to a length: 3.14cm throws TypeError
+PASS Setting 'transition-duration' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'transition-duration' to a percent: 0% throws TypeError
+PASS Setting 'transition-duration' to a percent: -3.14% throws TypeError
+PASS Setting 'transition-duration' to a percent: 3.14% throws TypeError
+PASS Setting 'transition-duration' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'transition-duration' to an angle: 0deg throws TypeError
+PASS Setting 'transition-duration' to an angle: 3.14rad throws TypeError
+PASS Setting 'transition-duration' to an angle: -3.14deg throws TypeError
+PASS Setting 'transition-duration' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'transition-duration' to a flexible length: 0fr throws TypeError
+PASS Setting 'transition-duration' to a flexible length: 1fr throws TypeError
+PASS Setting 'transition-duration' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'transition-duration' to a number: 0 throws TypeError
+PASS Setting 'transition-duration' to a number: -3.14 throws TypeError
+PASS Setting 'transition-duration' to a number: 3.14 throws TypeError
+PASS Setting 'transition-duration' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'transition-duration' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'transition-duration' to a transform: perspective(10em) throws TypeError
+PASS Setting 'transition-duration' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-expected.txt
@@ -1,6 +1,6 @@
 
-PASS 'transition' does not supported 'none'
-FAIL 'transition' does not supported 'none, none' assert_not_equals: Unsupported value must not be null got disallowed value null
-PASS 'transition' does not supported 'margin-right 4s'
-PASS 'transition' does not supported 'all 0.5s ease-out, color 1s'
+PASS 'transition' does not support 'none'
+FAIL 'transition' does not support 'none, none' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS 'transition' does not support 'margin-right 4s'
+PASS 'transition' does not support 'all 0.5s ease-out, color 1s'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-property-expected.txt
@@ -5,15 +5,33 @@ PASS Can set 'transition-property' to CSS-wide keywords: unset
 PASS Can set 'transition-property' to CSS-wide keywords: revert
 PASS Can set 'transition-property' to var() references:  var(--A)
 PASS Can set 'transition-property' to the 'none' keyword: none
-PASS Setting 'transition-property' to a length throws TypeError
-PASS Setting 'transition-property' to a percent throws TypeError
-PASS Setting 'transition-property' to a time throws TypeError
-PASS Setting 'transition-property' to an angle throws TypeError
-PASS Setting 'transition-property' to a flexible length throws TypeError
-PASS Setting 'transition-property' to a number throws TypeError
-PASS Setting 'transition-property' to a URL throws TypeError
-PASS Setting 'transition-property' to a transform throws TypeError
-FAIL 'transition-property' does not supported 'width' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'transition-property' does not supported 'width, height' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'transition-property' does not supported 'all' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'transition-property' to a length: 0px throws TypeError
+PASS Setting 'transition-property' to a length: -3.14em throws TypeError
+PASS Setting 'transition-property' to a length: 3.14cm throws TypeError
+PASS Setting 'transition-property' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'transition-property' to a percent: 0% throws TypeError
+PASS Setting 'transition-property' to a percent: -3.14% throws TypeError
+PASS Setting 'transition-property' to a percent: 3.14% throws TypeError
+PASS Setting 'transition-property' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'transition-property' to a time: 0s throws TypeError
+PASS Setting 'transition-property' to a time: -3.14ms throws TypeError
+PASS Setting 'transition-property' to a time: 3.14s throws TypeError
+PASS Setting 'transition-property' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'transition-property' to an angle: 0deg throws TypeError
+PASS Setting 'transition-property' to an angle: 3.14rad throws TypeError
+PASS Setting 'transition-property' to an angle: -3.14deg throws TypeError
+PASS Setting 'transition-property' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'transition-property' to a flexible length: 0fr throws TypeError
+PASS Setting 'transition-property' to a flexible length: 1fr throws TypeError
+PASS Setting 'transition-property' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'transition-property' to a number: 0 throws TypeError
+PASS Setting 'transition-property' to a number: -3.14 throws TypeError
+PASS Setting 'transition-property' to a number: 3.14 throws TypeError
+PASS Setting 'transition-property' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'transition-property' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'transition-property' to a transform: perspective(10em) throws TypeError
+PASS Setting 'transition-property' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'transition-property' does not support 'width' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'transition-property' does not support 'width, height' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'transition-property' does not support 'all' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-timing-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-timing-function-expected.txt
@@ -11,14 +11,32 @@ PASS Can set 'transition-timing-function' to the 'ease-out' keyword: ease-out
 PASS Can set 'transition-timing-function' to the 'ease-in-out' keyword: ease-in-out
 PASS Can set 'transition-timing-function' to the 'step-start' keyword: step-start
 PASS Can set 'transition-timing-function' to the 'step-end' keyword: step-end
-PASS Setting 'transition-timing-function' to a length throws TypeError
-PASS Setting 'transition-timing-function' to a percent throws TypeError
-PASS Setting 'transition-timing-function' to a time throws TypeError
-PASS Setting 'transition-timing-function' to an angle throws TypeError
-PASS Setting 'transition-timing-function' to a flexible length throws TypeError
-PASS Setting 'transition-timing-function' to a number throws TypeError
-PASS Setting 'transition-timing-function' to a URL throws TypeError
-PASS Setting 'transition-timing-function' to a transform throws TypeError
-PASS 'transition-timing-function' does not supported 'cubic-bezier(0.1, 0.7, 1.0, 0.1)'
-PASS 'transition-timing-function' does not supported 'steps(4, end)'
+PASS Setting 'transition-timing-function' to a length: 0px throws TypeError
+PASS Setting 'transition-timing-function' to a length: -3.14em throws TypeError
+PASS Setting 'transition-timing-function' to a length: 3.14cm throws TypeError
+PASS Setting 'transition-timing-function' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'transition-timing-function' to a percent: 0% throws TypeError
+PASS Setting 'transition-timing-function' to a percent: -3.14% throws TypeError
+PASS Setting 'transition-timing-function' to a percent: 3.14% throws TypeError
+PASS Setting 'transition-timing-function' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'transition-timing-function' to a time: 0s throws TypeError
+PASS Setting 'transition-timing-function' to a time: -3.14ms throws TypeError
+PASS Setting 'transition-timing-function' to a time: 3.14s throws TypeError
+PASS Setting 'transition-timing-function' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'transition-timing-function' to an angle: 0deg throws TypeError
+PASS Setting 'transition-timing-function' to an angle: 3.14rad throws TypeError
+PASS Setting 'transition-timing-function' to an angle: -3.14deg throws TypeError
+PASS Setting 'transition-timing-function' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'transition-timing-function' to a flexible length: 0fr throws TypeError
+PASS Setting 'transition-timing-function' to a flexible length: 1fr throws TypeError
+PASS Setting 'transition-timing-function' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'transition-timing-function' to a number: 0 throws TypeError
+PASS Setting 'transition-timing-function' to a number: -3.14 throws TypeError
+PASS Setting 'transition-timing-function' to a number: 3.14 throws TypeError
+PASS Setting 'transition-timing-function' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'transition-timing-function' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'transition-timing-function' to a transform: perspective(10em) throws TypeError
+PASS Setting 'transition-timing-function' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS 'transition-timing-function' does not support 'cubic-bezier(0.1, 0.7, 1.0, 0.1)'
+PASS 'transition-timing-function' does not support 'steps(4, end)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/unicode-bidi-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/unicode-bidi-expected.txt
@@ -10,12 +10,30 @@ PASS Can set 'unicode-bidi' to the 'isolate' keyword: isolate
 PASS Can set 'unicode-bidi' to the 'bidi-override' keyword: bidi-override
 PASS Can set 'unicode-bidi' to the 'isolate-override' keyword: isolate-override
 PASS Can set 'unicode-bidi' to the 'plaintext' keyword: plaintext
-PASS Setting 'unicode-bidi' to a length throws TypeError
-PASS Setting 'unicode-bidi' to a percent throws TypeError
-PASS Setting 'unicode-bidi' to a time throws TypeError
-PASS Setting 'unicode-bidi' to an angle throws TypeError
-PASS Setting 'unicode-bidi' to a flexible length throws TypeError
-PASS Setting 'unicode-bidi' to a number throws TypeError
-PASS Setting 'unicode-bidi' to a URL throws TypeError
-PASS Setting 'unicode-bidi' to a transform throws TypeError
+PASS Setting 'unicode-bidi' to a length: 0px throws TypeError
+PASS Setting 'unicode-bidi' to a length: -3.14em throws TypeError
+PASS Setting 'unicode-bidi' to a length: 3.14cm throws TypeError
+PASS Setting 'unicode-bidi' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'unicode-bidi' to a percent: 0% throws TypeError
+PASS Setting 'unicode-bidi' to a percent: -3.14% throws TypeError
+PASS Setting 'unicode-bidi' to a percent: 3.14% throws TypeError
+PASS Setting 'unicode-bidi' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'unicode-bidi' to a time: 0s throws TypeError
+PASS Setting 'unicode-bidi' to a time: -3.14ms throws TypeError
+PASS Setting 'unicode-bidi' to a time: 3.14s throws TypeError
+PASS Setting 'unicode-bidi' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'unicode-bidi' to an angle: 0deg throws TypeError
+PASS Setting 'unicode-bidi' to an angle: 3.14rad throws TypeError
+PASS Setting 'unicode-bidi' to an angle: -3.14deg throws TypeError
+PASS Setting 'unicode-bidi' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'unicode-bidi' to a flexible length: 0fr throws TypeError
+PASS Setting 'unicode-bidi' to a flexible length: 1fr throws TypeError
+PASS Setting 'unicode-bidi' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'unicode-bidi' to a number: 0 throws TypeError
+PASS Setting 'unicode-bidi' to a number: -3.14 throws TypeError
+PASS Setting 'unicode-bidi' to a number: 3.14 throws TypeError
+PASS Setting 'unicode-bidi' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'unicode-bidi' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'unicode-bidi' to a transform: perspective(10em) throws TypeError
+PASS Setting 'unicode-bidi' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select-expected.txt
@@ -9,12 +9,30 @@ FAIL Can set 'user-select' to the 'text' keyword: text Invalid property user-sel
 FAIL Can set 'user-select' to the 'none' keyword: none Invalid property user-select
 FAIL Can set 'user-select' to the 'contain' keyword: contain Invalid property user-select
 FAIL Can set 'user-select' to the 'all' keyword: all Invalid property user-select
-PASS Setting 'user-select' to a length throws TypeError
-PASS Setting 'user-select' to a percent throws TypeError
-PASS Setting 'user-select' to a time throws TypeError
-PASS Setting 'user-select' to an angle throws TypeError
-PASS Setting 'user-select' to a flexible length throws TypeError
-PASS Setting 'user-select' to a number throws TypeError
-PASS Setting 'user-select' to a URL throws TypeError
-PASS Setting 'user-select' to a transform throws TypeError
+PASS Setting 'user-select' to a length: 0px throws TypeError
+PASS Setting 'user-select' to a length: -3.14em throws TypeError
+PASS Setting 'user-select' to a length: 3.14cm throws TypeError
+PASS Setting 'user-select' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'user-select' to a percent: 0% throws TypeError
+PASS Setting 'user-select' to a percent: -3.14% throws TypeError
+PASS Setting 'user-select' to a percent: 3.14% throws TypeError
+PASS Setting 'user-select' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'user-select' to a time: 0s throws TypeError
+PASS Setting 'user-select' to a time: -3.14ms throws TypeError
+PASS Setting 'user-select' to a time: 3.14s throws TypeError
+PASS Setting 'user-select' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'user-select' to an angle: 0deg throws TypeError
+PASS Setting 'user-select' to an angle: 3.14rad throws TypeError
+PASS Setting 'user-select' to an angle: -3.14deg throws TypeError
+PASS Setting 'user-select' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'user-select' to a flexible length: 0fr throws TypeError
+PASS Setting 'user-select' to a flexible length: 1fr throws TypeError
+PASS Setting 'user-select' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'user-select' to a number: 0 throws TypeError
+PASS Setting 'user-select' to a number: -3.14 throws TypeError
+PASS Setting 'user-select' to a number: 3.14 throws TypeError
+PASS Setting 'user-select' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'user-select' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'user-select' to a transform: perspective(10em) throws TypeError
+PASS Setting 'user-select' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vector-effect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vector-effect-expected.txt
@@ -6,12 +6,30 @@ PASS Can set 'vector-effect' to CSS-wide keywords: revert
 PASS Can set 'vector-effect' to var() references:  var(--A)
 PASS Can set 'vector-effect' to the 'non-scaling-stroke' keyword: non-scaling-stroke
 PASS Can set 'vector-effect' to the 'none' keyword: none
-PASS Setting 'vector-effect' to a length throws TypeError
-PASS Setting 'vector-effect' to a percent throws TypeError
-PASS Setting 'vector-effect' to a time throws TypeError
-PASS Setting 'vector-effect' to an angle throws TypeError
-PASS Setting 'vector-effect' to a flexible length throws TypeError
-PASS Setting 'vector-effect' to a number throws TypeError
-PASS Setting 'vector-effect' to a URL throws TypeError
-PASS Setting 'vector-effect' to a transform throws TypeError
+PASS Setting 'vector-effect' to a length: 0px throws TypeError
+PASS Setting 'vector-effect' to a length: -3.14em throws TypeError
+PASS Setting 'vector-effect' to a length: 3.14cm throws TypeError
+PASS Setting 'vector-effect' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'vector-effect' to a percent: 0% throws TypeError
+PASS Setting 'vector-effect' to a percent: -3.14% throws TypeError
+PASS Setting 'vector-effect' to a percent: 3.14% throws TypeError
+PASS Setting 'vector-effect' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'vector-effect' to a time: 0s throws TypeError
+PASS Setting 'vector-effect' to a time: -3.14ms throws TypeError
+PASS Setting 'vector-effect' to a time: 3.14s throws TypeError
+PASS Setting 'vector-effect' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'vector-effect' to an angle: 0deg throws TypeError
+PASS Setting 'vector-effect' to an angle: 3.14rad throws TypeError
+PASS Setting 'vector-effect' to an angle: -3.14deg throws TypeError
+PASS Setting 'vector-effect' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'vector-effect' to a flexible length: 0fr throws TypeError
+PASS Setting 'vector-effect' to a flexible length: 1fr throws TypeError
+PASS Setting 'vector-effect' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'vector-effect' to a number: 0 throws TypeError
+PASS Setting 'vector-effect' to a number: -3.14 throws TypeError
+PASS Setting 'vector-effect' to a number: 3.14 throws TypeError
+PASS Setting 'vector-effect' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'vector-effect' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'vector-effect' to a transform: perspective(10em) throws TypeError
+PASS Setting 'vector-effect' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vertical-align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vertical-align-expected.txt
@@ -13,10 +13,22 @@ PASS Can set 'vertical-align' to a percent: 0%
 PASS Can set 'vertical-align' to a percent: -3.14%
 PASS Can set 'vertical-align' to a percent: 3.14%
 PASS Can set 'vertical-align' to a percent: calc(0% + 0%)
-PASS Setting 'vertical-align' to a time throws TypeError
-PASS Setting 'vertical-align' to an angle throws TypeError
-PASS Setting 'vertical-align' to a flexible length throws TypeError
-FAIL Setting 'vertical-align' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'vertical-align' to a URL throws TypeError
-PASS Setting 'vertical-align' to a transform throws TypeError
+PASS Setting 'vertical-align' to a time: 0s throws TypeError
+PASS Setting 'vertical-align' to a time: -3.14ms throws TypeError
+PASS Setting 'vertical-align' to a time: 3.14s throws TypeError
+PASS Setting 'vertical-align' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'vertical-align' to an angle: 0deg throws TypeError
+PASS Setting 'vertical-align' to an angle: 3.14rad throws TypeError
+PASS Setting 'vertical-align' to an angle: -3.14deg throws TypeError
+PASS Setting 'vertical-align' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'vertical-align' to a flexible length: 0fr throws TypeError
+PASS Setting 'vertical-align' to a flexible length: 1fr throws TypeError
+PASS Setting 'vertical-align' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'vertical-align' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'vertical-align' to a number: -3.14 throws TypeError
+PASS Setting 'vertical-align' to a number: 3.14 throws TypeError
+PASS Setting 'vertical-align' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'vertical-align' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'vertical-align' to a transform: perspective(10em) throws TypeError
+PASS Setting 'vertical-align' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/visibility-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/visibility-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'visibility' to var() references:  var(--A)
 PASS Can set 'visibility' to the 'visible' keyword: visible
 PASS Can set 'visibility' to the 'hidden' keyword: hidden
 PASS Can set 'visibility' to the 'collapse' keyword: collapse
-PASS Setting 'visibility' to a length throws TypeError
-PASS Setting 'visibility' to a percent throws TypeError
-PASS Setting 'visibility' to a time throws TypeError
-PASS Setting 'visibility' to an angle throws TypeError
-PASS Setting 'visibility' to a flexible length throws TypeError
-PASS Setting 'visibility' to a number throws TypeError
-PASS Setting 'visibility' to a URL throws TypeError
-PASS Setting 'visibility' to a transform throws TypeError
+PASS Setting 'visibility' to a length: 0px throws TypeError
+PASS Setting 'visibility' to a length: -3.14em throws TypeError
+PASS Setting 'visibility' to a length: 3.14cm throws TypeError
+PASS Setting 'visibility' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'visibility' to a percent: 0% throws TypeError
+PASS Setting 'visibility' to a percent: -3.14% throws TypeError
+PASS Setting 'visibility' to a percent: 3.14% throws TypeError
+PASS Setting 'visibility' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'visibility' to a time: 0s throws TypeError
+PASS Setting 'visibility' to a time: -3.14ms throws TypeError
+PASS Setting 'visibility' to a time: 3.14s throws TypeError
+PASS Setting 'visibility' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'visibility' to an angle: 0deg throws TypeError
+PASS Setting 'visibility' to an angle: 3.14rad throws TypeError
+PASS Setting 'visibility' to an angle: -3.14deg throws TypeError
+PASS Setting 'visibility' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'visibility' to a flexible length: 0fr throws TypeError
+PASS Setting 'visibility' to a flexible length: 1fr throws TypeError
+PASS Setting 'visibility' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'visibility' to a number: 0 throws TypeError
+PASS Setting 'visibility' to a number: -3.14 throws TypeError
+PASS Setting 'visibility' to a number: 3.14 throws TypeError
+PASS Setting 'visibility' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'visibility' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'visibility' to a transform: perspective(10em) throws TypeError
+PASS Setting 'visibility' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt
@@ -9,12 +9,30 @@ PASS Can set 'white-space' to the 'pre' keyword: pre
 PASS Can set 'white-space' to the 'nowrap' keyword: nowrap
 PASS Can set 'white-space' to the 'pre-wrap' keyword: pre-wrap
 PASS Can set 'white-space' to the 'pre-line' keyword: pre-line
-PASS Setting 'white-space' to a length throws TypeError
-PASS Setting 'white-space' to a percent throws TypeError
-PASS Setting 'white-space' to a time throws TypeError
-PASS Setting 'white-space' to an angle throws TypeError
-PASS Setting 'white-space' to a flexible length throws TypeError
-PASS Setting 'white-space' to a number throws TypeError
-PASS Setting 'white-space' to a URL throws TypeError
-PASS Setting 'white-space' to a transform throws TypeError
+PASS Setting 'white-space' to a length: 0px throws TypeError
+PASS Setting 'white-space' to a length: -3.14em throws TypeError
+PASS Setting 'white-space' to a length: 3.14cm throws TypeError
+PASS Setting 'white-space' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'white-space' to a percent: 0% throws TypeError
+PASS Setting 'white-space' to a percent: -3.14% throws TypeError
+PASS Setting 'white-space' to a percent: 3.14% throws TypeError
+PASS Setting 'white-space' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'white-space' to a time: 0s throws TypeError
+PASS Setting 'white-space' to a time: -3.14ms throws TypeError
+PASS Setting 'white-space' to a time: 3.14s throws TypeError
+PASS Setting 'white-space' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'white-space' to an angle: 0deg throws TypeError
+PASS Setting 'white-space' to an angle: 3.14rad throws TypeError
+PASS Setting 'white-space' to an angle: -3.14deg throws TypeError
+PASS Setting 'white-space' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'white-space' to a flexible length: 0fr throws TypeError
+PASS Setting 'white-space' to a flexible length: 1fr throws TypeError
+PASS Setting 'white-space' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'white-space' to a number: 0 throws TypeError
+PASS Setting 'white-space' to a number: -3.14 throws TypeError
+PASS Setting 'white-space' to a number: 3.14 throws TypeError
+PASS Setting 'white-space' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'white-space' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'white-space' to a transform: perspective(10em) throws TypeError
+PASS Setting 'white-space' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt
@@ -8,11 +8,26 @@ FAIL Can set 'widows' to a number: 0 assert_equals: expected "CSSUnitValue" but 
 FAIL Can set 'widows' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'widows' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'widows' to a number: calc(2 + 3) assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-PASS Setting 'widows' to a length throws TypeError
-PASS Setting 'widows' to a percent throws TypeError
-PASS Setting 'widows' to a time throws TypeError
-PASS Setting 'widows' to an angle throws TypeError
-PASS Setting 'widows' to a flexible length throws TypeError
-PASS Setting 'widows' to a URL throws TypeError
-PASS Setting 'widows' to a transform throws TypeError
+PASS Setting 'widows' to a length: 0px throws TypeError
+PASS Setting 'widows' to a length: -3.14em throws TypeError
+PASS Setting 'widows' to a length: 3.14cm throws TypeError
+PASS Setting 'widows' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'widows' to a percent: 0% throws TypeError
+PASS Setting 'widows' to a percent: -3.14% throws TypeError
+PASS Setting 'widows' to a percent: 3.14% throws TypeError
+PASS Setting 'widows' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'widows' to a time: 0s throws TypeError
+PASS Setting 'widows' to a time: -3.14ms throws TypeError
+PASS Setting 'widows' to a time: 3.14s throws TypeError
+PASS Setting 'widows' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'widows' to an angle: 0deg throws TypeError
+PASS Setting 'widows' to an angle: 3.14rad throws TypeError
+PASS Setting 'widows' to an angle: -3.14deg throws TypeError
+PASS Setting 'widows' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'widows' to a flexible length: 0fr throws TypeError
+PASS Setting 'widows' to a flexible length: 1fr throws TypeError
+PASS Setting 'widows' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'widows' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'widows' to a transform: perspective(10em) throws TypeError
+PASS Setting 'widows' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt
@@ -13,12 +13,24 @@ PASS Can set 'width' to a length: 0px
 PASS Can set 'width' to a length: -3.14em
 PASS Can set 'width' to a length: 3.14cm
 PASS Can set 'width' to a length: calc(0px + 0em)
-PASS Setting 'width' to a time throws TypeError
-PASS Setting 'width' to an angle throws TypeError
-PASS Setting 'width' to a flexible length throws TypeError
-FAIL Setting 'width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'width' to a URL throws TypeError
-PASS Setting 'width' to a transform throws TypeError
+PASS Setting 'width' to a time: 0s throws TypeError
+PASS Setting 'width' to a time: -3.14ms throws TypeError
+PASS Setting 'width' to a time: 3.14s throws TypeError
+PASS Setting 'width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'width' to an angle: 0deg throws TypeError
+PASS Setting 'width' to an angle: 3.14rad throws TypeError
+PASS Setting 'width' to an angle: -3.14deg throws TypeError
+PASS Setting 'width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'width' to a flexible length: 0fr throws TypeError
+PASS Setting 'width' to a flexible length: 1fr throws TypeError
+PASS Setting 'width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'width' to a number: -3.14 throws TypeError
+PASS Setting 'width' to a number: 3.14 throws TypeError
+PASS Setting 'width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'min-width' to CSS-wide keywords: initial
 PASS Can set 'min-width' to CSS-wide keywords: inherit
 PASS Can set 'min-width' to CSS-wide keywords: unset
@@ -32,12 +44,24 @@ PASS Can set 'min-width' to a length: 0px
 PASS Can set 'min-width' to a length: -3.14em
 PASS Can set 'min-width' to a length: 3.14cm
 PASS Can set 'min-width' to a length: calc(0px + 0em)
-PASS Setting 'min-width' to a time throws TypeError
-PASS Setting 'min-width' to an angle throws TypeError
-PASS Setting 'min-width' to a flexible length throws TypeError
-FAIL Setting 'min-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'min-width' to a URL throws TypeError
-PASS Setting 'min-width' to a transform throws TypeError
+PASS Setting 'min-width' to a time: 0s throws TypeError
+PASS Setting 'min-width' to a time: -3.14ms throws TypeError
+PASS Setting 'min-width' to a time: 3.14s throws TypeError
+PASS Setting 'min-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'min-width' to an angle: 0deg throws TypeError
+PASS Setting 'min-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'min-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'min-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'min-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'min-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'min-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'min-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'min-width' to a number: -3.14 throws TypeError
+PASS Setting 'min-width' to a number: 3.14 throws TypeError
+PASS Setting 'min-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'min-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'min-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'min-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'max-width' to CSS-wide keywords: initial
 PASS Can set 'max-width' to CSS-wide keywords: inherit
 PASS Can set 'max-width' to CSS-wide keywords: unset
@@ -52,10 +76,22 @@ PASS Can set 'max-width' to a length: 0px
 PASS Can set 'max-width' to a length: -3.14em
 PASS Can set 'max-width' to a length: 3.14cm
 PASS Can set 'max-width' to a length: calc(0px + 0em)
-PASS Setting 'max-width' to a time throws TypeError
-PASS Setting 'max-width' to an angle throws TypeError
-PASS Setting 'max-width' to a flexible length throws TypeError
-FAIL Setting 'max-width' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'max-width' to a URL throws TypeError
-PASS Setting 'max-width' to a transform throws TypeError
+PASS Setting 'max-width' to a time: 0s throws TypeError
+PASS Setting 'max-width' to a time: -3.14ms throws TypeError
+PASS Setting 'max-width' to a time: 3.14s throws TypeError
+PASS Setting 'max-width' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'max-width' to an angle: 0deg throws TypeError
+PASS Setting 'max-width' to an angle: 3.14rad throws TypeError
+PASS Setting 'max-width' to an angle: -3.14deg throws TypeError
+PASS Setting 'max-width' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'max-width' to a flexible length: 0fr throws TypeError
+PASS Setting 'max-width' to a flexible length: 1fr throws TypeError
+PASS Setting 'max-width' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'max-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'max-width' to a number: -3.14 throws TypeError
+PASS Setting 'max-width' to a number: 3.14 throws TypeError
+PASS Setting 'max-width' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'max-width' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'max-width' to a transform: perspective(10em) throws TypeError
+PASS Setting 'max-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt
@@ -5,14 +5,32 @@ PASS Can set 'will-change' to CSS-wide keywords: unset
 PASS Can set 'will-change' to CSS-wide keywords: revert
 PASS Can set 'will-change' to var() references:  var(--A)
 PASS Can set 'will-change' to the 'auto' keyword: auto
-PASS Setting 'will-change' to a length throws TypeError
-PASS Setting 'will-change' to a percent throws TypeError
-PASS Setting 'will-change' to a time throws TypeError
-PASS Setting 'will-change' to an angle throws TypeError
-PASS Setting 'will-change' to a flexible length throws TypeError
-PASS Setting 'will-change' to a number throws TypeError
-PASS Setting 'will-change' to a URL throws TypeError
-PASS Setting 'will-change' to a transform throws TypeError
-FAIL 'will-change' does not supported 'scroll-position' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'will-change' does not supported 'contents, foo, scroll-position' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS Setting 'will-change' to a length: 0px throws TypeError
+PASS Setting 'will-change' to a length: -3.14em throws TypeError
+PASS Setting 'will-change' to a length: 3.14cm throws TypeError
+PASS Setting 'will-change' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'will-change' to a percent: 0% throws TypeError
+PASS Setting 'will-change' to a percent: -3.14% throws TypeError
+PASS Setting 'will-change' to a percent: 3.14% throws TypeError
+PASS Setting 'will-change' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'will-change' to a time: 0s throws TypeError
+PASS Setting 'will-change' to a time: -3.14ms throws TypeError
+PASS Setting 'will-change' to a time: 3.14s throws TypeError
+PASS Setting 'will-change' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'will-change' to an angle: 0deg throws TypeError
+PASS Setting 'will-change' to an angle: 3.14rad throws TypeError
+PASS Setting 'will-change' to an angle: -3.14deg throws TypeError
+PASS Setting 'will-change' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'will-change' to a flexible length: 0fr throws TypeError
+PASS Setting 'will-change' to a flexible length: 1fr throws TypeError
+PASS Setting 'will-change' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'will-change' to a number: 0 throws TypeError
+PASS Setting 'will-change' to a number: -3.14 throws TypeError
+PASS Setting 'will-change' to a number: 3.14 throws TypeError
+PASS Setting 'will-change' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'will-change' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'will-change' to a transform: perspective(10em) throws TypeError
+PASS Setting 'will-change' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'will-change' does not support 'scroll-position' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'will-change' does not support 'contents, foo, scroll-position' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-break-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-break-expected.txt
@@ -7,12 +7,30 @@ PASS Can set 'word-break' to var() references:  var(--A)
 PASS Can set 'word-break' to the 'normal' keyword: normal
 PASS Can set 'word-break' to the 'keep-all' keyword: keep-all
 PASS Can set 'word-break' to the 'break-all' keyword: break-all
-PASS Setting 'word-break' to a length throws TypeError
-PASS Setting 'word-break' to a percent throws TypeError
-PASS Setting 'word-break' to a time throws TypeError
-PASS Setting 'word-break' to an angle throws TypeError
-PASS Setting 'word-break' to a flexible length throws TypeError
-PASS Setting 'word-break' to a number throws TypeError
-PASS Setting 'word-break' to a URL throws TypeError
-PASS Setting 'word-break' to a transform throws TypeError
+PASS Setting 'word-break' to a length: 0px throws TypeError
+PASS Setting 'word-break' to a length: -3.14em throws TypeError
+PASS Setting 'word-break' to a length: 3.14cm throws TypeError
+PASS Setting 'word-break' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'word-break' to a percent: 0% throws TypeError
+PASS Setting 'word-break' to a percent: -3.14% throws TypeError
+PASS Setting 'word-break' to a percent: 3.14% throws TypeError
+PASS Setting 'word-break' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'word-break' to a time: 0s throws TypeError
+PASS Setting 'word-break' to a time: -3.14ms throws TypeError
+PASS Setting 'word-break' to a time: 3.14s throws TypeError
+PASS Setting 'word-break' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'word-break' to an angle: 0deg throws TypeError
+PASS Setting 'word-break' to an angle: 3.14rad throws TypeError
+PASS Setting 'word-break' to an angle: -3.14deg throws TypeError
+PASS Setting 'word-break' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'word-break' to a flexible length: 0fr throws TypeError
+PASS Setting 'word-break' to a flexible length: 1fr throws TypeError
+PASS Setting 'word-break' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'word-break' to a number: 0 throws TypeError
+PASS Setting 'word-break' to a number: -3.14 throws TypeError
+PASS Setting 'word-break' to a number: 3.14 throws TypeError
+PASS Setting 'word-break' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'word-break' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'word-break' to a transform: perspective(10em) throws TypeError
+PASS Setting 'word-break' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-spacing-expected.txt
@@ -13,10 +13,22 @@ PASS Can set 'word-spacing' to a percent: 0%
 PASS Can set 'word-spacing' to a percent: -3.14%
 PASS Can set 'word-spacing' to a percent: 3.14%
 PASS Can set 'word-spacing' to a percent: calc(0% + 0%)
-PASS Setting 'word-spacing' to a time throws TypeError
-PASS Setting 'word-spacing' to an angle throws TypeError
-PASS Setting 'word-spacing' to a flexible length throws TypeError
-FAIL Setting 'word-spacing' to a number throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'word-spacing' to a URL throws TypeError
-PASS Setting 'word-spacing' to a transform throws TypeError
+PASS Setting 'word-spacing' to a time: 0s throws TypeError
+PASS Setting 'word-spacing' to a time: -3.14ms throws TypeError
+PASS Setting 'word-spacing' to a time: 3.14s throws TypeError
+PASS Setting 'word-spacing' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'word-spacing' to an angle: 0deg throws TypeError
+PASS Setting 'word-spacing' to an angle: 3.14rad throws TypeError
+PASS Setting 'word-spacing' to an angle: -3.14deg throws TypeError
+PASS Setting 'word-spacing' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'word-spacing' to a flexible length: 0fr throws TypeError
+PASS Setting 'word-spacing' to a flexible length: 1fr throws TypeError
+PASS Setting 'word-spacing' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'word-spacing' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'word-spacing' to a number: -3.14 throws TypeError
+PASS Setting 'word-spacing' to a number: 3.14 throws TypeError
+PASS Setting 'word-spacing' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'word-spacing' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'word-spacing' to a transform: perspective(10em) throws TypeError
+PASS Setting 'word-spacing' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-wrap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-wrap-expected.txt
@@ -7,13 +7,31 @@ PASS Can set 'word-wrap' to var() references:  var(--A)
 PASS Can set 'word-wrap' to the 'normal' keyword: normal
 PASS Can set 'word-wrap' to the 'break-word' keyword: break-word
 FAIL Can set 'word-wrap' to the 'break-spaces' keyword: break-spaces Invalid values
-PASS Setting 'word-wrap' to a length throws TypeError
-PASS Setting 'word-wrap' to a percent throws TypeError
-PASS Setting 'word-wrap' to a time throws TypeError
-PASS Setting 'word-wrap' to an angle throws TypeError
-PASS Setting 'word-wrap' to a flexible length throws TypeError
-PASS Setting 'word-wrap' to a number throws TypeError
-PASS Setting 'word-wrap' to a URL throws TypeError
-PASS Setting 'word-wrap' to a transform throws TypeError
-FAIL 'word-wrap' does not supported 'break-word break-spaces' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS Setting 'word-wrap' to a length: 0px throws TypeError
+PASS Setting 'word-wrap' to a length: -3.14em throws TypeError
+PASS Setting 'word-wrap' to a length: 3.14cm throws TypeError
+PASS Setting 'word-wrap' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'word-wrap' to a percent: 0% throws TypeError
+PASS Setting 'word-wrap' to a percent: -3.14% throws TypeError
+PASS Setting 'word-wrap' to a percent: 3.14% throws TypeError
+PASS Setting 'word-wrap' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'word-wrap' to a time: 0s throws TypeError
+PASS Setting 'word-wrap' to a time: -3.14ms throws TypeError
+PASS Setting 'word-wrap' to a time: 3.14s throws TypeError
+PASS Setting 'word-wrap' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'word-wrap' to an angle: 0deg throws TypeError
+PASS Setting 'word-wrap' to an angle: 3.14rad throws TypeError
+PASS Setting 'word-wrap' to an angle: -3.14deg throws TypeError
+PASS Setting 'word-wrap' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'word-wrap' to a flexible length: 0fr throws TypeError
+PASS Setting 'word-wrap' to a flexible length: 1fr throws TypeError
+PASS Setting 'word-wrap' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'word-wrap' to a number: 0 throws TypeError
+PASS Setting 'word-wrap' to a number: -3.14 throws TypeError
+PASS Setting 'word-wrap' to a number: 3.14 throws TypeError
+PASS Setting 'word-wrap' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'word-wrap' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'word-wrap' to a transform: perspective(10em) throws TypeError
+PASS Setting 'word-wrap' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'word-wrap' does not support 'break-word break-spaces' assert_not_equals: Unsupported value must not be null got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/writing-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/writing-mode-expected.txt
@@ -9,12 +9,30 @@ PASS Can set 'writing-mode' to the 'vertical-rl' keyword: vertical-rl
 PASS Can set 'writing-mode' to the 'vertical-lr' keyword: vertical-lr
 FAIL Can set 'writing-mode' to the 'sideways-rl' keyword: sideways-rl Invalid values
 FAIL Can set 'writing-mode' to the 'sideways-lr' keyword: sideways-lr Invalid values
-PASS Setting 'writing-mode' to a length throws TypeError
-PASS Setting 'writing-mode' to a percent throws TypeError
-PASS Setting 'writing-mode' to a time throws TypeError
-PASS Setting 'writing-mode' to an angle throws TypeError
-PASS Setting 'writing-mode' to a flexible length throws TypeError
-PASS Setting 'writing-mode' to a number throws TypeError
-PASS Setting 'writing-mode' to a URL throws TypeError
-PASS Setting 'writing-mode' to a transform throws TypeError
+PASS Setting 'writing-mode' to a length: 0px throws TypeError
+PASS Setting 'writing-mode' to a length: -3.14em throws TypeError
+PASS Setting 'writing-mode' to a length: 3.14cm throws TypeError
+PASS Setting 'writing-mode' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'writing-mode' to a percent: 0% throws TypeError
+PASS Setting 'writing-mode' to a percent: -3.14% throws TypeError
+PASS Setting 'writing-mode' to a percent: 3.14% throws TypeError
+PASS Setting 'writing-mode' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'writing-mode' to a time: 0s throws TypeError
+PASS Setting 'writing-mode' to a time: -3.14ms throws TypeError
+PASS Setting 'writing-mode' to a time: 3.14s throws TypeError
+PASS Setting 'writing-mode' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'writing-mode' to an angle: 0deg throws TypeError
+PASS Setting 'writing-mode' to an angle: 3.14rad throws TypeError
+PASS Setting 'writing-mode' to an angle: -3.14deg throws TypeError
+PASS Setting 'writing-mode' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'writing-mode' to a flexible length: 0fr throws TypeError
+PASS Setting 'writing-mode' to a flexible length: 1fr throws TypeError
+PASS Setting 'writing-mode' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'writing-mode' to a number: 0 throws TypeError
+PASS Setting 'writing-mode' to a number: -3.14 throws TypeError
+PASS Setting 'writing-mode' to a number: 3.14 throws TypeError
+PASS Setting 'writing-mode' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'writing-mode' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'writing-mode' to a transform: perspective(10em) throws TypeError
+PASS Setting 'writing-mode' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt
@@ -9,11 +9,26 @@ FAIL Can set 'z-index' to a number: 0 assert_equals: expected "CSSUnitValue" but
 FAIL Can set 'z-index' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'z-index' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'z-index' to a number: calc(2 + 3) assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-PASS Setting 'z-index' to a length throws TypeError
-PASS Setting 'z-index' to a percent throws TypeError
-PASS Setting 'z-index' to a time throws TypeError
-PASS Setting 'z-index' to an angle throws TypeError
-PASS Setting 'z-index' to a flexible length throws TypeError
-PASS Setting 'z-index' to a URL throws TypeError
-PASS Setting 'z-index' to a transform throws TypeError
+PASS Setting 'z-index' to a length: 0px throws TypeError
+PASS Setting 'z-index' to a length: -3.14em throws TypeError
+PASS Setting 'z-index' to a length: 3.14cm throws TypeError
+PASS Setting 'z-index' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'z-index' to a percent: 0% throws TypeError
+PASS Setting 'z-index' to a percent: -3.14% throws TypeError
+PASS Setting 'z-index' to a percent: 3.14% throws TypeError
+PASS Setting 'z-index' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'z-index' to a time: 0s throws TypeError
+PASS Setting 'z-index' to a time: -3.14ms throws TypeError
+PASS Setting 'z-index' to a time: 3.14s throws TypeError
+PASS Setting 'z-index' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'z-index' to an angle: 0deg throws TypeError
+PASS Setting 'z-index' to an angle: 3.14rad throws TypeError
+PASS Setting 'z-index' to an angle: -3.14deg throws TypeError
+PASS Setting 'z-index' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'z-index' to a flexible length: 0fr throws TypeError
+PASS Setting 'z-index' to a flexible length: 1fr throws TypeError
+PASS Setting 'z-index' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'z-index' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'z-index' to a transform: perspective(10em) throws TypeError
+PASS Setting 'z-index' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 


### PR DESCRIPTION
#### 952779e0423ea988d0793094865a63ea4bb1a667
<pre>
Add more subtests to css/css-typed-om/the-stylepropertymap/properties WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=249327">https://bugs.webkit.org/show_bug.cgi?id=249327</a>

Reviewed by Tim Nguyen.

Add more subtests to css/css-typed-om/the-stylepropertymap/properties WPT tests
to make it clearer which checks are actually failing.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/accent-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/alignment-baseline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/all-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-end.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay-start.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-direction-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-fill-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-play-state-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-timing-function-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backdrop-filter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backface-visibility-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-attachment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-blend-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-clip-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-image-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-collapse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-source-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/bottom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/box-sizing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/break-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caption-side-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/caret-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clear-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-path-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/clip-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/color-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-count-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-span-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/contain-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/container-type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-increment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-reset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/counter-set-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/cursor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/d-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/direction-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/display-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/dominant-baseline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/empty-cells-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/filter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-direction-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-flow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-grow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-shrink-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-wrap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/float-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-family-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-feature-settings-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-kerning-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-language-override-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-optical-sizing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-palette-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-presentation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-adjust-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-synthesis-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-alternates-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-caps-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-east-asian-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-emoji-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-ligatures-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-numeric-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variation-settings-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-area-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-flow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-gap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-areas-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/hyphens-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/isolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/left-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/lighting-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-break-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/line-height-step-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-image-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/list-style-type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/marker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-image-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mask-type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/mix-blend-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/object-fit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-distance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-path-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-rotate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-anchor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-clip-margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overflow-wrap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/overscroll-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/page-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/paint-order-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/pointer-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/quotes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resize-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resources/testsuite.js:
(set testPropertyInvalid):
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/right-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-align-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-stop-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-gutter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-image-threshold-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-outside-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-rendering-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/speak-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linecap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-linejoin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/tab-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/table-layout-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-align-last-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-anchor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-combine-upright-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-skip-ink-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-thickness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-emphasis-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-justify-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-orientation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-overflow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-rendering-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-size-adjust-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-transform-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/top-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/touch-action-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-box-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transform-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-delay-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-property-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-timing-function-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/unicode-bidi-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vector-effect-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vertical-align-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/visibility-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-break-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-wrap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/writing-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt:

Canonical link: <a href="https://commits.webkit.org/257883@main">https://commits.webkit.org/257883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06e69a0452e53a50cd251c15c4ed7aab45ad5728

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109595 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169822 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10342 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92689 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107482 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106047 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34501 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22503 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3192 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24021 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3173 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43511 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5420 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5001 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->