### PR TITLE
Separate single TransformOperation resolution from transformsForValue

### DIFF
--- a/Source/WebCore/css/DOMMatrixReadOnly.cpp
+++ b/Source/WebCore/css/DOMMatrixReadOnly.cpp
@@ -236,12 +236,12 @@ ExceptionOr<DOMMatrixReadOnly::AbstractMatrix> DOMMatrixReadOnly::parseStringInt
     if (!value || (is<CSSPrimitiveValue>(*value) && downcast<CSSPrimitiveValue>(*value).valueID() == CSSValueNone))
         return AbstractMatrix { };
 
-    TransformOperations operations;
-    if (!transformsForValue(*value, { }, operations))
+    auto operations = transformsForValue(*value, { });
+    if (!operations)
         return Exception { SyntaxError };
 
     AbstractMatrix matrix;
-    for (auto& operation : operations.operations()) {
+    for (auto& operation : operations->operations()) {
         if (operation->apply(matrix.matrix, { 0, 0 }))
             return Exception { SyntaxError };
         if (operation->is3DOperation())

--- a/Source/WebCore/css/TransformFunctions.cpp
+++ b/Source/WebCore/css/TransformFunctions.cpp
@@ -102,256 +102,257 @@ Length convertToFloatLength(const CSSPrimitiveValue* primitiveValue, const CSSTo
     return primitiveValue ? primitiveValue->convertToLength<FixedFloatConversion | PercentConversion | CalculatedConversion>(conversionData) : Length(LengthType::Undefined);
 }
 
-// FIXME: This should return std::optional<TransformOperations>
-bool transformsForValue(const CSSValue& value, const CSSToLengthConversionData& conversionData, TransformOperations& outOperations)
+std::optional<TransformOperations> transformsForValue(const CSSValue& value, const CSSToLengthConversionData& conversionData)
 {
-    ASSERT(!outOperations.size());
     if (!is<CSSValueList>(value))
-        return false;
+        return { };
 
-    auto& operations = outOperations.operations();
+    TransformOperations operations;
     for (auto& currentValue : downcast<CSSValueList>(value)) {
-        if (!is<CSSFunctionValue>(currentValue))
-            continue;
+        auto transform  = transformForValue(currentValue, conversionData);
+        if (!transform)
+            return { };
+        operations.operations().append(WTFMove(transform));
+    }
+    return operations;
+}
 
-        auto& transformValue = downcast<CSSFunctionValue>(currentValue.get());
-        if (!transformValue.length())
-            continue;
+RefPtr<TransformOperation> transformForValue(const CSSValue& value, const CSSToLengthConversionData& conversionData)
+{
+    if (!is<CSSFunctionValue>(value))
+        return nullptr;
 
-        bool haveNonPrimitiveValue = false;
-        for (unsigned j = 0; j < transformValue.length(); ++j) {
-            if (!is<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(j))) {
-                haveNonPrimitiveValue = true;
-                break;
-            }
-        }
-        if (haveNonPrimitiveValue)
-            continue;
+    auto& transformValue = downcast<CSSFunctionValue>(value);
+    if (!transformValue.length())
+        return nullptr;
 
-        auto& firstValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(0));
-
-        switch (transformValue.name()) {
-        case CSSValueScale:
-        case CSSValueScaleX:
-        case CSSValueScaleY: {
-            double sx = 1.0;
-            double sy = 1.0;
-            if (transformValue.name() == CSSValueScaleY)
-                sy = firstValue.doubleValueDividingBy100IfPercentage();
-            else {
-                sx = firstValue.doubleValueDividingBy100IfPercentage();
-                if (transformValue.name() != CSSValueScaleX) {
-                    if (transformValue.length() > 1) {
-                        auto& secondValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1));
-                        sy = secondValue.doubleValueDividingBy100IfPercentage();
-                    } else
-                        sy = sx;
-                }
-            }
-            operations.append(ScaleTransformOperation::create(sx, sy, 1.0, transformOperationType(transformValue.name())));
-            break;
-        }
-        case CSSValueScaleZ:
-        case CSSValueScale3d: {
-            double sx = 1.0;
-            double sy = 1.0;
-            double sz = 1.0;
-            if (transformValue.name() == CSSValueScaleZ)
-                sz = firstValue.doubleValueDividingBy100IfPercentage();
-            else if (transformValue.name() == CSSValueScaleY)
-                sy = firstValue.doubleValueDividingBy100IfPercentage();
-            else {
-                sx = firstValue.doubleValueDividingBy100IfPercentage();
-                if (transformValue.name() != CSSValueScaleX) {
-                    if (transformValue.length() > 2) {
-                        auto& thirdValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(2));
-                        sz = thirdValue.doubleValueDividingBy100IfPercentage();
-                    }
-                    if (transformValue.length() > 1) {
-                        auto& secondValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1));
-                        sy = secondValue.doubleValueDividingBy100IfPercentage();
-                    } else
-                        sy = sx;
-                }
-            }
-            operations.append(ScaleTransformOperation::create(sx, sy, sz, transformOperationType(transformValue.name())));
-            break;
-        }
-        case CSSValueTranslate:
-        case CSSValueTranslateX:
-        case CSSValueTranslateY: {
-            Length tx = Length(0, LengthType::Fixed);
-            Length ty = Length(0, LengthType::Fixed);
-            if (transformValue.name() == CSSValueTranslateY)
-                ty = convertToFloatLength(&firstValue, conversionData);
-            else {
-                tx = convertToFloatLength(&firstValue, conversionData);
-                if (transformValue.name() != CSSValueTranslateX) {
-                    if (transformValue.length() > 1) {
-                        auto& secondValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1));
-                        ty = convertToFloatLength(&secondValue, conversionData);
-                    }
-                }
-            }
-
-            if (tx.isUndefined() || ty.isUndefined()) {
-                operations.clear();
-                return false;
-            }
-
-            operations.append(TranslateTransformOperation::create(tx, ty, Length(0, LengthType::Fixed), transformOperationType(transformValue.name())));
-            break;
-        }
-        case CSSValueTranslateZ:
-        case CSSValueTranslate3d: {
-            Length tx = Length(0, LengthType::Fixed);
-            Length ty = Length(0, LengthType::Fixed);
-            Length tz = Length(0, LengthType::Fixed);
-            if (transformValue.name() == CSSValueTranslateZ)
-                tz = convertToFloatLength(&firstValue, conversionData);
-            else if (transformValue.name() == CSSValueTranslateY)
-                ty = convertToFloatLength(&firstValue, conversionData);
-            else {
-                tx = convertToFloatLength(&firstValue, conversionData);
-                if (transformValue.name() != CSSValueTranslateX) {
-                    if (transformValue.length() > 2) {
-                        auto& thirdValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(2));
-                        tz = convertToFloatLength(&thirdValue, conversionData);
-                    }
-                    if (transformValue.length() > 1) {
-                        auto& secondValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1));
-                        ty = convertToFloatLength(&secondValue, conversionData);
-                    }
-                }
-            }
-
-            if (tx.isUndefined() || ty.isUndefined() || tz.isUndefined()) {
-                operations.clear();
-                return false;
-            }
-
-            operations.append(TranslateTransformOperation::create(tx, ty, tz, transformOperationType(transformValue.name())));
-            break;
-        }
-        case CSSValueRotate: {
-            double angle = firstValue.computeDegrees();
-            operations.append(RotateTransformOperation::create(0, 0, 1, angle, transformOperationType(transformValue.name())));
-            break;
-        }
-        case CSSValueRotateX:
-        case CSSValueRotateY:
-        case CSSValueRotateZ: {
-            double x = 0;
-            double y = 0;
-            double z = 0;
-            double angle = firstValue.computeDegrees();
-
-            if (transformValue.name() == CSSValueRotateX)
-                x = 1;
-            else if (transformValue.name() == CSSValueRotateY)
-                y = 1;
-            else
-                z = 1;
-            operations.append(RotateTransformOperation::create(x, y, z, angle, transformOperationType(transformValue.name())));
-            break;
-        }
-        case CSSValueRotate3d: {
-            if (transformValue.length() < 4)
-                break;
-            auto& secondValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1));
-            auto& thirdValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(2));
-            auto& fourthValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(3));
-            double x = firstValue.doubleValue();
-            double y = secondValue.doubleValue();
-            double z = thirdValue.doubleValue();
-            double angle = fourthValue.computeDegrees();
-            operations.append(RotateTransformOperation::create(x, y, z, angle, transformOperationType(transformValue.name())));
-            break;
-        }
-        case CSSValueSkew:
-        case CSSValueSkewX:
-        case CSSValueSkewY: {
-            double angleX = 0;
-            double angleY = 0;
-            double angle = firstValue.computeDegrees();
-            if (transformValue.name() == CSSValueSkewY)
-                angleY = angle;
-            else {
-                angleX = angle;
-                if (transformValue.name() == CSSValueSkew) {
-                    if (transformValue.length() > 1) {
-                        auto& secondValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1));
-                        angleY = secondValue.computeDegrees();
-                    }
-                }
-            }
-            operations.append(SkewTransformOperation::create(angleX, angleY, transformOperationType(transformValue.name())));
-            break;
-        }
-        case CSSValueMatrix: {
-            if (transformValue.length() < 6)
-                break;
-            double a = firstValue.doubleValue();
-            double b = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1)).doubleValue();
-            double c = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(2)).doubleValue();
-            double d = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(3)).doubleValue();
-            double e = conversionData.zoom() * downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(4)).doubleValue();
-            double f = conversionData.zoom() * downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(5)).doubleValue();
-            operations.append(MatrixTransformOperation::create(a, b, c, d, e, f));
-            break;
-        }
-        case CSSValueMatrix3d: {
-            if (transformValue.length() < 16)
-                break;
-            TransformationMatrix matrix(downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(0)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(2)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(3)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(4)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(5)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(6)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(7)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(8)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(9)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(10)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(11)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(12)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(13)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(14)).doubleValue(),
-                downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(15)).doubleValue());
-            matrix.zoom(conversionData.zoom());
-            operations.append(Matrix3DTransformOperation::create(matrix));
-            break;
-        }
-        case CSSValuePerspective: {
-            std::optional<Length> perspectiveLength;
-            if (!firstValue.isValueID()) {
-                if (firstValue.isLength())
-                    perspectiveLength = convertToFloatLength(&firstValue, conversionData);
-                else {
-                    // This is a quirk that should go away when 3d transforms are finalized.
-                    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=232669
-                    // This does not deal properly with calc(), because we aren't passing conversionData here.
-                    double doubleValue = firstValue.doubleValue();
-                    if (doubleValue < 0) {
-                        operations.clear();
-                        return false;
-                    }
-                    perspectiveLength = Length(clampToPositiveInteger(doubleValue), LengthType::Fixed);
-                }
-            } else
-                ASSERT(firstValue.valueID() == CSSValueNone);
-
-            operations.append(PerspectiveTransformOperation::create(perspectiveLength));
-            break;
-        }
-        default:
-            ASSERT_NOT_REACHED();
+    bool haveNonPrimitiveValue = false;
+    for (unsigned j = 0; j < transformValue.length(); ++j) {
+        if (!is<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(j))) {
+            haveNonPrimitiveValue = true;
             break;
         }
     }
+    if (haveNonPrimitiveValue)
+        return nullptr;
 
-    return true;
+    auto& firstValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(0));
+
+    switch (transformValue.name()) {
+    case CSSValueScale:
+    case CSSValueScaleX:
+    case CSSValueScaleY: {
+        double sx = 1.0;
+        double sy = 1.0;
+        if (transformValue.name() == CSSValueScaleY)
+            sy = firstValue.doubleValueDividingBy100IfPercentage();
+        else {
+            sx = firstValue.doubleValueDividingBy100IfPercentage();
+            if (transformValue.name() != CSSValueScaleX) {
+                if (transformValue.length() > 1) {
+                    auto& secondValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1));
+                    sy = secondValue.doubleValueDividingBy100IfPercentage();
+                } else
+                    sy = sx;
+            }
+        }
+        return ScaleTransformOperation::create(sx, sy, 1.0, transformOperationType(transformValue.name()));
+    }
+
+    case CSSValueScaleZ:
+    case CSSValueScale3d: {
+        double sx = 1.0;
+        double sy = 1.0;
+        double sz = 1.0;
+        if (transformValue.name() == CSSValueScaleZ)
+            sz = firstValue.doubleValueDividingBy100IfPercentage();
+        else if (transformValue.name() == CSSValueScaleY)
+            sy = firstValue.doubleValueDividingBy100IfPercentage();
+        else {
+            sx = firstValue.doubleValueDividingBy100IfPercentage();
+            if (transformValue.name() != CSSValueScaleX) {
+                if (transformValue.length() > 2) {
+                    auto& thirdValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(2));
+                    sz = thirdValue.doubleValueDividingBy100IfPercentage();
+                }
+                if (transformValue.length() > 1) {
+                    auto& secondValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1));
+                    sy = secondValue.doubleValueDividingBy100IfPercentage();
+                } else
+                    sy = sx;
+            }
+        }
+        return ScaleTransformOperation::create(sx, sy, sz, transformOperationType(transformValue.name()));
+    }
+
+    case CSSValueTranslate:
+    case CSSValueTranslateX:
+    case CSSValueTranslateY: {
+        Length tx = Length(0, LengthType::Fixed);
+        Length ty = Length(0, LengthType::Fixed);
+        if (transformValue.name() == CSSValueTranslateY)
+            ty = convertToFloatLength(&firstValue, conversionData);
+        else {
+            tx = convertToFloatLength(&firstValue, conversionData);
+            if (transformValue.name() != CSSValueTranslateX) {
+                if (transformValue.length() > 1) {
+                    auto& secondValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1));
+                    ty = convertToFloatLength(&secondValue, conversionData);
+                }
+            }
+        }
+
+        if (tx.isUndefined() || ty.isUndefined())
+            return nullptr;
+
+        return TranslateTransformOperation::create(tx, ty, Length(0, LengthType::Fixed), transformOperationType(transformValue.name()));
+    }
+
+    case CSSValueTranslateZ:
+    case CSSValueTranslate3d: {
+        Length tx = Length(0, LengthType::Fixed);
+        Length ty = Length(0, LengthType::Fixed);
+        Length tz = Length(0, LengthType::Fixed);
+        if (transformValue.name() == CSSValueTranslateZ)
+            tz = convertToFloatLength(&firstValue, conversionData);
+        else if (transformValue.name() == CSSValueTranslateY)
+            ty = convertToFloatLength(&firstValue, conversionData);
+        else {
+            tx = convertToFloatLength(&firstValue, conversionData);
+            if (transformValue.name() != CSSValueTranslateX) {
+                if (transformValue.length() > 2) {
+                    auto& thirdValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(2));
+                    tz = convertToFloatLength(&thirdValue, conversionData);
+                }
+                if (transformValue.length() > 1) {
+                    auto& secondValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1));
+                    ty = convertToFloatLength(&secondValue, conversionData);
+                }
+            }
+        }
+
+        if (tx.isUndefined() || ty.isUndefined() || tz.isUndefined())
+            return nullptr;
+
+        return TranslateTransformOperation::create(tx, ty, tz, transformOperationType(transformValue.name()));
+    }
+
+    case CSSValueRotate: {
+        double angle = firstValue.computeDegrees();
+        return RotateTransformOperation::create(0, 0, 1, angle, transformOperationType(transformValue.name()));
+    }
+
+    case CSSValueRotateX:
+    case CSSValueRotateY:
+    case CSSValueRotateZ: {
+        double x = 0;
+        double y = 0;
+        double z = 0;
+        double angle = firstValue.computeDegrees();
+
+        if (transformValue.name() == CSSValueRotateX)
+            x = 1;
+        else if (transformValue.name() == CSSValueRotateY)
+            y = 1;
+        else
+            z = 1;
+        return RotateTransformOperation::create(x, y, z, angle, transformOperationType(transformValue.name()));
+    }
+
+    case CSSValueRotate3d: {
+        if (transformValue.length() < 4)
+            break;
+        auto& secondValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1));
+        auto& thirdValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(2));
+        auto& fourthValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(3));
+        double x = firstValue.doubleValue();
+        double y = secondValue.doubleValue();
+        double z = thirdValue.doubleValue();
+        double angle = fourthValue.computeDegrees();
+        return RotateTransformOperation::create(x, y, z, angle, transformOperationType(transformValue.name()));
+    }
+
+    case CSSValueSkew:
+    case CSSValueSkewX:
+    case CSSValueSkewY: {
+        double angleX = 0;
+        double angleY = 0;
+        double angle = firstValue.computeDegrees();
+        if (transformValue.name() == CSSValueSkewY)
+            angleY = angle;
+        else {
+            angleX = angle;
+            if (transformValue.name() == CSSValueSkew) {
+                if (transformValue.length() > 1) {
+                    auto& secondValue = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1));
+                    angleY = secondValue.computeDegrees();
+                }
+            }
+        }
+        return SkewTransformOperation::create(angleX, angleY, transformOperationType(transformValue.name()));
+    }
+
+    case CSSValueMatrix: {
+        if (transformValue.length() < 6)
+            break;
+        double a = firstValue.doubleValue();
+        double b = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1)).doubleValue();
+        double c = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(2)).doubleValue();
+        double d = downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(3)).doubleValue();
+        double e = conversionData.zoom() * downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(4)).doubleValue();
+        double f = conversionData.zoom() * downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(5)).doubleValue();
+        return MatrixTransformOperation::create(a, b, c, d, e, f);
+    }
+
+    case CSSValueMatrix3d: {
+        if (transformValue.length() < 16)
+            break;
+        TransformationMatrix matrix(downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(0)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(1)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(2)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(3)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(4)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(5)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(6)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(7)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(8)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(9)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(10)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(11)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(12)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(13)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(14)).doubleValue(),
+            downcast<CSSPrimitiveValue>(*transformValue.itemWithoutBoundsCheck(15)).doubleValue());
+        matrix.zoom(conversionData.zoom());
+        return Matrix3DTransformOperation::create(matrix);
+    }
+
+    case CSSValuePerspective: {
+        std::optional<Length> perspectiveLength;
+        if (!firstValue.isValueID()) {
+            if (firstValue.isLength())
+                perspectiveLength = convertToFloatLength(&firstValue, conversionData);
+            else {
+                // This is a quirk that should go away when 3d transforms are finalized.
+                // FIXME: https://bugs.webkit.org/show_bug.cgi?id=232669
+                // This does not deal properly with calc(), because we aren't passing conversionData here.
+                double doubleValue = firstValue.doubleValue();
+                if (doubleValue < 0)
+                    return nullptr;
+                perspectiveLength = Length(clampToPositiveInteger(doubleValue), LengthType::Fixed);
+            }
+        } else
+            ASSERT(firstValue.valueID() == CSSValueNone);
+
+        return PerspectiveTransformOperation::create(perspectiveLength);
+    }
+
+    default:
+        break;
+    }
+
+    ASSERT_NOT_REACHED();
+    return nullptr;
 }
 
 RefPtr<TranslateTransformOperation> translateForValue(const CSSValue& value, const CSSToLengthConversionData& conversionData)

--- a/Source/WebCore/css/TransformFunctions.h
+++ b/Source/WebCore/css/TransformFunctions.h
@@ -41,7 +41,8 @@ class CSSPrimitiveValue;
 class CSSToLengthConversionData;
 class CSSValue;
 
-bool transformsForValue(const CSSValue&, const CSSToLengthConversionData&, TransformOperations&);
+std::optional<TransformOperations> transformsForValue(const CSSValue&, const CSSToLengthConversionData&);
+RefPtr<TransformOperation> transformForValue(const CSSValue&, const CSSToLengthConversionData&);
 Length convertToFloatLength(const CSSPrimitiveValue*, const CSSToLengthConversionData&);
 RefPtr<TranslateTransformOperation> translateForValue(const CSSValue&, const CSSToLengthConversionData&);
 RefPtr<RotateTransformOperation> rotateForValue(const CSSValue&);

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -490,15 +490,11 @@ RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(
             return { primitiveValue->stringValue() };
 
         case CSSCustomPropertySyntax::Type::TransformFunction:
-        case CSSCustomPropertySyntax::Type::TransformList: {
-            auto listValue = CSSValueList::createSpaceSeparated();
-            listValue->append(const_cast<CSSValue&>(value));
-            TransformOperations operations;
-            transformsForValue(listValue, builderState.cssToLengthConversionData(), operations);
-            if (operations.operations().size() != 1)
-                return { };
-            return { operations.operations()[0] };
-        }
+        case CSSCustomPropertySyntax::Type::TransformList:
+            if (auto transform = transformForValue(value, builderState.cssToLengthConversionData()))
+                return { transform };
+            return { };
+    
         case CSSCustomPropertySyntax::Type::Unknown:
             return { };
         }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -488,9 +488,10 @@ inline ImageOrientation BuilderConverter::convertImageOrientation(BuilderState&,
 
 inline TransformOperations BuilderConverter::convertTransform(BuilderState& builderState, const CSSValue& value)
 {
-    TransformOperations operations;
-    transformsForValue(value, builderState.cssToLengthConversionData(), operations);
-    return operations;
+    auto operations = transformsForValue(value, builderState.cssToLengthConversionData());
+    if (!operations)
+        return TransformOperations { };
+    return *operations;
 }
 
 inline RefPtr<TranslateTransformOperation> BuilderConverter::convertTranslate(BuilderState& builderState, const CSSValue& value)


### PR DESCRIPTION
#### f5eb326e26ffc147b9421cbb3db9ce1d21750d8e
<pre>
Separate single TransformOperation resolution from transformsForValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=249471">https://bugs.webkit.org/show_bug.cgi?id=249471</a>
&lt;rdar://problem/103445247&gt;

Reviewed by Antoine Quint.

* Source/WebCore/css/DOMMatrixReadOnly.cpp:
(WebCore::DOMMatrixReadOnly::parseStringIntoAbstractMatrix):
* Source/WebCore/css/TransformFunctions.cpp:
(WebCore::transformsForValue):

Fix the FIXME by returning optional&lt;&gt;.

(WebCore::transformForValue):

Factor the code out from the loop.

* Source/WebCore/css/TransformFunctions.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertTransform):

Canonical link: <a href="https://commits.webkit.org/258035@main">https://commits.webkit.org/258035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35948ca477f2558fa31614ecbc68d29b641a1350

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109945 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170221 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/314 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93041 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107793 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91352 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34710 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90009 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77679 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3492 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24272 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3508 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43768 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5517 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5298 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->