### PR TITLE
Fix imported/w3c/web-platform-tests/css/css-box/inheritance.html for margin-trim.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/inheritance.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/inheritance.html
@@ -23,7 +23,7 @@ assert_not_inherited('margin-bottom', '0px', '10px');
 assert_not_inherited('margin-left', '0px', '10px');
 assert_not_inherited('margin-right', '0px', '10px');
 assert_not_inherited('margin-top', '0px', '10px');
-assert_not_inherited('margin-trim', 'none', 'all');
+assert_not_inherited('margin-trim', 'none', 'block');
 assert_not_inherited('padding-bottom', '0px', '10px');
 assert_not_inherited('padding-left', '0px', '10px');
 assert_not_inherited('padding-right', '0px', '10px');


### PR DESCRIPTION
#### 07575d8d452fec3df400dbfc6a258155ff690dae
<pre>
Fix imported/w3c/web-platform-tests/css/css-box/inheritance.html for margin-trim.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249366">https://bugs.webkit.org/show_bug.cgi?id=249366</a>
rdar://103383727

Reviewed by Tim Nguyen.

The test was using a value for the margin-trim property that is not
valid. The value that it was using, &quot;all,&quot; was in an old version of the
spec but is not valid anymore. This would cause the test to fail in any
scenarios since the parser would not recognize it as a value for the
property. Replacing it with &quot;block,&quot; should help resolve this issue.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/inheritance.html:

Canonical link: <a href="https://commits.webkit.org/257903@main">https://commits.webkit.org/257903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a99d43d52c807c27703f2d875a84b3e237585803

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109675 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169906 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/58 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107553 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106136 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3261 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24067 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3254 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43557 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5427 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5070 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->