### PR TITLE
[ews-build.webkit.org] Support proxy Twisted requests

### DIFF
--- a/Tools/CISupport/ews-build/twisted_additions.py
+++ b/Tools/CISupport/ews-build/twisted_additions.py
@@ -1,0 +1,248 @@
+# Copyright (c) 2014 Peter Ruibal. All rights reserved.
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+# 3.  Neither the name of the copyright holder nor the names of its contributors may
+#     be used to endorse or promote products derived from this software without
+#     specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED THE COPYRIGHT HOLDERS AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import os
+import re
+import twisted
+
+from twisted.internet import defer, error, interfaces, protocol, reactor, task
+from twisted.web.client import Agent
+from twisted.web.http_headers import Headers
+from twisted.web import http, _newclient
+
+from zope.interface import implementer
+
+
+@implementer(interfaces.IReactorTCP, interfaces.IReactorSSL)
+class HTTPProxyConnector(object):
+    """Helper to wrap reactor connection API (TCP, SSL) via a CONNECT proxy."""
+
+    def __init__(self, proxy_host, proxy_port,
+                 reactor=reactor):
+        self.proxy_host = proxy_host
+        self.proxy_port = proxy_port
+        self.reactor = reactor
+
+    def seconds(self):
+        return self.reactor.seconds()
+
+    def callLater(self, delay, callable, *args, **kw):
+        return self.reactor.callLater(delay, callable, *args, **kw)
+
+    def listenTCP(port, factory, backlog=50, interface=''):
+        raise error.CannotListenError('Cannot BIND via HTTP proxies')
+
+    def connectTCP(self, host, port, factory, timeout=30, bindAddress=None):
+        f = HTTPProxiedClientFactory(factory, host, port)
+        self.reactor.connectTCP(self.proxy_host,
+                                self.proxy_port,
+                                f, timeout, bindAddress)
+
+    def listenSSL(self, port, factory, contextFactory, backlog=50, interface=''):
+        raise error.CannotListenError('Cannot BIND via HTTP proxies')
+
+    def connectSSL(self, host, port, factory, contextFactory, timeout=30,
+                   bindAddress=None):
+        from twisted.protocols import tls
+        tlsFactory = tls.TLSMemoryBIOFactory(contextFactory, True, factory)
+        return self.connectTCP(host, port, tlsFactory, timeout, bindAddress)
+
+
+class HTTPProxiedClientFactory(protocol.ClientFactory):
+    """ClientFactory wrapper that triggers an HTTP proxy CONNECT on connect"""
+    def __init__(self, delegate, dst_host, dst_port):
+        self.delegate = delegate
+        self.dst_host = dst_host
+        self.dst_port = dst_port
+
+    def startedConnecting(self, connector):
+        return self.delegate.startedConnecting(connector)
+
+    def buildProtocol(self, addr):
+        p = HTTPConnectTunneler(self.dst_host, self.dst_port, addr)
+        p.factory = self
+        return p
+
+    def clientConnectionFailed(self, connector, reason):
+        return self.delegate.clientConnectionFailed(connector, reason)
+
+    def clientConnectionLost(self, connector, reason):
+        return self.delegate.clientConnectionLost(connector, reason)
+
+
+class HTTPConnectTunneler(protocol.Protocol):
+    """Protocol that wraps transport with CONNECT proxy handshake on connect
+    `factory` MUST be assigned in order to use this Protocol, and the value
+    *must* have a `delegate` attribute to trigger wrapped, post-connect,
+    factory (creation) methods.
+    """
+    http = None
+    otherConn = None
+
+    def __init__(self, host, port, orig_addr):
+        self.host = host
+        self.port = port
+        self.orig_addr = orig_addr
+
+    def connectionMade(self):
+        self.http = HTTPConnectSetup(self.host, self.port)
+        self.http.parent = self
+        self.http.makeConnection(self.transport)
+
+    def connectionLost(self, reason):
+        if self.otherConn is not None:
+            self.otherConn.connectionLost(reason)
+        if self.http is not None:
+            self.http.connectionLost(reason)
+
+    def proxyConnected(self):
+        # TODO: Bail if `self.factory` is unassigned or
+        # does not have a `delegate`
+        self.otherConn = self.factory.delegate.buildProtocol(self.orig_addr)
+        self.otherConn.makeConnection(self.transport)
+
+        # Get any pending data from the http buf and forward it to otherConn
+        buf = self.http.clearLineBuffer()
+        if buf:
+            self.otherConn.dataReceived(buf)
+
+    def dataReceived(self, data):
+        if self.otherConn is not None:
+            return self.otherConn.dataReceived(data)
+        elif self.http is not None:
+            return self.http.dataReceived(data)
+        else:
+            raise Exception('No handler for received data... :(')
+
+
+class HTTPConnectSetup(http.HTTPClient):
+    """HTTPClient protocol to send a CONNECT message for proxies.
+    `parent` MUST be assigned to an HTTPConnectTunneler instance, or have a
+    `proxyConnected` method that will be invoked post-CONNECT (http request)
+    """
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+
+    def connectionMade(self):
+        self.sendCommand(b'CONNECT', f'{self.host}:{self.port}'.encode('utf-8'))
+        self.endHeaders()
+
+    def handleStatus(self, version, status, message):
+        if status != b'200':
+            raise error.ConnectError(f'Unexpected status on CONNECT: {status}')
+
+    def handleEndHeaders(self):
+        # TODO: Make sure parent is assigned, and has a proxyConnected callback
+        self.parent.proxyConnected()
+
+    def handleResponse(self, body):
+        pass
+
+
+class TwistedAdditions(object):
+    PROXY_RE = re.compile(r'https?://(?P<host>.+):(?P<port>\d+)')
+
+    class Response(object):
+        def __init__(self, status_code, content=None, url=None, headers=None):
+            self.status_code = status_code
+            self.content = content or b''
+            self.url = url
+            self.headers = headers or {}
+
+        @property
+        def text(self):
+            return self.content.decode('utf-8')
+
+        def json(self):
+            return json.loads(self.text)
+
+    class Printer(protocol.Protocol):
+        def __init__(self, finished):
+            self.finished = finished
+            self.data = b''
+
+        def dataReceived(self, bytes):
+            self.data += bytes
+
+        def connectionLost(self, reason):
+            self.finished.callback(self.data)
+
+    @classmethod
+    @defer.inlineCallbacks
+    def request(cls, url, type=None, params=None, headers=None, logger=None, timeout=10):
+        logger = logger or (lambda _: None)
+        typ = type or b'GET'
+
+        if not url:
+            logger('No URL provided\n')
+            defer.returnValue(None)
+        hostname = '/'.join(url.split('/', 3)[:3])
+        if params:
+            url = '{}?{}'.format(url, '&'.join([f'{key}={value}' for key, value in params.items()]))
+
+        headers = headers or {}
+        if 'User-Agent' not in headers:
+            headers['User-Agent'] = ['python-twisted/{}'.format(twisted.__version__)]
+
+        try:
+            proxy = os.getenv('http_proxy') or os.getenv('https_proxy') or os.getenv('HTTP_PROXY') or os.getenv('HTTPS_PROXY')
+            match = cls.PROXY_RE.match(proxy) if proxy else None
+            if match:
+                proxy = HTTPProxyConnector(match.group('host'), int(match.group('port')))
+                agent = Agent(proxy, connectTimeout=timeout)
+            else:
+                agent = Agent(reactor, connectTimeout=timeout)
+
+            response = yield agent.request(typ, url.encode('utf-8'), Headers(headers))
+            finished = defer.Deferred()
+            response.deliverBody(cls.Printer(finished))
+            data = yield finished
+
+            headers = {}
+            for key, values in response.headers.getAllRawHeaders():
+                headers[key.decode('utf-8')] = [value.decode('utf-8') for value in values]
+
+            defer.returnValue(cls.Response(
+                status_code=response.code,
+                headers=headers,
+                content=data,
+                url=url,
+            ))
+            return
+
+        except error.ConnectError as e:
+            logger(f'Failed to connect to {hostname}\n')
+        except _newclient.ResponseFailed:
+            logger(f'No response from {hostname}\n')
+        except ValueError as e:
+            logger(f'{e}\n')
+        except Exception as e:
+            logger(f'Unknown exception when making request:\n{e}\n')
+
+        defer.returnValue(None)


### PR DESCRIPTION
#### 055b0ba705b4bc002b0f0ea7d5c7a9c33998d5da
<pre>
[ews-build.webkit.org] Support proxy Twisted requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=249484">https://bugs.webkit.org/show_bug.cgi?id=249484</a>
rdar://103451811

Reviewed by Dewei Zhu.

Create a Twisted based Response object that closely mirrors the response object
from the requests library, and add support for HTTP_PROXY environment variables.

* Tools/CISupport/ews-build/results_db.py:
(ResultsDatabase.get_results_summary): Use shared TwistedAdditions.request.
(ResultsDatabase.JsonPrinter): Deleted.
* Tools/CISupport/ews-build/twisted_additions.py: Added.
(HTTPProxyConnector): Based on <a href="https://github.com/fmoo/twisted-connect-proxy.">https://github.com/fmoo/twisted-connect-proxy.</a>
(HTTPProxiedClientFactory): Ditto.
(HTTPConnectTunneler): Ditto.
(HTTPConnectSetup): Ditto.
(TwistedAdditions): Added scoping class for some Twisted utilities.
(TwistedAdditions.Response): More ergonomic response class mirroring requests.
(TwistedAdditions.Printer): Generic protocol for consumer responses.
(TwistedAdditions.request): Perform a request a return a deferred respons.

Canonical link: <a href="https://commits.webkit.org/258027@main">https://commits.webkit.org/258027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23da2a99318a6c5f78cf9ce1451476517a9d3fda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100699 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/9844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/33742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/110001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/104687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/10785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106481 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/10785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/33742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/93103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/10785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/33742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/33742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/3563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/99627 "Passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/33742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2878 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->