### PR TITLE
[@property] Support <transform-function> and <transform-list> types

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
@@ -47,12 +47,12 @@ PASS syntax:'<time>', initialValue:'calc(2s - 9ms)' is valid
 PASS syntax:'<resolution>', initialValue:'10dpi' is valid
 PASS syntax:'<resolution>', initialValue:'3dPpX' is valid
 PASS syntax:'<resolution>', initialValue:'-5.3dpcm' is valid
-FAIL syntax:'<transform-function>', initialValue:'translateX(2px)' is valid The given initial value does not parse for the given syntax.
+PASS syntax:'<transform-function>', initialValue:'translateX(2px)' is valid
 PASS syntax:'<transform-function>|<integer>', initialValue:'5' is valid
-FAIL syntax:'<transform-function>|<integer>', initialValue:'scale(2)' is valid The given initial value does not parse for the given syntax.
-FAIL syntax:'<transform-function>+', initialValue:'translateX(2px) rotate(42deg)' is valid The given initial value does not parse for the given syntax.
-FAIL syntax:'<transform-list>', initialValue:'scale(2)' is valid The given initial value does not parse for the given syntax.
-FAIL syntax:'<transform-list>', initialValue:'translateX(2px) rotate(20deg)' is valid The given initial value does not parse for the given syntax.
+PASS syntax:'<transform-function>|<integer>', initialValue:'scale(2)' is valid
+PASS syntax:'<transform-function>+', initialValue:'translateX(2px) rotate(42deg)' is valid
+PASS syntax:'<transform-list>', initialValue:'scale(2)' is valid
+PASS syntax:'<transform-list>', initialValue:'translateX(2px) rotate(20deg)' is valid
 PASS syntax:'<color>', initialValue:'rgb(12, 34, 56)' is valid
 PASS syntax:'<color>', initialValue:'lightgoldenrodyellow' is valid
 PASS syntax:'<image>', initialValue:'url(a)' is valid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-expected.txt
@@ -27,10 +27,10 @@ PASS <length>+ values are computed correctly [10px 3em]
 PASS <length>+ values are computed correctly [4em 9px]
 PASS <length-percentage>+ values are computed correctly [3% 10vmax 22px]
 PASS <length-percentage>+ values are computed correctly [calc(50% + 1em) 4px]
-FAIL <transform-function> values are computed correctly [translateX(2px)] The given initial value does not parse for the given syntax.
-FAIL <transform-function> values are computed correctly [translateX(10em)] The given initial value does not parse for the given syntax.
-FAIL <transform-function> values are computed correctly [translateX(calc(11em + 10%))] The given initial value does not parse for the given syntax.
-FAIL <transform-function>+ values are computed correctly [translateX(10%) scale(2)] The given initial value does not parse for the given syntax.
+PASS <transform-function> values are computed correctly [translateX(2px)]
+PASS <transform-function> values are computed correctly [translateX(10em)]
+PASS <transform-function> values are computed correctly [translateX(calc(11em + 10%))]
+PASS <transform-function>+ values are computed correctly [translateX(10%) scale(2)]
 PASS <integer> values are computed correctly [15]
 PASS <integer> values are computed correctly [calc(15 + 15)]
 PASS <integer> values are computed correctly [calc(2.4)]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-initial-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-initial-expected.txt
@@ -9,9 +9,9 @@ PASS Initial value for <percentage> correctly computed [calc(10% + 20%)]
 PASS Initial value for <length-percentage> correctly computed [calc(1in + 10% + 4px)]
 PASS Initial value for <color> correctly computed [pink, inherits]
 PASS Initial value for <color> correctly computed [purple]
-FAIL Initial value for <transform-function> correctly computed [rotate(42deg)] The given initial value does not parse for the given syntax.
-FAIL Initial value for <transform-list> correctly computed [scale(calc(2 + 2))] The given initial value does not parse for the given syntax.
-FAIL Initial value for <transform-list> correctly computed [scale(calc(2 + 1)) translateX(calc(3px + 1px))] The given initial value does not parse for the given syntax.
+PASS Initial value for <transform-function> correctly computed [rotate(42deg)]
+PASS Initial value for <transform-list> correctly computed [scale(calc(2 + 2))]
+PASS Initial value for <transform-list> correctly computed [scale(calc(2 + 1)) translateX(calc(3px + 1px))]
 PASS Initial value for <url> correctly computed [url(a)]
 PASS Initial value for <url>+ correctly computed [url(a) url(a)]
 PASS Initial inherited value can be substituted [purple, color]
@@ -26,6 +26,6 @@ PASS Initial non-inherited value can be substituted [calc(10px + 15px), --x]
 PASS Initial non-inherited value can be substituted [calc(13 + 37), --x]
 PASS Initial non-inherited value can be substituted [calc(13% + 37%), --x]
 PASS Initial non-inherited value can be substituted [2000ms, --x]
-FAIL Initial non-inherited value can be substituted [scale(calc(2 + 2)), --x] The given initial value does not parse for the given syntax.
-FAIL Initial non-inherited value can be substituted [scale(calc(2 + 2)) translateX(calc(3px + 1px)), --x] The given initial value does not parse for the given syntax.
+PASS Initial non-inherited value can be substituted [scale(calc(2 + 2)), --x]
+PASS Initial non-inherited value can be substituted [scale(calc(2 + 2)) translateX(calc(3px + 1px)), --x]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/self-utils-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/self-utils-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Default initial values of generated properties are valid (self-test). The given initial value does not parse for the given syntax.
+PASS Default initial values of generated properties are valid (self-test).
 PASS Generated properties respect inherits flag
 PASS Can't generate property with unknown fields
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
@@ -45,10 +45,10 @@ PASS Specified <resolution> is reified as CSSUnparsedValue from get/getAll [attr
 PASS Specified <resolution> is reified as CSSUnparsedValue from get/getAll [styleMap]
 PASS Specified <time> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
 PASS Specified <time> is reified as CSSUnparsedValue from get/getAll [styleMap]
-FAIL Specified <transform-function> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL Specified <transform-function> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
-FAIL Specified <transform-list> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL Specified <transform-list> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
+PASS Specified <transform-function> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
+PASS Specified <transform-function> is reified as CSSUnparsedValue from get/getAll [styleMap]
+PASS Specified <transform-list> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
+PASS Specified <transform-list> is reified as CSSUnparsedValue from get/getAll [styleMap]
 PASS Specified <url> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
 PASS Specified <url> is reified as CSSUnparsedValue from get/getAll [styleMap]
 PASS Specified <length>+ is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
@@ -81,10 +81,10 @@ PASS Specified string "10dpi" accepted by set() for syntax <resolution> [attribu
 PASS Specified string "10dpi" accepted by set() for syntax <resolution> [styleMap]
 PASS Specified string "1s" accepted by set() for syntax <time> [attributeStyleMap]
 PASS Specified string "1s" accepted by set() for syntax <time> [styleMap]
-FAIL Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-function> [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-function> [styleMap] The given initial value does not parse for the given syntax.
-FAIL Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-list> [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
+PASS Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-function> [attributeStyleMap]
+PASS Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-function> [styleMap]
+PASS Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-list> [attributeStyleMap]
+PASS Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-list> [styleMap]
 PASS Specified string "url("a")" accepted by set() for syntax <url> [attributeStyleMap]
 PASS Specified string "url("a")" accepted by set() for syntax <url> [styleMap]
 PASS Specified string "10px 11px" accepted by set() for syntax <length>+ [attributeStyleMap]
@@ -115,10 +115,10 @@ PASS Specified string "blue" accepted by set() for syntax <resolution> [attribut
 PASS Specified string "blue" accepted by set() for syntax <resolution> [styleMap]
 PASS Specified string "1meter" accepted by set() for syntax <time> [attributeStyleMap]
 PASS Specified string "1meter" accepted by set() for syntax <time> [styleMap]
-FAIL Specified string "foo(0)" accepted by set() for syntax <transform-function> [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL Specified string "foo(0)" accepted by set() for syntax <transform-function> [styleMap] The given initial value does not parse for the given syntax.
-FAIL Specified string "bar(1)" accepted by set() for syntax <transform-list> [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL Specified string "bar(1)" accepted by set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
+PASS Specified string "foo(0)" accepted by set() for syntax <transform-function> [attributeStyleMap]
+PASS Specified string "foo(0)" accepted by set() for syntax <transform-function> [styleMap]
+PASS Specified string "bar(1)" accepted by set() for syntax <transform-list> [attributeStyleMap]
+PASS Specified string "bar(1)" accepted by set() for syntax <transform-list> [styleMap]
 PASS Specified string "a" accepted by set() for syntax <url> [attributeStyleMap]
 PASS Specified string "a" accepted by set() for syntax <url> [styleMap]
 PASS Specified string "a b" accepted by set() for syntax <length>+ [attributeStyleMap]
@@ -151,10 +151,10 @@ PASS CSSUnparsedValue is accepted via set() for syntax <resolution> [attributeSt
 PASS CSSUnparsedValue is accepted via set() for syntax <resolution> [styleMap]
 PASS CSSUnparsedValue is accepted via set() for syntax <time> [attributeStyleMap]
 PASS CSSUnparsedValue is accepted via set() for syntax <time> [styleMap]
-FAIL CSSUnparsedValue is accepted via set() for syntax <transform-function> [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL CSSUnparsedValue is accepted via set() for syntax <transform-function> [styleMap] The given initial value does not parse for the given syntax.
-FAIL CSSUnparsedValue is accepted via set() for syntax <transform-list> [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL CSSUnparsedValue is accepted via set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
+PASS CSSUnparsedValue is accepted via set() for syntax <transform-function> [attributeStyleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax <transform-function> [styleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax <transform-list> [attributeStyleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax <transform-list> [styleMap]
 PASS CSSUnparsedValue is accepted via set() for syntax <url> [attributeStyleMap]
 PASS CSSUnparsedValue is accepted via set() for syntax <url> [styleMap]
 PASS CSSUnparsedValue is accepted via set() for syntax <length>+ [attributeStyleMap]
@@ -185,8 +185,8 @@ PASS CSSUnitValue rejected by set() for syntax <resolution> [attributeStyleMap]
 PASS CSSUnitValue rejected by set() for syntax <resolution> [styleMap]
 PASS CSSUnitValue rejected by set() for syntax <time> [attributeStyleMap]
 PASS CSSUnitValue rejected by set() for syntax <time> [styleMap]
-FAIL CSSTransformValue rejected by set() for syntax <transform-list> [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL CSSTransformValue rejected by set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
+PASS CSSTransformValue rejected by set() for syntax <transform-list> [attributeStyleMap]
+PASS CSSTransformValue rejected by set() for syntax <transform-list> [styleMap]
 PASS CSSUnitValue rejected by set() for syntax <length>+ [attributeStyleMap]
 PASS CSSUnitValue rejected by set() for syntax <length>+ [styleMap]
 PASS CSSUnitValue rejected by set() for syntax <length># [attributeStyleMap]
@@ -217,10 +217,10 @@ PASS Appending a string to <resolution>+ is not allowed [attributeStyleMap]
 PASS Appending a string to <resolution>+ is not allowed [styleMap]
 PASS Appending a string to <time>+ is not allowed [attributeStyleMap]
 PASS Appending a string to <time>+ is not allowed [styleMap]
-FAIL Appending a string to <transform-function>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL Appending a string to <transform-function>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
-FAIL Appending a string to <transform-list> is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL Appending a string to <transform-list> is not allowed [styleMap] The given initial value does not parse for the given syntax.
+PASS Appending a string to <transform-function>+ is not allowed [attributeStyleMap]
+PASS Appending a string to <transform-function>+ is not allowed [styleMap]
+PASS Appending a string to <transform-list> is not allowed [attributeStyleMap]
+PASS Appending a string to <transform-list> is not allowed [styleMap]
 PASS Appending a string to <url>+ is not allowed [attributeStyleMap]
 PASS Appending a string to <url>+ is not allowed [styleMap]
 PASS Appending a string to <length># is not allowed [attributeStyleMap]
@@ -249,8 +249,8 @@ PASS Appending a CSSUnitValue to <resolution>+ is not allowed [attributeStyleMap
 PASS Appending a CSSUnitValue to <resolution>+ is not allowed [styleMap]
 PASS Appending a CSSUnitValue to <time>+ is not allowed [attributeStyleMap]
 PASS Appending a CSSUnitValue to <time>+ is not allowed [styleMap]
-FAIL Appending a CSSKeywordValue to <transform-list> is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL Appending a CSSKeywordValue to <transform-list> is not allowed [styleMap] The given initial value does not parse for the given syntax.
+PASS Appending a CSSKeywordValue to <transform-list> is not allowed [attributeStyleMap]
+PASS Appending a CSSKeywordValue to <transform-list> is not allowed [styleMap]
 PASS Appending a CSSUnitValue to <length># is not allowed [attributeStyleMap]
 PASS Appending a CSSUnitValue to <length># is not allowed [styleMap]
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax *
@@ -267,14 +267,14 @@ PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <number>
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <percentage>
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <resolution>
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <time>
-FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <transform-function> The given initial value does not parse for the given syntax.
-FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <transform-list> The given initial value does not parse for the given syntax.
+PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <transform-function>
+PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <transform-list>
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <url>
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax thing1 | THING2 | <url>
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length>+
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length>#
-FAIL Direct CSSStyleValue may not be set [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL Direct CSSStyleValue may not be set [styleMap] The given initial value does not parse for the given syntax.
+PASS Direct CSSStyleValue may not be set [attributeStyleMap]
+PASS Direct CSSStyleValue may not be set [styleMap]
 PASS Specified * is reified CSSUnparsedValue by iterator [attributeStyleMap]
 PASS Specified * is reified CSSUnparsedValue by iterator [styleMap]
 PASS Specified foo is reified CSSUnparsedValue by iterator [attributeStyleMap]
@@ -301,10 +301,10 @@ PASS Specified <resolution> is reified CSSUnparsedValue by iterator [attributeSt
 PASS Specified <resolution> is reified CSSUnparsedValue by iterator [styleMap]
 PASS Specified <time> is reified CSSUnparsedValue by iterator [attributeStyleMap]
 PASS Specified <time> is reified CSSUnparsedValue by iterator [styleMap]
-FAIL Specified <transform-function> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL Specified <transform-function> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
-FAIL Specified <transform-list> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
-FAIL Specified <transform-list> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
+PASS Specified <transform-function> is reified CSSUnparsedValue by iterator [attributeStyleMap]
+PASS Specified <transform-function> is reified CSSUnparsedValue by iterator [styleMap]
+PASS Specified <transform-list> is reified CSSUnparsedValue by iterator [attributeStyleMap]
+PASS Specified <transform-list> is reified CSSUnparsedValue by iterator [styleMap]
 PASS Specified <url> is reified CSSUnparsedValue by iterator [attributeStyleMap]
 PASS Specified <url> is reified CSSUnparsedValue by iterator [styleMap]
 PASS Specified <length>+ is reified CSSUnparsedValue by iterator [attributeStyleMap]

--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -79,6 +79,11 @@ String CSSCustomPropertyValue::customCSSText() const
             return serializeURL(value.string());
         }, [&](const String& value) {
             return value;
+        }, [&](const RefPtr<TransformOperation>& value) {
+            auto cssValue = transformOperationAsCSSValue(*value, RenderStyle::defaultStyle());
+            if (!cssValue)
+                return emptyString();
+            return cssValue->cssText();
         });
     };
 

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -31,6 +31,7 @@
 #include "Length.h"
 #include "StyleColor.h"
 #include "StyleImage.h"
+#include "TransformOperation.h"
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -45,8 +46,8 @@ public:
 
         bool operator==(const NumericSyntaxValue& other) const { return value == other.value && unitType == other.unitType; }
     };
-    
-    using SyntaxValue = std::variant<Length, NumericSyntaxValue, StyleColor, RefPtr<StyleImage>, URL, String>;
+
+    using SyntaxValue = std::variant<Length, NumericSyntaxValue, StyleColor, RefPtr<StyleImage>, URL, String, RefPtr<TransformOperation>>;
 
     struct SyntaxValueList {
         Vector<SyntaxValue> values;

--- a/Source/WebCore/css/ComputedStyleExtractor.h
+++ b/Source/WebCore/css/ComputedStyleExtractor.h
@@ -28,6 +28,7 @@
 namespace WebCore {
 
 class Animation;
+class CSSFunctionValue;
 class CSSPrimitiveValue;
 class CSSValueList;
 class Element;
@@ -38,6 +39,7 @@ class RenderElement;
 class RenderStyle;
 class ShadowData;
 class StylePropertyShorthand;
+class TransformOperation;
 
 class ComputedStyleExtractor {
     WTF_MAKE_FAST_ALLOCATED;
@@ -91,5 +93,7 @@ private:
     PseudoId m_pseudoElementSpecifier;
     bool m_allowVisitedStyle;
 };
+
+RefPtr<CSSFunctionValue> transformOperationAsCSSValue(const TransformOperation&, const RenderStyle&);
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.h
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.h
@@ -43,6 +43,8 @@ struct CSSCustomPropertySyntax {
         Image,
         URL,
         CustomIdent,
+        TransformFunction,
+        TransformList,
         Unknown
     };
 

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -6055,7 +6055,7 @@ static bool consumePerspectiveFunctionArgument(CSSParserTokenRange& range, const
     return false;
 }
 
-static RefPtr<CSSValue> consumeTransformValue(CSSParserTokenRange& range, const CSSParserContext& context)
+RefPtr<CSSValue> consumeTransformFunction(CSSParserTokenRange& range, const CSSParserContext& context)
 {
     CSSValueID functionId = range.peek().functionId();
     if (functionId == CSSValueInvalid)
@@ -6160,7 +6160,7 @@ RefPtr<CSSValue> consumeTransform(CSSParserTokenRange& range, const CSSParserCon
 
     RefPtr<CSSTransformListValue> list = CSSTransformListValue::create();
     do {
-        auto parsedTransformValue = consumeTransformValue(range, context);
+        auto parsedTransformValue = consumeTransformFunction(range, context);
         if (!parsedTransformValue)
             return nullptr;
         list->append(parsedTransformValue.releaseNonNull());

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -256,6 +256,7 @@ RefPtr<CSSValue> consumeTextEmphasisStyle(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeBorderWidth(CSSParserTokenRange&, CSSPropertyID currentShorthand, const CSSParserContext&);
 RefPtr<CSSValue> consumeBorderColor(CSSParserTokenRange&, CSSPropertyID currentShorthand, const CSSParserContext&);
 RefPtr<CSSValue> consumeTransform(CSSParserTokenRange&, const CSSParserContext&);
+RefPtr<CSSValue> consumeTransformFunction(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeTranslate(CSSParserTokenRange&, CSSParserMode);
 RefPtr<CSSValue> consumeScale(CSSParserTokenRange&, CSSParserMode);
 RefPtr<CSSValue> consumeRotate(CSSParserTokenRange&, CSSParserMode);


### PR DESCRIPTION
#### 41d246922c5892281b203d3deb209bac0501a13f
<pre>
[@property] Support &lt;transform-function&gt; and &lt;transform-list&gt; types
<a href="https://bugs.webkit.org/show_bug.cgi?id=249465">https://bugs.webkit.org/show_bug.cgi?id=249465</a>
rdar://103441980

Reviewed by Antoine Quint.

Add the remaining syntax types.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-computation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-initial-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/self-utils-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt:
* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::customCSSText const):
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::transformOperationAsCSSValue):

Factor this into a function so we can use it to serialize TransformOperation values in CSSCustomPropertyValue.

(WebCore::computedTransform):
* Source/WebCore/css/ComputedStyleExtractor.h:
* Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp:
(WebCore::CSSCustomPropertySyntax::parseComponent):
(WebCore::CSSCustomPropertySyntax::typeForTypeName):

Also use SortedArrayMap.

* Source/WebCore/css/parser/CSSCustomPropertySyntax.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeCustomPropertyValueWithSyntax):
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeTransformFunction):
(WebCore::CSSPropertyParserHelpers::consumeTransform):
(WebCore::CSSPropertyParserHelpers::consumeTransformValue): Deleted.
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/WebKit.xcscheme:

Canonical link: <a href="https://commits.webkit.org/257987@main">https://commits.webkit.org/257987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d553e55c89f8b76d628725ee267871b406f3092

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109910 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104591 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10683 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107759 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106387 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3460 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24246 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3474 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43740 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5476 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5267 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->