### PR TITLE
REGRESSION (iOS 16): WebGL 2 crashing on glReadPixels

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -37,6 +37,7 @@
 #include "StreamServerConnection.h"
 #include <WebCore/NotImplemented.h>
 #include <WebCore/PixelBuffer.h>
+#include <WebCore/ProcessIdentity.h>
 #include <wtf/ThreadAssertions.h>
 #include <wtf/WeakPtr.h>
 
@@ -130,7 +131,7 @@ protected:
     void copyTextureFromVideoFrame(RemoteVideoFrameReadReference, uint32_t texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY, CompletionHandler<void(bool)>&&);
 #endif
     void simulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting);
-    void readnPixels0(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, IPC::ArrayReference<uint8_t>&& data, CompletionHandler<void(IPC::ArrayReference<uint8_t>)>&&);
+    void readnPixels0(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, IPC::TransferRegion&& data, CompletionHandler<void(bool)>&&);
     void readnPixels1(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, uint64_t offset);
     void multiDrawArraysANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t>&& firstsAndCounts);
     void multiDrawArraysInstancedANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t>&& firstsCountsAndInstanceCounts);
@@ -164,6 +165,7 @@ protected:
 #endif
     ScopedWebGLRenderingResourcesRequest m_renderingResourcesRequest;
     WebCore::ProcessIdentifier m_webProcessIdentifier;
+    const WebCore::ProcessIdentity m_resourceOwner;
 };
 
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -51,7 +51,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void PaintCompositedResultsToVideoFrame() -> (std::optional<WebKit::RemoteVideoFrameProxy::Properties> properties) Synchronous
 #endif
     void SimulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting event)
-    void ReadnPixels0(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, IPC::ArrayReference<uint8_t> data) -> (IPC::ArrayReference<uint8_t> data) Synchronous
+    void ReadnPixels0(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, IPC::TransferRegion data) -> (bool hadError) Synchronous
     void ReadnPixels1(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, uint64_t offset)
     void MultiDrawArraysANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t> firstsAndCounts)
     void MultiDrawArraysInstancedANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t> firstsCountsAandInstanceCounts)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
@@ -30,7 +30,6 @@
 
 #include "GPUConnectionToWebProcess.h"
 #include "IPCUtilities.h"
-#include <WebCore/ProcessIdentity.h>
 #include <wtf/MachSendRight.h>
 
 
@@ -85,8 +84,6 @@ public:
     // RemoteGraphicsContextGL overrides.
     void platformWorkQueueInitialize(WebCore::GraphicsContextGLAttributes&&) final;
     void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&) final;
-private:
-    const WebCore::ProcessIdentity m_resourceOwner;
 };
 
 }
@@ -100,7 +97,6 @@ Ref<RemoteGraphicsContextGL> RemoteGraphicsContextGL::create(GPUConnectionToWebP
 
 RemoteGraphicsContextGLCocoa::RemoteGraphicsContextGLCocoa(GPUConnectionToWebProcess& gpuConnectionToWebProcess, GraphicsContextGLIdentifier graphicsContextGLIdentifier, RemoteRenderingBackend& renderingBackend, IPC::StreamServerConnection::Handle&& connectionHandle)
     : RemoteGraphicsContextGL(gpuConnectionToWebProcess, graphicsContextGLIdentifier, renderingBackend, WTFMove(connectionHandle))
-    , m_resourceOwner(gpuConnectionToWebProcess.webProcessIdentity())
 {
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -91,7 +91,7 @@ Ref<RemoteRenderingBackend> RemoteRenderingBackend::create(GPUConnectionToWebPro
 
 RemoteRenderingBackend::RemoteRenderingBackend(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteRenderingBackendCreationParameters&& creationParameters, IPC::StreamServerConnection::Handle&& connectionHandle)
     : m_workQueue(IPC::StreamConnectionWorkQueue::create("RemoteRenderingBackend work queue"))
-    , m_streamConnection(IPC::StreamServerConnection::create(WTFMove(connectionHandle), m_workQueue.get()))
+    , m_streamConnection(IPC::StreamServerConnection::create(WTFMove(connectionHandle), m_workQueue.get(), &gpuConnectionToWebProcess.connection()))
     , m_remoteResourceCache(gpuConnectionToWebProcess.webProcessIdentifier())
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_resourceOwner(gpuConnectionToWebProcess.webProcessIdentity())

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -47,7 +47,7 @@ namespace WebKit {
 RemoteGPU::RemoteGPU(WebGPUIdentifier identifier, GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteRenderingBackend& renderingBackend, IPC::StreamServerConnection::Handle&& connectionHandle)
     : m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_workQueue(IPC::StreamConnectionWorkQueue::create("WebGPU work queue"))
-    , m_streamConnection(IPC::StreamServerConnection::create(WTFMove(connectionHandle), workQueue()))
+    , m_streamConnection(IPC::StreamServerConnection::create(WTFMove(connectionHandle), workQueue(), &gpuConnectionToWebProcess.connection()))
     , m_objectHeap(WebGPU::ObjectHeap::create())
     , m_identifier(identifier)
     , m_renderingBackend(renderingBackend)

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -56,9 +56,12 @@ void StreamClientConnection::DedicatedConnectionClient::didReceiveInvalidMessage
     ASSERT_NOT_REACHED(); // The sender is expected to be trusted, so all invalid messages are programming errors.
 }
 
-StreamClientConnection::StreamConnectionPair StreamClientConnection::create(size_t bufferSize)
+StreamClientConnection::StreamConnectionPair StreamClientConnection::create(size_t bufferSize, Connection* mainConnection)
 {
     auto connectionIdentifiers = Connection::createConnectionIdentifierPair();
+    if (mainConnection)
+        mainConnection->addToTransferRegionGroup(connectionIdentifiers->server);
+
     // Create StreamClientConnection with "server" type Connection. The caller will send the "client" type connection identifier via
     // IPC to the other side, where StreamServerConnection will be created with "client" type Connection.
     // For Connection, "server" means the connection which was created first, the connection which is not sent through IPC to other party.

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -64,7 +64,8 @@ public:
     };
 
     // The messages from the server are delivered to the caller through the passed IPC::MessageReceiver.
-    static StreamConnectionPair create(size_t bufferSize);
+    // The optional main connection is used to inherit target process properties.
+    static StreamConnectionPair create(size_t bufferSize, Connection* mainConnection = nullptr);
 
     ~StreamClientConnection();
 
@@ -96,6 +97,16 @@ public:
 
     StreamConnectionBuffer& bufferForTesting();
     Connection& connectionForTesting();
+
+    auto reserveTransferRegion(size_t size)
+    {
+        return m_connection->reserveTransferRegion(size);
+    }
+
+    void releaseUnusedMemory()
+    {
+        m_connection->releaseUnusedMemory();
+    }
 
 private:
     StreamClientConnection(Ref<Connection>, size_t bufferSize);

--- a/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
@@ -78,12 +78,16 @@ public:
     size_t size() const { ASSERT(isValid()); return m_encodedSize; }
     bool isValid() const { return m_bufferCapacity; }
     operator bool() const { return isValid(); }
+    void markInvalid()
+    {
+        m_bufferCapacity = 0;
+    }
 private:
     bool reserve(size_t alignedSize, size_t additionalSize)
     {
         size_t size = alignedSize + additionalSize;
         if (size < alignedSize || size > m_bufferCapacity) {
-            m_bufferCapacity = 0;
+            markInvalid();
             return false;
         }
         return true;

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -48,9 +48,12 @@ private:
 
 }
 
-Ref<StreamServerConnection> StreamServerConnection::create(Handle&& handle, StreamConnectionWorkQueue& workQueue)
+Ref<StreamServerConnection> StreamServerConnection::create(Handle&& handle, StreamConnectionWorkQueue& workQueue, Connection* mainConnection)
 {
-    auto connection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTFMove(handle.outOfStreamConnection) });
+    IPC::Connection::Identifier identifier { WTFMove(handle.outOfStreamConnection) };
+    if (mainConnection)
+        mainConnection->addToTransferRegionGroup(identifier);
+    auto connection = IPC::Connection::createClientConnection(WTFMove(identifier));
     auto buffer = StreamConnectionBuffer::map(WTFMove(handle.buffer));
     RELEASE_ASSERT(buffer); // FIXME: make callers call this outside constructor.
     return adoptRef(*new StreamServerConnection(WTFMove(connection), WTFMove(*buffer), workQueue));

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -61,7 +61,7 @@ public:
         void encode(Encoder&) const;
         static std::optional<Handle> decode(Decoder&);
     };
-    static Ref<StreamServerConnection> create(Handle&&, StreamConnectionWorkQueue&);
+    static Ref<StreamServerConnection> create(Handle&&, StreamConnectionWorkQueue&, Connection* mainConnection);
     ~StreamServerConnection() final;
 
     void startReceivingMessages(StreamMessageReceiver&, ReceiverName, uint64_t destinationID);
@@ -87,6 +87,11 @@ public:
     void sendAsyncReply(AsyncReplyID, Arguments&&...);
 
     Semaphore& clientWaitSemaphore() { return m_clientWaitSemaphore; }
+
+    auto mapTransferRegion(TransferRegion&& region, const WebCore::ProcessIdentity& resourceOwner)
+    {
+        return m_connection->mapTransferRegion(WTFMove(region), resourceOwner);
+    }
 
 private:
     StreamServerConnection(Ref<Connection>, StreamConnectionBuffer&&, StreamConnectionWorkQueue&);

--- a/Source/WebKit/Platform/IPC/TransferRegion.cpp
+++ b/Source/WebKit/Platform/IPC/TransferRegion.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TransferRegion.h"
+
+namespace IPC {
+
+constexpr size_t minimumTransferBufferAllocation { 64 * KB };
+constexpr Seconds releaseUnusedBuffersTimeout = 5_s;
+
+Ref<TransferRegionPool> TransferRegionPool::create(Connection& connection)
+{
+    return adoptRef(*new TransferRegionPool { connection } );
+}
+
+TransferRegionPool::TransferRegionPool(Connection& connection)
+    : m_connection(&connection)
+{
+}
+
+void TransferRegionPool::invalidate()
+{
+    std::optional<TransferBuffer> freeBuffer;
+    {
+        Locker locker { m_lock };
+        unscheduleReleaseUnusedMemory();
+        freeBuffer = WTFMove(m_free);
+        m_connection = nullptr;
+    }
+}
+
+std::optional<ScopedTransferRegion> TransferRegionPool::reserveRegion(size_t size)
+{
+    if (!size)
+        return ScopedTransferRegion { *this, *TransferBuffer::create(0), 0 };
+
+    {
+        Locker locker { m_lock };
+        if (m_free && m_free->size() >= size) {
+            unscheduleReleaseUnusedMemory();
+            return ScopedTransferRegion { *this, *std::exchange(m_free, std::nullopt), size };
+        }
+    }
+    auto buffer = TransferBuffer::create(std::max(minimumTransferBufferAllocation, size));
+    if (!buffer)
+        return std::nullopt;
+    return ScopedTransferRegion { *this, WTFMove(*buffer), size };
+}
+
+void TransferRegionPool::releaseTransferBuffer(TransferBuffer&& buffer)
+{
+    if (!buffer.size())
+        return;
+    RefPtr<Connection> connection;
+    {
+        Locker locker { m_lock };
+        if (!m_free) {
+            scheduleReleaseUnusedMemory();
+            m_free = WTFMove(buffer);
+            return;
+        }
+        std::swap(*m_free, buffer);
+        connection = m_connection;
+    }
+
+    if (!connection || !buffer.hasBeenPassed())
+        return;
+    auto encoder = makeUniqueRef<Encoder>(MessageName::ReleaseTransferBuffer, buffer.identifier().toUInt64());
+    connection->sendMessage(WTFMove(encoder), { });
+}
+
+void TransferRegionPool::scheduleReleaseUnusedMemory()
+{
+    if (m_releaseUnusedTimer)
+        return;
+    m_releaseUnusedTimer = RunLoop::main().dispatchAfter(releaseUnusedBuffersTimeout, [self = Ref { *this }] {
+        self->releaseUnusedMemory();
+    });
+}
+
+void TransferRegionPool::unscheduleReleaseUnusedMemory()
+{
+    if (!m_releaseUnusedTimer)
+        return;
+    m_releaseUnusedTimer->stop();
+    m_releaseUnusedTimer->setFunction(nullptr); // FIXME: stopped DispatchTimer leaks.
+    m_releaseUnusedTimer = nullptr;
+}
+
+void TransferRegionPool::releaseUnusedMemory()
+{
+    std::optional<TransferBuffer> buffer;
+    RefPtr<Connection> connection;
+    {
+        Locker locker { m_lock };
+        buffer = WTFMove(m_free);
+        m_free = std::nullopt;
+        connection = m_connection;
+        unscheduleReleaseUnusedMemory();
+    }
+    if (!buffer || !connection)
+        return;
+    auto encoder = makeUniqueRef<Encoder>(MessageName::ReleaseTransferBuffer, buffer->identifier().toUInt64());
+    connection->sendMessage(WTFMove(encoder), { });
+}
+
+Ref<TransferRegionMapper> TransferRegionMapper::create()
+{
+    return adoptRef(*new TransferRegionMapper);
+}
+
+std::optional<ScopedTransferRegionMapping> TransferRegionMapper::mapRegion(TransferRegion&& region, const WebCore::ProcessIdentity& resourceOwner)
+{
+    if (!region.size)
+        return ScopedTransferRegionMapping { };
+    if (!TransferBufferMap::isValidKey(region.identifier))
+        return std::nullopt;
+    Locker locker { m_lock };
+    TransferBufferMap::iterator iterator;
+
+    if (!region.buffer) {
+        iterator = m_buffers.find(region.identifier);
+        if (iterator == m_buffers.end())
+            return std::nullopt;
+    } else {
+        region.buffer->setOwnershipOfMemory(resourceOwner, WebKit::MemoryLedger::Default);
+        auto buffer = WebKit::SharedMemory::map(WTFMove(*region.buffer), WebKit::SharedMemory::Protection::ReadWrite);
+        if (!buffer)
+            return std::nullopt;
+        auto addResult = m_buffers.add(region.identifier, buffer.releaseNonNull());
+        if (!addResult.isNewEntry)
+            return std::nullopt;
+        iterator = addResult.iterator;
+    }
+    auto& buffer = iterator->value;
+    if (region.size > buffer->size())
+        return std::nullopt;
+    return ScopedTransferRegionMapping { buffer, region.size };
+}
+
+void TransferRegionMapper::releaseBufferMapping(TransferBufferIdentifier identifier)
+{
+    Locker locker { m_lock };
+    m_buffers.remove(identifier);
+}
+
+void TransferRegionMapper::invalidate()
+{
+    Locker locker { m_lock };
+    m_buffers.clear();
+}
+
+}

--- a/Source/WebKit/Platform/IPC/TransferRegion.h
+++ b/Source/WebKit/Platform/IPC/TransferRegion.h
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ArgumentCoders.h"
+#include "SharedMemory.h"
+#include <optional>
+#include <span>
+#include <wtf/HashMap.h>
+#include <wtf/Lock.h>
+#include <wtf/ObjectIdentifier.h>
+#include <wtf/RunLoop.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/ThreadSafetyAnalysis.h>
+
+namespace WebCore {
+class ProcessIdentity;
+}
+
+namespace IPC {
+
+class ScopedTransferRegion;
+
+enum TransferBufferIdentifierType { };
+using TransferBufferIdentifier = ObjectIdentifier<TransferBufferIdentifierType>;
+
+class TransferRegion {
+public:
+    TransferBufferIdentifier identifier;
+    size_t size;
+    std::optional<WebKit::SharedMemory::Handle> buffer; // Null when expected to be already mapped in the target process.
+    static std::optional<TransferRegion> decode(Decoder&);
+    template<typename Encoder>
+    void encode(Encoder&) const;
+};
+
+class TransferBuffer {
+public:
+    static std::optional<TransferBuffer> create(size_t size)
+    {
+        if (!size)
+            return TransferBuffer { };
+        auto buffer = WebKit::SharedMemory::allocate(size);
+        if (!buffer)
+            return std::nullopt;
+        return TransferBuffer { buffer.releaseNonNull() };
+    }
+    TransferBuffer(TransferBuffer&&) = default;
+    TransferBuffer& operator=(TransferBuffer&&) = default;
+
+    TransferBufferIdentifier identifier() const
+    {
+        return m_identifier;
+    }
+
+    std::optional<WebKit::SharedMemory::Handle> passHandle()
+    {
+        if (m_hasBeenPassed || !m_buffer)
+            return std::nullopt;
+        m_hasBeenPassed = true;
+        return m_buffer->createHandle(WebKit::SharedMemory::Protection::ReadWrite);
+    }
+
+    std::span<uint8_t> data()
+    {
+        if (!m_buffer)
+            return { };
+        return std::span<uint8_t> { reinterpret_cast<uint8_t*>(m_buffer->data()), m_buffer->size() };
+    }
+
+    size_t size() const
+    {
+        if (!m_buffer)
+            return 0;
+        return m_buffer->size();
+    }
+
+    bool hasBeenPassed() const { return m_hasBeenPassed; }
+private:
+    TransferBuffer() = default;
+    TransferBuffer(Ref<WebKit::SharedMemory> buffer)
+        : m_buffer { WTFMove(buffer) }
+    {
+    }
+
+    TransferBufferIdentifier m_identifier { TransferBufferIdentifier::generateThreadSafe() };
+    RefPtr<WebKit::SharedMemory> m_buffer;
+    bool m_hasBeenPassed { false };
+};
+
+
+class ScopedTransferRegionMapping {
+public:
+    ScopedTransferRegionMapping(Ref<WebKit::SharedMemory> memory, size_t size)
+        : m_memory { WTFMove(memory) }
+        , m_size { size }
+    {
+    }
+    ScopedTransferRegionMapping() = default;
+
+    std::span<uint8_t> data() const
+    {
+        if (!m_memory)
+            return { };
+        return std::span<uint8_t> { reinterpret_cast<uint8_t*>(m_memory->data()), m_size };
+    }
+private:
+    RefPtr<WebKit::SharedMemory> m_memory;
+    size_t m_size { 0 };
+};
+
+// Class to hold shared memory instances that have been sent to a particular receiver process.
+class TransferRegionPool : public ThreadSafeRefCounted<TransferRegionPool> {
+    WTF_MAKE_NONCOPYABLE(TransferRegionPool);
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<TransferRegionPool> create(Connection&);
+    std::optional<ScopedTransferRegion> reserveRegion(size_t);
+    void invalidate();
+    void releaseUnusedMemory();
+
+private:
+    explicit TransferRegionPool(Connection&);
+    void releaseTransferBuffer(TransferBuffer&&);
+    void scheduleReleaseUnusedMemory() WTF_REQUIRES_LOCK(m_lock);
+    void unscheduleReleaseUnusedMemory() WTF_REQUIRES_LOCK(m_lock);
+
+    Lock m_lock;
+    Connection* m_connection WTF_GUARDED_BY_LOCK(m_lock);
+    RefPtr<RunLoop::DispatchTimer> m_releaseUnusedTimer WTF_GUARDED_BY_LOCK(m_lock);
+    std::optional<TransferBuffer> m_free WTF_GUARDED_BY_LOCK(m_lock);
+    friend class ScopedTransferRegion;
+};
+
+// Class to hold shared memory mappings from a particular sender process.
+class TransferRegionMapper : public ThreadSafeRefCounted<TransferRegionMapper> {
+    WTF_MAKE_NONCOPYABLE(TransferRegionMapper);
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<TransferRegionMapper> create();
+    std::optional<ScopedTransferRegionMapping> mapRegion(TransferRegion&&, const WebCore::ProcessIdentity&);
+    void releaseBufferMapping(TransferBufferIdentifier);
+    void invalidate();
+private:
+    TransferRegionMapper() = default;
+    using TransferBufferMap = HashMap<TransferBufferIdentifier, Ref<WebKit::SharedMemory>>;
+    Lock m_lock;
+    TransferBufferMap m_buffers WTF_GUARDED_BY_LOCK(m_lock);
+};
+
+class ScopedTransferRegion {
+    WTF_MAKE_NONCOPYABLE(ScopedTransferRegion);
+public:
+    ScopedTransferRegion(TransferRegionPool& pool, TransferBuffer&& buffer, size_t size)
+        : m_pool { &pool }
+        , m_buffer { WTFMove(buffer) }
+        , m_size { size }
+    {
+    }
+    ScopedTransferRegion(ScopedTransferRegion&&) = default;
+
+    ~ScopedTransferRegion()
+    {
+        if (m_pool)
+            m_pool->releaseTransferBuffer(WTFMove(m_buffer));
+    }
+
+    TransferRegion passRegion()
+    {
+        return { m_buffer.identifier(),  m_size, m_buffer.passHandle() };
+    }
+
+    std::span<uint8_t> data()
+    {
+        return m_buffer.data().subspan(0, m_size);
+    }
+
+private:
+    RefPtr<TransferRegionPool> m_pool;
+    TransferBuffer m_buffer;
+    size_t m_size { 0 };
+};
+
+inline std::optional<TransferRegion> TransferRegion::decode(Decoder& decoder)
+{
+    auto identifier = decoder.decode<TransferBufferIdentifier>();
+    auto size = decoder.decode<size_t>();
+    auto buffer = decoder.decode<std::optional<WebKit::SharedMemory::Handle>>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return TransferRegion { *identifier, *size, WTFMove(*buffer) };
+}
+
+template<typename Encoder>
+void TransferRegion::encode(Encoder& encoder) const
+{
+    encoder << identifier << size << buffer;
+}
+
+}

--- a/Source/WebKit/Platform/SharedMemory.cpp
+++ b/Source/WebKit/Platform/SharedMemory.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "SharedMemory.h"
+#include "StreamConnectionEncoder.h"
 
 #include <WebCore/SharedBuffer.h>
 
@@ -72,5 +73,13 @@ void SharedMemory::Handle::setOwnershipOfMemory(const ProcessIdentity&, MemoryLe
 {
 }
 #endif
+
+void SharedMemory::Handle::encode(IPC::StreamConnectionEncoder& encoder) const
+{
+    // This is useful when sending messages with std::optional<SharedMemory::Handle> instances.
+    // Messages with std::nullopt std::optional instances can be sent as stream messages
+    // and messages with engaged std::optional instances are sent as out-of-stream.
+    encoder.markInvalid();
+}
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/SharedMemory.h
+++ b/Source/WebKit/Platform/SharedMemory.h
@@ -45,6 +45,7 @@ namespace IPC {
 class Decoder;
 class Encoder;
 class Connection;
+class StreamConnectionEncoder;
 }
 
 namespace WebCore {
@@ -77,6 +78,7 @@ public:
         void clear();
 
         void encode(IPC::Encoder&) const;
+        void encode(IPC::StreamConnectionEncoder&) const;
         static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, Handle&);
 #if USE(UNIX_DOMAIN_SOCKETS)
         UnixFileDescriptor releaseHandle();

--- a/Source/WebKit/Platform/Sources.txt
+++ b/Source/WebKit/Platform/Sources.txt
@@ -21,3 +21,4 @@ Platform/IPC/StreamConnectionBuffer.cpp
 Platform/IPC/StreamConnectionWorkQueue.cpp
 Platform/IPC/SharedFileHandle.cpp
 Platform/IPC/StreamServerConnection.cpp
+Platform/IPC/TransferRegion.cpp

--- a/Source/WebKit/Scripts/webkit/model.py
+++ b/Source/WebKit/Scripts/webkit/model.py
@@ -80,6 +80,7 @@ ipc_receiver = MessageReceiver(name="IPC", superclass=None, attributes=[BUILTIN_
     Message('SetStreamDestinationID', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
     Message('ProcessOutOfStreamMessage', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
     Message('Terminate', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
+    Message('ReleaseTransferBuffer', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
 ], condition=None)
 
 

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -40,16 +40,16 @@
 
 namespace WebKit {
 
-RefPtr<IPCStreamTester> IPCStreamTester::create(IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle&& connectionHandle)
+RefPtr<IPCStreamTester> IPCStreamTester::create(IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle&& connectionHandle, IPC::Connection& otherConnection)
 {
-    auto tester = adoptRef(*new IPCStreamTester(identifier, WTFMove(connectionHandle)));
+    auto tester = adoptRef(*new IPCStreamTester(identifier, WTFMove(connectionHandle), otherConnection));
     tester->initialize();
     return tester;
 }
 
-IPCStreamTester::IPCStreamTester(IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle&& connectionHandle)
+IPCStreamTester::IPCStreamTester(IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle&& connectionHandle, IPC::Connection& otherConnection)
     : m_workQueue(IPC::StreamConnectionWorkQueue::create("IPCStreamTester work queue"))
-    , m_streamConnection(IPC::StreamServerConnection::create(WTFMove(connectionHandle), workQueue()))
+    , m_streamConnection(IPC::StreamServerConnection::create(WTFMove(connectionHandle), workQueue(), &otherConnection))
     , m_identifier(identifier)
 {
 }

--- a/Source/WebKit/Shared/IPCStreamTester.h
+++ b/Source/WebKit/Shared/IPCStreamTester.h
@@ -46,13 +46,13 @@ namespace WebKit {
 // Interface to test various IPC stream related activities.
 class IPCStreamTester final : public IPC::StreamMessageReceiver {
 public:
-    static RefPtr<IPCStreamTester> create(IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&);
+    static RefPtr<IPCStreamTester> create(IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&, IPC::Connection& otherConnection);
     void stopListeningForIPC(Ref<IPCStreamTester>&& refFromConnection);
 
     // IPC::StreamMessageReceiver overrides.
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 private:
-    IPCStreamTester(IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&);
+    IPCStreamTester(IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&, IPC::Connection& otherConnection);
     ~IPCStreamTester();
     void initialize();
     IPC::StreamConnectionWorkQueue& workQueue() const { return m_workQueue; }

--- a/Source/WebKit/Shared/IPCTester.h
+++ b/Source/WebKit/Shared/IPCTester.h
@@ -63,7 +63,7 @@ private:
     // Messages.
     void startMessageTesting(IPC::Connection&, String&& driverName);
     void stopMessageTesting(CompletionHandler<void()>&&);
-    void createStreamTester(IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&);
+    void createStreamTester(IPC::Connection&, IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&);
     void releaseStreamTester(IPCStreamTesterIdentifier, CompletionHandler<void()>&&);
     void createConnectionTester(IPC::Connection&, IPCConnectionTesterIdentifier, IPC::Connection::Handle&&);
     void createConnectionTesterAndSendAsyncMessages(IPC::Connection&, IPCConnectionTesterIdentifier, IPC::Connection::Handle&&, uint32_t messageCount);
@@ -71,6 +71,7 @@ private:
     void sendSameSemaphoreBack(IPC::Connection&, IPC::Semaphore&&);
     void sendSemaphoreBackAndSignalProtocol(IPC::Connection&, IPC::Semaphore&&);
     void sendAsyncMessageToReceiver(IPC::Connection&, uint32_t);
+    void sendTransferRegion(IPC::TransferRegion&&, CompletionHandler<void()>&&);
 
     void stopIfNeeded();
 

--- a/Source/WebKit/Shared/IPCTester.messages.in
+++ b/Source/WebKit/Shared/IPCTester.messages.in
@@ -25,7 +25,7 @@
 messages -> IPCTester NotRefCounted {
     StartMessageTesting(String driverName) WantsConnection
     StopMessageTesting() -> () Synchronous
-    CreateStreamTester(WebKit::IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle serverConnection)
+    CreateStreamTester(WebKit::IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle serverConnection) WantsConnection
     ReleaseStreamTester(WebKit::IPCStreamTesterIdentifier identifier) -> () Synchronous
     CreateConnectionTester(WebKit::IPCConnectionTesterIdentifier identifier, IPC::Connection::Handle connection) WantsConnection
     CreateConnectionTesterAndSendAsyncMessages(WebKit::IPCConnectionTesterIdentifier identifier, IPC::Connection::Handle connection, uint32_t messageCount) WantsConnection
@@ -35,6 +35,9 @@ messages -> IPCTester NotRefCounted {
     SendSemaphoreBackAndSignalProtocol(IPC::Semaphore semaphore) WantsConnection
 
     SendAsyncMessageToReceiver(uint32_t arg0) WantsConnection
+
+    // For TransferRegionTests only.
+    SendTransferRegion(IPC::TransferRegion region) -> () Synchronous
 }
 
 #endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1414,6 +1414,7 @@
 		7B483F1F25CDDA9C00120486 /* MessageReceiveQueueMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B483F1B25CDDA9B00120486 /* MessageReceiveQueueMap.h */; };
 		7B483F2025CDDA9C00120486 /* MessageReceiveQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B483F1C25CDDA9B00120486 /* MessageReceiveQueue.h */; };
 		7B483F2225CDDA9C00120486 /* MessageReceiveQueues.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B483F1E25CDDA9B00120486 /* MessageReceiveQueues.h */; };
+		7B4FAA74293E4AA800978827 /* TransferRegion.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B4FAA73293E4AA800978827 /* TransferRegion.h */; };
 		7B73123A25CC8525003B2796 /* StreamConnectionBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B73123125CC8523003B2796 /* StreamConnectionBuffer.h */; };
 		7B73123C25CC8525003B2796 /* StreamClientConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B73123325CC8523003B2796 /* StreamClientConnection.h */; };
 		7B73123E25CC8525003B2796 /* StreamConnectionWorkQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B73123525CC8524003B2796 /* StreamConnectionWorkQueue.h */; };
@@ -5826,6 +5827,7 @@
 		7B483F1C25CDDA9B00120486 /* MessageReceiveQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiveQueue.h; sourceTree = "<group>"; };
 		7B483F1D25CDDA9B00120486 /* MessageReceiveQueueMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MessageReceiveQueueMap.cpp; sourceTree = "<group>"; };
 		7B483F1E25CDDA9B00120486 /* MessageReceiveQueues.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiveQueues.h; sourceTree = "<group>"; };
+		7B4FAA73293E4AA800978827 /* TransferRegion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TransferRegion.h; sourceTree = "<group>"; };
 		7B50E97F2771F6CE003DAAC4 /* IPCTester.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPCTester.cpp; sourceTree = "<group>"; };
 		7B50E9802771F6CF003DAAC4 /* IPCTester.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCTester.h; sourceTree = "<group>"; };
 		7B5A3DA027A7DC1A006C6F97 /* RemoteVideoFrameIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteVideoFrameIdentifier.h; sourceTree = "<group>"; };
@@ -5835,6 +5837,7 @@
 		7B5A3DA827A7DCBC006C6F97 /* RemoteVideoFrameObjectHeap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteVideoFrameObjectHeap.cpp; sourceTree = "<group>"; };
 		7B5A3DC527AE501A006C6F97 /* ObjectIdentifierReferenceTracker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjectIdentifierReferenceTracker.h; sourceTree = "<group>"; };
 		7B64C0B6254C5C250006B4AF /* GraphicsContextGLIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GraphicsContextGLIdentifier.h; sourceTree = "<group>"; };
+		7B717E3C29409D3D003CD8EB /* TransferRegion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TransferRegion.cpp; sourceTree = "<group>"; };
 		7B73123125CC8523003B2796 /* StreamConnectionBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamConnectionBuffer.h; sourceTree = "<group>"; };
 		7B73123225CC8523003B2796 /* StreamConnectionWorkQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamConnectionWorkQueue.cpp; sourceTree = "<group>"; };
 		7B73123325CC8523003B2796 /* StreamClientConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamClientConnection.h; sourceTree = "<group>"; };
@@ -8810,6 +8813,8 @@
 				7B73123725CC8524003B2796 /* StreamServerConnection.cpp */,
 				7B73123825CC8524003B2796 /* StreamServerConnection.h */,
 				F48570A22644BEC400C05F71 /* Timeout.h */,
+				7B717E3C29409D3D003CD8EB /* TransferRegion.cpp */,
+				7B4FAA73293E4AA800978827 /* TransferRegion.h */,
 				7BDD9DDB28D205C6004CDF48 /* WorkQueueMessageReceiver.h */,
 			);
 			path = IPC;
@@ -15362,6 +15367,7 @@
 				1AF05D8714688348008B1E81 /* TiledCoreAnimationDrawingAreaProxy.h in Headers */,
 				F48570A32644BEC500C05F71 /* Timeout.h in Headers */,
 				2F8336861FA139DF00C6E080 /* TouchBarMenuData.h in Headers */,
+				7B4FAA74293E4AA800978827 /* TransferRegion.h in Headers */,
 				57EB2E3A21E1983E00B89CDF /* U2fAuthenticator.h in Headers */,
 				1AFE436618B6C081009C7A48 /* UIDelegate.h in Headers */,
 				515BE1B51D5917FF00DD7C68 /* UIGamepad.h in Headers */,

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -47,7 +47,7 @@ RemoteGPUProxy::RemoteGPUProxy(GPUProcessConnection& gpuProcessConnection, WebGP
     , m_convertToBackingContext(convertToBackingContext)
     , m_gpuProcessConnection(&gpuProcessConnection)
 {
-    auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(defaultStreamSize);
+    auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(defaultStreamSize, &gpuProcessConnection.connection());
     m_streamConnection = WTFMove(clientConnection);
     m_gpuProcessConnection->addClient(*this);
     m_gpuProcessConnection->connection().send(Messages::GPUConnectionToWebProcess::CreateRemoteGPU(identifier, renderingBackend, WTFMove(serverConnectionHandle)), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -455,6 +455,8 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters)
             WebCore::releaseMemory(critical, synchronous, maintainBackForwardCache, maintainMemoryCache);
             for (auto& page : m_pageMap.values())
                 page->releaseMemory(critical);
+            if (auto* gpuProcessConnection = existingGPUProcessConnection())
+                gpuProcessConnection->connection().releaseUnusedMemory();
         });
 #if ENABLE(PERIODIC_MEMORY_MONITOR)
         memoryPressureHandler.setShouldUsePeriodicMemoryMonitor(true);

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -115,7 +115,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {{
     void PaintCompositedResultsToVideoFrame() -> (std::optional<WebKit::RemoteVideoFrameProxy::Properties> properties) Synchronous
 #endif
     void SimulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting event)
-    void ReadnPixels0(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, IPC::ArrayReference<uint8_t> data) -> (IPC::ArrayReference<uint8_t> data) Synchronous
+    void ReadnPixels0(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, IPC::TransferBufferRegion) -> (bool hadError) Synchronous
     void ReadnPixels1(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, uint64_t offset)
     void MultiDrawArraysANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t> firstsAndCounts)
     void MultiDrawArraysInstancedANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t> firstsCountsAandInstanceCounts)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -560,6 +560,7 @@
 		7AEAD47F1E20116C00416EFE /* CrossPartitionFileSchemeAccess.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7AEAD47C1E20113800416EFE /* CrossPartitionFileSchemeAccess.mm */; };
 		7AEAD4811E20122700416EFE /* CrossPartitionFileSchemeAccess.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7AEAD47D1E20114E00416EFE /* CrossPartitionFileSchemeAccess.html */; };
 		7B18417C2673860200ED4F8D /* ImageBufferTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B18417B2673860200ED4F8D /* ImageBufferTests.cpp */; };
+		7B1F233D29478BAD00DF226C /* TransferRegionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B1F233529478BAD00DF226C /* TransferRegionTests.cpp */; };
 		7B2739F32632AB640040F182 /* ThreadAssertionsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B2739F22632AB640040F182 /* ThreadAssertionsTest.cpp */; };
 		7B397C0628BE0EAD00239202 /* ConnectionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */; };
 		7B397C0828BE394B00239202 /* UtilitiesCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C83E0391D0A602700FEBCF3 /* UtilitiesCocoa.mm */; };
@@ -2727,6 +2728,7 @@
 		7AEAD47C1E20113800416EFE /* CrossPartitionFileSchemeAccess.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CrossPartitionFileSchemeAccess.mm; sourceTree = "<group>"; };
 		7AEAD47D1E20114E00416EFE /* CrossPartitionFileSchemeAccess.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = CrossPartitionFileSchemeAccess.html; path = Tests/mac/CrossPartitionFileSchemeAccess.html; sourceTree = SOURCE_ROOT; };
 		7B18417B2673860200ED4F8D /* ImageBufferTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferTests.cpp; sourceTree = "<group>"; };
+		7B1F233529478BAD00DF226C /* TransferRegionTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TransferRegionTests.cpp; sourceTree = "<group>"; };
 		7B2739F22632AB640040F182 /* ThreadAssertionsTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadAssertionsTest.cpp; sourceTree = "<group>"; };
 		7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConnectionTests.cpp; sourceTree = "<group>"; };
 		7B7392E128F849EC007297FC /* MessageSenderTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MessageSenderTests.cpp; sourceTree = "<group>"; };
@@ -4412,6 +4414,7 @@
 				7B7392E128F849EC007297FC /* MessageSenderTests.cpp */,
 				7B9FC58328A26792007570E7 /* StreamConnectionBufferTests.cpp */,
 				7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */,
+				7B1F233529478BAD00DF226C /* TransferRegionTests.cpp */,
 			);
 			path = IPC;
 			sourceTree = "<group>";
@@ -5984,6 +5987,7 @@
 				7B9FC58428A26792007570E7 /* StreamConnectionBufferTests.cpp in Sources */,
 				7BAA4A9028CA14AE004CE938 /* StreamConnectionTests.cpp in Sources */,
 				7B9FC58C28A2717D007570E7 /* TestsController.cpp in Sources */,
+				7B1F233D29478BAD00DF226C /* TransferRegionTests.cpp in Sources */,
 				7B397C0828BE394B00239202 /* UtilitiesCocoa.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -171,8 +171,8 @@ public:
     void SetUp() override
     {
         WTF::initializeMainThread();
-        auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(10000);
-        auto serverConnection = IPC::StreamServerConnection::create(WTFMove(serverConnectionHandle), *m_workQueue);
+        auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(1000);
+        auto serverConnection = IPC::StreamServerConnection::create(WTFMove(serverConnectionHandle), *m_workQueue, nullptr);
         m_clientConnection = WTFMove(clientConnection);
         m_serverConnection = WTFMove(serverConnection);
     }

--- a/Tools/TestWebKitAPI/Tests/IPC/TransferRegionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/TransferRegionTests.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "IPCTestUtilities.h"
+#include "Test.h"
+#include <WebCore/ProcessIdentity.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/threads/BinarySemaphore.h>
+
+#define RUN_LOOP_NAME "RunLoop at TransferRegionTests.cpp:" STRINGIZE_VALUE_OF(__LINE__)
+namespace TestWebKitAPI {
+
+static constexpr Seconds kDefaultWaitForTimeout = 1_s;
+
+class MockSendTransferRegion {
+public:
+    using Arguments = std::tuple<IPC::TransferRegion>;
+    static IPC::MessageName name() { return IPC::MessageName::IPCTester_SendTransferRegion; }
+    static constexpr bool isSync = true;
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<>;
+    explicit MockSendTransferRegion(const IPC::TransferRegion& region)
+        : m_arguments(region)
+    {
+    }
+    const auto& arguments() const
+    {
+        return m_arguments;
+    }
+private:
+    std::tuple<const IPC::TransferRegion&> m_arguments;
+};
+
+class TransferRegionTest : public ConnectionTestABBA {
+};
+
+static size_t testBufferSize(size_t iteration)
+{
+    if (iteration < 5)
+        return static_cast<size_t>(iteration * 1.5f);
+    size_t rest = iteration % 2 ? -iteration : iteration;
+    if (iteration < 20)
+        return iteration * 2000 + rest;
+    if (iteration < 30)
+        return iteration * 30000 + rest;
+    if (iteration < 40)
+        return iteration * 500000 + rest;
+    return iteration * 7000000 + rest;
+}
+
+TEST_P(TransferRegionTest, SendSyncTransferRegion)
+{
+    auto cleanup = makeLocalReferenceBarrier();
+
+    ASSERT_TRUE(openA());
+    WebCore::ProcessIdentity resourceOwner;
+    bClient().setSyncMessageHandler([&] (IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder) -> bool {
+        auto region = decoder.decode<IPC::TransferRegion>();
+        if (!region)
+            return false;
+        auto mappedRegion = connection.mapTransferRegion(WTFMove(*region), resourceOwner);
+        if (!mappedRegion)
+            return false;
+        uint8_t value = static_cast<uint8_t>(decoder.destinationID());
+        for (auto& d : mappedRegion->data())
+            d = value++;
+        connection.sendSyncReply(WTFMove(encoder));
+        return true;
+    });
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    BinarySemaphore semaphore;
+    runLoop->dispatch([&] {
+        ASSERT_TRUE(openB());
+        bClient().waitForDidClose(kDefaultWaitForTimeout);
+        semaphore.signal();
+    });
+    for (uint64_t i = 0u; i < 1u; ++i) {
+        auto buffer = a()->reserveTransferRegion(testBufferSize(i));
+        ASSERT_TRUE(!!buffer);
+        auto data = buffer->data();
+        for (size_t j = 0u; j < 1; ++j) {
+            memset(data.data(), 0xee, data.size());
+            auto result = a()->sendSync(MockSendTransferRegion { buffer->passRegion() }, i);
+            ASSERT_TRUE(!!result);
+            uint8_t value = static_cast<uint8_t>(i);
+            for (size_t k = 0; k < data.size(); ++k)
+                EXPECT_EQ(value++, data[k]) << j << i;
+        }
+    }
+    a()->invalidate();
+    EXPECT_TRUE(semaphore.waitFor(kDefaultWaitForTimeout));
+}
+
+#undef RUN_LOOP_NAME
+
+INSTANTIATE_TEST_SUITE_P(ConnectionTest,
+    TransferRegionTest,
+    testing::Values(ConnectionTestDirection::ServerIsA, ConnectionTestDirection::ClientIsA),
+    TestParametersToStringFormatter());
+
+}


### PR DESCRIPTION
#### a6a0c539c8deaa15c333439371ee8046aade4189
<pre>
REGRESSION (iOS 16): WebGL 2 crashing on glReadPixels
<a href="https://bugs.webkit.org/show_bug.cgi?id=245476">https://bugs.webkit.org/show_bug.cgi?id=245476</a>
rdar://problem/100252324

Reviewed by NOBODY (OOPS!).

ReadPixels is currently a method that sends the client
passed data buffer to GPUP, reads the pixels into that
and passes the data back to WP.
  Conceptually message of form ReadPixels(uint8_t* data) -&gt; (uint8_t* data)

Before:
IPC encoding of memory arrays for calls like ReadPixels
would work as follows:
- If the array fits to the stream connection command buffer,
  copy the array there
- Alternatively downgrade the message to out-of-stream message.
  - Copy the array to the IPC::Encoder message body buffer.
  - Pass the message body as Mach message memory mapping.

IPC decoding of memory arrays for calls like ReadPixels
would work as follows:
- Allocate temp Vector for the data
- Copy the data from stream command buffer / Mach message memory
  mapping into the temp buffer
- Call ReadPixels
- Copy the temp Vector to IPC::Encoder message body buffer
  similar to the encoding phase, and send it back to WP.

This would have two problems:
 - Extensive copying is slow for very big buffers
 - The temp Vector and Mach message buffers via IPC encoding
   contribute to GPUP footprint.

   - The call IPC encoding buffer is not explicitly attributed to
     the caller. It&apos;s unclear to which process this belongs, likely
     this contributes to GPUP footprint.
   - The temp Vector is not attributed to the caller, contributing
     to GPUP footprint.
   - The reply IPC encoding buffer is not attributed to the caller,
     contributing to the GPUP footprint.
   - The ownership of the reply IPC encoding buffer, when passed as
     Mach message memory, is unclear. Likly this contributes to
     GPUP footprint. (Same as the encoding part).

After:
Introduce explicit per-target process shared memory buffers that can
be used to pass big memory areas. These are currently called IPC::TransferRegion
instances.

These managed transfer memory regions are a IPC connection primitive,
and as such the functionality is added directly to the Connection and
StreamClientConnection, StreamServerConnection implementations.
This adds a new IPC protocol message, ReleaseTransferBuffer.

For the first version, use following limitations:
 - Limited reuse: a free buffer can be reused, but only the full buffer (no subranges)
   Will be added once more adoption prompts it.

 - No synchronization: supports only synchronous messages.
   Will be added once stream connections support fast sync points.

IPC::Connection and IPC::StreamClientConnection instances can share the
same IPC::TransferRegionPool, which is used to allocate new memory regions
to be sent to the target process.

IPC::TransferRegionMapper can be used to receive the memory regions.

When the memory region is sent the first time, it is contains the
necessary handles to map the shared memory in the target process.
When the memory region is reused, it is referred to by an identifier.
This means that reused regions are fast to send via stream IPC.

Unused transfer regions will be freed from the sender after timeout,
currently 5s, and a message will be sent to the receiver to unmap
the region.

This functionality will be used in other places that currently
implement domain-specific variant of this logic, such as in
 - Other places in WebGL that pass client-side buffers
 - RemoteRenderingBackendProxy::getPixelBuffer
 - SharedVideoFrameWriter
 - Other generic IPC code that uses SharedMemory without adoption

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::RemoteGraphicsContextGL):
(WebKit::RemoteGraphicsContextGL::readnPixels0):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp:
(WebKit::RemoteGraphicsContextGLCocoa::RemoteGraphicsContextGLCocoa):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::RemoteRenderingBackend):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::RemoteGPU):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::Connection):
(IPC::Connection::invalidate):
(IPC::Connection::processIncomingMessage):
(IPC::Connection::addToTransferRegionGroup):
(IPC::Connection::reserveTransferRegion):
(IPC::Connection::mapTransferRegion):
(IPC::Connection::releaseUnusedMemory):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::create):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
* Source/WebKit/Platform/IPC/StreamConnectionEncoder.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::create):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Platform/IPC/TransferRegion.cpp: Added.
(IPC::TransferRegionPool::TransferRegionPool):
(IPC::TransferRegionPool::invalidate):
(IPC::TransferRegionPool::reserveRegion):
(IPC::TransferRegionPool::releaseTransferBuffer):
(IPC::TransferRegionPool::scheduleReleaseUnusedMemory):
(IPC::TransferRegionPool::unscheduleReleaseUnusedMemory):
(IPC::TransferRegionPool::releaseUnusedMemory):
(IPC::TransferRegionMapper::mapRegion):
(IPC::TransferRegionMapper::releaseBufferMapping):
(IPC::TransferRegionMapper::invalidate):
* Source/WebKit/Platform/IPC/TransferRegion.h: Added.
(IPC::TransferBuffer::create):
(IPC::TransferBuffer::identifier const):
(IPC::TransferBuffer::passHandle):
(IPC::TransferBuffer::data):
(IPC::TransferBuffer::size const):
(IPC::TransferBuffer::hasBeenPassed const):
(IPC::TransferBuffer::TransferBuffer):
(IPC::ScopedTransferRegionMapping::ScopedTransferRegionMapping):
(IPC::ScopedTransferRegionMapping::data const):
(IPC::ScopedTransferRegion::ScopedTransferRegion):
(IPC::ScopedTransferRegion::~ScopedTransferRegion):
(IPC::ScopedTransferRegion::passRegion):
(IPC::ScopedTransferRegion::data):
(IPC::TransferRegion::decode):
(IPC::TransferRegion::encode const):
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::createConnectionIdentifierPair):
* Source/WebKit/Platform/SharedMemory.cpp:
(WebKit::SharedMemory::Handle::encode const):
* Source/WebKit/Platform/SharedMemory.h:
* Source/WebKit/Platform/Sources.txt:
* Source/WebKit/Platform/unix/SharedMemoryUnix.cpp:
(WebKit::SharedMemory::Handle::decode): Deleted.
* Source/WebKit/Scripts/webkit/model.py:
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::create):
(WebKit::IPCStreamTester::IPCStreamTester):
* Source/WebKit/Shared/IPCStreamTester.h:
* Source/WebKit/Shared/IPCTester.cpp:
(WebKit::IPCTester::createStreamTester):
(WebKit::IPCTester::sendTransferRegion):
* Source/WebKit/Shared/IPCTester.h:
* Source/WebKit/Shared/IPCTester.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::RemoteGraphicsContextGLProxy):
(WebKit::RemoteGraphicsContextGLProxy::readnPixels):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::RemoteGPUProxy):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
* Tools/Scripts/generate-gpup-webgl:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
(TestWebKitAPI::dispatchSync): Deleted.
(TestWebKitAPI::dispatchAndWait): Deleted.
(TestWebKitAPI::ConnectionRunLoopTest::createRunLoop): Deleted.
(TestWebKitAPI::ConnectionRunLoopTest::localReferenceBarrier): Deleted.
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.cpp:
(TestWebKitAPI::ConnectionTestBase::teardownBase):
(TestWebKitAPI::ConnectionTestBase::createRunLoop):
(TestWebKitAPI::ConnectionTestBase::localReferenceBarrier):
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:
(TestWebKitAPI::ConnectionTestBase::makeLocalReferenceBarrier):
(TestWebKitAPI::dispatchSync):
(TestWebKitAPI::dispatchAndWait):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
* Tools/TestWebKitAPI/Tests/IPC/TransferRegionTests.cpp: Added.
(TestWebKitAPI::MockSendTransferRegion::name):
(TestWebKitAPI::MockSendTransferRegion::MockSendTransferRegion):
(TestWebKitAPI::MockSendTransferRegion::arguments const):
(TestWebKitAPI::testBufferSize):
(TestWebKitAPI::TEST_P):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6a0c539c8deaa15c333439371ee8046aade4189

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33892 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110148 "Hash a6a0c539 for PR 7688 does not build (failure)") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170422 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/890 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93256 "Hash a6a0c539 for PR 7688 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107993 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8256 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91518 "Found 2 new API test failures: TestIPC.StreamConnectionTest.SendAsyncReplyMessageCancel, TestIPC.StreamConnectionTest.SendAsyncReplyMessage (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/93256 "Hash a6a0c539 for PR 7688 does not build (failure)") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/104369 "Found 1 webkitpy python3 test failure: webkit.messages_unittest.GeneratedFileContentsTest.test_message_names") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90165 "Found 2 new API test failures: TestIPC.StreamConnectionTest.SendAsyncReplyMessageCancel, TestIPC.StreamConnectionTest.SendAsyncReplyMessage (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22914 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/93256 "Hash a6a0c539 for PR 7688 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3685 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24433 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/852 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43933 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5482 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->