### PR TITLE
RunLoop::Timer should use constructor templates instead of class templates

### DIFF
--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.cpp
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.cpp
@@ -40,7 +40,7 @@ namespace JSC {
 
 JSRunLoopTimer::Manager::PerVMData::PerVMData(Manager& manager, RunLoop& runLoop)
     : runLoop(runLoop)
-    , timer(makeUnique<RunLoop::Timer<Manager>>(runLoop, &manager, &JSRunLoopTimer::Manager::timerDidFireCallback))
+    , timer(makeUnique<RunLoop::Timer>(runLoop, &manager, &JSRunLoopTimer::Manager::timerDidFireCallback))
 {
 #if USE(GLIB_EVENT_LOOP)
     timer->setPriority(RunLoopSourcePriority::JavascriptTimer);

--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
@@ -72,7 +72,7 @@ public:
             ~PerVMData();
 
             Ref<WTF::RunLoop> runLoop;
-            std::unique_ptr<RunLoop::Timer<Manager>> timer;
+            std::unique_ptr<RunLoop::Timer> timer;
             Vector<std::pair<Ref<JSRunLoopTimer>, MonotonicTime>> timers;
         };
 

--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -85,7 +85,7 @@ void MemoryPressureHandler::setShouldUsePeriodicMemoryMonitor(bool use)
     }
 
     if (use) {
-        m_measurementTimer = makeUnique<RunLoop::Timer<MemoryPressureHandler>>(RunLoop::main(), this, &MemoryPressureHandler::measurementTimerFired);
+        m_measurementTimer = makeUnique<RunLoop::Timer>(RunLoop::main(), this, &MemoryPressureHandler::measurementTimerFired);
         m_measurementTimer->startRepeating(m_configuration.pollInterval);
     } else
         m_measurementTimer = nullptr;

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -261,7 +261,7 @@ private:
     
     MemoryUsagePolicy m_memoryUsagePolicy { MemoryUsagePolicy::Unrestricted };
 
-    std::unique_ptr<RunLoop::Timer<MemoryPressureHandler>> m_measurementTimer;
+    std::unique_ptr<RunLoop::Timer>m_measurementTimer;
     WTF::Function<void()> m_memoryKillCallback;
     WTF::Function<void(MemoryPressureStatus)> m_memoryPressureStatusChangedCallback;
     LowMemoryHandler m_lowMemoryHandler;
@@ -270,12 +270,12 @@ private:
 
 #if OS(WINDOWS)
     void windowsMeasurementTimerFired();
-    RunLoop::Timer<MemoryPressureHandler> m_windowsMeasurementTimer;
+    RunLoop::Timer m_windowsMeasurementTimer;
     Win32Handle m_lowMemoryHandle;
 #endif
 
 #if OS(LINUX) || OS(FREEBSD)
-    RunLoop::Timer<MemoryPressureHandler> m_holdOffTimer;
+    RunLoop::Timer m_holdOffTimer;
     void holdOffTimerFired();
 #endif
 

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -176,15 +176,12 @@ public:
 #endif
     };
 
-    template <typename TimerFiredClass>
     class Timer : public TimerBase {
         WTF_MAKE_FAST_ALLOCATED;
     public:
-        typedef void (TimerFiredClass::*TimerFiredFunction)();
-
-        Timer(RunLoop& runLoop, TimerFiredClass* o, TimerFiredFunction f)
-            : TimerBase(runLoop)
-            , m_function(std::bind(f, o))
+        template <typename TimerFiredClass>
+        Timer(RunLoop& runLoop, TimerFiredClass* o, void (TimerFiredClass::*f)())
+            : Timer(runLoop, std::bind(f, o))
         {
         }
 

--- a/Source/WTF/wtf/generic/RunLoopGeneric.cpp
+++ b/Source/WTF/wtf/generic/RunLoopGeneric.cpp
@@ -177,10 +177,10 @@ void RunLoop::runImpl(RunMode runMode)
     ASSERT(this == &RunLoop::current());
 
     if constexpr (report) {
-        static NeverDestroyed<DispatchTimer> reporter { *this };
+        static LazyNeverDestroyed<Timer> reporter;
         static std::once_flag onceKey;
         std::call_once(onceKey, [&] {
-            reporter->setFunction([this] {
+            reporter.construct(*this, [this] {
                 unsigned count = 0;
                 unsigned active = 0;
                 for (auto task = m_schedules.first(); task; task = task->successor()) {

--- a/Source/WTF/wtf/linux/RealTimeThreads.h
+++ b/Source/WTF/wtf/linux/RealTimeThreads.h
@@ -59,7 +59,7 @@ private:
     bool m_enabled { true };
 #if USE(GLIB)
     std::optional<GRefPtr<GDBusProxy>> m_realTimeKitProxy;
-    RunLoop::Timer<RealTimeThreads> m_discardRealTimeKitProxyTimer;
+    RunLoop::Timer m_discardRealTimeKitProxyTimer;
 #endif
 };
 

--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.h
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.h
@@ -103,8 +103,8 @@ private:
 
     WebMediaSessionLogger& logger();
 
-    RunLoop::Timer<WebMediaSessionManager> m_taskTimer;
-    RunLoop::Timer<WebMediaSessionManager> m_watchdogTimer;
+    RunLoop::Timer m_taskTimer;
+    RunLoop::Timer m_watchdogTimer;
 
     Vector<std::unique_ptr<ClientState>> m_clientState;
     RefPtr<MediaPlaybackTarget> m_playbackTarget;

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -124,7 +124,7 @@ private:
     };
     bool computeUserGesturePriviledge(GestureAllowedRequest);
 
-    RunLoop::Timer<MediaDevices> m_scheduledEventTimer;
+    RunLoop::Timer m_scheduledEventTimer;
     UserMediaClient::DeviceChangeObserverToken m_deviceChangeToken;
     const EventNames& m_eventNames; // Need to cache this so we can use it from GC threads.
     bool m_listeningForDeviceChanges { false };

--- a/Source/WebCore/PAL/pal/HysteresisActivity.h
+++ b/Source/WebCore/PAL/pal/HysteresisActivity.h
@@ -92,7 +92,7 @@ private:
     Function<void(HysteresisState)> m_callback;
     Seconds m_hysteresisSeconds;
     bool m_active;
-    RunLoop::Timer<HysteresisActivity> m_timer;
+    RunLoop::Timer m_timer;
 };
 
 } // namespace PAL

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
@@ -135,8 +135,8 @@ private:
     unsigned m_cacheID { 0 };
     HashMap<String, AccessibilityObjectAtspi*> m_cache;
     ListHashSet<RefPtr<AccessibilityObjectAtspi>> m_cacheUpdateList;
-    RunLoop::Timer<AccessibilityAtspi> m_cacheUpdateTimer;
-    RunLoop::Timer<AccessibilityAtspi> m_cacheClearTimer;
+    RunLoop::Timer m_cacheUpdateTimer;
+    RunLoop::Timer m_cacheClearTimer;
 #if ENABLE(DEVELOPER_MODE)
     HashMap<void*, NotificationObserver> m_notificationObservers;
 #endif

--- a/Source/WebCore/inspector/agents/WebHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.cpp
@@ -53,7 +53,7 @@ private:
     WebHeapAgent& m_agent;
     Lock m_collectionsLock;
     Vector<GarbageCollectionData> m_collections WTF_GUARDED_BY_LOCK(m_collectionsLock);
-    RunLoop::Timer<SendGarbageCollectionEventsTask> m_timer;
+    RunLoop::Timer m_timer;
 };
 
 SendGarbageCollectionEventsTask::SendGarbageCollectionEventsTask(WebHeapAgent& agent)

--- a/Source/WebCore/page/mac/TextIndicatorWindow.h
+++ b/Source/WebCore/page/mac/TextIndicatorWindow.h
@@ -62,7 +62,7 @@ private:
     RetainPtr<NSView> m_textIndicatorView;
     RetainPtr<WebTextIndicatorLayer> m_textIndicatorLayer;
 
-    RunLoop::Timer<TextIndicatorWindow> m_temporaryTextIndicatorTimer;
+    RunLoop::Timer m_temporaryTextIndicatorTimer;
 };
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -469,7 +469,7 @@ void ThreadedScrollingTree::scheduleDelayedRenderingUpdateDetectionTimer(Seconds
     ASSERT(m_treeLock.isLocked());
 
     if (!m_delayedRenderingUpdateDetectionTimer)
-        m_delayedRenderingUpdateDetectionTimer = makeUnique<RunLoop::Timer<ThreadedScrollingTree>>(RunLoop::current(), this, &ThreadedScrollingTree::delayedRenderingUpdateDetectionTimerFired);
+        m_delayedRenderingUpdateDetectionTimer = makeUnique<RunLoop::Timer>(RunLoop::current(), this, &ThreadedScrollingTree::delayedRenderingUpdateDetectionTimerFired);
 
     m_delayedRenderingUpdateDetectionTimer->startOneShot(delay);
 }

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
@@ -135,7 +135,7 @@ private:
     MonotonicTime m_lastDisplayDidRefreshTime;
 
     // Dynamically allocated because it has to use the ScrollingThread's runloop.
-    std::unique_ptr<RunLoop::Timer<ThreadedScrollingTree>> m_delayedRenderingUpdateDetectionTimer WTF_GUARDED_BY_LOCK(m_treeLock);
+    std::unique_ptr<RunLoop::Timer> m_delayedRenderingUpdateDetectionTimer WTF_GUARDED_BY_LOCK(m_treeLock);
 
     HashMap<ScrollingNodeID, RequestedScrollData> m_nodesWithPendingScrollAnimations WTF_GUARDED_BY_LOCK(m_treeLock);
     const bool m_scrollAnimatorEnabled { false };

--- a/Source/WebCore/platform/MainThreadSharedTimer.h
+++ b/Source/WebCore/platform/MainThreadSharedTimer.h
@@ -57,7 +57,7 @@ private:
 
     Function<void()> m_firedFunction;
 #if !USE(CF) && !OS(WINDOWS)
-    RunLoop::Timer<MainThreadSharedTimer> m_timer;
+    RunLoop::Timer m_timer;
 #endif
 };
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -132,7 +132,7 @@ private:
     AudioHardwareListener::BufferSizeRange m_supportedAudioHardwareBufferSizes;
     size_t m_defaultBufferSize;
 
-    RunLoop::Timer<MediaSessionManagerCocoa> m_delayCategoryChangeTimer;
+    RunLoop::Timer m_delayCategoryChangeTimer;
     AudioSession::CategoryType m_previousCategory { AudioSession::CategoryType::None };
     bool m_previousHadAudibleAudioOrVideoMediaType { false };
 };

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
@@ -86,7 +86,7 @@ private:
     RetainPtr<NSObject> m_connectObserver;
     RetainPtr<NSObject> m_disconnectObserver;
 
-    RunLoop::Timer<GameControllerGamepadProvider> m_inputNotificationTimer;
+    RunLoop::Timer m_inputNotificationTimer;
     bool m_shouldMakeInvisibleGamepadsVisible { false };
 };
 

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
@@ -77,8 +77,8 @@ private:
     std::unique_ptr<struct wpe_gamepad_provider, void (*)(struct wpe_gamepad_provider*)> m_provider;
     struct wpe_gamepad* m_lastActiveGamepad { nullptr };
 
-    RunLoop::Timer<GamepadProviderLibWPE> m_initialGamepadsConnectedTimer;
-    RunLoop::Timer<GamepadProviderLibWPE> m_inputNotificationTimer;
+    RunLoop::Timer m_initialGamepadsConnectedTimer;
+    RunLoop::Timer m_inputNotificationTimer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
@@ -70,8 +70,8 @@ private:
     bool m_initialGamepadsConnected { false };
 
     GRefPtr<ManetteMonitor> m_monitor;
-    RunLoop::Timer<ManetteGamepadProvider> m_initialGamepadsConnectedTimer;
-    RunLoop::Timer<ManetteGamepadProvider> m_inputNotificationTimer;
+    RunLoop::Timer m_initialGamepadsConnectedTimer;
+    RunLoop::Timer m_inputNotificationTimer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetPicker.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetPicker.h
@@ -81,7 +81,7 @@ private:
 
     PendingActionFlags m_pendingActionFlags { 0 };
     Client* m_client;
-    RunLoop::Timer<MediaPlaybackTargetPicker> m_pendingActionTimer;
+    RunLoop::Timer m_pendingActionTimer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ShadowBlur.cpp
+++ b/Source/WebCore/platform/graphics/ShadowBlur.cpp
@@ -152,7 +152,7 @@ private:
     static Lock s_lock;
 
     RefPtr<ImageBuffer> m_imageBuffer;
-    RunLoop::Timer<ScratchBuffer> m_purgeTimer;
+    RunLoop::Timer m_purgeTimer;
 
     FloatRect m_lastInsetBounds;
     FloatRect m_lastShadowRect;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2801,7 +2801,7 @@ void MediaPlayerPrivateAVFoundationObjC::waitForVideoOutputMediaDataWillChange()
     // Wait for 1 second.
     MonotonicTime start = MonotonicTime::now();
 
-    std::optional<RunLoop::Timer<MediaPlayerPrivateAVFoundationObjC>> timeoutTimer;
+    std::optional<RunLoop::Timer> timeoutTimer;
 
     if (!m_runLoopNestingLevel) {
         m_waitForVideoOutputMediaDataWillChangeObserver = WTF::makeUnique<Observer<void()>>([this, logIdentifier = LOGIDENTIFIER] () mutable {

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
@@ -108,7 +108,7 @@ private:
     String poolStatistics() const WTF_REQUIRES_LOCK(m_lock);
 
     Lock m_lock;
-    RunLoop::Timer<IOSurfacePool> m_collectionTimer WTF_GUARDED_BY_LOCK(m_lock);
+    RunLoop::Timer m_collectionTimer WTF_GUARDED_BY_LOCK(m_lock);
     CachedSurfaceMap m_cachedSurfaces WTF_GUARDED_BY_LOCK(m_lock);
     CachedSurfaceQueue m_inUseSurfaces WTF_GUARDED_BY_LOCK(m_lock);
     CachedSurfaceDetailsMap m_surfaceDetails WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/WebCore/platform/graphics/cg/SubimageCacheWithTimer.h
+++ b/Source/WebCore/platform/graphics/cg/SubimageCacheWithTimer.h
@@ -100,7 +100,7 @@ private:
     Lock m_lock;
     HashCountedSet<CGImageRef> m_imageCounts WTF_GUARDED_BY_LOCK(m_lock);
     SubimageCacheHashSet m_cache WTF_GUARDED_BY_LOCK(m_lock);
-    RunLoop::Timer<SubimageCacheWithTimer> m_timer WTF_GUARDED_BY_LOCK(m_lock);
+    RunLoop::Timer m_timer WTF_GUARDED_BY_LOCK(m_lock);
 
     static SubimageCacheWithTimer& subimageCache();
     static bool subimageCacheExists();

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -527,8 +527,8 @@ private:
     bool m_hasAudio { false };
     Condition m_drawCondition;
     Lock m_drawLock;
-    RunLoop::Timer<MediaPlayerPrivateGStreamer> m_drawTimer WTF_GUARDED_BY_LOCK(m_drawLock);
-    RunLoop::Timer<MediaPlayerPrivateGStreamer> m_readyTimerHandler;
+    RunLoop::Timer m_drawTimer WTF_GUARDED_BY_LOCK(m_drawLock);
+    RunLoop::Timer m_readyTimerHandler;
 #if USE(TEXTURE_MAPPER_GL)
 #if USE(NICOSIA)
     RefPtr<Nicosia::ContentLayer> m_nicosiaLayer;

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
@@ -109,7 +109,7 @@ private:
 
     MediaPlayer* m_player;
     IntSize m_size;
-    RunLoop::Timer<MediaPlayerPrivateHolePunch> m_readyTimer;
+    RunLoop::Timer m_readyTimer;
     MediaPlayer::NetworkState m_networkState;
 #if USE(TEXTURE_MAPPER_GL)
 #if USE(NICOSIA)

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
@@ -67,7 +67,7 @@ private:
 #endif
 
     Vector<Entry> m_textures;
-    RunLoop::Timer<BitmapTexturePool> m_releaseUnusedTexturesTimer;
+    RunLoop::Timer m_releaseUnusedTexturesTimer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp
@@ -72,8 +72,8 @@ void TextureMapperPlatformLayerProxyGL::activateOnCompositingThread(Compositor* 
         if (m_targetLayer && m_currentBuffer)
             m_targetLayer->setContentsLayer(m_currentBuffer.get());
 
-        m_releaseUnusedBuffersTimer = makeUnique<RunLoop::Timer<TextureMapperPlatformLayerProxyGL>>(RunLoop::current(), this, &TextureMapperPlatformLayerProxyGL::releaseUnusedBuffersTimerFired);
-        m_compositorThreadUpdateTimer = makeUnique<RunLoop::Timer<TextureMapperPlatformLayerProxyGL>>(RunLoop::current(), this, &TextureMapperPlatformLayerProxyGL::compositorThreadUpdateTimerFired);
+        m_releaseUnusedBuffersTimer = makeUnique<RunLoop::Timer>(RunLoop::current(), this, &TextureMapperPlatformLayerProxyGL::releaseUnusedBuffersTimerFired);
+        m_compositorThreadUpdateTimer = makeUnique<RunLoop::Timer>(RunLoop::current(), this, &TextureMapperPlatformLayerProxyGL::compositorThreadUpdateTimerFired);
 
 #if USE(GLIB_EVENT_LOOP)
         m_compositorThreadUpdateTimer->setPriority(RunLoopSourcePriority::CompositingThreadUpdateTimer);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.h
@@ -73,14 +73,14 @@ private:
     bool m_wasBufferDropped WTF_GUARDED_BY_LOCK(m_wasBufferDroppedLock) { false };
 
     Vector<std::unique_ptr<TextureMapperPlatformLayerBuffer>> m_usedBuffers;
-    std::unique_ptr<RunLoop::Timer<TextureMapperPlatformLayerProxyGL>> m_releaseUnusedBuffersTimer;
+    std::unique_ptr<RunLoop::Timer> m_releaseUnusedBuffersTimer;
 
 #if ASSERT_ENABLED
     RefPtr<Thread> m_compositorThread;
 #endif
 
     void compositorThreadUpdateTimerFired();
-    std::unique_ptr<RunLoop::Timer<TextureMapperPlatformLayerProxyGL>> m_compositorThreadUpdateTimer;
+    std::unique_ptr<RunLoop::Timer> m_compositorThreadUpdateTimer;
     Function<void()> m_compositorThreadUpdateFunction;
 };
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -234,7 +234,7 @@ private:
     RefPtr<NativeImage> m_compositedNativeImage;
 
     Timer m_animationStartedTimer;
-    RunLoop::Timer<CoordinatedGraphicsLayer> m_requestPendingTileCreationTimer;
+    RunLoop::Timer m_requestPendingTileCreationTimer;
     Nicosia::Animations m_animations;
     MonotonicTime m_lastAnimationStartTime;
 

--- a/Source/WebCore/platform/graphics/win/DisplayRefreshMonitorWin.h
+++ b/Source/WebCore/platform/graphics/win/DisplayRefreshMonitorWin.h
@@ -42,7 +42,7 @@ private:
     
     void displayLinkCallbackFired();
 
-    RunLoop::Timer<DisplayRefreshMonitorWin> m_timer;
+    RunLoop::Timer m_timer;
     DisplayUpdate m_currentUpdate;
 };
 

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h
@@ -193,7 +193,7 @@ protected:
     RetainPtr<UIWindow> m_parentWindow;
     RetainPtr<WebAVPlayerLayerView> m_playerLayerView;
     Function<void(bool)> m_prepareToInlineCallback;
-    RunLoop::Timer<VideoFullscreenInterfaceAVKit> m_watchdogTimer;
+    RunLoop::Timer m_watchdogTimer;
     FloatRect m_inlineRect;
     RouteSharingPolicy m_routeSharingPolicy { RouteSharingPolicy::Default };
     String m_routingContextUID;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -129,7 +129,7 @@ private:
 
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;
 
-    RunLoop::Timer<RealtimeMediaSourceCenter> m_debounceTimer;
+    RunLoop::Timer m_debounceTimer;
     void triggerDevicesChangedObservers();
 
     WeakHashSet<Observer> m_observers;

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -152,7 +152,7 @@ private:
     MonotonicTime m_startTime { MonotonicTime::nan() };
     Seconds m_elapsedTime { 0_s };
 
-    RunLoop::Timer<DisplayCaptureSourceCocoa> m_timer;
+    RunLoop::Timer m_timer;
     UserActivity m_userActivity;
 
     std::unique_ptr<ImageTransferSessionVT> m_imageTransferSession;

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -150,7 +150,7 @@ private:
     bool m_hasAudioUnit { false };
     Ref<MockAudioSharedInternalUnitState> m_internalState;
     bool m_enableEchoCancellation { true };
-    RunLoop::Timer<MockAudioSharedInternalUnit> m_timer;
+    RunLoop::Timer m_timer;
     MonotonicTime m_lastRenderTime { MonotonicTime::nan() };
     MonotonicTime m_delayUntil;
 

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
@@ -66,7 +66,7 @@ private:
     Vector<RetainPtr<SCContentSharingSession>> m_pendingCaptureSessions;
     RetainPtr<WebDisplayMediaPromptHelper> m_promptHelper;
     CompletionHandler<void(std::optional<CaptureDevice>)> m_completionHandler;
-    std::unique_ptr<RunLoop::Timer<ScreenCaptureKitSharingSessionManager>> m_promptWatchdogTimer;
+    std::unique_ptr<RunLoop::Timer> m_promptWatchdogTimer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
@@ -285,7 +285,7 @@ void ScreenCaptureKitSharingSessionManager::promptForGetDisplayMedia(PromptType 
     [session showPickerForType:promptType == PromptType::Window ? SCContentFilterTypeDesktopIndependentWindow : SCContentFilterTypeDisplay];
 
     constexpr Seconds userPromptWatchdogInterval = 60_s;
-    m_promptWatchdogTimer = makeUnique<RunLoop::Timer<ScreenCaptureKitSharingSessionManager>>(RunLoop::main(), [this, weakThis = WeakPtr { *this }, session = RetainPtr { session }, interval = userPromptWatchdogInterval]() mutable {
+    m_promptWatchdogTimer = makeUnique<RunLoop::Timer>(RunLoop::main(), [this, weakThis = WeakPtr { *this }, session = RetainPtr { session }, interval = userPromptWatchdogInterval]() mutable {
         if (!weakThis)
             return;
 

--- a/Source/WebCore/platform/mock/MockAudioDestinationCocoa.h
+++ b/Source/WebCore/platform/mock/MockAudioDestinationCocoa.h
@@ -53,7 +53,7 @@ private:
     void tick();
 
     Ref<WorkQueue> m_workQueue;
-    RunLoop::Timer<MockAudioDestinationCocoa> m_timer;
+    RunLoop::Timer m_timer;
     size_t m_numberOfFramesToProcess { 384 };
 };
 

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.h
@@ -81,7 +81,7 @@ private:
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;
 
-    RunLoop::Timer<MockRealtimeAudioSource> m_timer;
+    RunLoop::Timer m_timer;
     MonotonicTime m_startTime { MonotonicTime::nan() };
     MonotonicTime m_lastRenderTime { MonotonicTime::nan() };
     Seconds m_elapsedTime { 0_s };

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -115,7 +115,7 @@ private:
     MonotonicTime m_delayUntil;
 
     unsigned m_frameNumber { 0 };
-    RunLoop::Timer<MockRealtimeVideoSource> m_emitFrameTimer;
+    RunLoop::Timer m_emitFrameTimer;
     std::optional<RealtimeMediaSourceCapabilities> m_capabilities;
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -376,7 +376,7 @@ private:
     WeakPtr<RemoteMediaPlayerManagerProxy> m_manager;
     WebCore::MediaPlayerEnums::MediaEngineIdentifier m_engineIdentifier;
     Vector<WebCore::ContentType> m_typesRequiringHardwareSupport;
-    RunLoop::Timer<RemoteMediaPlayerProxy> m_updateCachedStateMessageTimer;
+    RunLoop::Timer m_updateCachedStateMessageTimer;
     RemoteMediaPlayerState m_cachedState;
     RemoteMediaPlayerProxyConfiguration m_configuration;
     PerformTaskAtMediaTimeCompletionHandler m_performTaskAtMediaTimeCompletionHandler;

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -269,7 +269,7 @@ private:
     Ref<SuspendableWorkQueue> m_statisticsQueue;
     std::unique_ptr<ResourceLoadStatisticsStore> m_statisticsStore;
 
-    RunLoop::Timer<WebResourceLoadStatisticsStore> m_dailyTasksTimer;
+    RunLoop::Timer m_dailyTasksTimer;
 
     WebCore::ResourceLoadStatistics::IsEphemeral m_isEphemeral { WebCore::ResourceLoadStatistics::IsEphemeral::No };
     HashSet<RegistrableDomain> m_domainsWithEphemeralUserInteraction;

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h
@@ -88,7 +88,7 @@ private:
     bool debugModeEnabled() const;
     Seconds randomlyBetweenFifteenAndThirtyMinutes() const;
 
-    RunLoop::Timer<PrivateClickMeasurementManager> m_firePendingAttributionRequestsTimer;
+    RunLoop::Timer m_firePendingAttributionRequestsTimer;
     bool m_isRunningTest { false };
     std::optional<URL> m_tokenPublicKeyURLForTesting;
     std::optional<URL> m_tokenSignatureURLForTesting;

--- a/Source/WebKit/NetworkProcess/glib/DNSCache.h
+++ b/Source/WebKit/NetworkProcess/glib/DNSCache.h
@@ -66,7 +66,7 @@ private:
     DNSCacheMap m_ipv4Map;
     DNSCacheMap m_ipv6Map;
 #endif
-    RunLoop::Timer<DNSCache> m_expiredTimer;
+    RunLoop::Timer m_expiredTimer;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h
@@ -209,7 +209,7 @@ private:
     WebCore::NetworkLoadMetrics m_networkLoadMetrics;
     bool m_isBlockingCookies { false };
     RefPtr<WebCore::SecurityOrigin> m_sourceOrigin;
-    RunLoop::Timer<NetworkDataTaskSoup> m_timeoutSource;
+    RunLoop::Timer m_timeoutSource;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.h
@@ -70,7 +70,7 @@ private:
     bool m_receivedDidFail { false };
     bool m_receivedDidClose { false };
     String m_delayErrorMessage;
-    RunLoop::Timer<WebSocketTask> m_delayFailTimer;
+    RunLoop::Timer m_delayFailTimer;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h
@@ -71,7 +71,7 @@ private:
     void updateTimerFired();
 
     Ref<RunLoop> m_runLoop;
-    RunLoop::Timer<CompositingRunLoop> m_updateTimer;
+    RunLoop::Timer m_updateTimer;
     Function<void ()> m_updateFunction;
     Lock m_dispatchSyncConditionLock;
     Condition m_dispatchSyncCondition;

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.h
@@ -63,7 +63,7 @@ private:
     void stopNotificationMechanism() final { }
 
     void displayRefreshCallback();
-    RunLoop::Timer<ThreadedDisplayRefreshMonitor> m_displayRefreshTimer;
+    RunLoop::Timer m_displayRefreshTimer;
     Client* m_client;
     unsigned m_targetRefreshRate;
     WebCore::DisplayUpdate m_currentUpdate;

--- a/Source/WebKit/Shared/SharedStringHashStore.h
+++ b/Source/WebKit/Shared/SharedStringHashStore.h
@@ -71,7 +71,7 @@ private:
     unsigned m_tableLength { 0 };
     SharedStringHashTable m_table;
     Vector<Operation> m_pendingOperations;
-    RunLoop::Timer<SharedStringHashStore> m_pendingOperationsTimer;
+    RunLoop::Timer m_pendingOperationsTimer;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
@@ -77,7 +77,7 @@ public:
 
 private:
     RetainPtr<JSContext> m_context;
-    RunLoop::Timer<SharedJSContext> m_timer;
+    RunLoop::Timer m_timer;
     MonotonicTime m_lastUseTime;
 };
 

--- a/Source/WebKit/UIProcess/API/glib/APISerializedScriptValueGLib.cpp
+++ b/Source/WebKit/UIProcess/API/glib/APISerializedScriptValueGLib.cpp
@@ -79,7 +79,7 @@ public:
 
 private:
     GRefPtr<JSCContext> m_context;
-    RunLoop::Timer<SharedJSContext> m_timer;
+    RunLoop::Timer m_timer;
     MonotonicTime m_lastUseTime;
 };
 

--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
@@ -88,7 +88,7 @@ IconDatabase::IconDatabase(const String& path, AllowDatabaseWrite allowDatabaseW
         m_db.executeCommand("PRAGMA cache_size = 200;"_s);
 
         if (allowDatabaseWrite == AllowDatabaseWrite::Yes) {
-            m_pruneTimer = makeUnique<RunLoop::Timer<IconDatabase>>(RunLoop::current(), this, &IconDatabase::pruneTimerFired);
+            m_pruneTimer = makeUnique<RunLoop::Timer>(RunLoop::current(), this, &IconDatabase::pruneTimerFired);
             m_pruneTimer->setPriority(RunLoopSourcePriority::ReleaseUnusedResourcesTimer);
         }
 

--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.h
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.h
@@ -85,8 +85,8 @@ private:
     std::unique_ptr<WebCore::SQLiteStatement> m_deleteIconStatement;
     std::unique_ptr<WebCore::SQLiteStatement> m_pruneIconsStatement;
 
-    std::unique_ptr<RunLoop::Timer<IconDatabase>> m_pruneTimer;
-    RunLoop::Timer<IconDatabase> m_clearLoadedIconsTimer;
+    std::unique_ptr<RunLoop::Timer> m_pruneTimer;
+    RunLoop::Timer m_clearLoadedIconsTimer;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
@@ -223,7 +223,7 @@ private:
 
             // We need the move/resize to happen synchronously in automation mode, so we use a nested RunLoop
             // to wait, up top 200 milliseconds, for the configure events.
-            auto timer = makeUnique<RunLoop::Timer<UIClient>>(RunLoop::main(), this, &UIClient::setWindowFrameTimerFired);
+            auto timer = makeUnique<RunLoop::Timer>(RunLoop::main(), this, &UIClient::setWindowFrameTimerFired);
             timer->setPriority(RunLoopSourcePriority::RunLoopTimer);
             timer->startOneShot(200_ms);
             RunLoop::run();

--- a/Source/WebKit/UIProcess/API/gtk/DropTarget.h
+++ b/Source/WebKit/UIProcess/API/gtk/DropTarget.h
@@ -86,7 +86,7 @@ private:
 #if USE(GTK4)
     GRefPtr<GCancellable> m_cancellable;
 #else
-    RunLoop::Timer<DropTarget> m_leaveTimer;
+    RunLoop::Timer m_leaveTimer;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -313,7 +313,7 @@ struct _WebKitWebViewBasePrivate {
     // View State.
     OptionSet<ActivityState::Flag> activityState;
     OptionSet<ActivityState::Flag> activityStateFlagsToUpdate;
-    RunLoop::Timer<WebKitWebViewBasePrivate> updateActivityStateTimer;
+    RunLoop::Timer updateActivityStateTimer;
 
 #if ENABLE(FULLSCREEN_API)
     bool fullScreenModeActive { false };
@@ -334,7 +334,7 @@ struct _WebKitWebViewBasePrivate {
 #if GTK_CHECK_VERSION(3, 24, 0)
     GtkWidget* emojiChooser;
     CompletionHandler<void(String)> emojiChooserCompletionHandler;
-    RunLoop::Timer<WebKitWebViewBasePrivate> releaseEmojiChooserTimer;
+    RunLoop::Timer releaseEmojiChooserTimer;
 #endif
 
     // Touch gestures state

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
@@ -152,7 +152,7 @@ struct WindowStateEvent {
 
     Type type;
     CompletionHandler<void()> completionHandler;
-    RunLoop::Timer<WindowStateEvent> completeTimer;
+    RunLoop::Timer completeTimer;
 };
 
 static const char* gWindowStateEventID = "wk-window-state-event";

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
@@ -177,7 +177,7 @@ private:
     std::optional<WebCore::FrameIdentifier> m_frameID;
     AutomationCompletionHandler m_runCompletionHandler;
     AutomationCompletionHandler m_keyFrameTransitionCompletionHandler;
-    RunLoop::Timer<SimulatedInputDispatcher> m_keyFrameTransitionDurationTimer;
+    RunLoop::Timer m_keyFrameTransitionDurationTimer;
 
     Vector<SimulatedInputKeyFrame> m_keyframes;
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -339,7 +339,7 @@ private:
     };
     Function<void(WindowTransitionedToState)> m_windowStateTransitionCallback { };
 
-    RunLoop::Timer<WebAutomationSession> m_loadTimer;
+    RunLoop::Timer m_loadTimer;
     Vector<String> m_filesToSelectForFileUpload;
 
     bool m_permissionForGetUserMedia { true };

--- a/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h
@@ -56,8 +56,8 @@ private:
 
     WebProcessProxy& m_webProcessProxy;
     Seconds m_checkingInterval;
-    RunLoop::Timer<BackgroundProcessResponsivenessTimer> m_responsivenessCheckTimer;
-    RunLoop::Timer<BackgroundProcessResponsivenessTimer> m_timeoutTimer;
+    RunLoop::Timer m_responsivenessCheckTimer;
+    RunLoop::Timer m_timeoutTimer;
     bool m_isResponsive { true };
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -273,7 +273,7 @@ private:
 
 #if USE(RUNNINGBOARD)
     std::unique_ptr<ProcessThrottler::BackgroundActivity> m_networkActivity;
-    RunLoop::Timer<NavigationState> m_releaseNetworkActivityTimer;
+    RunLoop::Timer m_releaseNetworkActivityTimer;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
+++ b/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
@@ -51,7 +51,7 @@ private:
     void watchdogTimerFired();
 
     OSObjectPtr<xpc_connection_t> m_xpcConnection;
-    RunLoop::Timer<XPCConnectionTerminationWatchdog> m_watchdogTimer;
+    RunLoop::Timer m_watchdogTimer;
 #if PLATFORM(IOS_FAMILY)
     Ref<ProcessAndUIAssertion> m_assertion;
 #endif

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -107,7 +107,7 @@ private:
 
         MonotonicTime m_startTime;
         WTF::Function<void(CallbackBase::Error)> m_callback;
-        RunLoop::Timer<DrawingMonitor> m_timer;
+        RunLoop::Timer m_timer;
 #if PLATFORM(GTK)
         WebPageProxy& m_webPage;
 #endif
@@ -135,7 +135,7 @@ private:
 #if !PLATFORM(WPE)
     bool m_isBackingStoreDiscardable { true };
     std::unique_ptr<BackingStore> m_backingStore;
-    RunLoop::Timer<DrawingAreaProxyCoordinatedGraphics> m_discardBackingStoreTimer;
+    RunLoop::Timer m_discardBackingStoreTimer;
 #endif
     std::unique_ptr<DrawingMonitor> m_drawingMonitor;
 };

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -165,7 +165,7 @@ private:
     virtual void didUpdateGeometry() { }
 
 #if PLATFORM(MAC)
-    RunLoop::Timer<DrawingAreaProxy> m_viewExposedRectChangedTimer;
+    RunLoop::Timer m_viewExposedRectChangedTimer;
     std::optional<WebCore::FloatRect> m_lastSentViewExposedRect;
 #endif // PLATFORM(MAC)
 #endif

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
@@ -83,7 +83,7 @@ private:
 
     Vector<std::unique_ptr<UIGamepad>> m_gamepads;
 
-    RunLoop::Timer<UIGamepadProvider> m_gamepadSyncTimer;
+    RunLoop::Timer m_gamepadSyncTimer;
 
     bool m_isMonitoringGamepads { false };
     bool m_shouldMakeGamepadsVisibleOnSync { false };

--- a/Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.h
+++ b/Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.h
@@ -40,7 +40,7 @@ private:
     void timerFired();
 
     WebProcessPool& m_webProcessPool;
-    RunLoop::Timer<HighPerformanceGraphicsUsageSampler> m_timer;
+    RunLoop::Timer m_timer;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -325,7 +325,7 @@ private:
     RetainPtr<NSWindow> m_inspectorWindow;
     RetainPtr<WKWebInspectorUIProxyObjCAdapter> m_objCAdapter;
     HashMap<String, RetainPtr<NSURL>> m_suggestedToActualURLMap;
-    RunLoop::Timer<WebInspectorUIProxy> m_closeFrontendAfterInactivityTimer;
+    RunLoop::Timer m_closeFrontendAfterInactivityTimer;
     String m_urlString;
     WebCore::FloatRect m_sheetRect;
     WebCore::InspectorFrontendClient::Appearance m_frontendAppearance { WebCore::InspectorFrontendClient::Appearance::System };

--- a/Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp
+++ b/Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp
@@ -215,7 +215,7 @@ public:
 
 private:
     HashMap<String, std::pair<uint32_t, std::variant<CString, GRefPtr<GBytes>>>> m_iconCache;
-    RunLoop::Timer<IconCache> m_timer;
+    RunLoop::Timer m_timer;
 };
 
 static IconCache& iconCache()

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h
@@ -47,7 +47,7 @@ private:
     RefPtr<WebPageProxy> pageForLogging() const;
 
     WebProcessPool& m_processPool;
-    RunLoop::Timer<PerActivityStateCPUUsageSampler> m_loggingTimer;
+    RunLoop::Timer m_loggingTimer;
     typedef HashMap<WebCore::ActivityStateForCPUSampling, Seconds, WTF::IntHash<WebCore::ActivityStateForCPUSampling>, WTF::StrongEnumHashTraits<WebCore::ActivityStateForCPUSampling>> CPUTimeInActivityStateMap;
     CPUTimeInActivityStateMap m_cpuTimeInActivityState;
     MonotonicTime m_lastCPUTime;

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -133,7 +133,7 @@ public:
         void activityTimedOut();
         void updateTimer();
 
-        RunLoop::Timer<TimedActivity> m_timer;
+        RunLoop::Timer m_timer;
         Seconds m_timeout;
         ActivityVariant m_activity;
     };
@@ -171,7 +171,7 @@ private:
     ProcessThrottlerClient& m_process;
     ProcessID m_processIdentifier { 0 };
     RefPtr<ProcessAssertion> m_assertion;
-    RunLoop::Timer<ProcessThrottler> m_prepareToSuspendTimeoutTimer;
+    RunLoop::Timer m_prepareToSuspendTimeoutTimer;
     HashSet<ForegroundActivity*> m_foregroundActivities;
     HashSet<BackgroundActivity*> m_backgroundActivities;
     std::optional<uint64_t> m_pendingRequestToSuspendID;

--- a/Source/WebKit/UIProcess/ResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/ResponsivenessTimer.h
@@ -82,7 +82,7 @@ private:
 
     ResponsivenessTimer::Client& m_client;
 
-    RunLoop::Timer<ResponsivenessTimer> m_timer;
+    RunLoop::Timer m_timer;
     MonotonicTime m_restartFireTime;
 
     bool m_isResponsive { true };

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -112,7 +112,7 @@ private:
 
     SuspensionState m_suspensionState { SuspensionState::Suspending };
     CompletionHandler<void(SuspendedPageProxy*)> m_readyToUnsuspendHandler;
-    RunLoop::Timer<SuspendedPageProxy> m_suspensionTimeoutTimer;
+    RunLoop::Timer m_suspensionTimeoutTimer;
 #if USE(RUNNINGBOARD)
     std::unique_ptr<ProcessThrottler::BackgroundActivity> m_suspensionActivity;
 #endif

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -176,7 +176,7 @@ private:
 
     WebPageProxy& m_page;
 
-    RunLoop::Timer<UserMediaPermissionRequestManagerProxy> m_rejectionTimer;
+    RunLoop::Timer m_rejectionTimer;
     Deque<Ref<UserMediaPermissionRequestProxy>> m_pendingRejections;
 
     Vector<Ref<UserMediaPermissionRequestProxy>> m_pregrantedRequests;
@@ -186,7 +186,7 @@ private:
     Vector<DeniedRequest> m_deniedRequests;
 
     WebCore::MediaProducerMediaStateFlags m_captureState;
-    RunLoop::Timer<UserMediaPermissionRequestManagerProxy> m_watchdogTimer;
+    RunLoop::Timer m_watchdogTimer;
     Seconds m_currentWatchdogInterval;
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -264,7 +264,7 @@ private:
 
         uint64_t m_renderTreeSizeThreshold { 0 };
 
-        RunLoop::Timer<SnapshotRemovalTracker> m_watchdogTimer;
+        RunLoop::Timer m_watchdogTimer;
 
         bool m_paused { true };
     };
@@ -349,7 +349,7 @@ private:
 
     bool m_swipeGestureEnabled { true };
 
-    RunLoop::Timer<ViewGestureController> m_swipeActiveLoadMonitoringTimer;
+    RunLoop::Timer m_swipeActiveLoadMonitoringTimer;
 
     WebCore::Color m_backgroundColorForCurrentSnapshot;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
@@ -75,7 +75,7 @@ public:
     void enableNativeSupport();
 
 protected:
-    RunLoop::Timer<AuthenticatorManager>& requestTimeOutTimer() { return m_requestTimeOutTimer; }
+    RunLoop::Timer& requestTimeOutTimer() { return m_requestTimeOutTimer; }
     void clearStateAsync(); // To void cyclic dependence.
     void clearState();
     void invokePendingCompletionHandler(Respond&&);
@@ -120,7 +120,7 @@ private:
     // Request: We only allow one request per time. A new request will cancel any pending ones.
     WebAuthenticationRequestData m_pendingRequestData;
     Callback m_pendingCompletionHandler; // Should not be invoked directly, use invokePendingCompletionHandler.
-    RunLoop::Timer<AuthenticatorManager> m_requestTimeOutTimer;
+    RunLoop::Timer m_requestTimeOutTimer;
     std::unique_ptr<AuthenticatorPresenterCoordinator> m_presenter;
 
     Vector<UniqueRef<AuthenticatorTransportService>> m_services;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.h
@@ -60,7 +60,7 @@ private:
 
     RetainPtr<TKSmartCard> m_smartCard;
     WeakPtr<CcidService> m_service;
-    RunLoop::Timer<CcidConnection> m_retryTimer;
+    RunLoop::Timer m_retryTimer;
     bool m_contactless { false };
 };
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h
@@ -57,7 +57,7 @@ private:
 
     virtual void platformStartDiscovery();
 
-    RunLoop::Timer<CcidService> m_restartTimer;
+    RunLoop::Timer m_restartTimer;
     RefPtr<CcidConnection> m_connection;
     HashSet<String> m_slotNames;
 };

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.h
@@ -60,7 +60,7 @@ private:
     RetainPtr<NFReaderSession> m_session;
     RetainPtr<WKNFReaderSessionDelegate> m_delegate;
     WeakPtr<NfcService> m_service;
-    RunLoop::Timer<NfcConnection> m_retryTimer;
+    RunLoop::Timer m_retryTimer;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.h
@@ -64,7 +64,7 @@ private:
     // Keep the reader session alive here when it tries to connect to a tag.
     RefPtr<NfcConnection> m_connection;
 #endif
-    RunLoop::Timer<NfcService> m_restartTimer;
+    RunLoop::Timer m_restartTimer;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.h
@@ -71,7 +71,7 @@ private:
     void continueBogusCommandNoCredentialsAfterResponseReceived(apdu::ApduResponse&&);
     void continueSignCommandAfterResponseReceived(apdu::ApduResponse&&);
 
-    RunLoop::Timer<U2fAuthenticator> m_retryTimer;
+    RunLoop::Timer m_retryTimer;
     Vector<uint8_t> m_lastCommand;
     CommandType m_lastCommandType;
     size_t m_nextListIndex { 0 };

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
@@ -56,7 +56,7 @@ private:
     WebCore::ProcessIdentifier m_processIdentifier;
     WebCore::BackForwardItemIdentifier m_backForwardItemID;
     std::unique_ptr<SuspendedPageProxy> m_suspendedPage;
-    RunLoop::Timer<WebBackForwardCacheEntry> m_expirationTimer;
+    RunLoop::Timer m_expirationTimer;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2902,7 +2902,7 @@ private:
     std::unique_ptr<ProcessThrottler::ForegroundActivity> m_isVisibleActivity;
     std::unique_ptr<ProcessThrottler::ForegroundActivity> m_isAudibleActivity;
     std::unique_ptr<ProcessThrottler::ForegroundActivity> m_isCapturingActivity;
-    RunLoop::Timer<WebPageProxy> m_audibleActivityTimer;
+    RunLoop::Timer m_audibleActivityTimer;
     std::unique_ptr<ProcessThrottler::BackgroundActivity> m_openingAppLinkActivity;
 #endif
     bool m_initialCapitalizationEnabled { false };
@@ -3170,7 +3170,7 @@ private:
 
     // To make sure capture indicators are visible long enough, m_reportedMediaCaptureState is the same as m_mediaState except that we might delay a bit transition from capturing to not-capturing.
     WebCore::MediaProducerMediaStateFlags m_reportedMediaCaptureState;
-    RunLoop::Timer<WebPageProxy> m_updateReportedMediaCaptureStateTimer;
+    RunLoop::Timer m_updateReportedMediaCaptureStateTimer;
     static constexpr Seconds DefaultMediaCaptureReportingDelay { 3_s };
     Seconds m_mediaCaptureReportingDelay { DefaultMediaCaptureReportingDelay };
 
@@ -3230,7 +3230,7 @@ private:
     std::optional<MonotonicTime> m_pageLoadStart;
     HashSet<String> m_previouslyVisitedPaths;
 
-    RunLoop::Timer<WebPageProxy> m_resetRecentCrashCountTimer;
+    RunLoop::Timer m_resetRecentCrashCountTimer;
     unsigned m_recentCrashCount { 0 };
 
     bool m_needsFontAttributes { false };
@@ -3241,7 +3241,7 @@ private:
     CompletionHandler<void(std::optional<WebCore::PageIdentifier>)> m_serviceWorkerOpenWindowCompletionCallback;
 #endif
 
-    RunLoop::Timer<WebPageProxy> m_tryCloseTimeoutTimer;
+    RunLoop::Timer m_tryCloseTimeoutTimer;
 
     std::unique_ptr<ProvisionalPageProxy> m_provisionalPage;
     std::unique_ptr<SuspendedPageProxy> m_suspendedPageKeptToPreventFlashing;
@@ -3345,7 +3345,7 @@ private:
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     std::optional<PlaybackSessionContextIdentifier> m_currentFullscreenVideoSessionIdentifier;
-    RunLoop::Timer<WebPageProxy> m_fullscreenVideoTextRecognitionTimer;
+    RunLoop::Timer m_fullscreenVideoTextRecognitionTimer;
 #endif
     bool m_isPerformingTextRecognitionInElementFullScreen { false };
 };

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -85,9 +85,9 @@ private:
 #endif
 
         RefPtr<WebProcessProxy> m_process;
-        RunLoop::Timer<CachedProcess> m_evictionTimer;
+        RunLoop::Timer m_evictionTimer;
 #if PLATFORM(MAC) || PLATFORM(GTK) || PLATFORM(WPE)
-        RunLoop::Timer<CachedProcess> m_suspensionTimer;
+        RunLoop::Timer m_suspensionTimer;
 #endif
     };
 
@@ -99,7 +99,7 @@ private:
 
     HashMap<uint64_t, std::unique_ptr<CachedProcess>> m_pendingAddRequests;
     HashMap<WebCore::RegistrableDomain, std::unique_ptr<CachedProcess>> m_processesPerRegistrableDomain;
-    RunLoop::Timer<WebProcessCache> m_evictionTimer;
+    RunLoop::Timer m_evictionTimer;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -731,10 +731,10 @@ private:
     UserObservablePageCounter m_userObservablePageCounter;
     ProcessSuppressionDisabledCounter m_processSuppressionDisabledForPageCounter;
     HiddenPageThrottlingAutoIncreasesCounter m_hiddenPageThrottlingAutoIncreasesCounter;
-    RunLoop::Timer<WebProcessPool> m_hiddenPageThrottlingTimer;
+    RunLoop::Timer m_hiddenPageThrottlingTimer;
 
 #if ENABLE(GPU_PROCESS)
-    RunLoop::Timer<WebProcessPool> m_resetGPUProcessCrashCountTimer;
+    RunLoop::Timer m_resetGPUProcessCrashCountTimer;
     unsigned m_recentGPUProcessCrashCount { 0 };
 #endif
 

--- a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h
+++ b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h
@@ -72,7 +72,7 @@ private:
     GRefPtr<GDBusProxy> m_client;
     GRefPtr<GCancellable> m_cancellable;
     UpdateNotifyFunction m_updateNotifyFunction;
-    RunLoop::Timer<GeoclueGeolocationProvider> m_destroyManagerLaterTimer;
+    RunLoop::Timer m_destroyManagerLaterTimer;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h
+++ b/Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h
@@ -54,7 +54,7 @@ private:
     void timerFired();
 
     WeakObjCPtr<WKContentView> m_view;
-    RunLoop::Timer<GestureRecognizerConsistencyEnforcer> m_timer;
+    RunLoop::Timer m_timer;
     HashSet<RetainPtr<WKDeferringGestureRecognizer>> m_deferringGestureRecognizersWithTouches;
 };
 

--- a/Source/WebKit/UIProcess/ios/ProcessStateMonitor.h
+++ b/Source/WebKit/UIProcess/ios/ProcessStateMonitor.h
@@ -50,7 +50,7 @@ private:
     enum class State : uint8_t { Running, WillSuspend, Suspended };
     State m_state { State::Running };
     Function<void(bool)> m_becomeSuspendedHandler;
-    RunLoop::Timer<ProcessStateMonitor> m_suspendTimer;
+    RunLoop::Timer m_suspendTimer;
     RetainPtr<RBSProcessMonitor> m_rbsMonitor;
 };
 

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -118,7 +118,7 @@ private:
     void setMainVideoElement(RefPtr<WebCore::HTMLVideoElement>&&);
 
     WeakPtr<WebCore::HTMLVideoElement, WebCore::WeakPtrImplWithEventTargetData> m_mainVideoElement;
-    RunLoop::Timer<WebFullScreenManager> m_mainVideoElementTextRecognitionTimer;
+    RunLoop::Timer m_mainVideoElementTextRecognitionTimer;
     bool m_isPerformingTextRecognitionInMainVideo { false };
 #endif // ENABLE(VIDEO)
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -131,7 +131,7 @@ private:
     }
 
     HashSet<RefPtr<WebCore::ResourceLoader>> m_internallyFailedResourceLoaders;
-    RunLoop::Timer<WebLoaderStrategy> m_internallyFailedLoadTimer;
+    RunLoop::Timer m_internallyFailedLoadTimer;
     
     HashMap<WebCore::ResourceLoaderIdentifier, RefPtr<WebResourceLoader>> m_webResourceLoaders;
     HashMap<WebCore::ResourceLoaderIdentifier, WebURLSchemeTaskProxy*> m_urlSchemeTasks;

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -153,7 +153,7 @@ private:
 
     // Pending request that the plug-in has made.
     std::unique_ptr<const WebCore::ResourceRequest> m_pendingResourceRequest;
-    RunLoop::Timer<PluginView> m_pendingResourceRequestTimer;
+    RunLoop::Timer m_pendingResourceRequestTimer;
 
     // Stream that the plug-in has requested to load.
     class Stream;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -134,13 +134,13 @@ private:
     // won't paint until painting has resumed again.
     bool m_isPaintingSuspended { false };
 
-    RunLoop::Timer<DrawingAreaCoordinatedGraphics> m_exitCompositingTimer;
+    RunLoop::Timer m_exitCompositingTimer;
 
     // The layer tree host that handles accelerated compositing.
     std::unique_ptr<LayerTreeHost> m_layerTreeHost;
 
     std::unique_ptr<LayerTreeHost> m_previousLayerTreeHost;
-    RunLoop::Timer<DrawingAreaCoordinatedGraphics> m_discardPreviousLayerTreeHostTimer;
+    RunLoop::Timer m_discardPreviousLayerTreeHostTimer;
 
     WebCore::Region m_dirtyRegion;
     WebCore::IntRect m_scrollRect;
@@ -155,7 +155,7 @@ private:
     bool m_supportsAsyncScrolling { true };
     bool m_forceRepaintAfterBackingStoreStateUpdate { false };
 
-    RunLoop::Timer<DrawingAreaCoordinatedGraphics> m_displayTimer;
+    RunLoop::Timer m_displayTimer;
 
 #if PLATFORM(GTK)
     bool m_transientZoom { false };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -163,7 +163,7 @@ private:
         CompletionHandler<void()> callback;
         bool needsFreshFlush { false };
     } m_forceRepaintAsync;
-    RunLoop::Timer<LayerTreeHost> m_layerFlushTimer;
+    RunLoop::Timer m_layerFlushTimer;
     CompositingCoordinator m_coordinator;
 #endif // USE(COORDINATED_GRAPHICS)
     WebCore::PlatformDisplayID m_displayID;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2181,7 +2181,7 @@ private:
     RefPtr<PageBanner> m_footerBanner;
 #endif
 
-    RunLoop::Timer<WebPage> m_setCanStartMediaTimer;
+    RunLoop::Timer m_setCanStartMediaTimer;
     bool m_mayStartMediaWhenInWindow { false };
 
     HashMap<WebUndoStepID, RefPtr<WebUndoStep>> m_undoStepMap;

--- a/Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp
@@ -119,10 +119,10 @@ TEST(WTF_RunLoop, CallOnMainCrossThreadWhileNested)
     Util::run(&done);
 }
 
-class DerivedOneShotTimer : public RunLoop::Timer<DerivedOneShotTimer> {
+class DerivedOneShotTimer : public RunLoop::Timer {
 public:
     DerivedOneShotTimer(bool& testFinished)
-        : RunLoop::Timer<DerivedOneShotTimer>(RunLoop::current(), this, &DerivedOneShotTimer::fired)
+        : RunLoop::Timer(RunLoop::current(), this, &DerivedOneShotTimer::fired)
         , m_testFinished(testFinished)
     {
     }
@@ -151,10 +151,10 @@ TEST(WTF_RunLoop, OneShotTimer)
     Util::run(&testFinished);
 }
 
-class DerivedRepeatingTimer : public RunLoop::Timer<DerivedRepeatingTimer> {
+class DerivedRepeatingTimer : public RunLoop::Timer {
 public:
     DerivedRepeatingTimer(bool& testFinished)
-        : RunLoop::Timer<DerivedRepeatingTimer>(RunLoop::current(), this, &DerivedRepeatingTimer::fired)
+        : RunLoop::Timer(RunLoop::current(), this, &DerivedRepeatingTimer::fired)
         , m_testFinished(testFinished)
     {
     }

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -149,8 +149,8 @@ private:
     
     WKRetainPtr<WKURLRef> m_url;
     String m_urlString;
-    RunLoop::Timer<TestInvocation> m_waitToDumpWatchdogTimer;
-    RunLoop::Timer<TestInvocation> m_waitForPostDumpWatchdogTimer;
+    RunLoop::Timer m_waitToDumpWatchdogTimer;
+    RunLoop::Timer m_waitForPostDumpWatchdogTimer;
 
     std::string m_expectedPixelHash;
 

--- a/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
@@ -71,7 +71,7 @@ void TestController::platformRunUntil(bool& done, WTF::Seconds timeout)
             RunLoop::main().stop();
         }
 
-        RunLoop::Timer<TimeoutTimer> timer;
+        RunLoop::Timer timer;
         bool timedOut { false };
     } timeoutTimer;
 

--- a/Tools/WebKitTestRunner/libwpe/PlatformWebViewLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/PlatformWebViewLibWPE.cpp
@@ -123,7 +123,7 @@ PlatformImage PlatformWebView::windowSnapshotImage()
             }
 
             void fired() { RunLoop::main().stop(); }
-            RunLoop::Timer<TimeoutTimer> timer;
+            RunLoop::Timer timer;
         } timeoutTimer;
 
         RunLoop::main().run();

--- a/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
@@ -74,7 +74,7 @@ void TestController::platformRunUntil(bool& done, WTF::Seconds timeout)
             RunLoop::main().stop();
         }
 
-        RunLoop::Timer<TimeoutTimer> timer;
+        RunLoop::Timer timer;
         bool timedOut { false };
     } timeoutTimer;
 


### PR DESCRIPTION
#### d94e96e0fc4ac0447579aa41f57ea6fe895070a9
<pre>
RunLoop::Timer should use constructor templates instead of class templates
<a href="https://bugs.webkit.org/show_bug.cgi?id=159153">https://bugs.webkit.org/show_bug.cgi?id=159153</a>
rdar://problem/27070856

Reviewed by Žan Doberšek.

RunLoop::Timer isn&apos;t specific to the member function it is invoking.

Needed to make RunLoopGeneric.cpp global variable to not be RunLoop::DispatchTimer.
That is needed to fix RunLoop::DispatchTimer leaks.

* Source/JavaScriptCore/runtime/JSRunLoopTimer.cpp:
(JSC::JSRunLoopTimer::Manager::PerVMData::PerVMData):
* Source/JavaScriptCore/runtime/JSRunLoopTimer.h:
* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::MemoryPressureHandler::setShouldUsePeriodicMemoryMonitor):
* Source/WTF/wtf/MemoryPressureHandler.h:
* Source/WTF/wtf/RunLoop.h:
* Source/WTF/wtf/generic/RunLoopGeneric.cpp:
(WTF::RunLoop::runImpl):
* Source/WTF/wtf/linux/RealTimeThreads.h:
* Source/WebCore/Modules/airplay/WebMediaSessionManager.h:
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/PAL/pal/HysteresisActivity.h:
* Source/WebCore/accessibility/atspi/AccessibilityAtspi.h:
* Source/WebCore/inspector/agents/WebHeapAgent.cpp:
* Source/WebCore/page/mac/TextIndicatorWindow.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::scheduleDelayedRenderingUpdateDetectionTimer):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
* Source/WebCore/platform/MainThreadSharedTimer.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h:
* Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h:
* Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h:
* Source/WebCore/platform/graphics/MediaPlaybackTargetPicker.h:
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::waitForVideoOutputMediaDataWillChange):
* Source/WebCore/platform/graphics/cg/IOSurfacePool.h:
* Source/WebCore/platform/graphics/cg/SubimageCacheWithTimer.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp:
(WebCore::TextureMapperPlatformLayerProxyGL::activateOnCompositingThread):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:
* Source/WebCore/platform/graphics/win/DisplayRefreshMonitorWin.h:
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h:
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(WebCore::ScreenCaptureKitSharingSessionManager::promptForGetDisplayMedia):
* Source/WebCore/platform/mock/MockAudioDestinationCocoa.h:
* Source/WebCore/platform/mock/MockRealtimeAudioSource.h:
* Source/WebCore/platform/mock/MockRealtimeVideoSource.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h:
* Source/WebKit/NetworkProcess/glib/DNSCache.h:
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h:
* Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.h:
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h:
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.h:
* Source/WebKit/Shared/SharedStringHashStore.h:
* Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm:
* Source/WebKit/UIProcess/API/glib/APISerializedScriptValueGLib.cpp:
* Source/WebKit/UIProcess/API/glib/IconDatabase.cpp:
(WebKit::IconDatabase::IconDatabase):
* Source/WebKit/UIProcess/API/glib/IconDatabase.h:
* Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp:
* Source/WebKit/UIProcess/API/gtk/DropTarget.h:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp:
* Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h:
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h:
* Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp:
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.h:
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/ResponsivenessTimer.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h:
(WebKit::AuthenticatorManager::requestTimeOutTimer):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.h:
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessCache.h:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.h:
* Source/WebKit/UIProcess/ios/GestureRecognizerConsistencyEnforcer.h:
* Source/WebKit/UIProcess/ios/ProcessStateMonitor.h:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp:
(TestWebKitAPI::DerivedOneShotTimer::DerivedOneShotTimer):
(TestWebKitAPI::DerivedRepeatingTimer::DerivedRepeatingTimer):
* Tools/WebKitTestRunner/TestInvocation.h:
* Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp:
(WTR::TestController::platformRunUntil):
* Tools/WebKitTestRunner/libwpe/PlatformWebViewLibWPE.cpp:
(WTR::PlatformWebView::windowSnapshotImage):
* Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp:
(WTR::TestController::platformRunUntil):

Canonical link: <a href="https://commits.webkit.org/257984@main">https://commits.webkit.org/257984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e332e721feef3627bb240c5f18b54d0b7dcd52a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109740 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170009 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10499 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107618 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91217 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34595 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77560 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90970 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3325 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24126 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86986 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/785 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3316 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/278 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 7693") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29119 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43616 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89868 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5473 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5132 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20090 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->