### PR TITLE
Add cloneable flag to ShadowRootInit

### DIFF
--- a/LayoutTests/fast/shadow-dom/cloneable-shadow-root-expected.txt
+++ b/LayoutTests/fast/shadow-dom/cloneable-shadow-root-expected.txt
@@ -1,0 +1,18 @@
+
+PASS ShadowRoot in "open" mode is not cloneable by default
+PASS ShadowRoot in "closed" mode is not cloneable by default
+PASS ShadowRoot in "open" mode is cloneable if cloneable flag is set
+PASS ShadowRoot in "closed" mode is cloneable if cloneable flag is set
+PASS Cloning ShadowRoot in "open" mode clones shadow root mode
+PASS Cloning ShadowRoot in "closed" mode clones shadow root mode
+PASS Cloning ShadowRoot in "open" mode clones delegatesFocus flag set to true
+PASS Cloning ShadowRoot in "open" mode clones delegatesFocus flag set to false
+PASS Cloning ShadowRoot in "closed" mode clones delegatesFocus flag set to true
+PASS Cloning ShadowRoot in "closed" mode clones delegatesFocus flag set to false
+PASS Cloning ShadowRoot in "open" mode clones slot assignment mode set to manual
+PASS Cloning ShadowRoot in "open" mode clones slot assignment mode set to named
+PASS Cloning ShadowRoot in "closed" mode clones slot assignment mode set to manual
+PASS Cloning ShadowRoot in "closed" mode clones slot assignment mode set to named
+PASS Cloning ShadowRoot in "open" mode clones shadow descendants
+PASS Cloning ShadowRoot in "closed" mode clones shadow descendants
+

--- a/LayoutTests/fast/shadow-dom/cloneable-shadow-root.html
+++ b/LayoutTests/fast/shadow-dom/cloneable-shadow-root.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+function testShadowRootIsNotCloneableByDefault(mode) {
+    test(() => {
+        const host = document.createElement('div');
+        const shadowRoot = host.attachShadow({mode});
+
+        const clonedHost = host.cloneNode(true);
+        assert_true(!!clonedHost.attachShadow({mode}));
+        assert_throws_dom('NotSupportedError', () => {
+            shadowRoot.cloneNode(true);
+        });
+    }, `ShadowRoot in "${mode}" mode is not cloneable by default`);
+}
+
+testShadowRootIsNotCloneableByDefault('open');
+testShadowRootIsNotCloneableByDefault('closed');
+
+function testShadowRootIsCloneable(mode) {
+    test(() => {
+        const host = document.createElement('div');
+        const shadowRoot = host.attachShadow({mode, cloneable: true});
+
+        const clonedHost = host.cloneNode(true);
+        assert_throws_dom('NotSupportedError', () => {
+            clonedHost.attachShadow({mode});
+        });
+        assert_equals(!!clonedHost.shadowRoot, mode == 'open');
+    }, `ShadowRoot in "${mode}" mode is cloneable if cloneable flag is set`);
+}
+
+testShadowRootIsCloneable('open');
+testShadowRootIsCloneable('closed');
+
+function testShadowRootClonesShadowRootMode(mode) {
+    test(() => {
+        const host = document.createElement('div');
+        const shadowRoot = host.attachShadow({mode, cloneable: true});
+        const clonedHost = host.cloneNode(true);
+        assert_equals(!!clonedHost.shadowRoot, mode == 'open');
+    }, `Cloning ShadowRoot in "${mode}" mode clones shadow root mode`);
+}
+testShadowRootClonesShadowRootMode('open');
+testShadowRootClonesShadowRootMode('closed');
+
+window.didFocusInputElement = false;
+function testShadowRootClonesDelegatesFocus(mode, delegatesFocus) {
+    test(() => {
+        const host = document.createElement('div');
+        const shadowRoot = host.attachShadow({mode, cloneable: true, delegatesFocus});
+        shadowRoot.innerHTML = '<input onfocus="window.didFocusInputElement = true">';
+
+        const clonedHost = host.cloneNode(true);
+        window.didFocusInputElement = false;
+        document.body.appendChild(clonedHost);
+        clonedHost.focus();
+        if (mode == 'open')
+            assert_equals(clonedHost.shadowRoot.delegatesFocus, delegatesFocus);
+        assert_equals(didFocusInputElement, delegatesFocus);
+        clonedHost.remove();
+    }, `Cloning ShadowRoot in "${mode}" mode clones delegatesFocus flag set to ${delegatesFocus}`);
+}
+
+testShadowRootClonesDelegatesFocus('open', true);
+testShadowRootClonesDelegatesFocus('open', false);
+testShadowRootClonesDelegatesFocus('closed', true);
+testShadowRootClonesDelegatesFocus('closed', false);
+
+function testShadowRootClonesSlotAssignment(mode) {
+    test(() => {
+        const host = document.createElement('span');
+        host.innerHTML = '<div style="width: 100px; height: 100px; display: inline-block;"></div>';
+        const shadowRoot = host.attachShadow({mode, cloneable: true, slotAssignment: 'manual'});
+        shadowRoot.innerHTML = '<slot></slot>';
+        const clonedHost = host.cloneNode(true);
+        if (mode == 'open')
+            assert_equals(clonedHost.shadowRoot.slotAssignment, 'manual');
+        document.body.appendChild(clonedHost);
+        assert_equals(clonedHost.offsetWidth, 0);
+        clonedHost.remove();
+    }, `Cloning ShadowRoot in "${mode}" mode clones slot assignment mode set to manual`);
+
+    test(() => {
+        const host = document.createElement('span');
+        host.innerHTML = '<div style="width: 100px; height: 100px; display: inline-block;"></div>';
+        const shadowRoot = host.attachShadow({mode, cloneable: true, slotAssignment: 'named'});
+        shadowRoot.innerHTML = '<slot></slot>';
+        const clonedHost = host.cloneNode(true);
+        if (mode == 'open')
+            assert_equals(clonedHost.shadowRoot.slotAssignment, 'named');
+        document.body.appendChild(clonedHost);
+        assert_equals(clonedHost.offsetWidth, 100);
+        clonedHost.remove();
+    }, `Cloning ShadowRoot in "${mode}" mode clones slot assignment mode set to named`);
+}
+
+testShadowRootClonesSlotAssignment('open');
+testShadowRootClonesSlotAssignment('closed');
+
+function testShadowRootClonesShadowDescendants(mode) {
+    test(() => {
+        const host = document.createElement('span');
+        const shadowRoot = host.attachShadow({mode, cloneable: true});
+        shadowRoot.innerHTML = '<div style="width: 100px; height: 100px; display: inline-block;"><div></div></div>';
+        const clonedHost = host.cloneNode(true);
+        if (mode == 'open')
+            assert_equals(clonedHost.shadowRoot.innerHTML, '<div style="width: 100px; height: 100px; display: inline-block;"><div></div></div>');
+        document.body.appendChild(clonedHost);
+        assert_equals(clonedHost.offsetWidth, 100);
+        clonedHost.remove();
+    }, `Cloning ShadowRoot in "${mode}" mode clones shadow descendants`);
+}
+testShadowRootClonesShadowDescendants('open');
+testShadowRootClonesShadowDescendants('closed');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic.tentative-expected.txt
@@ -8,10 +8,10 @@ PASS Declarative Shadow DOM: Closed shadow root attribute
 PASS Declarative Shadow DOM: Missing closing tag
 PASS Declarative Shadow DOM: delegates focus attribute
 PASS Declarative Shadow DOM: Multiple roots
-FAIL Declarative Shadow DOM: template containing declarative shadow root assert_true: Inner div should have a shadow root expected true got false
-FAIL Declarative Shadow DOM: template containing (deeply nested) declarative shadow root assert_true: Inner div should have a shadow root expected true got false
-FAIL Declarative Shadow DOM: template containing a template containing declarative shadow root assert_true: Inner div should have a shadow root expected true got false
-FAIL Declarative Shadow DOM: template containing declarative shadow root and UA shadow root assert_true: Inner div should have a shadow root expected true got false
+PASS Declarative Shadow DOM: template containing declarative shadow root
+PASS Declarative Shadow DOM: template containing (deeply nested) declarative shadow root
+PASS Declarative Shadow DOM: template containing a template containing declarative shadow root
+PASS Declarative Shadow DOM: template containing declarative shadow root and UA shadow root
 PASS Declarative Shadow DOM: template containing closed declarative shadow root and UA shadow root
 PASS Declarative Shadow DOM: template root element
 

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -3405,6 +3405,9 @@ webkit.org/b/149592 fast/shadow-dom/touch-event-ios.html [ Skip ]
 fast/shadow-dom/manual-assignment-multiple-shadow-roots.html [ Failure ]
 fast/shadow-dom/imperative-named-slot-mixture.html [ Failure ]
 
+# Declarative shadow DOM isn't enabled on Windows yet.
+fast/shadow-dom/cloneable-shadow-root.html [ Failure ]
+
 # The SVG -> OTF Font converter outputs 'kern' tables instead of 'GPOS' tables.
 webkit.org/b/137204 fast/text/svg-font-face-with-kerning.html [ Failure ]
 webkit.org/b/137204 svg/W3C-SVG-1.1/fonts-kern-01-t.svg [ Failure ]

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -560,18 +560,37 @@ Ref<Node> Element::cloneNodeInternal(Document& targetDocument, CloningOperation 
 {
     switch (type) {
     case CloningOperation::OnlySelf:
-    case CloningOperation::SelfWithTemplateContent:
         return cloneElementWithoutChildren(targetDocument);
+    case CloningOperation::SelfWithTemplateContent: {
+        Ref clone = cloneElementWithoutChildren(targetDocument);
+        ScriptDisallowedScope::EventAllowedScope eventAllowedScope { clone };
+        cloneShadowTreeIfPossible(clone);
+        return clone;
+    }
     case CloningOperation::Everything:
         break;
     }
     return cloneElementWithChildren(targetDocument);
 }
 
+void Element::cloneShadowTreeIfPossible(Element& newHost)
+{
+    RefPtr oldShadowRoot = this->shadowRoot();
+    if (!oldShadowRoot || !oldShadowRoot->isCloneable())
+        return;
+
+    Ref clone = oldShadowRoot->cloneNodeInternal(newHost.document(), Node::CloningOperation::SelfWithTemplateContent);
+    RELEASE_ASSERT(is<ShadowRoot>(clone));
+    auto& clonedShadowRoot = downcast<ShadowRoot>(clone.get());
+    newHost.addShadowRoot(clonedShadowRoot);
+    oldShadowRoot->cloneChildNodes(clonedShadowRoot);
+}
+
 Ref<Element> Element::cloneElementWithChildren(Document& targetDocument)
 {
     Ref<Element> clone = cloneElementWithoutChildren(targetDocument);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { clone };
+    cloneShadowTreeIfPossible(clone);
     cloneChildNodes(clone);
     return clone;
 }
@@ -2726,7 +2745,10 @@ ExceptionOr<ShadowRoot&> Element::attachShadow(const ShadowRootInit& init)
     }
     if (init.mode == ShadowRootMode::UserAgent)
         return Exception { TypeError };
-    auto shadow = ShadowRoot::create(document(), init.mode, init.slotAssignment, init.delegatesFocus ? ShadowRoot::DelegatesFocus::Yes : ShadowRoot::DelegatesFocus::No, isPrecustomizedOrDefinedCustomElement() ? ShadowRoot::AvailableToElementInternals::Yes : ShadowRoot::AvailableToElementInternals::No);
+    auto shadow = ShadowRoot::create(document(), init.mode, init.slotAssignment,
+        init.delegatesFocus ? ShadowRoot::DelegatesFocus::Yes : ShadowRoot::DelegatesFocus::No,
+        init.cloneable ? ShadowRoot::Cloneable::Yes : ShadowRoot::Cloneable::No,
+        isPrecustomizedOrDefinedCustomElement() ? ShadowRoot::AvailableToElementInternals::Yes : ShadowRoot::AvailableToElementInternals::No);
     auto& result = shadow.get();
     addShadowRoot(WTFMove(shadow));
     return result;
@@ -2734,7 +2756,7 @@ ExceptionOr<ShadowRoot&> Element::attachShadow(const ShadowRootInit& init)
 
 ExceptionOr<ShadowRoot&> Element::attachDeclarativeShadow(ShadowRootMode mode, bool delegatesFocus)
 {
-    auto exceptionOrShadowRoot = attachShadow({ mode, delegatesFocus });
+    auto exceptionOrShadowRoot = attachShadow({ mode, delegatesFocus, /* cloneable */ true });
     if (exceptionOrShadowRoot.hasException())
         return exceptionOrShadowRoot.releaseException();
     auto& shadowRoot = exceptionOrShadowRoot.releaseReturnValue();

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -792,6 +792,7 @@ private:
 
     // The cloneNode function is private so that non-virtual cloneElementWith/WithoutChildren are used instead.
     Ref<Node> cloneNodeInternal(Document&, CloningOperation) override;
+    void cloneShadowTreeIfPossible(Element& newHost);
     virtual Ref<Element> cloneElementWithoutAttributesAndChildren(Document&);
 
     void removeShadowRoot();

--- a/Source/WebCore/dom/ShadowRootInit.h
+++ b/Source/WebCore/dom/ShadowRootInit.h
@@ -33,6 +33,7 @@ namespace WebCore {
 struct ShadowRootInit {
     ShadowRootMode mode;
     bool delegatesFocus { false };
+    bool cloneable { false };
     SlotAssignmentMode slotAssignment { SlotAssignmentMode::Named };
 };
 

--- a/Source/WebCore/dom/ShadowRootInit.idl
+++ b/Source/WebCore/dom/ShadowRootInit.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,5 +26,6 @@
 dictionary ShadowRootInit {
     required ShadowRootMode mode;
     boolean delegatesFocus = false;
+    [EnabledBySetting=DeclarativeShadowDOMEnabled] boolean cloneable = false;
     [EnabledBySetting=ImperativeSlotAPIEnabled] SlotAssignmentMode slotAssignment = "named";
 };

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -535,7 +535,7 @@ void HTMLConstructionSite::insertHTMLElement(AtomHTMLToken&& token)
 void HTMLConstructionSite::insertHTMLTemplateElement(AtomHTMLToken&& token)
 {
     if (m_document.settings().declarativeShadowDOMEnabled() && m_document.settings().streamingDeclarativeShadowDOMEnabled()
-        && m_parserContentPolicy.contains(ParserContentPolicy::AllowDeclarativeShadowDOM) && !currentElement().document().templateDocumentHost()) {
+        && m_parserContentPolicy.contains(ParserContentPolicy::AllowDeclarativeShadowDOM)) {
         std::optional<ShadowRootMode> mode;
         bool delegatesFocus = false;
         for (auto& attribute : token.attributes()) {


### PR DESCRIPTION
#### d7d9268e700a19cd1b06de3920229b83f9071ad9
<pre>
Add cloneable flag to ShadowRootInit
<a href="https://bugs.webkit.org/show_bug.cgi?id=249369">https://bugs.webkit.org/show_bug.cgi?id=249369</a>

Reviewed by Chris Dumez.

Add the support for cloneable boolean flag on ShadowRootInit. ShadowRoot and its descendant nodes becomes cloneable
when this flag is set. The flag is set by default for declarative shadow DOM.

See <a href="https://github.com/whatwg/dom/issues/1137">https://github.com/whatwg/dom/issues/1137</a> for discussion.

* LayoutTests/fast/shadow-dom/cloneable-shadow-root-expected.txt: Added.
* LayoutTests/fast/shadow-dom/cloneable-shadow-root.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic.tentative-expected.txt:
* LayoutTests/platform/win/TestExpectations

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::cloneNodeInternal):
(WebCore::Element::cloneShadowTreeIfPossible): Added.
(WebCore::Element::cloneElementWithChildren):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ShadowRoot.cpp:s
(WebCore::ShadowRoot::ShadowRoot):
(WebCore::ShadowRoot::childrenChanged):
(WebCore::ShadowRoot::cloneNodeInternal): Added the implementation.
* Source/WebCore/dom/ShadowRoot.h:
(WebCore::ShadowRoot): Renamed m_type to m_mode for consistency &amp; clarity.
* Source/WebCore/dom/ShadowRootInit.h:
* Source/WebCore/dom/ShadowRootInit.idl:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::insertHTMLTemplateElement): Allow declarative shadow DOM inside in a template content.

Canonical link: <a href="https://commits.webkit.org/257978@main">https://commits.webkit.org/257978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70ebd8d70f5094118cc623fb0d6d1c23df91ab6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109850 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170140 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10621 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92941 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107705 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106325 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34645 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22670 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3411 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24188 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3419 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43679 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5217 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2856 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->