### PR TITLE
Fix media/audiosession test flakinesses

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -145,6 +145,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/applicationmanifest/ApplicationManifest.h
     Modules/applicationmanifest/ApplicationManifestParser.h
 
+    Modules/audiosession/DOMAudioSession.h
+
     Modules/badge/BadgeClient.h
     Modules/badge/EmptyBadgeClient.h
     Modules/badge/WorkerBadgeProxy.h

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(DOM_AUDIO_SESSION)
 
 #include "AudioSession.h"
+#include "Document.h"
 #include "EventNames.h"
 #include "PlatformMediaSessionManager.h"
 
@@ -76,36 +77,45 @@ DOMAudioSession::~DOMAudioSession()
     AudioSession::sharedSession().removeInterruptionObserver(*this);
 }
 
-DOMAudioSession::Type DOMAudioSession::s_type = DOMAudioSession::Type::Auto;
-
-void DOMAudioSession::setType(Type type)
+ExceptionOr<void> DOMAudioSession::setType(Type type)
 {
-    if (s_type == type)
-        return;
+    auto* document = downcast<Document>(scriptExecutionContext());
+    if (!document)
+        return Exception { InvalidStateError };
 
-    s_type = type;
+    document->topDocument().setAudioSessionType(type);
 
     auto categoryOverride = fromDOMAudioSessionType(type);
     AudioSession::sharedSession().setCategoryOverride(categoryOverride);
 
     if (categoryOverride == AudioSessionCategory::None)
         PlatformMediaSessionManager::updateAudioSessionCategoryIfNecessary();
+
+    return { };
 }
 
 DOMAudioSession::Type DOMAudioSession::type() const
 {
-    return s_type;
+    auto* document = downcast<Document>(scriptExecutionContext());
+    return document ? document->topDocument().audioSessionType() : DOMAudioSession::Type::Auto;
+}
+
+static DOMAudioSession::State computeAudioSessionState()
+{
+    if (AudioSession::sharedSession().isInterrupted())
+        return DOMAudioSession::State::Interrupted;
+
+    if (!AudioSession::sharedSession().isActive())
+        return DOMAudioSession::State::Inactive;
+
+    return DOMAudioSession::State::Active;
 }
 
 DOMAudioSession::State DOMAudioSession::state() const
 {
-    if (AudioSession::sharedSession().isInterrupted())
-        return State::Interrupted;
-
-    if (!AudioSession::sharedSession().isActive())
-        return State::Inactive;
-
-    return State::Active;
+    if (!m_state)
+        m_state = computeAudioSessionState();
+    return *m_state;
 }
 
 void DOMAudioSession::stop()
@@ -139,7 +149,23 @@ void DOMAudioSession::activeStateChanged()
 
 void DOMAudioSession::scheduleStateChangeEvent()
 {
-    queueTaskToDispatchEvent(*this, TaskSource::MediaElement, Event::create(eventNames().statechangeEvent, Event::CanBubble::No, Event::IsCancelable::No));
+    if (m_hasScheduleStateChangeEvent)
+        return;
+
+    m_hasScheduleStateChangeEvent = true;
+    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this] {
+        if (isContextStopped())
+            return;
+
+        m_hasScheduleStateChangeEvent = false;
+        auto newState = computeAudioSessionState();
+
+        if (m_state && *m_state == newState)
+            return;
+
+        m_state = newState;
+        dispatchEvent(Event::create(eventNames().statechangeEvent, Event::CanBubble::No, Event::IsCancelable::No));
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.h
@@ -30,6 +30,7 @@
 #include "ActiveDOMObject.h"
 #include "AudioSession.h"
 #include "EventTarget.h"
+#include "ExceptionOr.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/RefCounted.h>
 
@@ -44,7 +45,7 @@ public:
     enum class Type : uint8_t { Auto, Playback, Transient, TransientSolo, Ambient, PlayAndRecord };
     enum class State : uint8_t { Inactive, Active, Interrupted };
 
-    void setType(Type);
+    ExceptionOr<void> setType(Type);
     Type type() const;
     State state() const;
 
@@ -72,7 +73,8 @@ private:
 
     void scheduleStateChangeEvent();
 
-    static Type s_type;
+    bool m_hasScheduleStateChangeEvent { false };
+    mutable std::optional<State> m_state;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -31,6 +31,7 @@
 #include "CanvasBase.h"
 #include "ClientOrigin.h"
 #include "ContainerNode.h"
+#include "DOMAudioSession.h"
 #include "DisabledAdaptations.h"
 #include "DocumentEventTiming.h"
 #include "FocusOptions.h"
@@ -1729,6 +1730,11 @@ public:
     // This should be used over the settings lazy loading image flag due to a quirk, which may occur causing website images to fail to load properly.
     bool lazyImageLoadingEnabled() const;
 
+#if ENABLE(DOM_AUDIO_SESSION)
+    void setAudioSessionType(DOMAudioSession::Type type) { m_audioSessionType = type; }
+    DOMAudioSession::Type audioSessionType() const { return m_audioSessionType; }
+#endif
+
 protected:
     enum ConstructionFlags { Synthesized = 1, NonRenderedPlaceholder = 1 << 1 };
     WEBCORE_EXPORT Document(Frame*, const Settings&, const URL&, DocumentClasses = { }, unsigned constructionFlags = 0, ScriptExecutionContextIdentifier = { });
@@ -2332,6 +2338,10 @@ private:
     std::unique_ptr<WakeLockManager> m_wakeLockManager;
 
     std::unique_ptr<SleepDisabler> m_sleepDisabler;
+
+#if ENABLE(DOM_AUDIO_SESSION)
+    DOMAudioSession::Type m_audioSessionType { DOMAudioSession::Type::Auto };
+#endif
 };
 
 Element* eventTargetElementForDocument(Document*);

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -212,7 +212,7 @@ void PlatformMediaSessionManager::removeSession(PlatformMediaSession& session)
 
     m_sessions.remove(index);
 
-    if (hasNoSession())
+    if (hasNoSession() && !activeAudioSessionRequired())
         maybeDeactivateAudioSession();
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -91,9 +91,14 @@ void RemoteAudioSessionProxy::setPreferredBufferSize(uint64_t size)
 void RemoteAudioSessionProxy::tryToSetActive(bool active, SetActiveCompletion&& completion)
 {
     auto success = audioSessionManager().tryToSetActiveForProcess(*this, active);
+    bool hasActiveChanged = success && m_active != active;
     if (success)
         m_active = active;
+
     completion(success);
+
+    if (hasActiveChanged)
+        configurationChanged();
 
     audioSessionManager().updatePresentingProcesses();
 }


### PR DESCRIPTION
#### b09f48fad53589f569035766c4a73acb27668cf3
<pre>
Fix media/audiosession test flakinesses
<a href="https://bugs.webkit.org/show_bug.cgi?id=249470">https://bugs.webkit.org/show_bug.cgi?id=249470</a>
rdar://problem/103444561

Reviewed by Eric Carlson.

Instead of having a process wide value for DOMAudioSession type, store it in top level document.
This allows to clear it on navigation.

Add a m_state field in DOMAudioSession.
When its state is supposed to be changed, we now queue a task where we compute the new state and fire the statechange event if the new state is different from the old one.

Update RemoteAudioSessionProxy to send a configurationChanged event whenever the active state changes.
We do this since there might an ongoing configurationChanged message that may override the WebProcess remote audio session active state.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
* Source/WebCore/Modules/audiosession/DOMAudioSession.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:

Canonical link: <a href="https://commits.webkit.org/258141@main">https://commits.webkit.org/258141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34daf7eff37d99f9d3d3c5c8ff7d94fff2fe33f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110335 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1062 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93442 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108169 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8418 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35030 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3856 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24596 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3884 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/999 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44104 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5587 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5652 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->