### PR TITLE
[CSS-Typed-OM] Reification of primitive values of type CSS_INTEGER should construct CSSUnitValues

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt
@@ -31,7 +31,7 @@ FAIL Setting 'grid-row-start' to a number: calc(2 + 3) throws TypeError assert_t
 PASS Setting 'grid-row-start' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'grid-row-start' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-row-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-PASS 'grid-row-start' does not support '3'
+FAIL 'grid-row-start' does not support '3' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
 PASS 'grid-row-start' does not support 'span 2'
 PASS 'grid-row-start' does not support '5 somegridarea span'
 PASS Can set 'grid-row-end' to CSS-wide keywords: initial
@@ -66,7 +66,7 @@ FAIL Setting 'grid-row-end' to a number: calc(2 + 3) throws TypeError assert_thr
 PASS Setting 'grid-row-end' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'grid-row-end' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-row-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-PASS 'grid-row-end' does not support '3'
+FAIL 'grid-row-end' does not support '3' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
 PASS 'grid-row-end' does not support 'span 2'
 PASS 'grid-row-end' does not support '5 somegridarea span'
 PASS Can set 'grid-column-start' to CSS-wide keywords: initial
@@ -101,7 +101,7 @@ FAIL Setting 'grid-column-start' to a number: calc(2 + 3) throws TypeError asser
 PASS Setting 'grid-column-start' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'grid-column-start' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-column-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-PASS 'grid-column-start' does not support '3'
+FAIL 'grid-column-start' does not support '3' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
 PASS 'grid-column-start' does not support 'span 2'
 PASS 'grid-column-start' does not support '5 somegridarea span'
 PASS Can set 'grid-column-end' to CSS-wide keywords: initial
@@ -136,7 +136,7 @@ FAIL Setting 'grid-column-end' to a number: calc(2 + 3) throws TypeError assert_
 PASS Setting 'grid-column-end' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'grid-column-end' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-column-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-PASS 'grid-column-end' does not support '3'
+FAIL 'grid-column-end' does not support '3' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
 PASS 'grid-column-end' does not support 'span 2'
 PASS 'grid-column-end' does not support '5 somegridarea span'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt
@@ -4,10 +4,10 @@ PASS Can set 'order' to CSS-wide keywords: inherit
 PASS Can set 'order' to CSS-wide keywords: unset
 PASS Can set 'order' to CSS-wide keywords: revert
 PASS Can set 'order' to var() references:  var(--A)
-FAIL Can set 'order' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'order' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'order' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'order' to a number: calc(2 + 3) assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'order' to a number: 0
+FAIL Can set 'order' to a number: -3.14 assert_approx_equals: expected -3 +/- 0.000001 but got 0
+PASS Can set 'order' to a number: 3.14
+PASS Can set 'order' to a number: calc(2 + 3)
 PASS Setting 'order' to a length: 0px throws TypeError
 PASS Setting 'order' to a length: -3.14em throws TypeError
 PASS Setting 'order' to a length: 3.14cm throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt
@@ -4,10 +4,10 @@ PASS Can set 'orphans' to CSS-wide keywords: inherit
 PASS Can set 'orphans' to CSS-wide keywords: unset
 PASS Can set 'orphans' to CSS-wide keywords: revert
 PASS Can set 'orphans' to var() references:  var(--A)
-FAIL Can set 'orphans' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'orphans' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'orphans' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'orphans' to a number: calc(2 + 3) assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'orphans' to a number: 0 assert_approx_equals: expected 1 +/- 0.000001 but got 0
+FAIL Can set 'orphans' to a number: -3.14 assert_approx_equals: expected 1 +/- 0.000001 but got 0
+PASS Can set 'orphans' to a number: 3.14
+PASS Can set 'orphans' to a number: calc(2 + 3)
 PASS Setting 'orphans' to a length: 0px throws TypeError
 PASS Setting 'orphans' to a length: -3.14em throws TypeError
 PASS Setting 'orphans' to a length: 3.14cm throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt
@@ -4,10 +4,10 @@ PASS Can set 'widows' to CSS-wide keywords: inherit
 PASS Can set 'widows' to CSS-wide keywords: unset
 PASS Can set 'widows' to CSS-wide keywords: revert
 PASS Can set 'widows' to var() references:  var(--A)
-FAIL Can set 'widows' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'widows' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'widows' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'widows' to a number: calc(2 + 3) assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'widows' to a number: 0 assert_approx_equals: expected 1 +/- 0.000001 but got 0
+FAIL Can set 'widows' to a number: -3.14 assert_approx_equals: expected 1 +/- 0.000001 but got 0
+PASS Can set 'widows' to a number: 3.14
+PASS Can set 'widows' to a number: calc(2 + 3)
 PASS Setting 'widows' to a length: 0px throws TypeError
 PASS Setting 'widows' to a length: -3.14em throws TypeError
 PASS Setting 'widows' to a length: 3.14cm throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt
@@ -5,10 +5,10 @@ PASS Can set 'z-index' to CSS-wide keywords: unset
 PASS Can set 'z-index' to CSS-wide keywords: revert
 PASS Can set 'z-index' to var() references:  var(--A)
 PASS Can set 'z-index' to the 'auto' keyword: auto
-FAIL Can set 'z-index' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'z-index' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'z-index' to a number: 3.14 assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'z-index' to a number: calc(2 + 3) assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'z-index' to a number: 0
+FAIL Can set 'z-index' to a number: -3.14 assert_approx_equals: expected -3 +/- 0.000001 but got 0
+PASS Can set 'z-index' to a number: 3.14
+PASS Can set 'z-index' to a number: calc(2 + 3)
 PASS Setting 'z-index' to a length: 0px throws TypeError
 PASS Setting 'z-index' to a length: -3.14em throws TypeError
 PASS Setting 'z-index' to a length: 3.14cm throws TypeError

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -176,6 +176,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Ref<CSSValue> c
         }
         switch (primitiveValue->primitiveType()) {
         case CSSUnitType::CSS_NUMBER:
+        case CSSUnitType::CSS_INTEGER:
             return Ref<CSSStyleValue> { CSSNumericFactory::number(primitiveValue->doubleValue()) };
         case CSSUnitType::CSS_PERCENTAGE:
             return Ref<CSSStyleValue> { CSSNumericFactory::percent(primitiveValue->doubleValue()) };


### PR DESCRIPTION
#### 4f73843e66335b3316af13e710a49f01e9935a18
<pre>
[CSS-Typed-OM] Reification of primitive values of type CSS_INTEGER should construct CSSUnitValues
<a href="https://bugs.webkit.org/show_bug.cgi?id=249412">https://bugs.webkit.org/show_bug.cgi?id=249412</a>

Reviewed by Simon Fraser.

Reification of primitive values of type CSS_INTEGER should construct
CSSUnitValues (with type &apos;number&apos;), not generic CSSStyleValues.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt:
Rebaseline WPT tests now that more checks are passing.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt:
While this looks like a regression, I am not convinced the test is correct. The
test sets the `grid-row-start` property to 3 and expects a generic
CSSStyleValue back when querying the StylePropertyMap. However, since 3 is an
integer, we return a CSSUnitValue. I&apos;ll investigate this separately. I suspect
this may have to do with the fact that the `grid-row-start` value may be stored
as a list internally when an identifier is provided in addition to the integer.

* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::reifyValue):

Canonical link: <a href="https://commits.webkit.org/257968@main">https://commits.webkit.org/257968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70f6531eb39e82936cb0c9dbee012f1219243d76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109801 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170080 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/202 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92887 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107655 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106247 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34613 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22629 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3362 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24148 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3355 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43638 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5459 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5169 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->