### PR TITLE
Support optional parameters in several GPURenderPassEncoder functions

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.cpp
@@ -48,26 +48,28 @@ void GPURenderBundleEncoder::setPipeline(const GPURenderPipeline& renderPipeline
     m_backing->setPipeline(renderPipeline.backing());
 }
 
-void GPURenderBundleEncoder::setIndexBuffer(const GPUBuffer& buffer, GPUIndexFormat indexFormat, GPUSize64 offset, std::optional<GPUSize64> size)
+void GPURenderBundleEncoder::setIndexBuffer(const GPUBuffer& buffer, GPUIndexFormat indexFormat, std::optional<GPUSize64> offset, std::optional<GPUSize64> size)
 {
     m_backing->setIndexBuffer(buffer.backing(), convertToBacking(indexFormat), offset, size);
 }
 
-void GPURenderBundleEncoder::setVertexBuffer(GPUIndex32 slot, const GPUBuffer& buffer, GPUSize64 offset, std::optional<GPUSize64> size)
+void GPURenderBundleEncoder::setVertexBuffer(GPUIndex32 slot, const GPUBuffer& buffer, std::optional<GPUSize64> offset, std::optional<GPUSize64> size)
 {
     m_backing->setVertexBuffer(slot, buffer.backing(), offset, size);
 }
 
-void GPURenderBundleEncoder::draw(GPUSize32 vertexCount, GPUSize32 instanceCount,
-    GPUSize32 firstVertex, GPUSize32 firstInstance)
+void GPURenderBundleEncoder::draw(GPUSize32 vertexCount,
+    std::optional<GPUSize32> instanceCount,
+    std::optional<GPUSize32> firstVertex, std::optional<GPUSize32> firstInstance)
 {
     m_backing->draw(vertexCount, instanceCount, firstVertex, firstInstance);
 }
 
-void GPURenderBundleEncoder::drawIndexed(GPUSize32 indexCount, GPUSize32 instanceCount,
-    GPUSize32 firstIndex,
-    GPUSignedOffset32 baseVertex,
-    GPUSize32 firstInstance)
+void GPURenderBundleEncoder::drawIndexed(GPUSize32 indexCount,
+    std::optional<GPUSize32> instanceCount,
+    std::optional<GPUSize32> firstIndex,
+    std::optional<GPUSignedOffset32> baseVertex,
+    std::optional<GPUSize32> firstInstance)
 {
     m_backing->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
 }

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.h
@@ -55,15 +55,15 @@ public:
 
     void setPipeline(const GPURenderPipeline&);
 
-    void setIndexBuffer(const GPUBuffer&, GPUIndexFormat, GPUSize64 offset, std::optional<GPUSize64>);
-    void setVertexBuffer(GPUIndex32 slot, const GPUBuffer&, GPUSize64 offset, std::optional<GPUSize64>);
+    void setIndexBuffer(const GPUBuffer&, GPUIndexFormat, std::optional<GPUSize64> offset, std::optional<GPUSize64>);
+    void setVertexBuffer(GPUIndex32 slot, const GPUBuffer&, std::optional<GPUSize64> offset, std::optional<GPUSize64>);
 
-    void draw(GPUSize32 vertexCount, GPUSize32 instanceCount,
-        GPUSize32 firstVertex, GPUSize32 firstInstance);
-    void drawIndexed(GPUSize32 indexCount, GPUSize32 instanceCount,
-        GPUSize32 firstIndex,
-        GPUSignedOffset32 baseVertex,
-        GPUSize32 firstInstance);
+    void draw(GPUSize32 vertexCount, std::optional<GPUSize32> instanceCount,
+        std::optional<GPUSize32> firstVertex, std::optional<GPUSize32> firstInstance);
+    void drawIndexed(GPUSize32 indexCount, std::optional<GPUSize32> instanceCount,
+        std::optional<GPUSize32> firstIndex,
+        std::optional<GPUSignedOffset32> baseVertex,
+        std::optional<GPUSize32> firstInstance);
 
     void drawIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset);
     void drawIndexedIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset);

--- a/Source/WebCore/Modules/WebGPU/GPURenderEncoderBase.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderEncoderBase.idl
@@ -35,15 +35,19 @@ typedef [EnforceRange] long GPUSignedOffset32;
 interface mixin GPURenderEncoderBase {
     undefined setPipeline(GPURenderPipeline pipeline);
 
-    undefined setIndexBuffer(GPUBuffer buffer, GPUIndexFormat indexFormat, optional GPUSize64 offset = 0, optional GPUSize64 size);
-    undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size);
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=240219, last two parameters should have default value of 0
+    undefined setIndexBuffer(GPUBuffer buffer, GPUIndexFormat indexFormat, optional GPUSize64 offset, optional GPUSize64 size);
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=240219, last two parameters should have default value of 0
+    undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset, optional GPUSize64 size);
 
-    undefined draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount = 1,
-        optional GPUSize32 firstVertex = 0, optional GPUSize32 firstInstance = 0);
-    undefined drawIndexed(GPUSize32 indexCount, optional GPUSize32 instanceCount = 1,
-        optional GPUSize32 firstIndex = 0,
-        optional GPUSignedOffset32 baseVertex = 0,
-        optional GPUSize32 firstInstance = 0);
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=240219, last two parameters should have default value of 0, first 1
+    undefined draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount,
+        optional GPUSize32 firstVertex, optional GPUSize32 firstInstance);
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=240219, last three parameters should have default value of 0, first 1
+    undefined drawIndexed(GPUSize32 indexCount, optional GPUSize32 instanceCount,
+        optional GPUSize32 firstIndex,
+        optional GPUSignedOffset32 baseVertex,
+        optional GPUSize32 firstInstance);
 
     undefined drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
     undefined drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
@@ -49,26 +49,26 @@ void GPURenderPassEncoder::setPipeline(const GPURenderPipeline& renderPipeline)
     m_backing->setPipeline(renderPipeline.backing());
 }
 
-void GPURenderPassEncoder::setIndexBuffer(const GPUBuffer& buffer, GPUIndexFormat indexFormat, GPUSize64 offset, std::optional<GPUSize64> size)
+void GPURenderPassEncoder::setIndexBuffer(const GPUBuffer& buffer, GPUIndexFormat indexFormat, std::optional<GPUSize64> offset, std::optional<GPUSize64> size)
 {
     m_backing->setIndexBuffer(buffer.backing(), convertToBacking(indexFormat), offset, size);
 }
 
-void GPURenderPassEncoder::setVertexBuffer(GPUIndex32 slot, const GPUBuffer& buffer, GPUSize64 offset, std::optional<GPUSize64> size)
+void GPURenderPassEncoder::setVertexBuffer(GPUIndex32 slot, const GPUBuffer& buffer, std::optional<GPUSize64> offset, std::optional<GPUSize64> size)
 {
     m_backing->setVertexBuffer(slot, buffer.backing(), offset, size);
 }
 
-void GPURenderPassEncoder::draw(GPUSize32 vertexCount, GPUSize32 instanceCount,
-    GPUSize32 firstVertex, GPUSize32 firstInstance)
+void GPURenderPassEncoder::draw(GPUSize32 vertexCount, std::optional<GPUSize32> instanceCount,
+    std::optional<GPUSize32> firstVertex, std::optional<GPUSize32> firstInstance)
 {
     m_backing->draw(vertexCount, instanceCount, firstVertex, firstInstance);
 }
 
-void GPURenderPassEncoder::drawIndexed(GPUSize32 indexCount, GPUSize32 instanceCount,
-    GPUSize32 firstIndex,
-    GPUSignedOffset32 baseVertex,
-    GPUSize32 firstInstance)
+void GPURenderPassEncoder::drawIndexed(GPUSize32 indexCount, std::optional<GPUSize32> instanceCount,
+    std::optional<GPUSize32> firstIndex,
+    std::optional<GPUSignedOffset32> baseVertex,
+    std::optional<GPUSize32> firstInstance)
 {
     m_backing->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
 }

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h
@@ -57,15 +57,15 @@ public:
 
     void setPipeline(const GPURenderPipeline&);
 
-    void setIndexBuffer(const GPUBuffer&, GPUIndexFormat, GPUSize64 offset, std::optional<GPUSize64>);
-    void setVertexBuffer(GPUIndex32 slot, const GPUBuffer&, GPUSize64 offset, std::optional<GPUSize64>);
+    void setIndexBuffer(const GPUBuffer&, GPUIndexFormat, std::optional<GPUSize64> offset, std::optional<GPUSize64>);
+    void setVertexBuffer(GPUIndex32 slot, const GPUBuffer&, std::optional<GPUSize64> offset, std::optional<GPUSize64>);
 
-    void draw(GPUSize32 vertexCount, GPUSize32 instanceCount,
-        GPUSize32 firstVertex, GPUSize32 firstInstance);
-    void drawIndexed(GPUSize32 indexCount, GPUSize32 instanceCount,
-        GPUSize32 firstIndex,
-        GPUSignedOffset32 baseVertex,
-        GPUSize32 firstInstance);
+    void draw(GPUSize32 vertexCount, std::optional<GPUSize32> instanceCount,
+        std::optional<GPUSize32> firstVertex, std::optional<GPUSize32> firstInstance);
+    void drawIndexed(GPUSize32 indexCount, std::optional<GPUSize32> instanceCount,
+        std::optional<GPUSize32> firstIndex,
+        std::optional<GPUSignedOffset32> baseVertex,
+        std::optional<GPUSize32> firstInstance);
 
     void drawIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset);
     void drawIndexedIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset);

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderBundleEncoderImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderBundleEncoderImpl.cpp
@@ -53,28 +53,28 @@ void RenderBundleEncoderImpl::setPipeline(const RenderPipeline& renderPipeline)
     wgpuRenderBundleEncoderSetPipeline(m_backing, m_convertToBackingContext->convertToBacking(renderPipeline));
 }
 
-void RenderBundleEncoderImpl::setIndexBuffer(const Buffer& buffer, IndexFormat indexFormat, Size64 offset, std::optional<Size64> size)
+void RenderBundleEncoderImpl::setIndexBuffer(const Buffer& buffer, IndexFormat indexFormat, std::optional<Size64> offset, std::optional<Size64> size)
 {
-    wgpuRenderBundleEncoderSetIndexBuffer(m_backing, m_convertToBackingContext->convertToBacking(buffer), m_convertToBackingContext->convertToBacking(indexFormat), offset, size.value_or(WGPU_WHOLE_SIZE));
+    wgpuRenderBundleEncoderSetIndexBuffer(m_backing, m_convertToBackingContext->convertToBacking(buffer), m_convertToBackingContext->convertToBacking(indexFormat), offset.value_or(0), size.value_or(WGPU_WHOLE_SIZE));
 }
 
-void RenderBundleEncoderImpl::setVertexBuffer(Index32 slot, const Buffer& buffer, Size64 offset, std::optional<Size64> size)
+void RenderBundleEncoderImpl::setVertexBuffer(Index32 slot, const Buffer& buffer, std::optional<Size64> offset, std::optional<Size64> size)
 {
-    wgpuRenderBundleEncoderSetVertexBuffer(m_backing, slot, m_convertToBackingContext->convertToBacking(buffer), offset, size.value_or(WGPU_WHOLE_SIZE));
+    wgpuRenderBundleEncoderSetVertexBuffer(m_backing, slot, m_convertToBackingContext->convertToBacking(buffer), offset.value_or(0), size.value_or(WGPU_WHOLE_SIZE));
 }
 
-void RenderBundleEncoderImpl::draw(Size32 vertexCount, Size32 instanceCount,
-    Size32 firstVertex, Size32 firstInstance)
+void RenderBundleEncoderImpl::draw(Size32 vertexCount, std::optional<Size32> instanceCount,
+    std::optional<Size32> firstVertex, std::optional<Size32> firstInstance)
 {
-    wgpuRenderBundleEncoderDraw(m_backing, vertexCount, instanceCount, firstVertex, firstInstance);
+    wgpuRenderBundleEncoderDraw(m_backing, vertexCount, instanceCount.value_or(1), firstVertex.value_or(0), firstInstance.value_or(0));
 }
 
-void RenderBundleEncoderImpl::drawIndexed(Size32 indexCount, Size32 instanceCount,
-    Size32 firstIndex,
-    SignedOffset32 baseVertex,
-    Size32 firstInstance)
+void RenderBundleEncoderImpl::drawIndexed(Size32 indexCount, std::optional<Size32> instanceCount,
+    std::optional<Size32> firstIndex,
+    std::optional<SignedOffset32> baseVertex,
+    std::optional<Size32> firstInstance)
 {
-    wgpuRenderBundleEncoderDrawIndexed(m_backing, indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
+    wgpuRenderBundleEncoderDrawIndexed(m_backing, indexCount, instanceCount.value_or(1), firstIndex.value_or(0), baseVertex.value_or(0), firstInstance.value_or(0));
 }
 
 void RenderBundleEncoderImpl::drawIndirect(const Buffer& indirectBuffer, Size64 indirectOffset)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderBundleEncoderImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderBundleEncoderImpl.h
@@ -58,15 +58,15 @@ private:
 
     void setPipeline(const RenderPipeline&) final;
 
-    void setIndexBuffer(const Buffer&, IndexFormat, Size64 offset, std::optional<Size64>) final;
-    void setVertexBuffer(Index32 slot, const Buffer&, Size64 offset, std::optional<Size64>) final;
+    void setIndexBuffer(const Buffer&, IndexFormat, std::optional<Size64> offset, std::optional<Size64>) final;
+    void setVertexBuffer(Index32 slot, const Buffer&, std::optional<Size64> offset, std::optional<Size64>) final;
 
-    void draw(Size32 vertexCount, Size32 instanceCount,
-        Size32 firstVertex, Size32 firstInstance) final;
-    void drawIndexed(Size32 indexCount, Size32 instanceCount,
-        Size32 firstIndex,
-        SignedOffset32 baseVertex,
-        Size32 firstInstance) final;
+    void draw(Size32 vertexCount, std::optional<Size32> instanceCount,
+        std::optional<Size32> firstVertex, std::optional<Size32> firstInstance) final;
+    void drawIndexed(Size32 indexCount, std::optional<Size32> instanceCount,
+        std::optional<Size32> firstIndex,
+        std::optional<SignedOffset32> baseVertex,
+        std::optional<Size32> firstInstance) final;
 
     void drawIndirect(const Buffer& indirectBuffer, Size64 indirectOffset) final;
     void drawIndexedIndirect(const Buffer& indirectBuffer, Size64 indirectOffset) final;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPassEncoderImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPassEncoderImpl.cpp
@@ -54,28 +54,28 @@ void RenderPassEncoderImpl::setPipeline(const RenderPipeline& renderPipeline)
     wgpuRenderPassEncoderSetPipeline(m_backing, m_convertToBackingContext->convertToBacking(renderPipeline));
 }
 
-void RenderPassEncoderImpl::setIndexBuffer(const Buffer& buffer, IndexFormat indexFormat, Size64 offset, std::optional<Size64> size)
+void RenderPassEncoderImpl::setIndexBuffer(const Buffer& buffer, IndexFormat indexFormat, std::optional<Size64> offset, std::optional<Size64> size)
 {
-    wgpuRenderPassEncoderSetIndexBuffer(m_backing, m_convertToBackingContext->convertToBacking(buffer), m_convertToBackingContext->convertToBacking(indexFormat), offset, size.value_or(WGPU_WHOLE_SIZE));
+    wgpuRenderPassEncoderSetIndexBuffer(m_backing, m_convertToBackingContext->convertToBacking(buffer), m_convertToBackingContext->convertToBacking(indexFormat), offset.value_or(0), size.value_or(WGPU_WHOLE_SIZE));
 }
 
-void RenderPassEncoderImpl::setVertexBuffer(Index32 slot, const Buffer& buffer, Size64 offset, std::optional<Size64> size)
+void RenderPassEncoderImpl::setVertexBuffer(Index32 slot, const Buffer& buffer, std::optional<Size64> offset, std::optional<Size64> size)
 {
-    wgpuRenderPassEncoderSetVertexBuffer(m_backing, slot, m_convertToBackingContext->convertToBacking(buffer), offset, size.value_or(WGPU_WHOLE_SIZE));
+    wgpuRenderPassEncoderSetVertexBuffer(m_backing, slot, m_convertToBackingContext->convertToBacking(buffer), offset.value_or(0), size.value_or(WGPU_WHOLE_SIZE));
 }
 
-void RenderPassEncoderImpl::draw(Size32 vertexCount, Size32 instanceCount,
-    Size32 firstVertex, Size32 firstInstance)
+void RenderPassEncoderImpl::draw(Size32 vertexCount, std::optional<Size32> instanceCount,
+    std::optional<Size32> firstVertex, std::optional<Size32> firstInstance)
 {
-    wgpuRenderPassEncoderDraw(m_backing, vertexCount, instanceCount, firstVertex, firstInstance);
+    wgpuRenderPassEncoderDraw(m_backing, vertexCount, instanceCount.value_or(1), firstVertex.value_or(0), firstInstance.value_or(0));
 }
 
-void RenderPassEncoderImpl::drawIndexed(Size32 indexCount, Size32 instanceCount,
-    Size32 firstIndex,
-    SignedOffset32 baseVertex,
-    Size32 firstInstance)
+void RenderPassEncoderImpl::drawIndexed(Size32 indexCount, std::optional<Size32> instanceCount,
+    std::optional<Size32> firstIndex,
+    std::optional<SignedOffset32> baseVertex,
+    std::optional<Size32> firstInstance)
 {
-    wgpuRenderPassEncoderDrawIndexed(m_backing, indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
+    wgpuRenderPassEncoderDrawIndexed(m_backing, indexCount, instanceCount.value_or(1), firstIndex.value_or(0), baseVertex.value_or(0), firstInstance.value_or(0));
 }
 
 void RenderPassEncoderImpl::drawIndirect(const Buffer& indirectBuffer, Size64 indirectOffset)

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPassEncoderImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPassEncoderImpl.h
@@ -58,15 +58,15 @@ private:
 
     void setPipeline(const RenderPipeline&) final;
 
-    void setIndexBuffer(const Buffer&, IndexFormat, Size64 offset, std::optional<Size64>) final;
-    void setVertexBuffer(Index32 slot, const Buffer&, Size64 offset, std::optional<Size64>) final;
+    void setIndexBuffer(const Buffer&, IndexFormat, std::optional<Size64> offset, std::optional<Size64>) final;
+    void setVertexBuffer(Index32 slot, const Buffer&, std::optional<Size64> offset, std::optional<Size64>) final;
 
-    void draw(Size32 vertexCount, Size32 instanceCount,
-        Size32 firstVertex, Size32 firstInstance) final;
-    void drawIndexed(Size32 indexCount, Size32 instanceCount,
-        Size32 firstIndex,
-        SignedOffset32 baseVertex,
-        Size32 firstInstance) final;
+    void draw(Size32 vertexCount, std::optional<Size32> instanceCount,
+        std::optional<Size32> firstVertex, std::optional<Size32> firstInstance) final;
+    void drawIndexed(Size32 indexCount, std::optional<Size32> instanceCount,
+        std::optional<Size32> firstIndex,
+        std::optional<SignedOffset32> baseVertex,
+        std::optional<Size32> firstInstance) final;
 
     void drawIndirect(const Buffer& indirectBuffer, Size64 indirectOffset) final;
     void drawIndexedIndirect(const Buffer& indirectBuffer, Size64 indirectOffset) final;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPURenderBundleEncoder.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPURenderBundleEncoder.h
@@ -56,15 +56,15 @@ public:
 
     virtual void setPipeline(const RenderPipeline&) = 0;
 
-    virtual void setIndexBuffer(const Buffer&, IndexFormat, Size64 offset, std::optional<Size64>) = 0;
-    virtual void setVertexBuffer(Index32 slot, const Buffer&, Size64 offset, std::optional<Size64>) = 0;
+    virtual void setIndexBuffer(const Buffer&, IndexFormat, std::optional<Size64> offset, std::optional<Size64>) = 0;
+    virtual void setVertexBuffer(Index32 slot, const Buffer&, std::optional<Size64> offset, std::optional<Size64>) = 0;
 
-    virtual void draw(Size32 vertexCount, Size32 instanceCount,
-        Size32 firstVertex, Size32 firstInstance) = 0;
-    virtual void drawIndexed(Size32 indexCount, Size32 instanceCount,
-        Size32 firstIndex,
-        SignedOffset32 baseVertex,
-        Size32 firstInstance) = 0;
+    virtual void draw(Size32 vertexCount, std::optional<Size32> instanceCount,
+        std::optional<Size32> firstVertex, std::optional<Size32> firstInstance) = 0;
+    virtual void drawIndexed(Size32 indexCount, std::optional<Size32> instanceCount,
+        std::optional<Size32> firstIndex,
+        std::optional<SignedOffset32> baseVertex,
+        std::optional<Size32> firstInstance) = 0;
 
     virtual void drawIndirect(const Buffer& indirectBuffer, Size64 indirectOffset) = 0;
     virtual void drawIndexedIndirect(const Buffer& indirectBuffer, Size64 indirectOffset) = 0;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPURenderPassEncoder.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPURenderPassEncoder.h
@@ -58,15 +58,15 @@ public:
 
     virtual void setPipeline(const RenderPipeline&) = 0;
 
-    virtual void setIndexBuffer(const Buffer&, IndexFormat, Size64 offset, std::optional<Size64>) = 0;
-    virtual void setVertexBuffer(Index32 slot, const Buffer&, Size64 offset, std::optional<Size64>) = 0;
+    virtual void setIndexBuffer(const Buffer&, IndexFormat, std::optional<Size64> offset, std::optional<Size64>) = 0;
+    virtual void setVertexBuffer(Index32 slot, const Buffer&, std::optional<Size64> offset, std::optional<Size64>) = 0;
 
-    virtual void draw(Size32 vertexCount, Size32 instanceCount,
-        Size32 firstVertex, Size32 firstInstance) = 0;
-    virtual void drawIndexed(Size32 indexCount, Size32 instanceCount,
-        Size32 firstIndex,
-        SignedOffset32 baseVertex,
-        Size32 firstInstance) = 0;
+    virtual void draw(Size32 vertexCount, std::optional<Size32> instanceCount,
+        std::optional<Size32> firstVertex, std::optional<Size32> firstInstance) = 0;
+    virtual void drawIndexed(Size32 indexCount, std::optional<Size32> instanceCount,
+        std::optional<Size32> firstIndex,
+        std::optional<SignedOffset32> baseVertex,
+        std::optional<Size32> firstInstance) = 0;
 
     virtual void drawIndirect(const Buffer& indirectBuffer, Size64 indirectOffset) = 0;
     virtual void drawIndexedIndirect(const Buffer& indirectBuffer, Size64 indirectOffset) = 0;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
@@ -63,7 +63,7 @@ void RemoteRenderBundleEncoder::setPipeline(WebGPUIdentifier renderPipeline)
     m_backing->setPipeline(*convertedRenderPipeline);
 }
 
-void RemoteRenderBundleEncoder::setIndexBuffer(WebGPUIdentifier buffer, PAL::WebGPU::IndexFormat indexFormat, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size)
+void RemoteRenderBundleEncoder::setIndexBuffer(WebGPUIdentifier buffer, PAL::WebGPU::IndexFormat indexFormat, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
 {
     auto convertedBuffer = m_objectHeap.convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
@@ -73,7 +73,7 @@ void RemoteRenderBundleEncoder::setIndexBuffer(WebGPUIdentifier buffer, PAL::Web
     m_backing->setIndexBuffer(*convertedBuffer, indexFormat, offset, size);
 }
 
-void RemoteRenderBundleEncoder::setVertexBuffer(PAL::WebGPU::Index32 slot, WebGPUIdentifier buffer, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size)
+void RemoteRenderBundleEncoder::setVertexBuffer(PAL::WebGPU::Index32 slot, WebGPUIdentifier buffer, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
 {
     auto convertedBuffer = m_objectHeap.convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
@@ -83,16 +83,16 @@ void RemoteRenderBundleEncoder::setVertexBuffer(PAL::WebGPU::Index32 slot, WebGP
     m_backing->setVertexBuffer(slot, *convertedBuffer, offset, size);
 }
 
-void RemoteRenderBundleEncoder::draw(PAL::WebGPU::Size32 vertexCount, PAL::WebGPU::Size32 instanceCount,
-    PAL::WebGPU::Size32 firstVertex, PAL::WebGPU::Size32 firstInstance)
+void RemoteRenderBundleEncoder::draw(PAL::WebGPU::Size32 vertexCount, std::optional<PAL::WebGPU::Size32> instanceCount,
+    std::optional<PAL::WebGPU::Size32> firstVertex, std::optional<PAL::WebGPU::Size32> firstInstance)
 {
     m_backing->draw(vertexCount, instanceCount, firstVertex, firstInstance);
 }
 
-void RemoteRenderBundleEncoder::drawIndexed(PAL::WebGPU::Size32 indexCount, PAL::WebGPU::Size32 instanceCount,
-    PAL::WebGPU::Size32 firstIndex,
-    PAL::WebGPU::SignedOffset32 baseVertex,
-    PAL::WebGPU::Size32 firstInstance)
+void RemoteRenderBundleEncoder::drawIndexed(PAL::WebGPU::Size32 indexCount, std::optional<PAL::WebGPU::Size32> instanceCount,
+    std::optional<PAL::WebGPU::Size32> firstIndex,
+    std::optional<PAL::WebGPU::SignedOffset32> baseVertex,
+    std::optional<PAL::WebGPU::Size32> firstInstance)
 {
     m_backing->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
@@ -77,15 +77,15 @@ private:
 
     void setPipeline(WebGPUIdentifier);
 
-    void setIndexBuffer(WebGPUIdentifier, PAL::WebGPU::IndexFormat, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64>);
-    void setVertexBuffer(PAL::WebGPU::Index32 slot, WebGPUIdentifier, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64>);
+    void setIndexBuffer(WebGPUIdentifier, PAL::WebGPU::IndexFormat, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64>);
+    void setVertexBuffer(PAL::WebGPU::Index32 slot, WebGPUIdentifier, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64>);
 
-    void draw(PAL::WebGPU::Size32 vertexCount, PAL::WebGPU::Size32 instanceCount,
-        PAL::WebGPU::Size32 firstVertex, PAL::WebGPU::Size32 firstInstance);
-    void drawIndexed(PAL::WebGPU::Size32 indexCount, PAL::WebGPU::Size32 instanceCount,
-        PAL::WebGPU::Size32 firstIndex,
-        PAL::WebGPU::SignedOffset32 baseVertex,
-        PAL::WebGPU::Size32 firstInstance);
+    void draw(PAL::WebGPU::Size32 vertexCount, std::optional<PAL::WebGPU::Size32> instanceCount,
+        std::optional<PAL::WebGPU::Size32> firstVertex, std::optional<PAL::WebGPU::Size32> firstInstance);
+    void drawIndexed(PAL::WebGPU::Size32 indexCount, std::optional<PAL::WebGPU::Size32> instanceCount,
+        std::optional<PAL::WebGPU::Size32> firstIndex,
+        std::optional<PAL::WebGPU::SignedOffset32> baseVertex,
+        std::optional<PAL::WebGPU::Size32> firstInstance);
 
     void drawIndirect(WebGPUIdentifier indirectBuffer, PAL::WebGPU::Size64 indirectOffset);
     void drawIndexedIndirect(WebGPUIdentifier indirectBuffer, PAL::WebGPU::Size64 indirectOffset);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.messages.in
@@ -25,10 +25,10 @@
 
 messages -> RemoteRenderBundleEncoder NotRefCounted Stream {
     void SetPipeline(WebKit::WebGPUIdentifier identifier)
-    void SetIndexBuffer(WebKit::WebGPUIdentifier identifier, PAL::WebGPU::IndexFormat indexFormat, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size)
-    void SetVertexBuffer(PAL::WebGPU::Index32 slot, WebKit::WebGPUIdentifier identifier, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size)
-    void Draw(PAL::WebGPU::Size32 vertexCount, PAL::WebGPU::Size32 instanceCount, PAL::WebGPU::Size32 firstVertex, PAL::WebGPU::Size32 firstInstance)
-    void DrawIndexed(PAL::WebGPU::Size32 indexCount, PAL::WebGPU::Size32 instanceCount, PAL::WebGPU::Size32 firstIndex, PAL::WebGPU::SignedOffset32 baseVertex, PAL::WebGPU::Size32 firstInstance)
+    void SetIndexBuffer(WebKit::WebGPUIdentifier identifier, PAL::WebGPU::IndexFormat indexFormat, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
+    void SetVertexBuffer(PAL::WebGPU::Index32 slot, WebKit::WebGPUIdentifier identifier, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
+    void Draw(PAL::WebGPU::Size32 vertexCount, std::optional<PAL::WebGPU::Size32> instanceCount, std::optional<PAL::WebGPU::Size32> firstVertex, std::optional<PAL::WebGPU::Size32> firstInstance)
+    void DrawIndexed(PAL::WebGPU::Size32 indexCount, std::optional<PAL::WebGPU::Size32> instanceCount, std::optional<PAL::WebGPU::Size32> firstIndex, std::optional<PAL::WebGPU::SignedOffset32> baseVertex, std::optional<PAL::WebGPU::Size32> firstInstance)
     void DrawIndirect(WebKit::WebGPUIdentifier indirectBuffer, PAL::WebGPU::Size64 indirectOffset)
     void DrawIndexedIndirect(WebKit::WebGPUIdentifier indirectBuffer, PAL::WebGPU::Size64 indirectOffset)
     void SetBindGroup(PAL::WebGPU::Index32 index, WebKit::WebGPUIdentifier identifier, std::optional<Vector<PAL::WebGPU::BufferDynamicOffset>> dynamicOffsets)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
@@ -61,7 +61,7 @@ void RemoteRenderPassEncoder::setPipeline(WebGPUIdentifier renderPipeline)
     m_backing->setPipeline(*convertedRenderPipeline);
 }
 
-void RemoteRenderPassEncoder::setIndexBuffer(WebGPUIdentifier buffer, PAL::WebGPU::IndexFormat indexFormat, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size)
+void RemoteRenderPassEncoder::setIndexBuffer(WebGPUIdentifier buffer, PAL::WebGPU::IndexFormat indexFormat, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
 {
     auto convertedBuffer = m_objectHeap.convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
@@ -71,7 +71,7 @@ void RemoteRenderPassEncoder::setIndexBuffer(WebGPUIdentifier buffer, PAL::WebGP
     m_backing->setIndexBuffer(*convertedBuffer, indexFormat, offset, size);
 }
 
-void RemoteRenderPassEncoder::setVertexBuffer(PAL::WebGPU::Index32 slot, WebGPUIdentifier buffer, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size)
+void RemoteRenderPassEncoder::setVertexBuffer(PAL::WebGPU::Index32 slot, WebGPUIdentifier buffer, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
 {
     auto convertedBuffer = m_objectHeap.convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
@@ -81,16 +81,17 @@ void RemoteRenderPassEncoder::setVertexBuffer(PAL::WebGPU::Index32 slot, WebGPUI
     m_backing->setVertexBuffer(slot, *convertedBuffer, offset, size);
 }
 
-void RemoteRenderPassEncoder::draw(PAL::WebGPU::Size32 vertexCount, PAL::WebGPU::Size32 instanceCount,
-    PAL::WebGPU::Size32 firstVertex, PAL::WebGPU::Size32 firstInstance)
+void RemoteRenderPassEncoder::draw(PAL::WebGPU::Size32 vertexCount, std::optional<PAL::WebGPU::Size32> instanceCount,
+    std::optional<PAL::WebGPU::Size32> firstVertex, std::optional<PAL::WebGPU::Size32> firstInstance)
 {
     m_backing->draw(vertexCount, instanceCount, firstVertex, firstInstance);
 }
 
-void RemoteRenderPassEncoder::drawIndexed(PAL::WebGPU::Size32 indexCount, PAL::WebGPU::Size32 instanceCount,
-    PAL::WebGPU::Size32 firstIndex,
-    PAL::WebGPU::SignedOffset32 baseVertex,
-    PAL::WebGPU::Size32 firstInstance)
+void RemoteRenderPassEncoder::drawIndexed(PAL::WebGPU::Size32 indexCount,
+    std::optional<PAL::WebGPU::Size32> instanceCount,
+    std::optional<PAL::WebGPU::Size32> firstIndex,
+    std::optional<PAL::WebGPU::SignedOffset32> baseVertex,
+    std::optional<PAL::WebGPU::Size32> firstInstance)
 {
     m_backing->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
@@ -77,15 +77,15 @@ private:
 
     void setPipeline(WebGPUIdentifier);
 
-    void setIndexBuffer(WebGPUIdentifier, PAL::WebGPU::IndexFormat, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64>);
-    void setVertexBuffer(PAL::WebGPU::Index32 slot, WebGPUIdentifier, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64>);
+    void setIndexBuffer(WebGPUIdentifier, PAL::WebGPU::IndexFormat, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64>);
+    void setVertexBuffer(PAL::WebGPU::Index32 slot, WebGPUIdentifier, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64>);
 
-    void draw(PAL::WebGPU::Size32 vertexCount, PAL::WebGPU::Size32 instanceCount,
-        PAL::WebGPU::Size32 firstVertex, PAL::WebGPU::Size32 firstInstance);
-    void drawIndexed(PAL::WebGPU::Size32 indexCount, PAL::WebGPU::Size32 instanceCount,
-        PAL::WebGPU::Size32 firstIndex,
-        PAL::WebGPU::SignedOffset32 baseVertex,
-        PAL::WebGPU::Size32 firstInstance);
+    void draw(PAL::WebGPU::Size32 vertexCount, std::optional<PAL::WebGPU::Size32> instanceCount,
+        std::optional<PAL::WebGPU::Size32> firstVertex, std::optional<PAL::WebGPU::Size32> firstInstance);
+    void drawIndexed(PAL::WebGPU::Size32 indexCount, std::optional<PAL::WebGPU::Size32> instanceCount,
+        std::optional<PAL::WebGPU::Size32> firstIndex,
+        std::optional<PAL::WebGPU::SignedOffset32> baseVertex,
+        std::optional<PAL::WebGPU::Size32> firstInstance);
 
     void drawIndirect(WebGPUIdentifier indirectBuffer, PAL::WebGPU::Size64 indirectOffset);
     void drawIndexedIndirect(WebGPUIdentifier indirectBuffer, PAL::WebGPU::Size64 indirectOffset);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.messages.in
@@ -25,10 +25,10 @@
 
 messages -> RemoteRenderPassEncoder NotRefCounted Stream {
     void SetPipeline(WebKit::WebGPUIdentifier identifier)
-    void SetIndexBuffer(WebKit::WebGPUIdentifier identifier, PAL::WebGPU::IndexFormat indexFormat, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size)
-    void SetVertexBuffer(PAL::WebGPU::Index32 slot, WebKit::WebGPUIdentifier identifier, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size)
-    void Draw(PAL::WebGPU::Size32 vertexCount, PAL::WebGPU::Size32 instanceCount, PAL::WebGPU::Size32 firstVertex, PAL::WebGPU::Size32 firstInstance)
-    void DrawIndexed(PAL::WebGPU::Size32 indexCount, PAL::WebGPU::Size32 instanceCount, PAL::WebGPU::Size32 firstIndex, PAL::WebGPU::SignedOffset32 baseVertex, PAL::WebGPU::Size32 firstInstance)
+    void SetIndexBuffer(WebKit::WebGPUIdentifier identifier, PAL::WebGPU::IndexFormat indexFormat, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
+    void SetVertexBuffer(PAL::WebGPU::Index32 slot, WebKit::WebGPUIdentifier identifier, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
+    void Draw(PAL::WebGPU::Size32 vertexCount, std::optional<PAL::WebGPU::Size32> instanceCount, std::optional<PAL::WebGPU::Size32> firstVertex, std::optional<PAL::WebGPU::Size32> firstInstance)
+    void DrawIndexed(PAL::WebGPU::Size32 indexCount, std::optional<PAL::WebGPU::Size32> instanceCount, std::optional<PAL::WebGPU::Size32> firstIndex, std::optional<PAL::WebGPU::SignedOffset32> baseVertex, std::optional<PAL::WebGPU::Size32> firstInstance)
     void DrawIndirect(WebKit::WebGPUIdentifier indirectBuffer, PAL::WebGPU::Size64 indirectOffset)
     void DrawIndexedIndirect(WebKit::WebGPUIdentifier indirectBuffer, PAL::WebGPU::Size64 indirectOffset)
     void SetBindGroup(PAL::WebGPU::Index32 index, WebKit::WebGPUIdentifier identifier, std::optional<Vector<PAL::WebGPU::BufferDynamicOffset>> dynamicOffsets)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
@@ -56,7 +56,7 @@ void RemoteRenderBundleEncoderProxy::setPipeline(const PAL::WebGPU::RenderPipeli
     UNUSED_VARIABLE(sendResult);
 }
 
-void RemoteRenderBundleEncoderProxy::setIndexBuffer(const PAL::WebGPU::Buffer& buffer, PAL::WebGPU::IndexFormat indexFormat, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size)
+void RemoteRenderBundleEncoderProxy::setIndexBuffer(const PAL::WebGPU::Buffer& buffer, PAL::WebGPU::IndexFormat indexFormat, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
 {
     auto convertedBuffer = m_convertToBackingContext->convertToBacking(buffer);
     ASSERT(convertedBuffer);
@@ -67,7 +67,7 @@ void RemoteRenderBundleEncoderProxy::setIndexBuffer(const PAL::WebGPU::Buffer& b
     UNUSED_VARIABLE(sendResult);
 }
 
-void RemoteRenderBundleEncoderProxy::setVertexBuffer(PAL::WebGPU::Index32 slot, const PAL::WebGPU::Buffer& buffer, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size)
+void RemoteRenderBundleEncoderProxy::setVertexBuffer(PAL::WebGPU::Index32 slot, const PAL::WebGPU::Buffer& buffer, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
 {
     auto convertedBuffer = m_convertToBackingContext->convertToBacking(buffer);
     ASSERT(convertedBuffer);
@@ -78,17 +78,18 @@ void RemoteRenderBundleEncoderProxy::setVertexBuffer(PAL::WebGPU::Index32 slot, 
     UNUSED_VARIABLE(sendResult);
 }
 
-void RemoteRenderBundleEncoderProxy::draw(PAL::WebGPU::Size32 vertexCount, PAL::WebGPU::Size32 instanceCount,
-    PAL::WebGPU::Size32 firstVertex, PAL::WebGPU::Size32 firstInstance)
+void RemoteRenderBundleEncoderProxy::draw(PAL::WebGPU::Size32 vertexCount, std::optional<PAL::WebGPU::Size32> instanceCount,
+    std::optional<PAL::WebGPU::Size32> firstVertex, std::optional<PAL::WebGPU::Size32> firstInstance)
 {
     auto sendResult = send(Messages::RemoteRenderBundleEncoder::Draw(vertexCount, instanceCount, firstVertex, firstInstance));
     UNUSED_VARIABLE(sendResult);
 }
 
-void RemoteRenderBundleEncoderProxy::drawIndexed(PAL::WebGPU::Size32 indexCount, PAL::WebGPU::Size32 instanceCount,
-    PAL::WebGPU::Size32 firstIndex,
-    PAL::WebGPU::SignedOffset32 baseVertex,
-    PAL::WebGPU::Size32 firstInstance)
+void RemoteRenderBundleEncoderProxy::drawIndexed(PAL::WebGPU::Size32 indexCount,
+    std::optional<PAL::WebGPU::Size32> instanceCount,
+    std::optional<PAL::WebGPU::Size32> firstIndex,
+    std::optional<PAL::WebGPU::SignedOffset32> baseVertex,
+    std::optional<PAL::WebGPU::Size32> firstInstance)
 {
     auto sendResult = send(Messages::RemoteRenderBundleEncoder::DrawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance));
     UNUSED_VARIABLE(sendResult);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
@@ -74,15 +74,15 @@ private:
 
     void setPipeline(const PAL::WebGPU::RenderPipeline&) final;
 
-    void setIndexBuffer(const PAL::WebGPU::Buffer&, PAL::WebGPU::IndexFormat, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64>) final;
-    void setVertexBuffer(PAL::WebGPU::Index32 slot, const PAL::WebGPU::Buffer&, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64>) final;
+    void setIndexBuffer(const PAL::WebGPU::Buffer&, PAL::WebGPU::IndexFormat, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64>) final;
+    void setVertexBuffer(PAL::WebGPU::Index32 slot, const PAL::WebGPU::Buffer&, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64>) final;
 
-    void draw(PAL::WebGPU::Size32 vertexCount, PAL::WebGPU::Size32 instanceCount,
-        PAL::WebGPU::Size32 firstVertex, PAL::WebGPU::Size32 firstInstance) final;
-    void drawIndexed(PAL::WebGPU::Size32 indexCount, PAL::WebGPU::Size32 instanceCount,
-        PAL::WebGPU::Size32 firstIndex,
-        PAL::WebGPU::SignedOffset32 baseVertex,
-        PAL::WebGPU::Size32 firstInstance) final;
+    void draw(PAL::WebGPU::Size32 vertexCount, std::optional<PAL::WebGPU::Size32> instanceCount,
+        std::optional<PAL::WebGPU::Size32> firstVertex, std::optional<PAL::WebGPU::Size32> firstInstance) final;
+    void drawIndexed(PAL::WebGPU::Size32 indexCount, std::optional<PAL::WebGPU::Size32> instanceCount,
+        std::optional<PAL::WebGPU::Size32> firstIndex,
+        std::optional<PAL::WebGPU::SignedOffset32> baseVertex,
+        std::optional<PAL::WebGPU::Size32> firstInstance) final;
 
     void drawIndirect(const PAL::WebGPU::Buffer& indirectBuffer, PAL::WebGPU::Size64 indirectOffset) final;
     void drawIndexedIndirect(const PAL::WebGPU::Buffer& indirectBuffer, PAL::WebGPU::Size64 indirectOffset) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
@@ -55,7 +55,7 @@ void RemoteRenderPassEncoderProxy::setPipeline(const PAL::WebGPU::RenderPipeline
     UNUSED_VARIABLE(sendResult);
 }
 
-void RemoteRenderPassEncoderProxy::setIndexBuffer(const PAL::WebGPU::Buffer& buffer, PAL::WebGPU::IndexFormat indexFormat, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size)
+void RemoteRenderPassEncoderProxy::setIndexBuffer(const PAL::WebGPU::Buffer& buffer, PAL::WebGPU::IndexFormat indexFormat, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
 {
     auto convertedBuffer = m_convertToBackingContext->convertToBacking(buffer);
     ASSERT(convertedBuffer);
@@ -66,7 +66,7 @@ void RemoteRenderPassEncoderProxy::setIndexBuffer(const PAL::WebGPU::Buffer& buf
     UNUSED_VARIABLE(sendResult);
 }
 
-void RemoteRenderPassEncoderProxy::setVertexBuffer(PAL::WebGPU::Index32 slot, const PAL::WebGPU::Buffer& buffer, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size)
+void RemoteRenderPassEncoderProxy::setVertexBuffer(PAL::WebGPU::Index32 slot, const PAL::WebGPU::Buffer& buffer, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
 {
     auto convertedBuffer = m_convertToBackingContext->convertToBacking(buffer);
     ASSERT(convertedBuffer);
@@ -77,17 +77,17 @@ void RemoteRenderPassEncoderProxy::setVertexBuffer(PAL::WebGPU::Index32 slot, co
     UNUSED_VARIABLE(sendResult);
 }
 
-void RemoteRenderPassEncoderProxy::draw(PAL::WebGPU::Size32 vertexCount, PAL::WebGPU::Size32 instanceCount,
-    PAL::WebGPU::Size32 firstVertex, PAL::WebGPU::Size32 firstInstance)
+void RemoteRenderPassEncoderProxy::draw(PAL::WebGPU::Size32 vertexCount, std::optional<PAL::WebGPU::Size32> instanceCount,
+    std::optional<PAL::WebGPU::Size32> firstVertex, std::optional<PAL::WebGPU::Size32> firstInstance)
 {
     auto sendResult = send(Messages::RemoteRenderPassEncoder::Draw(vertexCount, instanceCount, firstVertex, firstInstance));
     UNUSED_VARIABLE(sendResult);
 }
 
-void RemoteRenderPassEncoderProxy::drawIndexed(PAL::WebGPU::Size32 indexCount, PAL::WebGPU::Size32 instanceCount,
-    PAL::WebGPU::Size32 firstIndex,
-    PAL::WebGPU::SignedOffset32 baseVertex,
-    PAL::WebGPU::Size32 firstInstance)
+void RemoteRenderPassEncoderProxy::drawIndexed(PAL::WebGPU::Size32 indexCount, std::optional<PAL::WebGPU::Size32> instanceCount,
+    std::optional<PAL::WebGPU::Size32> firstIndex,
+    std::optional<PAL::WebGPU::SignedOffset32> baseVertex,
+    std::optional<PAL::WebGPU::Size32> firstInstance)
 {
     auto sendResult = send(Messages::RemoteRenderPassEncoder::DrawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance));
     UNUSED_VARIABLE(sendResult);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
@@ -74,15 +74,15 @@ private:
 
     void setPipeline(const PAL::WebGPU::RenderPipeline&) final;
 
-    void setIndexBuffer(const PAL::WebGPU::Buffer&, PAL::WebGPU::IndexFormat, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64>) final;
-    void setVertexBuffer(PAL::WebGPU::Index32 slot, const PAL::WebGPU::Buffer&, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64>) final;
+    void setIndexBuffer(const PAL::WebGPU::Buffer&, PAL::WebGPU::IndexFormat, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64>) final;
+    void setVertexBuffer(PAL::WebGPU::Index32 slot, const PAL::WebGPU::Buffer&, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64>) final;
 
-    void draw(PAL::WebGPU::Size32 vertexCount, PAL::WebGPU::Size32 instanceCount,
-        PAL::WebGPU::Size32 firstVertex, PAL::WebGPU::Size32 firstInstance) final;
-    void drawIndexed(PAL::WebGPU::Size32 indexCount, PAL::WebGPU::Size32 instanceCount,
-        PAL::WebGPU::Size32 firstIndex,
-        PAL::WebGPU::SignedOffset32 baseVertex,
-        PAL::WebGPU::Size32 firstInstance) final;
+    void draw(PAL::WebGPU::Size32 vertexCount, std::optional<PAL::WebGPU::Size32> instanceCount,
+        std::optional<PAL::WebGPU::Size32> firstVertex, std::optional<PAL::WebGPU::Size32> firstInstance) final;
+    void drawIndexed(PAL::WebGPU::Size32 indexCount, std::optional<PAL::WebGPU::Size32> instanceCount,
+        std::optional<PAL::WebGPU::Size32> firstIndex,
+        std::optional<PAL::WebGPU::SignedOffset32> baseVertex,
+        std::optional<PAL::WebGPU::Size32> firstInstance) final;
 
     void drawIndirect(const PAL::WebGPU::Buffer& indirectBuffer, PAL::WebGPU::Size64 indirectOffset) final;
     void drawIndexedIndirect(const PAL::WebGPU::Buffer& indirectBuffer, PAL::WebGPU::Size64 indirectOffset) final;

--- a/Websites/webkit.org/demos/webgpu/scripts/textured-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/textured-cube.js
@@ -272,9 +272,9 @@ async function helloCube() {
         
         renderPassEncoder.setPipeline(renderPipeline);
         const vertexBufferSlot = 0;
-        renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
+        renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer);
         renderPassEncoder.setBindGroup(1, uniformBindGroup);
-        renderPassEncoder.draw(36, 1, 0, 0); // 36 vertices, 1 instance, 0th vertex, 0th instance.
+        renderPassEncoder.draw(36); // 36 vertices
         renderPassEncoder.end();
         
         /* GPUComamndBuffer */


### PR DESCRIPTION
#### cb87e94afed226f346682c06f9b19b0f9d4562f8
<pre>
Support optional parameters in several GPURenderPassEncoder functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=249374">https://bugs.webkit.org/show_bug.cgi?id=249374</a>
&lt;radar://61518858&gt;

Reviewed by Dean Jackson.

As noted in <a href="https://bugs.webkit.org/show_bug.cgi?id=240219">https://bugs.webkit.org/show_bug.cgi?id=240219</a> it is currently
problematic to have an optional Size32 with a default value. Workaround
is to remove the default value and add the default value when calling
.value_or(default_value)

Pipe std::optional throughout the Web and GPU process member function
declarations and definitions as we do for other optional parameters.

* Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.cpp:
(WebCore::GPURenderBundleEncoder::setIndexBuffer):
(WebCore::GPURenderBundleEncoder::setVertexBuffer):
(WebCore::GPURenderBundleEncoder::draw):
(WebCore::GPURenderBundleEncoder::drawIndexed):
* Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.h:
* Source/WebCore/Modules/WebGPU/GPURenderEncoderBase.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp:
(WebCore::GPURenderPassEncoder::setIndexBuffer):
(WebCore::GPURenderPassEncoder::setVertexBuffer):
(WebCore::GPURenderPassEncoder::draw):
(WebCore::GPURenderPassEncoder::drawIndexed):
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderBundleEncoderImpl.cpp:
(PAL::WebGPU::RenderBundleEncoderImpl::setIndexBuffer):
(PAL::WebGPU::RenderBundleEncoderImpl::setVertexBuffer):
(PAL::WebGPU::RenderBundleEncoderImpl::draw):
(PAL::WebGPU::RenderBundleEncoderImpl::drawIndexed):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderBundleEncoderImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPassEncoderImpl.cpp:
(PAL::WebGPU::RenderPassEncoderImpl::setIndexBuffer):
(PAL::WebGPU::RenderPassEncoderImpl::setVertexBuffer):
(PAL::WebGPU::RenderPassEncoderImpl::draw):
(PAL::WebGPU::RenderPassEncoderImpl::drawIndexed):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPassEncoderImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPURenderBundleEncoder.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPURenderPassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp:
(WebKit::RemoteRenderBundleEncoder::setIndexBuffer):
(WebKit::RemoteRenderBundleEncoder::setVertexBuffer):
(WebKit::RemoteRenderBundleEncoder::draw):
(WebKit::RemoteRenderBundleEncoder::drawIndexed):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp:
(WebKit::RemoteRenderPassEncoder::setIndexBuffer):
(WebKit::RemoteRenderPassEncoder::setVertexBuffer):
(WebKit::RemoteRenderPassEncoder::draw):
(WebKit::RemoteRenderPassEncoder::drawIndexed):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderBundleEncoderProxy::setIndexBuffer):
(WebKit::WebGPU::RemoteRenderBundleEncoderProxy::setVertexBuffer):
(WebKit::WebGPU::RemoteRenderBundleEncoderProxy::draw):
(WebKit::WebGPU::RemoteRenderBundleEncoderProxy::drawIndexed):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::setIndexBuffer):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::setVertexBuffer):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::draw):
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::drawIndexed):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h:
Pipe std::optional throughout the Web and GPU process member function
declarations and definitions as we do for other optional parameters.

* Websites/webkit.org/demos/webgpu/scripts/textured-cube.js:
(async helloCube.frameUpdate):
(async helloCube):
Update textured-cube to use the default values.

Canonical link: <a href="https://commits.webkit.org/258176@main">https://commits.webkit.org/258176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97c30a1e3ed753e5b785c3dac748a8af579cc15b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110395 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170646 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1125 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93506 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108224 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8464 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23130 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3908 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24647 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1056 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44155 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5613 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5707 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->