### PR TITLE
Add tests for _WKWebExtensionUtilities validateContentsOfDictionary:.

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.h
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.h
@@ -23,8 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <WebKit/WKFoundation.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
+WK_EXTERN
 @interface _WKWebExtensionUtilities : NSObject
 
 /// Verifies that a dictionary:

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.mm
@@ -27,14 +27,14 @@
 #error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
 #endif
 
-#if ENABLE(WK_WEB_EXTENSIONS)
-
 #import "config.h"
 #import "_WKWebExtensionUtilities.h"
 
 #import "CocoaHelpers.h"
 
 @implementation _WKWebExtensionUtilities
+
+#if ENABLE(WK_WEB_EXTENSIONS)
 
 static NSString *classToClassString(Class classType, BOOL plural = NO)
 {
@@ -129,5 +129,14 @@ static NSString *classToClassString(Class classType, BOOL plural = NO)
     return !errorString;
 }
 
-@end
+
+#else
+
++ (BOOL)validateContentsOfDictionary:(NSDictionary<NSString *, id> *)dictionary requiredKeys:(NSArray<NSString *> *)requiredKeys optionalKeys:(NSArray<NSString *> *)optionalKeys keyToExpectedValueType:(NSDictionary<NSString *, id> *)keyTypes outExceptionString:(NSString **)outExceptionString
+{
+    return NO;
+}
+
 #endif // ENABLE(WEB_EXTENSIONS)
+
+@end

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -818,7 +818,7 @@
 		3375A3772942A19D0028536D /* JSWebExtensionAPIWebNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3375A3762942A19C0028536D /* JSWebExtensionAPIWebNavigation.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		337822432947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.mm in Sources */ = {isa = PBXBuildFile; fileRef = 337822412947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		337822442947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 337822422947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		337822472947FBA5002106BB /* _WKWebExtensionUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 337822452947FBA4002106BB /* _WKWebExtensionUtilities.h */; };
+		337822472947FBA5002106BB /* _WKWebExtensionUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 337822452947FBA4002106BB /* _WKWebExtensionUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		337822482947FBA5002106BB /* _WKWebExtensionUtilities.mm in Sources */ = {isa = PBXBuildFile; fileRef = 337822462947FBA4002106BB /* _WKWebExtensionUtilities.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		33F68338293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 33F68336293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		33F6833E293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 33F6833D293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h */; };

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -290,6 +290,7 @@ Tests/WebKitCocoa/WKWebExtensionContext.mm
 Tests/WebKitCocoa/WKWebExtensionController.mm
 Tests/WebKitCocoa/WKWebExtensionControllerConfiguration.mm
 Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
+Tests/WebKitCocoa/WKWebExtensionUtilities.mm
 Tests/WebKitCocoa/WKWebViewAlwaysShowsScroller.mm
 Tests/WebKitCocoa/WKWebViewCandidateTests.mm
 Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2177,6 +2177,7 @@
 		333B9CE11277F23100FEFCE3 /* PreventEmptyUserAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PreventEmptyUserAgent.cpp; sourceTree = "<group>"; };
 		3378222C2947C095002106BB /* WKWebExtensionAPIWebNavigation.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIWebNavigation.mm; sourceTree = "<group>"; };
 		33976D8224DC479B00812304 /* IndexSparseSet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IndexSparseSet.cpp; sourceTree = "<group>"; };
+		339B4338294BA9A10050A7CF /* WKWebExtensionUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionUtilities.mm; sourceTree = "<group>"; };
 		33BE5AF4137B5A6C00705813 /* MouseMoveAfterCrash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MouseMoveAfterCrash.cpp; sourceTree = "<group>"; };
 		33BE5AF8137B5AAE00705813 /* MouseMoveAfterCrash_Bundle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MouseMoveAfterCrash_Bundle.cpp; sourceTree = "<group>"; };
 		33C2C9C02651F5B900E407F6 /* SmallSet.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SmallSet.cpp; sourceTree = "<group>"; };
@@ -4093,6 +4094,7 @@
 				1CAB9B7128F5E08900E6C77E /* WKWebExtensionController.mm */,
 				1C1549DA293A6D7F001B9E5B /* WKWebExtensionControllerConfiguration.mm */,
 				1CFAA40928974405009F894D /* WKWebExtensionMatchPattern.mm */,
+				339B4338294BA9A10050A7CF /* WKWebExtensionUtilities.mm */,
 				5C7148942123A40700FDE3C5 /* WKWebsiteDatastore.mm */,
 				371195AA1FE5797700A1FB92 /* WKWebViewAlwaysShowsScroller.mm */,
 				2EFF06D61D8AF34A0004BB30 /* WKWebViewCandidateTests.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionUtilities.mm
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "TestCocoa.h"
+#import <WebKit/WKFoundation.h>
+#import <WebKit/_WKWebExtensionUtilities.h>
+
+namespace TestWebKitAPI {
+
+TEST(WKWebExtensionUtilities, TestRequiredKeys)
+{
+    NSDictionary *dictionary = @{
+        @"A": @"A",
+        @"B": @"B",
+    };
+
+    NSString *error = nil;
+    BOOL result = [_WKWebExtensionUtilities validateContentsOfDictionary:dictionary
+        requiredKeys:@[ @"A", @"B" ]
+        optionalKeys:@[ ]
+        keyToExpectedValueType:@{ @"A": [NSObject class], @"B": [NSObject class] }
+        outExceptionString:&error];
+    EXPECT_TRUE(result);
+    EXPECT_NULL(error);
+
+    result = [_WKWebExtensionUtilities validateContentsOfDictionary:dictionary
+        requiredKeys:@[ @"A", @"B", @"C" ]
+        optionalKeys:@[ ]
+        keyToExpectedValueType:@{ @"A": [NSObject class], @"B": [NSObject class], @"C": [NSObject class] }
+        outExceptionString:&error];
+    EXPECT_FALSE(result);
+    EXPECT_NS_EQUAL(error, @"Missing required keys: C.");
+
+    result = [_WKWebExtensionUtilities validateContentsOfDictionary:@{ }
+        requiredKeys:@[ @"A", @"B", @"C" ]
+        optionalKeys:@[ ]
+        keyToExpectedValueType:@{ @"A": [NSObject class], @"B": [NSObject class], @"C": [NSObject class] }
+        outExceptionString:&error];
+    EXPECT_FALSE(result);
+    EXPECT_NS_EQUAL(error, @"Missing required keys: A, B, C.");
+}
+
+TEST(WKWebExtensionUtilities, TestOptionalKeys)
+{
+    NSDictionary *dictionary = @{
+        @"A": @"A",
+    };
+
+    NSString *error = nil;
+    BOOL result = [_WKWebExtensionUtilities validateContentsOfDictionary:dictionary
+        requiredKeys:@[ ]
+        optionalKeys:@[ @"A" ]
+        keyToExpectedValueType:@{ @"A": [NSObject class] }
+        outExceptionString:&error];
+    EXPECT_TRUE(result);
+    EXPECT_NULL(error);
+
+    result = [_WKWebExtensionUtilities validateContentsOfDictionary:dictionary
+        requiredKeys:@[ ]
+        optionalKeys:@[ @"A", @"B" ]
+        keyToExpectedValueType:@{ @"A": [NSObject class], @"B": [NSObject class] }
+        outExceptionString:&error];
+    EXPECT_TRUE(result);
+    EXPECT_NULL(error);
+}
+
+TEST(WKWebExtensionUtilities, TestUnexpectedKeys)
+{
+    NSDictionary *dictionary = @{
+        @"A": @"A",
+        @"B": @YES,
+    };
+
+    NSString *error = nil;
+    BOOL result = [_WKWebExtensionUtilities validateContentsOfDictionary:dictionary
+        requiredKeys:@[ ]
+        optionalKeys:@[ ]
+        keyToExpectedValueType:@{ }
+        outExceptionString:&error];
+    EXPECT_TRUE(result);
+    EXPECT_NULL(error);
+
+    error = nil;
+    result = [_WKWebExtensionUtilities validateContentsOfDictionary:dictionary
+        requiredKeys:@[ ]
+        optionalKeys:@[ @"B" ]
+        keyToExpectedValueType:@{ @"B": [@YES class] }
+        outExceptionString:&error];
+    EXPECT_TRUE(result);
+    EXPECT_NULL(error);
+
+    error = nil;
+    result = [_WKWebExtensionUtilities validateContentsOfDictionary:dictionary
+        requiredKeys:@[ @"B" ]
+        optionalKeys:@[ ]
+        keyToExpectedValueType:@{ @"B": [@YES class] }
+        outExceptionString:&error];
+    EXPECT_TRUE(result);
+    EXPECT_NULL(error);
+}
+
+TEST(WKWebExtensionUtilities, TestExpectedType)
+{
+    NSDictionary *dictionary = @{
+        @"A": @"A",
+        @"B": @"B",
+    };
+
+    NSString *error = nil;
+    BOOL result = [_WKWebExtensionUtilities validateContentsOfDictionary:dictionary
+        requiredKeys:@[ ]
+        optionalKeys:@[ @"A" ]
+        keyToExpectedValueType:@{ @"A": [NSString class] }
+        outExceptionString:&error];
+    EXPECT_TRUE(result);
+    EXPECT_NULL(error);
+
+    error = nil;
+    result = [_WKWebExtensionUtilities validateContentsOfDictionary:dictionary
+        requiredKeys:@[ ]
+        optionalKeys:@[ @"A" ]
+        keyToExpectedValueType:@{ @"A": [NSNumber class] }
+        outExceptionString:&error];
+    EXPECT_FALSE(result);
+    EXPECT_NS_EQUAL(error, @"Expected a number value for 'A', found a string value instead.");
+
+    error = nil;
+    result = [_WKWebExtensionUtilities validateContentsOfDictionary:dictionary
+        requiredKeys:@[ ]
+        optionalKeys:@[ @"B" ]
+        keyToExpectedValueType:@{ @"B": [@YES class] }
+        outExceptionString:&error];
+    EXPECT_FALSE(result);
+    EXPECT_NS_EQUAL(error, @"Expected a boolean value for 'B', found a string value instead.");
+}
+
+TEST(WKWebExtensionUtilities, TestExpectedTypeArrayOfTypes)
+{
+    NSDictionary *dictionary = @{
+        @"A": @[ @"AString" ],
+    };
+
+    NSString *error = nil;
+    BOOL result = [_WKWebExtensionUtilities validateContentsOfDictionary:dictionary
+        requiredKeys:@[ ]
+        optionalKeys:@[ @"A" ]
+        keyToExpectedValueType:@{ @"A": @[ [NSString class] ] }
+        outExceptionString:&error];
+    EXPECT_TRUE(result);
+    EXPECT_NULL(error);
+
+    error = nil;
+    result = [_WKWebExtensionUtilities validateContentsOfDictionary:dictionary
+        requiredKeys:@[ ]
+        optionalKeys:@[ @"A" ]
+        keyToExpectedValueType:@{ @"A": @[ [NSNumber class] ] }
+        outExceptionString:&error];
+    EXPECT_FALSE(result);
+    EXPECT_NS_EQUAL(error, @"Expected number values in the array for 'A', found a string value instead.");
+
+    dictionary = @{
+        @"A": @[ ],
+    };
+
+    error = nil;
+    result = [_WKWebExtensionUtilities validateContentsOfDictionary:dictionary
+        requiredKeys:@[ ]
+        optionalKeys:@[ @"A" ]
+        keyToExpectedValueType:@{ @"A": @[ [NSString class] ] }
+        outExceptionString:&error];
+    EXPECT_TRUE(result);
+    EXPECT_NULL(error);
+
+    error = nil;
+    dictionary = @{
+        @"A": @"Definitely not an array",
+    };
+
+    error = nil;
+    result = [_WKWebExtensionUtilities validateContentsOfDictionary:dictionary
+        requiredKeys:@[ ]
+        optionalKeys:@[ @"A" ]
+        keyToExpectedValueType:@{ @"A": @[ [NSString class] ] }
+        outExceptionString:&error];
+    EXPECT_FALSE(result);
+    EXPECT_NS_EQUAL(error, @"Expected an array for 'A'.");
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 753015b17a828ee7e9e453915d08d7b22704c9fd
<pre>
Add tests for _WKWebExtensionUtilities validateContentsOfDictionary:.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249425">https://bugs.webkit.org/show_bug.cgi?id=249425</a>
rdar://102820594

Reviewed by Timothy Hatcher.

This also requires _WKWebExtensionUtilities to be made a private header, which requires the ENABLE flags to be removed from the header,
so a stub implementation is needed.

* Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.h:
* Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.mm:
(+[_WKWebExtensionUtilities validateContentsOfDictionary:requiredKeys:optionalKeys:keyToExpectedValueType:outExceptionString:]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionUtilities.mm: Added.
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/258003@main">https://commits.webkit.org/258003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a996b198fe54d7c8db1950b1f96a1580bb9a1532

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109943 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104625 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10717 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93039 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107791 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106421 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3506 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43762 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5487 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->