### PR TITLE
[JSC] Fix VectorAbs for I64x2

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1827,6 +1827,9 @@ arm64: VectorExtractPair U:G:Ptr, U:G:8, U:F:128, U:F:128, D:F:128
 64: VectorAbs U:G:Ptr, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp
 
+x86_64: VectorAbsInt64 U:F:128, D:F:128, S:F:128
+    Tmp, Tmp, Tmp
+
 arm64: VectorNeg U:G:Ptr, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp
 

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
@@ -268,63 +268,65 @@ public:
         AIR_OP_CASE(ExtendHigh)
         AIR_OP_CASE(ExtendLow)
         AIR_OP_CASE(TruncSat)
-#if CPU(X86_64)
-        else if (op == SIMDLaneOperation::Not) {
-            // x86_64 has no vector bitwise NOT instruction, so we expand vxv.not v into vxv.xor -1, v
-            // here to give B3/Air a chance to optimize out repeated usage of the mask.
-            v128_t mask;
-            mask.u64x2[0] = 0xffffffffffffffff;
-            mask.u64x2[1] = 0xffffffffffffffff;
-            TypedTmp ones = addConstant(mask);
-            result = tmpForType(Types::V128);
-            append(VectorXor, Arg::simdInfo({ SIMDLane::v128, SIMDSignMode::None }), ones, v, result);
-            return { };
-        }
-        else if (op == SIMDLaneOperation::Neg) {
-            // x86_64 has no vector negate instruction. For integer vectors, we can replicate negation by
-            // subtracting from zero. For floating-point vectors, we need to toggle the sign using packed
-            // XOR.
-            result = tmpForType(Types::V128);
-            switch (info.lane) {
-            case SIMDLane::i8x16:
-            case SIMDLane::i16x8:
-            case SIMDLane::i32x4:
-            case SIMDLane::i64x2: {
-                TypedTmp zero = addConstant(v128_t());
-                append(VectorSub, Arg::simdInfo(info), zero, v, result);
-                break;
-            }
-            case SIMDLane::f32x4: {
-                TypedTmp gptmp = tmpForType(Types::I32);
-                TypedTmp fptmp = tmpForType(Types::V128);
-                append(Move, Arg::bigImm(0x80000000), gptmp);
-                append(Move32ToFloat, gptmp, fptmp);
-                append(VectorSplatFloat32, fptmp, fptmp);
-                append(VectorXor, Arg::simdInfo({ SIMDLane::v128, SIMDSignMode::None }), v, fptmp, result);
-                break;
-            }
-            case SIMDLane::f64x2: {
-                TypedTmp gptmp = tmpForType(Types::I64);
-                TypedTmp fptmp = tmpForType(Types::V128);
-                append(Move, Arg::bigImm(0x8000000000000000), gptmp);
-                append(Move64ToDouble, gptmp, fptmp);
-                append(VectorSplatFloat64, fptmp, fptmp);
-                append(VectorXor, Arg::simdInfo({ SIMDLane::v128, SIMDSignMode::None }), v, fptmp, result);
-                break;
-            }
-            default:
-                RELEASE_ASSERT_NOT_REACHED();
-            }
-            return { };
-        }
-#else
         AIR_OP_CASE(Not)
         AIR_OP_CASE(Neg)
-#endif
 
         result = tmpForType(Types::V128);
 
         if (isX86()) {
+            if (airOp == B3::Air::VectorNot) {
+                // x86_64 has no vector bitwise NOT instruction, so we expand vxv.not v into vxv.xor -1, v
+                // here to give B3/Air a chance to optimize out repeated usage of the mask.
+                v128_t mask;
+                mask.u64x2[0] = 0xffffffffffffffff;
+                mask.u64x2[1] = 0xffffffffffffffff;
+                TypedTmp ones = addConstant(mask);
+                append(VectorXor, Arg::simdInfo({ SIMDLane::v128, SIMDSignMode::None }), ones, v, result);
+                return { };
+            }
+
+            if (airOp == B3::Air::VectorNeg) {
+                // x86_64 has no vector negate instruction. For integer vectors, we can replicate negation by
+                // subtracting from zero. For floating-point vectors, we need to toggle the sign using packed
+                // XOR.
+                switch (info.lane) {
+                case SIMDLane::i8x16:
+                case SIMDLane::i16x8:
+                case SIMDLane::i32x4:
+                case SIMDLane::i64x2: {
+                    TypedTmp zero = addConstant(v128_t());
+                    append(VectorSub, Arg::simdInfo(info), zero, v, result);
+                    break;
+                }
+                case SIMDLane::f32x4: {
+                    TypedTmp gptmp = tmpForType(Types::I32);
+                    TypedTmp fptmp = tmpForType(Types::V128);
+                    append(Move, Arg::bigImm(0x80000000), gptmp);
+                    append(Move32ToFloat, gptmp, fptmp);
+                    append(VectorSplatFloat32, fptmp, fptmp);
+                    append(VectorXor, Arg::simdInfo({ SIMDLane::v128, SIMDSignMode::None }), v, fptmp, result);
+                    break;
+                }
+                case SIMDLane::f64x2: {
+                    TypedTmp gptmp = tmpForType(Types::I64);
+                    TypedTmp fptmp = tmpForType(Types::V128);
+                    append(Move, Arg::bigImm(0x8000000000000000), gptmp);
+                    append(Move64ToDouble, gptmp, fptmp);
+                    append(VectorSplatFloat64, fptmp, fptmp);
+                    append(VectorXor, Arg::simdInfo({ SIMDLane::v128, SIMDSignMode::None }), v, fptmp, result);
+                    break;
+                }
+                default:
+                    RELEASE_ASSERT_NOT_REACHED();
+                }
+                return { };
+            }
+
+            if (airOp == B3::Air::VectorAbs && info.lane == SIMDLane::i64x2) {
+                append(VectorAbsInt64, v, result, tmpForType(Types::V128));
+                return { };
+            }
+
             if (airOp == B3::Air::VectorExtaddPairwise) {
                 if (info.lane == SIMDLane::i16x8 && info.signMode == SIMDSignMode::Unsigned)
                     append(VectorExtaddPairwiseUnsignedInt16, v, result, tmpForType(Types::V128));
@@ -332,7 +334,6 @@ public:
                     append(airOp, Arg::simdInfo(info), v, result, tmpForType(Types::I64), tmpForType(Types::V128));
                 return { };
             }
-
 
             if (airOp == B3::Air::VectorConvert && info.signMode == SIMDSignMode::Unsigned) {
                 append(VectorConvertUnsigned, v, result, tmpForType(Types::V128));


### PR DESCRIPTION
#### 643ffd610e8b20bb11e7cca20b56462c4283fd7b
<pre>
[JSC] Fix VectorAbs for I64x2
<a href="https://bugs.webkit.org/show_bug.cgi?id=249358">https://bugs.webkit.org/show_bug.cgi?id=249358</a>
rdar://103380107

Reviewed by Justin Michaud.

VectorAbs for I64x2 in x64 requires a scratch register,
since input and dest can be the same. This patch fixes it.
Also we clean up the adhoc lowering part in Wasm::AirIRGenerator64.

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::vectorAbsInt64):
(JSC::MacroAssemblerX86_64::vectorAbs):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::addSIMDV_V):

Canonical link: <a href="https://commits.webkit.org/257901@main">https://commits.webkit.org/257901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a95b6b85ccccf31a7ef8175fb53fc0d65f7086e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109677 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/61 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107555 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106138 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/90906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3263 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86919 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/719 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3256 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/29104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9377 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89802 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5072 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/20076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2810 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->