### PR TITLE
text-transform:uppercase in SVG causes misplaced letters

### DIFF
--- a/LayoutTests/svg/text/text-transform-whitespace-rules-expected.svg
+++ b/LayoutTests/svg/text/text-transform-whitespace-rules-expected.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<text>
+<tspan x="0" y="1em">WORD1
+</tspan><tspan x="0" dy="1em">WORD2</tspan>
+</text>
+</svg>

--- a/LayoutTests/svg/text/text-transform-whitespace-rules.svg
+++ b/LayoutTests/svg/text/text-transform-whitespace-rules.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<style>
+svg {
+    text-transform: uppercase;
+}
+</style>
+<text>
+<tspan x="0" y="1em">Word1 
+</tspan><tspan x="0" dy="1em">Word2</tspan>
+</text>
+</svg>

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006 Oliver Hunt <ojh16@student.canterbury.ac.nz>
- * Copyright (C) 2006 Apple Inc.
+ * Copyright (C) 2006-2022 Apple Inc.
  * Copyright (C) 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2008 Rob Buis <buis@kde.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
@@ -97,13 +97,8 @@ void RenderSVGInlineText::styleDidChange(StyleDifference diff, const RenderStyle
 
     bool newPreserves = style().whiteSpace() == WhiteSpace::Pre;
     bool oldPreserves = oldStyle ? oldStyle->whiteSpace() == WhiteSpace::Pre : false;
-    if (oldPreserves && !newPreserves) {
-        setText(applySVGWhitespaceRules(originalText(), false), true);
-        return;
-    }
-
-    if (!oldPreserves && newPreserves) {
-        setText(applySVGWhitespaceRules(originalText(), true), true);
+    if (oldPreserves != newPreserves) {
+        setText(originalTextWS(), true);
         return;
     }
 
@@ -113,6 +108,15 @@ void RenderSVGInlineText::styleDidChange(StyleDifference diff, const RenderStyle
     // The text metrics may be influenced by style changes.
     if (auto* textAncestor = RenderSVGText::locateRenderSVGTextAncestor(*this))
         textAncestor->subtreeStyleDidChange(this);
+}
+
+RefPtr<StringImpl>&& RenderSVGInlineText::originalTextWS() const
+{
+    auto const textWithWS = style() && style().whiteSpace() == WhiteSpace::Pre;
+    RefPtr<StringImpl> result = RenderSVGInlineText::originalTextWS();
+    if (!result)
+        return nullptr;
+    return applySVGWhitespaceRules(text, textWithWS);
 }
 
 std::unique_ptr<LegacyInlineTextBox> RenderSVGInlineText::createTextBox()

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2006 Oliver Hunt <ojh16@student.canterbury.ac.nz>
- * Copyright (C) 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  * Copyright (C) 2008 Rob Buis <buis@kde.org>
  *
  * This library is free software; you can redistribute it and/or
@@ -47,6 +48,8 @@ public:
 
     // Preserves floating point precision for the use in DRT. It knows how to round and does a better job than enclosingIntRect.
     FloatRect floatLinesBoundingBox() const;
+
+    virtual RefPtr<StringImpl>&& originalTextWS() const override;
 
     SVGInlineTextBox* firstTextBox() const;
 


### PR DESCRIPTION
<pre>
text-transform:uppercase in SVG causes misplaced letters
<a href="https://bugs.webkit.org/show_bug.cgi?id=171664">https://bugs.webkit.org/show_bug.cgi?id=171664</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Partial Merge (Test Cases) - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=184655">https://src.chromium.org/viewvc/blink?view=revision&revision=184655</a>

It is to introduce new bool value by applying whitespace rules to text and use it in
'setRenderText' function to reflect that SVG whitespace rules can be applied.

* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp: (RenderSVGInlineText::setRendererText):
(1) Add bool "textWithWS" with whitespace rules
(2) Use "if" condition to return value to apply whitespace rules on need basis
* LayoutTests/svg/text/text-transform-whitespace-rules.svg: Add Test Case
* LayoutTests/svg/text/text-transform-whitespace-rules-expected.svg: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38b825cb5e1fd5a7a8d4af93290734b1f7a3d596

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100672 "1 style error") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9816 "Hash 38b825cb for PR 7635 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33712 "Hash 38b825cb for PR 7635 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109974 "Hash 38b825cb for PR 7635 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170245 "Hash 38b825cb for PR 7635 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104657 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10751 "Hash 38b825cb for PR 7635 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/335 "Hash 38b825cb for PR 7635 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93072 "Hash 38b825cb for PR 7635 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107818 "Hash 38b825cb for PR 7635 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106453 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/10751 "Hash 38b825cb for PR 7635 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/33712 "Hash 38b825cb for PR 7635 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/93072 "Hash 38b825cb for PR 7635 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/10751 "Hash 38b825cb for PR 7635 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/33712 "Hash 38b825cb for PR 7635 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/93072 "Hash 38b825cb for PR 7635 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3516 "Hash 38b825cb for PR 7635 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/33712 "Hash 38b825cb for PR 7635 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3535 "Hash 38b825cb for PR 7635 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/335 "Hash 38b825cb for PR 7635 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9647 "Hash 38b825cb for PR 7635 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/33712 "Hash 38b825cb for PR 7635 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5322 "Hash 38b825cb for PR 7635 does not build (failure)") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->