### PR TITLE
Integrate PGM for large heap allocations

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
@@ -31,7 +31,9 @@
 #include "pas_allocation_result.h"
 #include "pas_local_allocator_inlines.h"
 #include "pas_malloc_stack_logging.h"
+#include "pas_random.h"
 #include "pas_primitive_heap_ref.h"
+#include "pas_probabilistic_guard_malloc_allocator.h"
 #include "pas_segregated_heap_inlines.h"
 #include "pas_utils.h"
 
@@ -165,9 +167,11 @@ pas_try_allocate_common_impl_slow(
             
             pas_physical_memory_transaction_begin(&transaction);
             pas_heap_lock_lock();
-            
-            result = pas_large_heap_try_allocate(
-                &heap->large_heap, size, alignment, config.config_ptr, &transaction);
+                        
+            if (PAS_UNLIKELY(pas_get_fast_random(100) < PAS_PGM_PROBABILITY))
+                result = pas_large_heap_try_allocate_pgm(&heap->large_heap, size, alignment, config.config_ptr, &transaction);
+            else
+                result = pas_large_heap_try_allocate(&heap->large_heap, size, alignment, config.config_ptr, &transaction);
             
             pas_heap_lock_unlock();
         } while (!pas_physical_memory_transaction_end(&transaction));


### PR DESCRIPTION
#### bef479cf388225c9651ee453359a8a2d68aa1f46
<pre>
Integrate PGM for large heap allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=249371">https://bugs.webkit.org/show_bug.cgi?id=249371</a>

Reviewed by NOBODY (OOPS!).

Enable PGM for large heap allocations.

* Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h:
(pas_try_allocate_common_impl_slow):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bef479cf388225c9651ee453359a8a2d68aa1f46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100365 "2 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9527 "Hash bef479cf for PR 7668 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33428 "Hash bef479cf for PR 7668 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109682 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169907 "Built successfully and passed tests") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10439 "Hash bef479cf for PR 7668 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/69 "Hash bef479cf for PR 7668 does not build (failure)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107560 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106143 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/10439 "Hash bef479cf for PR 7668 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/33428 "Hash bef479cf for PR 7668 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34548 "layout-tests (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/10439 "Hash bef479cf for PR 7668 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/33428 "Hash bef479cf for PR 7668 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90911 "Hash bef479cf for PR 7668 does not build (failure)") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3268 "Hash bef479cf for PR 7668 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/33428 "Hash bef479cf for PR 7668 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86924 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/724 "Hash bef479cf for PR 7668 does not build (failure)") | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3261 "Hash bef479cf for PR 7668 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/69 "Hash bef479cf for PR 7668 does not build (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29105 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9382 "Hash bef479cf for PR 7668 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/33428 "Hash bef479cf for PR 7668 does not build (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89807 "Built successfully") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5077 "Hash bef479cf for PR 7668 does not build (failure)") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20077 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->