### PR TITLE
Send "isMonitoringWheelEvents" to the UI process

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -213,6 +213,7 @@ public:
     WEBCORE_EXPORT String scrollingTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> = { });
 
     bool isMonitoringWheelEvents() const { return m_isMonitoringWheelEvents; }
+    void setIsMonitoringWheelEvents(bool b) { m_isMonitoringWheelEvents = b; }
     bool inCommitTreeState() const { return m_inCommitTreeState; }
 
     void scrollBySimulatingWheelEventForTesting(ScrollingNodeID, FloatSize);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -91,6 +91,7 @@ struct WKAppPrivacyReportTestingData {
 - (void)_setThrottleStateForTesting:(int)type;
 
 - (void)_doAfterProcessingAllPendingMouseEvents:(dispatch_block_t)action;
+- (void)_startMonitoringWheelEvents;
 
 + (void)_setApplicationBundleIdentifier:(NSString *)bundleIdentifier;
 + (void)_clearApplicationBundleIdentifierTestingOverride;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -293,6 +293,11 @@
     });
 }
 
+- (void)_startMonitoringWheelEvents
+{
+    _page->startMonitoringWheelEventsForTesting();
+}
+
 + (void)_setApplicationBundleIdentifier:(NSString *)bundleIdentifier
 {
     WebCore::setApplicationBundleIdentifierOverride(String(bundleIdentifier));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -286,6 +286,11 @@ void RemoteScrollingCoordinatorProxy::reportSynchronousScrollingReasonsChanged(M
     m_webPageProxy.logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::SwitchedScrollingMode), timestamp, reasons.toRaw());
 }
 
+void RemoteScrollingCoordinatorProxy::startMonitoringWheelEventsForTesting()
+{
+    m_scrollingTree->setIsMonitoringWheelEvents(true);
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -33,6 +33,7 @@
 #include "RemoteScrollingUIState.h"
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/ScrollSnapOffsetsInfo.h>
+#include <WebCore/WheelEventTestMonitor.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
 #include <wtf/WeakPtr.h>
@@ -123,6 +124,8 @@ public:
     virtual void displayDidRefresh(WebCore::PlatformDisplayID);
     void reportExposedUnfilledArea(MonotonicTime, unsigned unfilledArea);
     void reportSynchronousScrollingReasonsChanged(MonotonicTime, OptionSet<WebCore::SynchronousScrollingReason>);
+
+    void startMonitoringWheelEventsForTesting();
 
 protected:
     RemoteScrollingTree* scrollingTree() const { return m_scrollingTree.get(); }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3072,6 +3072,14 @@ void WebPageProxy::handleWheelEvent(const NativeWebWheelEvent& event)
     }
 }
 
+void WebPageProxy::startMonitoringWheelEventsForTesting()
+{
+#if ENABLE(ASYNC_SCROLLING) && PLATFORM(COCOA)
+    if (m_scrollingCoordinatorProxy)
+        m_scrollingCoordinatorProxy->startMonitoringWheelEventsForTesting();
+#endif
+}
+
 #if HAVE(CVDISPLAYLINK)
 void WebPageProxy::wheelEventHysteresisUpdated(PAL::HysteresisState)
 {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1053,6 +1053,7 @@ public:
 
     bool isProcessingWheelEvents() const;
     void handleWheelEvent(const NativeWebWheelEvent&);
+    void startMonitoringWheelEventsForTesting();
 
     bool isProcessingKeyboardEvents() const;
     bool handleKeyboardEvent(const NativeWebKeyboardEvent&);

--- a/Tools/WebKitTestRunner/EventSenderProxy.h
+++ b/Tools/WebKitTestRunner/EventSenderProxy.h
@@ -68,6 +68,7 @@ public:
     void setWheelHasPreciseDeltas(bool);
 #endif
     void continuousMouseScrollBy(int x, int y, bool paged);
+    void monitorWheelEvents();
 
 #if PLATFORM(MAC)
     enum class WheelEventPhase : uint8_t {

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
@@ -516,6 +516,10 @@ void EventSendingController::monitorWheelEvents(MonitorWheelEventsOptions* optio
     m_sentWheelPhaseEndOrCancel = false;
     m_sentWheelMomentumPhaseEnd = false;
     WKBundlePageStartMonitoringScrollOperations(page, options ? options->resetLatching : true);
+
+    auto body = adoptWK(WKMutableDictionaryCreate());
+    setValue(body, "SubMessage", "MonitorWheelEvents");
+    postPageMessage("EventSender", body);
 }
 
 struct ScrollCompletionCallbackData {

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm
@@ -99,6 +99,10 @@ void EventSenderProxy::continuousMouseScrollBy(int x, int y, bool paged)
 {
 }
 
+void EventSenderProxy::monitorWheelEvents()
+{
+}
+
 #if ENABLE(TOUCH_EVENTS)
 
 void EventSenderProxy::addTouchPoint(int x, int y)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1861,6 +1861,11 @@ void TestController::didReceiveMessageFromInjectedBundle(WKStringRef messageName
             return;
         }
 
+        if (WKStringIsEqualToUTF8CString(subMessageName, "MonitorWheelEvents")) {
+            m_eventSenderProxy->monitorWheelEvents();
+            return;
+        }
+
 #if PLATFORM(GTK)
         if (WKStringIsEqualToUTF8CString(subMessageName, "SetWheelHasPreciseDeltas")) {
             auto hasPreciseDeltas = booleanValue(dictionary, "HasPreciseDeltas");

--- a/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
@@ -312,6 +312,10 @@ void EventSenderProxy::continuousMouseScrollBy(int horizontal, int vertical, boo
         horizontal / pixelsPerScrollTick, vertical / pixelsPerScrollTick, m_position.x, m_position.y, WheelEventPhase::NoPhase, WheelEventPhase::NoPhase, m_hasPreciseDeltas);
 }
 
+void EventSenderProxy::monitorWheelEvents()
+{
+}
+
 void EventSenderProxy::mouseScrollByWithWheelAndMomentumPhases(int horizontal, int vertical, int phase, int momentum)
 {
     WheelEventPhase eventPhase = WheelEventPhase::NoPhase;

--- a/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
@@ -194,6 +194,10 @@ void EventSenderProxy::continuousMouseScrollBy(int, int, bool)
 {
 }
 
+void EventSenderProxy::monitorWheelEvents()
+{
+}
+
 void EventSenderProxy::leapForward(int milliseconds)
 {
     m_time += milliseconds / 1000.0;

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -39,6 +39,7 @@
 #import <WebKit/WKPagePrivate.h>
 #import <WebKit/WKWebView.h>
 #import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
 #import <pal/spi/cocoa/IOKitSPI.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
@@ -821,6 +822,11 @@ void EventSenderProxy::sendWheelEvent(EventTimestamp timestamp, double windowX, 
         NSPoint windowLocation = [event locationInWindow];
         WTFLogAlways("EventSenderProxy::sendWheelEvent failed to find the target view at %f,%f\n", windowLocation.x, windowLocation.y);
     }
+}
+
+void EventSenderProxy::monitorWheelEvents()
+{
+    [m_testController->mainWebView()->platformView() _startMonitoringWheelEvents];
 }
 
 #if ENABLE(MAC_GESTURE_EVENTS)

--- a/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
+++ b/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
@@ -149,6 +149,10 @@ void EventSenderProxy::continuousMouseScrollBy(int, int, bool)
 {
 }
 
+void EventSenderProxy::monitorWheelEvents()
+{
+}
+
 void EventSenderProxy::leapForward(int milliseconds)
 {
     Sleep(milliseconds);


### PR DESCRIPTION
#### e505e7f1c203bf380dd18140c0dbb834f970b76c
<pre>
Send &quot;isMonitoringWheelEvents&quot; to the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=249450">https://bugs.webkit.org/show_bug.cgi?id=249450</a>
rdar://103434051

Reviewed by Brent Fulgham.

A test can do:
    eventSender.monitorWheelEvents();
    eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, &apos;began&apos;, &apos;none&apos;);

which means that we need to be able to start monitoring wheel events (in the
UI process if UI-side compositing is enabled) before the IPC to synthesize the
first wheel event is received.

Code exists to update the &quot;isMonitoringWheelEvents&quot; state on ScrollingTree via
scrolling tree commits (which reach the UI process after each rendering update),
but that&apos;s too late for this case; we need a direct IPC call.

So when EventSender::monitorWheelEvents() is called in the web process, post
an &quot;EventSender&quot; message which is handled by TestController::didReceiveMessageFromInjectedBundle()
and passed to EventSenderProxy, which gets it to RemoteScrollingCoordinatorProxy via
WKWebView testing SPI, and WebPageProxy. RemoteScrollingCoordinatorProxy can then set
state on the ScrollingTree in the UI process.

* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::setIsMonitoringWheelEvents):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _startMonitoringWheelEvents]):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::startMonitoringWheelEventsForTesting):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::startMonitoringWheelEventsForTesting):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/WebKitTestRunner/EventSenderProxy.h:
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp:
(WTR::EventSendingController::monitorWheelEvents):
* Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm:
(WTR::EventSenderProxy::monitorWheelEvents):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveMessageFromInjectedBundle):
* Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp:
(WTR::EventSenderProxy::monitorWheelEvents):
* Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp:
(WTR::EventSenderProxy::monitorWheelEvents):
* Tools/WebKitTestRunner/mac/EventSenderProxy.mm:
(WTR::EventSenderProxy::monitorWheelEvents):
* Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp:
(WTR::EventSenderProxy::monitorWheelEvents):

Canonical link: <a href="https://commits.webkit.org/258002@main">https://commits.webkit.org/258002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cf7f3a787caf51e8a02b01a867c2110202b986a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109857 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170147 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10629 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92949 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107712 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8038 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34654 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22675 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77626 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3419 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24194 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3427 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9540 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43685 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5489 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5225 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->