### PR TITLE
Make GPUProcessConnection::Client thread safe

### DIFF
--- a/Source/WTF/wtf/ThreadSafeWeakHashSet.h
+++ b/Source/WTF/wtf/ThreadSafeWeakHashSet.h
@@ -35,23 +35,79 @@ template<typename T>
 class ThreadSafeWeakHashSet final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    ThreadSafeWeakHashSet() = default;
+    ThreadSafeWeakHashSet(ThreadSafeWeakHashSet&& other) { moveFrom(WTFMove(other)); }
+    ThreadSafeWeakHashSet& operator=(ThreadSafeWeakHashSet&& other)
+    {
+        moveFrom(WTFMove(other));
+        return *this;
+    }
+
+    class const_iterator {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = T;
+        using pointer = const value_type*;
+        using reference = const value_type&;
+
+    private:
+        const_iterator(Vector<Ref<T>>&& strongReferences)
+            : m_strongReferences(WTFMove(strongReferences)) { }
+
+    public:
+        T* get() const
+        {
+            RELEASE_ASSERT(m_position < m_strongReferences.size());
+            return m_strongReferences[m_position].ptr();
+        }
+        T& operator*() const { return *get(); }
+        T* operator->() const { return get(); }
+
+        const_iterator& operator++()
+        {
+            RELEASE_ASSERT(m_position < m_strongReferences.size());
+            ++m_position;
+            return *this;
+        }
+
+        bool operator==(const const_iterator& other) const
+        {
+            // This should only be used to compare with end.
+            ASSERT_UNUSED(other, other.m_strongReferences.isEmpty());
+            return m_position == m_strongReferences.size();
+        }
+
+    private:
+        template<typename> friend class ThreadSafeWeakHashSet;
+
+        Vector<Ref<T>> m_strongReferences;
+        size_t m_position { 0 };
+    };
+
+    const_iterator begin() const
+    {
+        return { values() };
+    }
+
+    const_iterator end() const { return { { } }; }
 
     template<typename U, std::enable_if_t<std::is_convertible_v<U*, T*>>* = nullptr>
-    typename HashSet<Ref<ThreadSafeWeakPtrControlBlock<T>>>::AddResult add(const U& value)
+    typename HashSet<std::pair<RefPtr<ThreadSafeWeakPtrControlBlock>, const T*>>::AddResult add(const U& value)
     {
-        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!value.m_controlBlock.objectHasBeenDeleted());
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!value.controlBlock().objectHasBeenDeleted());
         Locker locker { m_lock };
+        RefPtr retainedControlBlock { &value.controlBlock() };
         amortizedCleanupIfNeeded();
-        return m_set.add(reinterpret_cast<ThreadSafeWeakPtrControlBlock<T>&>(value.m_controlBlock));
+        return m_set.add({ WTFMove(retainedControlBlock), static_cast<const T*>(&value) });
     }
 
     template<typename U, std::enable_if_t<std::is_convertible_v<U*, T*>>* = nullptr>
     bool remove(const U& value)
     {
-        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!value.m_controlBlock.objectHasBeenDeleted());
         Locker locker { m_lock };
+        RefPtr retainedControlBlock { &value.controlBlock() };
         amortizedCleanupIfNeeded();
-        return m_set.remove(reinterpret_cast<ThreadSafeWeakPtrControlBlock<T>&>(value.m_controlBlock));
+        return m_set.remove({ &value.controlBlock(), static_cast<const T*>(&value) });
     }
 
     void clear()
@@ -65,29 +121,33 @@ public:
     bool contains(const U& value) const
     {
         Locker locker { m_lock };
+        RefPtr retainedControlBlock { &value.controlBlock() };
         amortizedCleanupIfNeeded();
-        return m_set.contains(value.m_controlBlock);
+        return m_set.contains({ WTFMove(retainedControlBlock), static_cast<const T*>(&value) });
     }
 
     bool isEmptyIgnoringNullReferences() const
     {
         Locker locker { m_lock };
         amortizedCleanupIfNeeded();
-        for (auto& controlBlock : m_set) {
+        for (auto& pair : m_set) {
+            auto& controlBlock = pair.first;
             if (!controlBlock->objectHasBeenDeleted())
                 return false;
         }
         return true;
     }
 
-    Vector<Ref<T>> values()
+    Vector<Ref<T>> values() const
     {
         Vector<Ref<T>> strongReferences;
         {
             Locker locker { m_lock };
             strongReferences.reserveInitialCapacity(m_set.size());
-            m_set.removeIf([&] (auto& controlBlock) {
-                if (auto refPtr = controlBlock->makeStrongReferenceIfPossible()) {
+            m_set.removeIf([&] (auto& pair) {
+                auto& controlBlock = pair.first;
+                auto* objectOfCorrectType = pair.second;
+                if (auto refPtr = controlBlock->template makeStrongReferenceIfPossible<T>(objectOfCorrectType)) {
                     strongReferences.uncheckedAppend(refPtr.releaseNonNull());
                     return false;
                 }
@@ -99,25 +159,34 @@ public:
     }
 
     template<typename Functor>
-    void forEach(const Functor& callback)
+    void forEach(const Functor& callback) const
     {
         for (auto& item : values())
             callback(item.get());
     }
 
 private:
+    ALWAYS_INLINE void moveFrom(ThreadSafeWeakHashSet&& other)
+    {
+        Locker locker { m_lock };
+        Locker otherLocker { other.m_lock };
+        m_set = std::exchange(other.m_set, { });
+        m_operationCountSinceLastCleanup = std::exchange(other.m_operationCountSinceLastCleanup, 0);
+    }
 
     ALWAYS_INLINE void amortizedCleanupIfNeeded() const WTF_REQUIRES_LOCK(m_lock)
     {
         if (++m_operationCountSinceLastCleanup / 2 > m_set.size()) {
-            m_set.removeIf([] (auto& value) {
-                return value.get().objectHasBeenDeleted();
+            m_set.removeIf([] (auto& pair) {
+                return pair.first->objectHasBeenDeleted();
             });
             m_operationCountSinceLastCleanup = 0;
         }
     }
 
-    mutable HashSet<Ref<ThreadSafeWeakPtrControlBlock<T>>> m_set WTF_GUARDED_BY_LOCK(m_lock);
+    // FIXME: Make PairHashTraits and RefHashTraits work together and change this back to a Ref<ThreadSafeWeakPtrControlBlock>.
+    // We only add non-null pointers.
+    mutable HashSet<std::pair<RefPtr<ThreadSafeWeakPtrControlBlock>, const T*>> m_set WTF_GUARDED_BY_LOCK(m_lock);
     mutable unsigned m_operationCountSinceLastCleanup WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     mutable Lock m_lock;
 };

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -35,7 +35,6 @@ template<typename> class ThreadSafeWeakPtr;
 template<typename> class ThreadSafeWeakHashSet;
 template<typename, DestructionThread> class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
 
-template<typename T>
 class ThreadSafeWeakPtrControlBlock {
     WTF_MAKE_NONCOPYABLE(ThreadSafeWeakPtrControlBlock);
     WTF_MAKE_FAST_ALLOCATED;
@@ -66,7 +65,7 @@ public:
         ++m_strongReferenceCount;
     }
 
-    template<DestructionThread destructionThread>
+    template<typename T, DestructionThread destructionThread>
     void strongDeref() const
     {
         bool shouldDeleteControlBlock { false };
@@ -77,13 +76,15 @@ public:
             ASSERT_WITH_SECURITY_IMPLICATION(m_object);
             if (LIKELY(--m_strongReferenceCount))
                 return;
-            object = std::exchange(m_object, nullptr);
+            object = static_cast<T*>(std::exchange(m_object, nullptr));
             if (!m_weakReferenceCount)
                 shouldDeleteControlBlock = true;
         }
 
-        auto deleteObject = [object] {
+        auto deleteObject = [this, object, shouldDeleteControlBlock] {
             delete static_cast<const T*>(object);
+            if (shouldDeleteControlBlock)
+                delete this;
         };
         switch (destructionThread) {
         case DestructionThread::Any:
@@ -96,18 +97,16 @@ public:
             ensureOnMainRunLoop(WTFMove(deleteObject));
             break;
         }
-
-        if (shouldDeleteControlBlock)
-            delete this;
     }
 
-    RefPtr<T> makeStrongReferenceIfPossible() const
+    template<typename T>
+    RefPtr<T> makeStrongReferenceIfPossible(const T* objectOfCorrectType) const
     {
         Locker locker { m_lock };
         if (m_object) {
             // Calling the RefPtr constructor would call strongRef() and deadlock.
             ++m_strongReferenceCount;
-            return adoptRef(m_object);
+            return adoptRef(const_cast<T*>(objectOfCorrectType));
         }
         return nullptr;
     }
@@ -120,13 +119,14 @@ public:
 
 private:
     template<typename, DestructionThread> friend class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
+    template<typename T>
     explicit ThreadSafeWeakPtrControlBlock(T& object)
         : m_object(&object) { }
 
     mutable Lock m_lock;
     mutable size_t m_strongReferenceCount WTF_GUARDED_BY_LOCK(m_lock) { 1 };
     mutable size_t m_weakReferenceCount WTF_GUARDED_BY_LOCK(m_lock) { 0 };
-    mutable T* m_object WTF_GUARDED_BY_LOCK(m_lock) { nullptr };
+    mutable void* m_object WTF_GUARDED_BY_LOCK(m_lock) { nullptr };
 };
 
 template<typename T, DestructionThread destructionThread = DestructionThread::Any>
@@ -135,13 +135,14 @@ class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     void ref() const { m_controlBlock.strongRef(); }
-    void deref() const { m_controlBlock.template strongDeref<destructionThread>(); }
+    void deref() const { m_controlBlock.template strongDeref<T, destructionThread>(); }
 protected:
     ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr() = default;
+    ThreadSafeWeakPtrControlBlock& controlBlock() const { return m_controlBlock; }
 private:
     template<typename> friend class ThreadSafeWeakPtr;
     template<typename> friend class ThreadSafeWeakHashSet;
-    ThreadSafeWeakPtrControlBlock<T>& m_controlBlock { *new ThreadSafeWeakPtrControlBlock<T>(static_cast<T&>(*this)) };
+    ThreadSafeWeakPtrControlBlock& m_controlBlock { *new ThreadSafeWeakPtrControlBlock(static_cast<T&>(*this)) };
 };
 
 template<typename T>
@@ -152,11 +153,13 @@ public:
     ThreadSafeWeakPtr(std::nullptr_t) { }
 
     ThreadSafeWeakPtr(const ThreadSafeWeakPtr<T>& other)
-        : m_controlBlock(other.m_controlBlock) { }
+        : m_controlBlock(other.m_controlBlock)
+        , m_objectOfCorrectType(other.m_objectOfCorrectType) { }
 
     template<typename U, std::enable_if_t<!std::is_pointer_v<U>>* = nullptr>
     ThreadSafeWeakPtr(const U& retainedReference)
         : m_controlBlock(controlBlock(retainedReference))
+        , m_objectOfCorrectType(static_cast<const T*>(&retainedReference))
     {
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_controlBlock->objectHasBeenDeleted());
     }
@@ -164,24 +167,29 @@ public:
     template<typename U>
     ThreadSafeWeakPtr(const U* retainedPointer)
         : m_controlBlock(retainedPointer ? controlBlock(*retainedPointer) : nullptr)
+        , m_objectOfCorrectType(static_cast<const T*>(retainedPointer))
     {
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!retainedPointer || !m_controlBlock->objectHasBeenDeleted());
     }
 
     template<typename U>
     ThreadSafeWeakPtr(const Ref<U>& strongReference)
-        : m_controlBlock(controlBlock(strongReference)) { }
+        : m_controlBlock(controlBlock(strongReference))
+        , m_objectOfCorrectType(static_cast<const T*>(strongReference.ptr())) { }
 
     template<typename U>
     ThreadSafeWeakPtr(const RefPtr<U>& strongReference)
-        : m_controlBlock(strongReference ? controlBlock(*strongReference) : nullptr) { }
+        : m_controlBlock(strongReference ? controlBlock(*strongReference) : nullptr)
+        , m_objectOfCorrectType(static_cast<const T*>(strongReference.get())) { }
 
     ThreadSafeWeakPtr(ThreadSafeWeakPtr&& other)
-        : m_controlBlock(std::exchange(other.m_controlBlock, nullptr)) { }
+        : m_controlBlock(std::exchange(other.m_controlBlock, nullptr))
+        , m_objectOfCorrectType(std::exchange(other.m_objectOfCorrectType, nullptr)) { }
 
     ThreadSafeWeakPtr& operator=(ThreadSafeWeakPtr&& other)
     {
         m_controlBlock = std::exchange(other.m_controlBlock, nullptr);
+        m_objectOfCorrectType = std::exchange(other.m_objectOfCorrectType, nullptr);
         return *this;
     }
 
@@ -189,6 +197,8 @@ public:
     ThreadSafeWeakPtr& operator=(const U& retainedReference)
     {
         m_controlBlock = controlBlock(retainedReference);
+        const U* retainedPointer = static_cast<const U*>(&retainedReference);
+        m_objectOfCorrectType = static_cast<const T*>(retainedPointer);
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_controlBlock->objectHasBeenDeleted());
         return *this;
     }
@@ -197,6 +207,7 @@ public:
     ThreadSafeWeakPtr& operator=(const U* retainedPointer)
     {
         m_controlBlock = retainedPointer ? controlBlock(*retainedPointer) : nullptr;
+        m_objectOfCorrectType = static_cast<const T*>(retainedPointer);
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!retainedPointer || !m_controlBlock->objectHasBeenDeleted());
         return *this;
     }
@@ -204,6 +215,7 @@ public:
     ThreadSafeWeakPtr& operator=(std::nullptr_t)
     {
         m_controlBlock = nullptr;
+        m_objectOfCorrectType = nullptr;
         return *this;
     }
 
@@ -211,6 +223,7 @@ public:
     ThreadSafeWeakPtr& operator=(const Ref<U>& strongReference)
     {
         m_controlBlock = controlBlock(strongReference);
+        m_objectOfCorrectType = static_cast<const T*>(strongReference.ptr());
         return *this;
     }
 
@@ -218,24 +231,29 @@ public:
     ThreadSafeWeakPtr& operator=(const RefPtr<U>& strongReference)
     {
         m_controlBlock = strongReference ? controlBlock(*strongReference) : nullptr;
+        m_objectOfCorrectType = static_cast<const T*>(strongReference.get());
         return *this;
     }
 
-    RefPtr<T> get() const { return m_controlBlock ? m_controlBlock->makeStrongReferenceIfPossible() : nullptr; }
+    RefPtr<T> get() const { return m_controlBlock ? m_controlBlock->template makeStrongReferenceIfPossible<T>(m_objectOfCorrectType) : nullptr; }
 
 private:
     template<typename U, std::enable_if_t<std::is_convertible_v<U*, T*>>* = nullptr>
-    ThreadSafeWeakPtrControlBlock<T>* controlBlock(const U& classOrChildClass)
+    ThreadSafeWeakPtrControlBlock* controlBlock(const U& classOrChildClass)
     {
-        return &reinterpret_cast<ThreadSafeWeakPtrControlBlock<T>&>(classOrChildClass.m_controlBlock);
+        return &classOrChildClass.controlBlock();
     }
 
     template<typename, DestructionThread> friend class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
     template<typename> friend class ThreadSafeWeakHashSet;
-    explicit ThreadSafeWeakPtr(ThreadSafeWeakPtrControlBlock<T>& controlBlock)
+    explicit ThreadSafeWeakPtr(ThreadSafeWeakPtrControlBlock& controlBlock)
         : m_controlBlock(&controlBlock) { }
 
-    RefPtr<ThreadSafeWeakPtrControlBlock<T>> m_controlBlock;
+    // FIXME: Either remove ThreadSafeWeakPtrControlBlock::m_object as redundant information,
+    // or use CompactRefPtrTuple to reduce sizeof(ThreadSafeWeakPtr) by storing just an offset
+    // from ThreadSafeWeakPtrControlBlock::m_object and don't support structs larger than 65535.
+    RefPtr<ThreadSafeWeakPtrControlBlock> m_controlBlock;
+    const T* m_objectOfCorrectType { nullptr };
 };
 
 template<class T> ThreadSafeWeakPtr(const T&) -> ThreadSafeWeakPtr<T>;
@@ -243,5 +261,6 @@ template<class T> ThreadSafeWeakPtr(const T*) -> ThreadSafeWeakPtr<T>;
 
 }
 
-using WTF::ThreadSafeWeakPtr;
 using WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
+using WTF::ThreadSafeWeakPtr;
+using WTF::ThreadSafeWeakPtrControlBlock;

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
@@ -52,12 +52,16 @@ public:
 private:
     const char* activeDOMObjectName() const override;
 
-    class Source final : public RealtimeMediaSource, private CanvasObserver, private CanvasDisplayBufferObserver {
+    class Source final : public RealtimeMediaSource, private CanvasObserver, private CanvasDisplayBufferObserver, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop> {
     public:
         static Ref<Source> create(HTMLCanvasElement&, std::optional<double>&& frameRequestRate);
         
         void requestFrame() { m_shouldEmitFrame = true; }
         std::optional<double> frameRequestRate() const { return m_frameRequestRate; }
+
+        void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop>::ref(); }
+        void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop>::deref(); }
+        ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
 
     private:
         Source(HTMLCanvasElement&, std::optional<double>&&);

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSource.h
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSource.h
@@ -38,11 +38,14 @@ class AudioBus;
 class PlatformAudioData;
 class RealtimeMediaSourceCapabilities;
 
-class MediaStreamAudioSource final : public RealtimeMediaSource {
+class MediaStreamAudioSource final : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaStreamAudioSource, WTF::DestructionThread::MainRunLoop> {
 public:
     static Ref<MediaStreamAudioSource> create(float sampleRate) { return adoptRef(*new MediaStreamAudioSource { sampleRate }); }
 
     ~MediaStreamAudioSource();
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaStreamAudioSource, WTF::DestructionThread::MainRunLoop>::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaStreamAudioSource, WTF::DestructionThread::MainRunLoop>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaStreamAudioSource, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
 
     const RealtimeMediaSourceCapabilities& capabilities() final;
     const RealtimeMediaSourceSettings& settings() final;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.h
@@ -38,7 +38,7 @@ namespace PAL::WebGPU {
 
 class ConvertToBackingContext;
 
-class GPUImpl final : public GPU {
+class GPUImpl final : public GPU, public RefCounted<GPUImpl> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<GPUImpl> create(WebGPUPtr<WGPUInstance>&& instance, ConvertToBackingContext& convertToBackingContext)
@@ -47,6 +47,9 @@ public:
     }
 
     virtual ~GPUImpl();
+
+    void ref() const final { RefCounted<GPUImpl>::ref(); }
+    void deref() const final { RefCounted<GPUImpl>::deref(); }
 
 private:
     friend class DowncastConvertToBackingContext;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPU.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPU.h
@@ -38,11 +38,13 @@ class CompositorIntegration;
 class PresentationContext;
 struct PresentationContextDescriptor;
 
-class GPU : public RefCounted<GPU> {
+class GPU {
 public:
     virtual ~GPU() = default;
 
     virtual void requestAdapter(const RequestAdapterOptions&, CompletionHandler<void(RefPtr<Adapter>&&)>&&) = 0;
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 
     virtual Ref<PresentationContext> createPresentationContext(const PresentationContextDescriptor&) = 0;
 

--- a/Source/WebCore/platform/NowPlayingManager.h
+++ b/Source/WebCore/platform/NowPlayingManager.h
@@ -66,7 +66,7 @@ private:
     virtual void clearNowPlayingInfoPrivate();
     virtual void setNowPlayingInfoPrivate(const NowPlayingInfo&);
     void ensureRemoteCommandListenerCreated();
-    std::unique_ptr<RemoteCommandListener> m_remoteCommandListener;
+    RefPtr<RemoteCommandListener> m_remoteCommandListener;
     WeakPtr<Client> m_client;
     std::optional<NowPlayingInfo> m_nowPlayingInfo;
     struct ArtworkCache {

--- a/Source/WebCore/platform/RemoteCommandListener.cpp
+++ b/Source/WebCore/platform/RemoteCommandListener.cpp
@@ -51,7 +51,7 @@ void RemoteCommandListener::setCreationFunction(CreationFunction&& function)
 
 void RemoteCommandListener::resetCreationFunction()
 {
-    remoteCommandListenerCreationFunction() = [] (RemoteCommandListenerClient& client) {
+    remoteCommandListenerCreationFunction() = [] (RemoteCommandListenerClient& client) -> RefPtr<RemoteCommandListener> {
 #if PLATFORM(COCOA)
         return RemoteCommandListenerCocoa::create(client);
 #elif USE(GLIB) && ENABLE(MEDIA_SESSION)
@@ -63,7 +63,7 @@ void RemoteCommandListener::resetCreationFunction()
     };
 }
 
-std::unique_ptr<RemoteCommandListener> RemoteCommandListener::create(RemoteCommandListenerClient& client)
+RefPtr<RemoteCommandListener> RemoteCommandListener::create(RemoteCommandListenerClient& client)
 {
     if (!remoteCommandListenerCreationFunction())
         resetCreationFunction();

--- a/Source/WebCore/platform/RemoteCommandListener.h
+++ b/Source/WebCore/platform/RemoteCommandListener.h
@@ -23,8 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-#ifndef RemoteCommandListener_h
-#define RemoteCommandListener_h
+#pragma once
 
 #include "DeferrableTask.h"
 #include "PlatformMediaSession.h"
@@ -39,13 +38,15 @@ public:
 };
 
 class WEBCORE_EXPORT RemoteCommandListener {
-    WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<RemoteCommandListener> create(RemoteCommandListenerClient&);
+    static RefPtr<RemoteCommandListener> create(RemoteCommandListenerClient&);
     RemoteCommandListener(RemoteCommandListenerClient&);
     virtual ~RemoteCommandListener();
 
-    using CreationFunction = Function<std::unique_ptr<RemoteCommandListener>(RemoteCommandListenerClient&)>;
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
+
+    using CreationFunction = Function<RefPtr<RemoteCommandListener>(RemoteCommandListenerClient&)>;
     static void setCreationFunction(CreationFunction&&);
     static void resetCreationFunction();
 
@@ -72,5 +73,3 @@ private:
 };
 
 }
-
-#endif

--- a/Source/WebCore/platform/audio/AudioDestination.h
+++ b/Source/WebCore/platform/audio/AudioDestination.h
@@ -43,14 +43,15 @@ namespace WebCore {
 // The audio hardware periodically calls the AudioIOCallback render() method asking it to render/output the next render quantum of audio.
 // It optionally will pass in local/live audio input when it calls render().
 
-class AudioDestination : public ThreadSafeRefCounted<AudioDestination, WTF::DestructionThread::Main> {
-    WTF_MAKE_FAST_ALLOCATED;
+class AudioDestination {
 public:
     // Pass in (numberOfInputChannels > 0) if live/local audio input is desired.
     // Port-specific device identification information for live/local input streams can be passed in the inputDeviceId.
     WEBCORE_EXPORT static Ref<AudioDestination> create(AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate);
 
     virtual ~AudioDestination() = default;
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 
     void clearCallback();
 

--- a/Source/WebCore/platform/audio/AudioHardwareListener.cpp
+++ b/Source/WebCore/platform/audio/AudioHardwareListener.cpp
@@ -52,7 +52,14 @@ void AudioHardwareListener::resetCreationFunction()
 #if PLATFORM(MAC)
         return AudioHardwareListenerMac::create(client);
 #else
-        return adoptRef(*new AudioHardwareListener(client));
+        class RefCountedAudioHardwareListener : public AudioHardwareListener, public RefCounted<RefCountedAudioHardwareListener> {
+        public:
+            RefCountedAudioHardwareListener(AudioHardwareListener::Client& client)
+                : AudioHardwareListener(client) { }
+            void ref() const final { RefCounted<RefCountedAudioHardwareListener>::ref(); }
+            void deref() const final { RefCounted<RefCountedAudioHardwareListener>::deref(); }
+        };
+        return adoptRef(*new RefCountedAudioHardwareListener(client));
 #endif
     };
 }

--- a/Source/WebCore/platform/audio/AudioHardwareListener.h
+++ b/Source/WebCore/platform/audio/AudioHardwareListener.h
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef AudioHardwareListener_h
-#define AudioHardwareListener_h
+#pragma once
 
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -37,7 +36,7 @@ enum class AudioHardwareActivityType {
     IsInactive
 };
 
-class AudioHardwareListener : public RefCounted<AudioHardwareListener> {
+class AudioHardwareListener {
 public:
     class Client {
     public:
@@ -46,6 +45,9 @@ public:
         virtual void audioHardwareDidBecomeInactive() = 0;
         virtual void audioOutputDeviceChanged() = 0;
     };
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 
     using CreationFunction = Function<Ref<AudioHardwareListener>(AudioHardwareListener::Client&)>;
     WEBCORE_EXPORT static void setCreationFunction(CreationFunction&&);
@@ -76,5 +78,3 @@ protected:
 };
 
 }
-
-#endif // AudioHardwareListener_h

--- a/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.h
@@ -43,10 +43,12 @@ class PushPullFIFO;
 using CreateAudioDestinationCocoaOverride = Ref<AudioDestination>(*)(AudioIOCallback&, float sampleRate);
 
 // An AudioDestination using CoreAudio's default output AudioUnit
-class AudioDestinationCocoa : public AudioDestinationResampler, public AudioUnitRenderer {
+class AudioDestinationCocoa : public AudioDestinationResampler, public AudioUnitRenderer, public ThreadSafeRefCounted<AudioDestinationCocoa, WTF::DestructionThread::Main> {
 public:
     WEBCORE_EXPORT AudioDestinationCocoa(AudioIOCallback&, unsigned numberOfOutputChannels, float sampleRate);
     WEBCORE_EXPORT virtual ~AudioDestinationCocoa();
+    void ref() const final { return ThreadSafeRefCounted<AudioDestinationCocoa, WTF::DestructionThread::Main>::ref(); }
+    void deref() const final { return ThreadSafeRefCounted<AudioDestinationCocoa, WTF::DestructionThread::Main>::deref(); }
 
     WEBCORE_EXPORT static CreateAudioDestinationCocoaOverride createOverride;
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h
@@ -26,10 +26,13 @@
 
 namespace WebCore {
 
-class AudioDestinationGStreamer : public AudioDestination {
+class AudioDestinationGStreamer : public AudioDestination, public RefCounted<AudioDestinationGStreamer> {
 public:
     AudioDestinationGStreamer(AudioIOCallback&, unsigned long numberOfOutputChannels, float sampleRate);
     virtual ~AudioDestinationGStreamer();
+
+    void ref() const final { return RefCounted<AudioDestinationGStreamer>::ref(); }
+    void deref() const final { return RefCounted<AudioDestinationGStreamer>::deref(); }
 
     WEBCORE_EXPORT void start(Function<void(Function<void()>&&)>&& dispatchToRenderThread, CompletionHandler<void(bool)>&&) final;
     WEBCORE_EXPORT void stop(CompletionHandler<void(bool)>&&) final;

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
@@ -56,11 +56,10 @@ public:
     virtual void activeVideoRouteDidChange(SupportsAirPlayVideo, Ref<MediaPlaybackTarget>&&) = 0;
 };
 
-class WEBCORE_EXPORT MediaSessionHelper {
-    WTF_MAKE_FAST_ALLOCATED;
+class WEBCORE_EXPORT MediaSessionHelper : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaSessionHelper> {
 public:
     static MediaSessionHelper& sharedHelper();
-    static void setSharedHelper(UniqueRef<MediaSessionHelper>&&);
+    static void setSharedHelper(Ref<MediaSessionHelper>&&);
     static void resetSharedHelper();
 
     MediaSessionHelper() = default;

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -117,9 +117,9 @@ private:
 #endif
 };
 
-static std::unique_ptr<MediaSessionHelper>& sharedHelperInstance()
+static RefPtr<MediaSessionHelper>& sharedHelperInstance()
 {
-    static NeverDestroyed<std::unique_ptr<MediaSessionHelper>> helper;
+    static NeverDestroyed<RefPtr<MediaSessionHelper>> helper;
     return helper;
 }
 
@@ -135,12 +135,12 @@ MediaSessionHelper& MediaSessionHelper::sharedHelper()
 
 void MediaSessionHelper::resetSharedHelper()
 {
-    sharedHelperInstance() = makeUnique<MediaSessionHelperiOS>();
+    sharedHelperInstance() = adoptRef(*new MediaSessionHelperiOS());
 }
 
-void MediaSessionHelper::setSharedHelper(UniqueRef<MediaSessionHelper>&& helper)
+void MediaSessionHelper::setSharedHelper(Ref<MediaSessionHelper>&& helper)
 {
-    sharedHelperInstance() = helper.moveToUniquePtr();
+    sharedHelperInstance() = WTFMove(helper);
 }
 
 void MediaSessionHelper::addClient(MediaSessionHelperClient& client)

--- a/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.h
+++ b/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.h
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef AudioHardwareListenerMac_h
-#define AudioHardwareListenerMac_h
+#pragma once
 
 #include "AudioHardwareListener.h"
 #include <wtf/WeakPtr.h>
@@ -35,13 +34,15 @@
 
 namespace WebCore {
 
-class AudioHardwareListenerMac : public AudioHardwareListener, public CanMakeWeakPtr<AudioHardwareListenerMac> {
+class AudioHardwareListenerMac : public AudioHardwareListener, public RefCounted<AudioHardwareListenerMac>, public CanMakeWeakPtr<AudioHardwareListenerMac> {
 public:
     static Ref<AudioHardwareListenerMac> create(Client&);
+    virtual ~AudioHardwareListenerMac();
+    void ref() const final { return RefCounted<AudioHardwareListenerMac>::ref(); }
+    void deref() const final { return RefCounted<AudioHardwareListenerMac>::deref(); }
 
 private:
     AudioHardwareListenerMac(Client&);
-    virtual ~AudioHardwareListenerMac();
 
     void processIsRunningChanged();
     void outputDeviceChanged();
@@ -54,5 +55,3 @@ private:
 }
 
 #endif // PLATFORM(MAC)
-
-#endif // AudioHardwareListenerMac_h

--- a/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.h
+++ b/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.h
@@ -33,11 +33,14 @@
 
 namespace WebCore {
 
-class RemoteCommandListenerCocoa : public RemoteCommandListener, public CanMakeWeakPtr<RemoteCommandListenerCocoa> {
+class RemoteCommandListenerCocoa : public RemoteCommandListener, public CanMakeWeakPtr<RemoteCommandListenerCocoa>, public RefCounted<RemoteCommandListenerCocoa> {
 public:
-    static std::unique_ptr<RemoteCommandListenerCocoa> create(RemoteCommandListenerClient&);
+    static Ref<RemoteCommandListenerCocoa> create(RemoteCommandListenerClient&);
     RemoteCommandListenerCocoa(RemoteCommandListenerClient&);
     virtual ~RemoteCommandListenerCocoa();
+
+    void ref() const final { return RefCounted<RemoteCommandListenerCocoa>::ref(); }
+    void deref() const { return RefCounted<RemoteCommandListenerCocoa>::deref(); }
 
 private:
     void updateSupportedCommands() final;
@@ -50,4 +53,4 @@ private:
 
 }
 
-#endif // PLATFORM(MAC)
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm
@@ -58,9 +58,9 @@ static std::optional<MRMediaRemoteCommand> mediaRemoteCommandForPlatformCommand(
     return makeOptionalFromPointer(map.tryGet(command));
 }
 
-std::unique_ptr<RemoteCommandListenerCocoa> RemoteCommandListenerCocoa::create(RemoteCommandListenerClient& client)
+Ref<RemoteCommandListenerCocoa> RemoteCommandListenerCocoa::create(RemoteCommandListenerClient& client)
 {
-    return makeUnique<RemoteCommandListenerCocoa>(client);
+    return adoptRef(*new RemoteCommandListenerCocoa(client));
 }
 
 const RemoteCommandListener::RemoteCommandsSet& RemoteCommandListenerCocoa::defaultCommands()

--- a/Source/WebCore/platform/glib/RemoteCommandListenerGLib.cpp
+++ b/Source/WebCore/platform/glib/RemoteCommandListenerGLib.cpp
@@ -23,9 +23,9 @@
 
 namespace WebCore {
 
-std::unique_ptr<RemoteCommandListenerGLib> RemoteCommandListenerGLib::create(RemoteCommandListenerClient& client)
+Ref<RemoteCommandListenerGLib> RemoteCommandListenerGLib::create(RemoteCommandListenerClient& client)
 {
-    return makeUnique<RemoteCommandListenerGLib>(client);
+    return adoptRef(*new RemoteCommandListenerGLib(client));
 }
 
 void RemoteCommandListenerGLib::updateSupportedCommands()

--- a/Source/WebCore/platform/glib/RemoteCommandListenerGLib.h
+++ b/Source/WebCore/platform/glib/RemoteCommandListenerGLib.h
@@ -24,11 +24,14 @@
 
 namespace WebCore {
 
-class RemoteCommandListenerGLib : public RemoteCommandListener {
+class RemoteCommandListenerGLib : public RemoteCommandListener, public RefCounted<RemoteCommandListenerGLib> {
 public:
-    static std::unique_ptr<RemoteCommandListenerGLib> create(RemoteCommandListenerClient&);
+    static Ref<RemoteCommandListenerGLib> create(RemoteCommandListenerClient&);
     explicit RemoteCommandListenerGLib(RemoteCommandListenerClient&);
     virtual ~RemoteCommandListenerGLib();
+
+    void ref() const final { return RefCounted<RemoteCommandListenerGLib>::ref(); }
+    void deref() const { return RefCounted<RemoteCommandListenerGLib>::deref(); }
 
 private:
     void updateSupportedCommands() final;

--- a/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.cpp
@@ -37,7 +37,7 @@ void SampleBufferDisplayLayer::setCreator(LayerCreator creator)
     m_layerCreator = creator;
 }
 
-std::unique_ptr<SampleBufferDisplayLayer> SampleBufferDisplayLayer::create(Client& client)
+RefPtr<SampleBufferDisplayLayer> SampleBufferDisplayLayer::create(Client& client)
 {
     if (m_layerCreator)
         return m_layerCreator(client);

--- a/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
@@ -28,6 +28,7 @@
 #include "PlatformLayer.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/MachSendRight.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WTF {
@@ -42,7 +43,7 @@ enum class VideoFrameRotation : uint16_t;
 
 using LayerHostingContextID = uint32_t;
 
-class SampleBufferDisplayLayer {
+class SampleBufferDisplayLayer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SampleBufferDisplayLayer> {
 public:
     class Client : public CanMakeWeakPtr<Client> {
     public:
@@ -50,8 +51,8 @@ public:
         virtual void sampleBufferDisplayLayerStatusDidFail() = 0;
     };
 
-    WEBCORE_EXPORT static std::unique_ptr<SampleBufferDisplayLayer> create(Client&);
-    using LayerCreator = std::unique_ptr<SampleBufferDisplayLayer> (*)(Client&);
+    WEBCORE_EXPORT static RefPtr<SampleBufferDisplayLayer> create(Client&);
+    using LayerCreator = RefPtr<SampleBufferDisplayLayer> (*)(Client&);
     WEBCORE_EXPORT static void setCreator(LayerCreator);
 
     virtual ~SampleBufferDisplayLayer() = default;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
@@ -47,7 +47,7 @@ enum class VideoFrameRotation : uint16_t;
 class WEBCORE_EXPORT LocalSampleBufferDisplayLayer final : public SampleBufferDisplayLayer, public CanMakeWeakPtr<LocalSampleBufferDisplayLayer, WeakPtrFactoryInitialization::Eager> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<LocalSampleBufferDisplayLayer> create(Client&);
+    static RefPtr<LocalSampleBufferDisplayLayer> create(Client&);
 
     LocalSampleBufferDisplayLayer(RetainPtr<AVSampleBufferDisplayLayer>&&, Client&);
     ~LocalSampleBufferDisplayLayer();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -143,7 +143,7 @@ static void runWithoutAnimations(const WTF::Function<void()>& function)
     [CATransaction commit];
 }
 
-std::unique_ptr<LocalSampleBufferDisplayLayer> LocalSampleBufferDisplayLayer::create(Client& client)
+RefPtr<LocalSampleBufferDisplayLayer> LocalSampleBufferDisplayLayer::create(Client& client)
 {
     RetainPtr<AVSampleBufferDisplayLayer> sampleBufferDisplayLayer;
     @try {
@@ -154,7 +154,7 @@ std::unique_ptr<LocalSampleBufferDisplayLayer> LocalSampleBufferDisplayLayer::cr
     if (!sampleBufferDisplayLayer)
         return nullptr;
 
-    return makeUnique<LocalSampleBufferDisplayLayer>(WTFMove(sampleBufferDisplayLayer), client);
+    return adoptRef(*new LocalSampleBufferDisplayLayer(WTFMove(sampleBufferDisplayLayer), client));
 }
 
 LocalSampleBufferDisplayLayer::LocalSampleBufferDisplayLayer(RetainPtr<AVSampleBufferDisplayLayer>&& sampleBufferDisplayLayer, Client& client)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -263,7 +263,7 @@ private:
     PlaybackState m_playbackState { PlaybackState::None };
 
     // Used on both main thread and sample thread.
-    std::unique_ptr<SampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
+    RefPtr<SampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
     Lock m_sampleBufferDisplayLayerLock;
     bool m_shouldUpdateDisplayLayer { true };
     // Written on main thread, read on sample thread.

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h
@@ -53,6 +53,7 @@ class RealtimeIncomingAudioSource
     : public RealtimeMediaSource
     , private webrtc::AudioTrackSinkInterface
     , private webrtc::ObserverInterface
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingAudioSource, WTF::DestructionThread::MainRunLoop>
 {
 public:
     static Ref<RealtimeIncomingAudioSource> create(rtc::scoped_refptr<webrtc::AudioTrackInterface>&&, String&&);
@@ -60,9 +61,12 @@ public:
     void setAudioModule(RefPtr<LibWebRTCAudioModule>&&);
     LibWebRTCAudioModule* audioModule() { return m_audioModule.get(); }
 
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingAudioSource, WTF::DestructionThread::MainRunLoop>::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingAudioSource, WTF::DestructionThread::MainRunLoop>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingAudioSource, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+    ~RealtimeIncomingAudioSource();
 protected:
     RealtimeIncomingAudioSource(rtc::scoped_refptr<webrtc::AudioTrackInterface>&&, String&&);
-    ~RealtimeIncomingAudioSource();
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const final { return "RealtimeIncomingAudioSource"; }

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
@@ -54,10 +54,14 @@ class RealtimeIncomingVideoSource
     : public RealtimeMediaSource
     , private rtc::VideoSinkInterface<webrtc::VideoFrame>
     , private webrtc::ObserverInterface
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingVideoSource, WTF::DestructionThread::MainRunLoop>
 {
 public:
     static Ref<RealtimeIncomingVideoSource> create(rtc::scoped_refptr<webrtc::VideoTrackInterface>&&, String&&);
     ~RealtimeIncomingVideoSource();
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingVideoSource, WTF::DestructionThread::MainRunLoop>::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingVideoSource, WTF::DestructionThread::MainRunLoop>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingVideoSource, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
 
     void enableFrameRatedMonitoring();
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -77,10 +77,8 @@ struct CaptureSourceOrError;
 struct VideoFrameAdaptor;
 
 class WEBCORE_EXPORT RealtimeMediaSource
-    : public ThreadSafeRefCounted<RealtimeMediaSource, WTF::DestructionThread::MainRunLoop>
-    , public CanMakeWeakPtr<RealtimeMediaSource>
 #if !RELEASE_LOG_DISABLED
-    , public LoggerHelper
+    : public LoggerHelper
 #endif
 {
 public:
@@ -195,6 +193,9 @@ public:
 
     virtual const RealtimeMediaSourceCapabilities& capabilities() = 0;
     virtual const RealtimeMediaSourceSettings& settings() = 0;
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
+    virtual ThreadSafeWeakPtrControlBlock& controlBlock() const = 0;
 
     struct ApplyConstraintsError {
         String badConstraint;

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
@@ -42,8 +42,21 @@ RealtimeVideoCaptureSource::RealtimeVideoCaptureSource(const CaptureDevice& devi
 {
 }
 
-RealtimeVideoCaptureSource::~RealtimeVideoCaptureSource()
+RealtimeVideoCaptureSource::~RealtimeVideoCaptureSource() = default;
+
+void RealtimeVideoCaptureSource::ref() const
 {
+    ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeVideoCaptureSource, WTF::DestructionThread::MainRunLoop>::ref();
+}
+
+void RealtimeVideoCaptureSource::deref() const
+{
+    ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeVideoCaptureSource, WTF::DestructionThread::MainRunLoop>::deref();
+}
+
+ThreadSafeWeakPtrControlBlock& RealtimeVideoCaptureSource::controlBlock() const
+{
+    return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeVideoCaptureSource, WTF::DestructionThread::MainRunLoop>::controlBlock();
 }
 
 const Vector<VideoPreset>& RealtimeVideoCaptureSource::presets()

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
@@ -39,7 +39,7 @@ class ImageTransferSessionVT;
 
 enum class VideoFrameRotation : uint16_t;
 
-class WEBCORE_EXPORT RealtimeVideoCaptureSource : public RealtimeMediaSource {
+class WEBCORE_EXPORT RealtimeVideoCaptureSource : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeVideoCaptureSource, WTF::DestructionThread::MainRunLoop> {
 public:
     virtual ~RealtimeVideoCaptureSource();
 
@@ -54,6 +54,10 @@ public:
     void ensureIntrinsicSizeMaintainsAspectRatio();
 
     const std::optional<VideoPreset> currentPreset() const { return m_currentPreset; }
+
+    void ref() const final;
+    void deref() const final;
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final;
 
 protected:
     RealtimeVideoCaptureSource(const CaptureDevice&, MediaDeviceHashSalts&&, PageIdentifier);

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -64,7 +64,8 @@ public:
 
 class DisplayCaptureSourceCocoa final
     : public RealtimeMediaSource
-    , public CapturerObserver {
+    , public CapturerObserver
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<DisplayCaptureSourceCocoa, WTF::DestructionThread::MainRunLoop> {
 public:
     using DisplayFrameType = std::variant<RefPtr<NativeImage>, RetainPtr<IOSurfaceRef>, RetainPtr<CMSampleBufferRef>>;
 
@@ -119,9 +120,13 @@ public:
 
     Seconds elapsedTime();
 
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<DisplayCaptureSourceCocoa, WTF::DestructionThread::MainRunLoop>::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<DisplayCaptureSourceCocoa, WTF::DestructionThread::MainRunLoop>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<DisplayCaptureSourceCocoa, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+    virtual ~DisplayCaptureSourceCocoa();
+
 private:
     DisplayCaptureSourceCocoa(UniqueRef<Capturer>&&, const CaptureDevice&, MediaDeviceHashSalts&&, PageIdentifier);
-    virtual ~DisplayCaptureSourceCocoa();
 
     // RealtimeMediaSource
     void startProducingData() final;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-class GStreamerAudioCaptureSource : public RealtimeMediaSource {
+class GStreamerAudioCaptureSource : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource> {
 public:
     static CaptureSourceOrError create(String&& deviceID, MediaDeviceHashSalts&&, const MediaConstraints*);
     WEBCORE_EXPORT static AudioCaptureFactory& factory();
@@ -41,9 +41,13 @@ public:
     GstElement* pipeline() { return m_capturer->pipeline(); }
     GStreamerCapturer* capturer() { return m_capturer.get(); }
 
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>::controlBlock(); }
+    virtual ~GStreamerAudioCaptureSource();
+
 protected:
     GStreamerAudioCaptureSource(GStreamerCaptureDevice, MediaDeviceHashSalts&&);
-    virtual ~GStreamerAudioCaptureSource();
     void startProducingData() override;
     void stopProducingData() override;
     CaptureDevice::DeviceType deviceType() const override { return CaptureDevice::DeviceType::Microphone; }

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
@@ -26,8 +26,12 @@
 
 namespace WebCore {
 
-class RealtimeIncomingSourceGStreamer : public RealtimeMediaSource {
+class RealtimeIncomingSourceGStreamer : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer> {
 public:
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>::controlBlock(); }
+
     GstElement* bin() { return m_bin.get(); }
 
     int registerClient(GRefPtr<GstElement>&&);

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -50,7 +50,7 @@ class BaseAudioSharedUnit;
 class CaptureDeviceInfo;
 class WebAudioSourceProviderAVFObjC;
 
-class CoreAudioCaptureSource : public RealtimeMediaSource {
+class CoreAudioCaptureSource : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CoreAudioCaptureSource, WTF::DestructionThread::MainRunLoop> {
 public:
     WEBCORE_EXPORT static CaptureSourceOrError create(String&& deviceID, MediaDeviceHashSalts&&, const MediaConstraints*, PageIdentifier);
     static CaptureSourceOrError createForTesting(String&& deviceID, AtomString&& label, MediaDeviceHashSalts&&, const MediaConstraints*, BaseAudioSharedUnit& overrideUnit, PageIdentifier);
@@ -61,9 +61,13 @@ public:
 
     void handleNewCurrentMicrophoneDevice(const CaptureDevice&);
 
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CoreAudioCaptureSource, WTF::DestructionThread::MainRunLoop>::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CoreAudioCaptureSource, WTF::DestructionThread::MainRunLoop>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CoreAudioCaptureSource, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+    virtual ~CoreAudioCaptureSource();
+
 protected:
     CoreAudioCaptureSource(const CaptureDevice&, uint32_t, MediaDeviceHashSalts&&, BaseAudioSharedUnit*, PageIdentifier);
-    virtual ~CoreAudioCaptureSource();
     BaseAudioSharedUnit& unit();
     const BaseAudioSharedUnit& unit() const;
 

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.h
@@ -40,7 +40,7 @@
 
 namespace WebCore {
 
-class MockRealtimeAudioSource : public RealtimeMediaSource {
+class MockRealtimeAudioSource : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MockRealtimeAudioSource, WTF::DestructionThread::MainRunLoop> {
 public:
     static CaptureSourceOrError create(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, const MediaConstraints*, PageIdentifier);
     virtual ~MockRealtimeAudioSource();
@@ -48,6 +48,10 @@ public:
     static void setIsInterrupted(bool);
 
     WEBCORE_EXPORT void setChannelCount(unsigned);
+
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MockRealtimeAudioSource, WTF::DestructionThread::MainRunLoop>::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MockRealtimeAudioSource, WTF::DestructionThread::MainRunLoop>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MockRealtimeAudioSource, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
 
 protected:
     MockRealtimeAudioSource(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, PageIdentifier);

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -93,7 +93,7 @@ private:
     SampleBufferDisplayLayerIdentifier m_identifier;
     Ref<IPC::Connection> m_connection;
     std::unique_ptr<WebCore::ImageTransferSessionVT> m_imageTransferSession;
-    std::unique_ptr<WebCore::LocalSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
+    RefPtr<WebCore::LocalSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
     std::unique_ptr<LayerHostingContext> m_layerHostingContext;
     SharedVideoFrameReader m_sharedVideoFrameReader;
     ThreadLikeAssertion m_consumeThread NO_UNIQUE_ADDRESS;

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -330,7 +330,7 @@ CaptureSourceOrError UserMediaCaptureManagerProxy::createMicrophoneSource(const 
     auto& perPageSources = m_pageSources.ensure(pageIdentifier, [] { return PageSources { }; }).iterator->value;
 
     // FIXME: Support multiple microphones simultaneously.
-    if (auto* microphoneSource = perPageSources.microphoneSource.get()) {
+    if (auto microphoneSource = perPageSources.microphoneSource.get()) {
         if (microphoneSource->persistentID() != device.persistentId() && !microphoneSource->isEnded()) {
             RELEASE_LOG_ERROR(WebRTC, "Ending microphone source as new source is using a different device.");
             // FIXME: We should probably fail the capture in a way that shows a specific console log message.
@@ -339,7 +339,7 @@ CaptureSourceOrError UserMediaCaptureManagerProxy::createMicrophoneSource(const 
     }
 
     auto source = sourceOrError.source();
-    perPageSources.microphoneSource = WeakPtr { source.get() };
+    perPageSources.microphoneSource = ThreadSafeWeakPtr { source.get() };
     return source;
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -107,8 +107,8 @@ private:
     WebCore::OrientationNotifier m_orientationNotifier { 0 };
 
     struct PageSources {
-        WeakPtr<WebCore::RealtimeMediaSource> microphoneSource;
-        WeakHashSet<WebCore::RealtimeMediaSource> cameraSources;
+        ThreadSafeWeakPtr<WebCore::RealtimeMediaSource> microphoneSource;
+        ThreadSafeWeakHashSet<WebCore::RealtimeMediaSource> cameraSources;
     };
     HashMap<WebCore::PageIdentifier, PageSources> m_pageSources;
 };

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h
@@ -46,10 +46,13 @@ class WebAudioBufferList;
 namespace WebKit {
 class SpeechRecognitionRemoteRealtimeMediaSourceManager;
     
-class SpeechRecognitionRemoteRealtimeMediaSource : public WebCore::RealtimeMediaSource {
+class SpeechRecognitionRemoteRealtimeMediaSource : public WebCore::RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SpeechRecognitionRemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop> {
 public:
     static Ref<WebCore::RealtimeMediaSource> create(SpeechRecognitionRemoteRealtimeMediaSourceManager&, const WebCore::CaptureDevice&, WebCore::PageIdentifier);
     ~SpeechRecognitionRemoteRealtimeMediaSource();
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SpeechRecognitionRemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop>::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SpeechRecognitionRemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SpeechRecognitionRemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
 
     WebCore::RealtimeMediaSourceIdentifier identifier() const { return m_identifier; }
 

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
@@ -67,7 +67,7 @@ void SpeechRecognitionRemoteRealtimeMediaSourceManager::addSource(SpeechRecognit
 void SpeechRecognitionRemoteRealtimeMediaSourceManager::removeSource(SpeechRecognitionRemoteRealtimeMediaSource& source)
 {
     auto identifier = source.identifier();
-    ASSERT(m_sources.get(identifier) == &source);
+    ASSERT(!m_sources.get(identifier).get().get() || m_sources.get(identifier).get().get() == &source);
     m_sources.remove(identifier);
 
 #if ENABLE(SANDBOX_EXTENSIONS)
@@ -82,19 +82,19 @@ void SpeechRecognitionRemoteRealtimeMediaSourceManager::removeSource(SpeechRecog
 
 void SpeechRecognitionRemoteRealtimeMediaSourceManager::remoteAudioSamplesAvailable(WebCore::RealtimeMediaSourceIdentifier identifier, const WTF::MediaTime& time, uint64_t numberOfFrames)
 {
-    if (auto source = m_sources.get(identifier))
+    if (auto source = m_sources.get(identifier).get())
         source->remoteAudioSamplesAvailable(time, numberOfFrames);
 }
 
 void SpeechRecognitionRemoteRealtimeMediaSourceManager::remoteCaptureFailed(WebCore::RealtimeMediaSourceIdentifier identifier)
 {
-    if (auto source = m_sources.get(identifier))
+    if (auto source = m_sources.get(identifier).get())
         source->remoteCaptureFailed();
 }
 
 void SpeechRecognitionRemoteRealtimeMediaSourceManager::remoteSourceStopped(WebCore::RealtimeMediaSourceIdentifier identifier)
 {
-    if (auto source = m_sources.get(identifier))
+    if (auto source = m_sources.get(identifier).get())
         source->remoteSourceStopped();
 }
 
@@ -112,7 +112,7 @@ uint64_t SpeechRecognitionRemoteRealtimeMediaSourceManager::messageSenderDestina
 
 void SpeechRecognitionRemoteRealtimeMediaSourceManager::setStorage(WebCore::RealtimeMediaSourceIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description)
 {
-    if (auto source = m_sources.get(identifier))
+    if (auto source = m_sources.get(identifier).get())
         source->setStorage(WTFMove(handle), description);
 }
 

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
@@ -71,7 +71,7 @@ private:
     uint64_t messageSenderDestinationID() const final;
 
     Ref<IPC::Connection> m_connection;
-    HashMap<WebCore::RealtimeMediaSourceIdentifier, WeakPtr<SpeechRecognitionRemoteRealtimeMediaSource>> m_sources;
+    HashMap<WebCore::RealtimeMediaSourceIdentifier, ThreadSafeWeakPtr<SpeechRecognitionRemoteRealtimeMediaSource>> m_sources;
     HashSet<WebCore::RealtimeMediaSourceIdentifier> m_sourcesNeedingSandboxExtension;
 };
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -174,9 +174,10 @@ void GPUProcessConnection::didClose(IPC::Connection&)
         arbitrator->leaveRoutingAbritration();
 #endif
 
-    auto clients = m_clients;
-    for (auto& client : clients)
+    m_clients.forEach([this] (auto& client) {
         client.gpuProcessConnectionDidClose(*this);
+    });
+    m_clients.clear();
 }
 
 void GPUProcessConnection::didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName)

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
@@ -55,28 +55,27 @@ IPC::Connection* RemoteWCLayerTreeHostProxy::messageSenderConnection() const
 
 GPUProcessConnection& RemoteWCLayerTreeHostProxy::ensureGPUProcessConnection()
 {
-    if (!m_gpuProcessConnection) {
-        auto& gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
-        gpuProcessConnection.addClient(*this);
-        gpuProcessConnection.connection().send(
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!gpuProcessConnection) {
+        gpuProcessConnection = &WebProcess::singleton().ensureGPUProcessConnection();
+        m_gpuProcessConnection = gpuProcessConnection;
+        gpuProcessConnection->addClient(*this);
+        gpuProcessConnection->connection().send(
             Messages::GPUConnectionToWebProcess::CreateWCLayerTreeHost(wcLayerTreeHostIdentifier(), m_page.nativeWindowHandle(), m_usesOffscreenRendering),
             0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
-        m_gpuProcessConnection = gpuProcessConnection;
     }
-    return *m_gpuProcessConnection;
+    return *gpuProcessConnection;
 }
 
 void RemoteWCLayerTreeHostProxy::disconnectGpuProcessIfNeeded()
 {
-    if (auto gpuProcessConnection = std::exchange(m_gpuProcessConnection, nullptr)) {
-        gpuProcessConnection->removeClient(*this);
+    if (auto gpuProcessConnection = std::exchange(m_gpuProcessConnection, nullptr).get()) {
         gpuProcessConnection->connection().send(Messages::GPUConnectionToWebProcess::ReleaseWCLayerTreeHost(wcLayerTreeHostIdentifier()), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
     }
 }
 
 void RemoteWCLayerTreeHostProxy::gpuProcessConnectionDidClose(GPUProcessConnection& previousConnection)
 {
-    previousConnection.removeClient(*this);
     m_gpuProcessConnection = nullptr;
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.h
@@ -39,13 +39,18 @@ struct WCUpateInfo;
 
 class RemoteWCLayerTreeHostProxy
     : private IPC::MessageSender
-    , private GPUProcessConnection::Client {
+    , private GPUProcessConnection::Client
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteWCLayerTreeHostProxy> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     RemoteWCLayerTreeHostProxy(WebPage&, bool usesOffscreenRendering);
     ~RemoteWCLayerTreeHostProxy();
 
     void update(WCUpateInfo&&, CompletionHandler<void(std::optional<WebKit::UpdateInfo>)>&&);
+
+    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteWCLayerTreeHostProxy>::ref(); }
+    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteWCLayerTreeHostProxy>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteWCLayerTreeHostProxy>::controlBlock(); }
 
 private:
     WCLayerTreeHostIdentifier wcLayerTreeHostIdentifier() const { return m_wcLayerTreeHostIdentifier; };
@@ -59,7 +64,7 @@ private:
     IPC::Connection* messageSenderConnection() const override;
     uint64_t messageSenderDestinationID() const override;
 
-    WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     WCLayerTreeHostIdentifier m_wcLayerTreeHostIdentifier { WCLayerTreeHostIdentifier::generate() };
     WebPage& m_page;
     bool m_usesOffscreenRendering { false };

--- a/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.cpp
@@ -46,11 +46,12 @@ AudioTrackPrivateRemote::AudioTrackPrivateRemote(GPUProcessConnection& gpuProces
 
 void AudioTrackPrivateRemote::setEnabled(bool enabled)
 {
-    if (!m_gpuProcessConnection)
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!gpuProcessConnection)
         return;
 
     if (enabled != this->enabled())
-        m_gpuProcessConnection->connection().send(Messages::RemoteMediaPlayerProxy::AudioTrackSetEnabled(m_identifier, enabled), m_playerIdentifier);
+        gpuProcessConnection->connection().send(Messages::RemoteMediaPlayerProxy::AudioTrackSetEnabled(m_identifier, enabled), m_playerIdentifier);
 
     AudioTrackPrivate::setEnabled(enabled);
 }

--- a/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.h
@@ -60,7 +60,7 @@ private:
     void setEnabled(bool) final;
     MediaTime startTimeVariance() const final { return m_startTimeVariance; }
 
-    WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     AudioTrackKind m_kind { None };
     AtomString m_id;
     AtomString m_label;

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -66,7 +66,7 @@ MediaSourcePrivateRemote::MediaSourcePrivateRemote(GPUProcessConnection& gpuProc
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    m_gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::MediaSourcePrivateRemote::messageReceiverName(), m_identifier.toUInt64(), *this);
+    gpuProcessConnection.messageReceiverMap().addMessageReceiver(Messages::MediaSourcePrivateRemote::messageReceiverName(), m_identifier.toUInt64(), *this);
 
 #if !RELEASE_LOG_DISABLED
     client.setLogIdentifier(m_logIdentifier);
@@ -76,8 +76,8 @@ MediaSourcePrivateRemote::MediaSourcePrivateRemote(GPUProcessConnection& gpuProc
 MediaSourcePrivateRemote::~MediaSourcePrivateRemote()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    if (m_gpuProcessConnection)
-        m_gpuProcessConnection->messageReceiverMap().removeMessageReceiver(Messages::MediaSourcePrivateRemote::messageReceiverName(), m_identifier.toUInt64());
+    if (auto gpuProcessConnection = m_gpuProcessConnection.get())
+        gpuProcessConnection->messageReceiverMap().removeMessageReceiver(Messages::MediaSourcePrivateRemote::messageReceiverName(), m_identifier.toUInt64());
 
     for (auto& sourceBuffer : m_sourceBuffers)
         sourceBuffer->clearMediaSource();
@@ -93,15 +93,16 @@ MediaSourcePrivate::AddStatus MediaSourcePrivateRemote::addSourceBuffer(const Co
     if (m_mimeTypeCache.supportsTypeAndCodecs(parameters) == MediaPlayer::SupportsType::IsNotSupported)
         return AddStatus::NotSupported;
 
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
     if (!isGPURunning() || !m_mediaPlayerPrivate)
         return AddStatus::NotSupported;
 
-    auto sendResult = m_gpuProcessConnection->connection().sendSync(Messages::RemoteMediaSourceProxy::AddSourceBuffer(contentType), m_identifier);
+    auto sendResult = gpuProcessConnection->connection().sendSync(Messages::RemoteMediaSourceProxy::AddSourceBuffer(contentType), m_identifier);
     auto [status, remoteSourceBufferIdentifier] = sendResult.takeReplyOr(AddStatus::NotSupported, std::nullopt);
 
     if (status == AddStatus::Ok) {
         ASSERT(remoteSourceBufferIdentifier.has_value());
-        auto newSourceBuffer = SourceBufferPrivateRemote::create(*m_gpuProcessConnection, *remoteSourceBufferIdentifier, *this, *m_mediaPlayerPrivate);
+        auto newSourceBuffer = SourceBufferPrivateRemote::create(*gpuProcessConnection, *remoteSourceBufferIdentifier, *this, *m_mediaPlayerPrivate);
         outPrivate = newSourceBuffer.copyRef();
         m_sourceBuffers.append(WTFMove(newSourceBuffer));
     }
@@ -111,33 +112,35 @@ MediaSourcePrivate::AddStatus MediaSourcePrivateRemote::addSourceBuffer(const Co
 
 void MediaSourcePrivateRemote::durationChanged(const MediaTime& duration)
 {
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
     if (!isGPURunning())
         return;
 
-    m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::DurationChanged(duration), m_identifier);
+    gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::DurationChanged(duration), m_identifier);
 }
 
 void MediaSourcePrivateRemote::bufferedChanged(const PlatformTimeRanges& buffered)
 {
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
     if (!isGPURunning())
         return;
 
-    m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::BufferedChanged(buffered), m_identifier);
+    gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::BufferedChanged(buffered), m_identifier);
 }
 
 void MediaSourcePrivateRemote::markEndOfStream(EndOfStreamStatus status)
 {
     m_ended = true;
-    if (m_gpuProcessConnection)
-        m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::MarkEndOfStream(status), m_identifier);
+    if (auto gpuProcessConnection = m_gpuProcessConnection.get())
+        gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::MarkEndOfStream(status), m_identifier);
 }
 
 void MediaSourcePrivateRemote::unmarkEndOfStream()
 {
     // FIXME(125159): implement unmarkEndOfStream()
     m_ended = false;
-    if (m_gpuProcessConnection)
-        m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::UnmarkEndOfStream(), m_identifier);
+    if (auto gpuProcessConnection = m_gpuProcessConnection.get())
+        gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::UnmarkEndOfStream(), m_identifier);
 }
 
 bool MediaSourcePrivateRemote::isEnded() const
@@ -152,44 +155,49 @@ MediaPlayer::ReadyState MediaSourcePrivateRemote::readyState() const
 
 void MediaSourcePrivateRemote::setReadyState(MediaPlayer::ReadyState readyState)
 {
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
     if (!isGPURunning())
         return;
 
-    m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::SetReadyState(readyState), m_identifier);
+    gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::SetReadyState(readyState), m_identifier);
 }
 
 void MediaSourcePrivateRemote::setIsSeeking(bool isSeeking)
 {
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
     if (!isGPURunning())
         return;
 
     MediaSourcePrivate::setIsSeeking(isSeeking);
-    m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::SetIsSeeking(isSeeking), m_identifier);
+    gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::SetIsSeeking(isSeeking), m_identifier);
 }
 
 void MediaSourcePrivateRemote::waitForSeekCompleted()
 {
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
     if (!isGPURunning())
         return;
 
-    m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::WaitForSeekCompleted(), m_identifier);
+    gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::WaitForSeekCompleted(), m_identifier);
 }
 
 void MediaSourcePrivateRemote::seekCompleted()
 {
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
     if (!isGPURunning())
         return;
 
-    m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::SeekCompleted(), m_identifier);
+    gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::SeekCompleted(), m_identifier);
 }
 
 void MediaSourcePrivateRemote::setTimeFudgeFactor(const MediaTime& fudgeFactor)
 {
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
     if (!isGPURunning())
         return;
 
     MediaSourcePrivate::setTimeFudgeFactor(fudgeFactor);
-    m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::SetTimeFudgeFactor(fudgeFactor), m_identifier);
+    gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::SetTimeFudgeFactor(fudgeFactor), m_identifier);
 }
 
 void MediaSourcePrivateRemote::seekToTime(const MediaTime& time)

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -87,9 +87,9 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     void seekToTime(const MediaTime&);
     void mediaSourcePrivateShuttingDown(CompletionHandler<void()>&&);
-    bool isGPURunning() const { return !m_shutdown && m_gpuProcessConnection; }
+    bool isGPURunning() const { return !m_shutdown && m_gpuProcessConnection.get(); }
 
-    WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     RemoteMediaSourceIdentifier m_identifier;
     RemoteMediaPlayerMIMETypeCache& m_mimeTypeCache;
     WeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
@@ -49,7 +49,7 @@ class WebAudioBufferList;
 
 namespace WebKit {
 
-class RemoteAudioDestinationProxy final : public WebCore::AudioDestinationResampler, public GPUProcessConnection::Client {
+class RemoteAudioDestinationProxy final : public WebCore::AudioDestinationResampler, public GPUProcessConnection::Client, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioDestinationProxy> {
     WTF_MAKE_NONCOPYABLE(RemoteAudioDestinationProxy);
 public:
     using AudioIOCallback = WebCore::AudioIOCallback;
@@ -58,6 +58,10 @@ public:
 
     RemoteAudioDestinationProxy(AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate);
     ~RemoteAudioDestinationProxy();
+
+    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioDestinationProxy>::ref(); }
+    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioDestinationProxy>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioDestinationProxy>::controlBlock(); }
 
 private:
     void startRendering(CompletionHandler<void(bool)>&&) final;
@@ -75,7 +79,7 @@ private:
 
     RemoteAudioDestinationIdentifier m_destinationID; // Call destinationID() getter to make sure the destinationID is valid.
 
-    WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 #if PLATFORM(COCOA)
     std::unique_ptr<ProducerSharedCARingBuffer> m_ringBuffer;
     std::unique_ptr<WebCore::WebAudioBufferList> m_audioBufferList;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h
@@ -44,11 +44,16 @@ class WebProcess;
 class RemoteAudioHardwareListener final
     : public WebCore::AudioHardwareListener
     , private GPUProcessConnection::Client
-    , private IPC::MessageReceiver {
+    , private IPC::MessageReceiver
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioHardwareListener> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<RemoteAudioHardwareListener> create(WebCore::AudioHardwareListener::Client&, WebProcess&);
     ~RemoteAudioHardwareListener();
+
+    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioHardwareListener>::ref(); }
+    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioHardwareListener>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioHardwareListener>::controlBlock(); }
 
 private:
     RemoteAudioHardwareListener(WebCore::AudioHardwareListener::Client&, WebProcess&);
@@ -65,7 +70,7 @@ private:
     void audioOutputDeviceChanged(size_t bufferSizeMinimum, size_t bufferSizeMaximum);
 
     RemoteAudioHardwareListenerIdentifier m_identifier;
-    WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -52,8 +52,8 @@ RemoteAudioSession::RemoteAudioSession(WebProcess& process)
 
 RemoteAudioSession::~RemoteAudioSession()
 {
-    if (m_gpuProcessConnection)
-        m_gpuProcessConnection->messageReceiverMap().removeMessageReceiver(Messages::RemoteAudioSession::messageReceiverName());
+    if (auto gpuProcessConnection = m_gpuProcessConnection.get())
+        gpuProcessConnection->messageReceiverMap().removeMessageReceiver(Messages::RemoteAudioSession::messageReceiverName());
 
     removeInterruptionObserver(*this);
 }
@@ -63,20 +63,21 @@ void RemoteAudioSession::gpuProcessConnectionDidClose(GPUProcessConnection& conn
     ASSERT(m_gpuProcessConnection.get() == &connection);
     m_gpuProcessConnection = nullptr;
     connection.messageReceiverMap().removeMessageReceiver(Messages::RemoteAudioSession::messageReceiverName());
-    connection.removeClient(*this);
 }
 
 IPC::Connection& RemoteAudioSession::ensureConnection()
 {
-    if (!m_gpuProcessConnection) {
-        m_gpuProcessConnection = m_process.ensureGPUProcessConnection();
-        m_gpuProcessConnection->addClient(*this);
-        m_gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteAudioSession::messageReceiverName(), *this);
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!gpuProcessConnection) {
+        gpuProcessConnection = &WebProcess::singleton().ensureGPUProcessConnection();
+        m_gpuProcessConnection = gpuProcessConnection;
+        gpuProcessConnection->addClient(*this);
+        gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteAudioSession::messageReceiverName(), *this);
 
         auto sendResult = ensureConnection().sendSync(Messages::GPUConnectionToWebProcess::EnsureAudioSession(), { });
         std::tie(m_configuration) = sendResult.takeReplyOr(RemoteAudioSessionConfiguration { });
     }
-    return m_gpuProcessConnection->connection();
+    return gpuProcessConnection->connection();
 }
 
 const RemoteAudioSessionConfiguration& RemoteAudioSession::configuration() const

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -45,11 +45,16 @@ class RemoteAudioSession final
     : public WebCore::AudioSession
     , public WebCore::AudioSession::InterruptionObserver
     , public GPUProcessConnection::Client
-    , IPC::MessageReceiver {
+    , IPC::MessageReceiver
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static UniqueRef<RemoteAudioSession> create(WebProcess&);
     ~RemoteAudioSession();
+
+    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession>::ref(); }
+    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession>::controlBlock(); }
 
 private:
     friend UniqueRef<RemoteAudioSession> WTF::makeUniqueRefWithoutFastMallocCheck<RemoteAudioSession>(WebProcess&);
@@ -114,7 +119,7 @@ private:
     WebCore::RouteSharingPolicy m_routeSharingPolicy { WebCore::RouteSharingPolicy::Default };
     bool m_isPlayingToBluetoothOverrideChanged { false };
     std::optional<RemoteAudioSessionConfiguration> m_configuration;
-    WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.h
@@ -66,7 +66,7 @@ private:
 #endif
 
     WebCore::MediaPlayerIdentifier m_identifier;
-    WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
     const void* m_logIdentifier;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.cpp
@@ -163,10 +163,11 @@ PlatformImagePtr RemoteImageDecoderAVF::createFrameImageAtIndex(size_t index, Su
         return m_frameImages.get(index);
 
     auto createFrameImage = [&] {
-        if (!m_gpuProcessConnection)
+        auto gpuProcessConnection = m_gpuProcessConnection.get();
+        if (!gpuProcessConnection)
             return;
 
-        auto sendResult = m_gpuProcessConnection->connection().sendSync(Messages::RemoteImageDecoderAVFProxy::CreateFrameImageAtIndex(m_identifier, index), 0);
+        auto sendResult = gpuProcessConnection->connection().sendSync(Messages::RemoteImageDecoderAVFProxy::CreateFrameImageAtIndex(m_identifier, index), 0);
         auto [imageHandle] = sendResult.takeReplyOr(std::nullopt);
         if (!imageHandle)
             return;
@@ -187,20 +188,22 @@ PlatformImagePtr RemoteImageDecoderAVF::createFrameImageAtIndex(size_t index, Su
 
 void RemoteImageDecoderAVF::setExpectedContentSize(long long expectedContentSize)
 {
-    if (!m_gpuProcessConnection)
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!gpuProcessConnection)
         return;
 
-    m_gpuProcessConnection->connection().send(Messages::RemoteImageDecoderAVFProxy::SetExpectedContentSize(m_identifier, expectedContentSize), 0);
+    gpuProcessConnection->connection().send(Messages::RemoteImageDecoderAVFProxy::SetExpectedContentSize(m_identifier, expectedContentSize), 0);
 }
 
 // If allDataReceived is true, the caller expects encodedDataStatus() to be >= EncodedDataStatus::SizeAvailable
 // after this function returns (in the same run loop).
 void RemoteImageDecoderAVF::setData(const FragmentedSharedBuffer& data, bool allDataReceived)
 {
-    if (!m_gpuProcessConnection)
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!gpuProcessConnection)
         return;
 
-    auto sendResult = m_gpuProcessConnection->connection().sendSync(Messages::RemoteImageDecoderAVFProxy::SetData(m_identifier, IPC::SharedBufferReference(data), allDataReceived), 0);
+    auto sendResult = gpuProcessConnection->connection().sendSync(Messages::RemoteImageDecoderAVFProxy::SetData(m_identifier, IPC::SharedBufferReference(data), allDataReceived), 0);
     if (!sendResult)
         return;
     auto [frameCount, size, hasTrack, frameInfos] = sendResult.takeReply();
@@ -220,8 +223,8 @@ void RemoteImageDecoderAVF::clearFrameBufferCache(size_t index)
     for (size_t i = 0; i < std::min(index + 1, m_frameCount); ++i)
         m_frameImages.remove(i);
 
-    if (m_gpuProcessConnection)
-        m_gpuProcessConnection->connection().send(Messages::RemoteImageDecoderAVFProxy::ClearFrameBufferCache(m_identifier, index), 0);
+    if (auto gpuProcessConnection = m_gpuProcessConnection.get())
+        gpuProcessConnection->connection().send(Messages::RemoteImageDecoderAVFProxy::ClearFrameBufferCache(m_identifier, index), 0);
 }
 
 void RemoteImageDecoderAVF::encodedDataStatusChanged(size_t frameCount, const WebCore::IntSize& size, bool hasTrack)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.h
@@ -87,7 +87,7 @@ public:
     void encodedDataStatusChanged(size_t frameCount, const WebCore::IntSize&, bool hasTrack);
 
 private:
-    WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     RemoteImageDecoderAVFManager& m_manager;
     WebCore::ImageDecoderIdentifier m_identifier;
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
@@ -55,8 +55,8 @@ RefPtr<RemoteImageDecoderAVF> RemoteImageDecoderAVFManager::createImageDecoder(F
 void RemoteImageDecoderAVFManager::deleteRemoteImageDecoder(const ImageDecoderIdentifier& identifier)
 {
     m_remoteImageDecoders.take(identifier);
-    if (m_gpuProcessConnection)
-        m_gpuProcessConnection->connection().send(Messages::RemoteImageDecoderAVFProxy::DeleteDecoder(identifier), 0);
+    if (auto gpuProcessConnection = m_gpuProcessConnection.get())
+        gpuProcessConnection->connection().send(Messages::RemoteImageDecoderAVFProxy::DeleteDecoder(identifier), 0);
 }
 
 RemoteImageDecoderAVFManager::RemoteImageDecoderAVFManager(WebProcess& process)
@@ -66,15 +66,15 @@ RemoteImageDecoderAVFManager::RemoteImageDecoderAVFManager(WebProcess& process)
 
 RemoteImageDecoderAVFManager::~RemoteImageDecoderAVFManager()
 {
-    if (m_gpuProcessConnection)
-        m_gpuProcessConnection->messageReceiverMap().removeMessageReceiver(Messages::RemoteImageDecoderAVFManager::messageReceiverName());
+    if (auto gpuProcessConnection = m_gpuProcessConnection.get())
+        gpuProcessConnection->messageReceiverMap().removeMessageReceiver(Messages::RemoteImageDecoderAVFManager::messageReceiverName());
 }
 
 void RemoteImageDecoderAVFManager::gpuProcessConnectionDidClose(GPUProcessConnection& connection)
 {
-    ASSERT(m_gpuProcessConnection == &connection);
-    connection.removeClient(*this);
-    m_gpuProcessConnection->messageReceiverMap().removeMessageReceiver(Messages::RemoteImageDecoderAVFManager::messageReceiverName());
+    ASSERT(m_gpuProcessConnection.get() == &connection);
+    if (auto gpuProcessConnection = m_gpuProcessConnection.get())
+        gpuProcessConnection->messageReceiverMap().removeMessageReceiver(Messages::RemoteImageDecoderAVFManager::messageReceiverName());
     m_gpuProcessConnection = nullptr;
     // FIXME: Do we need to do more when m_remoteImageDecoders is not empty to re-create them?
 }
@@ -86,12 +86,14 @@ const char*  RemoteImageDecoderAVFManager::supplementName()
 
 GPUProcessConnection& RemoteImageDecoderAVFManager::ensureGPUProcessConnection()
 {
-    if (!m_gpuProcessConnection) {
-        m_gpuProcessConnection = m_process.ensureGPUProcessConnection();
-        m_gpuProcessConnection->addClient(*this);
-        m_gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteImageDecoderAVFManager::messageReceiverName(), *this);
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!gpuProcessConnection) {
+        gpuProcessConnection = &WebProcess::singleton().ensureGPUProcessConnection();
+        m_gpuProcessConnection = gpuProcessConnection;
+        gpuProcessConnection->addClient(*this);
+        gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteImageDecoderAVFManager::messageReceiverName(), *this);
     }
-    return *m_gpuProcessConnection;
+    return *gpuProcessConnection;
 }
 
 void RemoteImageDecoderAVFManager::setUseGPUProcess(bool useGPUProcess)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
@@ -45,7 +45,8 @@ class WebProcess;
 class RemoteImageDecoderAVFManager final
     : public WebProcessSupplement
     , private GPUProcessConnection::Client
-    , private IPC::MessageReceiver {
+    , private IPC::MessageReceiver
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteImageDecoderAVFManager> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit RemoteImageDecoderAVFManager(WebProcess&);
@@ -57,6 +58,10 @@ public:
 
     void setUseGPUProcess(bool);
     GPUProcessConnection& ensureGPUProcessConnection();
+
+    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteImageDecoderAVFManager>::ref(); }
+    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteImageDecoderAVFManager>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteImageDecoderAVFManager>::controlBlock(); }
 
 private:
     RefPtr<RemoteImageDecoderAVF> createImageDecoder(WebCore::FragmentedSharedBuffer& data, const String& mimeType, WebCore::AlphaOption, WebCore::GammaAndColorProfileOption);
@@ -70,7 +75,7 @@ private:
     HashMap<WebCore::ImageDecoderIdentifier, WeakPtr<RemoteImageDecoderAVF>> m_remoteImageDecoders;
 
     WebProcess& m_process;
-    WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
@@ -47,7 +47,8 @@ struct TrackPrivateRemoteConfiguration;
 
 class RemoteMediaPlayerManager
     : public WebProcessSupplement
-    , public GPUProcessConnection::Client {
+    , public GPUProcessConnection::Client
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteMediaPlayerManager> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit RemoteMediaPlayerManager(WebProcess&);
@@ -58,7 +59,7 @@ public:
 
     void setUseGPUProcess(bool);
 
-    GPUProcessConnection& gpuProcessConnection() const;
+    GPUProcessConnection& gpuProcessConnection();
 
     void didReceivePlayerMessage(IPC::Connection&, IPC::Decoder&);
 
@@ -67,6 +68,10 @@ public:
     WebCore::MediaPlayerIdentifier findRemotePlayerId(const WebCore::MediaPlayerPrivateInterface*);
 
     RemoteMediaPlayerMIMETypeCache& typeCache(WebCore::MediaPlayerEnums::MediaEngineIdentifier);
+
+    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteMediaPlayerManager>::ref(); }
+    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteMediaPlayerManager>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteMediaPlayerManager>::controlBlock(); }
 
 private:
     std::unique_ptr<WebCore::MediaPlayerPrivateInterface> createRemoteMediaPlayer(WebCore::MediaPlayer*, WebCore::MediaPlayerEnums::MediaEngineIdentifier);
@@ -87,7 +92,7 @@ private:
 
     HashMap<WebCore::MediaPlayerIdentifier, WeakPtr<MediaPlayerPrivateRemote>> m_players;
     WebProcess& m_process;
-    mutable GPUProcessConnection* m_gpuProcessConnection { nullptr };
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
@@ -44,12 +44,17 @@ class WebProcess;
 class RemoteRemoteCommandListener final
     : public WebCore::RemoteCommandListener
     , private GPUProcessConnection::Client
-    , private IPC::MessageReceiver {
+    , private IPC::MessageReceiver
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRemoteCommandListener> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<RemoteRemoteCommandListener> create(WebCore::RemoteCommandListenerClient&, WebProcess&);
+    static Ref<RemoteRemoteCommandListener> create(WebCore::RemoteCommandListenerClient&, WebProcess&);
     RemoteRemoteCommandListener(WebCore::RemoteCommandListenerClient&, WebProcess&);
     ~RemoteRemoteCommandListener();
+
+    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRemoteCommandListener>::ref(); }
+    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRemoteCommandListener>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRemoteCommandListener>::controlBlock(); }
 
 private:
     // IPC::MessageReceiver
@@ -70,7 +75,7 @@ private:
     RemoteRemoteCommandListenerIdentifier m_identifier;
     WebCore::RemoteCommandListener::RemoteCommandsSet m_currentCommands;
     bool m_currentSupportSeeking { false };
-    WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -127,7 +127,7 @@ private:
     MediaTime minimumUpcomingPresentationTimeForTrackID(const AtomString&) override;
     void setMaximumQueueDepthForTrackID(const AtomString&, uint64_t) override;
 
-    WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     RemoteSourceBufferIdentifier m_remoteSourceBufferIdentifier;
     WeakPtr<MediaSourcePrivateRemote> m_mediaSourcePrivate;
     WeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
@@ -139,7 +139,7 @@ private:
     bool m_isActive { false };
     uint64_t m_totalTrackBufferSizeInBytes = { 0 };
 
-    bool isGPURunning() const { return !m_disconnected && m_gpuProcessConnection; }
+    bool isGPURunning() const { return !m_disconnected && m_gpuProcessConnection.get(); }
     bool m_disconnected { false };
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
@@ -48,13 +48,14 @@ TextTrackPrivateRemote::TextTrackPrivateRemote(GPUProcessConnection& gpuProcessC
 
 void TextTrackPrivateRemote::setMode(TextTrackMode mode)
 {
-    if (!m_gpuProcessConnection)
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!gpuProcessConnection)
         return;
 
     if (mode == InbandTextTrackPrivate::mode())
         return;
 
-    m_gpuProcessConnection->connection().send(Messages::RemoteMediaPlayerProxy::TextTrackSetMode(m_identifier, mode), m_playerIdentifier);
+    gpuProcessConnection->connection().send(Messages::RemoteMediaPlayerProxy::TextTrackSetMode(m_identifier, mode), m_playerIdentifier);
     InbandTextTrackPrivate::setMode(mode);
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.h
@@ -97,7 +97,7 @@ public:
 private:
     TextTrackPrivateRemote(GPUProcessConnection&, WebCore::MediaPlayerIdentifier, TrackPrivateRemoteIdentifier, TextTrackPrivateRemoteConfiguration&&);
 
-    WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     AtomString m_id;
     AtomString m_label;
     AtomString m_language;

--- a/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp
@@ -46,11 +46,12 @@ VideoTrackPrivateRemote::VideoTrackPrivateRemote(GPUProcessConnection& gpuProces
 
 void VideoTrackPrivateRemote::setSelected(bool selected)
 {
-    if (!m_gpuProcessConnection)
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!gpuProcessConnection)
         return;
 
     if (selected != this->selected())
-        m_gpuProcessConnection->connection().send(Messages::RemoteMediaPlayerProxy::VideoTrackSetSelected(m_identifier, selected), m_playerIdentifier);
+        gpuProcessConnection->connection().send(Messages::RemoteMediaPlayerProxy::VideoTrackSetSelected(m_identifier, selected), m_playerIdentifier);
 
     VideoTrackPrivate::setSelected(selected);
 }

--- a/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.h
@@ -62,7 +62,7 @@ private:
 
     void setSelected(bool) final;
 
-    WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     WebCore::MediaPlayerIdentifier m_playerIdentifier;
     VideoTrackKind m_kind { None };
     AtomString m_id;

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
@@ -52,6 +52,10 @@ public:
     using SupportsAirPlayVideo = WebCore::MediaSessionHelperClient::SupportsAirPlayVideo;
     using SuspendedUnderLock = WebCore::MediaSessionHelperClient::SuspendedUnderLock;
 
+    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCore::MediaSessionHelper>::ref(); }
+    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCore::MediaSessionHelper>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCore::MediaSessionHelper>::controlBlock(); }
+
 private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -68,7 +72,7 @@ private:
     void activeVideoRouteDidChange(SupportsAirPlayVideo, WebCore::MediaPlaybackTargetContext&&);
 
     WebProcess& m_process;
-    WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -155,6 +155,10 @@ public:
     void setHasVP9ExtensionSupport(bool);
     bool hasVP9ExtensionSupport() const { return m_hasVP9ExtensionSupport; }
 
+    void ref() const final { return IPC::WorkQueueMessageReceiver::ref(); }
+    void deref() const final { return IPC::WorkQueueMessageReceiver::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return IPC::WorkQueueMessageReceiver::controlBlock(); }
+
 private:
     LibWebRTCCodecs();
     void ensureGPUProcessConnectionAndDispatchToThread(Function<void()>&&);

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
@@ -64,8 +64,9 @@ void MediaRecorderPrivate::startRecording(StartRecordingCallback&& callback)
     // Currently we only choose the first track as the recorded track.
 
     auto selectedTracks = MediaRecorderPrivate::selectTracks(m_stream);
-    m_connection->sendWithAsyncReply(Messages::RemoteMediaRecorderManager::CreateRecorder { m_identifier, !!selectedTracks.audioTrack, !!selectedTracks.videoTrack, m_options }, [this, weakThis = WeakPtr { *this }, audioTrack = RefPtr { selectedTracks.audioTrack }, videoTrack = RefPtr { selectedTracks.videoTrack }, callback = WTFMove(callback)](auto&& exception, String&& mimeType, unsigned audioBitRate, unsigned videoBitRate) mutable {
-        if (!weakThis) {
+    m_connection->sendWithAsyncReply(Messages::RemoteMediaRecorderManager::CreateRecorder { m_identifier, !!selectedTracks.audioTrack, !!selectedTracks.videoTrack, m_options }, [this, weakThis = ThreadSafeWeakPtr { *this }, audioTrack = RefPtr { selectedTracks.audioTrack }, videoTrack = RefPtr { selectedTracks.videoTrack }, callback = WTFMove(callback)](auto&& exception, String&& mimeType, unsigned audioBitRate, unsigned videoBitRate) mutable {
+        auto strongThis = weakThis.get();
+        if (!strongThis) {
             callback(Exception { InvalidStateError }, 0, 0);
             return;
         }
@@ -86,7 +87,6 @@ void MediaRecorderPrivate::startRecording(StartRecordingCallback&& callback)
 MediaRecorderPrivate::~MediaRecorderPrivate()
 {
     m_connection->send(Messages::RemoteMediaRecorderManager::ReleaseRecorder { m_identifier }, 0);
-    WebProcess::singleton().ensureGPUProcessConnection().removeClient(*this);
 }
 
 void MediaRecorderPrivate::videoFrameAvailable(VideoFrame& videoFrame, VideoFrameTimeMetadata)

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
@@ -49,11 +49,16 @@ namespace WebKit {
 
 class MediaRecorderPrivate final
     : public WebCore::MediaRecorderPrivate
-    , public GPUProcessConnection::Client {
+    , public GPUProcessConnection::Client
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivate> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     MediaRecorderPrivate(WebCore::MediaStreamPrivate&, const WebCore::MediaRecorderPrivateOptions&);
     ~MediaRecorderPrivate();
+
+    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivate>::ref(); }
+    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivate>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivate>::controlBlock(); }
 
 private:
     // WebCore::MediaRecorderPrivate

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
@@ -64,6 +64,10 @@ public:
     void getVideoFrameBuffer(const RemoteVideoFrameProxy&, bool canUseIOSurfce, Callback&&);
     RefPtr<WebCore::NativeImage> getNativeImage(const WebCore::VideoFrame&);
 
+    void ref() const final { return IPC::WorkQueueMessageReceiver::ref(); }
+    void deref() const final { return IPC::WorkQueueMessageReceiver::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return IPC::WorkQueueMessageReceiver::controlBlock(); }
+
 private:
     explicit RemoteVideoFrameObjectHeapProxyProcessor(GPUProcessConnection&);
     void initialize();

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
@@ -44,7 +44,7 @@ class SampleBufferDisplayLayerManager;
 
 class SampleBufferDisplayLayer final : public WebCore::SampleBufferDisplayLayer, public IPC::MessageReceiver, public GPUProcessConnection::Client {
 public:
-    static std::unique_ptr<SampleBufferDisplayLayer> create(SampleBufferDisplayLayerManager&, WebCore::SampleBufferDisplayLayer::Client&);
+    static Ref<SampleBufferDisplayLayer> create(SampleBufferDisplayLayerManager&, WebCore::SampleBufferDisplayLayer::Client&);
     ~SampleBufferDisplayLayer();
 
     SampleBufferDisplayLayerIdentifier identifier() const { return m_identifier; }
@@ -53,13 +53,12 @@ public:
 
     WebCore::LayerHostingContextID hostingContextID() const final { return m_hostingContextID; }
 
-    using GPUProcessConnection::Client::weakPtrFactory;
-    using GPUProcessConnection::Client::WeakValueType;
-    using GPUProcessConnection::Client::WeakPtrImplType;
+    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCore::SampleBufferDisplayLayer>::ref(); }
+    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCore::SampleBufferDisplayLayer>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCore::SampleBufferDisplayLayer>::controlBlock(); }
 
 private:
     SampleBufferDisplayLayer(SampleBufferDisplayLayerManager&, WebCore::SampleBufferDisplayLayer::Client&);
-    void disconnectGPUProcessConnectionIfNeeded();
 
     // WebCore::SampleBufferDisplayLayer
     void initialize(bool hideRootLayer, WebCore::IntSize, CompletionHandler<void(bool)>&&) final;
@@ -84,7 +83,7 @@ private:
 
     void setDidFail(bool);
 
-    GPUProcessConnection* m_gpuProcessConnection;
+    ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     WeakPtr<SampleBufferDisplayLayerManager> m_manager;
     Ref<IPC::Connection> m_connection;
     SampleBufferDisplayLayerIdentifier m_identifier;

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
@@ -40,13 +40,10 @@ void SampleBufferDisplayLayerManager::didReceiveLayerMessage(IPC::Connection& co
         layer->didReceiveMessage(connection, decoder);
 }
 
-std::unique_ptr<WebCore::SampleBufferDisplayLayer> SampleBufferDisplayLayerManager::createLayer(WebCore::SampleBufferDisplayLayer::Client& client)
+RefPtr<WebCore::SampleBufferDisplayLayer> SampleBufferDisplayLayerManager::createLayer(WebCore::SampleBufferDisplayLayer::Client& client)
 {
     auto layer = SampleBufferDisplayLayer::create(*this, client);
-    if (!layer)
-        return { };
-
-    m_layers.add(layer->identifier(), *layer);
+    m_layers.add(layer->identifier(), layer.get());
     return layer;
 }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.h
@@ -42,7 +42,7 @@ public:
     void removeLayer(SampleBufferDisplayLayer&);
 
     void didReceiveLayerMessage(IPC::Connection&, IPC::Decoder&);
-    std::unique_ptr<WebCore::SampleBufferDisplayLayer> createLayer(WebCore::SampleBufferDisplayLayer::Client&);
+    RefPtr<WebCore::SampleBufferDisplayLayer> createLayer(WebCore::SampleBufferDisplayLayer::Client&);
 
 private:
     HashMap<SampleBufferDisplayLayerIdentifier, WeakPtr<SampleBufferDisplayLayer>> m_layers;

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
@@ -69,8 +69,8 @@ public:
 
     WebCore::PageIdentifier pageIdentifier() const final { return m_pageID; }
 
-    void ref() const final { IPC::WorkQueueMessageReceiver::ref(); }
-    void deref() const final { IPC::WorkQueueMessageReceiver ::deref(); }
+    void ref() const final { return IPC::WorkQueueMessageReceiver::ref(); }
+    void deref() const final { return IPC::WorkQueueMessageReceiver::deref(); }
 
 private:
     WebSWContextManagerConnection(Ref<IPC::Connection>&&, WebCore::RegistrableDomain&&, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, PageGroupIdentifier, WebPageProxyIdentifier, WebCore::PageIdentifier, const WebPreferencesStore&, RemoteWorkerInitializationData&&);

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2197,7 +2197,7 @@ void WebProcess::setUseGPUProcessForMedia(bool useGPUProcessForMedia)
 
 #if PLATFORM(IOS_FAMILY)
     if (useGPUProcessForMedia)
-        MediaSessionHelper::setSharedHelper(makeUniqueRef<RemoteMediaSessionHelper>(*this));
+        MediaSessionHelper::setSharedHelper(adoptRef(*new RemoteMediaSessionHelper(*this)));
     else
         MediaSessionHelper::resetSharedHelper();
 #endif

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.cpp
@@ -50,10 +50,7 @@ RemoteRealtimeAudioSource::RemoteRealtimeAudioSource(RealtimeMediaSourceIdentifi
     ASSERT(device.type() == CaptureDevice::DeviceType::Microphone);
 }
 
-RemoteRealtimeAudioSource::~RemoteRealtimeAudioSource()
-{
-    removeAsClient();
-}
+RemoteRealtimeAudioSource::~RemoteRealtimeAudioSource() = default;
 
 void RemoteRealtimeAudioSource::remoteAudioSamplesAvailable(const MediaTime& time, const PlatformAudioData& data, const AudioStreamDescription& description, size_t size)
 {

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
@@ -68,14 +68,6 @@ void RemoteRealtimeMediaSource::createRemoteMediaSource()
     }, m_proxy.shouldCaptureInGPUProcess() && m_manager.shouldUseGPUProcessRemoteFrames());
 }
 
-void RemoteRealtimeMediaSource::removeAsClient()
-{
-    if (m_proxy.shouldCaptureInGPUProcess()) {
-        if (auto* connection = WebProcess::singleton().existingGPUProcessConnection())
-            connection->removeClient(*this);
-    }
-}
-
 void RemoteRealtimeMediaSource::setCapabilities(RealtimeMediaSourceCapabilities&& capabilities)
 {
     m_capabilities = WTFMove(capabilities);

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
@@ -39,11 +39,9 @@ class RemoteRealtimeMediaSource : public WebCore::RealtimeMediaSource
 #if ENABLE(GPU_PROCESS)
     , public GPUProcessConnection::Client
 #endif
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop>
 {
 public:
-    RemoteRealtimeMediaSource(WebCore::RealtimeMediaSourceIdentifier, const WebCore::CaptureDevice&, const WebCore::MediaConstraints*, WebCore::MediaDeviceHashSalts&&, UserMediaCaptureManager&, bool shouldCaptureInGPUProcess, WebCore::PageIdentifier);
-    RemoteRealtimeMediaSource(RemoteRealtimeMediaSourceProxy&&, WebCore::MediaDeviceHashSalts&&, UserMediaCaptureManager&, WebCore::PageIdentifier);
-
     WebCore::RealtimeMediaSourceIdentifier identifier() const { return m_proxy.identifier(); }
     IPC::Connection& connection() { return m_proxy.connection(); }
 
@@ -57,9 +55,16 @@ public:
 
     void configurationChanged(String&& persistentID, WebCore::RealtimeMediaSourceSettings&&, WebCore::RealtimeMediaSourceCapabilities&&);
 
+#if ENABLE(GPU_PROCESS)
+    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop>::ref(); }
+    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop>::controlBlock(); }
+#endif
+
 protected:
+    RemoteRealtimeMediaSource(WebCore::RealtimeMediaSourceIdentifier, const WebCore::CaptureDevice&, const WebCore::MediaConstraints*, WebCore::MediaDeviceHashSalts&&, UserMediaCaptureManager&, bool shouldCaptureInGPUProcess, WebCore::PageIdentifier);
+    RemoteRealtimeMediaSource(RemoteRealtimeMediaSourceProxy&&, WebCore::MediaDeviceHashSalts&&, UserMediaCaptureManager&, WebCore::PageIdentifier);
     void createRemoteMediaSource();
-    void removeAsClient();
 
     RemoteRealtimeMediaSourceProxy& proxy() { return m_proxy; }
     UserMediaCaptureManager& manager() { return m_manager; }

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
@@ -54,10 +54,7 @@ RemoteRealtimeVideoSource::RemoteRealtimeVideoSource(RemoteRealtimeMediaSourcePr
     ASSERT(this->pageIdentifier());
 }
 
-RemoteRealtimeVideoSource::~RemoteRealtimeVideoSource()
-{
-    removeAsClient();
-}
+RemoteRealtimeVideoSource::~RemoteRealtimeVideoSource() = default;
 
 void RemoteRealtimeVideoSource::endProducingData()
 {

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -27,6 +27,7 @@
 
 #include "Test.h"
 #include <thread>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
@@ -2885,6 +2886,125 @@ TEST(WTF_ThreadSafeWeakPtr, ThreadSafeWeakHashSet)
     EXPECT_TRUE(set.isEmptyIgnoringNullReferences());
     first = nullptr;
     EXPECT_EQ(ThreadSafeInstanceCounter::instanceCount, 0u);
+}
+
+TEST(WTF_ThreadSafeWeakPtr, MultipleInheritance)
+{
+    enum class Destructor : uint8_t { Cat, Dog, CatDog };
+    static Vector<Destructor> destructors;
+
+    struct Cat : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Cat> {
+        virtual ~Cat() { destructors.append(Destructor::Cat); }
+        virtual void meow() = 0;
+
+        bool cat { true };
+    };
+
+    struct Dog {
+        ~Dog() { destructors.append(Destructor::Dog); }
+        virtual void woof() = 0;
+
+        virtual void ref() const = 0;
+        virtual void deref() const = 0;
+        virtual ThreadSafeWeakPtrControlBlock& controlBlock() const = 0;
+
+        bool dog { true };
+    };
+
+    struct CatDog : public Cat, public Dog {
+        ~CatDog() { destructors.append(Destructor::CatDog); }
+
+        void ref() const final { Cat::ref(); }
+        void deref() const final { Cat::deref(); }
+        ThreadSafeWeakPtrControlBlock& controlBlock() const final { return Cat::controlBlock(); }
+
+        void meow() final { meowed = true; }
+        void woof() final { barked = true; }
+
+        bool meowed { false };
+        bool barked { false };
+    };
+
+    ThreadSafeWeakHashSet<Dog> dogs;
+    ThreadSafeWeakHashSet<Cat> cats;
+    {
+        auto catDog = adoptRef(*new CatDog);
+        Cat* catPointer { nullptr };
+        Dog* dogPointer { nullptr };
+
+        cats.add(catDog.get());
+        dogs.add(catDog.get());
+        for (auto& cat : cats) {
+            cat.meow();
+            catPointer = &cat;
+        }
+        for (auto& dog : dogs) {
+            dogPointer = &dog;
+            dog.woof();
+        }
+        EXPECT_NE((size_t)catPointer, (size_t)dogPointer);
+        EXPECT_TRUE(catDog->meowed);
+        EXPECT_TRUE(catDog->barked);
+    }
+    EXPECT_TRUE(dogs.isEmptyIgnoringNullReferences());
+    EXPECT_TRUE(cats.isEmptyIgnoringNullReferences());
+
+    auto keepCat = adoptRef(new CatDog);
+    RefPtr<Cat> cat(keepCat.get());
+    keepCat = nullptr;
+    cat = nullptr;
+
+    auto keepDog = adoptRef(new CatDog);
+    RefPtr<Dog> dog(keepDog.get());
+    keepDog = nullptr;
+    dog = nullptr;
+
+    Vector<Destructor> expectedDestructors {
+        Destructor::CatDog,
+        Destructor::Dog,
+        Destructor::Cat,
+        Destructor::CatDog,
+        Destructor::Dog,
+        Destructor::Cat,
+        Destructor::CatDog,
+        Destructor::Dog,
+        Destructor::Cat,
+    };
+    EXPECT_EQ(destructors, expectedDestructors);
+}
+
+struct Struct : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Struct> {
+    Struct();
+    ~Struct();
+};
+
+static ThreadSafeWeakHashSet<Struct>& set()
+{
+    static NeverDestroyed<ThreadSafeWeakHashSet<Struct>> set;
+    return set.get();
+}
+
+Struct::Struct()
+{
+    set().add(*this);
+}
+
+Struct::~Struct()
+{
+    set().remove(*this);
+}
+
+TEST(WTF_ThreadSafeWeakPtr, RemoveInDestructor)
+{
+    for (size_t i = 0; i < 100; i++) {
+        Vector<Ref<Struct>> vector;
+        vector.reserveInitialCapacity(i);
+        ThreadSafeWeakHashSet<Struct> set;
+        for (size_t j = 0; j < i; j++) {
+            vector.uncheckedAppend(adoptRef(*new Struct()));
+            set.add(vector.last().get());
+        }
+    }
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### d1cbec4c36d40118f5549264674a7a7fe280c18b
<pre>
Make GPUProcessConnection::Client thread safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=249451">https://bugs.webkit.org/show_bug.cgi?id=249451</a>

Reviewed by David Kilzer and Mike Wyrzykowski.

For UserMediaCaptureManagerProxy::createCameraSource I made an actual iterator
for ThreadSafeWeakHashSet that stores a vector of strong references.

I made ThreadSafeWeakPtrControlBlock non-templatized so that pure virtual functions
can return the control block which is only available from another parent class
of a subclass.

In order to support this multiple inheritance, a ThreadSafeWeakPtr needs to store
more information than just a pointer.  I took the approach that std::weak_ptr takes
and stored two pointers, one to the control block and one to the object of correct
type, which may be different than the object that the control block points to in the
case of multiple inheritance.  I added an API test to verify this works correctly.
Calling the proper destructor works because it always casts the void* to the correct
type, and my API test verifies this works correctly.  Keeping a pointer to the control
block in ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr prevents us from needing
strong references to keep two pointers also, so it can continue to work with Ref/RefPtr.

GPUProcessConnection::m_clients is now a ThreadSafeWeakHashSet.  The cleanup in many clients&apos;
gpuProcessConnectionDidClose is replaced by calling clear() in GPUProcessConnection::didClose.

Many of the clients had a member pointing back to the GPUProcessConnection, usually
a WeakPtr&lt;GPUProcessConnection&gt;.  These were changed to ThreadSafeWeakPtr&lt;GPUProcessConnection&gt;.

* Source/WTF/wtf/ThreadSafeWeakHashSet.h:
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakPtrControlBlock::strongDeref const):
(WTF::ThreadSafeWeakPtrControlBlock::makeStrongReferenceIfPossible const):
(WTF::ThreadSafeWeakPtrControlBlock::WTF_GUARDED_BY_LOCK):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::controlBlock const):
(WTF::ThreadSafeWeakPtr::ThreadSafeWeakPtr):
(WTF::ThreadSafeWeakPtr::operator=):
(WTF::ThreadSafeWeakPtr::get const):
(WTF::ThreadSafeWeakPtr::controlBlock):
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h:
* Source/WebCore/Modules/webaudio/MediaStreamAudioSource.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPU.h:
* Source/WebCore/platform/NowPlayingManager.h:
* Source/WebCore/platform/RemoteCommandListener.cpp:
(WebCore::RemoteCommandListener::create):
* Source/WebCore/platform/RemoteCommandListener.h:
* Source/WebCore/platform/audio/AudioDestination.h:
* Source/WebCore/platform/audio/AudioHardwareListener.cpp:
(WebCore::AudioHardwareListener::resetCreationFunction):
* Source/WebCore/platform/audio/AudioHardwareListener.h:
* Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.h:
* Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.h:
* Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.h:
* Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm:
(WebCore::RemoteCommandListenerCocoa::create):
* Source/WebCore/platform/glib/RemoteCommandListenerGLib.cpp:
(WebCore::RemoteCommandListenerGLib::create):
* Source/WebCore/platform/glib/RemoteCommandListenerGLib.h:
* Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.h:
* Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp:
(WebCore::RealtimeVideoCaptureSource::ref const):
(WebCore::RealtimeVideoCaptureSource::deref const):
(WebCore::RealtimeVideoCaptureSource::controlBlock const):
(WebCore::RealtimeVideoCaptureSource::~RealtimeVideoCaptureSource): Deleted.
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h:
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mock/MockRealtimeAudioSource.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/Platform/IPC/WorkQueueMessageReceiver.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::createMicrophoneSource):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRemoteRealtimeMediaSourceManager::removeSource):
(WebKit::SpeechRecognitionRemoteRealtimeMediaSourceManager::remoteAudioSamplesAvailable):
(WebKit::SpeechRecognitionRemoteRealtimeMediaSourceManager::remoteCaptureFailed):
(WebKit::SpeechRecognitionRemoteRealtimeMediaSourceManager::remoteSourceStopped):
(WebKit::SpeechRecognitionRemoteRealtimeMediaSourceManager::setStorage):
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::didClose):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp:
(WebKit::RemoteRemoteCommandListener::create):
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h:
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp:
(WebKit::MediaRecorderPrivate::startRecording):
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h:
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.cpp:
(WebKit::RemoteRealtimeAudioSource::~RemoteRealtimeAudioSource): Deleted.
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp:
(WebKit::RemoteRealtimeMediaSource::removeAsClient): Deleted.
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp:
(WebKit::RemoteRealtimeVideoSource::~RemoteRealtimeVideoSource): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/264919@main">https://commits.webkit.org/264919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06a2596707f9c15a9221c8981f63ced613b98d2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10764 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9055 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9364 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11907 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10219 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10923 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15797 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/7838 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8641 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11787 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/8741 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7317 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/9275 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8208 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2218 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12431 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/9513 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1051 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8743 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2335 "Passed tests") | 
<!--EWS-Status-Bubble-End-->