### PR TITLE
REGRESSION(257606@main): WebProcess::didClose fix ENABLE_VIDEO=OFF

### DIFF
--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -948,7 +948,9 @@ void WebProcess::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& de
 
 void WebProcess::didClose(IPC::Connection& connection)
 {
+#if ENABLE(VIDEO)
     FileSystem::markPurgeable(WebCore::HTMLMediaElement::mediaCacheDirectory());
+#endif
     if (m_applicationCacheStorage)
         FileSystem::markPurgeable(m_applicationCacheStorage->cacheDirectory());
 #if ENABLE(ARKIT_INLINE_PREVIEW_MAC)


### PR DESCRIPTION
#### bd303d9606440dbd2418660cc6f245a38517c054
<pre>
REGRESSION(257606@main): WebProcess::didClose fix ENABLE_VIDEO=OFF

<a href="https://bugs.webkit.org/show_bug.cgi?id=249462">https://bugs.webkit.org/show_bug.cgi?id=249462</a>

Reviewed by Philippe Normand.

No HTMLMediaElement is defined if video support is not compiled.

```
In file included from /home/buildbot/buildbot/slave-buildroot/build/output/build/webkitgtk-2.39.3/DerivedSources/WebKit/unified-sources/UnifiedSource-54928a2b-1.cpp:2:
/home/buildbot/buildbot/slave-buildroot/build/output/build/webkitgtk-2.39.3/Source/WebKit/WebProcess/WebProcess.cpp: In member function ‘virtual void WebKit::WebProcess::didClose(IPC::Connection&amp;)’:
/home/buildbot/buildbot/slave-buildroot/build/output/build/webkitgtk-2.39.3/Source/WebKit/WebProcess/WebProcess.cpp:949:58: error: incomplete type ‘WebCore::HTMLMediaElement’ used in nested name specifier
  949 |     FileSystem::markPurgeable(WebCore::HTMLMediaElement::mediaCacheDirectory());
      |                                                          ^~~~~~~~~~~~~~~~~~~
```

Signed-off-by: Thomas Devoogdt &lt;thomas.devoogdt@barco.com&gt;

Canonical link: <a href="https://commits.webkit.org/258052@main">https://commits.webkit.org/258052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8b59648d49e3f64eea6d7dfea9535e8446379a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110052 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/481 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93153 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107898 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91434 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34791 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77763 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3591 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24351 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3615 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43850 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5527 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5392 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->