### PR TITLE
Move the declaration of `applyAdditionalSettings` into `NetworkConnectionIntegrityHelpers.h`

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkConnectionIntegrityHelpers.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkConnectionIntegrityHelpers.h
@@ -29,10 +29,13 @@
 #import <wtf/HashSet.h>
 #import <wtf/text/WTFString.h>
 
+OBJC_CLASS NSURLSession;
+
 namespace WebKit {
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
 
+void configureForNetworkConnectionIntegrity(NSURLSession *);
 void requestLookalikeCharacterStrings(CompletionHandler<void(const HashSet<String>&)>&&);
 
 #endif

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -34,6 +34,7 @@
 #import "Download.h"
 #import "LegacyCustomProtocolManager.h"
 #import "Logging.h"
+#import "NetworkConnectionIntegrityHelpers.h"
 #import "NetworkDataTaskCocoa.h"
 #import "NetworkLoad.h"
 #import "NetworkProcess.h"
@@ -468,14 +469,6 @@ static String stringForSSLCipher(SSLCipherSuite cipher)
 #undef STRINGIFY_CIPHER
 }
 #endif // HAVE(CFNETWORK_METRICS_APIS_V4)
-
-#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/NetworkSessionCocoaAdditions.mm>)
-#import <WebKitAdditions/NetworkSessionCocoaAdditions.mm>
-#else
-namespace WebKit {
-inline static void applyAdditionalSettings(NSURLSession *) { }
-}
-#endif
 
 @interface WKNetworkSessionDelegate : NSObject <NSURLSessionDataDelegate
 #if HAVE(NSURLSESSION_WEBSOCKET)
@@ -1114,7 +1107,9 @@ namespace WebKit {
 static RetainPtr<NSURLSession> createURLSession(NSURLSessionConfiguration *configuration, id<NSURLSessionDelegate> delegate)
 {
     RetainPtr session = [NSURLSession sessionWithConfiguration:configuration delegate:delegate delegateQueue:NSOperationQueue.mainQueue];
-    applyAdditionalSettings(session.get());
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+    configureForNetworkConnectionIntegrity(session.get());
+#endif
     return session;
 }
 


### PR DESCRIPTION
#### fc46521b5a06124e9cdadf987d31d36aea9b6ac2
<pre>
Move the declaration of `applyAdditionalSettings` into `NetworkConnectionIntegrityHelpers.h`
<a href="https://bugs.webkit.org/show_bug.cgi?id=249485">https://bugs.webkit.org/show_bug.cgi?id=249485</a>

Reviewed by Tim Horton.

Refactor some logic in `NetworkSession`.

* Source/WebKit/NetworkProcess/cocoa/NetworkConnectionIntegrityHelpers.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::createURLSession):
(WebKit::applyAdditionalSettings): Deleted.

Canonical link: <a href="https://commits.webkit.org/258012@main">https://commits.webkit.org/258012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac63d84288221599fca6e7cf7c60191309e9305c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109952 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10729 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93050 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107800 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106432 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34719 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3499 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24275 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3515 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9627 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43772 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5498 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5305 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->