### PR TITLE
[git-webkit] Cap identifier and revision size

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.10.0',
+    version='5.10.1',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 10, 0)
+version = Version(5, 10, 1)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py
@@ -31,9 +31,9 @@ from webkitscmpy import Contributor
 
 class Commit(object):
     HASH_RE = re.compile(r'^[a-f0-9A-F]+$')
-    REVISION_RE = re.compile(r'^[Rr]?(?P<revision>\d+)$')
-    IDENTIFIER_RE = re.compile(r'^((?P<branch_point>\d+)\.)?(?P<identifier>-?\d+)(@(?P<branch>\S*))?$')
-    NUMBER_RE = re.compile(r'^-?\d*$')
+    REVISION_RE = re.compile(r'^[Rr]?(?P<revision>\d{1,10})$')
+    IDENTIFIER_RE = re.compile(r'^((?P<branch_point>\d{1,10})\.)?(?P<identifier>-?\d{1,10})(@(?P<branch>\S*))?$')
+    NUMBER_RE = re.compile(r'^-?\d{1,10}$')
     HASH_LABEL_SIZE = 12
     UUID_MULTIPLIER = 100
 
@@ -87,7 +87,7 @@ class Commit(object):
             match = cls.REVISION_RE.match(revision)
             if match:
                 revision = int(match.group('revision'))
-            elif revision.isdigit():
+            elif cls.NUMBER_RE.match(revision):
                 revision = int(revision)
             else:
                 if do_assert:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py
@@ -60,6 +60,7 @@ class TestCommit(unittest.TestCase):
         self.assertEqual(None, Commit._parse_revision('-1'))
         self.assertEqual(None, Commit._parse_revision('3.141592'))
         self.assertEqual(None, Commit._parse_revision(3.141592))
+        self.assertEqual(None, Commit._parse_revision('12345678901'))
 
     def test_parse_identifier(self):
         self.assertEqual((None, 1234, None), Commit._parse_identifier('1234'))
@@ -80,6 +81,7 @@ class TestCommit(unittest.TestCase):
         self.assertEqual(None, Commit._parse_identifier('r266896'))
         self.assertEqual(None, Commit._parse_identifier('c3bd784f8b88bd03'))
         self.assertEqual(None, Commit._parse_identifier(3.141592))
+        self.assertEqual(None, Commit._parse_identifier('12345678901'))
 
     def test_parse(self):
         self.assertEqual(Commit.parse('123@main'), Commit(identifier=123, branch='main'))
@@ -90,6 +92,10 @@ class TestCommit(unittest.TestCase):
         self.assertEqual(
             Commit.parse('c3bd784f8b88bd03f64467ddd3304ed8be28acbe'),
             Commit(hash='c3bd784f8b88bd03f64467ddd3304ed8be28acbe'),
+        )
+        self.assertEqual(
+            Commit.parse('12345678901'),
+            Commit(hash='12345678901'),
         )
 
     def test_pretty_print(self):


### PR DESCRIPTION
#### b38081b1f8544e6f6a546c6704b9463a976fdd0c
<pre>
[git-webkit] Cap identifier and revision size
<a href="https://bugs.webkit.org/show_bug.cgi?id=249496">https://bugs.webkit.org/show_bug.cgi?id=249496</a>
rdar://103457359

Reviewed by Elliott Williams.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py:
(Commit): Cap integers at 10 billion.
(Commit._parse_revision): Use NUMBER_RE.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py:
(TestCommit.test_parse_revision):
(TestCommit.test_parse_identifier):
(TestCommit.test_parse):

Canonical link: <a href="https://commits.webkit.org/258020@main">https://commits.webkit.org/258020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99271fd7880b9a4ccb97e6651facc228cf444e3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/100692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/9837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/33735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/109994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/104679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/10771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/106474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/10771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/33735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/93096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/104213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/10771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/33735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/33735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/3556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/99620 "Passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/33735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90150 "Build is in progress. Recent messages:") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/37/builds/90150 "Build is in progress. Recent messages:") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2874 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->