### PR TITLE
Port InlinePathData to the new CoreIPC serialization format

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1957,6 +1957,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/text/TextBoundaries.h
     platform/text/TextCheckerClient.h
     platform/text/TextChecking.h
+    platform/text/TextCheckingRequestIdentifier.h
     platform/text/TextDirection.h
     platform/text/TextFlags.h
     platform/text/UnicodeBidi.h

--- a/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.h
+++ b/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.h
@@ -31,25 +31,12 @@
 
 namespace WebCore {
 
-enum class AttestationConveyancePreference {
+enum class AttestationConveyancePreference : uint8_t {
     None,
     Indirect,
     Direct
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::AttestationConveyancePreference> {
-    using values = EnumValues<
-        WebCore::AttestationConveyancePreference,
-        WebCore::AttestationConveyancePreference::None,
-        WebCore::AttestationConveyancePreference::Indirect,
-        WebCore::AttestationConveyancePreference::Direct
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/page/AutoplayEvent.h
+++ b/Source/WebCore/page/AutoplayEvent.h
@@ -41,16 +41,3 @@ enum class AutoplayEventFlags : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::AutoplayEventFlags> {
-    using values = EnumValues<
-        WebCore::AutoplayEventFlags,
-        WebCore::AutoplayEventFlags::HasAudio,
-        WebCore::AutoplayEventFlags::PlaybackWasPrevented,
-        WebCore::AutoplayEventFlags::MediaIsMainContent
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/page/ModalContainerTypes.h
+++ b/Source/WebCore/page/ModalContainerTypes.h
@@ -57,14 +57,4 @@ template<> struct EnumTraits<WebCore::ModalContainerControlType> {
     >;
 };
 
-template<> struct EnumTraits<WebCore::ModalContainerDecision> {
-    using values = EnumValues<
-        WebCore::ModalContainerDecision,
-        WebCore::ModalContainerDecision::Show,
-        WebCore::ModalContainerDecision::HideAndIgnore,
-        WebCore::ModalContainerDecision::HideAndAllow,
-        WebCore::ModalContainerDecision::HideAndDisallow
-    >;
-};
-
 } // namespace WTF

--- a/Source/WebCore/platform/TextRecognitionResult.h
+++ b/Source/WebCore/platform/TextRecognitionResult.h
@@ -53,37 +53,7 @@ struct TextRecognitionWordData {
     String text;
     FloatQuad normalizedQuad;
     bool hasLeadingWhitespace { true };
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<TextRecognitionWordData> decode(Decoder&);
 };
-
-template<class Encoder> void TextRecognitionWordData::encode(Encoder& encoder) const
-{
-    encoder << text;
-    encoder << normalizedQuad;
-    encoder << hasLeadingWhitespace;
-}
-
-template<class Decoder> std::optional<TextRecognitionWordData> TextRecognitionWordData::decode(Decoder& decoder)
-{
-    std::optional<String> text;
-    decoder >> text;
-    if (!text)
-        return std::nullopt;
-
-    std::optional<FloatQuad> normalizedQuad;
-    decoder >> normalizedQuad;
-    if (!normalizedQuad)
-        return std::nullopt;
-
-    std::optional<bool> hasLeadingWhitespace;
-    decoder >> hasLeadingWhitespace;
-    if (!hasLeadingWhitespace)
-        return std::nullopt;
-
-    return {{ WTFMove(*text), WTFMove(*normalizedQuad), *hasLeadingWhitespace }};
-}
 
 struct TextRecognitionLineData {
     TextRecognitionLineData(FloatQuad&& quad, Vector<TextRecognitionWordData>&& theChildren, bool newline)
@@ -96,9 +66,6 @@ struct TextRecognitionLineData {
     FloatQuad normalizedQuad;
     Vector<TextRecognitionWordData> children;
     bool hasTrailingNewline { true };
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<TextRecognitionLineData> decode(Decoder&);
 };
 
 #if ENABLE(DATA_DETECTION)
@@ -117,33 +84,6 @@ struct TextRecognitionDataDetector {
 
 #endif // ENABLE(DATA_DETECTION)
 
-template<class Encoder> void TextRecognitionLineData::encode(Encoder& encoder) const
-{
-    encoder << normalizedQuad;
-    encoder << children;
-    encoder << hasTrailingNewline;
-}
-
-template<class Decoder> std::optional<TextRecognitionLineData> TextRecognitionLineData::decode(Decoder& decoder)
-{
-    std::optional<FloatQuad> normalizedQuad;
-    decoder >> normalizedQuad;
-    if (!normalizedQuad)
-        return std::nullopt;
-
-    std::optional<Vector<TextRecognitionWordData>> children;
-    decoder >> children;
-    if (!children)
-        return std::nullopt;
-
-    std::optional<bool> hasTrailingNewline;
-    decoder >> hasTrailingNewline;
-    if (!hasTrailingNewline)
-        return std::nullopt;
-
-    return { { WTFMove(*normalizedQuad), WTFMove(*children), *hasTrailingNewline } };
-}
-
 struct TextRecognitionBlockData {
     TextRecognitionBlockData(const String& theText, FloatQuad&& quad)
         : text(theText)
@@ -153,31 +93,7 @@ struct TextRecognitionBlockData {
 
     String text;
     FloatQuad normalizedQuad;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<TextRecognitionBlockData> decode(Decoder&);
 };
-
-template<class Encoder> void TextRecognitionBlockData::encode(Encoder& encoder) const
-{
-    encoder << text;
-    encoder << normalizedQuad;
-}
-
-template<class Decoder> std::optional<TextRecognitionBlockData> TextRecognitionBlockData::decode(Decoder& decoder)
-{
-    std::optional<String> text;
-    decoder >> text;
-    if (!text)
-        return std::nullopt;
-
-    std::optional<FloatQuad> normalizedQuad;
-    decoder >> normalizedQuad;
-    if (!normalizedQuad)
-        return std::nullopt;
-
-    return { { WTFMove(*text), WTFMove(*normalizedQuad) } };
-}
 
 struct TextRecognitionResult {
     Vector<TextRecognitionLineData> lines;
@@ -207,60 +123,7 @@ struct TextRecognitionResult {
 
         return true;
     }
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<TextRecognitionResult> decode(Decoder&);
 };
-
-template<class Encoder> void TextRecognitionResult::encode(Encoder& encoder) const
-{
-    encoder << lines;
-#if ENABLE(DATA_DETECTION)
-    encoder << dataDetectors;
-#endif
-    encoder << blocks;
-#if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    encoder << platformData;
-#endif
-}
-
-template<class Decoder> std::optional<TextRecognitionResult> TextRecognitionResult::decode(Decoder& decoder)
-{
-    std::optional<Vector<TextRecognitionLineData>> lines;
-    decoder >> lines;
-    if (!lines)
-        return std::nullopt;
-
-#if ENABLE(DATA_DETECTION)
-    std::optional<Vector<TextRecognitionDataDetector>> dataDetectors;
-    decoder >> dataDetectors;
-    if (!dataDetectors)
-        return std::nullopt;
-#endif
-
-    std::optional<Vector<TextRecognitionBlockData>> blocks;
-    decoder >> blocks;
-    if (!blocks)
-        return std::nullopt;
-
-#if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    std::optional<RetainPtr<VKCImageAnalysis>> platformData;
-    decoder >> platformData;
-    if (!platformData)
-        return std::nullopt;
-#endif
-
-    return {{
-        WTFMove(*lines),
-#if ENABLE(DATA_DETECTION)
-        WTFMove(*dataDetectors),
-#endif
-        WTFMove(*blocks),
-#if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-        WTFMove(*platformData),
-#endif
-    }};
-}
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 RetainPtr<NSAttributedString> stringForRange(const TextRecognitionResult&, const CharacterRange&);

--- a/Source/WebCore/platform/graphics/InlinePathData.h
+++ b/Source/WebCore/platform/graphics/InlinePathData.h
@@ -35,9 +35,6 @@ namespace WebCore {
 struct LineData {
     FloatPoint start;
     FloatPoint end;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<LineData> decode(Decoder&);
 };
 
 struct ArcData {
@@ -54,25 +51,16 @@ struct ArcData {
     float endAngle { 0 };
     bool clockwise { false };
     Type type { Type::ArcOnly };
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<ArcData> decode(Decoder&);
 };
 
 struct MoveData {
     FloatPoint location;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<MoveData> decode(Decoder&);
 };
 
 struct QuadCurveData {
     FloatPoint startPoint;
     FloatPoint controlPoint;
     FloatPoint endPoint;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<QuadCurveData> decode(Decoder&);
 };
 
 struct BezierCurveData {
@@ -80,143 +68,10 @@ struct BezierCurveData {
     FloatPoint controlPoint1;
     FloatPoint controlPoint2;
     FloatPoint endPoint;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<BezierCurveData> decode(Decoder&);
 };
-
-template<class Encoder> void MoveData::encode(Encoder& encoder) const
-{
-    encoder << location;
-}
-
-template<class Decoder> std::optional<MoveData> MoveData::decode(Decoder& decoder)
-{
-    MoveData data;
-    if (!decoder.decode(data.location))
-        return std::nullopt;
-    return data;
-}
-
-template<class Encoder> void LineData::encode(Encoder& encoder) const
-{
-    encoder << start;
-    encoder << end;
-}
-
-template<class Decoder> std::optional<LineData> LineData::decode(Decoder& decoder)
-{
-    LineData data;
-    if (!decoder.decode(data.start))
-        return std::nullopt;
-
-    if (!decoder.decode(data.end))
-        return std::nullopt;
-
-    return data;
-}
-
-template<class Encoder> void ArcData::encode(Encoder& encoder) const
-{
-    encoder << start;
-    encoder << center;
-    encoder << radius;
-    encoder << startAngle;
-    encoder << endAngle;
-    encoder << clockwise;
-    encoder << type;
-}
-
-template<class Decoder> std::optional<ArcData> ArcData::decode(Decoder& decoder)
-{
-    ArcData data;
-    if (!decoder.decode(data.start))
-        return std::nullopt;
-
-    if (!decoder.decode(data.center))
-        return std::nullopt;
-
-    if (!decoder.decode(data.radius))
-        return std::nullopt;
-
-    if (!decoder.decode(data.startAngle))
-        return std::nullopt;
-
-    if (!decoder.decode(data.endAngle))
-        return std::nullopt;
-
-    if (!decoder.decode(data.clockwise))
-        return std::nullopt;
-
-    if (!decoder.decode(data.type))
-        return std::nullopt;
-
-    return data;
-}
-
-template<class Encoder> void QuadCurveData::encode(Encoder& encoder) const
-{
-    encoder << startPoint;
-    encoder << controlPoint;
-    encoder << endPoint;
-}
-
-template<class Decoder> std::optional<QuadCurveData> QuadCurveData::decode(Decoder& decoder)
-{
-    QuadCurveData data;
-    if (!decoder.decode(data.startPoint))
-        return std::nullopt;
-
-    if (!decoder.decode(data.controlPoint))
-        return std::nullopt;
-
-    if (!decoder.decode(data.endPoint))
-        return std::nullopt;
-
-    return data;
-}
-
-template<class Encoder> void BezierCurveData::encode(Encoder& encoder) const
-{
-    encoder << startPoint;
-    encoder << controlPoint1;
-    encoder << controlPoint2;
-    encoder << endPoint;
-}
-
-template<class Decoder> std::optional<BezierCurveData> BezierCurveData::decode(Decoder& decoder)
-{
-    BezierCurveData data;
-    if (!decoder.decode(data.startPoint))
-        return std::nullopt;
-
-    if (!decoder.decode(data.controlPoint1))
-        return std::nullopt;
-
-    if (!decoder.decode(data.controlPoint2))
-        return std::nullopt;
-
-    if (!decoder.decode(data.endPoint))
-        return std::nullopt;
-
-    return data;
-}
 
 using InlinePathData = std::variant<std::monostate, MoveData, LineData, ArcData, QuadCurveData, BezierCurveData>;
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ArcData::Type> {
-    using values = EnumValues<
-        WebCore::ArcData::Type,
-        WebCore::ArcData::Type::ArcOnly,
-        WebCore::ArcData::Type::LineAndArc,
-        WebCore::ArcData::Type::ClosedLineAndArc
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(INLINE_PATH_DATA)

--- a/Source/WebCore/platform/text/TextChecking.h
+++ b/Source/WebCore/platform/text/TextChecking.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "CharacterRange.h"
+#include "TextCheckingRequestIdentifier.h"
 #include <wtf/EnumTraits.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/OptionSet.h>
@@ -81,8 +82,6 @@ struct TextCheckingGuesses {
     bool ungrammatical { false };
 };
 
-enum TextCheckingRequestIdentifierType { };
-using TextCheckingRequestIdentifier = ObjectIdentifier<TextCheckingRequestIdentifierType>;
 
 class TextCheckingRequestData {
     friend class SpellCheckRequest; // For access to m_identifier.

--- a/Source/WebCore/platform/text/TextCheckingRequestIdentifier.h
+++ b/Source/WebCore/platform/text/TextCheckingRequestIdentifier.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ObjectIdentifier.h>
+
+namespace WebCore {
+
+enum TextCheckingRequestIdentifierType { };
+using TextCheckingRequestIdentifier = ObjectIdentifier<TextCheckingRequestIdentifierType>;
+
+}

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -515,6 +515,7 @@ GENERATE_MESSAGE_SOURCES(WebKit_DERIVED_SOURCES "${WebKit_MESSAGES_IN_FILES}")
 set(WebKit_SERIALIZATION_IN_FILES
     GPUProcess/GPUProcessSessionParameters.serialization.in
 
+    GPUProcess/graphics/InlinePathData.serialization.in
     GPUProcess/graphics/RemoteRenderingBackendCreationParameters.serialization.in
 
     GPUProcess/media/InitializationSegmentInfo.serialization.in
@@ -533,6 +534,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/SessionState.serialization.in
     Shared/ShareableBitmap.serialization.in
     Shared/TextFlags.serialization.in
+    Shared/TextRecognitionResult.serialization.in
     Shared/WTFArgumentCoders.serialization.in
     Shared/WebCoreArgumentCoders.serialization.in
     Shared/WebEvent.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -33,6 +33,7 @@ $(PROJECT_DIR)/DerivedSources.make
 $(PROJECT_DIR)/GPUProcess/GPUConnectionToWebProcess.messages.in
 $(PROJECT_DIR)/GPUProcess/GPUProcess.messages.in
 $(PROJECT_DIR)/GPUProcess/GPUProcessSessionParameters.serialization.in
+$(PROJECT_DIR)/GPUProcess/graphics/InlinePathData.serialization.in
 $(PROJECT_DIR)/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/RemoteGraphicsContext.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -176,6 +177,7 @@ $(PROJECT_DIR)/Shared/SessionState.serialization.in
 $(PROJECT_DIR)/Shared/ShareableBitmap.serialization.in
 $(PROJECT_DIR)/Shared/Shared/EditorState.serialization.in
 $(PROJECT_DIR)/Shared/TextFlags.serialization.in
+$(PROJECT_DIR)/Shared/TextRecognitionResult.serialization.in
 $(PROJECT_DIR)/Shared/WTFArgumentCoders.serialization.in
 $(PROJECT_DIR)/Shared/WebConnection.messages.in
 $(PROJECT_DIR)/Shared/WebCoreArgumentCoders.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -468,6 +468,7 @@ $(WEB_PREFERENCES_PATTERNS) : $(WTF_BUILD_SCRIPTS_DIR)/GeneratePreferences.rb $(
 
 SERIALIZATION_DESCRIPTION_FILES = \
 	GPUProcess/GPUProcessSessionParameters.serialization.in \
+	GPUProcess/graphics/InlinePathData.serialization.in \
 	GPUProcess/graphics/RemoteRenderingBackendCreationParameters.serialization.in \
 	GPUProcess/media/InitializationSegmentInfo.serialization.in \
 	GPUProcess/media/MediaDescriptionInfo.serialization.in \
@@ -488,6 +489,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/SessionState.serialization.in \
 	Shared/ShareableBitmap.serialization.in \
 	Shared/TextFlags.serialization.in \
+	Shared/TextRecognitionResult.serialization.in \
 	Shared/WTFArgumentCoders.serialization.in \
 	Shared/WebCoreArgumentCoders.serialization.in \
 	Shared/WebExtensionContextParameters.serialization.in \

--- a/Source/WebKit/GPUProcess/graphics/InlinePathData.serialization.in
+++ b/Source/WebKit/GPUProcess/graphics/InlinePathData.serialization.in
@@ -1,0 +1,69 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(INLINE_PATH_DATA)
+
+header: <WebCore/InlinePathData.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::LineData {
+    WebCore::FloatPoint start;
+    WebCore::FloatPoint end;
+};
+
+header: <WebCore/InlinePathData.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::MoveData {
+    WebCore::FloatPoint location;
+};
+
+header: <WebCore/InlinePathData.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::QuadCurveData {
+    WebCore::FloatPoint startPoint;
+    WebCore::FloatPoint controlPoint;
+    WebCore::FloatPoint endPoint;
+};
+
+header: <WebCore/InlinePathData.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::BezierCurveData {
+    WebCore::FloatPoint startPoint;
+    WebCore::FloatPoint controlPoint1;
+    WebCore::FloatPoint controlPoint2;
+    WebCore::FloatPoint endPoint;
+};
+
+header: <WebCore/InlinePathData.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder, NestedClass] enum class WebCore::ArcData::Type : uint8_t {
+    ArcOnly,
+    LineAndArc,
+    ClosedLineAndArc
+};
+    
+header: <WebCore/InlinePathData.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ArcData {
+    WebCore::FloatPoint start;
+    WebCore::FloatPoint center;
+    float radius;
+    float startAngle;
+    float endAngle;
+    bool clockwise;
+    WebCore::ArcData::Type type;
+};
+
+#endif

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -253,6 +253,7 @@ def serialized_identifiers():
         'WebCore::SharedWorkerIdentifier',
         'WebCore::SleepDisablerIdentifier',
         'WebCore::SpeechRecognitionConnectionClientIdentifier',
+        'WebCore::TextCheckingRequestIdentifier',
         'WebCore::UserMediaRequestIdentifier',
         'WebCore::WebSocketIdentifier',
         'WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier',

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -99,6 +99,7 @@
 #include <WebCore/SharedWorkerIdentifier.h>
 #include <WebCore/SleepDisablerIdentifier.h>
 #include <WebCore/SpeechRecognitionConnectionClientIdentifier.h>
+#include <WebCore/TextCheckingRequestIdentifier.h>
 #include <WebCore/UserMediaRequestIdentifier.h>
 #include <WebCore/WebSocketIdentifier.h>
 #include "TestWithSuperclassMessages.h" // NOLINT
@@ -407,6 +408,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
     static_assert(sizeof(uint64_t) == sizeof(WebCore::SharedWorkerIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::SleepDisablerIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::SpeechRecognitionConnectionClientIdentifier));
+    static_assert(sizeof(uint64_t) == sizeof(WebCore::TextCheckingRequestIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::UserMediaRequestIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::WebSocketIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier));
@@ -486,6 +488,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
         "WebCore::SharedWorkerIdentifier"_s,
         "WebCore::SleepDisablerIdentifier"_s,
         "WebCore::SpeechRecognitionConnectionClientIdentifier"_s,
+        "WebCore::TextCheckingRequestIdentifier"_s,
         "WebCore::UserMediaRequestIdentifier"_s,
         "WebCore::WebSocketIdentifier"_s,
         "WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier"_s,

--- a/Source/WebKit/Shared/TextRecognitionResult.serialization.in
+++ b/Source/WebKit/Shared/TextRecognitionResult.serialization.in
@@ -1,0 +1,57 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(IMAGE_ANALYSIS)
+
+header: <WebCore/TextRecognitionResult.h>
+[CustomHeader] struct WebCore::TextRecognitionWordData {
+    String text;
+    WebCore::FloatQuad normalizedQuad;
+    bool hasLeadingWhitespace;
+};
+
+header: <WebCore/TextRecognitionResult.h>
+[CustomHeader] struct WebCore::TextRecognitionLineData {
+    WebCore::FloatQuad normalizedQuad;
+    Vector<WebCore::TextRecognitionWordData> children;
+    bool hasTrailingNewline;
+};
+
+header: <WebCore/TextRecognitionResult.h>
+[CustomHeader] struct WebCore::TextRecognitionBlockData {
+    String text;
+    WebCore::FloatQuad normalizedQuad;
+};
+
+header: <WebCore/TextRecognitionResult.h>
+[CustomHeader] struct WebCore::TextRecognitionResult {
+    Vector<WebCore::TextRecognitionLineData> lines;
+#if ENABLE(DATA_DETECTION)
+    Vector<WebCore::TextRecognitionDataDetector> dataDetectors;
+#endif
+    Vector<WebCore::TextRecognitionBlockData> blocks;
+#if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
+    RetainPtr<VKCImageAnalysis> platformData;
+#endifs
+};
+
+#endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -961,6 +961,14 @@ struct WebCore::PublicKeyCredentialDescriptor {
 };
 #endif // ENABLE(WEB_AUTHN)
 
+#if ENABLE(WEB_AUTHN)
+enum class WebCore::AttestationConveyancePreference : uint8_t {
+    None,
+    Indirect,
+    Direct
+};
+#endif
+
 struct WebCore::PublicKeyCredentialCreationOptions {
 #if ENABLE(WEB_AUTHN)
     WebCore::PublicKeyCredentialCreationOptions::RpEntity rp;
@@ -2415,3 +2423,20 @@ enum class WebCore::ControlPartType : uint8_t {
     double minimum();
     double maximum();
 };
+
+enum class WebCore::HasInsecureContent : bool
+
+header: <WebCore/ModalContainerTypes.h>
+[CustomHeader] enum class WebCore::ModalContainerDecision : uint8_t {
+    Show,
+    HideAndIgnore,
+    HideAndAllow,
+    HideAndDisallow,
+};
+
+[OptionSet] enum class WebCore::AutoplayEventFlags : uint8_t {
+    HasAudio,
+    PlaybackWasPrevented,
+    MediaIsMainContent,
+};
+

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6055,6 +6055,8 @@
 		86760A6928DB305F00D07D06 /* GeneratedSerializers.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GeneratedSerializers.mm; sourceTree = "<group>"; };
 		868160CD18763D4B0021E79D /* WindowServerConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WindowServerConnection.h; sourceTree = "<group>"; };
 		868160CF187645370021E79D /* WindowServerConnection.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WindowServerConnection.mm; sourceTree = "<group>"; };
+		86890B80294B6E1000DB95CE /* InlinePathData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = InlinePathData.serialization.in; sourceTree = "<group>"; };
+		86890B81294B6FD900DB95CE /* TextRecognitionResult.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = TextRecognitionResult.serialization.in; sourceTree = "<group>"; };
 		869055832912C6B000B5ECD3 /* Model.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = Model.serialization.in; sourceTree = "<group>"; };
 		86AA520C292522460065399E /* WebGPUFeatureName.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUFeatureName.serialization.in; sourceTree = "<group>"; };
 		86AA520D292523AF0065399E /* XRSystem.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = XRSystem.serialization.in; sourceTree = "<group>"; };
@@ -8426,6 +8428,7 @@
 				932CA81B283C35EB00C20BEB /* StorageAreaIdentifier.h */,
 				1A5E4DA312D3BD3D0099A2BB /* TextCheckerState.h */,
 				86DD518B28EF028500DF2A58 /* TextFlags.serialization.in */,
+				86890B81294B6FD900DB95CE /* TextRecognitionResult.serialization.in */,
 				F4A7CE842667EB4E00228685 /* TextRecognitionUpdateResult.h */,
 				7BE37F6F27B1475F007A6CD3 /* ThreadSafeObjectHeap.h */,
 				2FD43B921FA006A30083F51C /* TouchBarMenuData.cpp */,
@@ -11243,6 +11246,7 @@
 				1C98C01C27446926002CCB78 /* WebGPU */,
 				724DCF22284862FC0026ACF4 /* ImageBufferShareableAllocator.cpp */,
 				724DCF21284862FC0026ACF4 /* ImageBufferShareableAllocator.h */,
+				86890B80294B6E1000DB95CE /* InlinePathData.serialization.in */,
 				1CC54AFD270F9654005BF8BE /* QualifiedRenderingResourceIdentifier.h */,
 				1CBF9012271018B5000C457D /* QualifiedResourceHeap.h */,
 				F48BB8E026F96392001C1C40 /* RemoteDisplayListRecorder.cpp */,


### PR DESCRIPTION
#### d37103ac313f95c0d98ac255013f469f3e0d1a5a
<pre>
Port InlinePathData to the new CoreIPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=249398">https://bugs.webkit.org/show_bug.cgi?id=249398</a>
rdar://103404505

Reviewed by Alex Christensen.

This change ports the below to the new IPC serialization format:
    - LineData
    - MoveData
    - QuadCurveData
    - BezierCurveData
    - ArcData::Type
    - ArcData
    - TextRecognitionWordData
    - TextRecognitionLineData
    - TextRecognitionBlockData
    - TextRecognitionResult
    - ModalContainerDecision
    - AutoplayEventFlags
    - AttestationConveyancePreference

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/webauthn/AttestationConveyancePreference.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/AutoplayEvent.h:
* Source/WebCore/page/ModalContainerTypes.h:
* Source/WebCore/platform/TextRecognitionResult.h:
(WebCore::TextRecognitionResult::isEmpty const):
(WebCore::TextRecognitionWordData::encode const): Deleted.
(WebCore::TextRecognitionWordData::decode): Deleted.
(WebCore::TextRecognitionLineData::encode const): Deleted.
(WebCore::TextRecognitionLineData::decode): Deleted.
(WebCore::TextRecognitionBlockData::encode const): Deleted.
(WebCore::TextRecognitionBlockData::decode): Deleted.
(WebCore::TextRecognitionResult::encode const): Deleted.
(WebCore::TextRecognitionResult::decode): Deleted.
* Source/WebCore/platform/graphics/InlinePathData.h:
(WebCore::MoveData::encode const): Deleted.
(WebCore::MoveData::decode): Deleted.
(WebCore::LineData::encode const): Deleted.
(WebCore::LineData::decode): Deleted.
(WebCore::ArcData::encode const): Deleted.
(WebCore::ArcData::decode): Deleted.
(WebCore::QuadCurveData::encode const): Deleted.
(WebCore::QuadCurveData::decode): Deleted.
(WebCore::BezierCurveData::encode const): Deleted.
(WebCore::BezierCurveData::decode): Deleted.
* Source/WebCore/platform/text/TextChecking.h:
* Source/WebCore/platform/text/TextCheckingRequestIdentifier.h: Copied from Source/WebCore/page/AutoplayEvent.h.
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/graphics/InlinePathData.serialization.in: Added.
* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::serializedIdentifiers):
* Source/WebKit/Shared/TextRecognitionResult.serialization.in: Added.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/258391@main">https://commits.webkit.org/258391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4c249ea6f56014c0d9630bd27ee82099ab65904

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111138 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171343 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1864 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94210 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108898 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92374 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/36844 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/105325 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91000 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegateReload (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78676 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4545 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25290 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1731 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10710 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44777 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5748 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6376 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->