### PR TITLE
Stop adjusting position to absolute for root element in fullscreen

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-fills-page-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-fills-page-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <style>
+        html, body {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: green;
+        }
+    </style>
+</head>
+
+<body>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script>
+        document.addEventListener("fullscreenchange", () => {
+            document.documentElement.classList.remove("reftest-wait");
+        });
+        test_driver.bless("fullscreen")
+            .then(() => document.documentElement.requestFullscreen())
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-fills-page-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-fills-page-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <style>
+        html, body {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background-color: green;
+        }
+    </style>
+</head>
+
+<body>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script>
+        document.addEventListener("fullscreenchange", () => {
+            document.documentElement.classList.remove("reftest-wait");
+        });
+        test_driver.bless("fullscreen")
+            .then(() => document.documentElement.requestFullscreen())
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-fills-page.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-fills-page.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <link rel="author" href="https://github.com/nt1m">
+    <link rel="match" href="fullscreen-root-fills-page-ref.html">
+    <style>
+        html {
+            background-color: red;
+            height: 100%;
+            overflow: hidden;
+
+            /* These should be no-op */
+            top: 200px;
+            left: 200px;
+            right: 200px;
+            bottom: 200px;
+        }
+
+        html, body {
+            margin: 0;
+            padding: 0;
+        }
+
+        body, #cover {
+            height: 100%;
+            width: 100%;
+        }
+
+        #cover {
+            background-color: green;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="cover"></div>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script>
+        document.addEventListener("fullscreenchange", () => {
+            document.documentElement.classList.remove("reftest-wait");
+        });
+        test_driver.bless("fullscreen")
+            .then(() => document.documentElement.requestFullscreen())
+    </script>
+</body>
+</html>

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -306,7 +306,7 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
 
         // Top layer elements are always position: absolute; unless the position is set to fixed.
         // https://fullscreen.spec.whatwg.org/#new-stacking-layer
-        if (style.position() != PositionType::Absolute && style.position() != PositionType::Fixed && isInTopLayerOrBackdrop(style, m_element))
+        if (m_element != m_document.documentElement() && style.position() != PositionType::Absolute && style.position() != PositionType::Fixed && isInTopLayerOrBackdrop(style, m_element))
             style.setPosition(PositionType::Absolute);
 
         // Absolute/fixed positioned elements, floating elements and the document element need block-like outside display.


### PR DESCRIPTION
#### 9dcd18cf6f84a66fe763ab00f04fd0571f98ec6e
<pre>
Stop adjusting position to absolute for root element in fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=249404">https://bugs.webkit.org/show_bug.cgi?id=249404</a>
rdar://103313030

Reviewed by Alan Baradlay.

Other browsers do not adjust the position to absolute for the root element (tested by applying inset properties).
The adjustment in WebKit causes the root to collapse, which is an unwanted side-effect.

* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-fills-page-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-fills-page-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-fills-page.html: Added.
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):

Canonical link: <a href="https://commits.webkit.org/257946@main">https://commits.webkit.org/257946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b535bf37c287c913ca8bd8842a5b4f0071a1397

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33509 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/109783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10519 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106226 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3335 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5443 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->