### PR TITLE
[web-animations] Refactor CSSPropertyAnimation::blendProperties()

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.h
+++ b/Source/WebCore/animation/CSSPropertyAnimation.h
@@ -40,6 +40,8 @@ class RenderStyle;
 
 class CSSPropertyAnimation {
 public:
+    using Property = std::variant<CSSPropertyID, AtomString>;
+
     static bool isPropertyAnimatable(CSSPropertyID);
     static bool isPropertyAdditiveOrCumulative(CSSPropertyID);
     static bool propertyRequiresBlendingForAccumulativeIteration(CSSPropertyID, const RenderStyle& a, const RenderStyle& b);
@@ -49,8 +51,7 @@ public:
     static CSSPropertyID getPropertyAtIndex(int, std::optional<bool>& isShorthand);
     static int getNumProperties();
 
-    static void blendProperties(const CSSPropertyBlendingClient*, CSSPropertyID, RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, double progress, CompositeOperation, IterationCompositeOperation = IterationCompositeOperation::Replace, double currentIteration = 0);
-    static void blendCustomProperty(const CSSPropertyBlendingClient&, const AtomString&, RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, double progress, CompositeOperation, IterationCompositeOperation = IterationCompositeOperation::Replace, double currentIteration = 0);
+    static void blendProperty(const CSSPropertyBlendingClient&, Property, RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, double progress, CompositeOperation, IterationCompositeOperation = IterationCompositeOperation::Replace, double currentIteration = 0);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1559,14 +1559,14 @@ ExceptionOr<void> WebAnimation::commitStyles()
 
     auto& keyframeStack = styledElement.ensureKeyframeEffectStack(PseudoId::None);
 
-    auto effectAnimatesProperty = [](KeyframeEffect& effect, std::variant<CSSPropertyID, AtomString> property) {
+    auto effectAnimatesProperty = [](KeyframeEffect& effect, CSSPropertyAnimation::Property property) {
         return WTF::switchOn(property,
             [&] (CSSPropertyID propertyId) { return effect.animatedProperties().contains(propertyId); },
             [&] (AtomString customProperty) { return effect.animatedCustomProperties().contains(customProperty); }
         );
     };
 
-    auto commitProperty = [&](std::variant<CSSPropertyID, AtomString> property) {
+    auto commitProperty = [&](CSSPropertyAnimation::Property property) {
         // 1. Let partialEffectStack be a copy of the effect stack for property on target.
         // 2. If animation's replace state is removed, add all animation effects associated with animation whose effect target is target and which include
         // property as a target property to partialEffectStack.

--- a/Source/WebCore/rendering/style/KeyframeList.cpp
+++ b/Source/WebCore/rendering/style/KeyframeList.cpp
@@ -182,7 +182,7 @@ void KeyframeList::fillImplicitKeyframes(const KeyframeEffect& effect, const Ren
             ASSERT(existingImplicitKeyframeValue->style());
             auto keyframeStyle = RenderStyle::clonePtr(*existingImplicitKeyframeValue->style());
             for (auto cssPropertyId : implicitProperties) {
-                CSSPropertyAnimation::blendProperties(&effect, cssPropertyId, *keyframeStyle, underlyingStyle, underlyingStyle, 1, CompositeOperation::Replace);
+                CSSPropertyAnimation::blendProperty(effect, cssPropertyId, *keyframeStyle, underlyingStyle, underlyingStyle, 1, CompositeOperation::Replace);
                 existingImplicitKeyframeValue->addProperty(cssPropertyId);
             }
             existingImplicitKeyframeValue->setStyle(WTFMove(keyframeStyle));


### PR DESCRIPTION
#### 24ceea27a0d54229a64fa1339438b7890c98e63f
<pre>
[web-animations] Refactor CSSPropertyAnimation::blendProperties()
<a href="https://bugs.webkit.org/show_bug.cgi?id=249320">https://bugs.webkit.org/show_bug.cgi?id=249320</a>

Reviewed by Antti Koivisto.

As we are getting ready to call CSSPropertyAnimation::blendCustomProperty() from more places
to support additivity for custom properties, we first refactor things a bit to have a single
CSSPropertyAnimation::blendProperty() method which takes in a CSSPropertyAnimation::Property
argument which is a variant for either a standard property or a custom property.

This will greatly reduce the need at call sites to use WTF::switchOn to deal with the two
types of CSS properties.

Additionally, we start using CSSPropertyBlendingClient references instead of pointers since
those values were never nullptr, at least not for a good reason.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyBlendingContext::CSSPropertyBlendingContext):
(WebCore::blendFunc):
(WebCore::blendStandardProperty):
(WebCore::blendCustomProperty):
(WebCore::CSSPropertyAnimation::blendProperty):
(WebCore::CSSPropertyAnimation::blendProperties): Deleted.
(WebCore::CSSPropertyAnimation::blendCustomProperty): Deleted.
* Source/WebCore/animation/CSSPropertyAnimation.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setAnimatedPropertiesInStyle):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::commitStyles):
* Source/WebCore/rendering/style/KeyframeList.cpp:
(WebCore::KeyframeList::fillImplicitKeyframes):

Canonical link: <a href="https://commits.webkit.org/257910@main">https://commits.webkit.org/257910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfe1002c5fa1cd66e8859866a9e857298dcbcb56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109703 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169944 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104380 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/107 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92791 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107581 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106166 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3290 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3282 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9403 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5098 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2813 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->