### PR TITLE
ifdef out IPC::MessageName values that aren't applicable

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import collections
+import itertools
 import re
 import sys
 
@@ -87,9 +88,20 @@ class MessageEnumerator(object):
             return self.messages[0].name
         return '%s_%s' % (self.receiver.name, self.messages[0].name)
 
+    def condition(self):
+        conditions = [message.condition for message in self.messages]
+        if any([condition is None for condition in conditions]):
+            return None
+        return " || ".join(conditions)
+
+    def synchronous(self):
+        is_synchronous = self.messages[0].has_attribute(SYNCHRONOUS_ATTRIBUTE)
+        assert(all([message.has_attribute(SYNCHRONOUS_ATTRIBUTE) == is_synchronous for message in self.messages]))
+        return is_synchronous
+
     @classmethod
     def sort_key(cls, obj):
-        return obj.messages[0].has_attribute(SYNCHRONOUS_ATTRIBUTE), receiver_enumerator_order_key(obj.receiver.name), str(obj)
+        return obj.synchronous(), receiver_enumerator_order_key(obj.receiver.name), str(obj)
 
 
 def get_message_enumerators(receivers):
@@ -492,7 +504,7 @@ def async_message_statement(receiver, message):
     result = []
     result.append('    if (decoder.messageName() == Messages::%s::%s::name())\n' % (receiver.name, message.name))
     result.append('        return IPC::%s<Messages::%s::%s>(%s, %s);\n' % (dispatch_function, receiver.name, message.name, connection, ', '.join(dispatch_function_args)))
-    return surround_in_condition(''.join(result), message.condition)
+    return result
 
 
 def sync_message_statement(receiver, message):
@@ -513,7 +525,7 @@ def sync_message_statement(receiver, message):
     result = []
     result.append('    if (decoder.messageName() == Messages::%s::%s::name())\n' % (receiver.name, message.name))
     result.append('        return IPC::%s<Messages::%s::%s>(connection, decoder%s, this, &%s);\n' % (dispatch_function, receiver.name, message.name, maybe_reply_encoder, handler_function(receiver, message)))
-    return surround_in_condition(''.join(result), message.condition)
+    return result
 
 
 def class_template_headers(template_string):
@@ -996,16 +1008,28 @@ def generate_message_handler(receiver):
         else:
             async_messages.append(message)
 
+    def collect_message_statements(messages, message_statement_function):
+        result = []
+        for condition, messages in itertools.groupby(messages, lambda m: m.condition):
+            if condition:
+                result.append('#if %s\n' % condition)
+            for message in messages:
+                result += message_statement_function(receiver, message)
+            if condition:
+                result.append('#endif\n')
+        return result
+
+    async_message_statements = collect_message_statements(async_messages, async_message_statement)
+    sync_message_statements = collect_message_statements(sync_messages, sync_message_statement)
+
     if receiver.has_attribute(STREAM_ATTRIBUTE):
         result.append('void %s::didReceiveStreamMessage(IPC::StreamServerConnection& connection, IPC::Decoder& decoder)\n' % (receiver.name))
         result.append('{\n')
         assert(receiver.has_attribute(NOT_REFCOUNTED_RECEIVER_ATTRIBUTE))
         assert(not receiver.has_attribute(WANTS_DISPATCH_MESSAGE_ATTRIBUTE))
         assert(not receiver.has_attribute(WANTS_ASYNC_DISPATCH_MESSAGE_ATTRIBUTE))
-
-        result += [async_message_statement(receiver, message) for message in async_messages]
-        result += [sync_message_statement(receiver, message) for message in sync_messages]
-
+        result += async_message_statements
+        result += sync_message_statements
         if (receiver.superclass):
             result.append('    %s::didReceiveStreamMessage(connection, decoder);\n' % (receiver.superclass))
         else:
@@ -1023,9 +1047,7 @@ def generate_message_handler(receiver):
         result.append('{\n')
         if not (receiver.has_attribute(NOT_REFCOUNTED_RECEIVER_ATTRIBUTE) or receiver.has_attribute(STREAM_ATTRIBUTE)):
             result.append('    Ref protectedThis { *this };\n')
-
-        result += [async_message_statement(receiver, message) for message in async_messages]
-
+        result += async_message_statements
         if receiver.has_attribute(WANTS_DISPATCH_MESSAGE_ATTRIBUTE) or receiver.has_attribute(WANTS_ASYNC_DISPATCH_MESSAGE_ATTRIBUTE):
             result.append('    if (dispatchMessage(connection, decoder))\n')
             result.append('        return;\n')
@@ -1047,7 +1069,7 @@ def generate_message_handler(receiver):
         result.append('{\n')
         if not receiver.has_attribute(NOT_REFCOUNTED_RECEIVER_ATTRIBUTE):
             result.append('    Ref protectedThis { *this };\n')
-        result += [sync_message_statement(receiver, message) for message in sync_messages]
+        result += sync_message_statements
         if receiver.has_attribute(WANTS_DISPATCH_MESSAGE_ATTRIBUTE):
             result.append('    if (dispatchSyncMessage(connection, decoder, replyEncoder))\n')
             result.append('        return true;\n')
@@ -1062,37 +1084,39 @@ def generate_message_handler(receiver):
         result.append('    return false;\n')
         result.append('}\n')
 
-    result.append('\n} // namespace WebKit\n')
+    result.append('\n')
+    result.append('} // namespace WebKit\n')
 
     result.append('\n')
-    result.append('#if ENABLE(IPC_TESTING_API)\n\n')
-    result.append('namespace IPC {\n\n')
-    previous_message_condition = None
-    for message in receiver.messages:
-        if previous_message_condition != message.condition:
-            if previous_message_condition:
-                result.append('#endif\n')
-            if message.condition:
-                result.append('#if %s\n' % message.condition)
-            previous_message_condition = message.condition
-        result.append('template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::%s_%s>(JSC::JSGlobalObject* globalObject, Decoder& decoder)\n' % (receiver.name, message.name))
-        result.append('{\n')
-        result.append('    return jsValueForDecodedArguments<Messages::%s::%s::%s>(globalObject, decoder);\n' % (receiver.name, message.name, 'Arguments'))
-        result.append('}\n')
-        has_reply = message.reply_parameters is not None
-        if not has_reply:
-            continue
-        result.append('template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::%s_%s>(JSC::JSGlobalObject* globalObject, Decoder& decoder)\n' % (receiver.name, message.name))
-        result.append('{\n')
-        result.append('    return jsValueForDecodedArguments<Messages::%s::%s::%s>(globalObject, decoder);\n' % (receiver.name, message.name, 'ReplyArguments'))
-        result.append('}\n')
-    if previous_message_condition:
-        result.append('#endif\n')
-    result.append('\n}\n\n')
-    result.append('#endif\n\n')
+    result.append('#if ENABLE(IPC_TESTING_API)\n')
+    result.append('\n')
+    result.append('namespace IPC {\n')
+    result.append('\n')
+    for condition, messages in itertools.groupby(receiver.messages, lambda m: m.condition):
+        if condition:
+            result.append('#if %s\n' % condition)
+        for message in messages:
+            result.append('template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::%s_%s>(JSC::JSGlobalObject* globalObject, Decoder& decoder)\n' % (receiver.name, message.name))
+            result.append('{\n')
+            result.append('    return jsValueForDecodedArguments<Messages::%s::%s::%s>(globalObject, decoder);\n' % (receiver.name, message.name, 'Arguments'))
+            result.append('}\n')
+            has_reply = message.reply_parameters is not None
+            if has_reply:
+                result.append('template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::%s_%s>(JSC::JSGlobalObject* globalObject, Decoder& decoder)\n' % (receiver.name, message.name))
+                result.append('{\n')
+                result.append('    return jsValueForDecodedArguments<Messages::%s::%s::%s>(globalObject, decoder);\n' % (receiver.name, message.name, 'ReplyArguments'))
+                result.append('}\n')
+        if condition:
+            result.append('#endif\n')
+    result.append('\n')
+    result.append('}\n')
+    result.append('\n')
+    result.append('#endif\n')
+    result.append('\n')
 
     if receiver.condition:
-        result.append('\n#endif // %s\n' % receiver.condition)
+        result.append('\n')
+        result.append('#endif // %s\n' % receiver.condition)
 
     return ''.join(result)
 
@@ -1102,6 +1126,7 @@ def generate_message_names_header(receivers):
     result.append(_license_header)
     result.append('#pragma once\n')
     result.append('\n')
+    result.append('#include <algorithm>\n')
     result.append('#include <wtf/EnumTraits.h>\n')
     result.append('\n')
     result.append('namespace IPC {\n')
@@ -1114,35 +1139,61 @@ def generate_message_names_header(receivers):
     result.append('\n};\n')
     result.append('\n')
 
+    result.append('enum class MessageName : uint16_t {\n')
     message_enumerators = get_message_enumerators(receivers)
-
-    result.append('enum class MessageName : uint16_t {')
-    result.append('\n    ')
-    result.append('\n    , '.join(str(e) for e in message_enumerators))
-    result.append('\n    , Last = %s' % message_enumerators[-1])
-    result.append('\n};\n')
+    seen_synchronous = False
+    for (condition, synchronous), enumerators in itertools.groupby(message_enumerators, lambda e: (e.condition(), e.synchronous())):
+        if synchronous and not seen_synchronous:
+            result.append('    FirstSynchronous,\n')
+            result.append('    LastAsynchronous = FirstSynchronous - 1,\n')
+            seen_synchronous = True
+        if condition:
+            result.append('#if %s\n' % condition)
+        for enumerator in enumerators:
+            result.append('    %s,\n' % enumerator)
+        if condition:
+            result.append('#endif\n')
+    result.append('    Count,\n')
+    result.append('    Last = Count - 1\n')
+    result.append('};\n')
     result.append('\n')
-    result.append('ReceiverName receiverName(MessageName);\n')
-    result.append('const char* description(MessageName);\n')
+    result.append('namespace Detail {\n')
+    result.append('struct MessageDescription {\n')
+    result.append('    const char* const description;\n')
+    result.append('    ReceiverName receiverName;\n')
+    for fname, _ in sorted(attributes_to_generate_validators.items()):
+        result.append('    bool %s : 1;\n' % fname)
+    result.append('};\n')
+    result.append('\n')
+    result.append('extern const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Count) + 1];\n')
+    result.append('}\n')
+    result.append('\n')
+    fnames = [('ReceiverName', 'receiverName'), ('const char*', 'description')]
+    fnames += [('bool', fname) for fname, _ in sorted(attributes_to_generate_validators.items())]
+    for returnType, fname in fnames:
+        result.append('inline %s %s(MessageName messageName)\n' % (returnType, fname))
+        result.append('{\n')
+        result.append('    messageName = std::min(messageName, MessageName::Last);\n')
+        result.append('    return Detail::messageDescriptions[static_cast<size_t>(messageName)].%s;\n' % fname)
+        result.append('}\n')
+        result.append('\n')
     result.append('constexpr bool messageIsSync(MessageName name)\n')
     result.append('{\n')
-    first_synchronous = next((e for e in message_enumerators if e.messages[0].has_attribute(SYNCHRONOUS_ATTRIBUTE)), None)
-    if first_synchronous:
-        result.append('    return name >= MessageName::%s;\n' % first_synchronous)
+    if seen_synchronous:
+        result.append('    return name >= MessageName::FirstSynchronous;\n')
     else:
         result.append('    UNUSED_PARAM(name);\n')
         result.append('    return false;\n')
     result.append('}\n')
     result.append('\n')
-
-    for fname, _ in sorted(attributes_to_generate_validators.items()):
-        result.append('bool %s(MessageName);\n' % fname)
-
     result.append('} // namespace IPC\n')
     result.append('\n')
     result.append('namespace WTF {\n')
     result.append('\n')
-    result.append('template<> bool isValidEnum<IPC::MessageName, void>(std::underlying_type_t<IPC::MessageName>);\n')
+    result.append('template<> constexpr bool isValidEnum<IPC::MessageName, void>(std::underlying_type_t<IPC::MessageName> messageName)\n')
+    result.append('{\n')
+    result.append('    return messageName <= WTF::enumToUnderlyingType(IPC::MessageName::Last);\n')
+    result.append('}\n')
     result.append('\n')
     result.append('} // namespace WTF\n')
     return ''.join(result)
@@ -1154,69 +1205,26 @@ def generate_message_names_implementation(receivers):
     result.append('#include "config.h"\n')
     result.append('#include "MessageNames.h"\n')
     result.append('\n')
-    result.append('namespace IPC {\n')
+    result.append('namespace IPC::Detail {\n')
     result.append('\n')
-    result.append('const char* description(MessageName name)\n')
-    result.append('{\n')
-    result.append('    switch (name) {\n')
+    result.append('const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Count) + 1] = {\n')
 
     message_enumerators = get_message_enumerators(receivers)
-    for enumerator in message_enumerators:
-        result.append('    case MessageName::%s:\n' % enumerator)
-        result.append('        return "%s";\n' % enumerator)
-    result.append('    }\n')
-    result.append('    ASSERT_NOT_REACHED();\n')
-    result.append('    return "<invalid message name>";\n')
-    result.append('}\n')
-    result.append('\n')
-    result.append('ReceiverName receiverName(MessageName messageName)\n')
-    result.append('{\n')
-    result.append('    switch (messageName) {\n')
-    prev_enumerator = None
-    for enumerator in message_enumerators:
-        if prev_enumerator and prev_enumerator.receiver != enumerator.receiver:
-            result.append('        return ReceiverName::%s;\n' % prev_enumerator.receiver.name)
-        result.append('    case MessageName::%s:\n' % enumerator)
-        prev_enumerator = enumerator
-    if prev_enumerator:
-        result.append('        return ReceiverName::%s;\n' % prev_enumerator.receiver.name)
-    result.append('    }\n')
-    result.append('    ASSERT_NOT_REACHED();\n')
-    result.append('    return ReceiverName::Invalid;\n')
-    result.append('}\n')
-    for fnam, attr_list in sorted(attributes_to_generate_validators.items()):
-        result.append('bool %s(MessageName name)\n' % fnam)
-        result.append('{\n')
-        result.append('    switch (name) {\n')
-        for e in message_enumerators:
-            if set(attr_list).intersection(set(e.messages[0].attributes).union(set(e.receiver.attributes))):
-                result.append('    case MessageName::%s:\n' % e)
-        if [e for e in message_enumerators if set(attr_list).intersection(set(e.messages[0].attributes).union(set(e.receiver.attributes)))]:
-            result.append('        return true;\n')
-        result.append('    default:\n')
-        result.append('        return false;\n')
-        result.append('    }\n')
-        result.append('}\n')
-        result.append('\n')
-    result.append('\n')
-    result.append('} // namespace IPC\n')
-    result.append('\n')
-    result.append('namespace WTF {\n')
-    result.append('template<> bool isValidEnum<IPC::MessageName, void>(std::underlying_type_t<IPC::MessageName> underlyingType)\n')
-    result.append('{\n')
-    result.append('    auto messageName = static_cast<IPC::MessageName>(underlyingType);\n')
-    for enumerator in message_enumerators:
-        for message in enumerator.messages:
-            if message.condition:
-                result.append('#if %s\n' % message.condition)
-            result.append('    if (messageName == IPC::MessageName::%s)\n' % enumerator)
-            result.append('        return true;\n')
-            if message.condition:
-                result.append('#endif\n')
-    result.append('    return false;\n')
+    for condition, enumerators in itertools.groupby(message_enumerators, lambda e: e.condition()):
+        if condition:
+            result.append('#if %s\n' % condition)
+        for enumerator in enumerators:
+            result.append('    { "%s", ReceiverName::%s' % (enumerator, enumerator.receiver.name))
+            for attr_list in sorted(attributes_to_generate_validators.values()):
+                value = "true" if set(attr_list).intersection(set(enumerator.messages[0].attributes).union(set(enumerator.receiver.attributes))) else "false"
+                result.append(', %s' % value)
+            result.append(' },\n')
+        if condition:
+            result.append('#endif\n')
+    result.append('    { "<invalid message name>", ReceiverName::Invalid%s }\n' % (", false" * len(attributes_to_generate_validators)))
     result.append('};\n')
     result.append('\n')
-    result.append('} // namespace WTF\n')
+    result.append('} // namespace IPC::Detail\n')
     return ''.join(result)
 
 

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -25,596 +25,147 @@
 #include "config.h"
 #include "MessageNames.h"
 
-namespace IPC {
+namespace IPC::Detail {
 
-const char* description(MessageName name)
-{
-    switch (name) {
-    case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
-        return "TestWithCVPixelBuffer_ReceiveCVPixelBuffer";
-    case MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer:
-        return "TestWithCVPixelBuffer_SendCVPixelBuffer";
-    case MessageName::TestWithIfMessage_LoadURL:
-        return "TestWithIfMessage_LoadURL";
-    case MessageName::TestWithImageData_ReceiveImageData:
-        return "TestWithImageData_ReceiveImageData";
-    case MessageName::TestWithImageData_SendImageData:
-        return "TestWithImageData_SendImageData";
-    case MessageName::TestWithLegacyReceiver_AddEvent:
-        return "TestWithLegacyReceiver_AddEvent";
-    case MessageName::TestWithLegacyReceiver_Close:
-        return "TestWithLegacyReceiver_Close";
-    case MessageName::TestWithLegacyReceiver_CreatePlugin:
-        return "TestWithLegacyReceiver_CreatePlugin";
-    case MessageName::TestWithLegacyReceiver_DeprecatedOperation:
-        return "TestWithLegacyReceiver_DeprecatedOperation";
-    case MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection:
-        return "TestWithLegacyReceiver_DidCreateWebProcessConnection";
-    case MessageName::TestWithLegacyReceiver_DidReceivePolicyDecision:
-        return "TestWithLegacyReceiver_DidReceivePolicyDecision";
-    case MessageName::TestWithLegacyReceiver_ExperimentalOperation:
-        return "TestWithLegacyReceiver_ExperimentalOperation";
-    case MessageName::TestWithLegacyReceiver_GetPlugins:
-        return "TestWithLegacyReceiver_GetPlugins";
-    case MessageName::TestWithLegacyReceiver_InterpretKeyEvent:
-        return "TestWithLegacyReceiver_InterpretKeyEvent";
-    case MessageName::TestWithLegacyReceiver_LoadSomething:
-        return "TestWithLegacyReceiver_LoadSomething";
-    case MessageName::TestWithLegacyReceiver_LoadSomethingElse:
-        return "TestWithLegacyReceiver_LoadSomethingElse";
-    case MessageName::TestWithLegacyReceiver_LoadURL:
-        return "TestWithLegacyReceiver_LoadURL";
-    case MessageName::TestWithLegacyReceiver_PreferencesDidChange:
-        return "TestWithLegacyReceiver_PreferencesDidChange";
-    case MessageName::TestWithLegacyReceiver_RunJavaScriptAlert:
-        return "TestWithLegacyReceiver_RunJavaScriptAlert";
-    case MessageName::TestWithLegacyReceiver_SendDoubleAndFloat:
-        return "TestWithLegacyReceiver_SendDoubleAndFloat";
-    case MessageName::TestWithLegacyReceiver_SendInts:
-        return "TestWithLegacyReceiver_SendInts";
-    case MessageName::TestWithLegacyReceiver_SetVideoLayerID:
-        return "TestWithLegacyReceiver_SetVideoLayerID";
-    case MessageName::TestWithLegacyReceiver_TemplateTest:
-        return "TestWithLegacyReceiver_TemplateTest";
-    case MessageName::TestWithLegacyReceiver_TestParameterAttributes:
-        return "TestWithLegacyReceiver_TestParameterAttributes";
-    case MessageName::TestWithLegacyReceiver_TouchEvent:
-        return "TestWithLegacyReceiver_TouchEvent";
-    case MessageName::TestWithSemaphore_ReceiveSemaphore:
-        return "TestWithSemaphore_ReceiveSemaphore";
-    case MessageName::TestWithSemaphore_SendSemaphore:
-        return "TestWithSemaphore_SendSemaphore";
-    case MessageName::TestWithStreamBatched_SendString:
-        return "TestWithStreamBatched_SendString";
-    case MessageName::TestWithStreamBuffer_SendStreamBuffer:
-        return "TestWithStreamBuffer_SendStreamBuffer";
-    case MessageName::TestWithStream_SendMachSendRight:
-        return "TestWithStream_SendMachSendRight";
-    case MessageName::TestWithStream_SendString:
-        return "TestWithStream_SendString";
-    case MessageName::TestWithStream_SendStringAsync:
-        return "TestWithStream_SendStringAsync";
-    case MessageName::TestWithSuperclass_LoadURL:
-        return "TestWithSuperclass_LoadURL";
-    case MessageName::TestWithSuperclass_TestAsyncMessage:
-        return "TestWithSuperclass_TestAsyncMessage";
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithConnection:
-        return "TestWithSuperclass_TestAsyncMessageWithConnection";
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments:
-        return "TestWithSuperclass_TestAsyncMessageWithMultipleArguments";
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments:
-        return "TestWithSuperclass_TestAsyncMessageWithNoArguments";
-    case MessageName::TestWithoutAttributes_AddEvent:
-        return "TestWithoutAttributes_AddEvent";
-    case MessageName::TestWithoutAttributes_Close:
-        return "TestWithoutAttributes_Close";
-    case MessageName::TestWithoutAttributes_CreatePlugin:
-        return "TestWithoutAttributes_CreatePlugin";
-    case MessageName::TestWithoutAttributes_DeprecatedOperation:
-        return "TestWithoutAttributes_DeprecatedOperation";
-    case MessageName::TestWithoutAttributes_DidCreateWebProcessConnection:
-        return "TestWithoutAttributes_DidCreateWebProcessConnection";
-    case MessageName::TestWithoutAttributes_DidReceivePolicyDecision:
-        return "TestWithoutAttributes_DidReceivePolicyDecision";
-    case MessageName::TestWithoutAttributes_ExperimentalOperation:
-        return "TestWithoutAttributes_ExperimentalOperation";
-    case MessageName::TestWithoutAttributes_GetPlugins:
-        return "TestWithoutAttributes_GetPlugins";
-    case MessageName::TestWithoutAttributes_InterpretKeyEvent:
-        return "TestWithoutAttributes_InterpretKeyEvent";
-    case MessageName::TestWithoutAttributes_LoadSomething:
-        return "TestWithoutAttributes_LoadSomething";
-    case MessageName::TestWithoutAttributes_LoadSomethingElse:
-        return "TestWithoutAttributes_LoadSomethingElse";
-    case MessageName::TestWithoutAttributes_LoadURL:
-        return "TestWithoutAttributes_LoadURL";
-    case MessageName::TestWithoutAttributes_PreferencesDidChange:
-        return "TestWithoutAttributes_PreferencesDidChange";
-    case MessageName::TestWithoutAttributes_RunJavaScriptAlert:
-        return "TestWithoutAttributes_RunJavaScriptAlert";
-    case MessageName::TestWithoutAttributes_SendDoubleAndFloat:
-        return "TestWithoutAttributes_SendDoubleAndFloat";
-    case MessageName::TestWithoutAttributes_SendInts:
-        return "TestWithoutAttributes_SendInts";
-    case MessageName::TestWithoutAttributes_SetVideoLayerID:
-        return "TestWithoutAttributes_SetVideoLayerID";
-    case MessageName::TestWithoutAttributes_TemplateTest:
-        return "TestWithoutAttributes_TemplateTest";
-    case MessageName::TestWithoutAttributes_TestParameterAttributes:
-        return "TestWithoutAttributes_TestParameterAttributes";
-    case MessageName::TestWithoutAttributes_TouchEvent:
-        return "TestWithoutAttributes_TouchEvent";
-    case MessageName::InitializeConnection:
-        return "InitializeConnection";
-    case MessageName::LegacySessionState:
-        return "LegacySessionState";
-    case MessageName::ProcessOutOfStreamMessage:
-        return "ProcessOutOfStreamMessage";
-    case MessageName::SetStreamDestinationID:
-        return "SetStreamDestinationID";
-    case MessageName::SyncMessageReply:
-        return "SyncMessageReply";
-    case MessageName::Terminate:
-        return "Terminate";
-    case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBufferReply:
-        return "TestWithCVPixelBuffer_ReceiveCVPixelBufferReply";
-    case MessageName::TestWithImageData_ReceiveImageDataReply:
-        return "TestWithImageData_ReceiveImageDataReply";
-    case MessageName::TestWithLegacyReceiver_CreatePluginReply:
-        return "TestWithLegacyReceiver_CreatePluginReply";
-    case MessageName::TestWithLegacyReceiver_GetPluginsReply:
-        return "TestWithLegacyReceiver_GetPluginsReply";
-    case MessageName::TestWithLegacyReceiver_InterpretKeyEventReply:
-        return "TestWithLegacyReceiver_InterpretKeyEventReply";
-    case MessageName::TestWithLegacyReceiver_RunJavaScriptAlertReply:
-        return "TestWithLegacyReceiver_RunJavaScriptAlertReply";
-    case MessageName::TestWithSemaphore_ReceiveSemaphoreReply:
-        return "TestWithSemaphore_ReceiveSemaphoreReply";
-    case MessageName::TestWithStream_SendStringAsyncReply:
-        return "TestWithStream_SendStringAsyncReply";
-    case MessageName::TestWithSuperclass_TestAsyncMessageReply:
-        return "TestWithSuperclass_TestAsyncMessageReply";
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithConnectionReply:
-        return "TestWithSuperclass_TestAsyncMessageWithConnectionReply";
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply:
-        return "TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply";
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply:
-        return "TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply";
-    case MessageName::TestWithoutAttributes_CreatePluginReply:
-        return "TestWithoutAttributes_CreatePluginReply";
-    case MessageName::TestWithoutAttributes_GetPluginsReply:
-        return "TestWithoutAttributes_GetPluginsReply";
-    case MessageName::TestWithoutAttributes_InterpretKeyEventReply:
-        return "TestWithoutAttributes_InterpretKeyEventReply";
-    case MessageName::TestWithoutAttributes_RunJavaScriptAlertReply:
-        return "TestWithoutAttributes_RunJavaScriptAlertReply";
-    case MessageName::TestWithLegacyReceiver_GetPluginProcessConnection:
-        return "TestWithLegacyReceiver_GetPluginProcessConnection";
-    case MessageName::TestWithLegacyReceiver_TestMultipleAttributes:
-        return "TestWithLegacyReceiver_TestMultipleAttributes";
-    case MessageName::TestWithStream_ReceiveMachSendRight:
-        return "TestWithStream_ReceiveMachSendRight";
-    case MessageName::TestWithStream_SendAndReceiveMachSendRight:
-        return "TestWithStream_SendAndReceiveMachSendRight";
-    case MessageName::TestWithStream_SendStringSync:
-        return "TestWithStream_SendStringSync";
-    case MessageName::TestWithSuperclass_TestSyncMessage:
-        return "TestWithSuperclass_TestSyncMessage";
-    case MessageName::TestWithSuperclass_TestSynchronousMessage:
-        return "TestWithSuperclass_TestSynchronousMessage";
-    case MessageName::TestWithoutAttributes_GetPluginProcessConnection:
-        return "TestWithoutAttributes_GetPluginProcessConnection";
-    case MessageName::TestWithoutAttributes_TestMultipleAttributes:
-        return "TestWithoutAttributes_TestMultipleAttributes";
-    case MessageName::WrappedAsyncMessageForTesting:
-        return "WrappedAsyncMessageForTesting";
-    }
-    ASSERT_NOT_REACHED();
-    return "<invalid message name>";
-}
-
-ReceiverName receiverName(MessageName messageName)
-{
-    switch (messageName) {
-    case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
-    case MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer:
-        return ReceiverName::TestWithCVPixelBuffer;
-    case MessageName::TestWithIfMessage_LoadURL:
-        return ReceiverName::TestWithIfMessage;
-    case MessageName::TestWithImageData_ReceiveImageData:
-    case MessageName::TestWithImageData_SendImageData:
-        return ReceiverName::TestWithImageData;
-    case MessageName::TestWithLegacyReceiver_AddEvent:
-    case MessageName::TestWithLegacyReceiver_Close:
-    case MessageName::TestWithLegacyReceiver_CreatePlugin:
-    case MessageName::TestWithLegacyReceiver_DeprecatedOperation:
-    case MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection:
-    case MessageName::TestWithLegacyReceiver_DidReceivePolicyDecision:
-    case MessageName::TestWithLegacyReceiver_ExperimentalOperation:
-    case MessageName::TestWithLegacyReceiver_GetPlugins:
-    case MessageName::TestWithLegacyReceiver_InterpretKeyEvent:
-    case MessageName::TestWithLegacyReceiver_LoadSomething:
-    case MessageName::TestWithLegacyReceiver_LoadSomethingElse:
-    case MessageName::TestWithLegacyReceiver_LoadURL:
-    case MessageName::TestWithLegacyReceiver_PreferencesDidChange:
-    case MessageName::TestWithLegacyReceiver_RunJavaScriptAlert:
-    case MessageName::TestWithLegacyReceiver_SendDoubleAndFloat:
-    case MessageName::TestWithLegacyReceiver_SendInts:
-    case MessageName::TestWithLegacyReceiver_SetVideoLayerID:
-    case MessageName::TestWithLegacyReceiver_TemplateTest:
-    case MessageName::TestWithLegacyReceiver_TestParameterAttributes:
-    case MessageName::TestWithLegacyReceiver_TouchEvent:
-        return ReceiverName::TestWithLegacyReceiver;
-    case MessageName::TestWithSemaphore_ReceiveSemaphore:
-    case MessageName::TestWithSemaphore_SendSemaphore:
-        return ReceiverName::TestWithSemaphore;
-    case MessageName::TestWithStreamBatched_SendString:
-        return ReceiverName::TestWithStreamBatched;
-    case MessageName::TestWithStreamBuffer_SendStreamBuffer:
-        return ReceiverName::TestWithStreamBuffer;
-    case MessageName::TestWithStream_SendMachSendRight:
-    case MessageName::TestWithStream_SendString:
-    case MessageName::TestWithStream_SendStringAsync:
-        return ReceiverName::TestWithStream;
-    case MessageName::TestWithSuperclass_LoadURL:
-    case MessageName::TestWithSuperclass_TestAsyncMessage:
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithConnection:
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments:
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments:
-        return ReceiverName::TestWithSuperclass;
-    case MessageName::TestWithoutAttributes_AddEvent:
-    case MessageName::TestWithoutAttributes_Close:
-    case MessageName::TestWithoutAttributes_CreatePlugin:
-    case MessageName::TestWithoutAttributes_DeprecatedOperation:
-    case MessageName::TestWithoutAttributes_DidCreateWebProcessConnection:
-    case MessageName::TestWithoutAttributes_DidReceivePolicyDecision:
-    case MessageName::TestWithoutAttributes_ExperimentalOperation:
-    case MessageName::TestWithoutAttributes_GetPlugins:
-    case MessageName::TestWithoutAttributes_InterpretKeyEvent:
-    case MessageName::TestWithoutAttributes_LoadSomething:
-    case MessageName::TestWithoutAttributes_LoadSomethingElse:
-    case MessageName::TestWithoutAttributes_LoadURL:
-    case MessageName::TestWithoutAttributes_PreferencesDidChange:
-    case MessageName::TestWithoutAttributes_RunJavaScriptAlert:
-    case MessageName::TestWithoutAttributes_SendDoubleAndFloat:
-    case MessageName::TestWithoutAttributes_SendInts:
-    case MessageName::TestWithoutAttributes_SetVideoLayerID:
-    case MessageName::TestWithoutAttributes_TemplateTest:
-    case MessageName::TestWithoutAttributes_TestParameterAttributes:
-    case MessageName::TestWithoutAttributes_TouchEvent:
-        return ReceiverName::TestWithoutAttributes;
-    case MessageName::InitializeConnection:
-    case MessageName::LegacySessionState:
-    case MessageName::ProcessOutOfStreamMessage:
-    case MessageName::SetStreamDestinationID:
-    case MessageName::SyncMessageReply:
-    case MessageName::Terminate:
-        return ReceiverName::IPC;
-    case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBufferReply:
-    case MessageName::TestWithImageData_ReceiveImageDataReply:
-    case MessageName::TestWithLegacyReceiver_CreatePluginReply:
-    case MessageName::TestWithLegacyReceiver_GetPluginsReply:
-    case MessageName::TestWithLegacyReceiver_InterpretKeyEventReply:
-    case MessageName::TestWithLegacyReceiver_RunJavaScriptAlertReply:
-    case MessageName::TestWithSemaphore_ReceiveSemaphoreReply:
-    case MessageName::TestWithStream_SendStringAsyncReply:
-    case MessageName::TestWithSuperclass_TestAsyncMessageReply:
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithConnectionReply:
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply:
-    case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply:
-    case MessageName::TestWithoutAttributes_CreatePluginReply:
-    case MessageName::TestWithoutAttributes_GetPluginsReply:
-    case MessageName::TestWithoutAttributes_InterpretKeyEventReply:
-    case MessageName::TestWithoutAttributes_RunJavaScriptAlertReply:
-        return ReceiverName::AsyncReply;
-    case MessageName::TestWithLegacyReceiver_GetPluginProcessConnection:
-    case MessageName::TestWithLegacyReceiver_TestMultipleAttributes:
-        return ReceiverName::TestWithLegacyReceiver;
-    case MessageName::TestWithStream_ReceiveMachSendRight:
-    case MessageName::TestWithStream_SendAndReceiveMachSendRight:
-    case MessageName::TestWithStream_SendStringSync:
-        return ReceiverName::TestWithStream;
-    case MessageName::TestWithSuperclass_TestSyncMessage:
-    case MessageName::TestWithSuperclass_TestSynchronousMessage:
-        return ReceiverName::TestWithSuperclass;
-    case MessageName::TestWithoutAttributes_GetPluginProcessConnection:
-    case MessageName::TestWithoutAttributes_TestMultipleAttributes:
-        return ReceiverName::TestWithoutAttributes;
-    case MessageName::WrappedAsyncMessageForTesting:
-        return ReceiverName::IPC;
-    }
-    ASSERT_NOT_REACHED();
-    return ReceiverName::Invalid;
-}
-bool messageAllowedWhenWaitingForSyncReply(MessageName name)
-{
-    switch (name) {
-    case MessageName::TestWithStreamBatched_SendString:
-    case MessageName::TestWithStream_SendMachSendRight:
-    case MessageName::TestWithStream_SendString:
-    case MessageName::TestWithStream_SendStringAsync:
-    case MessageName::TestWithLegacyReceiver_GetPluginProcessConnection:
-    case MessageName::TestWithLegacyReceiver_TestMultipleAttributes:
-    case MessageName::TestWithStream_ReceiveMachSendRight:
-    case MessageName::TestWithStream_SendAndReceiveMachSendRight:
-    case MessageName::TestWithStream_SendStringSync:
-    case MessageName::TestWithSuperclass_TestSyncMessage:
-    case MessageName::TestWithSuperclass_TestSynchronousMessage:
-    case MessageName::TestWithoutAttributes_GetPluginProcessConnection:
-    case MessageName::TestWithoutAttributes_TestMultipleAttributes:
-    case MessageName::WrappedAsyncMessageForTesting:
-        return true;
-    default:
-        return false;
-    }
-}
-
-bool messageAllowedWhenWaitingForUnboundedSyncReply(MessageName name)
-{
-    switch (name) {
-    default:
-        return false;
-    }
-}
-
-
-} // namespace IPC
-
-namespace WTF {
-template<> bool isValidEnum<IPC::MessageName, void>(std::underlying_type_t<IPC::MessageName> underlyingType)
-{
-    auto messageName = static_cast<IPC::MessageName>(underlyingType);
+const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Count) + 1] = {
 #if USE(AVFOUNDATION)
-    if (messageName == IPC::MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer)
-        return true;
+    { "TestWithCVPixelBuffer_ReceiveCVPixelBuffer", ReceiverName::TestWithCVPixelBuffer, false, false },
+    { "TestWithCVPixelBuffer_SendCVPixelBuffer", ReceiverName::TestWithCVPixelBuffer, false, false },
 #endif
-#if USE(AVFOUNDATION)
-    if (messageName == IPC::MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer)
-        return true;
+#if PLATFORM(COCOA) || PLATFORM(GTK)
+    { "TestWithIfMessage_LoadURL", ReceiverName::TestWithIfMessage, false, false },
 #endif
-#if PLATFORM(COCOA)
-    if (messageName == IPC::MessageName::TestWithIfMessage_LoadURL)
-        return true;
-#endif
-#if PLATFORM(GTK)
-    if (messageName == IPC::MessageName::TestWithIfMessage_LoadURL)
-        return true;
-#endif
-    if (messageName == IPC::MessageName::TestWithImageData_ReceiveImageData)
-        return true;
-    if (messageName == IPC::MessageName::TestWithImageData_SendImageData)
-        return true;
+    { "TestWithImageData_ReceiveImageData", ReceiverName::TestWithImageData, false, false },
+    { "TestWithImageData_SendImageData", ReceiverName::TestWithImageData, false, false },
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_AddEvent)
-        return true;
+    { "TestWithLegacyReceiver_AddEvent", ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_Close)
-        return true;
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_CreatePlugin)
-        return true;
+    { "TestWithLegacyReceiver_Close", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_CreatePlugin", ReceiverName::TestWithLegacyReceiver, false, false },
 #if ENABLE(DEPRECATED_FEATURE)
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_DeprecatedOperation)
-        return true;
+    { "TestWithLegacyReceiver_DeprecatedOperation", ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
 #if PLATFORM(MAC)
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection)
-        return true;
+    { "TestWithLegacyReceiver_DidCreateWebProcessConnection", ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_DidReceivePolicyDecision)
-        return true;
+    { "TestWithLegacyReceiver_DidReceivePolicyDecision", ReceiverName::TestWithLegacyReceiver, false, false },
 #if ENABLE(FEATURE_FOR_TESTING)
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_ExperimentalOperation)
-        return true;
+    { "TestWithLegacyReceiver_ExperimentalOperation", ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_GetPlugins)
-        return true;
+    { "TestWithLegacyReceiver_GetPlugins", ReceiverName::TestWithLegacyReceiver, false, false },
 #if PLATFORM(MAC)
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_InterpretKeyEvent)
-        return true;
+    { "TestWithLegacyReceiver_InterpretKeyEvent", ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
 #if ENABLE(TOUCH_EVENTS)
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_LoadSomething)
-        return true;
+    { "TestWithLegacyReceiver_LoadSomething", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_LoadSomethingElse", ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-#if ENABLE(TOUCH_EVENTS)
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_LoadSomethingElse)
-        return true;
-#endif
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_LoadURL)
-        return true;
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_PreferencesDidChange)
-        return true;
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_RunJavaScriptAlert)
-        return true;
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_SendDoubleAndFloat)
-        return true;
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_SendInts)
-        return true;
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_SetVideoLayerID)
-        return true;
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_TemplateTest)
-        return true;
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_TestParameterAttributes)
-        return true;
+    { "TestWithLegacyReceiver_LoadURL", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_PreferencesDidChange", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_RunJavaScriptAlert", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_SendDoubleAndFloat", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_SendInts", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_SetVideoLayerID", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_TemplateTest", ReceiverName::TestWithLegacyReceiver, false, false },
+    { "TestWithLegacyReceiver_TestParameterAttributes", ReceiverName::TestWithLegacyReceiver, false, false },
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_TouchEvent)
-        return true;
+    { "TestWithLegacyReceiver_TouchEvent", ReceiverName::TestWithLegacyReceiver, false, false },
 #endif
-    if (messageName == IPC::MessageName::TestWithSemaphore_ReceiveSemaphore)
-        return true;
-    if (messageName == IPC::MessageName::TestWithSemaphore_SendSemaphore)
-        return true;
-    if (messageName == IPC::MessageName::TestWithStreamBatched_SendString)
-        return true;
-    if (messageName == IPC::MessageName::TestWithStreamBuffer_SendStreamBuffer)
-        return true;
+    { "TestWithSemaphore_ReceiveSemaphore", ReceiverName::TestWithSemaphore, false, false },
+    { "TestWithSemaphore_SendSemaphore", ReceiverName::TestWithSemaphore, false, false },
+    { "TestWithStreamBatched_SendString", ReceiverName::TestWithStreamBatched, true, false },
+    { "TestWithStreamBuffer_SendStreamBuffer", ReceiverName::TestWithStreamBuffer, false, false },
 #if PLATFORM(COCOA)
-    if (messageName == IPC::MessageName::TestWithStream_SendMachSendRight)
-        return true;
+    { "TestWithStream_SendMachSendRight", ReceiverName::TestWithStream, true, false },
 #endif
-    if (messageName == IPC::MessageName::TestWithStream_SendString)
-        return true;
-    if (messageName == IPC::MessageName::TestWithStream_SendStringAsync)
-        return true;
-    if (messageName == IPC::MessageName::TestWithSuperclass_LoadURL)
-        return true;
+    { "TestWithStream_SendString", ReceiverName::TestWithStream, true, false },
+    { "TestWithStream_SendStringAsync", ReceiverName::TestWithStream, true, false },
+    { "TestWithSuperclass_LoadURL", ReceiverName::TestWithSuperclass, false, false },
 #if ENABLE(TEST_FEATURE)
-    if (messageName == IPC::MessageName::TestWithSuperclass_TestAsyncMessage)
-        return true;
-#endif
-#if ENABLE(TEST_FEATURE)
-    if (messageName == IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithConnection)
-        return true;
-#endif
-#if ENABLE(TEST_FEATURE)
-    if (messageName == IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments)
-        return true;
-#endif
-#if ENABLE(TEST_FEATURE)
-    if (messageName == IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments)
-        return true;
+    { "TestWithSuperclass_TestAsyncMessage", ReceiverName::TestWithSuperclass, false, false },
+    { "TestWithSuperclass_TestAsyncMessageWithConnection", ReceiverName::TestWithSuperclass, false, false },
+    { "TestWithSuperclass_TestAsyncMessageWithMultipleArguments", ReceiverName::TestWithSuperclass, false, false },
+    { "TestWithSuperclass_TestAsyncMessageWithNoArguments", ReceiverName::TestWithSuperclass, false, false },
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
-    if (messageName == IPC::MessageName::TestWithoutAttributes_AddEvent)
-        return true;
+    { "TestWithoutAttributes_AddEvent", ReceiverName::TestWithoutAttributes, false, false },
 #endif
-    if (messageName == IPC::MessageName::TestWithoutAttributes_Close)
-        return true;
-    if (messageName == IPC::MessageName::TestWithoutAttributes_CreatePlugin)
-        return true;
+    { "TestWithoutAttributes_Close", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_CreatePlugin", ReceiverName::TestWithoutAttributes, false, false },
 #if ENABLE(DEPRECATED_FEATURE)
-    if (messageName == IPC::MessageName::TestWithoutAttributes_DeprecatedOperation)
-        return true;
+    { "TestWithoutAttributes_DeprecatedOperation", ReceiverName::TestWithoutAttributes, false, false },
 #endif
 #if PLATFORM(MAC)
-    if (messageName == IPC::MessageName::TestWithoutAttributes_DidCreateWebProcessConnection)
-        return true;
+    { "TestWithoutAttributes_DidCreateWebProcessConnection", ReceiverName::TestWithoutAttributes, false, false },
 #endif
-    if (messageName == IPC::MessageName::TestWithoutAttributes_DidReceivePolicyDecision)
-        return true;
+    { "TestWithoutAttributes_DidReceivePolicyDecision", ReceiverName::TestWithoutAttributes, false, false },
 #if ENABLE(FEATURE_FOR_TESTING)
-    if (messageName == IPC::MessageName::TestWithoutAttributes_ExperimentalOperation)
-        return true;
+    { "TestWithoutAttributes_ExperimentalOperation", ReceiverName::TestWithoutAttributes, false, false },
 #endif
-    if (messageName == IPC::MessageName::TestWithoutAttributes_GetPlugins)
-        return true;
+    { "TestWithoutAttributes_GetPlugins", ReceiverName::TestWithoutAttributes, false, false },
 #if PLATFORM(MAC)
-    if (messageName == IPC::MessageName::TestWithoutAttributes_InterpretKeyEvent)
-        return true;
+    { "TestWithoutAttributes_InterpretKeyEvent", ReceiverName::TestWithoutAttributes, false, false },
 #endif
 #if ENABLE(TOUCH_EVENTS)
-    if (messageName == IPC::MessageName::TestWithoutAttributes_LoadSomething)
-        return true;
+    { "TestWithoutAttributes_LoadSomething", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_LoadSomethingElse", ReceiverName::TestWithoutAttributes, false, false },
 #endif
-#if ENABLE(TOUCH_EVENTS)
-    if (messageName == IPC::MessageName::TestWithoutAttributes_LoadSomethingElse)
-        return true;
-#endif
-    if (messageName == IPC::MessageName::TestWithoutAttributes_LoadURL)
-        return true;
-    if (messageName == IPC::MessageName::TestWithoutAttributes_PreferencesDidChange)
-        return true;
-    if (messageName == IPC::MessageName::TestWithoutAttributes_RunJavaScriptAlert)
-        return true;
-    if (messageName == IPC::MessageName::TestWithoutAttributes_SendDoubleAndFloat)
-        return true;
-    if (messageName == IPC::MessageName::TestWithoutAttributes_SendInts)
-        return true;
-    if (messageName == IPC::MessageName::TestWithoutAttributes_SetVideoLayerID)
-        return true;
-    if (messageName == IPC::MessageName::TestWithoutAttributes_TemplateTest)
-        return true;
-    if (messageName == IPC::MessageName::TestWithoutAttributes_TestParameterAttributes)
-        return true;
+    { "TestWithoutAttributes_LoadURL", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_PreferencesDidChange", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_RunJavaScriptAlert", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_SendDoubleAndFloat", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_SendInts", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_SetVideoLayerID", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_TemplateTest", ReceiverName::TestWithoutAttributes, false, false },
+    { "TestWithoutAttributes_TestParameterAttributes", ReceiverName::TestWithoutAttributes, false, false },
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-    if (messageName == IPC::MessageName::TestWithoutAttributes_TouchEvent)
-        return true;
+    { "TestWithoutAttributes_TouchEvent", ReceiverName::TestWithoutAttributes, false, false },
 #endif
 #if PLATFORM(COCOA)
-    if (messageName == IPC::MessageName::InitializeConnection)
-        return true;
+    { "InitializeConnection", ReceiverName::IPC, false, false },
 #endif
-    if (messageName == IPC::MessageName::LegacySessionState)
-        return true;
-    if (messageName == IPC::MessageName::ProcessOutOfStreamMessage)
-        return true;
-    if (messageName == IPC::MessageName::SetStreamDestinationID)
-        return true;
-    if (messageName == IPC::MessageName::SyncMessageReply)
-        return true;
-    if (messageName == IPC::MessageName::Terminate)
-        return true;
+    { "LegacySessionState", ReceiverName::IPC, false, false },
+    { "ProcessOutOfStreamMessage", ReceiverName::IPC, false, false },
+    { "SetStreamDestinationID", ReceiverName::IPC, false, false },
+    { "SyncMessageReply", ReceiverName::IPC, false, false },
+    { "Terminate", ReceiverName::IPC, false, false },
 #if USE(AVFOUNDATION)
-    if (messageName == IPC::MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBufferReply)
-        return true;
+    { "TestWithCVPixelBuffer_ReceiveCVPixelBufferReply", ReceiverName::AsyncReply, false, false },
 #endif
-    if (messageName == IPC::MessageName::TestWithImageData_ReceiveImageDataReply)
-        return true;
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_CreatePluginReply)
-        return true;
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_GetPluginsReply)
-        return true;
+    { "TestWithImageData_ReceiveImageDataReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithLegacyReceiver_CreatePluginReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithLegacyReceiver_GetPluginsReply", ReceiverName::AsyncReply, false, false },
 #if PLATFORM(MAC)
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_InterpretKeyEventReply)
-        return true;
+    { "TestWithLegacyReceiver_InterpretKeyEventReply", ReceiverName::AsyncReply, false, false },
 #endif
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_RunJavaScriptAlertReply)
-        return true;
-    if (messageName == IPC::MessageName::TestWithSemaphore_ReceiveSemaphoreReply)
-        return true;
-    if (messageName == IPC::MessageName::TestWithStream_SendStringAsyncReply)
-        return true;
+    { "TestWithLegacyReceiver_RunJavaScriptAlertReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithSemaphore_ReceiveSemaphoreReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithStream_SendStringAsyncReply", ReceiverName::AsyncReply, false, false },
 #if ENABLE(TEST_FEATURE)
-    if (messageName == IPC::MessageName::TestWithSuperclass_TestAsyncMessageReply)
-        return true;
+    { "TestWithSuperclass_TestAsyncMessageReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithSuperclass_TestAsyncMessageWithConnectionReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply", ReceiverName::AsyncReply, false, false },
 #endif
-#if ENABLE(TEST_FEATURE)
-    if (messageName == IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithConnectionReply)
-        return true;
-#endif
-#if ENABLE(TEST_FEATURE)
-    if (messageName == IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply)
-        return true;
-#endif
-#if ENABLE(TEST_FEATURE)
-    if (messageName == IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply)
-        return true;
-#endif
-    if (messageName == IPC::MessageName::TestWithoutAttributes_CreatePluginReply)
-        return true;
-    if (messageName == IPC::MessageName::TestWithoutAttributes_GetPluginsReply)
-        return true;
+    { "TestWithoutAttributes_CreatePluginReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithoutAttributes_GetPluginsReply", ReceiverName::AsyncReply, false, false },
 #if PLATFORM(MAC)
-    if (messageName == IPC::MessageName::TestWithoutAttributes_InterpretKeyEventReply)
-        return true;
+    { "TestWithoutAttributes_InterpretKeyEventReply", ReceiverName::AsyncReply, false, false },
 #endif
-    if (messageName == IPC::MessageName::TestWithoutAttributes_RunJavaScriptAlertReply)
-        return true;
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_GetPluginProcessConnection)
-        return true;
-    if (messageName == IPC::MessageName::TestWithLegacyReceiver_TestMultipleAttributes)
-        return true;
+    { "TestWithoutAttributes_RunJavaScriptAlertReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithLegacyReceiver_GetPluginProcessConnection", ReceiverName::TestWithLegacyReceiver, true, false },
+    { "TestWithLegacyReceiver_TestMultipleAttributes", ReceiverName::TestWithLegacyReceiver, true, false },
 #if PLATFORM(COCOA)
-    if (messageName == IPC::MessageName::TestWithStream_ReceiveMachSendRight)
-        return true;
+    { "TestWithStream_ReceiveMachSendRight", ReceiverName::TestWithStream, true, false },
+    { "TestWithStream_SendAndReceiveMachSendRight", ReceiverName::TestWithStream, true, false },
 #endif
-#if PLATFORM(COCOA)
-    if (messageName == IPC::MessageName::TestWithStream_SendAndReceiveMachSendRight)
-        return true;
-#endif
-    if (messageName == IPC::MessageName::TestWithStream_SendStringSync)
-        return true;
-    if (messageName == IPC::MessageName::TestWithSuperclass_TestSyncMessage)
-        return true;
-    if (messageName == IPC::MessageName::TestWithSuperclass_TestSynchronousMessage)
-        return true;
-    if (messageName == IPC::MessageName::TestWithoutAttributes_GetPluginProcessConnection)
-        return true;
-    if (messageName == IPC::MessageName::TestWithoutAttributes_TestMultipleAttributes)
-        return true;
-    if (messageName == IPC::MessageName::WrappedAsyncMessageForTesting)
-        return true;
-    return false;
+    { "TestWithStream_SendStringSync", ReceiverName::TestWithStream, true, false },
+    { "TestWithSuperclass_TestSyncMessage", ReceiverName::TestWithSuperclass, true, false },
+    { "TestWithSuperclass_TestSynchronousMessage", ReceiverName::TestWithSuperclass, true, false },
+    { "TestWithoutAttributes_GetPluginProcessConnection", ReceiverName::TestWithoutAttributes, true, false },
+    { "TestWithoutAttributes_TestMultipleAttributes", ReceiverName::TestWithoutAttributes, true, false },
+    { "WrappedAsyncMessageForTesting", ReceiverName::IPC, true, false },
+    { "<invalid message name>", ReceiverName::Invalid, false, false }
 };
 
-} // namespace WTF
+} // namespace IPC::Detail

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <wtf/EnumTraits.h>
 
 namespace IPC {
@@ -45,111 +46,196 @@ enum class ReceiverName : uint8_t {
 };
 
 enum class MessageName : uint16_t {
-    TestWithCVPixelBuffer_ReceiveCVPixelBuffer
-    , TestWithCVPixelBuffer_SendCVPixelBuffer
-    , TestWithIfMessage_LoadURL
-    , TestWithImageData_ReceiveImageData
-    , TestWithImageData_SendImageData
-    , TestWithLegacyReceiver_AddEvent
-    , TestWithLegacyReceiver_Close
-    , TestWithLegacyReceiver_CreatePlugin
-    , TestWithLegacyReceiver_DeprecatedOperation
-    , TestWithLegacyReceiver_DidCreateWebProcessConnection
-    , TestWithLegacyReceiver_DidReceivePolicyDecision
-    , TestWithLegacyReceiver_ExperimentalOperation
-    , TestWithLegacyReceiver_GetPlugins
-    , TestWithLegacyReceiver_InterpretKeyEvent
-    , TestWithLegacyReceiver_LoadSomething
-    , TestWithLegacyReceiver_LoadSomethingElse
-    , TestWithLegacyReceiver_LoadURL
-    , TestWithLegacyReceiver_PreferencesDidChange
-    , TestWithLegacyReceiver_RunJavaScriptAlert
-    , TestWithLegacyReceiver_SendDoubleAndFloat
-    , TestWithLegacyReceiver_SendInts
-    , TestWithLegacyReceiver_SetVideoLayerID
-    , TestWithLegacyReceiver_TemplateTest
-    , TestWithLegacyReceiver_TestParameterAttributes
-    , TestWithLegacyReceiver_TouchEvent
-    , TestWithSemaphore_ReceiveSemaphore
-    , TestWithSemaphore_SendSemaphore
-    , TestWithStreamBatched_SendString
-    , TestWithStreamBuffer_SendStreamBuffer
-    , TestWithStream_SendMachSendRight
-    , TestWithStream_SendString
-    , TestWithStream_SendStringAsync
-    , TestWithSuperclass_LoadURL
-    , TestWithSuperclass_TestAsyncMessage
-    , TestWithSuperclass_TestAsyncMessageWithConnection
-    , TestWithSuperclass_TestAsyncMessageWithMultipleArguments
-    , TestWithSuperclass_TestAsyncMessageWithNoArguments
-    , TestWithoutAttributes_AddEvent
-    , TestWithoutAttributes_Close
-    , TestWithoutAttributes_CreatePlugin
-    , TestWithoutAttributes_DeprecatedOperation
-    , TestWithoutAttributes_DidCreateWebProcessConnection
-    , TestWithoutAttributes_DidReceivePolicyDecision
-    , TestWithoutAttributes_ExperimentalOperation
-    , TestWithoutAttributes_GetPlugins
-    , TestWithoutAttributes_InterpretKeyEvent
-    , TestWithoutAttributes_LoadSomething
-    , TestWithoutAttributes_LoadSomethingElse
-    , TestWithoutAttributes_LoadURL
-    , TestWithoutAttributes_PreferencesDidChange
-    , TestWithoutAttributes_RunJavaScriptAlert
-    , TestWithoutAttributes_SendDoubleAndFloat
-    , TestWithoutAttributes_SendInts
-    , TestWithoutAttributes_SetVideoLayerID
-    , TestWithoutAttributes_TemplateTest
-    , TestWithoutAttributes_TestParameterAttributes
-    , TestWithoutAttributes_TouchEvent
-    , InitializeConnection
-    , LegacySessionState
-    , ProcessOutOfStreamMessage
-    , SetStreamDestinationID
-    , SyncMessageReply
-    , Terminate
-    , TestWithCVPixelBuffer_ReceiveCVPixelBufferReply
-    , TestWithImageData_ReceiveImageDataReply
-    , TestWithLegacyReceiver_CreatePluginReply
-    , TestWithLegacyReceiver_GetPluginsReply
-    , TestWithLegacyReceiver_InterpretKeyEventReply
-    , TestWithLegacyReceiver_RunJavaScriptAlertReply
-    , TestWithSemaphore_ReceiveSemaphoreReply
-    , TestWithStream_SendStringAsyncReply
-    , TestWithSuperclass_TestAsyncMessageReply
-    , TestWithSuperclass_TestAsyncMessageWithConnectionReply
-    , TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply
-    , TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply
-    , TestWithoutAttributes_CreatePluginReply
-    , TestWithoutAttributes_GetPluginsReply
-    , TestWithoutAttributes_InterpretKeyEventReply
-    , TestWithoutAttributes_RunJavaScriptAlertReply
-    , TestWithLegacyReceiver_GetPluginProcessConnection
-    , TestWithLegacyReceiver_TestMultipleAttributes
-    , TestWithStream_ReceiveMachSendRight
-    , TestWithStream_SendAndReceiveMachSendRight
-    , TestWithStream_SendStringSync
-    , TestWithSuperclass_TestSyncMessage
-    , TestWithSuperclass_TestSynchronousMessage
-    , TestWithoutAttributes_GetPluginProcessConnection
-    , TestWithoutAttributes_TestMultipleAttributes
-    , WrappedAsyncMessageForTesting
-    , Last = WrappedAsyncMessageForTesting
+#if USE(AVFOUNDATION)
+    TestWithCVPixelBuffer_ReceiveCVPixelBuffer,
+    TestWithCVPixelBuffer_SendCVPixelBuffer,
+#endif
+#if PLATFORM(COCOA) || PLATFORM(GTK)
+    TestWithIfMessage_LoadURL,
+#endif
+    TestWithImageData_ReceiveImageData,
+    TestWithImageData_SendImageData,
+#if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
+    TestWithLegacyReceiver_AddEvent,
+#endif
+    TestWithLegacyReceiver_Close,
+    TestWithLegacyReceiver_CreatePlugin,
+#if ENABLE(DEPRECATED_FEATURE)
+    TestWithLegacyReceiver_DeprecatedOperation,
+#endif
+#if PLATFORM(MAC)
+    TestWithLegacyReceiver_DidCreateWebProcessConnection,
+#endif
+    TestWithLegacyReceiver_DidReceivePolicyDecision,
+#if ENABLE(FEATURE_FOR_TESTING)
+    TestWithLegacyReceiver_ExperimentalOperation,
+#endif
+    TestWithLegacyReceiver_GetPlugins,
+#if PLATFORM(MAC)
+    TestWithLegacyReceiver_InterpretKeyEvent,
+#endif
+#if ENABLE(TOUCH_EVENTS)
+    TestWithLegacyReceiver_LoadSomething,
+    TestWithLegacyReceiver_LoadSomethingElse,
+#endif
+    TestWithLegacyReceiver_LoadURL,
+    TestWithLegacyReceiver_PreferencesDidChange,
+    TestWithLegacyReceiver_RunJavaScriptAlert,
+    TestWithLegacyReceiver_SendDoubleAndFloat,
+    TestWithLegacyReceiver_SendInts,
+    TestWithLegacyReceiver_SetVideoLayerID,
+    TestWithLegacyReceiver_TemplateTest,
+    TestWithLegacyReceiver_TestParameterAttributes,
+#if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
+    TestWithLegacyReceiver_TouchEvent,
+#endif
+    TestWithSemaphore_ReceiveSemaphore,
+    TestWithSemaphore_SendSemaphore,
+    TestWithStreamBatched_SendString,
+    TestWithStreamBuffer_SendStreamBuffer,
+#if PLATFORM(COCOA)
+    TestWithStream_SendMachSendRight,
+#endif
+    TestWithStream_SendString,
+    TestWithStream_SendStringAsync,
+    TestWithSuperclass_LoadURL,
+#if ENABLE(TEST_FEATURE)
+    TestWithSuperclass_TestAsyncMessage,
+    TestWithSuperclass_TestAsyncMessageWithConnection,
+    TestWithSuperclass_TestAsyncMessageWithMultipleArguments,
+    TestWithSuperclass_TestAsyncMessageWithNoArguments,
+#endif
+#if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
+    TestWithoutAttributes_AddEvent,
+#endif
+    TestWithoutAttributes_Close,
+    TestWithoutAttributes_CreatePlugin,
+#if ENABLE(DEPRECATED_FEATURE)
+    TestWithoutAttributes_DeprecatedOperation,
+#endif
+#if PLATFORM(MAC)
+    TestWithoutAttributes_DidCreateWebProcessConnection,
+#endif
+    TestWithoutAttributes_DidReceivePolicyDecision,
+#if ENABLE(FEATURE_FOR_TESTING)
+    TestWithoutAttributes_ExperimentalOperation,
+#endif
+    TestWithoutAttributes_GetPlugins,
+#if PLATFORM(MAC)
+    TestWithoutAttributes_InterpretKeyEvent,
+#endif
+#if ENABLE(TOUCH_EVENTS)
+    TestWithoutAttributes_LoadSomething,
+    TestWithoutAttributes_LoadSomethingElse,
+#endif
+    TestWithoutAttributes_LoadURL,
+    TestWithoutAttributes_PreferencesDidChange,
+    TestWithoutAttributes_RunJavaScriptAlert,
+    TestWithoutAttributes_SendDoubleAndFloat,
+    TestWithoutAttributes_SendInts,
+    TestWithoutAttributes_SetVideoLayerID,
+    TestWithoutAttributes_TemplateTest,
+    TestWithoutAttributes_TestParameterAttributes,
+#if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
+    TestWithoutAttributes_TouchEvent,
+#endif
+#if PLATFORM(COCOA)
+    InitializeConnection,
+#endif
+    LegacySessionState,
+    ProcessOutOfStreamMessage,
+    SetStreamDestinationID,
+    SyncMessageReply,
+    Terminate,
+#if USE(AVFOUNDATION)
+    TestWithCVPixelBuffer_ReceiveCVPixelBufferReply,
+#endif
+    TestWithImageData_ReceiveImageDataReply,
+    TestWithLegacyReceiver_CreatePluginReply,
+    TestWithLegacyReceiver_GetPluginsReply,
+#if PLATFORM(MAC)
+    TestWithLegacyReceiver_InterpretKeyEventReply,
+#endif
+    TestWithLegacyReceiver_RunJavaScriptAlertReply,
+    TestWithSemaphore_ReceiveSemaphoreReply,
+    TestWithStream_SendStringAsyncReply,
+#if ENABLE(TEST_FEATURE)
+    TestWithSuperclass_TestAsyncMessageReply,
+    TestWithSuperclass_TestAsyncMessageWithConnectionReply,
+    TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply,
+    TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply,
+#endif
+    TestWithoutAttributes_CreatePluginReply,
+    TestWithoutAttributes_GetPluginsReply,
+#if PLATFORM(MAC)
+    TestWithoutAttributes_InterpretKeyEventReply,
+#endif
+    TestWithoutAttributes_RunJavaScriptAlertReply,
+    FirstSynchronous,
+    LastAsynchronous = FirstSynchronous - 1,
+    TestWithLegacyReceiver_GetPluginProcessConnection,
+    TestWithLegacyReceiver_TestMultipleAttributes,
+#if PLATFORM(COCOA)
+    TestWithStream_ReceiveMachSendRight,
+    TestWithStream_SendAndReceiveMachSendRight,
+#endif
+    TestWithStream_SendStringSync,
+    TestWithSuperclass_TestSyncMessage,
+    TestWithSuperclass_TestSynchronousMessage,
+    TestWithoutAttributes_GetPluginProcessConnection,
+    TestWithoutAttributes_TestMultipleAttributes,
+    WrappedAsyncMessageForTesting,
+    Count,
+    Last = Count - 1
 };
 
-ReceiverName receiverName(MessageName);
-const char* description(MessageName);
-constexpr bool messageIsSync(MessageName name)
-{
-    return name >= MessageName::TestWithLegacyReceiver_GetPluginProcessConnection;
+namespace Detail {
+struct MessageDescription {
+    const char* const description;
+    ReceiverName receiverName;
+    bool messageAllowedWhenWaitingForSyncReply : 1;
+    bool messageAllowedWhenWaitingForUnboundedSyncReply : 1;
+};
+
+extern const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Count) + 1];
 }
 
-bool messageAllowedWhenWaitingForSyncReply(MessageName);
-bool messageAllowedWhenWaitingForUnboundedSyncReply(MessageName);
+inline ReceiverName receiverName(MessageName messageName)
+{
+    messageName = std::min(messageName, MessageName::Last);
+    return Detail::messageDescriptions[static_cast<size_t>(messageName)].receiverName;
+}
+
+inline const char* description(MessageName messageName)
+{
+    messageName = std::min(messageName, MessageName::Last);
+    return Detail::messageDescriptions[static_cast<size_t>(messageName)].description;
+}
+
+inline bool messageAllowedWhenWaitingForSyncReply(MessageName messageName)
+{
+    messageName = std::min(messageName, MessageName::Last);
+    return Detail::messageDescriptions[static_cast<size_t>(messageName)].messageAllowedWhenWaitingForSyncReply;
+}
+
+inline bool messageAllowedWhenWaitingForUnboundedSyncReply(MessageName messageName)
+{
+    messageName = std::min(messageName, MessageName::Last);
+    return Detail::messageDescriptions[static_cast<size_t>(messageName)].messageAllowedWhenWaitingForUnboundedSyncReply;
+}
+
+constexpr bool messageIsSync(MessageName name)
+{
+    return name >= MessageName::FirstSynchronous;
+}
+
 } // namespace IPC
 
 namespace WTF {
 
-template<> bool isValidEnum<IPC::MessageName, void>(std::underlying_type_t<IPC::MessageName>);
+template<> constexpr bool isValidEnum<IPC::MessageName, void>(std::underlying_type_t<IPC::MessageName> messageName)
+{
+    return messageName <= WTF::enumToUnderlyingType(IPC::MessageName::Last);
+}
 
 } // namespace WTF

--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
@@ -50,8 +50,6 @@ void TestWithCVPixelBuffer::didReceiveMessage(IPC::Connection& connection, IPC::
 #if USE(AVFOUNDATION)
     if (decoder.messageName() == Messages::TestWithCVPixelBuffer::SendCVPixelBuffer::name())
         return IPC::handleMessage<Messages::TestWithCVPixelBuffer::SendCVPixelBuffer>(connection, decoder, this, &TestWithCVPixelBuffer::sendCVPixelBuffer);
-#endif
-#if USE(AVFOUNDATION)
     if (decoder.messageName() == Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::name())
         return IPC::handleMessageAsync<Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer>(connection, decoder, this, &TestWithCVPixelBuffer::receiveCVPixelBuffer);
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
@@ -114,8 +114,6 @@ void TestWithLegacyReceiver::didReceiveTestWithLegacyReceiverMessage(IPC::Connec
 #if PLATFORM(MAC)
     if (decoder.messageName() == Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection::name())
         return IPC::handleMessage<Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection>(connection, decoder, this, &TestWithLegacyReceiver::didCreateWebProcessConnection);
-#endif
-#if PLATFORM(MAC)
     if (decoder.messageName() == Messages::TestWithLegacyReceiver::InterpretKeyEvent::name())
         return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::InterpretKeyEvent>(connection, decoder, this, &TestWithLegacyReceiver::interpretKeyEvent);
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
@@ -58,8 +58,6 @@ void TestWithStream::didReceiveStreamMessage(IPC::StreamServerConnection& connec
 #if PLATFORM(COCOA)
     if (decoder.messageName() == Messages::TestWithStream::ReceiveMachSendRight::name())
         return IPC::handleMessageSynchronous<Messages::TestWithStream::ReceiveMachSendRight>(connection, decoder, this, &TestWithStream::receiveMachSendRight);
-#endif
-#if PLATFORM(COCOA)
     if (decoder.messageName() == Messages::TestWithStream::SendAndReceiveMachSendRight::name())
         return IPC::handleMessageSynchronous<Messages::TestWithStream::SendAndReceiveMachSendRight>(connection, decoder, this, &TestWithStream::sendAndReceiveMachSendRight);
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
@@ -50,16 +50,10 @@ void TestWithSuperclass::didReceiveMessage(IPC::Connection& connection, IPC::Dec
 #if ENABLE(TEST_FEATURE)
     if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessage::name())
         return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessage>(connection, decoder, this, &TestWithSuperclass::testAsyncMessage);
-#endif
-#if ENABLE(TEST_FEATURE)
     if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::name())
         return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithNoArguments);
-#endif
-#if ENABLE(TEST_FEATURE)
     if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::name())
         return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithMultipleArguments);
-#endif
-#if ENABLE(TEST_FEATURE)
     if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithConnection::name())
         return IPC::handleMessageAsyncWantsConnection<Messages::TestWithSuperclass::TestAsyncMessageWithConnection>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithConnection);
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
@@ -114,8 +114,6 @@ void TestWithoutAttributes::didReceiveMessage(IPC::Connection& connection, IPC::
 #if PLATFORM(MAC)
     if (decoder.messageName() == Messages::TestWithoutAttributes::DidCreateWebProcessConnection::name())
         return IPC::handleMessage<Messages::TestWithoutAttributes::DidCreateWebProcessConnection>(connection, decoder, this, &TestWithoutAttributes::didCreateWebProcessConnection);
-#endif
-#if PLATFORM(MAC)
     if (decoder.messageName() == Messages::TestWithoutAttributes::InterpretKeyEvent::name())
         return IPC::handleMessageAsync<Messages::TestWithoutAttributes::InterpretKeyEvent>(connection, decoder, this, &TestWithoutAttributes::interpretKeyEvent);
 #endif


### PR DESCRIPTION
#### 03178c5e0622131ae0a2b19155e8c25b32e16447
<pre>
ifdef out IPC::MessageName values that aren&apos;t applicable
<a href="https://bugs.webkit.org/show_bug.cgi?id=239893">https://bugs.webkit.org/show_bug.cgi?id=239893</a>
rdar://problem/92511440

Reviewed by Chris Dumez.

Patch by Cameron McCormack &lt;heycam@apple.com&gt; and Kimmo Kinnunen &lt;kkinnunen@apple.com&gt;.

IPC MessageName validation is slow. The message name is validated on decoding,
and it is also validated on Debug builds when encoding.

Fix by making sure the ifdefs are part of the enum definition. The compiler
allocates consecutive enum values and as such the validation can be a comparison
instead of a large switch statement.

Improves webgl/2.0.y/conformance2/state/gl-object-get-calls.html Debug runtime
from 150s to 80s on M1 Max for WebGL GPUP.

* Source/WebKit/Scripts/webkit/messages.py:
(MessageEnumerator.condition):
(MessageEnumerator):
(MessageEnumerator.synchronous):
(MessageEnumerator.sort_key):
(async_message_statement):
(sync_message_statement):
(generate_message_handler.collect_message_statements):
(generate_message_handler):
(generate_message_names_header):
(generate_message_names_header.MessageName):
(generate_message_names_implementation):
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
(IPC::description): Deleted.
(IPC::receiverName): Deleted.
(IPC::messageAllowedWhenWaitingForSyncReply): Deleted.
(IPC::messageAllowedWhenWaitingForUnboundedSyncReply): Deleted.
(WTF::void&gt;): Deleted.
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
(IPC::receiverName):
(IPC::description):
(IPC::messageAllowedWhenWaitingForSyncReply):
(IPC::messageAllowedWhenWaitingForUnboundedSyncReply):
(IPC::messageIsSync):
(WTF::void&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp:
(WebKit::TestWithCVPixelBuffer::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp:
(WebKit::TestWithLegacyReceiver::didReceiveTestWithLegacyReceiverMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp:
(WebKit::TestWithStream::didReceiveStreamMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp:
(WebKit::TestWithSuperclass::didReceiveMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp:
(WebKit::TestWithoutAttributes::didReceiveMessage):

Canonical link: <a href="https://commits.webkit.org/258073@main">https://commits.webkit.org/258073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8ad4f499d290de794911528fd1afbfd12cadf59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109690 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/375 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92775 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107568 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34557 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/103889 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89832 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77514 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3276 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24082 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/374 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43572 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5538 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5085 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->