### PR TITLE
[CSS-Typed-OM] Reification of non-list valued properties is incorrect

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backdrop-filter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backdrop-filter-expected.txt
@@ -32,5 +32,5 @@ PASS Setting 'backdrop-filter' to a transform: translate(50%, 50%) throws TypeEr
 PASS Setting 'backdrop-filter' to a transform: perspective(10em) throws TypeError
 PASS Setting 'backdrop-filter' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS 'filter' does not support 'blur(2px)'
-FAIL 'filter' does not support 'url(filters.svg) blur(4px) saturate(150%)' assert_equals: Unsupported value can be set on different element expected "url(\"filters.svg\") blur(4px) saturate(150%)" but got "url(\"filters.svg\")"
+PASS 'filter' does not support 'url(filters.svg) blur(4px) saturate(150%)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/contain-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/contain-expected.txt
@@ -38,6 +38,6 @@ PASS Setting 'contain' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'contain' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'contain' to a transform: perspective(10em) throws TypeError
 PASS Setting 'contain' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'contain' does not support 'size layout' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'contain' does not support 'paint style layout size' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'contain' does not support 'size layout'
+PASS 'contain' does not support 'paint style layout size'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/cursor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/cursor-expected.txt
@@ -66,6 +66,6 @@ PASS Setting 'cursor' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'cursor' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'cursor' to a transform: perspective(10em) throws TypeError
 PASS Setting 'cursor' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'cursor' does not support 'url(hand.cur), pointer' Invalid values
-FAIL 'cursor' does not support 'url(cursor1.png) 4 12, auto' Invalid values
+PASS 'cursor' does not support 'url(hand.cur), pointer'
+PASS 'cursor' does not support 'url(cursor1.png) 4 12, auto'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/filter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/filter-expected.txt
@@ -32,5 +32,5 @@ PASS Setting 'filter' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'filter' to a transform: perspective(10em) throws TypeError
 PASS Setting 'filter' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS 'filter' does not support 'blur(2px)'
-FAIL 'filter' does not support 'url(filters.svg) blur(4px) saturate(150%)' assert_equals: Unsupported value can be set on different element expected "url(\"filters.svg\") blur(4px) saturate(150%)" but got "url(\"filters.svg\")"
+PASS 'filter' does not support 'url(filters.svg) blur(4px) saturate(150%)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-east-asian-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-east-asian-expected.txt
@@ -40,6 +40,6 @@ PASS Setting 'font-variant-east-asian' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'font-variant-east-asian' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'font-variant-east-asian' to a transform: perspective(10em) throws TypeError
 PASS Setting 'font-variant-east-asian' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'font-variant-east-asian' does not support 'jis78 full-width' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'font-variant-east-asian' does not support 'traditional proportional-width ruby' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'font-variant-east-asian' does not support 'jis78 full-width'
+PASS 'font-variant-east-asian' does not support 'traditional proportional-width ruby'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-ligatures-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-ligatures-expected.txt
@@ -40,6 +40,6 @@ PASS Setting 'font-variant-ligatures' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'font-variant-ligatures' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'font-variant-ligatures' to a transform: perspective(10em) throws TypeError
 PASS Setting 'font-variant-ligatures' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'font-variant-ligatures' does not support 'common-ligatures contextual' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'font-variant-ligatures' does not support 'no-common-ligatures discretionary-ligatures no-historical-ligatures no-contextual' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'font-variant-ligatures' does not support 'common-ligatures contextual'
+PASS 'font-variant-ligatures' does not support 'no-common-ligatures discretionary-ligatures no-historical-ligatures no-contextual'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-numeric-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-numeric-expected.txt
@@ -39,6 +39,6 @@ PASS Setting 'font-variant-numeric' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'font-variant-numeric' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'font-variant-numeric' to a transform: perspective(10em) throws TypeError
 PASS Setting 'font-variant-numeric' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'font-variant-numeric' does not support 'lining-nums ordinal' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'font-variant-numeric' does not support 'oldstyle-nums tabular-nums stacked-fractions ordinal slashed-zero' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'font-variant-numeric' does not support 'lining-nums ordinal'
+PASS 'font-variant-numeric' does not support 'oldstyle-nums tabular-nums stacked-fractions ordinal slashed-zero'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-flow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-flow-expected.txt
@@ -32,5 +32,5 @@ PASS Setting 'grid-auto-flow' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'grid-auto-flow' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'grid-auto-flow' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-auto-flow' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'grid-auto-flow' does not support 'column dense' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'grid-auto-flow' does not support 'column dense'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt
@@ -32,8 +32,8 @@ PASS Setting 'grid-row-start' to a transform: translate(50%, 50%) throws TypeErr
 PASS Setting 'grid-row-start' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-row-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS 'grid-row-start' does not support '3'
-FAIL 'grid-row-start' does not support 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'grid-row-start' does not support '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'grid-row-start' does not support 'span 2'
+PASS 'grid-row-start' does not support '5 somegridarea span'
 PASS Can set 'grid-row-end' to CSS-wide keywords: initial
 PASS Can set 'grid-row-end' to CSS-wide keywords: inherit
 PASS Can set 'grid-row-end' to CSS-wide keywords: unset
@@ -67,8 +67,8 @@ PASS Setting 'grid-row-end' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'grid-row-end' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-row-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS 'grid-row-end' does not support '3'
-FAIL 'grid-row-end' does not support 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'grid-row-end' does not support '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'grid-row-end' does not support 'span 2'
+PASS 'grid-row-end' does not support '5 somegridarea span'
 PASS Can set 'grid-column-start' to CSS-wide keywords: initial
 PASS Can set 'grid-column-start' to CSS-wide keywords: inherit
 PASS Can set 'grid-column-start' to CSS-wide keywords: unset
@@ -102,8 +102,8 @@ PASS Setting 'grid-column-start' to a transform: translate(50%, 50%) throws Type
 PASS Setting 'grid-column-start' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-column-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS 'grid-column-start' does not support '3'
-FAIL 'grid-column-start' does not support 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'grid-column-start' does not support '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'grid-column-start' does not support 'span 2'
+PASS 'grid-column-start' does not support '5 somegridarea span'
 PASS Can set 'grid-column-end' to CSS-wide keywords: initial
 PASS Can set 'grid-column-end' to CSS-wide keywords: inherit
 PASS Can set 'grid-column-end' to CSS-wide keywords: unset
@@ -137,6 +137,6 @@ PASS Setting 'grid-column-end' to a transform: translate(50%, 50%) throws TypeEr
 PASS Setting 'grid-column-end' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-column-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS 'grid-column-end' does not support '3'
-FAIL 'grid-column-end' does not support 'span 2' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'grid-column-end' does not support '5 somegridarea span' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'grid-column-end' does not support 'span 2'
+PASS 'grid-column-end' does not support '5 somegridarea span'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt
@@ -31,8 +31,8 @@ PASS Setting 'grid-template-columns' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'grid-template-columns' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'grid-template-columns' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-template-columns' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'grid-template-columns' does not support '[linename1] 100px [linename2 linename3]' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'grid-template-columns' does not support '200px repeat(auto-fill, 100px) 300px' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+PASS 'grid-template-columns' does not support '[linename1] 100px [linename2 linename3]'
+PASS 'grid-template-columns' does not support '200px repeat(auto-fill, 100px) 300px'
 PASS Can set 'grid-template-rows' to CSS-wide keywords: initial
 PASS Can set 'grid-template-rows' to CSS-wide keywords: inherit
 PASS Can set 'grid-template-rows' to CSS-wide keywords: unset
@@ -65,6 +65,6 @@ PASS Setting 'grid-template-rows' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'grid-template-rows' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'grid-template-rows' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-template-rows' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'grid-template-rows' does not support '[linename1] 100px [linename2 linename3]' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'grid-template-rows' does not support '200px repeat(auto-fill, 100px) 300px' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+PASS 'grid-template-rows' does not support '[linename1] 100px [linename2 linename3]'
+PASS 'grid-template-rows' does not support '200px repeat(auto-fill, 100px) 300px'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-rotate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-rotate-expected.txt
@@ -4,8 +4,8 @@ PASS Can set 'offset-rotate' to CSS-wide keywords: inherit
 PASS Can set 'offset-rotate' to CSS-wide keywords: unset
 PASS Can set 'offset-rotate' to CSS-wide keywords: revert
 PASS Can set 'offset-rotate' to var() references:  var(--A)
-PASS Can set 'offset-rotate' to the 'auto' keyword: auto
-FAIL Can set 'offset-rotate' to the 'reverse' keyword: reverse assert_equals: expected "reverse" but got "auto"
+FAIL Can set 'offset-rotate' to the 'auto' keyword: auto assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'offset-rotate' to the 'reverse' keyword: reverse assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 PASS Can set 'offset-rotate' to an angle: 0deg
 PASS Can set 'offset-rotate' to an angle: 3.14rad
 PASS Can set 'offset-rotate' to an angle: -3.14deg

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/quotes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/quotes-expected.txt
@@ -31,5 +31,5 @@ PASS Setting 'quotes' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'quotes' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'quotes' to a transform: perspective(10em) throws TypeError
 PASS Setting 'quotes' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'quotes' does not support '"<<" ">>" "<" ">"' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'quotes' does not support '"<<" ">>" "<" ">"'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-align-expected.txt
@@ -34,6 +34,6 @@ PASS Setting 'scroll-snap-align' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'scroll-snap-align' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'scroll-snap-align' to a transform: perspective(10em) throws TypeError
 PASS Setting 'scroll-snap-align' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'scroll-snap-align' does not support 'none center' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'scroll-snap-align' does not support 'end start' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'scroll-snap-align' does not support 'none center'
+PASS 'scroll-snap-align' does not support 'end start'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-type-expected.txt
@@ -36,6 +36,6 @@ PASS Setting 'scroll-snap-type' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'scroll-snap-type' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'scroll-snap-type' to a transform: perspective(10em) throws TypeError
 PASS Setting 'scroll-snap-type' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'scroll-snap-type' does not support 'x mandatory' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'scroll-snap-type' does not support 'x mandatory'
 FAIL 'scroll-snap-type' does not support 'inline proximity' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt
@@ -31,5 +31,5 @@ FAIL Setting 'stroke-dasharray' to a number: calc(2 + 3) throws TypeError assert
 PASS Setting 'stroke-dasharray' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'stroke-dasharray' to a transform: perspective(10em) throws TypeError
 PASS Setting 'stroke-dasharray' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'stroke-dasharray' does not support '5% 1em 2%' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+PASS 'stroke-dasharray' does not support '5% 1em 2%'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt
@@ -30,7 +30,7 @@ PASS Setting 'text-indent' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'text-indent' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'text-indent' to a transform: perspective(10em) throws TypeError
 PASS Setting 'text-indent' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'text-indent' does not support '5em each-line' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
-FAIL 'text-indent' does not support '5em hanging' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
-FAIL 'text-indent' does not support '5em hanging each-line' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+PASS 'text-indent' does not support '5em each-line'
+PASS 'text-indent' does not support '5em hanging'
+PASS 'text-indent' does not support '5em hanging each-line'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-shadow-expected.txt
@@ -32,5 +32,5 @@ PASS Setting 'text-shadow' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'text-shadow' to a transform: perspective(10em) throws TypeError
 PASS Setting 'text-shadow' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS 'text-shadow' does not support '1px 1px 2px pink'
-FAIL 'text-shadow' does not support '1px 1px 2px red, 0 0 1em blue, 0 0 0.2em blue' assert_equals: Unsupported value can be set on different element expected "red 1px 1px 2px, blue 0px 0px 1em, blue 0px 0px 0.2em" but got "red 1px 1px 2px"
+PASS 'text-shadow' does not support '1px 1px 2px red, 0 0 1em blue, 0 0 0.2em blue'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-property-expected.txt
@@ -32,6 +32,6 @@ PASS Setting 'transition-property' to a transform: translate(50%, 50%) throws Ty
 PASS Setting 'transition-property' to a transform: perspective(10em) throws TypeError
 PASS Setting 'transition-property' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL 'transition-property' does not support 'width' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'transition-property' does not support 'width, height' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'transition-property' does not support 'width, height'
 FAIL 'transition-property' does not support 'all' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt
@@ -32,5 +32,5 @@ PASS Setting 'will-change' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'will-change' to a transform: perspective(10em) throws TypeError
 PASS Setting 'will-change' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL 'will-change' does not support 'scroll-position' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
-FAIL 'will-change' does not support 'contents, foo, scroll-position' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'will-change' does not support 'contents, foo, scroll-position'
 

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.h
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.h
@@ -43,7 +43,7 @@ class StylePropertyShorthand;
 
 class CSSStyleValueFactory {
 public:
-    static ExceptionOr<Ref<CSSStyleValue>> reifyValue(Ref<CSSValue>, Document* = nullptr);
+    static ExceptionOr<Ref<CSSStyleValue>> reifyValue(Ref<CSSValue>, std::optional<CSSPropertyID>, Document* = nullptr);
     static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseStyleValue(const AtomString&, const String&, bool);
     static RefPtr<CSSStyleValue> constructStyleValueForShorthandSerialization(const String&);
     static ExceptionOr<Vector<Ref<CSSStyleValue>>> vectorFromStyleValuesOrStrings(const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values);

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -87,12 +87,12 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
     values.reserveInitialCapacity(exposedComputedCSSPropertyIDs.size() + inheritedCustomProperties.size() + nonInheritedCustomProperties.size());
     for (auto propertyID : exposedComputedCSSPropertyIDs) {
         auto value = ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::No, ComputedStyleExtractor::PropertyValueType::Computed);
-        values.uncheckedAppend(makeKeyValuePair(nameString(propertyID), StylePropertyMapReadOnly::reifyValueToVector(WTFMove(value), m_element->document())));
+        values.uncheckedAppend(makeKeyValuePair(nameString(propertyID), StylePropertyMapReadOnly::reifyValueToVector(WTFMove(value), propertyID, m_element->document())));
     }
 
     for (auto* map : { &nonInheritedCustomProperties, &inheritedCustomProperties }) {
         for (const auto& it : *map)
-            values.uncheckedAppend(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(it.value.copyRef(), m_element->document())));
+            values.uncheckedAppend(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(it.value.copyRef(), std::nullopt, m_element->document())));
     }
 
     std::sort(values.begin(), values.end(), [](const auto& a, const auto& b) {

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
@@ -64,7 +64,7 @@ auto DeclaredStylePropertyMap::entries(ScriptExecutionContext* context) const ->
 
     auto& document = downcast<Document>(*context);
     return map(styleRule->properties(), [&] (auto propertyReference) {
-        return StylePropertyMapEntry { propertyReference.cssName(), reifyValueToVector(RefPtr<CSSValue> { propertyReference.value() }, document) };
+        return StylePropertyMapEntry { propertyReference.cssName(), reifyValueToVector(RefPtr<CSSValue> { propertyReference.value() }, propertyReference.id(), document) };
     });
 }
 

--- a/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp
@@ -70,7 +70,7 @@ auto HashMapStylePropertyMapReadOnly::entries(ScriptExecutionContext* context) c
     Vector<StylePropertyMapEntry> result;
     result.reserveInitialCapacity(m_map.size());
     for (auto& [propertyName, cssValue] : m_map)
-        result.uncheckedAppend(makeKeyValuePair(propertyName,  Vector<RefPtr<CSSStyleValue>> { reifyValue(cssValue.get(), *document) }));
+        result.uncheckedAppend(makeKeyValuePair(propertyName,  Vector<RefPtr<CSSStyleValue>> { reifyValue(cssValue.get(), cssPropertyID(propertyName), *document) }));
     return result;
 }
 

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
@@ -78,7 +78,7 @@ auto InlineStylePropertyMap::entries(ScriptExecutionContext* context) const -> V
 
     auto& document = downcast<Document>(*context);
     return map(*inlineStyle, [&document] (auto property) {
-        return StylePropertyMapEntry(property.cssName(), reifyValueToVector(RefPtr<CSSValue> { property.value() }, document));
+        return StylePropertyMapEntry(property.cssName(), reifyValueToVector(RefPtr<CSSValue> { property.value() }, property.id(), document));
     });
 }
 

--- a/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
@@ -61,7 +61,7 @@ ExceptionOr<RefPtr<CSSStyleValue>> MainThreadStylePropertyMapReadOnly::get(Scrip
         return nullptr;
 
     if (isCustomPropertyName(property))
-        return reifyValue(customPropertyValue(property), *document);
+        return reifyValue(customPropertyValue(property), std::nullopt, *document);
 
     auto propertyID = cssPropertyID(property);
     if (!isExposed(propertyID, &document->settings()))
@@ -70,7 +70,7 @@ ExceptionOr<RefPtr<CSSStyleValue>> MainThreadStylePropertyMapReadOnly::get(Scrip
     if (isShorthandCSSProperty(propertyID))
         return CSSStyleValueFactory::constructStyleValueForShorthandSerialization(shorthandPropertySerialization(propertyID));
 
-    return reifyValue(propertyValue(propertyID), *document);
+    return reifyValue(propertyValue(propertyID), propertyID, *document);
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-getall
@@ -81,7 +81,7 @@ ExceptionOr<Vector<RefPtr<CSSStyleValue>>> MainThreadStylePropertyMapReadOnly::g
         return Vector<RefPtr<CSSStyleValue>> { };
 
     if (isCustomPropertyName(property))
-        return reifyValueToVector(customPropertyValue(property), *document);
+        return reifyValueToVector(customPropertyValue(property), std::nullopt, *document);
 
     auto propertyID = cssPropertyID(property);
     if (!isExposed(propertyID, &document->settings()))
@@ -93,7 +93,7 @@ ExceptionOr<Vector<RefPtr<CSSStyleValue>>> MainThreadStylePropertyMapReadOnly::g
         return Vector<RefPtr<CSSStyleValue>> { };
     }
 
-    return reifyValueToVector(propertyValue(propertyID), *document);
+    return reifyValueToVector(propertyValue(propertyID), propertyID, *document);
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-has

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
@@ -58,8 +58,8 @@ public:
     virtual ExceptionOr<bool> has(ScriptExecutionContext&, const AtomString&) const = 0;
     virtual unsigned size() const = 0;
 
-    static RefPtr<CSSStyleValue> reifyValue(RefPtr<CSSValue>&&, Document&);
-    static Vector<RefPtr<CSSStyleValue>> reifyValueToVector(RefPtr<CSSValue>&&, Document&);
+    static RefPtr<CSSStyleValue> reifyValue(RefPtr<CSSValue>&&, std::optional<CSSPropertyID>, Document&);
+    static Vector<RefPtr<CSSStyleValue>> reifyValueToVector(RefPtr<CSSValue>&&, std::optional<CSSPropertyID>, Document&);
 
 protected:
     virtual Vector<StylePropertyMapEntry> entries(ScriptExecutionContext*) const = 0;

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
@@ -56,7 +56,7 @@ ExceptionOr<Ref<CSSTransformComponent>> CSSMatrixComponent::create(CSSFunctionVa
     auto makeMatrix = [&](const Function<Ref<CSSTransformComponent>(Vector<double>&&)>& create, size_t expectedNumberOfComponents) -> ExceptionOr<Ref<CSSTransformComponent>> {
         Vector<double> components;
         for (auto componentCSSValue : cssFunctionValue) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             if (!is<CSSUnitValue>(valueOrException.returnValue()))

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
@@ -83,7 +83,7 @@ ExceptionOr<Ref<CSSPerspective>> CSSPerspective::create(CSSFunctionValue& cssFun
         return Exception { TypeError, "Unexpected number of values."_s };
     }
 
-    auto keywordOrNumeric = CSSStyleValueFactory::reifyValue(*cssFunctionValue.item(0));
+    auto keywordOrNumeric = CSSStyleValueFactory::reifyValue(*cssFunctionValue.item(0), std::nullopt);
     if (keywordOrNumeric.hasException())
         return keywordOrNumeric.releaseException();
     auto& keywordOrNumericValue = keywordOrNumeric.returnValue().get();

--- a/Source/WebCore/css/typedom/transform/CSSRotate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSRotate.cpp
@@ -77,7 +77,7 @@ ExceptionOr<Ref<CSSRotate>> CSSRotate::create(CSSFunctionValue& cssFunctionValue
     auto makeRotate = [&](const Function<ExceptionOr<Ref<CSSRotate>>(Vector<RefPtr<CSSNumericValue>>&&)>& create, size_t expectedNumberOfComponents) -> ExceptionOr<Ref<CSSRotate>> {
         Vector<RefPtr<CSSNumericValue>> components;
         for (auto componentCSSValue : cssFunctionValue) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             if (!is<CSSNumericValue>(valueOrException.returnValue()))

--- a/Source/WebCore/css/typedom/transform/CSSScale.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSScale.cpp
@@ -75,7 +75,7 @@ ExceptionOr<Ref<CSSScale>> CSSScale::create(CSSFunctionValue& cssFunctionValue)
     auto makeScale = [&](const Function<ExceptionOr<Ref<CSSScale>>(Vector<RefPtr<CSSNumericValue>>&&)>& create, size_t minNumberOfComponents, std::optional<size_t> maxNumberOfComponents = std::nullopt) -> ExceptionOr<Ref<CSSScale>> {
         Vector<RefPtr<CSSNumericValue>> components;
         for (auto componentCSSValue : cssFunctionValue) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             if (!is<CSSNumericValue>(valueOrException.returnValue()))

--- a/Source/WebCore/css/typedom/transform/CSSSkew.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkew.cpp
@@ -60,7 +60,7 @@ ExceptionOr<Ref<CSSSkew>> CSSSkew::create(CSSFunctionValue& cssFunctionValue)
 
     Vector<Ref<CSSNumericValue>> components;
     for (auto componentCSSValue : cssFunctionValue) {
-        auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue);
+        auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
         if (valueOrException.hasException())
             return valueOrException.releaseException();
         if (!is<CSSNumericValue>(valueOrException.returnValue()))

--- a/Source/WebCore/css/typedom/transform/CSSSkewX.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkewX.cpp
@@ -61,7 +61,7 @@ ExceptionOr<Ref<CSSSkewX>> CSSSkewX::create(CSSFunctionValue& cssFunctionValue)
         return Exception { TypeError, "Unexpected number of values."_s };
     }
 
-    auto valueOrException = CSSStyleValueFactory::reifyValue(*cssFunctionValue.item(0));
+    auto valueOrException = CSSStyleValueFactory::reifyValue(*cssFunctionValue.item(0), std::nullopt);
     if (valueOrException.hasException())
         return valueOrException.releaseException();
     if (!is<CSSNumericValue>(valueOrException.returnValue()))

--- a/Source/WebCore/css/typedom/transform/CSSSkewY.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkewY.cpp
@@ -61,7 +61,7 @@ ExceptionOr<Ref<CSSSkewY>> CSSSkewY::create(CSSFunctionValue& cssFunctionValue)
         return Exception { TypeError, "Unexpected number of values."_s };
     }
 
-    auto valueOrException = CSSStyleValueFactory::reifyValue(*cssFunctionValue.item(0));
+    auto valueOrException = CSSStyleValueFactory::reifyValue(*cssFunctionValue.item(0), std::nullopt);
     if (valueOrException.hasException())
         return valueOrException.releaseException();
     if (!is<CSSNumericValue>(valueOrException.returnValue()))

--- a/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
@@ -63,7 +63,7 @@ ExceptionOr<Ref<CSSTranslate>> CSSTranslate::create(CSSFunctionValue& cssFunctio
     auto makeTranslate = [&](const Function<ExceptionOr<Ref<CSSTranslate>>(Vector<Ref<CSSNumericValue>>&&)>& create, size_t minNumberOfComponents, std::optional<size_t> maxNumberOfComponents = std::nullopt) -> ExceptionOr<Ref<CSSTranslate>> {
         Vector<Ref<CSSNumericValue>> components;
         for (auto componentCSSValue : cssFunctionValue) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(componentCSSValue, std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             if (!is<CSSNumericValue>(valueOrException.returnValue()))


### PR DESCRIPTION
#### 1d99a936a0dbf27116604766f70d1ecf74bcdf98
<pre>
[CSS-Typed-OM] Reification of non-list valued properties is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=249351">https://bugs.webkit.org/show_bug.cgi?id=249351</a>

Reviewed by Simon Fraser.

During reification of CSSValues, if encountering a CSSValueList, we would:
1. Return the first value in the list for StylePropertyMap.get()
2. Return each item in the list in an array for StylePropertyMap.getAll()

However, we&apos;re only supposed to do this if he property is a list-valued
property [1][2]. For non-list valued properties, we&apos;re should:
1. Return a generic CSSStyleValue wrapping the list for StylePropertyMap.get()
2. Return an array containing a single item that is a generic CSSStyleValue
   wrapping the list, for StylePropertyMap.getAll()

See:
[1] <a href="https://drafts.css-houdini.org/css-typed-om/#list-valued-properties">https://drafts.css-houdini.org/css-typed-om/#list-valued-properties</a>
[2] <a href="https://drafts.css-houdini.org/css-typed-om/#reify-stylevalue">https://drafts.css-houdini.org/css-typed-om/#reify-stylevalue</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backdrop-filter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/contain-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/cursor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/filter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-east-asian-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-ligatures-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-numeric-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-flow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/quotes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-align-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-snap-type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-property-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt:
Rebaseline WPT tests now that more checks are passing.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-rotate-expected.txt:
The rebaseline actually looks like a regression here but I suspect the test is wrong. Our new behavior here is actually
aligned with Blink here. When setting the `offset-rotate` property to `auto` via StylePropertyMap.set(), we properly return
`new CSSKeywordValue(&quot;auto&quot;)` when calling StylePropertyMap.get() on the inline property map. However, for the computed
style property map, we now return `new CSSStylePropertyMap(&quot;auto 0deg&quot;)` instead of `new CSSKeywordValue(&quot;auto&quot;)`. The reason
for this is that the computed value actually contains an angle as part of a CSSValueList. I&apos;ll investigate this test separately
but I suspect our new behavior is correct and the test just needs updating.

* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::parseStyleValue):
(WebCore::CSSStyleValueFactory::reifyValue):
* Source/WebCore/css/typedom/CSSStyleValueFactory.h:
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
(WebCore::ComputedStylePropertyMapReadOnly::entries const):
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp:
(WebCore::DeclaredStylePropertyMap::entries const):
* Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp:
(WebCore::HashMapStylePropertyMapReadOnly::entries const):
* Source/WebCore/css/typedom/InlineStylePropertyMap.cpp:
(WebCore::InlineStylePropertyMap::entries const):
* Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp:
(WebCore::MainThreadStylePropertyMapReadOnly::get const):
(WebCore::MainThreadStylePropertyMapReadOnly::getAll const):
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp:
(WebCore::StylePropertyMapReadOnly::reifyValue):
(WebCore::StylePropertyMapReadOnly::reifyValueToVector):
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.h:
* Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp:
(WebCore::CSSMatrixComponent::create):
* Source/WebCore/css/typedom/transform/CSSPerspective.cpp:
(WebCore::CSSPerspective::create):
* Source/WebCore/css/typedom/transform/CSSRotate.cpp:
(WebCore::CSSRotate::create):
* Source/WebCore/css/typedom/transform/CSSScale.cpp:
(WebCore::CSSScale::create):
* Source/WebCore/css/typedom/transform/CSSSkew.cpp:
(WebCore::CSSSkew::create):
* Source/WebCore/css/typedom/transform/CSSSkewX.cpp:
(WebCore::CSSSkewX::create):
* Source/WebCore/css/typedom/transform/CSSSkewY.cpp:
(WebCore::CSSSkewY::create):
* Source/WebCore/css/typedom/transform/CSSTranslate.cpp:
(WebCore::CSSTranslate::create):

Canonical link: <a href="https://commits.webkit.org/257927@main">https://commits.webkit.org/257927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc01b81421918c451436badbe4db2b28db2bc6f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109648 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169863 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/29 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92731 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107526 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7870 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34529 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77484 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3234 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24054 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/159 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43544 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5043 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2825 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->