### PR TITLE
`font-variant-alternates: historical-forms` doesn't reflect properly via StylePropertyMap

### DIFF
--- a/LayoutTests/fast/css/font-variant-alternates-computed-value-expected.txt
+++ b/LayoutTests/fast/css/font-variant-alternates-computed-value-expected.txt
@@ -1,0 +1,15 @@
+Testing for the font-variant-alternates computed values
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+target.style.fontVariantAlternates = 'historical-forms swash(flowing)';
+PASS getComputedStyle(target).fontVariantAlternates is "historical-forms swash(flowing)"
+target.style.fontVariantAlternates = 'historical-forms';
+PASS getComputedStyle(target).fontVariantAlternates is "historical-forms"
+target.style.fontVariantAlternates = 'normal';
+PASS getComputedStyle(target).fontVariantAlternates is "normal"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/font-variant-alternates-computed-value.html
+++ b/LayoutTests/fast/css/font-variant-alternates-computed-value.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+description("Testing for the font-variant-alternates computed values");
+
+const target = document.getElementById("target");
+evalAndLog("target.style.fontVariantAlternates = 'historical-forms swash(flowing)';");
+shouldBeEqualToString("getComputedStyle(target).fontVariantAlternates", "historical-forms swash(flowing)");
+
+evalAndLog("target.style.fontVariantAlternates = 'historical-forms';");
+shouldBeEqualToString("getComputedStyle(target).fontVariantAlternates", "historical-forms");
+
+evalAndLog("target.style.fontVariantAlternates = 'normal';");
+shouldBeEqualToString("getComputedStyle(target).fontVariantAlternates", "normal");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-alternates-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-alternates-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'font-variant-alternates' to CSS-wide keywords: unset
 PASS Can set 'font-variant-alternates' to CSS-wide keywords: revert
 PASS Can set 'font-variant-alternates' to var() references:  var(--A)
 PASS Can set 'font-variant-alternates' to the 'normal' keyword: normal
-FAIL Can set 'font-variant-alternates' to the 'historical-forms' keyword: historical-forms assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+PASS Can set 'font-variant-alternates' to the 'historical-forms' keyword: historical-forms
 PASS Setting 'font-variant-alternates' to a length: 0px throws TypeError
 PASS Setting 'font-variant-alternates' to a length: -3.14em throws TypeError
 PASS Setting 'font-variant-alternates' to a length: 3.14cm throws TypeError

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1473,10 +1473,19 @@ static Ref<CSSValue> fontVariantNumericPropertyValue(FontVariantNumericFigure fi
     return valueList;
 }
 
+static FontVariantAlternatesValues historicalFormsValues()
+{
+    FontVariantAlternatesValues values;
+    values.historicalForms = true;
+    return values;
+}
+
 static Ref<CSSValue> fontVariantAlternatesPropertyValue(FontVariantAlternates alternates)
 {
     if (alternates.isNormal())
         return CSSValuePool::singleton().createIdentifierValue(CSSValueNormal);
+    if (alternates.values() == historicalFormsValues())
+        return CSSValuePool::singleton().createIdentifierValue(CSSValueHistoricalForms);
 
     return CSSFontVariantAlternatesValue::create(WTFMove(alternates));
 }


### PR DESCRIPTION
#### 37f48652e37e505cc21a3a655d024de17fcc02ce
<pre>
`font-variant-alternates: historical-forms` doesn&apos;t reflect properly via StylePropertyMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=249337">https://bugs.webkit.org/show_bug.cgi?id=249337</a>

Reviewed by Tim Nguyen.

`font-variant-alternates: historical-forms` doesn&apos;t reflect properly via
StylePropertyMap. Even though `historical-forms` is a supported keyword for
this CSS property [1], we wouldn&apos;t get a CSSKeywordValue when reading the
property value back. The issue is that we convert to a FontVariantAlternates
internally and then back to a CSSValue. The function to convert back to a
CSSValue (fontVariantAlternatesPropertyValue) was only handling the `normal`
keyword but not the `historical-forms` one.

[1] <a href="https://w3c.github.io/csswg-drafts/css-fonts/#font-variant-alternates-prop">https://w3c.github.io/csswg-drafts/css-fonts/#font-variant-alternates-prop</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-alternates-expected.txt:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::fontVariantAlternatesPropertyValue):

Canonical link: <a href="https://commits.webkit.org/257955@main">https://commits.webkit.org/257955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7df940c0bd6c8386e8aab279e310937d0bdc6219

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33505 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/109777 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170026 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/182 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107632 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91226 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22615 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3339 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24134 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3331 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/281 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43624 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5146 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2848 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->