### PR TITLE
[CMake][AppleWin] Use namespaced targets

### DIFF
--- a/Source/WebKitLegacy/PlatformWin.cmake
+++ b/Source/WebKitLegacy/PlatformWin.cmake
@@ -15,10 +15,10 @@ else ()
         Apple::CoreText
         Apple::QuartzCore
         Apple::libdispatch
-        libxml2${DEBUG_SUFFIX}
-        libxslt${DEBUG_SUFFIX}
-        zdll${DEBUG_SUFFIX}
-        SQLite3${DEBUG_SUFFIX}
+        LibXml2::LibXml2
+        LibXslt::LibXslt
+        SQLite::SQLite3
+        ZLIB::ZLIB
     )
 endif ()
 

--- a/Tools/DumpRenderTree/PlatformWin.cmake
+++ b/Tools/DumpRenderTree/PlatformWin.cmake
@@ -46,8 +46,8 @@ if (${WTF_PLATFORM_WIN_CAIRO})
     )
 else ()
     list(APPEND DumpRenderTree_LIBRARIES
-        CFNetwork
-        CoreText
+        Apple::CFNetwork
+        Apple::CoreText
     )
     list(APPEND DumpRenderTree_PRIVATE_INCLUDE_DIRECTORIES
         ${DumpRenderTree_DIR}/cg
@@ -56,7 +56,7 @@ else ()
         cg/PixelDumpSupportCG.cpp
     )
     list(APPEND DumpRenderTree_LIBRARIES
-        CoreGraphics
+        Apple::CoreGraphics
     )
 endif ()
 

--- a/Tools/ImageDiff/CoreGraphics.cmake
+++ b/Tools/ImageDiff/CoreGraphics.cmake
@@ -3,7 +3,7 @@ list(APPEND ImageDiff_SOURCES
 )
 
 list(APPEND ImageDiff_LIBRARIES
-    CoreFoundation
-    CoreGraphics
-    CoreText
+    Apple::CoreFoundation
+    Apple::CoreGraphics
+    Apple::CoreText
 )


### PR DESCRIPTION
#### 55b2d9464261cc47db3862cb3c1038a34e643ea9
<pre>
[CMake][AppleWin] Use namespaced targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=249344">https://bugs.webkit.org/show_bug.cgi?id=249344</a>

Reviewed by Alex Christensen.

* Source/WebKitLegacy/PlatformWin.cmake:
* Tools/DumpRenderTree/PlatformWin.cmake:
* Tools/ImageDiff/CoreGraphics.cmake:

Canonical link: <a href="https://commits.webkit.org/257962@main">https://commits.webkit.org/257962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4ca969fba3eaaa53007b530b5e22f5129355e89

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109788 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170041 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10524 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92875 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107641 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34606 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22623 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3348 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24142 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3340 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9461 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43632 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5457 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5155 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->