### PR TITLE
[web-animations] custom properties should support interpolation with a single keyframe

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-length-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-length-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Animating a custom property of type <length>
-FAIL Animating a custom property of type <length> with a single keyframe assert_equals: expected "150px" but got "100px"
+PASS Animating a custom property of type <length> with a single keyframe
 FAIL Animating a custom property of type <length> with additivity assert_equals: expected "350px" but got "250px"
-FAIL Animating a custom property of type <length> with a single keyframe and additivity assert_equals: expected "250px" but got "100px"
+FAIL Animating a custom property of type <length> with a single keyframe and additivity assert_equals: expected "250px" but got "200px"
 FAIL Animating a custom property of type <length> with iterationComposite assert_equals: expected "250px" but got "50px"
 

--- a/Source/WebCore/animation/CSSPropertyBlendingClient.h
+++ b/Source/WebCore/animation/CSSPropertyBlendingClient.h
@@ -29,12 +29,13 @@
 
 namespace WebCore {
 
+class Document;
 class RenderElement;
 class RenderStyle;
 
 class CSSPropertyBlendingClient {
 public:
-
+    virtual Document* document() const = 0;
     virtual RenderElement* renderer() const = 0;
     virtual const RenderStyle& currentStyle() const = 0;
     virtual std::optional<unsigned> transformFunctionListPrefix() const = 0;

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -135,6 +135,7 @@ public:
 
     void willChangeRenderer();
 
+    Document* document() const override;
     RenderElement* renderer() const override;
     const RenderStyle& currentStyle() const override;
     bool triggersStackingContext() const { return m_triggersStackingContext; }
@@ -203,7 +204,6 @@ private:
         bool m_couldOriginallyPreventAcceleration;
     };
 
-    Document* document() const;
     void updateEffectStackMembership();
     void copyPropertiesFromSource(Ref<KeyframeEffect>&&);
     void didChangeTargetStyleable(const std::optional<const Styleable>&);


### PR DESCRIPTION
#### c3591d297f097a553bbf668e6096d96fb62e546d
<pre>
[web-animations] custom properties should support interpolation with a single keyframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=249384">https://bugs.webkit.org/show_bug.cgi?id=249384</a>

Reviewed by Antti Koivisto.

Custom properties can specify an initial value when registered. However, that value is not
available in RenderStyle if the custom property is not provided with an explicit value. This
means that when we added basic support for interpolating custom properties in bug 249312, we
would fail to gather the right values for interpolating as we&apos;d have a null value if the keyframes
did not set explicit values.

We can get to the initial value of a custom property through the custom property registry held
by the document. So we add a new document() method to CSSPropertyBlendingClient such that we may
be able to read from this registry when interpolating from within CSSPropertyAnimation.

Then we add a static method customPropertyValuesForBlending that returns a pair of CSSCustomPropertyValue
pointers containing either the explicit value set for a custom property, or its initial value.

Now we are guaranteed to get the correct values when interpolating.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-length-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendCustomProperty):
* Source/WebCore/animation/CSSPropertyBlendingClient.h:
* Source/WebCore/animation/KeyframeEffect.h:

Canonical link: <a href="https://commits.webkit.org/257911@main">https://commits.webkit.org/257911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea9ab0200fa5b3de9bb67bca2aa29483a3077e8b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109707 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169949 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/112 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92795 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107585 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106170 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3294 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3285 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9406 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5101 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2814 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->