### PR TITLE
Add View Results button for embedded WebKit surveys

### DIFF
--- a/Websites/webkit.org/wp-content/plugins/webkit-survey/results.php
+++ b/Websites/webkit.org/wp-content/plugins/webkit-survey/results.php
@@ -1,59 +1,72 @@
 <style>
-    .survey-results {
+    .webkit-survey-results {
+        display: none;
+    }
+   
+    .webkit-survey-results.visible {
+        display: block;
+    }
+
+    .webkit-survey-results .results {
         position: relative;
         list-style: none;
         padding-left: 0;
     }
 
-    .survey-results > li {
+    .webkit-survey-results .results > li {
         margin-bottom: 1.7rem;
         position: relative;
     }
     
-    .label {
+    .webkit-survey-results .label {
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
         align-items: flex-end;
     }
     
-    .bar {
+    .webkit-survey-results .bar {
         display: block;
-        height: 0.7rem;
+        height: 7px;
         width: 100%;
         border-radius: 3px;
         background-color: var(--text-color-coolgray);
     }
     
-    .winner .bar {
+    .webkit-survey-results .winner .bar {
         background-image: linear-gradient(90deg, hsl(198, 100%, 20%) 0%, var(--background-color) 100%);
         background-color: transparent;
     }
     
-    .option {
+    .webkit-survey-results .option {
         flex-shrink: 1;
         align-self: end;
         overflow: visible;
     }
     
-    .percentage {
+    .webkit-survey-results .percentage {
         flex-shrink: 1;
-        width: 4rem;
+        width: 3.8ch;
         font-weight: 700;
-        margin-left: 1rem;
+        margin-left: 1ch;
         align-self: end;
     }
 
-    .percentage.right {
+    .webkit-survey-results .percentage.right {
         text-align: right;
     }
 </style>
 <?php 
     $SurveyResults = WebKit_Survey::calculate_results();
     foreach ($SurveyResults->survey as $id => $Entry): $total = isset($Entry->scores['total']) ? $Entry->scores['total'] : 1; 
+    
+    $results_classes = ['webkit-survey-results'];
+    if ($SurveyResults->status == 'closed' || $SurveyResults->results == 'visible' || WebKit_Survey::responded()) 
+        $results_classes[] = 'visible';
 ?>
+<div class="<?php esc_attr_e(join(' ', $results_classes)); ?>">
     <h3><?php echo $Entry->question; ?></h3>
-    <ul class="survey-results">
+    <ul class="results">
         <?php 
         foreach ($Entry->responses as $value => $option): 
             if ($option == "Other:") {
@@ -64,7 +77,7 @@
         ?>
         <li<?php if ($SurveyResults->winner == $value) echo ' class="winner"'; ?>>
             <div class="label">
-                <div class="option" style="min-width: calc(<?php esc_attr_e($percentage); ?>% - 5rem);"><?php echo esc_html($option); ?></div>
+                <div class="option" style="min-width: calc(<?php esc_attr_e($percentage); ?>% - 4.8ch);"><?php echo esc_html($option); ?></div>
                 <div class="percentage"><?php echo number_format($percentage, 0); ?>%</div>
             </div>
             <div class="bar" style="width: <?php echo esc_attr(max(1,$percentage)); ?>%">&nbsp;</div>
@@ -72,3 +85,4 @@
     <?php endforeach; ?>
     </ul>
 <?php endforeach; ?>
+</div>

--- a/Websites/webkit.org/wp-content/plugins/webkit-survey/survey.php
+++ b/Websites/webkit.org/wp-content/plugins/webkit-survey/survey.php
@@ -1,9 +1,9 @@
 <style>
-.webkit-survey ul {
+.webkit-survey-form ul {
     list-style: none;
 }
 
-.webkit-survey ul li {
+.webkit-survey-form ul li {
     display: block;
     margin: 0 3rem;
     position: relative;
@@ -14,7 +14,7 @@
     perspective: 500px;
 }
 
-.webkit-survey input[type=text] {
+.webkit-survey-form input[type=text] {
     display: inline-block;
     vertical-align: baseline;
     margin-left: 1rem;
@@ -25,34 +25,34 @@
     visibility: hidden;
 }
 
-.webkit-survey input[type=radio] {
+.webkit-survey-form input[type=radio] {
     margin-top: 0;
     vertical-align: middle;
     transition: opacity 500ms ease;
 }
 
-.webkit-survey input[type=radio]:checked ~ input[type=text] {
+.webkit-survey-form input[type=radio]:checked ~ input[type=text] {
     transform: rotateX( 0deg );
     visibility: visible;
 }
 
-.webkit-survey input[type=radio]:checked,
-.webkit-survey input[type=radio]:checked + span {
+.webkit-survey-form input[type=radio]:checked,
+.webkit-survey-form input[type=radio]:checked + span {
     opacity: 1;
     color: var(--text-color);
 }
 
-.webkit-survey input[type=radio] + span {
+.webkit-survey-form input[type=radio] + span {
     color: var(--text-color-coolgray);
     transition: color 500ms ease;
 }
 
-.webkit-survey input[type=submit],
-.webkit-survey a.button {
+.webkit-survey-form input[type=submit],
+.webkit-survey-form a.button {
     padding: 1rem 3rem;
 }
 
-.webkit-survey label {
+.webkit-survey-form label {
     box-sizing: border-box;
     display: inline-block;
     border-radius: 0.3rem;
@@ -62,18 +62,33 @@
     text-indent: -2.4rem;
 }
 
-.webkit-survey ul label:hover {
+.webkit-survey-form ul label:hover {
     background: var(--tile-background-color);
 }
 
-.webkit-survey .button-align-right {
+.webkit-survey-form .button-align-right {
     text-align: right;
+}
+
+.webkit-survey-form .preview-button {
+    background-color: var(--button-background-color);
+    border-radius: 4px;
+    color: var(--text-color);
+    cursor: pointer;
+    font-size: 1.5rem;
+    font-weight: 500;
+    text-align: center;
+    border: 0;
+    padding: 1rem 3rem;
+}
+.webkit-survey-form .preview-button:hover {
+    background-color: var(--text-color-coolgray);
+    color: white;
 }
 </style>
 
-<form class="webkit-survey" method="POST">
+<form class="webkit-survey-form" method="POST">
 <?php
-
 wp_nonce_field("webkit_survey-" . get_the_ID(), "_nonce", $true);
 foreach ($Survey->survey as $id => $Entry):
 ?>
@@ -90,6 +105,23 @@ foreach ($Survey->survey as $id => $Entry):
     </ul>
 <?php endforeach; ?>
 <p class="button-align-right">
+    <?php if ($SurveyResults->results != 'visible'): ?>
+    <input type="button" name="preview" value="View Results" class="preview-button">
+    <?php endif; ?>
     <input type="submit" name="Submit" value="Submit" class="submit-button">
 </p>
 </form>
+<?php if ($SurveyResults->results != 'visible'): ?>
+<script>
+    let surveys = Array.from(document.getElementsByClassName('webkit-survey'));
+    surveys.forEach(survey => {
+        let form = survey.getElementsByClassName('webkit-survey-form')[0],
+            results = survey.getElementsByClassName('webkit-survey-results')[0],
+            previewButton = document.getElementsByClassName('preview-button')[0];
+        previewButton.addEventListener('click', () => {
+            results.classList.add('visible');
+            form.remove();
+        });
+    });
+</script>
+<?php endif; ?>


### PR DESCRIPTION
#### bf3646af2826cb06de1749568935e92ce12801e2
<pre>
Add View Results button for embedded WebKit surveys
<a href="https://bugs.webkit.org/show_bug.cgi?id=249416">https://bugs.webkit.org/show_bug.cgi?id=249416</a>

Reviewed by Timothy Hatcher.

* Websites/webkit.org/wp-content/plugins/webkit-survey/plugin.php:
* Websites/webkit.org/wp-content/plugins/webkit-survey/results.php:
* Websites/webkit.org/wp-content/plugins/webkit-survey/survey.php:

Canonical link: <a href="https://commits.webkit.org/257944@main">https://commits.webkit.org/257944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5341fbd59399bb4e06a907bd425c3a6f2d8f6a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/100471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/9630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/33532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/109804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/10555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106250 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/10555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/33532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/10555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/33532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/33532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/3358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/33532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2841 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->