### PR TITLE
Fix testapi to work with JITCage and LLInt only runs.

### DIFF
--- a/Source/JavaScriptCore/API/tests/PingPongStackOverflowTest.cpp
+++ b/Source/JavaScriptCore/API/tests/PingPongStackOverflowTest.cpp
@@ -125,7 +125,8 @@ int testPingPongStackOverflow()
     // Normally, we want to disable the LLINT to force the use of JITted code which is necessary for
     // reproducing the regression in https://bugs.webkit.org/show_bug.cgi?id=148749. However, we only
     // want to do this if the LLINT isn't the only available execution engine.
-    Options::useLLInt() = false;
+    if (Options::useJIT())
+        Options::useLLInt() = false;
 #endif
 
     const char* scriptString =


### PR DESCRIPTION
#### f93a35064d8090d4875d5fd62e44cafa1b3da44a
<pre>
Fix testapi to work with JITCage and LLInt only runs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249475">https://bugs.webkit.org/show_bug.cgi?id=249475</a>
&lt;rdar://problem/103447329&gt;

Reviewed by Justin Michaud.

1. Fix PingPongStackOverflowTest to handle the case where the JIT is disable.
   It should not force disable the LLInt if the JIT is not available.

2. Fix ExecutionTimeLimitTest tier options to use Options::useBaselineJIT(), instead of
   Options::useJIT(), to determine whether the baseline JIT is enabled of not.  The value
   of Options::useJIT() is determined at launch and already puts in place infrastructure
   that assumes either the JIT is enabled or not.  As a result, it should never be changed
   at runtime.  This especially impacts runs with the JITCage enabled which installs JIT
   thunks that expect JITCage conformant behavior.

3. Fix ExecutionTimeLimitTest to not run the test with JIT tiers if JIT&apos;ing is disabled.

* Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp:
(testExecutionTimeLimit):
* Source/JavaScriptCore/API/tests/PingPongStackOverflowTest.cpp:
(testPingPongStackOverflow):

Canonical link: <a href="https://commits.webkit.org/258007@main">https://commits.webkit.org/258007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b3623642123c94822259738142fada43ce0c3ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100623 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109926 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170203 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10699 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93021 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107775 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106403 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34701 "Found 1 new test failure: fast/scrolling/gtk/user-scroll-snapping-interaction.html (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22731 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91125 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3475 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24259 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87191 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/976 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3489 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29174 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9601 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43754 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90075 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5282 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20149 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2868 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->