### PR TITLE
Include overflows from visual effects in RenderTable

### DIFF
--- a/LayoutTests/fast/repaint/table-section-visual-overflow-expected.txt
+++ b/LayoutTests/fast/repaint/table-section-visual-overflow-expected.txt
@@ -1,0 +1,5 @@
+(repaint rects
+  (rect 143 -2 120 120)
+  (rect -2 -2 120 120)
+)
+

--- a/LayoutTests/fast/repaint/table-section-visual-overflow.html
+++ b/LayoutTests/fast/repaint/table-section-visual-overflow.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<style type="text/css">
+    #test
+    {
+        display: table-row-group;
+        outline-color: black;
+        outline-style: solid;
+        outline-width: 10px;
+    }
+    #row
+    {
+        display: table-row;
+    }
+    #table
+    {
+        display: table;
+        table-layout: fixed;
+        /* Position the table to overlap a raster tile only for outline */
+        position: relative;
+        left: 145px;
+    }
+    #cell
+    {
+        display: table-cell;
+        height: 100px;
+        width: 100px;
+    }
+</style>
+<script type="text/javascript" src="resources/text-based-repaint.js"></script>
+<script type="text/javascript">
+function repaintTest() {
+    // Moving to 0px will demonstrate the bug, since the invalidation rectangle will not include
+    // the outline.
+    var table = document.getElementById("table");
+    table.style.left = "0px";
+}
+</script>
+<body onload="runRepaintTest()">
+    <div id="table">
+        <div id="test">
+            <div id="row">
+                <div id="cell"></div>
+            </div>
+        </div>
+    </div>
+</body>

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -422,6 +422,7 @@ void RenderTable::simplifiedNormalFlowLayout()
         section->layoutIfNeeded();
         section->layoutRows();
         section->computeOverflowFromCells();
+        section->addVisualEffectOverflow();
     }
 }
 
@@ -561,6 +562,8 @@ void RenderTable::layout()
             section->setLogicalLocation(LayoutPoint(sectionLogicalLeft, logicalHeight()));
 
             setLogicalHeight(logicalHeight() + section->logicalHeight());
+            section->addVisualEffectOverflow();
+            
             section = sectionBelow(section);
         }
 


### PR DESCRIPTION
#### e87838633996aea9c5bf950e843d297baf78d224
<pre>
Include overflows from visual effects in RenderTable

Include overflows from visual effects in RenderTable
<a href="https://bugs.webkit.org/show_bug.cgi?id=249279">https://bugs.webkit.org/show_bug.cgi?id=249279</a>

Reviewed by Alan Baradlay.

This patch is to fix repaint issue in WebKit, which is not present in Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=rev&amp">https://src.chromium.org/viewvc/blink?view=rev&amp</a>;revision=196609

By not including visual overflow effects results in incorrect paint invalidation (as exhibited by the attached test), and also incorrect painting.

* Source/WebCore/rendering/RenderTable.cpp:
(RenderTable::simplifiedNormalFlowLayout): Account for &apos;addVisualEffectOverflow&apos;
(RenderTable::layout): Ditto
* LayoutTests/fast/repaint/table-section-visual-overflow.html: Add Test Case
* LayoutTests/fast/repaint/table-section-visual-overflow-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/258596@main">https://commits.webkit.org/258596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95aea76c26b928123b526810580428888c979859

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111630 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171805 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2373 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94650 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109340 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9532 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92795 "Build was cancelled. Recent messages:Encountered some issues during cleanup; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (warnings); re-run-api-tests (warnings); Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change (warnings); Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change_1 (warnings); Running unapply-patch_2; Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change_2 (warnings); Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change_3 (warnings); Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change_4 (warnings); Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change_5 (warnings); Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change_6 (warnings); Reverted pull request changes; Compiled WebKit (warnings); run-api-tests-without-change_7 (cancelled)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37277 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24276 "Build is being retried. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Pull request contains relevant changes; Skipped layout-tests; layout-tests running") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25704 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5108 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2147 "Found 1 new test failure: imported/w3c/web-platform-tests/fs/FileSystemFileHandle-create-sync-access-handle.https.tentative.window.html (failure)") | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-9-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45197 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5903 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6860 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->