### PR TITLE
[:has() pseudo-class] Support invalidation for :picture-in-picture pseudo-class

### DIFF
--- a/LayoutTests/media/picture-in-picture/picture-in-picture-api-css-selector-expected.txt
+++ b/LayoutTests/media/picture-in-picture/picture-in-picture-api-css-selector-expected.txt
@@ -5,9 +5,12 @@ RUN(internals.setMockVideoPresentationModeEnabled(true))
 RUN(video.src = findMediaFile("video", "../content/test"))
 EVENT(canplaythrough)
 EXPECTED (getComputedStyle(video).color == 'rgb(0, 0, 255)') OK
+EXPECTED (getComputedStyle(subject).backgroundColor == 'rgb(255, 0, 0)') OK
 EVENT(enterpictureinpicture)
 EXPECTED (getComputedStyle(video).color == 'rgb(0, 255, 0)') OK
+EXPECTED (getComputedStyle(subject).backgroundColor == 'rgb(0, 128, 0)') OK
 EVENT(leavepictureinpicture)
 EXPECTED (getComputedStyle(video).color == 'rgb(0, 0, 255)') OK
+EXPECTED (getComputedStyle(subject).backgroundColor == 'rgb(255, 0, 0)') OK
 END OF TEST
 

--- a/LayoutTests/media/picture-in-picture/picture-in-picture-api-css-selector.html
+++ b/LayoutTests/media/picture-in-picture/picture-in-picture-api-css-selector.html
@@ -4,6 +4,13 @@
     <script src="../video-test.js"></script>
     <script src="../media-file.js"></script>
     <style>
+        #subject {
+            background-color: red;
+        }
+        #subject:has(:picture-in-picture) {
+            background-color: green;
+        }
+
         video {
             color: rgb(0, 0, 255);
         }
@@ -30,17 +37,19 @@
             run('video.src = findMediaFile("video", "../content/test")');
             await waitFor(video, 'canplaythrough');
             testExpected('getComputedStyle(video).color', 'rgb(0, 0, 255)');
-
+            testExpected('getComputedStyle(subject).backgroundColor', 'rgb(255, 0, 0)');
             runWithKeyDown(() => {
                 video.requestPictureInPicture();
             });
 
             await waitFor(video, 'enterpictureinpicture');
             testExpected('getComputedStyle(video).color', 'rgb(0, 255, 0)');
+            testExpected('getComputedStyle(subject).backgroundColor', 'rgb(0, 128, 0)');
 
             document.exitPictureInPicture();
             await waitFor(video, 'leavepictureinpicture');
             testExpected('getComputedStyle(video).color', 'rgb(0, 0, 255)');
+            testExpected('getComputedStyle(subject).backgroundColor', 'rgb(255, 0, 0)');
 
             endTest();
         });
@@ -48,6 +57,8 @@
 </head>
 <body>
     <div>This tests that entering and leaving Picture-in-Picture toggles CSS selector.</div>
-    <video controls></video>
+    <div id="subject">
+        <video controls></video>
+    </div>
 </body>
 </html>

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
@@ -154,7 +154,6 @@ void HTMLVideoElementPictureInPicture::exitPictureInPicture(Ref<DeferredPromise>
 void HTMLVideoElementPictureInPicture::didEnterPictureInPicture(const IntSize& windowSize)
 {
     INFO_LOG(LOGIDENTIFIER);
-    m_videoElement.invalidateStyle();
     m_videoElement.document().setPictureInPictureElement(&m_videoElement);
     m_pictureInPictureWindow->setSize(windowSize);
 
@@ -172,7 +171,6 @@ void HTMLVideoElementPictureInPicture::didEnterPictureInPicture(const IntSize& w
 void HTMLVideoElementPictureInPicture::didExitPictureInPicture()
 {
     INFO_LOG(LOGIDENTIFIER);
-    m_videoElement.invalidateStyle();
     m_pictureInPictureWindow->close();
     m_videoElement.document().setPictureInPictureElement(nullptr);
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9192,6 +9192,18 @@ HTMLVideoElement* Document::pictureInPictureElement() const
 
 void Document::setPictureInPictureElement(HTMLVideoElement* element)
 {
+    auto* oldElement = m_pictureInPictureElement.get();
+    if (oldElement == element)
+        return;
+
+    std::optional<Style::PseudoClassChangeInvalidation> oldInvalidation;
+    if (oldElement)
+        emplace(oldInvalidation, *oldElement, { { CSSSelector::PseudoClassPictureInPicture, false } });
+
+    std::optional<Style::PseudoClassChangeInvalidation> newInvalidation;
+    if (element)
+        emplace(newInvalidation, *element, { { CSSSelector::PseudoClassPictureInPicture, true } });
+
     m_pictureInPictureElement = element;
 }
 #endif


### PR DESCRIPTION
#### b0e1661e0d64d9656ead17b7c9cb6ff8472fa94f
<pre>
[:has() pseudo-class] Support invalidation for :picture-in-picture pseudo-class
<a href="https://bugs.webkit.org/show_bug.cgi?id=249456">https://bugs.webkit.org/show_bug.cgi?id=249456</a>
rdar://103438114

Reviewed by Antti Koivisto.

* LayoutTests/media/picture-in-picture/picture-in-picture-api-css-selector-expected.txt:
* LayoutTests/media/picture-in-picture/picture-in-picture-api-css-selector.html:
* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp:
(WebCore::HTMLVideoElementPictureInPicture::didEnterPictureInPicture):
(WebCore::HTMLVideoElementPictureInPicture::didExitPictureInPicture):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setPictureInPictureElement):

Canonical link: <a href="https://commits.webkit.org/257995@main">https://commits.webkit.org/257995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef0f077bc98fbdbce54219fce52bc31d98ae5c10

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109886 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170168 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10658 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92979 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107736 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8053 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34664 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89965 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3439 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3452 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9564 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43709 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5479 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5246 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->