### PR TITLE
fix script assertion (WIP)

### DIFF
--- a/Source/.vscode/settings.json
+++ b/Source/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "valarray": "cpp"
+    }
+}

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2227,6 +2227,8 @@ bool Document::needsStyleRecalc() const
 
 static bool isSafeToUpdateStyleOrLayout()
 {
+    WTFLogAlways("Chirag - ScriptDisallowedScope::InMainThread::isScriptAllowed(): %d", ScriptDisallowedScope::InMainThread::isScriptAllowed());
+    WTFLogAlways("Chirag - !isInWebProcess(): %d", !isInWebProcess());
     return ScriptDisallowedScope::InMainThread::isScriptAllowed() || !isInWebProcess();
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2227,8 +2227,8 @@ bool Document::needsStyleRecalc() const
 
 static bool isSafeToUpdateStyleOrLayout()
 {
-    WTFLogAlways("Chirag - ScriptDisallowedScope::InMainThread::isScriptAllowed(): %d", ScriptDisallowedScope::InMainThread::isScriptAllowed());
-    WTFLogAlways("Chirag - !isInWebProcess(): %d", !isInWebProcess());
+    // WTFLogAlways("Chirag - ScriptDisallowedScope::InMainThread::isScriptAllowed(): %d", ScriptDisallowedScope::InMainThread::isScriptAllowed());
+    // WTFLogAlways("Chirag - !isInWebProcess(): %d", !isInWebProcess());
     return ScriptDisallowedScope::InMainThread::isScriptAllowed() || !isInWebProcess();
 }
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1014,7 +1014,7 @@ static std::optional<std::pair<RenderElement*, LayoutRect>> listBoxElementScroll
 
 void Element::scrollIntoView(std::optional<std::variant<bool, ScrollIntoViewOptions>>&& arg)
 {
-    WTFLogAlways("Chirag - Element::scrollIntoView: %d", ScriptDisallowedScope::InMainThread::isScriptAllowed());
+    // WTFLogAlways("Chirag - Element::scrollIntoView: %d", ScriptDisallowedScope::InMainThread::isScriptAllowed());
     document().updateLayoutIgnorePendingStylesheets();
 
     RenderElement* renderer = nullptr;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1014,6 +1014,7 @@ static std::optional<std::pair<RenderElement*, LayoutRect>> listBoxElementScroll
 
 void Element::scrollIntoView(std::optional<std::variant<bool, ScrollIntoViewOptions>>&& arg)
 {
+    WTFLogAlways("Chirag - Element::scrollIntoView: %d", ScriptDisallowedScope::InMainThread::isScriptAllowed());
     document().updateLayoutIgnorePendingStylesheets();
 
     RenderElement* renderer = nullptr;

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -2412,6 +2412,7 @@ void FrameView::scrollElementToRect(const Element& element, const IntRect& rect)
 
 void FrameView::setScrollPosition(const ScrollPosition& scrollPosition, const ScrollPositionChangeOptions& options)
 {
+    WTFLogAlways("Chirag 1 - FrameView::setScrollPosition: %d", ScriptDisallowedScope::InMainThread::isScriptAllowed());
     LOG_WITH_STREAM(Scrolling, stream << "FrameView::setScrollPosition " << scrollPosition << " animated " << (options.animated == ScrollIsAnimated::Yes) << ", clearing anchor");
 
     auto oldScrollType = currentScrollType();
@@ -2597,6 +2598,7 @@ void FrameView::cancelScheduledTextFragmentIndicatorTimer()
 
 bool FrameView::scrollRectToVisible(const LayoutRect& absoluteRect, const RenderObject& renderer, bool insideFixed, const ScrollRectToVisibleOptions& options)
 {
+    WTFLogAlways("FrameView::scrollRectToVisible: %d", ScriptDisallowedScope::InMainThread::isScriptAllowed());
     if (options.revealMode == SelectionRevealMode::DoNotReveal)
         return false;
 
@@ -2633,6 +2635,7 @@ static ScrollPositionChangeOptions scrollPositionChangeOptionsForElement(const F
 
 void FrameView::scrollRectToVisibleInChildView(const LayoutRect& absoluteRect, bool insideFixed, const ScrollRectToVisibleOptions& options, const HTMLFrameOwnerElement* ownerElement)
 {
+    WTFLogAlways("FrameView::scrollRectToVisibleInChildView: %d", ScriptDisallowedScope::InMainThread::isScriptAllowed());
     // If scrollbars aren't explicitly forbidden, permit scrolling.
     const HTMLFrameElementBase* frameElementBase = dynamicDowncast<HTMLFrameElementBase>(ownerElement);
     if (frameElementBase && frameElementBase->scrollingMode() == ScrollbarMode::AlwaysOff) {
@@ -2668,8 +2671,10 @@ void FrameView::scrollRectToVisibleInChildView(const LayoutRect& absoluteRect, b
         return;
 
     // FIXME: ideally need to determine if this <iframe> is inside position:fixed.
-    if (auto* ownerRenderer = ownerElement->renderer())
+    if (auto* ownerRenderer = ownerElement->renderer()) {
+        WTFLogAlways("Chirag -- before calling: scrollRectToVisible: %d", ScriptDisallowedScope::InMainThread::isScriptAllowed());
         scrollRectToVisible(contentsToContainingViewContents(enclosingIntRect(targetRect)), *ownerRenderer, false /* insideFixed */, options);
+    }
 }
 
 void FrameView::scrollRectToVisibleInTopLevelView(const LayoutRect& absoluteRect, bool insideFixed, const ScrollRectToVisibleOptions& options)
@@ -3756,12 +3761,6 @@ void FrameView::performPostLayoutTasks()
     // FIXME: We should not run any JavaScript code in this function.
     LOG(Layout, "FrameView %p performPostLayoutTasks", this);
     updateHasReachedSignificantRenderedTextThreshold();
-
-    if (auto& selection = frame().selection(); selection.isFocusedAndActive()) {
-        // FIXME (247041): We should be able to remove this appearance update altogether,
-        // and instead defer updates until the next rendering update.
-        selection.updateAppearanceAfterLayout();
-    }
 
     flushPostLayoutTasksQueue();
 

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -2598,7 +2598,7 @@ void FrameView::cancelScheduledTextFragmentIndicatorTimer()
 
 bool FrameView::scrollRectToVisible(const LayoutRect& absoluteRect, const RenderObject& renderer, bool insideFixed, const ScrollRectToVisibleOptions& options)
 {
-    WTFLogAlways("FrameView::scrollRectToVisible: %d", ScriptDisallowedScope::InMainThread::isScriptAllowed());
+    // WTFLogAlways("FrameView::scrollRectToVisible: %d", ScriptDisallowedScope::InMainThread::isScriptAllowed());
     if (options.revealMode == SelectionRevealMode::DoNotReveal)
         return false;
 

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -2672,7 +2672,7 @@ void FrameView::scrollRectToVisibleInChildView(const LayoutRect& absoluteRect, b
 
     // FIXME: ideally need to determine if this <iframe> is inside position:fixed.
     if (auto* ownerRenderer = ownerElement->renderer()) {
-        WTFLogAlways("Chirag -- before calling: scrollRectToVisible: %d", ScriptDisallowedScope::InMainThread::isScriptAllowed());
+        // WTFLogAlways("Chirag -- before calling: scrollRectToVisible: %d", ScriptDisallowedScope::InMainThread::isScriptAllowed());
         scrollRectToVisible(contentsToContainingViewContents(enclosingIntRect(targetRect)), *ownerRenderer, false /* insideFixed */, options);
     }
 }


### PR DESCRIPTION
#### 24ac8c0ad1a1d9c25652040fe777e879e7615edf
<pre>
fix script assertion (WIP)

Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

* Source/WebCore/dom/Document.cpp:
(WebCore::isSafeToUpdateStyleOrLayout):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::scrollIntoView):
</pre>
----------------------------------------------------------------------
#### 73b4d8d663bd056ca6152d8e269ec36419fa5e13
<pre>
WIP temp fix
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

* Source/WebCore/dom/Document.cpp:
(WebCore::isSafeToUpdateStyleOrLayout):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::scrollIntoView):
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::setScrollPosition):
(WebCore::FrameView::scrollRectToVisible):
(WebCore::FrameView::scrollRectToVisibleInChildView):
(WebCore::FrameView::performPostLayoutTasks):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4cc90534cc37ab7a84a1ff0da3bf79170cfb149

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109983 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170252 "Found 1 new test failure: fast/forms/autofocus-opera-003.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/641 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93084 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107826 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91386 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34743 "Found 3 new test failures: fast/forms/autofocus-opera-003.html, fast/forms/scroll-into-view-and-show-validation-message.html, fast/repaint/4776765.html (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90043 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegateReload (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22780 "Found 3 new test failures: accessibility/mac/selection-element-tabbing-to-link.html, accessibility/mac/selection-value-changes-for-aria-textbox.html, fast/repaint/4776765.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77718 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3523 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24307 "Found 6 new test failures: accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html, accessibility/mac/selection-element-tabbing-to-link.html, accessibility/mac/selection-value-changes-for-aria-textbox.html, fast/forms/autofocus-opera-003.html, fast/forms/password-scrolled-after-caps-lock-toggled.html, fast/repaint/4776765.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3544 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/623 "Found 6 new test failures: accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html, accessibility/mac/selection-element-tabbing-to-link.html, accessibility/mac/selection-value-changes-for-aria-textbox.html, fast/forms/autofocus-opera-003.html, fast/forms/password-scrolled-after-caps-lock-toggled.html, fast/repaint/4776765.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43802 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5328 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->