### PR TITLE
[JSC] Remove remaining 32bit x86 assembler part

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -1617,7 +1617,7 @@ public:
 
 #endif // USE(JSVALUE64)
 
-#if !CPU(X86) && !CPU(X86_64) && !CPU(ARM64)
+#if !CPU(X86_64) && !CPU(ARM64)
     // We should implement this the right way eventually, but for now, it's fine because it arises so
     // infrequently.
     void compareDouble(DoubleCondition cond, FPRegisterID left, FPRegisterID right, RegisterID dest)
@@ -1887,11 +1887,11 @@ public:
     void store32(Imm32 imm, Address dest)
     {
         if (shouldBlind(imm)) {
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
             BlindedImm32 blind = xorBlindConstant(imm);
             store32(blind.value1, dest);
             xor32(blind.value2, dest);
-#else // CPU(X86) || CPU(X86_64)
+#else // CPU(X86_64)
             if (haveScratchRegisterForBlinding()) {
                 loadXorBlindedConstant(xorBlindConstant(imm), scratchRegisterForBlinding());
                 store32(scratchRegisterForBlinding(), dest);
@@ -1903,7 +1903,7 @@ public:
                     nop();
                 store32(imm.asTrustedImm32(), dest);
             }
-#endif // CPU(X86) || CPU(X86_64)
+#endif // CPU(X86_64)
         } else
             store32(imm.asTrustedImm32(), dest);
     }

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -39,7 +39,6 @@ class MacroAssemblerX86Common : public AbstractMacroAssembler<Assembler> {
 public:
     static constexpr size_t nearJumpRange = 2 * GB;
 
-#if CPU(X86_64)
     // Use this directly only if you're not generating code with it.
     static constexpr X86Registers::RegisterID s_scratchRegister = X86Registers::r11;
 
@@ -50,8 +49,7 @@ public:
         RELEASE_ASSERT(m_allowScratchRegister);
         return s_scratchRegister;
     }
-#endif
-    
+
 protected:
     static constexpr int DoubleConditionBitInvert = 0x10;
     static constexpr int DoubleConditionBitSpecial = 0x20;
@@ -420,12 +418,10 @@ public:
         zeroExtend16To32(dst, dst);
     }
 
-#if CPU(X86_64)
     void byteSwap64(RegisterID dst)
     {
         m_assembler.bswapq_r(dst);
     }
-#endif
 
     // Only used for testing purposes.
     void illegalInstruction()
@@ -1459,39 +1455,11 @@ public:
 
     void store8(RegisterID src, BaseIndex address)
     {
-#if CPU(X86)
-        // On 32-bit x86 we can only store from the first 4 registers;
-        // esp..edi are mapped to the 'h' registers!
-        if (src >= 4) {
-            // Pick a temporary register.
-            RegisterID temp = getUnusedRegister(address);
-
-            // Swap to the temporary register to perform the store.
-            swap(src, temp);
-            m_assembler.movb_rm(temp, address.offset, address.base, address.index, address.scale);
-            swap(src, temp);
-            return;
-        }
-#endif
         m_assembler.movb_rm(src, address.offset, address.base, address.index, address.scale);
     }
     
     void store8(RegisterID src, Address address)
     {
-#if CPU(X86)
-        // On 32-bit x86 we can only store from the first 4 registers;
-        // esp..edi are mapped to the 'h' registers!
-        if (src >= 4) {
-            // Pick a temporary register.
-            RegisterID temp = getUnusedRegister(address);
-
-            // Swap to the temporary register to perform the store.
-            swap(src, temp);
-            m_assembler.movb_rm(temp, address.offset, address.base);
-            swap(src, temp);
-            return;
-        }
-#endif
         m_assembler.movb_rm(src, address.offset, address.base);
     }
 
@@ -1529,12 +1497,8 @@ public:
 
     void loadDouble(TrustedImmPtr address, FPRegisterID dest)
     {
-#if CPU(X86)
-        m_assembler.movsd_mr(address.asPtr(), dest);
-#else
         move(address, scratchRegister());
         loadDouble(Address(scratchRegister()), dest);
-#endif
     }
 
     void loadDouble(Address address, FPRegisterID dest)
@@ -1555,12 +1519,8 @@ public:
 
     void loadFloat(TrustedImmPtr address, FPRegisterID dest)
     {
-#if CPU(X86)
-        m_assembler.movss_mr(address.asPtr(), dest);
-#else
         move(address, scratchRegister());
         loadFloat(Address(scratchRegister()), dest);
-#endif
     }
 
     void loadFloat(Address address, FPRegisterID dest)
@@ -2269,7 +2229,6 @@ public:
             m_assembler.cvttsd2si_rr(src, dest);
 
         // If the result is zero, it might have been -0.0, and the double comparison won't catch this!
-#if CPU(X86_64)
         if (negZeroCheck) {
             Jump valueIsNonZero = branchTest32(NonZero, dest);
             if (supportsAVX())
@@ -2279,10 +2238,6 @@ public:
             failureCases.append(branchTest32(NonZero, scratchRegister(), TrustedImm32(1)));
             valueIsNonZero.link(this);
         }
-#else
-        if (negZeroCheck)
-            failureCases.append(branchTest32(Zero, dest));
-#endif
 
         // Convert the integer result back to float & compare to the original value - if not equal or unordered (NaN) then jump.
         convertInt32ToDouble(dest, fpTemp);
@@ -2390,7 +2345,6 @@ public:
             m_assembler.movl_i32r(imm.m_value, dest);
     }
 
-#if CPU(X86_64)
     void move(RegisterID src, RegisterID dest)
     {
         // Note: on 64-bit this is is a full register move; perhaps it would be
@@ -2546,97 +2500,6 @@ public:
     {
         m_assembler.movl_i32r(src.m_value, dest);
     }
-#else
-    void move(RegisterID src, RegisterID dest)
-    {
-        if (src != dest)
-            m_assembler.movl_rr(src, dest);
-    }
-
-    void move(TrustedImmPtr imm, RegisterID dest)
-    {
-        if (!imm.m_value)
-            m_assembler.xorl_rr(dest, dest);
-        else
-            m_assembler.movl_i32r(imm.asIntptr(), dest);
-    }
-
-    // Only here for templates!
-    void move(TrustedImm64, RegisterID)
-    {
-        UNREACHABLE_FOR_PLATFORM();
-    }
-
-    void moveConditionallyDouble(DoubleCondition cond, FPRegisterID left, FPRegisterID right, RegisterID src, RegisterID dest)
-    {
-        if (cond & DoubleConditionBitInvert) {
-            if (supportsAVX())
-                m_assembler.vucomisd_rr(left, right);
-            else
-                m_assembler.ucomisd_rr(left, right);
-        } else {
-            if (supportsAVX())
-                m_assembler.vucomisd_rr(right, left);
-            else
-                m_assembler.ucomisd_rr(right, left);
-        }
-
-        if (cond == DoubleEqualAndOrdered) {
-            if (left == right) {
-                m_assembler.cmovnpl_rr(src, dest);
-                return;
-            }
-
-            Jump isUnordered(m_assembler.jp());
-            m_assembler.cmovel_rr(src, dest);
-            isUnordered.link(this);
-            return;
-        }
-
-        if (cond == DoubleNotEqualOrUnordered) {
-            if (left == right) {
-                m_assembler.cmovpl_rr(src, dest);
-                return;
-            }
-
-            m_assembler.cmovpl_rr(src, dest);
-            m_assembler.cmovnel_rr(src, dest);
-            return;
-        }
-
-        ASSERT(!(cond & DoubleConditionBitSpecial));
-        m_assembler.cmovl_rr(static_cast<X86Assembler::Condition>(cond & ~DoubleConditionBits), src, dest);
-    }
-
-    void swap(RegisterID reg1, RegisterID reg2)
-    {
-        if (reg1 != reg2)
-            m_assembler.xchgl_rr(reg1, reg2);
-    }
-
-    void swap(FPRegisterID reg1, FPRegisterID reg2)
-    {
-        if (reg1 == reg2)
-            return;
-
-        // FIXME: This is kinda a hack since we don't use xmm7 as a temp.
-        ASSERT(reg1 != FPRegisterID::xmm7);
-        ASSERT(reg2 != FPRegisterID::xmm7);
-        moveDouble(reg1, FPRegisterID::xmm7);
-        moveDouble(reg2, reg1);
-        moveDouble(FPRegisterID::xmm7, reg2);
-    }
-
-    void signExtend32ToPtr(RegisterID src, RegisterID dest)
-    {
-        move(src, dest);
-    }
-
-    void zeroExtend32ToWord(RegisterID src, RegisterID dest)
-    {
-        move(src, dest);
-    }
-#endif
 
     void swap32(RegisterID src, RegisterID dest)
     {
@@ -4333,28 +4196,13 @@ protected:
 
     void set32(X86Assembler::Condition cond, RegisterID dest)
     {
-#if CPU(X86)
-        // On 32-bit x86 we can only set the first 4 registers;
-        // esp..edi are mapped to the 'h' registers!
-        if (dest >= 4) {
-            m_assembler.xchgl_rr(dest, X86Registers::eax);
-            m_assembler.setCC_r(cond, X86Registers::eax);
-            m_assembler.movzbl_rr(X86Registers::eax, X86Registers::eax);
-            m_assembler.xchgl_rr(dest, X86Registers::eax);
-            return;
-        }
-#endif
         m_assembler.setCC_r(cond, dest);
         m_assembler.movzbl_rr(dest, dest);
     }
 
     void cmov(X86Assembler::Condition cond, RegisterID src, RegisterID dest)
     {
-#if CPU(X86_64)
         m_assembler.cmovq_rr(cond, src, dest);
-#else
-        m_assembler.cmovl_rr(cond, src, dest);
-#endif
     }
 
     static bool supportsLZCNT()
@@ -4524,7 +4372,6 @@ private:
         m_assembler.movl_rr(src, dest);
     }
 
-#if CPU(X86_64)
     void moveConditionallyAfterFloatingPointCompare(DoubleCondition cond, FPRegisterID left, FPRegisterID right, RegisterID src, RegisterID dest)
     {
         if (cond == DoubleEqualAndOrdered) {
@@ -4553,7 +4400,6 @@ private:
         ASSERT(!(cond & DoubleConditionBitSpecial));
         cmov(static_cast<X86Assembler::Condition>(cond & ~DoubleConditionBits), src, dest);
     }
-#endif
 
     using CPUID = std::array<unsigned, 4>;
     static CPUID getCPUID(unsigned level);

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(ASSEMBLER) && (CPU(X86) || CPU(X86_64))
+#if ENABLE(ASSEMBLER) && CPU(X86_64)
 
 #include "AssemblerBuffer.h"
 #include "AssemblerCommon.h"
@@ -76,11 +76,7 @@ public:
     static constexpr RegisterID firstRegister() { return X86Registers::eax; }
     static constexpr RegisterID lastRegister()
     {
-#if CPU(X86_64)
         return X86Registers::r15;
-#else
-        return X86Registers::edi;
-#endif
     }
     static constexpr unsigned numberOfRegisters() { return lastRegister() - firstRegister() + 1; }
     
@@ -96,11 +92,7 @@ public:
     static constexpr FPRegisterID firstFPRegister() { return X86Registers::xmm0; }
     static constexpr FPRegisterID lastFPRegister()
     {
-#if CPU(X86_64)
         return X86Registers::xmm15;
-#else
-        return X86Registers::xmm7;
-#endif
     }
     static constexpr unsigned numberOfFPRegisters() { return lastFPRegister() - firstFPRegister() + 1; }
     
@@ -202,14 +194,10 @@ private:
         OP_CMP_EvGv                     = 0x39,
         OP_CMP_GvEv                     = 0x3B,
         OP_CMP_EAXIv                    = 0x3D,
-#if CPU(X86_64)
         PRE_REX                         = 0x40,
-#endif
         OP_PUSH_EAX                     = 0x50,
         OP_POP_EAX                      = 0x58,
-#if CPU(X86_64)
         OP_MOVSXD_GvEv                  = 0x63,
-#endif
         PRE_GS                          = 0x65,
         PRE_OPERAND_SIZE                = 0x66,
         PRE_SSE_66                      = 0x66,
@@ -573,19 +561,6 @@ public:
 
     // Arithmetic operations:
 
-#if !CPU(X86_64)
-    void adcl_im(int imm, const void* addr)
-    {
-        if (CAN_SIGN_EXTEND_8_32(imm)) {
-            m_formatter.oneByteOpAddr(OP_GROUP1_EvIb, GROUP1_OP_ADC, bitwise_cast<uint32_t>(addr));
-            m_formatter.immediate8(imm);
-        } else {
-            m_formatter.oneByteOpAddr(OP_GROUP1_EvIz, GROUP1_OP_ADC, bitwise_cast<uint32_t>(addr));
-            m_formatter.immediate32(imm);
-        }
-    }
-#endif
-
     void addl_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.oneByteOp(OP_ADD_EvGv, src, dst);
@@ -600,13 +575,6 @@ public:
     {
         m_formatter.oneByteOp(OP_ADD_GvEv, dst, base, index, scale, offset);
     }
-    
-#if !CPU(X86_64)
-    void addl_mr(const void* addr, RegisterID dst)
-    {
-        m_formatter.oneByteOpAddr(OP_ADD_GvEv, dst, bitwise_cast<uint32_t>(addr));
-    }
-#endif
 
     void addl_rm(RegisterID src, int offset, RegisterID base)
     {
@@ -712,7 +680,6 @@ public:
         }
     }
 
-#if CPU(X86_64)
     void addq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_ADD_EvGv, src, dst);
@@ -773,18 +740,6 @@ public:
             m_formatter.immediate32(imm);
         }
     }
-#else
-    void addl_im(int imm, const void* addr)
-    {
-        if (CAN_SIGN_EXTEND_8_32(imm)) {
-            m_formatter.oneByteOpAddr(OP_GROUP1_EvIb, GROUP1_OP_ADD, bitwise_cast<uint32_t>(addr));
-            m_formatter.immediate8(imm);
-        } else {
-            m_formatter.oneByteOpAddr(OP_GROUP1_EvIz, GROUP1_OP_ADD, bitwise_cast<uint32_t>(addr));
-            m_formatter.immediate32(imm);
-        }
-    }
-#endif
 
     void andl_rr(RegisterID src, RegisterID dst)
     {
@@ -914,7 +869,6 @@ public:
         m_formatter.immediate8(imm);
     }
 
-#if CPU(X86_64)
     void andq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_AND_EvGv, src, dst);
@@ -972,30 +926,16 @@ public:
             m_formatter.immediate32(imm);
         }
     }
-#else
-    void andl_im(int imm, const void* addr)
-    {
-        if (CAN_SIGN_EXTEND_8_32(imm)) {
-            m_formatter.oneByteOpAddr(OP_GROUP1_EvIb, GROUP1_OP_AND, bitwise_cast<uint32_t>(addr));
-            m_formatter.immediate8(imm);
-        } else {
-            m_formatter.oneByteOpAddr(OP_GROUP1_EvIz, GROUP1_OP_AND, bitwise_cast<uint32_t>(addr));
-            m_formatter.immediate32(imm);
-        }
-    }
-#endif
 
     void dec_r(RegisterID dst)
     {
         m_formatter.oneByteOp(OP_GROUP5_Ev, GROUP1_OP_OR, dst);
     }
 
-#if CPU(X86_64)
     void decq_r(RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_GROUP5_Ev, GROUP1_OP_OR, dst);
     }
-#endif // CPU(X86_64)
 
     // Only used for testing purposes.
     void illegalInstruction()
@@ -1008,7 +948,6 @@ public:
         m_formatter.oneByteOp(OP_GROUP5_Ev, GROUP1_OP_ADD, dst);
     }
 
-#if CPU(X86_64)
     void incq_r(RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_GROUP5_Ev, GROUP1_OP_ADD, dst);
@@ -1023,14 +962,12 @@ public:
     {
         m_formatter.oneByteOp64(OP_GROUP5_Ev, GROUP1_OP_ADD, base, index, scale, offset);
     }
-#endif // CPU(X86_64)
 
     void negl_r(RegisterID dst)
     {
         m_formatter.oneByteOp(OP_GROUP3_Ev, GROUP3_OP_NEG, dst);
     }
 
-#if CPU(X86_64)
     void negq_r(RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_GROUP3_Ev, GROUP3_OP_NEG, dst);
@@ -1045,7 +982,6 @@ public:
     {
         m_formatter.oneByteOp64(OP_GROUP3_Ev, GROUP3_OP_NEG, base, index, scale, offset);
     }
-#endif
 
     void negl_m(int offset, RegisterID base)
     {
@@ -1116,7 +1052,6 @@ public:
         m_formatter.oneByteOp(OP_GROUP3_Eb, GROUP3_OP_NOT, base, index, scale, offset);
     }
 
-#if CPU(X86_64)
     void notq_r(RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_GROUP3_Ev, GROUP3_OP_NOT, dst);
@@ -1131,7 +1066,6 @@ public:
     {
         m_formatter.oneByteOp64(OP_GROUP3_Ev, GROUP3_OP_NOT, base, index, scale, offset);
     }
-#endif
 
     void orl_rr(RegisterID src, RegisterID dst)
     {
@@ -1252,7 +1186,6 @@ public:
         m_formatter.immediate8(imm);
     }
 
-#if CPU(X86_64)
     void orq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_OR_EvGv, src, dst);
@@ -1313,23 +1246,6 @@ public:
             m_formatter.immediate32(imm);
         }
     }
-#else
-    void orl_im(int imm, const void* addr)
-    {
-        if (CAN_SIGN_EXTEND_8_32(imm)) {
-            m_formatter.oneByteOpAddr(OP_GROUP1_EvIb, GROUP1_OP_OR, bitwise_cast<uint32_t>(addr));
-            m_formatter.immediate8(imm);
-        } else {
-            m_formatter.oneByteOpAddr(OP_GROUP1_EvIz, GROUP1_OP_OR, bitwise_cast<uint32_t>(addr));
-            m_formatter.immediate32(imm);
-        }
-    }
-
-    void orl_rm(RegisterID src, const void* addr)
-    {
-        m_formatter.oneByteOpAddr(OP_OR_EvGv, src, bitwise_cast<uint32_t>(addr));
-    }
-#endif
 
     void subl_rr(RegisterID src, RegisterID dst)
     {
@@ -1450,7 +1366,6 @@ public:
         m_formatter.immediate8(imm);
     }
 
-#if CPU(X86_64)
     void subq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_SUB_EvGv, src, dst);
@@ -1511,18 +1426,6 @@ public:
             m_formatter.immediate32(imm);
         }
     }
-#else
-    void subl_im(int imm, const void* addr)
-    {
-        if (CAN_SIGN_EXTEND_8_32(imm)) {
-            m_formatter.oneByteOpAddr(OP_GROUP1_EvIb, GROUP1_OP_SUB, bitwise_cast<uint32_t>(addr));
-            m_formatter.immediate8(imm);
-        } else {
-            m_formatter.oneByteOpAddr(OP_GROUP1_EvIz, GROUP1_OP_SUB, bitwise_cast<uint32_t>(addr));
-            m_formatter.immediate32(imm);
-        }
-    }
-#endif
 
     void xorl_rr(RegisterID src, RegisterID dst)
     {
@@ -1643,7 +1546,6 @@ public:
         }
     }
 
-#if CPU(X86_64)
     void xorq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_XOR_EvGv, src, dst);
@@ -1704,7 +1606,6 @@ public:
     {
         m_formatter.oneByteOp64(OP_XOR_GvEv, dest, base, index, scale, offset);
     }
-#endif
 
     void lzcnt_rr(RegisterID src, RegisterID dst)
     {
@@ -1718,7 +1619,6 @@ public:
         m_formatter.twoByteOp(OP2_LZCNT, dst, base, offset);
     }
 
-#if CPU(X86_64)
     void lzcntq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_F3);
@@ -1730,7 +1630,6 @@ public:
         m_formatter.prefix(PRE_SSE_F3);
         m_formatter.twoByteOp64(OP2_LZCNT, dst, base, offset);
     }
-#endif
 
     void bsr_rr(RegisterID src, RegisterID dst)
     {
@@ -1742,7 +1641,6 @@ public:
         m_formatter.twoByteOp(OP2_BSR, dst, base, offset);
     }
 
-#if CPU(X86_64)
     void bsrq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.twoByteOp64(OP2_BSR, dst, src);
@@ -1752,19 +1650,16 @@ public:
     {
         m_formatter.twoByteOp64(OP2_BSR, dst, base, offset);
     }
-#endif
 
     void bswapl_r(RegisterID dst)
     {
         m_formatter.twoByteOp(OP2_BSWAP, dst);
     }
 
-#if CPU(X86_64)
     void bswapq_r(RegisterID dst)
     {
         m_formatter.twoByteOp64(OP2_BSWAP, dst);
     }
-#endif
 
     void tzcnt_rr(RegisterID src, RegisterID dst)
     {
@@ -1772,32 +1667,26 @@ public:
         m_formatter.twoByteOp(OP2_TZCNT, dst, src);
     }
 
-#if CPU(X86_64)
     void tzcntq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_F3);
         m_formatter.twoByteOp64(OP2_TZCNT, dst, src);
     }
-#endif
 
     void bsf_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.twoByteOp(OP2_BSF, dst, src);
     }
 
-#if CPU(X86_64)
     void bsfq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.twoByteOp64(OP2_BSF, dst, src);
     }
-#endif
 
-#if CPU(X86_64)
     void btrq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.twoByteOp64(OP2_BTR, dst, src);
     }
-#endif
 
     void popcnt_rr(RegisterID src, RegisterID dst)
     {
@@ -1811,7 +1700,6 @@ public:
         m_formatter.twoByteOp(OP2_POPCNT, dst, base, offset);
     }
 
-#if CPU(X86_64)
     void popcntq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_F3);
@@ -1823,7 +1711,6 @@ public:
         m_formatter.prefix(PRE_SSE_F3);
         m_formatter.twoByteOp64(OP2_POPCNT, dst, base, offset);
     }
-#endif
 
 private:
     template<GroupOpcodeID op>
@@ -1905,7 +1792,6 @@ public:
         shiftInstruction16<GROUP2_OP_ROL>(imm, dst);
     }
 
-#if CPU(X86_64)
 private:
     template<GroupOpcodeID op>
     void shiftInstruction64(int imm, RegisterID dst)
@@ -1967,19 +1853,16 @@ public:
     {
         m_formatter.oneByteOp64(OP_GROUP2_EvCL, GROUP2_OP_ROL, dst);
     }
-#endif // CPU(X86_64)
 
     void imull_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.twoByteOp(OP2_IMUL_GvEv, dst, src);
     }
 
-#if CPU(X86_64)
     void imulq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.twoByteOp64(OP2_IMUL_GvEv, dst, src);
     }
-#endif // CPU(X86_64)
 
     void imull_mr(int offset, RegisterID base, RegisterID dst)
     {
@@ -2002,7 +1885,6 @@ public:
         m_formatter.oneByteOp(OP_GROUP3_Ev, GROUP3_OP_IDIV, dst);
     }
 
-#if CPU(X86_64)
     void divq_r(RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_GROUP3_Ev, GROUP3_OP_DIV, dst);
@@ -2012,7 +1894,6 @@ public:
     {
         m_formatter.oneByteOp64(OP_GROUP3_Ev, GROUP3_OP_IDIV, dst);
     }
-#endif // CPU(X86_64)
 
     // Comparisons:
 
@@ -2074,14 +1955,6 @@ public:
         m_formatter.immediate8(imm);
     }
     
-#if CPU(X86)
-    void cmpb_im(int imm, const void* addr)
-    {
-        m_formatter.oneByteOpAddr(OP_GROUP1_EbIb, GROUP1_OP_CMP, bitwise_cast<uint32_t>(addr));
-        m_formatter.immediate8(imm);
-    }
-#endif
-
     void cmpl_im(int imm, int offset, RegisterID base, RegisterID index, int scale)
     {
         if (CAN_SIGN_EXTEND_8_32(imm)) {
@@ -2099,7 +1972,6 @@ public:
         m_formatter.immediate32(imm);
     }
 
-#if CPU(X86_64)
     void cmpq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_CMP_EvGv, src, dst);
@@ -2155,23 +2027,6 @@ public:
             m_formatter.immediate32(imm);
         }
     }
-#else
-    void cmpl_rm(RegisterID reg, const void* addr)
-    {
-        m_formatter.oneByteOpAddr(OP_CMP_EvGv, reg, bitwise_cast<uint32_t>(addr));
-    }
-
-    void cmpl_im(int imm, const void* addr)
-    {
-        if (CAN_SIGN_EXTEND_8_32(imm)) {
-            m_formatter.oneByteOpAddr(OP_GROUP1_EvIb, GROUP1_OP_CMP, bitwise_cast<uint32_t>(addr));
-            m_formatter.immediate8(imm);
-        } else {
-            m_formatter.oneByteOpAddr(OP_GROUP1_EvIz, GROUP1_OP_CMP, bitwise_cast<uint32_t>(addr));
-            m_formatter.immediate32(imm);
-        }
-    }
-#endif
 
     void cmpw_ir(int imm, RegisterID dst)
     {
@@ -2255,21 +2110,12 @@ public:
         m_formatter.immediate8(imm);
     }
 
-#if CPU(X86)
-    void testb_im(int imm, const void* addr)
-    {
-        m_formatter.oneByteOpAddr(OP_GROUP3_EbIb, GROUP3_OP_TEST, bitwise_cast<uint32_t>(addr));
-        m_formatter.immediate8(imm);
-    }
-#endif
-
     void testl_i32m(int imm, int offset, RegisterID base, RegisterID index, int scale)
     {
         m_formatter.oneByteOp(OP_GROUP3_EvIz, GROUP3_OP_TEST, base, index, scale, offset);
         m_formatter.immediate32(imm);
     }
 
-#if CPU(X86_64)
     void testq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_TEST_EvGv, src, dst);
@@ -2300,7 +2146,6 @@ public:
         m_formatter.oneByteOp64(OP_GROUP3_EvIz, GROUP3_OP_TEST, base, index, scale, offset);
         m_formatter.immediate32(imm);
     }
-#endif 
 
     void testw_rr(RegisterID src, RegisterID dst)
     {
@@ -2355,7 +2200,6 @@ public:
         m_formatter.twoByteOp(OP2_BT_EvEv, bitOffset, base, offset);
     }
 
-#if CPU(X86_64)
     void btw_ir(int bitOffset, RegisterID testValue)
     {
         ASSERT(-128 <= bitOffset && bitOffset < 128);
@@ -2379,7 +2223,6 @@ public:
     {
         m_formatter.twoByteOp64(OP2_BT_EvEv, bitOffset, base, offset);
     }
-#endif
 
     void setCC_r(Condition cond, RegisterID dst)
     {
@@ -2423,12 +2266,10 @@ public:
         m_formatter.oneByteOp(OP_CDQ);
     }
 
-#if CPU(X86_64)
     void cqo()
     {
         m_formatter.oneByteOp64(OP_CDQ);
     }
-#endif
 
     void fstps(int offset, RegisterID base)
     {
@@ -2482,7 +2323,6 @@ public:
         m_formatter.oneByteOp(OP_XCHG_EvGv, src, base, index, scale, offset);
     }
 
-#if CPU(X86_64)
     void xchgq_rr(RegisterID src, RegisterID dst)
     {
         if (src == X86Registers::eax)
@@ -2502,8 +2342,7 @@ public:
     {
         m_formatter.oneByteOp64(OP_XCHG_EvGv, src, base, index, scale, offset);
     }
-#endif
-    
+
     void pinsrb_i8rr(uint8_t laneIndex, RegisterID rn, XMMRegisterID vd)
     {
         ASSERT(laneIndex < 16);
@@ -3030,11 +2869,7 @@ public:
     void movl_mEAX(const void* addr)
     {
         m_formatter.oneByteOp(OP_MOV_EAXOv);
-#if CPU(X86_64)
         m_formatter.immediate64(reinterpret_cast<int64_t>(addr));
-#else
-        m_formatter.immediate32(reinterpret_cast<int>(addr));
-#endif
     }
 
     void movl_mr(int offset, RegisterID base, RegisterID dst)
@@ -3075,15 +2910,6 @@ public:
         m_formatter.immediate32(imm);
     }
 
-#if !CPU(X86_64)
-    void movb_i8m(int imm, const void* addr)
-    {
-        ASSERT(-128 <= imm && imm < 128);
-        m_formatter.oneByteOpAddr(OP_GROUP11_EvIb, GROUP11_MOV, bitwise_cast<uint32_t>(addr));
-        m_formatter.immediate8(imm);
-    }
-#endif
-
     void movb_i8m(int imm, int offset, RegisterID base)
     {
         ASSERT(-128 <= imm && imm < 128);
@@ -3098,13 +2924,6 @@ public:
         m_formatter.immediate8(imm);
     }
 
-#if !CPU(X86_64)
-    void movb_rm(RegisterID src, const void* addr)
-    {
-        m_formatter.oneByteOpAddr(OP_MOV_EbGb, src, bitwise_cast<uint32_t>(addr));
-    }
-#endif
-    
     void movb_rm(RegisterID src, int offset, RegisterID base)
     {
         m_formatter.oneByteOp8(OP_MOV_EbGb, src, base, offset);
@@ -3147,11 +2966,7 @@ public:
     void movl_EAXm(const void* addr)
     {
         m_formatter.oneByteOp(OP_MOV_OvEAX);
-#if CPU(X86_64)
         m_formatter.immediate64(reinterpret_cast<int64_t>(addr));
-#else
-        m_formatter.immediate32(reinterpret_cast<int>(addr));
-#endif
     }
 
     void movl_mr(uint32_t addr, RegisterID dst)
@@ -3164,7 +2979,6 @@ public:
         m_formatter.oneByteOpAddr(OP_MOV_EvGv, src, addr);
     }
 
-#if CPU(X86_64)
     void movq_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_MOV_EvGv, src, dst);
@@ -3255,29 +3069,6 @@ public:
     {
         m_formatter.oneByteOp64(OP_MOVSXD_GvEv, dst, src);
     }
-#else
-    void movl_mr(const void* addr, RegisterID dst)
-    {
-        if (dst == X86Registers::eax)
-            movl_mEAX(addr);
-        else
-            m_formatter.oneByteOpAddr(OP_MOV_GvEv, dst, bitwise_cast<uint32_t>(addr));
-    }
-
-    void movl_rm(RegisterID src, const void* addr)
-    {
-        if (src == X86Registers::eax)
-            movl_EAXm(addr);
-        else 
-            m_formatter.oneByteOpAddr(OP_MOV_EvGv, src, bitwise_cast<uint32_t>(addr));
-    }
-    
-    void movl_i32m(int imm, const void* addr)
-    {
-        m_formatter.oneByteOpAddr(OP_GROUP11_EvIz, GROUP11_MOV, bitwise_cast<uint32_t>(addr));
-        m_formatter.immediate32(imm);
-    }
-#endif
 
     void movzwl_mr(int offset, RegisterID base, RegisterID dst)
     {
@@ -3308,13 +3099,6 @@ public:
     {
         m_formatter.twoByteOp(OP2_MOVZX_GvEb, dst, base, index, scale, offset);
     }
-
-#if !CPU(X86_64)
-    void movzbl_mr(const void* address, RegisterID dst)
-    {
-        m_formatter.twoByteOpAddr(OP2_MOVZX_GvEb, dst, bitwise_cast<uint32_t>(address));
-    }
-#endif
 
     void movsbl_mr(int offset, RegisterID base, RegisterID dst)
     {
@@ -3384,7 +3168,6 @@ public:
         m_formatter.twoByteOp(cmovcc(ConditionNP), dst, src);
     }
 
-#if CPU(X86_64)
     void cmovq_rr(Condition cond, RegisterID src, RegisterID dst)
     {
         m_formatter.twoByteOp64(cmovcc(cond), dst, src);
@@ -3419,12 +3202,6 @@ public:
     {
         m_formatter.twoByteOp64(cmovcc(ConditionNP), dst, src);
     }
-#else
-    void cmovl_mr(Condition cond, const void* addr, RegisterID dst)
-    {
-        m_formatter.twoByteOpAddr(cmovcc(cond), dst, bitwise_cast<uint32_t>(addr));
-    }
-#endif
 
     void leal_mr(int offset, RegisterID base, RegisterID dst)
     {
@@ -3436,7 +3213,6 @@ public:
         m_formatter.oneByteOp(OP_LEA, dst, base, index, scale, offset);
     }
 
-#if CPU(X86_64)
     void leaq_mr(int offset, RegisterID base, RegisterID dst)
     {
         m_formatter.oneByteOp64(OP_LEA, dst, base, offset);
@@ -3446,7 +3222,6 @@ public:
     {
         m_formatter.oneByteOp64(OP_LEA, dst, base, index, scale, offset);
     }
-#endif
 
     // Flow control:
 
@@ -3491,13 +3266,6 @@ public:
     {
         m_formatter.oneByteOp(OP_GROUP5_Ev, GROUP5_OP_JMPN, base, index, scale, offset);
     }
-    
-#if !CPU(X86_64)
-    void jmp_m(const void* address)
-    {
-        m_formatter.oneByteOpAddr(OP_GROUP5_Ev, GROUP5_OP_JMPN, bitwise_cast<uint32_t>(address));
-    }
-#endif
 
     AssemblerLabel jne()
     {
@@ -3637,14 +3405,6 @@ public:
         m_formatter.twoByteOp(OP2_ADDSD_VsdWsd, dst, base, index, scale, offset);
     }
 
-#if !CPU(X86_64)
-    void addsd_mr(const void* address, XMMRegisterID dst)
-    {
-        m_formatter.prefix(PRE_SSE_F2);
-        m_formatter.twoByteOpAddr(OP2_ADDSD_VsdWsd, (RegisterID)dst, bitwise_cast<uint32_t>(address));
-    }
-#endif
-
     void cvtsi2sd_rr(RegisterID src, XMMRegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_F2);
@@ -3657,7 +3417,6 @@ public:
         m_formatter.twoByteOp(OP2_CVTSI2SD_VsdEd, (RegisterID)dst, src);
     }
 
-#if CPU(X86_64)
     void cvtsi2sdq_rr(RegisterID src, XMMRegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_F2);
@@ -3681,7 +3440,6 @@ public:
         m_formatter.prefix(PRE_SSE_F3);
         m_formatter.twoByteOp64(OP2_CVTSI2SD_VsdEd, (RegisterID)dst, base, offset);
     }
-#endif
 
     void cvtsi2sd_mr(int offset, RegisterID base, XMMRegisterID dst)
     {
@@ -3695,14 +3453,6 @@ public:
         m_formatter.twoByteOp(OP2_CVTSI2SD_VsdEd, (RegisterID)dst, base, offset);
     }
 
-#if !CPU(X86_64)
-    void cvtsi2sd_mr(const void* address, XMMRegisterID dst)
-    {
-        m_formatter.prefix(PRE_SSE_F2);
-        m_formatter.twoByteOpAddr(OP2_CVTSI2SD_VsdEd, (RegisterID)dst, bitwise_cast<uint32_t>(address));
-    }
-#endif
-
     void cvttsd2si_rr(XMMRegisterID src, RegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_F2);
@@ -3715,13 +3465,11 @@ public:
         m_formatter.twoByteOp(OP2_CVTTSS2SI_GdWsd, dst, (RegisterID)src);
     }
 
-#if CPU(X86_64)
     void cvttss2siq_rr(XMMRegisterID src, RegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_F3);
         m_formatter.twoByteOp64(OP2_CVTTSS2SI_GdWsd, dst, (RegisterID)src);
     }
-#endif
 
     void cvtsd2ss_rr(XMMRegisterID src, XMMRegisterID dst)
     {
@@ -3747,13 +3495,11 @@ public:
         m_formatter.twoByteOp(OP2_CVTSS2SD_VsdWsd, dst, base, offset);
     }
 
-#if CPU(X86_64)
     void cvttsd2siq_rr(XMMRegisterID src, RegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_F2);
         m_formatter.twoByteOp64(OP2_CVTTSD2SI_GdWsd, dst, (RegisterID)src);
     }
-#endif
 
     void movd_rr(XMMRegisterID src, RegisterID dst)
     {
@@ -3775,7 +3521,6 @@ public:
         m_formatter.twoByteOp(OP2_MOVDDUP_VqWq, (RegisterID)dst, (RegisterID)src);
     }
 
-#if CPU(X86_64)
     void movmskpd_rr(XMMRegisterID src, RegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_66);
@@ -3793,7 +3538,6 @@ public:
         m_formatter.prefix(PRE_SSE_66);
         m_formatter.twoByteOp64(OP2_MOVD_VdEd, (RegisterID)dst, src);
     }
-#endif
 
     void movapd_rr(XMMRegisterID src, XMMRegisterID dst)
     {
@@ -3876,29 +3620,6 @@ public:
         m_formatter.prefix(PRE_SSE_F3);
         m_formatter.twoByteOp(OP2_MOVSLDUP_VqWq, (RegisterID)dst, (RegisterID)src);
     }
-
-#if !CPU(X86_64)
-    void movsd_mr(const void* address, XMMRegisterID dst)
-    {
-        m_formatter.prefix(PRE_SSE_F2);
-        m_formatter.twoByteOpAddr(OP2_MOVSD_VsdWsd, (RegisterID)dst, bitwise_cast<uint32_t>(address));
-    }
-    void movsd_rm(XMMRegisterID src, const void* address)
-    {
-        m_formatter.prefix(PRE_SSE_F2);
-        m_formatter.twoByteOpAddr(OP2_MOVSD_WsdVsd, (RegisterID)src, bitwise_cast<uint32_t>(address));
-    }
-    void movss_mr(const void* address, XMMRegisterID dst)
-    {
-        m_formatter.prefix(PRE_SSE_F3);
-        m_formatter.twoByteOpAddr(OP2_MOVSS_VsdWsd, (RegisterID)dst, bitwise_cast<uint32_t>(address));
-    }
-    void movss_rm(XMMRegisterID src, const void* address)
-    {
-        m_formatter.prefix(PRE_SSE_F3);
-        m_formatter.twoByteOpAddr(OP2_MOVSS_WsdVsd, (RegisterID)src, bitwise_cast<uint32_t>(address));
-    }
-#endif
 
     void mulsd_rr(XMMRegisterID src, XMMRegisterID dst)
     {
@@ -4206,18 +3927,16 @@ public:
         m_formatter.twoByteOp(OP2_CMPXCHG, src, base, index, scale, offset);
     }
 
-#if CPU(X86_64)    
     void cmpxchgq_rm(RegisterID src, int offset, RegisterID base)
     {
         m_formatter.twoByteOp64(OP2_CMPXCHG, src, base, offset);
     }
-    
+
     void cmpxchgq_rm(RegisterID src, int offset, RegisterID base, RegisterID index, int scale)
     {
         m_formatter.twoByteOp64(OP2_CMPXCHG, src, base, index, scale, offset);
     }
-#endif // CPU(X86_64)
-    
+
     void xaddb_rm(RegisterID src, int offset, RegisterID base)
     {
         m_formatter.twoByteOp8(OP2_XADDb, src, base, offset);
@@ -4250,7 +3969,6 @@ public:
         m_formatter.twoByteOp(OP2_XADD, src, base, index, scale, offset);
     }
 
-#if CPU(X86_64)    
     void xaddq_rm(RegisterID src, int offset, RegisterID base)
     {
         m_formatter.twoByteOp64(OP2_XADD, src, base, offset);
@@ -4260,7 +3978,6 @@ public:
     {
         m_formatter.twoByteOp64(OP2_XADD, src, base, index, scale, offset);
     }
-#endif // CPU(X86_64)
 
     void lfence()
     {
@@ -6221,7 +5938,6 @@ public:
         return 5;
     }
     
-#if CPU(X86_64)
     static void revertJumpTo_movq_i64r(void* instructionStart, int64_t imm, RegisterID dst)
     {
         const unsigned instructionSize = 10; // REX.W MOV IMM64
@@ -6261,7 +5977,6 @@ public:
         for (unsigned i = rexBytes + opcodeBytes; i < instructionSize; ++i)
             ptr[i] = u.asBytes[i - rexBytes - opcodeBytes];
     }
-#endif
 
     static void revertJumpTo_cmpl_ir_force32(void* instructionStart, int32_t imm, RegisterID dst)
     {
@@ -6301,10 +6016,8 @@ public:
     static void replaceWithLoad(void* instructionStart)
     {
         uint8_t* ptr = reinterpret_cast<uint8_t*>(instructionStart);
-#if CPU(X86_64)
         if ((*ptr & ~15) == PRE_REX)
             ptr++;
-#endif
         switch (*ptr) {
         case OP_MOV_GvEv:
             break;
@@ -6319,10 +6032,8 @@ public:
     static void replaceWithAddressComputation(void* instructionStart)
     {
         uint8_t* ptr = reinterpret_cast<uint8_t*>(instructionStart);
-#if CPU(X86_64)
         if ((*ptr & ~15) == PRE_REX)
             ptr++;
-#endif
         switch (*ptr) {
         case OP_MOV_GvEv:
             *ptr = OP_LEA;
@@ -6364,7 +6075,6 @@ public:
     static void fillNops(void* base, size_t size)
     {
         UNUSED_PARAM(copy);
-#if CPU(X86_64)
         static const uint8_t nops[10][10] = {
             // nop
             {0x90},
@@ -6401,9 +6111,6 @@ public:
 
             size -= nopSize;
         }
-#else
-        memset(base, OP_NOP, size);
-#endif
     }
 
     // This is a no-op on x86
@@ -6454,7 +6161,6 @@ private:
             m_buffer.putByte(pre);
         }
 
-#if CPU(X86_64)
         // Byte operand register spl & above require a REX prefix (to prevent the 'H' registers be accessed).
         static bool byteRegRequiresRex(int reg)
         {
@@ -6480,13 +6186,6 @@ private:
         {
             return regRequiresRex(a | b | c);
         }
-#else
-        static bool byteRegRequiresRex(int) { return false; }
-        static bool byteRegRequiresRex(int, int) { return false; }
-        static bool regRequiresRex(int) { return false; }
-        static bool regRequiresRex(int, int) { return false; }
-        static bool regRequiresRex(int, int, int) { return false; }
-#endif
 
         class SingleInstructionBufferWriter : public AssemblerBuffer::LocalWriter {
         public:
@@ -6501,7 +6200,6 @@ private:
             static constexpr RegisterID hasSib = X86Registers::esp;
             static constexpr RegisterID noIndex = X86Registers::esp;
 
-#if CPU(X86_64)
             static constexpr RegisterID noBase2 = X86Registers::r13;
             static constexpr RegisterID hasSib2 = X86Registers::r12;
 
@@ -6533,11 +6231,6 @@ private:
             {
                 emitRexIf(regRequiresRex(r, x, b), r, x, b);
             }
-#else
-            // No REX prefix bytes on 32-bit x86.
-            ALWAYS_INLINE void emitRexIf(bool, int, int, int) { }
-            ALWAYS_INLINE void emitRexIfNeeded(int, int, int) { }
-#endif
 
             ALWAYS_INLINE void putModRm(ModRmMode mode, int reg, RegisterID rm)
             {
@@ -6560,11 +6253,7 @@ private:
             ALWAYS_INLINE void memoryModRM(int reg, RegisterID base, int offset)
             {
                 // A base of esp or r12 would be interpreted as a sib, so force a sib with no index & put the base in there.
-#if CPU(X86_64)
                 if ((base == hasSib) || (base == hasSib2)) {
-#else
-                if (base == hasSib) {
-#endif
                     if (!offset) // No need to check if the base is noBase, since we know it is hasSib!
                         putModRmSib(ModRmMemoryNoDisp, reg, base, noIndex, 0);
                     else if (CAN_SIGN_EXTEND_8_32(offset)) {
@@ -6575,11 +6264,7 @@ private:
                         putIntUnchecked(offset);
                     }
                 } else {
-#if CPU(X86_64)
                     if (!offset && (base != noBase) && (base != noBase2))
-#else
-                    if (!offset && (base != noBase))
-#endif
                         putModRm(ModRmMemoryNoDisp, reg, base);
                     else if (CAN_SIGN_EXTEND_8_32(offset)) {
                         putModRm(ModRmMemoryDisp8, reg, base);
@@ -6595,11 +6280,7 @@ private:
             {
                 // A base of esp or r12 would be interpreted as a sib, so force a sib with no index & put the base in there.
                 ASSERT(CAN_SIGN_EXTEND_8_32(offset));
-#if CPU(X86_64)
                 if ((base == hasSib) || (base == hasSib2)) {
-#else
-                if (base == hasSib) {
-#endif
                     putModRmSib(ModRmMemoryDisp8, reg, base, noIndex, 0);
                     putByteUnchecked(offset);
                 } else {
@@ -6611,11 +6292,7 @@ private:
             ALWAYS_INLINE void memoryModRM_disp32(int reg, RegisterID base, int offset)
             {
                 // A base of esp or r12 would be interpreted as a sib, so force a sib with no index & put the base in there.
-#if CPU(X86_64)
                 if ((base == hasSib) || (base == hasSib2)) {
-#else
-                if (base == hasSib) {
-#endif
                     putModRmSib(ModRmMemoryDisp32, reg, base, noIndex, 0);
                     putIntUnchecked(offset);
                 } else {
@@ -6628,11 +6305,7 @@ private:
             {
                 ASSERT(index != noIndex);
 
-#if CPU(X86_64)
                 if (!offset && (base != noBase) && (base != noBase2))
-#else
-                if (!offset && (base != noBase))
-#endif
                     putModRmSib(ModRmMemoryNoDisp, reg, base, index, scale);
                 else if (CAN_SIGN_EXTEND_8_32(offset)) {
                     putModRmSib(ModRmMemoryDisp8, reg, base, index, scale);
@@ -6645,12 +6318,7 @@ private:
 
             ALWAYS_INLINE void memoryModRMAddr(int reg, uint32_t address)
             {
-#if CPU(X86_64)
                 putModRmSib(ModRmMemoryNoDisp, reg, noBase, noIndex, 0);
-#else
-                // noBase + ModRmMemoryNoDisp means noBase + ModRmMemoryDisp32!
-                putModRm(ModRmMemoryNoDisp, reg, noBase);
-#endif
                 putIntUnchecked(address);
             }
 
@@ -7011,7 +6679,6 @@ private:
             writer.memoryModRM(reg, base, displacement);
         }
 
-#if CPU(X86_64)
         // Quad-word-sized operands:
         //
         // Used to format 64-bit operantions, planting a REX.w prefix.
@@ -7124,7 +6791,6 @@ private:
             writer.putByteUnchecked(opcode);
             writer.registerModRM(reg, rm);
         }
-#endif
 
         // Byte-operands:
         //
@@ -7268,4 +6934,4 @@ private:
 
 } // namespace JSC
 
-#endif // ENABLE(ASSEMBLER) && CPU(X86)
+#endif // ENABLE(ASSEMBLER) && CPU(X86_64)

--- a/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -74,7 +74,7 @@ static Vector<double> doubleOperands()
 }
 
 
-#if CPU(X86) || CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
+#if CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
 static Vector<float> floatOperands()
 {
     return Vector<float> {
@@ -2968,7 +2968,7 @@ void testOrUnsignedRightShift64()
 }
 #endif
 
-#if CPU(X86) || CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
+#if CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
 void testCompareFloat(MacroAssembler::DoubleCondition condition)
 {
     float arg1 = 0;
@@ -3009,7 +3009,7 @@ void testCompareFloat(MacroAssembler::DoubleCondition condition)
         }
     }
 }
-#endif // CPU(X86) || CPU(X86_64) || CPU(ARM64)
+#endif // CPU(X86_64) || CPU(ARM64)
 
 #if CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
 
@@ -4758,7 +4758,7 @@ void testProbeModifiesStackPointer(WTF::Function<void*(Probe::Context&)> compute
     uintptr_t modifiedFlags { 0 };
 #endif
     
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
     auto flagsSPR = X86Registers::eflags;
     uintptr_t flagsMask = 0xc5;
 #elif CPU(ARM_THUMB2)
@@ -4940,7 +4940,7 @@ void testProbeModifiesStackValues()
 #endif
     size_t numberOfExtraEntriesToWrite { 10 }; // ARM64 requires that this be 2 word aligned.
 
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
     MacroAssembler::SPRegisterID flagsSPR = X86Registers::eflags;
     uintptr_t flagsMask = 0xc5;
 #elif CPU(ARM_THUMB2)
@@ -5897,7 +5897,7 @@ void run(const char* filter) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     RUN(testAtomicStrongCASFill16());
 #endif
 
-#if CPU(X86) || CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
+#if CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
     FOR_EACH_DOUBLE_CONDITION_RUN(testCompareFloat);
 #endif
 

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -103,7 +103,7 @@ public:
         , m_procedure(procedure)
         , m_code(procedure.code())
         , m_blockInsertionSet(m_code)
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
         , m_eax(X86Registers::eax)
         , m_ecx(X86Registers::ecx)
         , m_edx(X86Registers::edx)

--- a/Source/JavaScriptCore/b3/air/AirInstInlines.h
+++ b/Source/JavaScriptCore/b3/air/AirInstInlines.h
@@ -145,7 +145,7 @@ inline std::optional<unsigned> Inst::shouldTryAliasingDef()
     case AddFloat:
     case MulDouble:
     case MulFloat:
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
         if (MacroAssembler::supportsAVX())
             return std::nullopt;
 #endif
@@ -183,7 +183,7 @@ inline std::optional<unsigned> Inst::shouldTryAliasingDef()
 
 inline bool isShiftValid(const Inst& inst)
 {
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
     return inst.args[0] == Tmp(X86Registers::ecx);
 #else
     UNUSED_PARAM(inst);
@@ -243,7 +243,7 @@ inline bool isRotateLeft64Valid(const Inst& inst)
 
 inline bool isX86DivHelperValid(const Inst& inst)
 {
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
     return inst.args[0] == Tmp(X86Registers::eax)
         && inst.args[1] == Tmp(X86Registers::edx);
 #else
@@ -284,7 +284,7 @@ inline bool isX86UDiv64Valid(const Inst& inst)
 
 inline bool isAtomicStrongCASValid(const Inst& inst)
 {
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
     switch (inst.args.size()) {
     case 3:
         return inst.args[0] == Tmp(X86Registers::eax);
@@ -293,20 +293,20 @@ inline bool isAtomicStrongCASValid(const Inst& inst)
     default:
         return false;
     }
-#else // CPU(X86) || CPU(X86_64)
+#else // CPU(X86_64)
     UNUSED_PARAM(inst);
     return false;
-#endif // CPU(X86) || CPU(X86_64)
+#endif // CPU(X86_64)
 }
 
 inline bool isBranchAtomicStrongCASValid(const Inst& inst)
 {
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
     return inst.args[1] == Tmp(X86Registers::eax);
-#else // CPU(X86) || CPU(X86_64)
+#else // CPU(X86_64)
     UNUSED_PARAM(inst);
     return false;
-#endif // CPU(X86) || CPU(X86_64)
+#endif // CPU(X86_64)
 }
 
 inline bool isAtomicStrongCAS8Valid(const Inst& inst)

--- a/Source/JavaScriptCore/b3/air/testair.cpp
+++ b/Source/JavaScriptCore/b3/air/testair.cpp
@@ -1678,7 +1678,7 @@ void testShuffleShiftDouble()
     CHECK(things[3] == 3);
 }
 
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
 void testX86VMULSD()
 {
     B3::Procedure proc;
@@ -1869,7 +1869,7 @@ void testX86VMULSDBaseIndexNeedRex()
     uint64_t index = 16;
     CHECK(compileAndRun<double>(proc, 2.4, &secondArg - 2, index, pureNaN()) == 2.4 * 4.2);
 }
-#endif // #if CPU(X86) || CPU(X86_64)
+#endif // #if CPU(X86_64)
 
 #if CPU(ARM64)
 void testInvalidateCachedTempRegisters()
@@ -2621,7 +2621,7 @@ void run(const char* filter)
     RUN(testShuffleSwapDouble());
     RUN(testShuffleShiftDouble());
 
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
     RUN(testX86VMULSD());
     RUN(testX86VMULSDDestRex());
     RUN(testX86VMULSDOp1DestRex());

--- a/Source/JavaScriptCore/b3/testb3_3.cpp
+++ b/Source/JavaScriptCore/b3/testb3_3.cpp
@@ -2287,7 +2287,7 @@ void testFloorArgWithEffectfulDoubleConversion(float a)
 
 double correctSqrt(double value)
 {
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
     double result;
     asm ("sqrtsd %1, %0" : "=x"(result) : "x"(value));
     return result;

--- a/Source/JavaScriptCore/bytecode/InlineAccess.h
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.h
@@ -46,8 +46,6 @@ public:
     {
 #if CPU(X86_64)
         return 26;
-#elif CPU(X86)
-        return 27;
 #elif CPU(ARM64)
         return 40;
 #elif CPU(ARM_THUMB2)
@@ -66,8 +64,6 @@ public:
     {
 #if CPU(X86_64)
         return 26;
-#elif CPU(X86)
-        return 27;
 #elif CPU(ARM64)
         return 40;
 #elif CPU(ARM_THUMB2)
@@ -89,8 +85,6 @@ public:
     {
 #if CPU(X86_64)
         size_t size = 43;
-#elif CPU(X86)
-        size_t size = 27;
 #elif CPU(ARM64)
         size_t size = 44;
 #elif CPU(ARM_THUMB2)

--- a/Source/JavaScriptCore/bytecode/PolymorphicAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/PolymorphicAccess.cpp
@@ -733,7 +733,7 @@ AccessGenerationResult PolymorphicAccess::regenerate(const GCSafeConcurrentJSLoc
         // patch things if the countdown reaches zero. We increment the slow path count here to ensure
         // that the slow path does not try to patch.
         if (codeBlock->useDataIC()) {
-#if CPU(X86) || CPU(X86_64) || CPU(ARM64)
+#if CPU(X86_64) || CPU(ARM64)
             jit.add8(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(stubInfo.m_stubInfoGPR, StructureStubInfo::offsetOfCountdown()));
 #else
             jit.load8(CCallHelpers::Address(stubInfo.m_stubInfoGPR, StructureStubInfo::offsetOfCountdown()), state.scratchGPR);
@@ -741,7 +741,7 @@ AccessGenerationResult PolymorphicAccess::regenerate(const GCSafeConcurrentJSLoc
             jit.store8(state.scratchGPR, CCallHelpers::Address(stubInfo.m_stubInfoGPR, StructureStubInfo::offsetOfCountdown()));
 #endif
         } else {
-#if CPU(X86) || CPU(X86_64) || CPU(ARM64)
+#if CPU(X86_64) || CPU(ARM64)
             jit.move(CCallHelpers::TrustedImmPtr(&stubInfo.countdown), state.scratchGPR);
             jit.add8(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(state.scratchGPR));
 #else

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
@@ -2741,7 +2741,7 @@ TypedTmp AirIRGenerator::appendGeneralAtomic(ExtAtomicOpType op, B3::Air::Opcode
     }
 
     if (isX86()) {
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
         Tmp eax(X86Registers::eax);
         B3::Air::Opcode casOpcode = OPCODE_FOR_WIDTH(BranchAtomicStrongCAS, accessWidth);
         append(Move, oldValue, eax);
@@ -2782,7 +2782,7 @@ TypedTmp AirIRGenerator::appendStrongCAS(ExtAtomicOpType op, TypedTmp expected, 
     Tmp newValueTmp = tmp(value);
 
     if (isX86()) {
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
         Tmp eax(X86Registers::eax);
         append(Move, expectedValueTmp, eax);
         appendEffectful(OPCODE_FOR_WIDTH(AtomicStrongCAS, accessWidth), eax, newValueTmp, address);

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
@@ -1278,7 +1278,7 @@ TypedTmp AirIRGenerator64::appendGeneralAtomic(ExtAtomicOpType op, B3::Air::Opco
     }
 
     if (isX86()) {
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
         Tmp eax(X86Registers::eax);
         B3::Air::Opcode casOpcode = OPCODE_FOR_WIDTH(BranchAtomicStrongCAS, accessWidth);
         append(Move, oldValue, eax);
@@ -1319,7 +1319,7 @@ TypedTmp AirIRGenerator64::appendStrongCAS(ExtAtomicOpType op, TypedTmp expected
     Tmp newValueTmp = tmp(value);
 
     if (isX86()) {
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86_64)
         Tmp eax(X86Registers::eax);
         append(Move, expectedValueTmp, eax);
         appendEffectful(OPCODE_FOR_WIDTH(AtomicStrongCAS, accessWidth), eax, newValueTmp, address);


### PR DESCRIPTION
#### a8445079d788036af6b5b3138a276bf94d50f1cc
<pre>
[JSC] Remove remaining 32bit x86 assembler part
<a href="https://bugs.webkit.org/show_bug.cgi?id=249333">https://bugs.webkit.org/show_bug.cgi?id=249333</a>
rdar://103371626

Reviewed by NOBODY (OOPS!).

This patch sweeps remaining 32bit X86 things in our assembler.

* Source/JavaScriptCore/assembler/MacroAssembler.h:
(JSC::MacroAssembler::store32):
* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.cpp:
(JSC::MacroAssembler::probe):
(JSC::ctiMasmProbeTrampoline): Deleted.
* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h:
(JSC::MacroAssemblerX86Common::byteSwap64):
(JSC::MacroAssemblerX86Common::store8):
(JSC::MacroAssemblerX86Common::loadDouble):
(JSC::MacroAssemblerX86Common::loadFloat):
(JSC::MacroAssemblerX86Common::branchConvertDoubleToInt32):
(JSC::MacroAssemblerX86Common::zeroExtend32ToWord):
(JSC::MacroAssemblerX86Common::set32):
(JSC::MacroAssemblerX86Common::cmov):
(JSC::MacroAssemblerX86Common::moveConditionallyAfterFloatingPointCompare):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::lastRegister):
(JSC::X86Assembler::lastFPRegister):
(JSC::X86Assembler::addl_mr):
(JSC::X86Assembler::addq_im):
(JSC::X86Assembler::andq_im):
(JSC::X86Assembler::decq_r):
(JSC::X86Assembler::incq_m):
(JSC::X86Assembler::negq_m):
(JSC::X86Assembler::notq_m):
(JSC::X86Assembler::orq_ir):
(JSC::X86Assembler::subq_im):
(JSC::X86Assembler::xorq_mr):
(JSC::X86Assembler::lzcntq_mr):
(JSC::X86Assembler::bsrq_mr):
(JSC::X86Assembler::bswapq_r):
(JSC::X86Assembler::tzcntq_rr):
(JSC::X86Assembler::bsfq_rr):
(JSC::X86Assembler::btrq_rr):
(JSC::X86Assembler::popcntq_mr):
(JSC::X86Assembler::rolq_CLr):
(JSC::X86Assembler::imulq_rr):
(JSC::X86Assembler::idivq_r):
(JSC::X86Assembler::cmpq_im):
(JSC::X86Assembler::testq_i32m):
(JSC::X86Assembler::btw_im):
(JSC::X86Assembler::cqo):
(JSC::X86Assembler::movl_mEAX):
(JSC::X86Assembler::movl_EAXm):
(JSC::X86Assembler::movl_i32m):
(JSC::X86Assembler::cmovnpq_rr):
(JSC::X86Assembler::leaq_mr):
(JSC::X86Assembler::jmp_m):
(JSC::X86Assembler::cvtsi2ssq_mr):
(JSC::X86Assembler::cvttss2siq_rr):
(JSC::X86Assembler::cvttsd2siq_rr):
(JSC::X86Assembler::movq_rr):
(JSC::X86Assembler::xaddq_rm):
(JSC::X86Assembler::revertJumpTo_movl_i32r):
(JSC::X86Assembler::replaceWithLoad):
(JSC::X86Assembler::replaceWithAddressComputation):
(JSC::X86Assembler::fillNops):
(JSC::X86Assembler::X86InstructionFormatter::regRequiresRex):
(JSC::X86Assembler::X86InstructionFormatter::SingleInstructionBufferWriter::emitRexIfNeeded):
(JSC::X86Assembler::X86InstructionFormatter::SingleInstructionBufferWriter::memoryModRM):
(JSC::X86Assembler::X86InstructionFormatter::SingleInstructionBufferWriter::memoryModRM_disp8):
(JSC::X86Assembler::X86InstructionFormatter::SingleInstructionBufferWriter::memoryModRM_disp32):
(JSC::X86Assembler::X86InstructionFormatter::SingleInstructionBufferWriter::memoryModRMAddr):
(JSC::X86Assembler::X86InstructionFormatter::threeByteOp64):
(JSC::X86Assembler::adcl_im): Deleted.
* Source/JavaScriptCore/assembler/testmasm.cpp:
(JSC::testProbeModifiesStackPointer):
(JSC::testProbeModifiesStackValues):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/air/AirInstInlines.h:
(JSC::B3::Air::Inst::shouldTryAliasingDef):
(JSC::B3::Air::isShiftValid):
(JSC::B3::Air::isX86DivHelperValid):
(JSC::B3::Air::isAtomicStrongCASValid):
(JSC::B3::Air::isBranchAtomicStrongCASValid):
* Source/JavaScriptCore/b3/air/testair.cpp:
* Source/JavaScriptCore/b3/testb3_3.cpp:
(correctSqrt):
* Source/JavaScriptCore/bytecode/InlineAccess.h:
(JSC::InlineAccess::sizeForPropertyAccess):
(JSC::InlineAccess::sizeForPropertyReplace):
(JSC::InlineAccess::sizeForLengthAccess):
* Source/JavaScriptCore/bytecode/PolymorphicAccess.cpp:
(JSC::PolymorphicAccess::regenerate):
* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::appendGeneralAtomic):
(JSC::Wasm::AirIRGenerator::appendStrongCAS):
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::appendGeneralAtomic):
(JSC::Wasm::AirIRGenerator64::appendStrongCAS):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8445079d788036af6b5b3138a276bf94d50f1cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109634 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169883 "Failed to checkout and rebase branch from PR 7637") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10546 "Failed to checkout and rebase branch from PR 7637") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/17 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92719 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107514 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34521 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89784 "Build was cancelled. Recent messages:Encountered some issues during cleanup") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77476 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90867 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3222 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24037 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86870 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/674 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/150 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29091 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43527 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89750 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5031 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20063 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->