### PR TITLE
[web-animations] add tests to see that an animated CSS variable is accounted for when used in standard properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-inherited-used-by-standard-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-inherited-used-by-standard-property-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Animating an inherited CSS variable on a parent is reflected on a standard property using that variable as a value on a child
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-inherited-used-by-standard-property.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-inherited-used-by-standard-property.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="container">
+    <div id="target"></div>
+</div>
+<script>
+
+test(() => {
+  CSS.registerProperty({
+    name: "--my-length",
+    syntax: "<length>",
+    inherits: true,
+    initialValue: "0px"
+  });
+
+  target.style.marginLeft = "var(--my-length)";
+
+  const duration = 1000;
+  const animation = container.animate({ "--my-length": "100px" }, duration);
+  animation.pause();
+  animation.currentTime = duration / 4;
+
+  assert_equals(getComputedStyle(target).marginLeft, "25px");
+}, "Animating an inherited CSS variable on a parent is reflected on a standard property using that variable as a value on a child");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Animating a non-inherited CSS variable is reflected on a standard property using that variable as a value assert_equals: expected "25px" but got "0px"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+test(() => {
+  CSS.registerProperty({
+    name: "--my-length",
+    syntax: "<length>",
+    inherits: false,
+    initialValue: "0px"
+  });
+
+  target.style.marginLeft = "var(--my-length)";
+
+  const duration = 1000;
+  const animation = target.animate({ "--my-length": "100px" }, duration);
+  animation.pause();
+  animation.currentTime = duration / 4;
+
+  assert_equals(getComputedStyle(target).marginLeft, "25px");
+}, "Animating a non-inherited CSS variable is reflected on a standard property using that variable as a value");
+
+</script>


### PR DESCRIPTION
#### fa664e0f3367f2a8f5e09250bf795b813927c91d
<pre>
[web-animations] add tests to see that an animated CSS variable is accounted for when used in standard properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=249396">https://bugs.webkit.org/show_bug.cgi?id=249396</a>

Reviewed by Antti Koivisto.

So far all of the tests we have for interpolation of CSS variables have been looking at whether
the CSS variable itself is correctly interpolated. In practice, it&apos;s important to test that an
interpolated value is picked up by other standard CSS properties that use that CSS variable.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-inherited-used-by-standard-property-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-inherited-used-by-standard-property.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property.html: Added.

Canonical link: <a href="https://commits.webkit.org/257924@main">https://commits.webkit.org/257924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b806bf34330250bd9eeff64b6cd051461894a0c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9585 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/33487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/109737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/158 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92826 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106202 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/33487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/33487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/33487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/3313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/33487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2823 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->