### PR TITLE
Add support for embedded surveys in post or page content on webkit.org

### DIFF
--- a/Websites/webkit.org/wp-content/plugins/webkit-survey/plugin.php
+++ b/Websites/webkit.org/wp-content/plugins/webkit-survey/plugin.php
@@ -1,0 +1,224 @@
+<?php
+/*
+Plugin Name: WebKit Surveys
+Description: Create surveys to include on pages or posts
+Version:     1.0
+Author:      Jonathan Davis
+Author URI:  http://webkit.org
+*/
+
+defined('WPINC') || header('HTTP/1.1 403') & exit; // Prevent direct access
+
+class WebKit_Survey {
+    
+    static $responded = false;   // Track when a user has responded
+    static $post_update = false; // Track when the host post/page is updated
+    
+    public static function init() {
+        add_action('init', [__CLASS__, 'register_shortcodes']);
+        add_action('post_updated', [__CLASS__, 'process_survey'], 10, 3);
+        add_action('wp', [__CLASS__, 'process_vote']);
+        
+        add_action( 'add_meta_boxes', [__CLASS__, 'add_survey_boxes'] );
+    }
+
+    public static function register_shortcodes() {
+        add_shortcode('survey', ['WebKit_Survey', 'survey_shortcode']);
+    }
+    
+    public function process_survey($post_id, $post_after, $post_before) {
+        self::$post_update = true;
+        do_shortcode($post_after->post_content);
+    }
+    
+    public function survey_shortcode($atts, $content) {
+        $json_string = str_replace(array('“','”'), '"', html_entity_decode(strip_tags($content)));
+        $Survey = json_decode($json_string);
+
+        // Capture survey settings data when updating the post
+        if (self::$post_update) {
+            $post_id = get_the_ID();
+            $Survey->status = $atts['closed'] == 'true' ? 'closed' : 'open';
+            if (!add_post_meta($post_id, 'webkit_survey_settings', $Survey, true))
+                update_post_meta($post_id, 'webkit_survey_settings', $Survey);
+        }
+
+        $survey_template = dirname(__FILE__) . '/survey.php';
+        $results_template = dirname(__FILE__) . '/results.php';
+        $ui_template = $survey_template;
+        
+        if ($atts['closed'] == "true" || self::responded())
+            $ui_template = $results_template;
+        
+        ob_start();
+        if ($atts['visible-results'] == "true")
+            include($results_template);
+        include_once($ui_template);
+        return ob_get_clean();
+    }
+
+    public function add_survey_boxes() {
+        $post_id = get_the_ID();
+        $settings = get_post_meta($post_id, 'webkit_survey_settings');
+        if (!$settings)
+            return;
+
+        $screens = [ 'post', 'page' ];
+        foreach ( $screens as $screen ) {
+            add_meta_box(
+                'webkit_survey',
+                'WebKit Survey',
+                [__CLASS__, 'admin_box'],
+                $screen
+            );
+        }
+    }
+    
+    public function admin_box() {
+        $post_id = get_the_ID();
+        $settings = get_post_meta($post_id, 'webkit_survey_settings');
+        ?>
+        <style>
+            :root {
+                --background-color: hsl(203.6, 100%, 12%);
+                --text-color-coolgray: hsl(240, 2.3%, 56.7%);
+            }
+            html {
+                font-size: 62.5%;
+            }
+        </style>
+        <?php
+        include(dirname(__FILE__) . '/results.php');
+    }
+
+    public function process_vote() {
+        if (self::responded()) {
+            self::$responded = true;
+            return;
+        }
+
+        $post_id = get_the_ID();
+        $settings = get_post_meta($post_id, 'webkit_survey_settings');
+        $Survey = $settings[0];
+        $key = sha1(json_encode($Survey->survey));
+
+        if (!wp_verify_nonce(filter_input(INPUT_POST, '_nonce'), "webkit_survey-$post_id"))
+            return;
+
+        $posted_input = filter_input_array(INPUT_POST, [
+            'questions' => [
+                'flags'     => FILTER_REQUIRE_ARRAY,
+                'filter'    => FILTER_VALIDATE_INT
+            ],
+            'other' => [
+                'flags'     => FILTER_REQUIRE_ARRAY,
+                'filter'    => FILTER_VALIDATE_SCALAR
+            ]
+        ]);
+
+        $data = $posted_input['questions'];
+        foreach ($Survey->survey as $id => $SurveyQuestion) {
+            $response = $posted_input['questions'][$id];
+            $answer = empty($SurveyQuestion->responses[$response]) ? $response : $SurveyQuestion->responses[$response];
+            if ($answer == 'Other:')
+                $data[$id] .= "::" . $posted_input['other'][$id];
+        }
+
+        if (!is_null($data)) {
+            add_post_meta($post_id, $key, $data);
+            
+            // Same day, same device vote-stuffing protection
+            set_transient($post_id . '_' . self::voter_hash(), true, DAY_IN_SECONDS);
+            
+            // Ensure vote calculations get updated
+            delete_transient($key);
+        }
+
+        self::$responded = true;
+
+        $post_url_parts = parse_url(get_permalink());
+        setcookie(
+            self::cookie_name($post_id),     // name
+            1,                               // value
+            time() + YEAR_IN_SECONDS,        // expires
+            $post_url_parts['path'],         // path
+            $post_url_parts['host'],         // domain
+            false,                           // secure
+            true                             // httponly
+        );
+        
+        // Redirect for reload POST protection
+        header('Location: ' . get_permalink());
+    }
+    
+    public static function calculate_results() {
+        $post_id = get_the_ID();
+        $settings = get_post_meta($post_id, 'webkit_survey_settings');
+        $Survey = $settings[0];
+        $key = sha1(json_encode($Survey->survey));
+
+        // Use cached tabulated responses if they exist
+        if (false !== ($cached = get_transient($key)))
+            return unserialize($cached);
+
+        $responses = get_post_custom_values($key);
+        $max = 0;
+
+        // Add the tabulated responses to the survey data
+        foreach ($responses as $response) {
+            $response = unserialize($response);
+            foreach ($response as $question_index => $option) {
+                $SurveyQuestion = $Survey->survey[$question_index];
+                
+                if (!isset($SurveyQuestion->scores))
+                    $SurveyQuestion->scores = [];
+        
+                if (strpos($option, "::")!== false) {
+                    list($option, $other_value) = explode("::", $option);
+                    
+                    if (!isset($SurveyQuestion->other))                
+                        $SurveyQuestion->other = [];
+                    
+                    $SurveyQuestion->other[] = $other_value;
+                }
+                
+                $option = intval($option);
+                
+                if (!isset($SurveyQuestion->scores[$option]))
+                    $SurveyQuestion->scores[$option] = 0;
+                
+                $SurveyQuestion->scores[$option]++;
+                if ($SurveyQuestion->scores[$option] > $max)
+                   $Survey->winner = $option;
+                
+                if (!isset($SurveyQuestion->scores['total']))
+                    $SurveyQuestion->scores['total'] = 0;
+                    
+                $SurveyQuestion->scores['total']++;
+
+            }
+        }
+        
+        // Cache the tabulated responses
+        set_transient($key, serialize($Survey), 300);
+        return $Survey;
+    }
+
+    public static function responded() {
+        $voter_hash_transient = get_transient(get_the_ID() . '_' . self::voter_hash());
+        $voted_cookie = filter_input(INPUT_COOKIE, self::cookie_name(get_the_ID()));
+        return self::$responded || $voter_hash_transient || $voted_cookie;
+    }
+
+    private static function cookie_name($key) {
+        return $key . COOKIEHASH;
+    }
+    
+    private static function voter_hash() {
+        $ip = filter_input(INPUT_SERVER, 'REMOTE_ADDR');
+        $ua = filter_input(INPUT_SERVER, 'HTTP_USER_AGENT');
+        return sha1($ip . $ua);
+    }
+}
+
+WebKit_Survey::init();

--- a/Websites/webkit.org/wp-content/plugins/webkit-survey/results.php
+++ b/Websites/webkit.org/wp-content/plugins/webkit-survey/results.php
@@ -1,0 +1,74 @@
+<style>
+    .survey-results {
+        position: relative;
+        list-style: none;
+        padding-left: 0;
+    }
+
+    .survey-results > li {
+        margin-bottom: 1.7rem;
+        position: relative;
+    }
+    
+    .label {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: flex-end;
+    }
+    
+    .bar {
+        display: block;
+        height: 0.7rem;
+        width: 100%;
+        border-radius: 3px;
+        background-color: var(--text-color-coolgray);
+    }
+    
+    .winner .bar {
+        background-image: linear-gradient(90deg, hsl(198, 100%, 20%) 0%, var(--background-color) 100%);
+        background-color: transparent;
+    }
+    
+    .option {
+        flex-shrink: 1;
+        align-self: end;
+        overflow: visible;
+    }
+    
+    .percentage {
+        flex-shrink: 1;
+        width: 4rem;
+        font-weight: 700;
+        margin-left: 1rem;
+        align-self: end;
+    }
+
+    .percentage.right {
+        text-align: right;
+    }
+</style>
+<?php 
+    $SurveyResults = WebKit_Survey::calculate_results();
+    foreach ($SurveyResults->survey as $id => $Entry): $total = isset($Entry->scores['total']) ? $Entry->scores['total'] : 1; 
+?>
+    <h3><?php echo $Entry->question; ?></h3>
+    <ul class="survey-results">
+        <?php 
+        foreach ($Entry->responses as $value => $option): 
+            if ($option == "Other:") {
+                $option = "Other";
+            }
+            $score = isset($Entry->scores[$value]) ? $Entry->scores[$value] : 0; 
+            $percentage = $score * 100 / $total;
+        ?>
+        <li<?php if ($SurveyResults->winner == $value) echo ' class="winner"'; ?>>
+            <div class="label">
+                <div class="option" style="min-width: calc(<?php esc_attr_e($percentage); ?>% - 5rem);"><?php echo esc_html($option); ?></div>
+                <div class="percentage"><?php echo number_format($percentage, 0); ?>%</div>
+            </div>
+            <div class="bar" style="width: <?php echo esc_attr(max(1,$percentage)); ?>%">&nbsp;</div>
+        </li>
+    <?php endforeach; ?>
+    </ul>
+<?php endforeach; ?>

--- a/Websites/webkit.org/wp-content/plugins/webkit-survey/survey.php
+++ b/Websites/webkit.org/wp-content/plugins/webkit-survey/survey.php
@@ -1,0 +1,95 @@
+<style>
+.webkit-survey ul {
+    list-style: none;
+}
+
+.webkit-survey ul li {
+    display: block;
+    margin: 0 3rem;
+    position: relative;
+    vertical-align: top;
+    box-sizing: border-box;
+    overflow: hidden;
+    min-height: 62px;
+    perspective: 500px;
+}
+
+.webkit-survey input[type=text] {
+    display: inline-block;
+    vertical-align: baseline;
+    margin-left: 1rem;
+    margin-bottom: 0;
+    backface-visibility: hidden;
+    transform: rotateX( 90deg );
+    transition: transform 500ms ease;
+    visibility: hidden;
+}
+
+.webkit-survey input[type=radio] {
+    margin-top: 0;
+    vertical-align: middle;
+    transition: opacity 500ms ease;
+}
+
+.webkit-survey input[type=radio]:checked ~ input[type=text] {
+    transform: rotateX( 0deg );
+    visibility: visible;
+}
+
+.webkit-survey input[type=radio]:checked,
+.webkit-survey input[type=radio]:checked + span {
+    opacity: 1;
+    color: var(--text-color);
+}
+
+.webkit-survey input[type=radio] + span {
+    color: var(--text-color-coolgray);
+    transition: color 500ms ease;
+}
+
+.webkit-survey input[type=submit],
+.webkit-survey a.button {
+    padding: 1rem 3rem;
+}
+
+.webkit-survey label {
+    box-sizing: border-box;
+    display: inline-block;
+    border-radius: 0.3rem;
+    padding: 1rem 3rem 1rem 5rem;
+    transition: background-color 500ms ease;
+    cursor: pointer;
+    text-indent: -2.4rem;
+}
+
+.webkit-survey ul label:hover {
+    background: var(--tile-background-color);
+}
+
+.webkit-survey .button-align-right {
+    text-align: right;
+}
+</style>
+
+<form class="webkit-survey" method="POST">
+<?php
+
+wp_nonce_field("webkit_survey-" . get_the_ID(), "_nonce", $true);
+foreach ($Survey->survey as $id => $Entry):
+?>
+    <h3><?php echo $Entry->question; ?></h3>
+    
+    <ul>
+    <?php foreach ($Entry->responses as $value => $response): ?>
+        <li><label><input type="radio" name="questions[<?php echo esc_attr($id); ?>]" value="<?php echo esc_attr($value); ?>" required> <span><?php echo esc_html($response); ?></span>
+        <?php if ($response == "Other:"): ?>
+            <input type="text" name="other[<?php echo esc_attr($id); ?>]" maxlength="144">
+        <?php endif; ?>
+        </label></li>
+    <?php endforeach; ?>
+    </ul>
+<?php endforeach; ?>
+<p class="button-align-right">
+    <input type="submit" name="Submit" value="Submit" class="submit-button">
+</p>
+</form>


### PR DESCRIPTION
#### 0ee248acc11659aa7ba747c89638068a5e5116b9
<pre>
Add support for embedded surveys in post or page content on webkit.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=249342">https://bugs.webkit.org/show_bug.cgi?id=249342</a>

Reviewed by Timothy Hatcher.

* Websites/webkit.org/wp-content/plugins/webkit-survey/plugin.php: Added.
* Websites/webkit.org/wp-content/plugins/webkit-survey/results.php: Added.
* Websites/webkit.org/wp-content/plugins/webkit-survey/survey.php: Added.

Canonical link: <a href="https://commits.webkit.org/257891@main">https://commits.webkit.org/257891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e91f004be5c5d8a51df45f9220f10bd0928f4ebb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/100339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/9501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/33403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/109657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/10412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/38 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106117 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/10412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/33403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/10412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/33403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/33403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/3236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/38 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/33403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2801 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->