### PR TITLE
Use WeakHashSet<ScrollableArea> instead of HashSet<ScrollableArea*>

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4472,7 +4472,7 @@ void Document::setNeedsVisualViewportScrollEvent()
     m_needsVisualViewportScrollEvent = true;
 }
 
-static bool serviceScrollAnimationForScrollableArea(ScrollableArea* scrollableArea, MonotonicTime time)
+static bool serviceScrollAnimationForScrollableArea(const ScrollableArea* scrollableArea, MonotonicTime time)
 {
     if (!scrollableArea)
         return false;
@@ -4491,13 +4491,18 @@ void Document::runScrollSteps()
     if (frameView) {
         MonotonicTime now = MonotonicTime::now();
         bool scrollAnimationsInProgress = serviceScrollAnimationForScrollableArea(frameView.get(), now);
-        HashSet<ScrollableArea*> scrollableAreasToUpdate;
-        if (auto userScrollableAreas = frameView->scrollableAreas())
-            scrollableAreasToUpdate.add(userScrollableAreas->begin(), userScrollableAreas->end());
-        if (auto nonUserScrollableAreas = frameView->scrollableAreasForAnimatedScroll())
-            scrollableAreasToUpdate.add(nonUserScrollableAreas->begin(), nonUserScrollableAreas->end());
-        for (auto* scrollableArea : scrollableAreasToUpdate) {
-            if (serviceScrollAnimationForScrollableArea(scrollableArea, now))
+        HashSet<CheckedPtr<ScrollableArea>> scrollableAreasToUpdate;
+        if (auto userScrollableAreas = frameView->scrollableAreas()) {
+            for (auto& area : *userScrollableAreas)
+                scrollableAreasToUpdate.add(CheckedPtr<ScrollableArea>(area));
+        }
+            
+        if (auto nonUserScrollableAreas = frameView->scrollableAreasForAnimatedScroll()) {
+            for (auto& area : *nonUserScrollableAreas)
+                scrollableAreasToUpdate.add(CheckedPtr<ScrollableArea>(area));
+        }
+        for (auto& scrollableArea : scrollableAreasToUpdate) {
+            if (serviceScrollAnimationForScrollableArea(scrollableArea.get(), now))
                 scrollAnimationsInProgress = true;
         }
         if (scrollAnimationsInProgress)

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -964,13 +964,14 @@ void FocusController::setIsVisibleAndActiveInternal(bool contentIsVisible)
         if (!frameView)
             continue;
 
-        const HashSet<ScrollableArea*>* scrollableAreas = frameView->scrollableAreas();
+        auto scrollableAreas = frameView->scrollableAreas();
         if (!scrollableAreas)
             continue;
 
-        for (auto& scrollableArea : *scrollableAreas) {
+        for (auto& area : *scrollableAreas) {
+            CheckedPtr<ScrollableArea> scrollableArea(area);
             ASSERT(scrollableArea->scrollbarsCanBeActive() || m_page.shouldSuppressScrollbarAnimations());
-            contentAreaDidShowOrHide(scrollableArea, contentIsVisible);
+            contentAreaDidShowOrHide(scrollableArea.get(), contentIsVisible);
         }
     }
 }

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -820,8 +820,10 @@ void FrameView::invalidateScrollbarsForAllScrollableAreas()
     if (!m_scrollableAreas)
         return;
 
-    for (auto* scrollableArea : *m_scrollableAreas)
+    for (auto& area : *m_scrollableAreas) {
+        CheckedPtr<ScrollableArea> scrollableArea(area);
         scrollableArea->invalidateScrollbars();
+    }
 }
 
 GraphicsLayer* FrameView::layerForHorizontalScrollbar() const
@@ -4447,7 +4449,8 @@ void FrameView::notifyScrollableAreasThatContentAreaWillPaint() const
     if (!m_scrollableAreas)
         return;
 
-    for (auto& scrollableArea : *m_scrollableAreas) {
+    for (auto& area : *m_scrollableAreas) {
+        CheckedPtr<ScrollableArea> scrollableArea(area);
         // ScrollView ScrollableAreas will be handled via the Frame tree traversal above.
         if (!is<ScrollView>(scrollableArea))
             scrollableArea->contentAreaWillPaint();
@@ -5550,13 +5553,13 @@ void FrameView::addScrollableAreaForAnimatedScroll(ScrollableArea* scrollableAre
     if (!m_scrollableAreasForAnimatedScroll)
         m_scrollableAreasForAnimatedScroll = makeUnique<ScrollableAreaSet>();
     
-    m_scrollableAreasForAnimatedScroll->add(scrollableArea);
+    m_scrollableAreasForAnimatedScroll->add(*scrollableArea);
 }
 
 void FrameView::removeScrollableAreaForAnimatedScroll(ScrollableArea* scrollableArea)
 {
     if (m_scrollableAreasForAnimatedScroll)
-        m_scrollableAreasForAnimatedScroll->remove(scrollableArea);
+        m_scrollableAreasForAnimatedScroll->remove(*scrollableArea);
 }
 
 bool FrameView::addScrollableArea(ScrollableArea* scrollableArea)
@@ -5564,7 +5567,7 @@ bool FrameView::addScrollableArea(ScrollableArea* scrollableArea)
     if (!m_scrollableAreas)
         m_scrollableAreas = makeUnique<ScrollableAreaSet>();
     
-    if (m_scrollableAreas->add(scrollableArea).isNewEntry) {
+    if (m_scrollableAreas->add(*scrollableArea).isNewEntry) {
         scrollableAreaSetChanged();
         return true;
     }
@@ -5574,7 +5577,7 @@ bool FrameView::addScrollableArea(ScrollableArea* scrollableArea)
 
 bool FrameView::removeScrollableArea(ScrollableArea* scrollableArea)
 {
-    if (m_scrollableAreas && m_scrollableAreas->remove(scrollableArea)) {
+    if (m_scrollableAreas && m_scrollableAreas->remove(*scrollableArea)) {
         scrollableAreaSetChanged();
         return true;
     }
@@ -5583,7 +5586,7 @@ bool FrameView::removeScrollableArea(ScrollableArea* scrollableArea)
 
 bool FrameView::containsScrollableArea(ScrollableArea* scrollableArea) const
 {
-    return m_scrollableAreas && m_scrollableAreas->contains(scrollableArea);
+    return m_scrollableAreas && m_scrollableAreas->contains(*scrollableArea);
 }
 
 void FrameView::scrollableAreaSetChanged()

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -587,7 +587,7 @@ public:
     const Vector<FloatRect>& trackedRepaintRects() const { return m_trackedRepaintRects; }
     String trackedRepaintRectsAsText() const;
 
-    typedef HashSet<ScrollableArea*> ScrollableAreaSet;
+    typedef WeakHashSet<ScrollableArea> ScrollableAreaSet;
     // Returns whether the scrollable area has just been newly added.
     WEBCORE_EXPORT bool addScrollableArea(ScrollableArea*);
     // Returns whether the scrollable area has just been removed.

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1508,12 +1508,14 @@ void Page::lockAllOverlayScrollbarsToHidden(bool lockOverlayScrollbars)
         if (!frameView)
             continue;
 
-        const HashSet<ScrollableArea*>* scrollableAreas = frameView->scrollableAreas();
+        auto scrollableAreas = frameView->scrollableAreas();
         if (!scrollableAreas)
             continue;
 
-        for (auto& scrollableArea : *scrollableAreas)
+        for (auto& area : *scrollableAreas) {
+            CheckedPtr<ScrollableArea> scrollableArea(area);
             scrollableArea->lockOverlayScrollbarStateToHidden(lockOverlayScrollbars);
+        }
     }
 }
     
@@ -2566,7 +2568,8 @@ void Page::stopKeyboardScrollAnimation()
         if (!scrollableAreas)
             continue;
 
-        for (auto& scrollableArea : *scrollableAreas) {
+        for (auto& area : *scrollableAreas) {
+            CheckedPtr<ScrollableArea> scrollableArea(area);
             // First call stopAsyncAnimatedScroll() to prepare for the keyboard scroller running on the scrolling thread.
             scrollableArea->stopAsyncAnimatedScroll();
             scrollableArea->stopKeyboardScrollAnimation();

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -128,7 +128,8 @@ EventTrackingRegions ScrollingCoordinator::absoluteEventTrackingRegionsForFrame(
     // to not ask for regions at bad times.
 
     if (auto* scrollableAreas = frameView->scrollableAreas()) {
-        for (auto& scrollableArea : *scrollableAreas) {
+        for (auto& area : *scrollableAreas) {
+            CheckedPtr<ScrollableArea> scrollableArea(area);
             // Composited scrollable areas can be scrolled off the main thread.
             if (!scrollableArea->isVisibleToHitTesting() || scrollableArea->usesAsyncScrolling())
                 continue;

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -45,7 +45,7 @@
 
 namespace WebCore {
 
-struct SameSizeAsScrollableArea {
+struct SameSizeAsScrollableArea : public CanMakeCheckedPtr {
     virtual ~SameSizeAsScrollableArea();
 #if ASSERT_ENABLED
     bool weakPtrFactorWasConstructedOnMainThread;

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -31,6 +31,7 @@
 #include "ScrollSnapOffsetsInfo.h"
 #include "ScrollTypes.h"
 #include "Scrollbar.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakPtr.h>
 
@@ -63,7 +64,7 @@ inline int offsetForOrientation(ScrollOffset offset, ScrollbarOrientation orient
     return 0;
 }
 
-class ScrollableArea : public CanMakeWeakPtr<ScrollableArea> {
+class ScrollableArea : public CanMakeWeakPtr<ScrollableArea>, public CanMakeCheckedPtr {
 public:
     virtual bool isScrollView() const { return false; }
     virtual bool isRenderLayer() const { return false; }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2961,7 +2961,7 @@ unsigned Internals::numberOfScrollableAreas()
     unsigned count = 0;
     Frame* frame = document->frame();
     if (frame->view()->scrollableAreas())
-        count += frame->view()->scrollableAreas()->size();
+        count += frame->view()->scrollableAreas()->computeSize();
 
     for (AbstractFrame* child = frame->tree().firstChild(); child; child = child->tree().nextSibling()) {
         auto* localChild = dynamicDowncast<LocalFrame>(child);
@@ -2971,7 +2971,7 @@ unsigned Internals::numberOfScrollableAreas()
         if (!frameView)
             continue;
         if (frameView->scrollableAreas())
-            count += frameView->scrollableAreas()->size();
+            count += frameView->scrollableAreas()->computeSize();
     }
 
     return count;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6090,15 +6090,16 @@ static bool pageContainsAnyHorizontalScrollbars(Frame* mainFrame)
         if (!frameView)
             continue;
 
-        const HashSet<ScrollableArea*>* scrollableAreas = frameView->scrollableAreas();
+        auto scrollableAreas = frameView->scrollableAreas();
         if (!scrollableAreas)
             continue;
 
-        for (auto* scrollableArea : *scrollableAreas) {
+        for (auto& area : *scrollableAreas) {
+            CheckedPtr<ScrollableArea> scrollableArea(area);
             if (!scrollableArea->scrollbarsCanBeActive())
                 continue;
 
-            if (hasEnabledHorizontalScrollbar(scrollableArea))
+            if (hasEnabledHorizontalScrollbar(scrollableArea.get()))
                 return true;
         }
     }


### PR DESCRIPTION
#### 90f1d32abbcef785e1ae4b21fa131346c87f2fb1
<pre>
Use WeakHashSet&lt;ScrollableArea&gt; instead of HashSet&lt;ScrollableArea*&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=249428">https://bugs.webkit.org/show_bug.cgi?id=249428</a>
rdar://103418459

Reviewed by Ryosuke Niwa.

Use WeakHashSet&lt;ScrollableArea&gt; instead of HashSet&lt;ScrollableArea*&gt;.
Make ScrollableArea compatible with CheckedPtr.

* Source/WebCore/dom/Document.cpp:
(WebCore::serviceScrollAnimationForScrollableArea):
(WebCore::Document::runScrollSteps):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setIsVisibleAndActiveInternal):
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::invalidateScrollbarsForAllScrollableAreas):
(WebCore::FrameView::notifyScrollableAreasThatContentAreaWillPaint const):
(WebCore::FrameView::addScrollableAreaForAnimatedScroll):
(WebCore::FrameView::removeScrollableAreaForAnimatedScroll):
(WebCore::FrameView::addScrollableArea):
(WebCore::FrameView::removeScrollableArea):
(WebCore::FrameView::containsScrollableArea const):
* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::lockAllOverlayScrollbarsToHidden):
(WebCore::Page::stopKeyboardScrollAnimation):
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::absoluteEventTrackingRegionsForFrame const):
* Source/WebCore/platform/ScrollableArea.cpp:
* Source/WebCore/platform/ScrollableArea.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::numberOfScrollableAreas):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::pageContainsAnyHorizontalScrollbars):

Canonical link: <a href="https://commits.webkit.org/258255@main">https://commits.webkit.org/258255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dde4f0b2b0e0d3c2932d870ad0384488e24af0fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110425 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170673 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105127 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1158 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93533 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108255 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91784 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35089 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90432 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23184 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78084 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3936 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24676 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1115 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44186 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5736 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2975 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->