### PR TITLE
REGRESSION(205039@main): StyledMarkupAccumulator sometimes does not emit an end tag

### DIFF
--- a/LayoutTests/editing/pasteboard/copy-content-with-display-none-exiting-ancestors-expected.txt
+++ b/LayoutTests/editing/pasteboard/copy-content-with-display-none-exiting-ancestors-expected.txt
@@ -1,0 +1,6 @@
+| <i>
+|   "hello "
+| <b>
+|   "world"
+|   " "
+| "bar<#selection-caret>"

--- a/LayoutTests/editing/pasteboard/copy-content-with-display-none-exiting-ancestors.html
+++ b/LayoutTests/editing/pasteboard/copy-content-with-display-none-exiting-ancestors.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p id="description">This tests copying excludes content with user-select: none.<br>
+To manually test, copy "hello world foo bar" below then paste. The pasted content should look identical</p>
+<div id="source"><i>hello </i><b>world <span style="display: none">foo </span></b><span>bar </span></div>
+<div id="destination" contenteditable></div>
+<pre id="output"></pre>
+</body>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+jsTestIsAsync = true;
+getSelection().setBaseAndExtent(source, 0, source, source.childNodes.length);
+
+if (window.testRunner && window.internals) {
+    testRunner.dumpAsText();
+    testRunner.execCommand("Copy");
+    destination.focus();
+    testRunner.execCommand("Paste");
+    Markup.dump(destination);
+} else {
+    Markup.noAutoDump();
+    source.addEventListener("copy", () => {
+        setTimeout(() => destination.focus(), 0);
+    });
+    destination.addEventListener("paste", () => {
+        setTimeout(() => {
+            Markup.dump(destination);
+            Markup.notifyDone();
+        }, 0);
+    });
+}
+
+</script>
+</html>

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -696,19 +696,26 @@ Node* StyledMarkupAccumulator::traverseNodesForSerialization(Node& startNode, No
 
         Vector<Node*, 8> exitedAncestors;
         next = nullptr;
-        if (auto* child = firstChild(*n))
-            next = child;
-        else if (auto* sibling = nextSibling(*n))
-            next = sibling;
-        else {
+
+        auto advanceToAncestorSibling = [&]() {
+            if (auto* sibling = nextSibling(*n)) {
+                next = sibling;
+                return;
+            }
             for (auto* ancestor = parentNode(*n); ancestor; ancestor = parentNode(*ancestor)) {
                 exitedAncestors.append(ancestor);
                 if (auto* sibling = nextSibling(*ancestor)) {
                     next = sibling;
-                    break;
+                    return;
                 }
             }
-        }
+        };
+
+        if (auto* child = firstChild(*n))
+            next = child;
+        else
+            advanceToAncestorSibling();
+
         ASSERT(next || !pastEnd || n->containsIncludingShadowDOM(pastEnd));
 
         if (isBlock(n) && canHaveChildrenForEditing(*n) && next == pastEnd) {
@@ -717,9 +724,10 @@ Node* StyledMarkupAccumulator::traverseNodesForSerialization(Node& startNode, No
         }
 
         bool didEnterNode = false;
-        if (!enterNode(*n))
-            next = nextSkippingChildren(*n);
-        else if (!hasChildNodes(*n))
+        if (!enterNode(*n)) {
+            exitedAncestors.clear();
+            advanceToAncestorSibling();
+        } else if (!hasChildNodes(*n))
             exitNode(*n);
         else
             didEnterNode = true;


### PR DESCRIPTION
#### 24540c7a6767717f61a5423cbf468b162bd1b88a
<pre>
REGRESSION(205039@main): StyledMarkupAccumulator sometimes does not emit an end tag
<a href="https://bugs.webkit.org/show_bug.cgi?id=249426">https://bugs.webkit.org/show_bug.cgi?id=249426</a>

Reviewed by Wenson Hsieh.

The bug was caused by traverseNodesForSerialization failing to register ancestors that climbed out of
when enterNode returns false. Fixed the bug by re-using the normal traversal code.

* LayoutTests/editing/pasteboard/copy-content-with-display-none-exiting-ancestors-expected.txt: Added.
* LayoutTests/editing/pasteboard/copy-content-with-display-none-exiting-ancestors.html: Added.
* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::traverseNodesForSerialization):

Canonical link: <a href="https://commits.webkit.org/257977@main">https://commits.webkit.org/257977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fd4cf9363a06b21b1ffeeb14dab8364c895be4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109823 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170111 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104492 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10581 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107678 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34630 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22647 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3384 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24166 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3382 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9501 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43656 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5190 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2855 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->