### PR TITLE
Get WheelEventTestMonitor out of ScrollingTree

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3016,7 +3016,7 @@ bool EventHandler::handleWheelEventInternal(const PlatformWheelEvent& event, Opt
     LOG_WITH_STREAM(Scrolling, stream << "EventHandler::handleWheelEvent " << event << " processing steps " << processingSteps);
     auto monitor = m_frame.page()->wheelEventTestMonitor();
     if (monitor)
-        monitor->receivedWheelEvent(event);
+        monitor->receivedWheelEventWithPhases(event.phase(), event.momentumPhase());
 
     auto deferrer = WheelEventTestMonitorCompletionDeferrer { monitor.get(), this, WheelEventTestMonitor::DeferReason::HandlingWheelEventOnMainThread };
 #endif

--- a/Source/WebCore/page/WheelEventTestMonitor.cpp
+++ b/Source/WebCore/page/WheelEventTestMonitor.cpp
@@ -111,18 +111,19 @@ void WheelEventTestMonitor::removeDeferralForReason(ScrollableAreaIdentifier ide
     scheduleCallbackCheck();
 }
 
-void WheelEventTestMonitor::receivedWheelEvent(const PlatformWheelEvent& event)
+void WheelEventTestMonitor::receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase)
 {
 #if ENABLE(KINETIC_SCROLLING)
     Locker locker { m_lock };
 
-    if (event.phase() == PlatformWheelEventPhase::Ended || event.phase() == PlatformWheelEventPhase::Cancelled)
+    if (phase == PlatformWheelEventPhase::Ended || phase == PlatformWheelEventPhase::Cancelled)
         m_receivedWheelEndOrCancel = true;
 
-    if (event.momentumPhase() == PlatformWheelEventPhase::Ended)
+    if (momentumPhase == PlatformWheelEventPhase::Ended)
         m_receivedMomentumEnd = true;
 #else
-    UNUSED_PARAM(event);
+    UNUSED_PARAM(phase);
+    UNUSED_PARAM(momentumPhase);
 #endif
 }
 

--- a/Source/WebCore/page/WheelEventTestMonitor.h
+++ b/Source/WebCore/page/WheelEventTestMonitor.h
@@ -60,7 +60,7 @@ public:
     };
     typedef const void* ScrollableAreaIdentifier;
 
-    WEBCORE_EXPORT void receivedWheelEvent(const PlatformWheelEvent&);
+    WEBCORE_EXPORT void receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase);
     WEBCORE_EXPORT void deferForReason(ScrollableAreaIdentifier, DeferReason);
     WEBCORE_EXPORT void removeDeferralForReason(ScrollableAreaIdentifier, DeferReason);
     

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -363,6 +363,27 @@ ScrollingNodeID ScrollingCoordinator::uniqueScrollingNodeID()
     return uniqueScrollingNodeID++;
 }
 
+void ScrollingCoordinator::receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase)
+{
+    ASSERT(isMainThread());
+    if (auto monitor = m_page->wheelEventTestMonitor())
+        monitor->receivedWheelEventWithPhases(phase, momentumPhase);
+}
+
+void ScrollingCoordinator::deferWheelEventTestCompletionForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
+{
+    ASSERT(isMainThread());
+    if (auto monitor = m_page->wheelEventTestMonitor())
+        monitor->deferForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
+}
+
+void ScrollingCoordinator::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
+{
+    ASSERT(isMainThread());
+    if (auto monitor = m_page->wheelEventTestMonitor())
+        monitor->removeDeferralForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
+}
+
 String ScrollingCoordinator::scrollingStateTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior>) const
 {
     return emptyString();

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -31,6 +31,7 @@
 #include "ScrollSnapOffsetsInfo.h"
 #include "ScrollTypes.h"
 #include "ScrollingCoordinatorTypes.h"
+#include "WheelEventTestMonitor.h"
 #include <variant>
 #include <wtf/Forward.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -197,6 +198,10 @@ public:
 
     virtual void startMonitoringWheelEvents(bool /* clearLatchingState */) { }
     virtual void stopMonitoringWheelEvents() { }
+
+    void receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase);
+    void deferWheelEventTestCompletionForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason);
+    void removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason);
 
 protected:
     explicit ScrollingCoordinator(Page*);

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -147,7 +147,7 @@ WheelEventHandlingResult ScrollingTree::handleWheelEvent(const PlatformWheelEven
     Locker locker { m_treeLock };
 
     if (isMonitoringWheelEvents())
-        receivedWheelEvent(wheelEvent);
+        receivedWheelEventWithPhases(wheelEvent.phase(), wheelEvent.momentumPhase());
 
     m_latchingController.receivedWheelEvent(wheelEvent, processingSteps, m_allowLatching);
 
@@ -515,30 +515,6 @@ std::optional<ScrollingNodeID> ScrollingTree::latchedNodeID() const
 void ScrollingTree::clearLatchedNode()
 {
     m_latchingController.clearLatchedNode();
-}
-
-void ScrollingTree::receivedWheelEvent(const PlatformWheelEvent& event)
-{
-    if (m_wheelEventTestMonitor)
-        m_wheelEventTestMonitor->receivedWheelEvent(event);
-}
-
-void ScrollingTree::deferWheelEventTestCompletionForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
-{
-    if (!m_wheelEventTestMonitor)
-        return;
-
-    LOG_WITH_STREAM(WheelEventTestMonitor, stream << "    (!) ScrollingTree::deferForReason: Deferring on " << nodeID << " for reason " << reason);
-    m_wheelEventTestMonitor->deferForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
-}
-
-void ScrollingTree::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
-{
-    if (!m_wheelEventTestMonitor)
-        return;
-
-    LOG_WITH_STREAM(WheelEventTestMonitor, stream << "    (!) ScrollingTree::removeDeferralForReason: Removing deferral on " << nodeID << " for reason " << reason);
-    m_wheelEventTestMonitor->removeDeferralForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
 }
 
 FloatPoint ScrollingTree::mainFrameScrollPosition() const

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -159,10 +159,9 @@ public:
 
     WEBCORE_EXPORT TrackingType eventTrackingTypeForPoint(EventTrackingRegions::EventType, IntPoint);
 
-    WheelEventTestMonitor* wheelEventTestMonitor() { return m_wheelEventTestMonitor.get(); }
-    void setWheelEventTestMonitor(RefPtr<WheelEventTestMonitor>&& monitor) { m_wheelEventTestMonitor = WTFMove(monitor); }
-    void deferWheelEventTestCompletionForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason);
-    void removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason);
+    virtual void receivedWheelEventWithPhases(PlatformWheelEventPhase /* phase */, PlatformWheelEventPhase /* momentumPhase */) { }
+    virtual void deferWheelEventTestCompletionForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason) { }
+    virtual void removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason) { }
 
 #if PLATFORM(MAC)
     virtual void handleWheelEventPhase(ScrollingNodeID, PlatformWheelEventPhase) = 0;
@@ -280,8 +279,6 @@ private:
 
     OptionSet<WheelEventProcessingSteps> computeWheelProcessingSteps(const PlatformWheelEvent&) WTF_REQUIRES_LOCK(m_treeStateLock);
 
-    void receivedWheelEvent(const PlatformWheelEvent&);
-
     RefPtr<ScrollingTreeFrameScrollingNode> m_rootNode;
 
     using ScrollingTreeNodeMap = HashMap<ScrollingNodeID, RefPtr<ScrollingTreeNode>>;
@@ -330,8 +327,6 @@ private:
     Lock m_lastWheelEventTimeLock;
     MonotonicTime m_lastWheelEventTime WTF_GUARDED_BY_LOCK(m_lastWheelEventTimeLock);
 
-    RefPtr<WheelEventTestMonitor> m_wheelEventTestMonitor;
-
 protected:
     bool m_allowLatching { true };
 
@@ -344,6 +339,27 @@ private:
     bool m_wheelEventGesturesBecomeNonBlocking { false };
     bool m_needsApplyLayerPositionsAfterCommit { false };
     bool m_inCommitTreeState { false };
+};
+
+class ScrollingTreeWheelEventTestMonitorCompletionDeferrer {
+public:
+    ScrollingTreeWheelEventTestMonitorCompletionDeferrer(ScrollingTree& scrollingTree, ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
+        : m_scrollingTree(scrollingTree)
+        , m_scrollingNodeID(nodeID)
+        , m_deferReason(reason)
+    {
+        m_scrollingTree->deferWheelEventTestCompletionForReason(m_scrollingNodeID, m_deferReason);
+    }
+    
+    ~ScrollingTreeWheelEventTestMonitorCompletionDeferrer()
+    {
+        m_scrollingTree->removeWheelEventTestCompletionDeferralForReason(m_scrollingNodeID, m_deferReason);
+    }
+
+private:
+    Ref<ScrollingTree> m_scrollingTree;
+    ScrollingNodeID m_scrollingNodeID;
+    WheelEventTestMonitor::DeferReason m_deferReason;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
@@ -139,13 +139,6 @@ void ThreadedScrollingCoordinator::startMonitoringWheelEvents(bool clearLatching
 {
     if (clearLatchingState)
         scrollingTree()->clearLatchedNode();
-    auto monitor = m_page->wheelEventTestMonitor();
-    scrollingTree()->setWheelEventTestMonitor(WTFMove(monitor));
-}
-
-void ThreadedScrollingCoordinator::stopMonitoringWheelEvents()
-{
-    scrollingTree()->setWheelEventTestMonitor(nullptr);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.h
@@ -51,7 +51,6 @@ private:
     WEBCORE_EXPORT void wheelEventWasProcessedByMainThread(const PlatformWheelEvent&, std::optional<WheelScrollGestureState>) final;
 
     WEBCORE_EXPORT void startMonitoringWheelEvents(bool clearLatchingState) final;
-    WEBCORE_EXPORT void stopMonitoringWheelEvents() final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
@@ -116,6 +116,10 @@ private:
     
     bool scrollingThreadIsActive();
 
+    void receivedWheelEventWithPhases(PlatformWheelEventPhase, PlatformWheelEventPhase) final;
+    void deferWheelEventTestCompletionForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason) final;
+    void removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason) final;
+
     void lockLayersForHitTesting() final WTF_ACQUIRES_LOCK(m_layerHitTestMutex);
     void unlockLayersForHitTesting() final WTF_RELEASES_LOCK(m_layerHitTestMutex);
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -80,7 +80,7 @@ bool ScrollingTreeScrollingNodeDelegateMac::handleWheelEvent(const PlatformWheel
         [m_horizontalScrollerImp setUsePresentationValue:m_inMomentumPhase];
     }
 
-    auto deferrer = WheelEventTestMonitorCompletionDeferrer { scrollingTree().wheelEventTestMonitor(), reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(scrollingNode().scrollingNodeID()), WheelEventTestMonitor::HandlingWheelEvent };
+    auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { scrollingTree(), scrollingNode().scrollingNodeID(), WheelEventTestMonitor::HandlingWheelEvent };
 
     updateUserScrollInProgressForEvent(wheelEvent);
 

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp
@@ -49,7 +49,7 @@ void ScrollingTreeScrollingNodeDelegateNicosia::updateVisibleLengths()
 
 bool ScrollingTreeScrollingNodeDelegateNicosia::handleWheelEvent(const PlatformWheelEvent& wheelEvent)
 {
-    auto deferrer = WheelEventTestMonitorCompletionDeferrer { scrollingTree().wheelEventTestMonitor(), reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(scrollingNode().scrollingNodeID()), WheelEventTestMonitor::HandlingWheelEvent };
+    auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { scrollingTree(), scrollingNode().scrollingNodeID(), WheelEventTestMonitor::HandlingWheelEvent };
 
     updateUserScrollInProgressForEvent(wheelEvent);
 

--- a/Source/WebCore/platform/PlatformWheelEvent.cpp
+++ b/Source/WebCore/platform/PlatformWheelEvent.cpp
@@ -85,31 +85,26 @@ PlatformWheelEvent PlatformWheelEvent::createFromGesture(const PlatformGestureEv
 
 #endif // ENABLE(MAC_GESTURE_EVENTS)
 
-#if ENABLE(KINETIC_SCROLLING)
-
 TextStream& operator<<(TextStream& ts, PlatformWheelEventPhase phase)
 {
     switch (phase) {
     case PlatformWheelEventPhase::None: ts << "none"; break;
+#if ENABLE(KINETIC_SCROLLING)
     case PlatformWheelEventPhase::Began: ts << "began"; break;
     case PlatformWheelEventPhase::Stationary: ts << "stationary"; break;
     case PlatformWheelEventPhase::Changed: ts << "changed"; break;
     case PlatformWheelEventPhase::Ended: ts << "ended"; break;
     case PlatformWheelEventPhase::Cancelled: ts << "cancelled"; break;
     case PlatformWheelEventPhase::MayBegin: ts << "mayBegin"; break;
+#endif
     }
     return ts;
 }
 
-#endif
-
 TextStream& operator<<(TextStream& ts, const PlatformWheelEvent& event)
 {
     ts << "PlatformWheelEvent " << &event << " at " << event.position() << " deltaX " << event.deltaX() << " deltaY " << event.deltaY();
-
-#if ENABLE(KINETIC_SCROLLING)
     ts << " phase \"" << event.phase() << "\" momentum phase \"" << event.momentumPhase() << "\"";
-#endif
     ts << " velocity " << event.scrollingVelocity();
 
     return ts;

--- a/Source/WebCore/platform/PlatformWheelEvent.h
+++ b/Source/WebCore/platform/PlatformWheelEvent.h
@@ -62,21 +62,20 @@ enum PlatformWheelEventGranularity : uint8_t {
     ScrollByPixelWheelEvent,
 };
 
-#if ENABLE(KINETIC_SCROLLING)
-
 enum class PlatformWheelEventPhase : uint8_t {
     None        = 0,
+#if ENABLE(KINETIC_SCROLLING)
     Began       = 1 << 0,
     Stationary  = 1 << 1,
     Changed     = 1 << 2,
     Ended       = 1 << 3,
     Cancelled   = 1 << 4,
     MayBegin    = 1 << 5,
+#endif
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, PlatformWheelEventPhase);
 
-#endif
 
 #if PLATFORM(WIN)
 // How many pixels should we scroll per line? Gecko uses the height of the
@@ -173,10 +172,10 @@ public:
     bool useLatchedEventElement() const { return false; }
 #endif
 
-#if ENABLE(KINETIC_SCROLLING)
     PlatformWheelEventPhase phase() const { return m_phase; }
     PlatformWheelEventPhase momentumPhase() const { return m_momentumPhase; }
 
+#if ENABLE(KINETIC_SCROLLING)
     bool isGestureStart() const;
     bool isGestureCancel() const;
 
@@ -207,10 +206,9 @@ protected:
     // Scrolling velocity in pixels per second.
     FloatSize m_scrollingVelocity;
 
-#if ENABLE(KINETIC_SCROLLING)
     PlatformWheelEventPhase m_phase { PlatformWheelEventPhase::None };
     PlatformWheelEventPhase m_momentumPhase { PlatformWheelEventPhase::None };
-#endif
+
 #if PLATFORM(COCOA)
     WallTime m_ioHIDEventTimestamp;
     std::optional<FloatSize> m_rawPlatformDelta;


### PR DESCRIPTION
#### 69b12c5f50b343cd28d0300a828947acbec88988
<pre>
Get WheelEventTestMonitor out of ScrollingTree
<a href="https://bugs.webkit.org/show_bug.cgi?id=249443">https://bugs.webkit.org/show_bug.cgi?id=249443</a>
&lt;rdar://problem/103427202&gt;

Reviewed by Tim Horton.

WheelEventTestMonitor is used by layout tests that use
`monitorWheelEvents()/waitForScrollCompletion()`. To make these tests work with UI-side
compositing, we have to send defer/removeDeferral messages from the UI process to the
Page-owned WheelEventTestMonitor in the web process, so ScrollingTree can&apos;t have a
reference to the Page&apos;s WheelEventTestMonitor as it does now.

So remove ScrollingTree&apos;s reference to WheelEventTestMonitor, and send messages via the
ScrollingCoordinator to the Page&apos;s WheelEventTestMonitor.

Add ScrollingTreeWheelEventTestMonitorCompletionDeferrer as a convenience RAII class
that starts/stops deferral given a ScrollingTree, ScrollingNodeID and reason.

Also change `receivedWheelEvent(const PlatformWheelEvent&amp;)` to
`receivedWheelEventWithPhases(PlatformWheelEventPhase, PlatformWheelEventPhase)` so we
don&apos;t have to IPC-encode PlatformWheelEvent when a future patch sends this back from the
UI process to the web process. To reduce #ifdeffing, expose PlatformWheelEventPhase for
non-ENABLE(KINETIC_SCROLLING) platforms, but just with the `None` value.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleWheelEventInternal):
* Source/WebCore/page/WheelEventTestMonitor.cpp:
(WebCore::WheelEventTestMonitor::receivedWheelEventWithPhases):
(WebCore::WheelEventTestMonitor::receivedWheelEvent): Deleted.
* Source/WebCore/page/WheelEventTestMonitor.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::receivedWheelEventWithPhases):
(WebCore::ScrollingCoordinator::deferWheelEventTestCompletionForReason):
(WebCore::ScrollingCoordinator::removeWheelEventTestCompletionDeferralForReason):
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::handleWheelEvent):
(WebCore::ScrollingTree::receivedWheelEvent): Deleted.
(WebCore::ScrollingTree::deferWheelEventTestCompletionForReason): Deleted.
(WebCore::ScrollingTree::removeWheelEventTestCompletionDeferralForReason): Deleted.
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::receivedWheelEventWithPhases):
(WebCore::ScrollingTree::deferWheelEventTestCompletionForReason):
(WebCore::ScrollingTree::removeWheelEventTestCompletionDeferralForReason):
(WebCore::ScrollingTreeWheelEventTestMonitorCompletionDeferrer::ScrollingTreeWheelEventTestMonitorCompletionDeferrer):
(WebCore::ScrollingTreeWheelEventTestMonitorCompletionDeferrer::~ScrollingTreeWheelEventTestMonitorCompletionDeferrer):
(WebCore::ScrollingTree::wheelEventTestMonitor): Deleted.
(WebCore::ScrollingTree::setWheelEventTestMonitor): Deleted.
* Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp:
(WebCore::ThreadedScrollingCoordinator::startMonitoringWheelEvents):
(WebCore::ThreadedScrollingCoordinator::stopMonitoringWheelEvents): Deleted.
* Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::scrollingTreeNodeDidScroll):
(WebCore::ThreadedScrollingTree::receivedWheelEventWithPhases):
(WebCore::ThreadedScrollingTree::deferWheelEventTestCompletionForReason):
(WebCore::ThreadedScrollingTree::removeWheelEventTestCompletionDeferralForReason):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::handleWheelEvent):
* Source/WebCore/platform/PlatformWheelEvent.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/PlatformWheelEvent.h:

Canonical link: <a href="https://commits.webkit.org/258031@main">https://commits.webkit.org/258031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d63eb027af6c799660af9767bf3bce0c18bdb9f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100661 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109963 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170235 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104646 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10741 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93062 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107808 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34727 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90029 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22757 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3506 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24287 "Found 1 new test failure: fast/scrolling/arrow-key-scroll-in-rtl-document.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3525 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9637 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43784 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5512 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5312 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->