### PR TITLE
Consider using HAL output unit in case echo cancellation is disabled

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -201,6 +201,16 @@ void CoreAudioCaptureSourceFactory::whenAudioCaptureUnitIsNotRunning(Function<vo
     return CoreAudioSharedUnit::unit().whenAudioCaptureUnitIsNotRunning(WTFMove(callback));
 }
 
+bool CoreAudioCaptureSourceFactory::shouldAudioCaptureUnitRenderAudio()
+{
+    auto& unit = CoreAudioSharedUnit::unit();
+#if PLATFORM(IOS_FAMILY)
+    return unit.isRunning();
+#else
+    return unit.isRunning() && unit.isUsingVPIO();
+#endif // PLATFORM(IOS_FAMILY)
+}
+
 CoreAudioCaptureSource::CoreAudioCaptureSource(const CaptureDevice& device, uint32_t captureDeviceID, MediaDeviceHashSalts&& hashSalts, BaseAudioSharedUnit* overrideUnit, PageIdentifier pageIdentifier)
     : RealtimeMediaSource(device, WTFMove(hashSalts), pageIdentifier)
     , m_captureDeviceID(captureDeviceID)

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -137,6 +137,7 @@ public:
     WEBCORE_EXPORT void unregisterSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer&);
     WEBCORE_EXPORT bool isAudioCaptureUnitRunning();
     WEBCORE_EXPORT void whenAudioCaptureUnitIsNotRunning(Function<void()>&&);
+    WEBCORE_EXPORT bool shouldAudioCaptureUnitRenderAudio();
 
     void setOverrideUnit(BaseAudioSharedUnit* unit) { m_overrideUnit = unit; }
     BaseAudioSharedUnit& unit();

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -71,7 +71,7 @@ public:
     CoreAudioSharedUnit();
     ~CoreAudioSharedUnit();
 
-    using CreationCallback = Function<Expected<UniqueRef<InternalUnit>, OSStatus>()>;
+    using CreationCallback = Function<Expected<UniqueRef<InternalUnit>, OSStatus>(bool enableEchoCancellation)>;
     void setInternalUnitCreationCallback(CreationCallback&& callback) { m_creationCallback = WTFMove(callback); }
     using GetSampleRateCallback = Function<int()>;
     void setInternalUnitGetSampleRateCallback(GetSampleRateCallback&& callback) { m_getSampleRateCallback = WTFMove(callback); }
@@ -85,6 +85,8 @@ public:
     void setIsInBackground(bool);
     void setStatusBarWasTappedCallback(Function<void(CompletionHandler<void()>&&)>&& callback) { m_statusBarWasTappedCallback = WTFMove(callback); }
 #endif
+
+    bool isUsingVPIO() const { return m_shouldUseVPIO; }
 
 private:
     static size_t preferredIOBufferSize();
@@ -164,6 +166,8 @@ private:
     std::unique_ptr<MediaCaptureStatusBarManager> m_statusBarManager;
     Function<void(CompletionHandler<void()>&&)> m_statusBarWasTappedCallback;
 #endif
+
+    bool m_shouldUseVPIO { true };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -210,7 +210,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start(Consume
 
     if (m_shouldRegisterAsSpeakerSamplesProducer) {
         WebCore::CoreAudioCaptureSourceFactory::singleton().registerSpeakerSamplesProducer(*this);
-        bool shouldNotStartLocalUnit = WebCore::CoreAudioCaptureSourceFactory::singleton().isAudioCaptureUnitRunning() || WebCore::AudioSession::sharedSession().isInterrupted();
+        bool shouldNotStartLocalUnit = WebCore::CoreAudioCaptureSourceFactory::singleton().shouldAudioCaptureUnitRenderAudio() || WebCore::AudioSession::sharedSession().isInterrupted();
         if (shouldNotStartLocalUnit)
             return;
     }
@@ -254,8 +254,8 @@ OSStatus RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::render(si
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::captureUnitIsStarting()
 {
-    // Capture unit is starting and audio will be rendered through it and not by our lcoal unit so stop the local unit.
-    if (m_isPlaying)
+    // Capture unit is starting and audio will be rendered through it and not by our local unit so stop the local unit.
+    if (m_isPlaying && WebCore::CoreAudioCaptureSourceFactory::singleton().shouldAudioCaptureUnitRenderAudio())
         m_localUnit->stop();
 }
 


### PR DESCRIPTION
#### 1796e2f138aba9c879d20e49e6458ae7e3fef898
<pre>
Consider using HAL output unit in case echo cancellation is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=235643">https://bugs.webkit.org/show_bug.cgi?id=235643</a>
rdar://problem/88379822

Reviewed by Eric Carlson.

We use RemoteIO aon iOS or HAL on macOS to capture microphone when echo cancellation is off.
This allows to bypass voice specific processing and gets higher fidelity recording.
On macOS, we only use HAL for recording and not rendering of audio.
For that reason we introduce isAudioCaptureUnitRenderingAudio in WebCore that is used in WebKit to play audio or not through the capture unit.
Update MockAudioSharedInternalUnit to enable echo cancellation according the boolean parameter instead of properties provided to MockAudioSharedInternalUnit.

* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSourceFactory::isAudioCaptureUnitRenderingAudio):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedInternalUnit::create):
(WebCore::CoreAudioSharedUnit::setupAudioUnit):
(WebCore::CoreAudioSharedUnit::validateOutputDevice):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
(WebCore::MockAudioSharedUnit::singleton):
(WebCore::MockAudioSharedInternalUnit::MockAudioSharedInternalUnit):
(WebCore::MockAudioSharedInternalUnit::set):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::captureUnitIsStarting):

Canonical link: <a href="https://commits.webkit.org/258428@main">https://commits.webkit.org/258428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acd45bb6b421d93643025224a6cefb8d90609d3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111264 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171467 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1993 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94337 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109018 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107712 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9218 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92485 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23933 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4661 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25396 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4750 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1836 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44884 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5785 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6500 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->