### PR TITLE
[JSC] Materialize Const128 as MemoryValue

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -4075,14 +4075,8 @@ private:
         }
 
         case Const128: {
-            auto value = m_value->as<Const128Value>()->value();
-            auto a = tmpForType(Int64);
-            auto result = tmp(m_value);
-            append(MoveZeroToVector, result);
-            append(Move, Arg::bigImm(value.u64x2[0]), a);
-            append(Air::VectorReplaceLaneInt64, Arg::imm(0), a, result);
-            append(Move, Arg::bigImm(value.u64x2[1]), a);
-            append(Air::VectorReplaceLaneInt64, Arg::imm(1), a, result);
+            // We expect that the moveConstants() phase has run, and any constant vector referenced from stackmaps get fused.
+            append(MoveZeroToVector, tmp(m_value));
             return;
         }
 

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -2416,6 +2416,7 @@ private:
 
         case Const32:
         case Const64:
+        case Const128:
         case ConstFloat:
         case ConstDouble: {
             ValueKey key = m_value->key();

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -197,6 +197,12 @@ void Value::dump(PrintStream& out) const
         out.print("$", asInt64(), "(");
         isConstant = true;
         break;
+    case Const128: {
+        v128_t vector = asV128();
+        out.print("$", vector.u64x2[0], vector.u64x2[1], "(");
+        isConstant = true;
+        break;
+    }
     case ConstFloat:
         out.print("$", asFloat(), "(");
         isConstant = true;
@@ -848,6 +854,8 @@ ValueKey Value::key() const
         return ValueKey(Const32, type(), static_cast<int64_t>(asInt32()));
     case Const64:
         return ValueKey(Const64, type(), asInt64());
+    case Const128:
+        return ValueKey(Const128, type(), asV128());
     case ConstDouble:
         return ValueKey(ConstDouble, type(), asDouble());
     case ConstFloat:

--- a/Source/JavaScriptCore/b3/B3ValueKey.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueKey.cpp
@@ -114,6 +114,8 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
         return proc.add<Const32Value>(origin, static_cast<int32_t>(value()));
     case Const64:
         return proc.add<Const64Value>(origin, value());
+    case Const128:
+        return proc.add<Const128Value>(origin, vectorValue());
     case ConstDouble:
         return proc.add<ConstDoubleValue>(origin, doubleValue());
     case ConstFloat:

--- a/Source/JavaScriptCore/b3/B3ValueKey.h
+++ b/Source/JavaScriptCore/b3/B3ValueKey.h
@@ -86,6 +86,13 @@ public:
         u.floatValue = value;
     }
 
+    ValueKey(Kind kind, Type type, v128_t value)
+        : m_kind(kind)
+        , m_type(type)
+    {
+        u.vectorValue = value;
+    }
+
     static ValueKey intConstant(Type type, int64_t value);
 
     Kind kind() const { return m_kind; }
@@ -96,6 +103,7 @@ public:
     int64_t value() const { return u.value; }
     double doubleValue() const { return u.doubleValue; }
     float floatValue() const { return u.floatValue; }
+    v128_t vectorValue() const { return u.vectorValue; }
 
     bool operator==(const ValueKey& other) const
     {
@@ -111,7 +119,7 @@ public:
 
     unsigned hash() const
     {
-        return m_kind.hash() + m_type.hash() + WTF::IntHash<int32_t>::hash(u.indices[0]) + u.indices[1] + u.indices[2];
+        return m_kind.hash() + m_type.hash() + WTF::IntHash<int32_t>::hash(u.indices[0]) + u.indices[1] + u.indices[2] + u.indices[3];
     }
 
     explicit operator bool() const { return *this != ValueKey(); }
@@ -156,23 +164,26 @@ private:
     Kind m_kind;
     Type m_type { Void };
     union U {
-        unsigned indices[3];
+        unsigned indices[4];
         int64_t value;
         double doubleValue;
         float floatValue;
+        v128_t vectorValue;
 
         U()
         {
             indices[0] = 0;
             indices[1] = 0;
             indices[2] = 0;
+            indices[3] = 0;
         }
 
         bool operator==(const U& other) const
         {
             return indices[0] == other.indices[0]
                 && indices[1] == other.indices[1]
-                && indices[2] == other.indices[2];
+                && indices[2] == other.indices[2]
+                && indices[3] == other.indices[3];
         }
     } u;
 };

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -555,6 +555,7 @@ void testTrappingLoadDCE();
 void testTrappingStoreElimination();
 void testMoveConstants();
 void testMoveConstantsWithLargeOffsets();
+void testMoveConstantsSIMD();
 void testPCOriginMapDoesntInsertNops();
 void testBitOrBitOrArgImmImm32(int, int, int c);
 void testBitOrImmBitOrArgImm32(int, int, int c);

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -765,6 +765,8 @@ void run(const char* filter)
     RUN(testTrappingStoreElimination());
     RUN(testMoveConstants());
     RUN(testMoveConstantsWithLargeOffsets());
+    if (Options::useWebAssemblySIMD())
+        RUN(testMoveConstantsSIMD());
     RUN(testPCOriginMapDoesntInsertNops());
     RUN(testPinRegisters());
     RUN(testReduceStrengthReassociation(true));

--- a/Source/JavaScriptCore/jit/SIMDInfo.h
+++ b/Source/JavaScriptCore/jit/SIMDInfo.h
@@ -39,6 +39,12 @@ typedef union v128_u {
     v128_u() = default;
 } v128_t;
 
+// Comparing based on bits. Not using float/double comparison.
+inline bool bitEquals(const v128_t& lhs, const v128_t rhs)
+{
+    return lhs.u64x2[0] == rhs.u64x2[0] && lhs.u64x2[1] == rhs.u64x2[1];
+}
+
 enum class SIMDLane : uint8_t {
     v128,
     i8x16,


### PR DESCRIPTION
#### 5ec607384e6cab3e0822efcc9f6bc3227b7d5505
<pre>
[JSC] Materialize Const128 as MemoryValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=249372">https://bugs.webkit.org/show_bug.cgi?id=249372</a>
rdar://103388495

Reviewed by Justin Michaud.

This patch implements Const128 MemroyValue materialization in B3 MoveConstants phase.
Materializing Const128 takes a lot of instructions. So usually compiler makes it
load-from-data-section. We already did this for double / float, so this patch extends
B3 MoveConstants to handle Const128 too.

We reorganize our DataSection in B3. Previously all the slots are 8-bytes. But now,
we create this section as follows.

    [ V128 slots ... ][ Double slots ... ][ Float slots ... ]

Since the section starts with V128, which has the largest alignment, we do not need to
consider about alignment when calculating offset in this table. Each slot is exact-sized
so that we do not waste much memory for double / float even though there is a V128 slot.

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3MoveConstants.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::dump const):
(JSC::B3::Value::key const):
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/b3/B3ValueKey.h:
(JSC::B3::ValueKey::ValueKey):
(JSC::B3::ValueKey::vectorValue const):
(JSC::B3::ValueKey::hash const):
* Source/JavaScriptCore/jit/SIMDInfo.h:
(JSC::bitEquals):

Canonical link: <a href="https://commits.webkit.org/257939@main">https://commits.webkit.org/257939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2026d08d288e900072f0e7dd3ec35d9f1ac1d33f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100384 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109700 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169939 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/100 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92788 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107578 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34570 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22573 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90927 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3287 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24092 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86943 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/742 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3279 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/217 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/source-list-parsing-05.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29115 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9400 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43582 "Passed tests") | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89826 "Hash 2026d08d for PR 7671 does not build (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5095 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/37/builds/89826 "Hash 2026d08d for PR 7671 does not build (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2835 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->