### PR TITLE
[web-animations] add interpolation support for <transform-function> custom properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-function-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Animating a custom property of type <transform-function>
+PASS Animating a custom property of type <transform-function> with a single keyframe
+PASS Animating a custom property of type <transform-function> with additivity
+PASS Animating a custom property of type <transform-function> with a single keyframe and additivity
+PASS Animating a custom property of type <transform-function> with iterationComposite
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-function.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-function.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<transform-function>",
+  inherits: false,
+  initialValue: "translateX(0px)"
+}, {
+  keyframes: ["translateX(100px)", "translateX(200px)"],
+  expected: "translateX(150px)"
+}, 'Animating a custom property of type <transform-function>');
+
+animation_test({
+  syntax: "<transform-function>",
+  inherits: false,
+  initialValue: "translateX(100px)"
+}, {
+  keyframes: "translateX(200px)",
+  expected: "translateX(150px)"
+}, 'Animating a custom property of type <transform-function> with a single keyframe');
+
+animation_test({
+  syntax: "<transform-function>",
+  inherits: false,
+  initialValue: "translateX(100px)"
+}, {
+  composite: "add",
+  keyframes: ["translateX(200px)", "translateX(300px)"],
+  expected: "translateX(350px)"
+}, 'Animating a custom property of type <transform-function> with additivity');
+
+animation_test({
+  syntax: "<transform-function>",
+  inherits: false,
+  initialValue: "translateX(100px)"
+}, {
+  composite: "add",
+  keyframes: "translateX(300px)",
+  expected: "translateX(250px)"
+}, 'Animating a custom property of type <transform-function> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<transform-function>",
+  inherits: false,
+  initialValue: "translateX(100px)"
+}, {
+  iterationComposite: "accumulate",
+  keyframes: ["translateX(0px)", "translateX(100px)"],
+  expected: "translateX(250px)"
+}, 'Animating a custom property of type <transform-function> with iterationComposite');
+
+</script>

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -306,6 +306,13 @@ static RefPtr<TranslateTransformOperation> blendFunc(TranslateTransformOperation
     return nullptr;
 }
 
+static RefPtr<TransformOperation> blendFunc(TransformOperation* from, TransformOperation* to, const CSSPropertyBlendingContext& context)
+{
+    if (from && to)
+        return to->blend(from, context);
+    return nullptr;
+}
+
 static inline RefPtr<PathOperation> blendFunc(PathOperation* from, PathOperation* to, const CSSPropertyBlendingContext& context)
 {
     if (is<ShapePathOperation>(from) && is<ShapePathOperation>(to)) {
@@ -3937,6 +3944,12 @@ static std::optional<CSSCustomPropertyValue::SyntaxValue> blendSyntaxValues(cons
         auto& toNumeric = std::get<CSSCustomPropertyValue::NumericSyntaxValue>(to);
         if (fromNumeric.unitType == toNumeric.unitType)
             return blendFunc(fromNumeric, toNumeric, blendingContext);
+    }
+
+    if (std::holds_alternative<RefPtr<TransformOperation>>(from) && std::holds_alternative<RefPtr<TransformOperation>>(to)) {
+        auto& fromTransformOperation = std::get<RefPtr<TransformOperation>>(from);
+        auto& toTransformOperation = std::get<RefPtr<TransformOperation>>(to);
+        return blendFunc(fromTransformOperation.get(), toTransformOperation.get(), blendingContext);
     }
 
     return std::nullopt;


### PR DESCRIPTION
#### b841cb737eaeeafc7105d09214fa2f131cf7acc2
<pre>
[web-animations] add interpolation support for &lt;transform-function&gt; custom properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=249478">https://bugs.webkit.org/show_bug.cgi?id=249478</a>

Reviewed by Antti Koivisto.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-function-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-function.html: Added.
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
(WebCore::blendSyntaxValues):

Canonical link: <a href="https://commits.webkit.org/258009@main">https://commits.webkit.org/258009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ea2bf18735e4d1e586bdae737ec387e7f0d08d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109931 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170208 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10704 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93026 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107780 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8088 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34703 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22733 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3480 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24261 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3494 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43756 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5286 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2869 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->