### PR TITLE
Increase WASM SIMD test coverage.

### DIFF
--- a/JSTests/wasm/assert.js
+++ b/JSTests/wasm/assert.js
@@ -176,8 +176,9 @@ const asyncTestImpl = (promise, thenFunc, catchFunc) => {
 };
 
 const printExn = (e) => {
-    print("Failed: ", e);
+    print("Test failed with exception: ", e);
     print(e.stack);
+    print(typeof e);
     $vm.abort();
 };
 

--- a/JSTests/wasm/stress/dont-stack-overflow-in-air.js
+++ b/JSTests/wasm/stress/dont-stack-overflow-in-air.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--maxPerThreadStackUsage=512000")
+//@ requireOptions("--maxPerThreadStackUsage=512000", "--useWebAssemblySIMD=false")
 
 import Builder from '../Builder.js'
 import * as assert from '../assert.js'

--- a/JSTests/wasm/stress/simd-const-spill.js
+++ b/JSTests/wasm/stress/simd-const-spill.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64" && $architecture != "x86_64"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const.js
+++ b/JSTests/wasm/stress/simd-const.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64" && $architecture != "x86_64"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-exception.js
+++ b/JSTests/wasm/stress/simd-exception.js
@@ -1,0 +1,64 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip
+//FIXME: this test is currently failing.
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+const tag = new WebAssembly.Tag({ parameters: ["i32"] });
+
+let wat = `
+(module
+    (import "m" "tag" (tag $e-i32 (param i32)))
+
+    (func $test_throw (export "test_throw") (param $sz i32)
+        (local $i i32)
+        (local.set $i (i32.const 0))
+
+        (loop $loop
+            local.get $i
+            i32.const 1
+            i32.add
+            local.set $i
+
+            local.get $i
+            local.get $sz
+            (if (i32.eq) (then (throw $e-i32 (local.get $i))))
+
+            local.get $i
+            i32.const 1000
+            i32.lt_s
+            br_if $loop)
+    )
+
+    (func $test_catch (export "test_catch") (result i32)
+        (v128.const i32x4 1337 1337 1337 1337)
+        (try
+            (do 
+                (call $test_throw (i32.const 500)))
+        (catch $e-i32
+            (i32.const 500)
+            (if (i32.ne) (then (unreachable)))
+        ))
+
+        (i32x4.extract_lane 3))
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, { m: { tag } }, { simd: true, exceptions: true })
+    const { test_throw, test_catch } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        try {
+            test_throw(42)
+            assert.truthy(false)
+        } catch (e) {
+            assert.truthy(e.is(tag))
+            assert.eq(e.getArg(tag, 0), 42)
+        }
+        assert.eq(test_catch(), 1337)
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-kitchen-sink.js
+++ b/JSTests/wasm/stress/simd-kitchen-sink.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-load.js
+++ b/JSTests/wasm/stress/simd-load.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64" && $architecture != "x86_64"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-osr.js
+++ b/JSTests/wasm/stress/simd-osr.js
@@ -1,0 +1,45 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip
+//FIXME: this test is currently broken.
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test") (result i32)
+        (local $r v128)
+        (local $i i32)
+        (v128.const i32x4 42 42 42 42)
+
+        (loop $loop
+            local.get $i
+            i32.const 1
+            i32.add
+            local.set $i
+
+            (i32x4.add (local.get $r) (v128.const i32x4 1 2 3 4))
+            local.set $r
+
+            local.get $i
+            i32.const 1000
+            i32.lt_s
+            br_if $loop)
+
+        (i32x4.extract_lane 0)
+        (i32x4.extract_lane 3 (local.get $r))
+        i32.add
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const { test } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(), 1000*4 + 42)
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-register-allocation.js
+++ b/JSTests/wasm/stress/simd-register-allocation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64" && $architecture != "x86_64"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-return-value-alignment.js
+++ b/JSTests/wasm/stress/simd-return-value-alignment.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64" && $architecture != "x86_64"
 
 /*

--- a/JSTests/wasm/stress/simd-tiny-loop.js
+++ b/JSTests/wasm/stress/simd-tiny-loop.js
@@ -1,0 +1,29 @@
+//@ requireOptions("--useWebAssemblySIMD=1", "--watchdog=1000", "--watchdog-exception-ok")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip
+//FIXME: this test is currently broken.
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test") (;0;)
+        (local v128)
+        loop (result v128)  ;; label = @1
+        br 0 (;@1;)
+        end
+        local.set 0
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const { test } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        test()
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/v8/exceptions-simd.js
+++ b/JSTests/wasm/v8/exceptions-simd.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -24,7 +24,8 @@ load("exceptions-utils.js");
   var instance = builder.instantiate();
 
   // NOTE: changed from original test since this part of the spec is still in flux.
-  assertThrows(() => instance.exports.throw_simd());
+  for (let i = 0; i < 1000; ++i)
+    assertThrows(() => instance.exports.throw_simd());
 })();
 
 (function TestThrowCatchS128Default() {
@@ -47,7 +48,8 @@ load("exceptions-utils.js");
       .exportFunc();
   var instance = builder.instantiate();
 
-  assertThrows(() => instance.exports.throw_catch_simd());
+  for (let i = 0; i < 1000; ++i)
+    assertThrows(() => instance.exports.throw_catch_simd());
 })();
 
 (function TestThrowCatchS128WithValue() {
@@ -77,6 +79,7 @@ load("exceptions-utils.js");
              0x89, 0x9a, 0xab, 0xbc, 0xcd, 0xde, 0xef, 0xf0];
   var array = new Uint8Array(memory.buffer);
   array.set(ref, in_idx);  // Store reference value in memory.
-  assertThrows(() => instance.exports.throw_catch_simd());
+  for (let i = 0; i < 1000; ++i)
+    assertThrows(() => instance.exports.throw_catch_simd());
   // assertArrayEquals(ref, array.slice(out_idx, out_idx + 0x10));
 })();

--- a/JSTests/wasm/v8/liftoff-simd-params.js
+++ b/JSTests/wasm/v8/liftoff-simd-params.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/multi-value-simd.js
+++ b/JSTests/wasm/v8/multi-value-simd.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-10309.js
+++ b/JSTests/wasm/v8/regress/regress-10309.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1054466.js
+++ b/JSTests/wasm/v8/regress/regress-1054466.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1065599.js
+++ b/JSTests/wasm/v8/regress/regress-1065599.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1070078.js
+++ b/JSTests/wasm/v8/regress/regress-1070078.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1081030.js
+++ b/JSTests/wasm/v8/regress/regress-1081030.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-10831.js
+++ b/JSTests/wasm/v8/regress/regress-10831.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1111522.js
+++ b/JSTests/wasm/v8/regress/regress-1111522.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1112124.js
+++ b/JSTests/wasm/v8/regress/regress-1112124.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1116019.js
+++ b/JSTests/wasm/v8/regress/regress-1116019.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1124885.js
+++ b/JSTests/wasm/v8/regress/regress-1124885.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1132461.js
+++ b/JSTests/wasm/v8/regress/regress-1132461.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1161555.js
+++ b/JSTests/wasm/v8/regress/regress-1161555.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1161654.js
+++ b/JSTests/wasm/v8/regress/regress-1161654.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1161954.js
+++ b/JSTests/wasm/v8/regress/regress-1161954.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1165966.js
+++ b/JSTests/wasm/v8/regress/regress-1165966.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1179182.js
+++ b/JSTests/wasm/v8/regress/regress-1179182.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1187831.js
+++ b/JSTests/wasm/v8/regress/regress-1187831.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1188975.js
+++ b/JSTests/wasm/v8/regress/regress-1188975.js
@@ -1,6 +1,6 @@
 //@ skip
 //@ skip if $architecture != "arm64"
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1199662.js
+++ b/JSTests/wasm/v8/regress/regress-1199662.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1231950.js
+++ b/JSTests/wasm/v8/regress/regress-1231950.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1242300.js
+++ b/JSTests/wasm/v8/regress/regress-1242300.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1242689.js
+++ b/JSTests/wasm/v8/regress/regress-1242689.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1264462.js
+++ b/JSTests/wasm/v8/regress/regress-1264462.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1271244.js
+++ b/JSTests/wasm/v8/regress/regress-1271244.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1271456.js
+++ b/JSTests/wasm/v8/regress/regress-1271456.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1271538.js
+++ b/JSTests/wasm/v8/regress/regress-1271538.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1282224.js
+++ b/JSTests/wasm/v8/regress/regress-1282224.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1283042.js
+++ b/JSTests/wasm/v8/regress/regress-1283042.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1283395.js
+++ b/JSTests/wasm/v8/regress/regress-1283395.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1284980.js
+++ b/JSTests/wasm/v8/regress/regress-1284980.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1286253.js
+++ b/JSTests/wasm/v8/regress/regress-1286253.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1289678.js
+++ b/JSTests/wasm/v8/regress/regress-1289678.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1290079.js
+++ b/JSTests/wasm/v8/regress/regress-1290079.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-9447.js
+++ b/JSTests/wasm/v8/regress/regress-9447.js
@@ -1,5 +1,5 @@
 //@ skip if $architecture != "arm64"
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-crbug-1338980.js
+++ b/JSTests/wasm/v8/regress/regress-crbug-1338980.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-crbug-1355070.js
+++ b/JSTests/wasm/v8/regress/regress-crbug-1355070.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-crbug-1356718.js
+++ b/JSTests/wasm/v8/regress/regress-crbug-1356718.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/simd-call.js
+++ b/JSTests/wasm/v8/simd-call.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/simd-errors.js
+++ b/JSTests/wasm/v8/simd-errors.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/simd-globals.js
+++ b/JSTests/wasm/v8/simd-globals.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/simd-i64x2-mul.js
+++ b/JSTests/wasm/v8/simd-i64x2-mul.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1")
 //@ skip if $architecture != "arm64"
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/Source/JavaScriptCore/b3/B3Procedure.cpp
+++ b/Source/JavaScriptCore/b3/B3Procedure.cpp
@@ -146,6 +146,9 @@ Value* Procedure::addConstant(Origin origin, Type type, uint64_t bits)
         return add<ConstFloatValue>(origin, bitwise_cast<float>(static_cast<int32_t>(bits)));
     case Double:
         return add<ConstDoubleValue>(origin, bitwise_cast<double>(bits));
+    case V128:
+        RELEASE_ASSERT(!bits);
+        return addConstant(origin, type, v128_t { });
     default:
         RELEASE_ASSERT_NOT_REACHED();
         return nullptr;

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -288,7 +288,18 @@ public:
         RELEASE_ASSERT(Options::useWebAssemblySIMD());
         m_usesSIMD = true;
     }
-    bool usesSIMD() const { return m_usesSIMD; }
+    bool usesSIMD() const
+    {
+        if (!Options::useWebAssemblySIMD())
+            return false;
+        // The LLInt is responsible for discovering this.
+        // If we can't run using it, then we should be conservative.
+        if (!Options::useWasmLLInt())
+            return true;
+        if (Options::forceAllFunctionsToUseSIMD())
+            return true;
+        return m_usesSIMD;
+    }
 
 private:
     friend class BlockInsertionSet;

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -659,15 +659,11 @@ void Options::notifyOptionsChanged()
         ASSERT((static_cast<int64_t>(Options::thresholdForOptimizeAfterLongWarmUp()) << Options::reoptimizationRetryCounterMax()) > 0);
         ASSERT((static_cast<int64_t>(Options::thresholdForOptimizeAfterLongWarmUp()) << Options::reoptimizationRetryCounterMax()) <= static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
 
-        // FIXME: This should be removed when we add LLint/OMG support for WASM SIMD
-        if (Options::useWebAssemblySIMD()) {
-            bool isValid = true;
-            isValid &= Options::useBBQJIT();
-            isValid &= Options::useWasmLLInt();
-            isValid &= Options::wasmLLIntTiersUpToBBQ();
-            if (!isValid)
-                Options::useWebAssemblySIMD() = false;
-        }
+        if (!Options::useBBQJIT() && Options::useOMGJIT())
+            Options::wasmLLIntTiersUpToBBQ() = false;
+
+        if (Options::forceAllFunctionsToUseSIMD() && !Options::useWebAssemblySIMD())
+            Options::forceAllFunctionsToUseSIMD() = false;
     }
 
     if (Options::dumpFuzzerAgentPredictions())

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -558,6 +558,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useWebAssemblyThreading, true, Normal, "Allow instructions from the wasm threading spec.") \
     v(Bool, useWebAssemblyTypedFunctionReferences, false, Normal, "Allow function types from the wasm typed function references spec.") \
     v(Bool, useWebAssemblyGC, false, Normal, "Allow gc types from the wasm gc proposal.") \
+    v(Bool, forceAllFunctionsToUseSIMD, false, Normal, "Force all functions to act conservatively w.r.t fp/vector registers for testing.") \
     v(Bool, useWebAssemblySIMD, isARM64(), Normal, "Allow the new simd instructions and types from the wasm simd spec.") \
 
 

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -296,6 +296,11 @@ struct AirIRGeneratorBase {
 
         explicit operator bool() const { return !!tmp; }
 
+        void dump(PrintStream& out) const
+        {
+            out.print("ConstrainedTmp { ", tmp, ", ", rep, " }");
+        }
+
         ExpressionType tmp;
         B3::ValueRep rep;
     };
@@ -674,7 +679,7 @@ protected:
             // validation. We should abstract Patch enough so ValueRep's don't need to be
             // backed by Values.
             // https://bugs.webkit.org/show_bug.cgi?id=194040
-            B3::Value* dummyValue = m_proc.addConstant(B3::Origin(), tmp.tmp.tmp().isGP() ? B3::pointerType() : B3::Double, 0);
+            B3::Value* dummyValue = m_proc.addConstant(B3::Origin(), tmp.tmp.tmp().isGP() ? B3::pointerType() : (m_proc.usesSIMD() ? B3::V128 : B3::Double), 0);
             patch->append(dummyValue, tmp.rep);
             switch (tmp.rep.kind()) {
             // B3::Value propagates (Late)ColdAny information and later Air will allocate appropriate stack.

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -184,7 +184,11 @@ inline bool jitCompileSIMDFunction(Wasm::LLIntCallee* callee, Wasm::Instance* in
 
     uint32_t functionIndex = callee->functionIndex();
     ASSERT(instance->module().moduleInformation().isSIMDFunction(functionIndex));
-    RefPtr<Wasm::Plan> plan = adoptRef(*new Wasm::BBQPlan(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), instance->calleeGroup(), Wasm::Plan::dontFinalize()));
+    RefPtr<Wasm::Plan> plan;
+    if (Options::wasmLLIntTiersUpToBBQ())
+        plan = adoptRef(*new Wasm::BBQPlan(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), instance->calleeGroup(), Wasm::Plan::dontFinalize()));
+    else
+        plan = adoptRef(*new Wasm::OMGPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), functionIndex, callee->hasExceptionHandlers(), instance->memory()->mode(), Wasm::Plan::dontFinalize()));
 
     Wasm::ensureWorklist().enqueue(*plan);
     plan->waitForCompletion();

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -1757,6 +1757,7 @@ def runWebAssembly
         run("wasm-air", "-m", "--useWasmLLInt=false", "--useRandomizingExecutableIslandAllocation=true", *FTL_OPTIONS)
         if $isFTLPlatform
             run("wasm-b3", "-m", "--useWasmLLInt=false", "--wasmBBQUsesAir=false", *FTL_OPTIONS)
+            run("wasm-simd", "-m", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
         end
     end
 end
@@ -1786,6 +1787,7 @@ def runWebAssemblyJetStream2
         run("wasm-air", "--useWasmLLInt=false", "--useRandomizingExecutableIslandAllocation=true", *FTL_OPTIONS)
         if $isFTLPlatform
             run("wasm-b3", "--useWasmLLInt=false", "--wasmBBQUsesAir=false", *FTL_OPTIONS)
+            run("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
         end
     end
 end
@@ -1813,6 +1815,7 @@ def runWebAssemblySuite(*optionalTestSpecificOptions)
         if $isFTLPlatform
             run("wasm-b3", "--useWasmLLInt=false", "--wasmBBQUsesAir=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
             run("wasm-bbqb3", "--useWasmLLInt=true", "--wasmBBQUsesAir=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+            run("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless !$isSIMDPlatform
         end
     end
 end
@@ -1838,6 +1841,7 @@ def runV8WebAssemblySuite(*optionalTestSpecificOptions)
             run("wasm-b3", "--useWasmLLInt=false", "--wasmBBQUsesAir=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
             run("wasm-air", "--useWasmLLInt=false", "--useRandomizingExecutableIslandAllocation=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
             run("wasm-bbqb3", "--useWasmLLInt=true", "--wasmBBQUsesAir=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+            run("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless !$isSIMDPlatform
         end
     end
 end
@@ -1871,6 +1875,7 @@ def runWebAssemblyWithHarness(*optionalTestSpecificOptions)
         if $isFTLPlatform
             runHarnessTest("wasm-b3", "--useWasmLLInt=false", "--wasmBBQUsesAir=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
             runHarnessTest("wasm-bbqb3", "--useWasmLLInt=true", "--wasmBBQUsesAir=false", *FTL_OPTIONS)
+            runHarnessTest("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
         end
     end
 end
@@ -1893,6 +1898,7 @@ def runWebAssemblyEmscripten(mode)
         run("wasm-air", "--useWasmLLInt=false", "--useRandomizingExecutableIslandAllocation=true", *FTL_OPTIONS)
         if $isFTLPlatform
             run("wasm-b3", "--useWasmLLInt=false", "--wasmBBQUsesAir=false", *FTL_OPTIONS)
+            run("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
         end
     end
 end
@@ -1922,6 +1928,7 @@ def runWebAssemblySpecTestBase(mode, specHarnessPath, postfix, *optionalTestSpec
       runWithOutputHandler("wasm-air" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWasmLLInt=false", "--useRandomizingExecutableIslandAllocation=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
       if $isFTLPlatform
           runWithOutputHandler("wasm-b3" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWasmLLInt=false", "--wasmBBQUsesAir=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+          runWithOutputHandler("wasm-simd" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *(FTL_OPTIONS + optionalTestSpecificOptions))
       end
     end
 end
@@ -1944,8 +1951,7 @@ end
 
 def runWebAssemblySIMDSpecTest(mode)
     return if !$isSIMDPlatform
-    runWebAssemblySpecTestBase(mode, "simd-spec-harness", nil, "--useWebAssemblySIMD=true", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-    # fixme: temporary extra tests since the simd options don't play nicely without BBQ Air enabled
+    runWebAssemblySpecTestBase(mode, "simd-spec-harness", nil, "--useWebAssemblySIMD=true")
     runWebAssemblySpecTestBase(mode, "simd-spec-harness", "-eager", "--useWebAssemblySIMD=true", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0")
 end
 


### PR DESCRIPTION
#### a11ede1047e4c83f9f3b73a65bd88764616203a4
<pre>
Increase WASM SIMD test coverage.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249357">https://bugs.webkit.org/show_bug.cgi?id=249357</a>

Reviewed by Yusuke Suzuki.

Increase simd test coverage:

1) Add a new testing mode to force every function to be conservative w.r.t. treating floating point registers as vectors
2) Allow tier-up directly to OMG for SIMD functions
3) Remove extra test options implied when using SIMD. Note that we now assume all functions might use SIMD if the LLInt is disabled.
4) Add new (currently failing) tests: simd-exception.js, simd-osr.js, simd-tiny-loop.js. Note that these all pass in v8.
5) Update dont-stack-overflow-in-air.js. It uses f64 locals, which become 128-bit when the LLInt is disabled. This is a
   real regression introduced by this patch, but this mode is not very important for performance so we force the LLInt to be enabled in this mode.

* JSTests/wasm/assert.js:
* JSTests/wasm/stress/simd-const-spill.js:
* JSTests/wasm/stress/simd-const.js:
* JSTests/wasm/stress/simd-exception.js: Added.
(let.wat.module.import.string_appeared_here.string_appeared_here.tag.e.i32.param.i32.func.test_throw.export.string_appeared_here.param.sz.i32.local.i.i32.local.i.i32.const.0.loop.loop.local.i.i32.const.1.i32.add.local.i.local.i.local.sz.i32.eq.then.throw.e.i32.local.i.local.i.i32.const.1000.i32.lt_s.br_if.loop.func.test_catch.export.string_appeared_here.result.i32.v128.const.i32x4.1337.1337.1337.1337.try.call.test_throw.i32.const.500.catch.e.i32.i32.const.500.i32.ne.then.unreachable.i32x4.extract_lane.3.async test):
* JSTests/wasm/stress/simd-kitchen-sink.js:
* JSTests/wasm/stress/simd-load.js:
* JSTests/wasm/stress/simd-register-allocation.js:
* JSTests/wasm/stress/simd-return-value-alignment.js:
* JSTests/wasm/v8/exceptions-simd.js:
(TestThrowS128Default):
* JSTests/wasm/v8/liftoff-simd-params.js:
* JSTests/wasm/v8/multi-value-simd.js:
* JSTests/wasm/v8/regress/regress-10309.js:
* JSTests/wasm/v8/regress/regress-1054466.js:
* JSTests/wasm/v8/regress/regress-1065599.js:
* JSTests/wasm/v8/regress/regress-1070078.js:
* JSTests/wasm/v8/regress/regress-1081030.js:
* JSTests/wasm/v8/regress/regress-10831.js:
* JSTests/wasm/v8/regress/regress-1111522.js:
* JSTests/wasm/v8/regress/regress-1112124.js:
* JSTests/wasm/v8/regress/regress-1116019.js:
* JSTests/wasm/v8/regress/regress-1124885.js:
* JSTests/wasm/v8/regress/regress-1132461.js:
* JSTests/wasm/v8/regress/regress-1161555.js:
* JSTests/wasm/v8/regress/regress-1161654.js:
* JSTests/wasm/v8/regress/regress-1161954.js:
* JSTests/wasm/v8/regress/regress-1165966.js:
* JSTests/wasm/v8/regress/regress-1179182.js:
* JSTests/wasm/v8/regress/regress-1187831.js:
* JSTests/wasm/v8/regress/regress-1188975.js:
* JSTests/wasm/v8/regress/regress-1199662.js:
* JSTests/wasm/v8/regress/regress-1231950.js:
* JSTests/wasm/v8/regress/regress-1242300.js:
* JSTests/wasm/v8/regress/regress-1242689.js:
* JSTests/wasm/v8/regress/regress-1264462.js:
* JSTests/wasm/v8/regress/regress-1271244.js:
* JSTests/wasm/v8/regress/regress-1271456.js:
* JSTests/wasm/v8/regress/regress-1271538.js:
* JSTests/wasm/v8/regress/regress-1282224.js:
* JSTests/wasm/v8/regress/regress-1283042.js:
* JSTests/wasm/v8/regress/regress-1283395.js:
* JSTests/wasm/v8/regress/regress-1284980.js:
* JSTests/wasm/v8/regress/regress-1286253.js:
* JSTests/wasm/v8/regress/regress-1289678.js:
* JSTests/wasm/v8/regress/regress-1290079.js:
* JSTests/wasm/v8/regress/regress-9447.js:
* JSTests/wasm/v8/regress/regress-crbug-1338980.js:
* JSTests/wasm/v8/regress/regress-crbug-1355070.js:
* JSTests/wasm/v8/regress/regress-crbug-1356718.js:
* JSTests/wasm/v8/simd-call.js:
* JSTests/wasm/v8/simd-errors.js:
* JSTests/wasm/v8/simd-globals.js:
* JSTests/wasm/v8/simd-i64x2-mul.js:
* Source/JavaScriptCore/b3/B3Procedure.h:
(JSC::B3::Procedure::usesSIMD const):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::jitCompileSIMDFunction):
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/257974@main">https://commits.webkit.org/257974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5416a6b02bc2b0000179d1265cd13f275affaf14

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109843 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10614 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92933 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107698 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106318 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34640 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91053 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3404 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24184 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87103 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/886 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3412 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29148 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43675 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89987 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5463 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5210 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20121 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->