### PR TITLE
[WebGPU] GPU::getPreferredCanvasFormat() should return BGRA8

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPU.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPU.cpp
@@ -65,7 +65,7 @@ void GPU::requestAdapter(const std::optional<GPURequestAdapterOptions>& options,
 
 GPUTextureFormat GPU::getPreferredCanvasFormat()
 {
-    return GPUTextureFormat::Rgba8unorm;
+    return GPUTextureFormat::Bgra8unorm;
 }
 
 }

--- a/Websites/webkit.org/demos/webgpu/scripts/textured-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/textured-cube.js
@@ -11,6 +11,7 @@ async function helloCube() {
     const adapter = await navigator.gpu.requestAdapter();
     const device = await adapter.requestDevice();
     
+    const preferredBackingFormat = navigator.gpu.getPreferredCanvasFormat();
     /*** Vertex Buffer Setup ***/
     
     /* Vertex Data */
@@ -99,7 +100,7 @@ async function helloCube() {
         mipLevelCount: 1,
         sampleCount: 1,
         dimension: "2d",
-        format: "bgra8unorm",
+        format: preferredBackingFormat,
         usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST
     };
     const texture = device.createTexture(textureDescriptor);
@@ -207,7 +208,7 @@ async function helloCube() {
     /* GPUPipelineStageDescriptors */
     const vertexStageDescriptor = { module: shaderModule, entryPoint: "vsmain" };
 
-    const fragmentStageDescriptor = { module: shaderModule, entryPoint: "fsmain", targets: [ {format: "bgra8unorm" }, ],  };
+    const fragmentStageDescriptor = { module: shaderModule, entryPoint: "fsmain", targets: [ {format: preferredBackingFormat }, ],  };
 
     /* GPURenderPipelineDescriptor */
 
@@ -236,7 +237,7 @@ async function helloCube() {
         const gpuContext = canvas.getContext("webgpu");
         
         /* GPUCanvasConfiguration */
-        const canvasConfiguration = { device: device, format: "bgra8unorm" };
+        const canvasConfiguration = { device: device, format: preferredBackingFormat };
         gpuContext.configure(canvasConfiguration);
         /* GPUTexture */
         const currentTexture = gpuContext.getCurrentTexture();


### PR DESCRIPTION
#### 5b954c5707fd762b05170c63ab9a4abda2ae4a98
<pre>
[WebGPU] GPU::getPreferredCanvasFormat() should return BGRA8
<a href="https://bugs.webkit.org/show_bug.cgi?id=249359">https://bugs.webkit.org/show_bug.cgi?id=249359</a>
&lt;radar://103380144&gt;

Reviewed by Dean Jackson.

As noted <a href="https://github.com/WebKit/WebKit/pull/2337#discussion_r922583630">https://github.com/WebKit/WebKit/pull/2337#discussion_r922583630</a>, we
should prefer BGRA8 for Metal.

* Source/WebCore/Modules/WebGPU/GPU.cpp:
(WebCore::GPU::getPreferredCanvasFormat):
Prefer BGRA8.

* Websites/webkit.org/demos/webgpu/scripts/textured-cube.js:
(async helloCube.frameUpdate):
(async helloCube):
Update textured-cube demo to use the preferred canvas format.

Canonical link: <a href="https://commits.webkit.org/258158@main">https://commits.webkit.org/258158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1208843936a6b75a785623531ae3e2f0af165091

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109661 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169877 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/236 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92744 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107539 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34533 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89910 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77488 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3247 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24052 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/317 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43542 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5600 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5056 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->