### PR TITLE
Fix inline-block abspos bug

### DIFF
--- a/LayoutTests/fast/block/positioning/bug369123-expected.html
+++ b/LayoutTests/fast/block/positioning/bug369123-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<p>The blue block should be on the right of the green block, not below it.</p>
+<div>
+    <div style='display: inline-block; width: 50px; height: 50px; background: green;'></div>
+    <div style='display: inline-block; position: fixed; width: 50px; height: 50px; background: blue;'></div>
+</div>

--- a/LayoutTests/fast/block/positioning/bug369123.html
+++ b/LayoutTests/fast/block/positioning/bug369123.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<p>The blue block should be on the right of the green block, not below it.</p>
+<div>
+    <div style='display: inline-block; width: 50px; height: 50px; background: green;'></div>
+    <div id=blue style='position: fixed; width: 50px; height: 50px; background: blue;'></div>
+</div>
+<script>
+document.body.offsetTop;
+blue.style.display = 'inline-block';
+</script>


### PR DESCRIPTION
<pre>
Fix inline-block abspos bug
<a href="https://bugs.webkit.org/show_bug.cgi?id=249391">https://bugs.webkit.org/show_bug.cgi?id=249391</a>

Reviewed by NOBODY (OOPS!).

This patch is to align Webkit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/b1dbd0d86f09b9dccd410d1d106c76f029fa5b48">https://chromium.googlesource.com/chromium/blink/+/b1dbd0d86f09b9dccd410d1d106c76f029fa5b48</a>

When an out-of-flow-positioned element changes its display between block and inline-block,
then an incremental layout on the element's containing block lays out the element through
LayoutPositionedObjects, which skips laying out the element's parent. The element's parent
needs to relayout so that it calls RenderBlockFlow::setStaticInlinePositionForChild with
the out-of-flow-positioned child, so that when it's laid out, its
RenderBox::computePositionedLogicalWidth/Height takes into account its new inline/block
position rather than its old block/inline position.

* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(RenderLayerModelObject::styleDidChange):
- Add Comment
- Add function to do layout update on conditions of changes between inline/block
* LayoutTests/fast/block/positioning/bug369123.html: Add Test Case
* LayoutTests/fast/block/positioning/bug369123-expected.html: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cea8178d67e9299e8f30eee58fabcfd19bd21875

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100414 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9576 "Hash cea8178d for PR 7685 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33478 "Hash cea8178d for PR 7685 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109729 "Hash cea8178d for PR 7685 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170001 "Hash cea8178d for PR 7685 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104407 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10487 "Hash cea8178d for PR 7685 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/147 "Hash cea8178d for PR 7685 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92817 "Hash cea8178d for PR 7685 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107606 "Hash cea8178d for PR 7685 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106193 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/10487 "Hash cea8178d for PR 7685 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/33478 "Hash cea8178d for PR 7685 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/92817 "Hash cea8178d for PR 7685 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/10487 "Hash cea8178d for PR 7685 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/33478 "Hash cea8178d for PR 7685 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/92817 "Hash cea8178d for PR 7685 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3314 "Hash cea8178d for PR 7685 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/33478 "Hash cea8178d for PR 7685 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3304 "Hash cea8178d for PR 7685 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/147 "Hash cea8178d for PR 7685 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9426 "Hash cea8178d for PR 7685 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/33478 "Hash cea8178d for PR 7685 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5121 "Hash cea8178d for PR 7685 does not build (failure)") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->