### PR TITLE
Add a way to register custom URL schemes with _WKWebExtensionMatchPattern.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h
@@ -74,6 +74,14 @@ NS_SWIFT_NAME(_WKWebExtension.MatchPattern)
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
+/*!
+ @abstract Registers a custom URL scheme that can be used in match patterns.
+ @discussion This method should be used to register any custom URL schemes used by the app for the extension base URLs,
+ other than `webkit-extension`, or if extensions should have access to other supported URL schemes when using `<all_urls>`.
+ @param urlScheme The custom URL scheme to register.
+*/
++ (void)registerCustomURLScheme:(NSString *)urlScheme;
+
 /*! @abstract Returns a pattern object for `<all_urls>`. */
 + (instancetype)allURLsMatchPattern;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
@@ -32,6 +32,7 @@
 
 #import "WebExtensionMatchPattern.h"
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/URLParser.h>
 
 static NSString * const stringCodingKey = @"string";
 
@@ -65,6 +66,13 @@ NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMa
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS)
+
++ (void)registerCustomURLScheme:(NSString *)urlScheme
+{
+    NSAssert1(WTF::URLParser::maybeCanonicalizeScheme(String(urlScheme)), @"Invalid parameter: '%@' is not a valid URL scheme", urlScheme);
+
+    WebKit::WebExtensionMatchPattern::registerCustomURLScheme(urlScheme);
+}
 
 + (instancetype)allURLsMatchPattern
 {
@@ -246,6 +254,10 @@ static OptionSet<WebKit::WebExtensionMatchPattern::Options> toImpl(_WKWebExtensi
 }
 
 #else // ENABLE(WK_WEB_EXTENSIONS)
+
++ (void)registerCustomURLScheme:(NSString *)urlScheme
+{
+}
 
 + (instancetype)allURLsMatchPattern
 {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
@@ -37,6 +37,7 @@
 #import <wtf/HashMap.h>
 #import <wtf/HashSet.h>
 #import <wtf/NeverDestroyed.h>
+#import <wtf/URLParser.h>
 #import <wtf/text/StringHash.h>
 
 namespace WebKit {
@@ -45,16 +46,14 @@ static NSString * const allURLsPattern = @"<all_urls>";
 static NSString * const allHostsAndSchemesPattern = @"*://*/*";
 static NSString * const patternFormat = @"%@://%@%@";
 
-const WebExtensionMatchPattern::URLSchemeSet& WebExtensionMatchPattern::validSchemes()
+WebExtensionMatchPattern::URLSchemeSet& WebExtensionMatchPattern::validSchemes()
 {
-    // FIXME: Add custom extension schemes to this set.
     static MainThreadNeverDestroyed<URLSchemeSet> schemes = std::initializer_list<String> { "*"_s, "http"_s, "https"_s, "file"_s, "ftp"_s, "webkit-extension"_s };
     return schemes;
 }
 
-const WebExtensionMatchPattern::URLSchemeSet& WebExtensionMatchPattern::supportedSchemes()
+WebExtensionMatchPattern::URLSchemeSet& WebExtensionMatchPattern::supportedSchemes()
 {
-    // FIXME: Add custom extension schemes to this set.
     static MainThreadNeverDestroyed<URLSchemeSet> schemes = std::initializer_list<String> { "*"_s, "http"_s, "https"_s, "webkit-extension"_s };
     return schemes;
 }
@@ -63,6 +62,15 @@ static HashMap<String, RefPtr<WebExtensionMatchPattern>>& patternCache()
 {
     static MainThreadNeverDestroyed<HashMap<String, RefPtr<WebExtensionMatchPattern>>> cache;
     return cache;
+}
+
+void WebExtensionMatchPattern::registerCustomURLScheme(String urlScheme)
+{
+    auto canonicalScheme = WTF::URLParser::maybeCanonicalizeScheme(String(urlScheme));
+    ASSERT(canonicalScheme);
+
+    validSchemes().addVoid(canonicalScheme.value());
+    supportedSchemes().addVoid(canonicalScheme.value());
 }
 
 RefPtr<WebExtensionMatchPattern> WebExtensionMatchPattern::getOrCreate(NSString *pattern)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -74,8 +74,10 @@ public:
         MatchBidirectionally = 1 << 2, // Match two patterns in either direction (A matches B, or B matches A). Invalid for matching URLs.
     };
 
-    static const URLSchemeSet& validSchemes();
-    static const URLSchemeSet& supportedSchemes();
+    static URLSchemeSet& validSchemes();
+    static URLSchemeSet& supportedSchemes();
+
+    static void registerCustomURLScheme(String);
 
     bool operator==(const WebExtensionMatchPattern&) const;
     bool operator!=(const WebExtensionMatchPattern& other) const { return !(this == &other); }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
@@ -479,6 +479,49 @@ TEST(WKWebExtensionMatchPattern, PatternCacheAndEquality)
     }
 }
 
+TEST(WKWebExtensionMatchPattern, CustomURLScheme)
+{
+    {
+        NSError *error;
+        EXPECT_NULL(toPatternAlloc(@"foo", @"*", @"/", &error));
+        EXPECT_NS_EQUAL(error.userInfo[NSDebugDescriptionErrorKey], @"Scheme \"foo\" is invalid.");
+    }
+
+    {
+        NSError *error;
+        EXPECT_NULL(toPatternAlloc(@"bar", @"*", @"/", &error));
+        EXPECT_NS_EQUAL(error.userInfo[NSDebugDescriptionErrorKey], @"Scheme \"bar\" is invalid.");
+    }
+
+    [_WKWebExtensionMatchPattern registerCustomURLScheme:@"foo"];
+
+    {
+        NSError *error;
+        EXPECT_NOT_NULL(toPatternAlloc(@"foo", @"*", @"/", &error));
+        EXPECT_NULL(error);
+    }
+
+    {
+        NSError *error;
+        EXPECT_NULL(toPatternAlloc(@"bar", @"*", @"/", &error));
+        EXPECT_NS_EQUAL(error.userInfo[NSDebugDescriptionErrorKey], @"Scheme \"bar\" is invalid.");
+    }
+
+    [_WKWebExtensionMatchPattern registerCustomURLScheme:@"bar"];
+
+    {
+        NSError *error;
+        EXPECT_NOT_NULL(toPatternAlloc(@"foo", @"*", @"/", &error));
+        EXPECT_NULL(error);
+    }
+
+    {
+        NSError *error;
+        EXPECT_NOT_NULL(toPatternAlloc(@"bar", @"*", @"/", &error));
+        EXPECT_NULL(error);
+    }
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### d9e131c11be037bf572da8e2c71c42245ac99351
<pre>
Add a way to register custom URL schemes with _WKWebExtensionMatchPattern.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249336">https://bugs.webkit.org/show_bug.cgi?id=249336</a>

Reviewed by Brian Weinstein.

This method is needed to register any custom URL schemes used by the app for the extension base URLs, other than
`webkit-extension`, or if extensions should have access to other supported URL schemes when using `&lt;all_urls&gt;`.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm:
(+[_WKWebExtensionMatchPattern registerCustomURLScheme:]): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm:
(WebKit::WebExtensionMatchPattern::validSchemes):
(WebKit::WebExtensionMatchPattern::supportedSchemes):
(WebKit::WebExtensionMatchPattern::registerCustomURLScheme):
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/257895@main">https://commits.webkit.org/257895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfb851c931d3f12bbce5af511eacac8bb1970945

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109642 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/23 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92725 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107520 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106101 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91133 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3228 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24042 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3220 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43532 "Passed tests") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2805 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->