### PR TITLE
Stop allowing numbers during parsing of baseline-shift CSS property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt
@@ -26,9 +26,9 @@ PASS Setting 'baseline-shift' to a flexible length: 0fr throws TypeError
 PASS Setting 'baseline-shift' to a flexible length: 1fr throws TypeError
 PASS Setting 'baseline-shift' to a flexible length: -3.14fr throws TypeError
 FAIL Setting 'baseline-shift' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'baseline-shift' to a number: -3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'baseline-shift' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'baseline-shift' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'baseline-shift' to a number: -3.14 throws TypeError
+PASS Setting 'baseline-shift' to a number: 3.14 throws TypeError
+PASS Setting 'baseline-shift' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'baseline-shift' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'baseline-shift' to a transform: perspective(10em) throws TypeError
 PASS Setting 'baseline-shift' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1470,7 +1470,7 @@
             "codegen-properties": {
                 "custom": "Value",
                 "svg": true,
-                "parser-grammar": "baseline | sub | super | <length-percentage svg>"
+                "parser-grammar": "baseline | sub | super | <length-percentage>"
             },
             "specification": {
                 "category": "svg",


### PR DESCRIPTION
#### 5e3c6ae374505bbac841e970337a2fd6d9f59dcf
<pre>
Stop allowing numbers during parsing of baseline-shift CSS property
<a href="https://bugs.webkit.org/show_bug.cgi?id=249482">https://bugs.webkit.org/show_bug.cgi?id=249482</a>

Reviewed by Sam Weinig.

Stop allowing numbers during parsing of baseline-shift CSS property.

Per the specification, we should allow &lt;length-percentage&gt;, not &lt;number&gt;:
- <a href="https://w3c.github.io/csswg-drafts/css-inline/#baseline-shift-property">https://w3c.github.io/csswg-drafts/css-inline/#baseline-shift-property</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt:
Rebaseline WPT test now that more checks are passing.

* Source/WebCore/css/CSSProperties.json:
Drop svg attribute mode since it allows unitless values during parsing.

Canonical link: <a href="https://commits.webkit.org/258025@main">https://commits.webkit.org/258025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f9509c3baabb36109085ff38802826101408850

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109942 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170218 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10716 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93038 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107790 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34709 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22738 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3489 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24266 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3505 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43761 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5504 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5295 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->