### PR TITLE
[web-animations] support interpolation of numeric custom properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-angle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-angle-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Animating a custom property of type <angle>
+PASS Animating a custom property of type <angle> with a single keyframe
+PASS Animating a custom property of type <angle> with additivity
+PASS Animating a custom property of type <angle> with a single keyframe and additivity
+PASS Animating a custom property of type <angle> with iterationComposite
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-angle.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-angle.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "0deg"
+}, {
+  keyframes: ["100deg", "200deg"],
+  expected: "150deg"
+}, 'Animating a custom property of type <angle>');
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "100deg"
+}, {
+  keyframes: "200deg",
+  expected: "150deg"
+}, 'Animating a custom property of type <angle> with a single keyframe');
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "100deg"
+}, {
+  composite: "add",
+  keyframes: ["200deg", "300deg"],
+  expected: "350deg"
+}, 'Animating a custom property of type <angle> with additivity');
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "100deg"
+}, {
+  composite: "add",
+  keyframes: "300deg",
+  expected: "250deg"
+}, 'Animating a custom property of type <angle> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "100deg"
+}, {
+  iterationComposite: "accumulate",
+  keyframes: ["0deg", "100deg"],
+  expected: "250deg"
+}, 'Animating a custom property of type <angle> with iterationComposite');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-integer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-integer-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Animating a custom property of type <integer>
+PASS Animating a custom property of type <integer> with a single keyframe
+PASS Animating a custom property of type <integer> with additivity
+PASS Animating a custom property of type <integer> with a single keyframe and additivity
+PASS Animating a custom property of type <integer> with iterationComposite
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-integer.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-integer.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<integer>",
+  inherits: false,
+  initialValue: 0
+}, {
+  keyframes: [100, 200],
+  expected: "150"
+}, 'Animating a custom property of type <integer>');
+
+animation_test({
+  syntax: "<integer>",
+  inherits: false,
+  initialValue: 100
+}, {
+  keyframes: 200,
+  expected: "150"
+}, 'Animating a custom property of type <integer> with a single keyframe');
+
+animation_test({
+  syntax: "<integer>",
+  inherits: false,
+  initialValue: 100
+}, {
+  composite: "add",
+  keyframes: [200, 300],
+  expected: "350"
+}, 'Animating a custom property of type <integer> with additivity');
+
+animation_test({
+  syntax: "<integer>",
+  inherits: false,
+  initialValue: 100
+}, {
+  composite: "add",
+  keyframes: 300,
+  expected: "250"
+}, 'Animating a custom property of type <integer> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<integer>",
+  inherits: false,
+  initialValue: 100
+}, {
+  iterationComposite: "accumulate",
+  keyframes: [0, 100],
+  expected: "250"
+}, 'Animating a custom property of type <integer> with iterationComposite');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-number-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-number-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Animating a custom property of type <number>
+PASS Animating a custom property of type <number> with a single keyframe
+PASS Animating a custom property of type <number> with additivity
+PASS Animating a custom property of type <number> with a single keyframe and additivity
+PASS Animating a custom property of type <number> with iterationComposite
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-number.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-number.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 0
+}, {
+  keyframes: [100, 200],
+  expected: "150"
+}, 'Animating a custom property of type <number>');
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 100
+}, {
+  keyframes: 200,
+  expected: "150"
+}, 'Animating a custom property of type <number> with a single keyframe');
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 100
+}, {
+  composite: "add",
+  keyframes: [200, 300],
+  expected: "350"
+}, 'Animating a custom property of type <number> with additivity');
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 100
+}, {
+  composite: "add",
+  keyframes: 300,
+  expected: "250"
+}, 'Animating a custom property of type <number> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 100
+}, {
+  iterationComposite: "accumulate",
+  keyframes: [0, 100],
+  expected: "250"
+}, 'Animating a custom property of type <number> with iterationComposite');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-percentage-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-percentage-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Animating a custom property of type <percentage>
+PASS Animating a custom property of type <percentage> with a single keyframe
+PASS Animating a custom property of type <percentage> with additivity
+PASS Animating a custom property of type <percentage> with a single keyframe and additivity
+PASS Animating a custom property of type <percentage> with iterationComposite
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-percentage.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-percentage.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<percentage>",
+  inherits: false,
+  initialValue: "0%"
+}, {
+  keyframes: ["100%", "200%"],
+  expected: "150%"
+}, 'Animating a custom property of type <percentage>');
+
+animation_test({
+  syntax: "<percentage>",
+  inherits: false,
+  initialValue: "100%"
+}, {
+  keyframes: "200%",
+  expected: "150%"
+}, 'Animating a custom property of type <percentage> with a single keyframe');
+
+animation_test({
+  syntax: "<percentage>",
+  inherits: false,
+  initialValue: "100%"
+}, {
+  composite: "add",
+  keyframes: ["200%", "300%"],
+  expected: "350%"
+}, 'Animating a custom property of type <percentage> with additivity');
+
+animation_test({
+  syntax: "<percentage>",
+  inherits: false,
+  initialValue: "100%"
+}, {
+  composite: "add",
+  keyframes: "300%",
+  expected: "250%"
+}, 'Animating a custom property of type <percentage> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<percentage>",
+  inherits: false,
+  initialValue: "100%"
+}, {
+  iterationComposite: "accumulate",
+  keyframes: ["0%", "100%"],
+  expected: "250%"
+}, 'Animating a custom property of type <percentage> with iterationComposite');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-resolution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-resolution-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Animating a custom property of type <resolution>
+PASS Animating a custom property of type <resolution> with a single keyframe
+PASS Animating a custom property of type <resolution> with additivity
+PASS Animating a custom property of type <resolution> with a single keyframe and additivity
+PASS Animating a custom property of type <resolution> with iterationComposite
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-resolution.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-resolution.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<resolution>",
+  inherits: false,
+  initialValue: "0dppx"
+}, {
+  keyframes: ["100dppx", "200dppx"],
+  expected: "150dppx"
+}, 'Animating a custom property of type <resolution>');
+
+animation_test({
+  syntax: "<resolution>",
+  inherits: false,
+  initialValue: "100dppx"
+}, {
+  keyframes: "200dppx",
+  expected: "150dppx"
+}, 'Animating a custom property of type <resolution> with a single keyframe');
+
+animation_test({
+  syntax: "<resolution>",
+  inherits: false,
+  initialValue: "100dppx"
+}, {
+  composite: "add",
+  keyframes: ["200dppx", "300dppx"],
+  expected: "350dppx"
+}, 'Animating a custom property of type <resolution> with additivity');
+
+animation_test({
+  syntax: "<resolution>",
+  inherits: false,
+  initialValue: "100dppx"
+}, {
+  composite: "add",
+  keyframes: "300dppx",
+  expected: "250dppx"
+}, 'Animating a custom property of type <resolution> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<resolution>",
+  inherits: false,
+  initialValue: "100dppx"
+}, {
+  iterationComposite: "accumulate",
+  keyframes: ["0dppx", "100dppx"],
+  expected: "250dppx"
+}, 'Animating a custom property of type <resolution> with iterationComposite');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-time-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-time-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Animating a custom property of type <time>
+PASS Animating a custom property of type <time> with a single keyframe
+PASS Animating a custom property of type <time> with additivity
+PASS Animating a custom property of type <time> with a single keyframe and additivity
+PASS Animating a custom property of type <time> with iterationComposite
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-time.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-time.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<time>",
+  inherits: false,
+  initialValue: "0s"
+}, {
+  keyframes: ["100s", "200s"],
+  expected: "150s"
+}, 'Animating a custom property of type <time>');
+
+animation_test({
+  syntax: "<time>",
+  inherits: false,
+  initialValue: "100s"
+}, {
+  keyframes: "200s",
+  expected: "150s"
+}, 'Animating a custom property of type <time> with a single keyframe');
+
+animation_test({
+  syntax: "<time>",
+  inherits: false,
+  initialValue: "100s"
+}, {
+  composite: "add",
+  keyframes: ["200s", "300s"],
+  expected: "350s"
+}, 'Animating a custom property of type <time> with additivity');
+
+animation_test({
+  syntax: "<time>",
+  inherits: false,
+  initialValue: "100s"
+}, {
+  composite: "add",
+  keyframes: "300s",
+  expected: "250s"
+}, 'Animating a custom property of type <time> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<time>",
+  inherits: false,
+  initialValue: "100s"
+}, {
+  iterationComposite: "accumulate",
+  keyframes: ["0s", "100s"],
+  expected: "250s"
+}, 'Animating a custom property of type <time> with iterationComposite');
+
+</script>

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3913,6 +3913,12 @@ static void blendStandardProperty(const CSSPropertyBlendingClient& client, CSSPr
     }
 }
 
+static CSSCustomPropertyValue::NumericSyntaxValue blendFunc(const CSSCustomPropertyValue::NumericSyntaxValue& from, const CSSCustomPropertyValue::NumericSyntaxValue& to, const CSSPropertyBlendingContext& blendingContext)
+{
+    ASSERT(from.unitType == to.unitType);
+    return { blendFunc(from.value, to.value, blendingContext), from.unitType };
+}
+
 static std::optional<CSSCustomPropertyValue::SyntaxValue> blendSyntaxValues(const RenderStyle& fromStyle, const RenderStyle& toStyle, const CSSCustomPropertyValue::SyntaxValue& from, const CSSCustomPropertyValue::SyntaxValue& to, const CSSPropertyBlendingContext& blendingContext)
 {
     if (std::holds_alternative<Length>(from) && std::holds_alternative<Length>(to))
@@ -3923,6 +3929,13 @@ static std::optional<CSSCustomPropertyValue::SyntaxValue> blendSyntaxValues(cons
         auto& toStyleColor = std::get<StyleColor>(to);
         if (!RenderStyle::isCurrentColor(fromStyleColor) || !RenderStyle::isCurrentColor(toStyleColor))
             return blendFunc(fromStyle.colorResolvingCurrentColor(fromStyleColor), toStyle.colorResolvingCurrentColor(toStyleColor), blendingContext);
+    }
+
+    if (std::holds_alternative<CSSCustomPropertyValue::NumericSyntaxValue>(from) && std::holds_alternative<CSSCustomPropertyValue::NumericSyntaxValue>(to)) {
+        auto& fromNumeric = std::get<CSSCustomPropertyValue::NumericSyntaxValue>(from);
+        auto& toNumeric = std::get<CSSCustomPropertyValue::NumericSyntaxValue>(to);
+        if (fromNumeric.unitType == toNumeric.unitType)
+            return blendFunc(fromNumeric, toNumeric, blendingContext);
     }
 
     return std::nullopt;


### PR DESCRIPTION
#### c7b7097190c62dc6c3a040c895c8e0e06039104e
<pre>
[web-animations] support interpolation of numeric custom properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=249401">https://bugs.webkit.org/show_bug.cgi?id=249401</a>

Reviewed by Antti Koivisto.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-angle-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-angle.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-integer-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-integer.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-number-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-number.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-percentage-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-percentage.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-resolution-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-resolution.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-time-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-time.html: Added.
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
(WebCore::blendSyntaxValues):

Canonical link: <a href="https://commits.webkit.org/257930@main">https://commits.webkit.org/257930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e3da1a5fb369e21a44a7c5d12e4ab1a65307bc2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/100437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/9597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/33499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/109749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/104429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/10509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/106216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/10509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/33499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/10509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/33499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/33499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/3325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/33499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2828 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->