### PR TITLE
[CMake] Remove WEBKIT_CREATE_FORWARDING_HEADER macro

### DIFF
--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -369,28 +369,6 @@ macro(WEBKIT_WRAP_EXECUTABLE _target)
     set(${_target}_DEPENDENCIES ${_wrapped_target_name})
 endmacro()
 
-macro(WEBKIT_CREATE_FORWARDING_HEADER _target_directory _file)
-    get_filename_component(_source_path "${CMAKE_SOURCE_DIR}/Source/" ABSOLUTE)
-    get_filename_component(_absolute "${_file}" ABSOLUTE)
-    get_filename_component(_name "${_file}" NAME)
-    set(_target_filename "${_target_directory}/${_name}")
-
-    # Try to make the path in the forwarding header relative to the Source directory
-    # so that these forwarding headers are compatible with the ones created by the
-    # WebKit2 generate-forwarding-headers script.
-    string(REGEX REPLACE "${_source_path}/" "" _relative ${_absolute})
-
-    set(_content "#include \"${_relative}\"\n")
-
-    if (EXISTS "${_target_filename}")
-        file(READ "${_target_filename}" _old_content)
-    endif ()
-
-    if (NOT _old_content STREQUAL _content)
-        file(WRITE "${_target_filename}" "${_content}")
-    endif ()
-endmacro()
-
 function(WEBKIT_COPY_FILES target_name)
     set(options FLATTENED)
     set(oneValueArgs DESTINATION)


### PR DESCRIPTION
#### a9b23fd18699936c541c05a51c582a32822537ec
<pre>
[CMake] Remove WEBKIT_CREATE_FORWARDING_HEADER macro
<a href="https://bugs.webkit.org/show_bug.cgi?id=249343">https://bugs.webkit.org/show_bug.cgi?id=249343</a>

Reviewed by Michael Catanzaro.

The macro is no longer used so delete it.

* Source/cmake/WebKitMacros.cmake:

Canonical link: <a href="https://commits.webkit.org/257897@main">https://commits.webkit.org/257897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6db4a146c2bfe04b8c82cc1a368828b68f70d7d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109636 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/19 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92721 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107516 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106094 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91125 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34520 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22516 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90869 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3224 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24034 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86872 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/676 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3213 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29092 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43524 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89753 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5424 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5033 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20064 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->