### PR TITLE
[iOS] Changing the mute state of autoplaying silent videos can interrupt system audio

### DIFF
--- a/LayoutTests/media/audio-session-category-unmute-mute-expected.txt
+++ b/LayoutTests/media/audio-session-category-unmute-mute-expected.txt
@@ -1,0 +1,13 @@
+
+Test that silent, autoplaying videos with audio tracks do not interrupt other system audio
+RUN(video.muted = true)
+RUN(video.src = findMediaFile("video", "content/audio-tracks"))
+EVENT(loadedmetadata)
+RUN(video.play())
+RUN(video.pause())
+RUN(video.muted = false)
+RUN(video.muted = true)
+RUN(video.play())
+EXPECTED (internals.audioSessionCategory() == 'None') OK
+END OF TEST
+

--- a/LayoutTests/media/audio-session-category-unmute-mute.html
+++ b/LayoutTests/media/audio-session-category-unmute-mute.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>audio-session-category</title>
+    <script src='video-test.js'></script>
+    <script src='media-file.js'></script>
+    <script>
+        window.addEventListener('load', async event => {
+            if (!window.internals) {
+                failTest(`<br>This test requires internals!`);
+                return;
+            }
+
+            consoleWrite('Test that silent, autoplaying videos with audio tracks do not interrupt other system audio')
+
+            internals.settings.setShouldManageAudioSessionCategory(true);
+
+            video = document.getElementsByTagName('video')[0];
+
+            run('video.muted = true');
+            run('video.src = findMediaFile("video", "content/audio-tracks")');
+
+            await waitFor(video, 'loadedmetadata')
+
+            // Avoid a console warning in test output about a unhandled rejected play() promise:
+            try {
+                let playPromise = run('video.play()');
+                run('video.pause()');
+                await playPromise;
+            } catch(e) { }
+
+            run('video.muted = false');
+            await sleepFor(0);
+            run('video.muted = true');
+            await sleepFor(0);
+
+            await run('video.play()');
+
+            testExpected('internals.audioSessionCategory()', 'None')
+
+            endTest();
+        });
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/media/video-test.js
+++ b/LayoutTests/media/video-test.js
@@ -172,7 +172,7 @@ function runSilently(testFuncString)
     if (printFullTestDetails)
         consoleWrite("RUN(" + testFuncString + ")");
     try {
-        eval(testFuncString);
+        return eval(testFuncString);
     } catch (ex) {
         if (!printFullTestDetails) {
             // No details were printed previous, give some now.
@@ -187,7 +187,7 @@ function run(testFuncString)
 {
     consoleWrite("RUN(" + testFuncString + ")");
     try {
-        eval(testFuncString);
+        return eval(testFuncString);
     } catch (ex) {
         consoleWrite(ex);
     }

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1972,3 +1972,5 @@ webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-a
 
 # vertical form controls
 imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional.html [ Failure ]
+
+webkit.org/b/249477 media/audioSession/audioSessionType.html [ Skip ]

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -160,8 +160,8 @@ void PlatformMediaSession::setState(State state)
 
     ALWAYS_LOG(LOGIDENTIFIER, state);
     m_state = state;
-    if (m_state == State::Playing)
-        m_hasPlayedSinceLastInterruption = true;
+    if (m_state == State::Playing && canProduceAudio())
+        m_hasPlayedAudiblySinceLastInterruption = true;
     PlatformMediaSessionManager::sharedManager().sessionStateChanged(*this);
 }
 

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -185,8 +185,8 @@ public:
     virtual void resetPlaybackSessionState() { }
     String sourceApplicationIdentifier() const;
 
-    bool hasPlayedSinceLastInterruption() const { return m_hasPlayedSinceLastInterruption; }
-    void clearHasPlayedSinceLastInterruption() { m_hasPlayedSinceLastInterruption = false; }
+    bool hasPlayedAudiblySinceLastInterruption() const { return m_hasPlayedAudiblySinceLastInterruption; }
+    void clearHasPlayedAudiblySinceLastInterruption() { m_hasPlayedAudiblySinceLastInterruption = false; }
 
     bool preparingToPlay() const { return m_preparingToPlay; }
 
@@ -227,7 +227,7 @@ private:
     bool m_active { false };
     bool m_notifyingClient { false };
     bool m_isPlayingToWirelessPlaybackTarget { false };
-    bool m_hasPlayedSinceLastInterruption { false };
+    bool m_hasPlayedAudiblySinceLastInterruption { false };
     bool m_preparingToPlay { false };
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -147,7 +147,7 @@ void MediaSessionManagerCocoa::updateSessionState()
             bool isPotentiallyAudible = session.isPlayingToWirelessPlaybackTarget()
                 || ((type == PlatformMediaSession::MediaType::VideoAudio || type == PlatformMediaSession::MediaType::Audio)
                     && session.canProduceAudio()
-                    && (session.hasPlayedSinceLastInterruption() || session.preparingToPlay()));
+                    && (session.isPlaying() || session.preparingToPlay() || session.hasPlayedAudiblySinceLastInterruption()));
             if (isPotentiallyAudible) {
                 hasAudibleAudioOrVideoMediaType = true;
                 isPlayingAudio |= session.isPlaying();
@@ -224,7 +224,7 @@ void MediaSessionManagerCocoa::beginInterruption(PlatformMediaSession::Interrupt
 {
     if (type == PlatformMediaSession::InterruptionType::SystemInterruption) {
         forEachSession([] (auto& session) {
-            session.clearHasPlayedSinceLastInterruption();
+            session.clearHasPlayedAudiblySinceLastInterruption();
         });
     }
 

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
@@ -134,7 +134,7 @@ void MediaSessionManagerGLib::beginInterruption(PlatformMediaSession::Interrupti
 {
     if (type == PlatformMediaSession::InterruptionType::SystemInterruption) {
         forEachSession([] (auto& session) {
-            session.clearHasPlayedSinceLastInterruption();
+            session.clearHasPlayedAudiblySinceLastInterruption();
         });
     }
 


### PR DESCRIPTION
#### 2ed67ffbd825092a1f4b879fb1efe63e7e04a07a
<pre>
[iOS] Changing the mute state of autoplaying silent videos can interrupt system audio
<a href="https://bugs.webkit.org/show_bug.cgi?id=249408">https://bugs.webkit.org/show_bug.cgi?id=249408</a>
rdar://103408312

Reviewed by Eric Carlson.

WebKit will attempt to leave the default AVAudioSession category in &quot;ambient&quot;
when no audible playback exists. However, when an audible media element pauses,
WebKit will leave the category in &quot;media playback&quot;, which allows APIs like Now
Playing to continue working. It does this by tracking, for each media element,
that the element has played sometime since the last time WebKit received an
interruption. The assumption is that elements which have previously played
should not cause the category to drop to &quot;none&quot; when they pause.

However, this logic gets confused when a previously silent media element
(i.e., muted) pauses, then becomes not-silent (i.e., unmuted). The
PlatformMediaSessionManager sees that the element is capable of producing
audio, and has played since the last interruption, so sets the AVAudioSession
category to &quot;media playback&quot;. When that element is then played, AVFoundation
will activate the AVAudioSession, which by virtue of being configured for
&quot;media playback&quot;, will interrupt other system audio.

To resolve this, rather than tracking whether the element has &quot;played since the
last interruption&quot;, track whether the element has &quot;played _audibly_ since the
last interruption.&quot; Rename hasPlayedSinceLastInterruption() -&gt;
hasPlayedAudiblySinceLastInterruption() to clarify the new behavior.

* LayoutTests/media/audio-session-category-unmute-mute-expected.txt: Added.
* LayoutTests/media/audio-session-category-unmute-mute.html: Added.
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::setState):
* Source/WebCore/platform/audio/PlatformMediaSession.h:
(WebCore::PlatformMediaSession::hasPlayedAudiblySinceLastInterruption const):
(WebCore::PlatformMediaSession::clearHasPlayedAudiblySinceLastInterruption):
(WebCore::PlatformMediaSession::hasPlayedSinceLastInterruption const): Deleted.
(WebCore::PlatformMediaSession::clearHasPlayedSinceLastInterruption): Deleted.
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateSessionState):
(WebCore::MediaSessionManagerCocoa::beginInterruption):

Canonical link: <a href="https://commits.webkit.org/258000@main">https://commits.webkit.org/258000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e270c14df804df5549456b9c56c292843631f2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109930 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104611 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10703 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93025 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107779 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106407 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3479 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24257 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3493 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43752 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5481 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5285 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->