### PR TITLE
Stop allowing numbers during parsing of cx, cy, x, y CSS properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt
@@ -24,9 +24,9 @@ PASS Setting 'cx' to a flexible length: 0fr throws TypeError
 PASS Setting 'cx' to a flexible length: 1fr throws TypeError
 PASS Setting 'cx' to a flexible length: -3.14fr throws TypeError
 FAIL Setting 'cx' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'cx' to a number: -3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'cx' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'cx' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'cx' to a number: -3.14 throws TypeError
+PASS Setting 'cx' to a number: 3.14 throws TypeError
+PASS Setting 'cx' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'cx' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'cx' to a transform: perspective(10em) throws TypeError
 PASS Setting 'cx' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
@@ -55,9 +55,9 @@ PASS Setting 'cy' to a flexible length: 0fr throws TypeError
 PASS Setting 'cy' to a flexible length: 1fr throws TypeError
 PASS Setting 'cy' to a flexible length: -3.14fr throws TypeError
 FAIL Setting 'cy' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'cy' to a number: -3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'cy' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'cy' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'cy' to a number: -3.14 throws TypeError
+PASS Setting 'cy' to a number: 3.14 throws TypeError
+PASS Setting 'cy' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'cy' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'cy' to a transform: perspective(10em) throws TypeError
 PASS Setting 'cy' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt
@@ -24,9 +24,9 @@ PASS Setting 'x' to a flexible length: 0fr throws TypeError
 PASS Setting 'x' to a flexible length: 1fr throws TypeError
 PASS Setting 'x' to a flexible length: -3.14fr throws TypeError
 FAIL Setting 'x' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'x' to a number: -3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'x' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'x' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'x' to a number: -3.14 throws TypeError
+PASS Setting 'x' to a number: 3.14 throws TypeError
+PASS Setting 'x' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'x' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'x' to a transform: perspective(10em) throws TypeError
 PASS Setting 'x' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
@@ -55,9 +55,9 @@ PASS Setting 'y' to a flexible length: 0fr throws TypeError
 PASS Setting 'y' to a flexible length: 1fr throws TypeError
 PASS Setting 'y' to a flexible length: -3.14fr throws TypeError
 FAIL Setting 'y' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'y' to a number: -3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'y' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'y' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'y' to a number: -3.14 throws TypeError
+PASS Setting 'y' to a number: 3.14 throws TypeError
+PASS Setting 'y' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'y' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'y' to a transform: perspective(10em) throws TypeError
 PASS Setting 'y' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-invalid-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL e.style['cx'] = "10" should not set the property value assert_equals: expected "" but got "10px"
+PASS e.style['cx'] = "10" should not set the property value
 PASS e.style['cx'] = "auto" should not set the property value
 PASS e.style['cx'] = "10px 20px" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-invalid-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL e.style['cy'] = "10" should not set the property value assert_equals: expected "" but got "10px"
+PASS e.style['cy'] = "10" should not set the property value
 PASS e.style['cy'] = "auto" should not set the property value
 PASS e.style['cy'] = "10px 20px" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-invalid-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL e.style['x'] = "10" should not set the property value assert_equals: expected "" but got "10px"
+PASS e.style['x'] = "10" should not set the property value
 PASS e.style['x'] = "auto" should not set the property value
 PASS e.style['x'] = "10px 20px" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-invalid-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL e.style['y'] = "10" should not set the property value assert_equals: expected "" but got "10px"
+PASS e.style['y'] = "10" should not set the property value
 PASS e.style['y'] = "auto" should not set the property value
 PASS e.style['y'] = "10px 20px" should not set the property value
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -2898,7 +2898,7 @@
             "codegen-properties": {
                 "initial": "initialZeroLength",
                 "converter": "Length",
-                "parser-grammar": "<length-percentage svg>"
+                "parser-grammar": "<length-percentage>"
             },
             "specification": {
                 "category": "svg",
@@ -2909,7 +2909,7 @@
             "codegen-properties": {
                 "initial": "initialZeroLength",
                 "converter": "Length",
-                "parser-grammar": "<length-percentage svg>"
+                "parser-grammar": "<length-percentage>"
             },
             "specification": {
                 "category": "svg",
@@ -5767,7 +5767,7 @@
             "codegen-properties": {
                 "initial": "initialZeroLength",
                 "converter": "Length",
-                "parser-grammar": "<length-percentage svg>"
+                "parser-grammar": "<length-percentage>"
             },
             "specification": {
                 "category": "svg",
@@ -5778,7 +5778,7 @@
             "codegen-properties": {
                 "initial": "initialZeroLength",
                 "converter": "Length",
-                "parser-grammar": "<length-percentage svg>"
+                "parser-grammar": "<length-percentage>"
             },
             "specification": {
                 "category": "svg",


### PR DESCRIPTION
#### 90112a7d702fa28ce9886a5b0ca62ff2edb9d708
<pre>
Stop allowing numbers during parsing of cx, cy, x, y CSS properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=249479">https://bugs.webkit.org/show_bug.cgi?id=249479</a>

Reviewed by Sam Weinig.

Stop allowing numbers during parsing of cx, cy, x, y CSS properties.

Per the specification, we should allow &lt;length-percentage&gt;, not &lt;number&gt;:
- <a href="https://svgwg.org/svg2-draft/geometry.html#CX">https://svgwg.org/svg2-draft/geometry.html#CX</a>
- <a href="https://svgwg.org/svg2-draft/geometry.html#CY">https://svgwg.org/svg2-draft/geometry.html#CY</a>
- <a href="https://svgwg.org/svg2-draft/geometry.html#X">https://svgwg.org/svg2-draft/geometry.html#X</a>
- <a href="https://svgwg.org/svg2-draft/geometry.html#Y">https://svgwg.org/svg2-draft/geometry.html#Y</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-invalid-expected.txt:
Rebaseline WPT tests now that more checks are passing.

* Source/WebCore/css/CSSProperties.json:
Use &lt;length-percentage&gt; instead of &lt;length-percentage svg&gt; for the parser grammar,
since the svg attribute parsing mode allows unitless values.

Canonical link: <a href="https://commits.webkit.org/258029@main">https://commits.webkit.org/258029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8771eea1af61f066c77b3f40555916acbab9c58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109934 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170211 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10707 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93029 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107783 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34706 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90003 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77675 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3483 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24263 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3497 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43758 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5510 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5289 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->