### PR TITLE
[GStreamer] VideoPixelFormat to GstVideoFormat mapping

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1003,6 +1003,33 @@ void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo* info, const PlatformVi
         GST_VIDEO_INFO_COLORIMETRY(info).range = GST_VIDEO_COLOR_RANGE_UNKNOWN;
 }
 
+GstVideoFormat gstVideoFormatFromVideoPixelFormat(VideoPixelFormat pixelFormat)
+{
+    switch (pixelFormat) {
+    case VideoPixelFormat::I420:
+        return GST_VIDEO_FORMAT_I420;
+    case VideoPixelFormat::I420A:
+        return GST_VIDEO_FORMAT_A420;
+    case VideoPixelFormat::I422:
+        return GST_VIDEO_FORMAT_Y42B;
+    case VideoPixelFormat::I444:
+        return GST_VIDEO_FORMAT_Y444;
+    case VideoPixelFormat::NV12:
+        return GST_VIDEO_FORMAT_NV12;
+    case VideoPixelFormat::RGBA:
+        return GST_VIDEO_FORMAT_RGBA;
+    case VideoPixelFormat::RGBX:
+        return GST_VIDEO_FORMAT_RGBx;
+    case VideoPixelFormat::BGRA:
+        return GST_VIDEO_FORMAT_BGRA;
+    case VideoPixelFormat::BGRX:
+        return GST_VIDEO_FORMAT_BGRx;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+    return GST_VIDEO_FORMAT_UNKNOWN;
+}
+
 } // namespace WebCore
 
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -24,6 +24,7 @@
 #include "GRefPtrGStreamer.h"
 #include "GUniquePtrGStreamer.h"
 #include "PlatformVideoColorSpace.h"
+#include "VideoPixelFormat.h"
 #include <gst/gst.h>
 #include <gst/video/video-format.h>
 #include <gst/video/video-info.h>
@@ -342,6 +343,8 @@ GstClockTime webkitGstElementGetCurrentRunningTime(GstElement*);
 PlatformVideoColorSpace videoColorSpaceFromCaps(const GstCaps*);
 PlatformVideoColorSpace videoColorSpaceFromInfo(const GstVideoInfo&);
 void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo*, const PlatformVideoColorSpace&);
+
+GstVideoFormat gstVideoFormatFromVideoPixelFormat(VideoPixelFormat);
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 96c4f01234e67836503084d4546ba220f7705fce
<pre>
[GStreamer] VideoPixelFormat to GstVideoFormat mapping
<a href="https://bugs.webkit.org/show_bug.cgi?id=249469">https://bugs.webkit.org/show_bug.cgi?id=249469</a>

Reviewed by NOBODY (OOPS!).

This is going to be useful for the implementation of VideoFrame::copyTo().

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::gstVideoFormatFromVideoPixelFormat):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96c4f01234e67836503084d4546ba220f7705fce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109902 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170183 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/850 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92996 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107752 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34685 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22709 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77654 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3453 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24235 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/807 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43729 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5260 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->