### PR TITLE
WebKit engine support for Badging API

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -253,7 +253,18 @@ AnimatedImageAsyncDecodingEnabled:
       default: true
     WebCore:
       default: true
-      
+
+AppBadgeEnabled:
+  type: bool
+  condition: ENABLE(BADGING)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 AppHighlightsEnabled:
   type: bool
   condition: ENABLE(APP_HIGHLIGHTS)
@@ -375,6 +386,17 @@ CanvasUsesAcceleratedDrawing:
 
 CaretBrowsingEnabled:
   type: bool
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
+ClientBadgeEnabled:
+  type: bool
+  condition: ENABLE(BADGING)
   defaultValue:
     WebKitLegacy:
       default: false

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -560,6 +560,10 @@
 #define ENABLE_WEBXR_HANDS 0
 #endif
 
+#if !defined(ENABLE_BADGING)
+#define ENABLE_BADGING 1
+#endif
+
 /*
  * Enable this to put each IsoHeap and other allocation categories into their own malloc heaps, so that tools like vmmap can show how big each heap is.
  * Turn BENABLE_MALLOC_HEAP_BREAKDOWN on in bmalloc together when using this.

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -25,6 +25,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/Modules/applicationmanifest"
     "${WEBCORE_DIR}/Modules/async-clipboard"
     "${WEBCORE_DIR}/Modules/audiosession"
+    "${WEBCORE_DIR}/Modules/badge"
     "${WEBCORE_DIR}/Modules/beacon"
     "${WEBCORE_DIR}/Modules/cache"
     "${WEBCORE_DIR}/Modules/compression"
@@ -209,6 +210,7 @@ set(WebCore_IDL_INCLUDES
 
     Modules/WebGPU
     Modules/airplay
+    Modules/badge
     Modules/cache
     Modules/compression
     Modules/credentialmanagement
@@ -260,6 +262,9 @@ set(WebCore_NON_SVG_IDL_FILES
 
     Modules/audiosession/DOMAudioSession.idl
     Modules/audiosession/Navigator+AudioSession.idl
+
+    Modules/badge/Navigator+Badge.idl
+    Modules/badge/NavigatorBadge.idl
 
     Modules/beacon/Navigator+Beacon.idl
 

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -231,6 +231,8 @@ $(PROJECT_DIR)/Modules/async-clipboard/ClipboardItem.idl
 $(PROJECT_DIR)/Modules/async-clipboard/Navigator+Clipboard.idl
 $(PROJECT_DIR)/Modules/audiosession/DOMAudioSession.idl
 $(PROJECT_DIR)/Modules/audiosession/Navigator+AudioSession.idl
+$(PROJECT_DIR)/Modules/badge/Navigator+Badge.idl
+$(PROJECT_DIR)/Modules/badge/NavigatorBadge.idl
 $(PROJECT_DIR)/Modules/beacon/Navigator+Beacon.idl
 $(PROJECT_DIR)/Modules/cache/CacheQueryOptions.idl
 $(PROJECT_DIR)/Modules/cache/DOMCache.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1751,6 +1751,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigationPreloadState.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigationPreloadState.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+AudioSession.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+AudioSession.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Badge.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Badge.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Beacon.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Beacon.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Clipboard.cpp
@@ -1787,6 +1789,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+WebXR.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+WebXR.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorBadge.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorBadge.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorCookies.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorCookies.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorGPU.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -252,6 +252,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/async-clipboard/Navigator+Clipboard.idl \
     $(WebCore)/Modules/audiosession/DOMAudioSession.idl \
     $(WebCore)/Modules/audiosession/Navigator+AudioSession.idl \
+    $(WebCore)/Modules/badge/Navigator+Badge.idl \
+    $(WebCore)/Modules/badge/NavigatorBadge.idl \
     $(WebCore)/Modules/beacon/Navigator+Beacon.idl \
     $(WebCore)/Modules/cache/CacheQueryOptions.idl \
     $(WebCore)/Modules/cache/DOMCache.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -145,6 +145,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/applicationmanifest/ApplicationManifest.h
     Modules/applicationmanifest/ApplicationManifestParser.h
 
+    Modules/badge/BadgeClient.h
+    Modules/badge/EmptyBadgeClient.h
+    Modules/badge/WorkerBadgeProxy.h
+
     Modules/cache/CacheQueryOptions.h
     Modules/cache/CacheStorageConnection.h
     Modules/cache/DOMCacheEngine.h

--- a/Source/WebCore/Modules/badge/BadgeClient.h
+++ b/Source/WebCore/Modules/badge/BadgeClient.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class Page;
+struct SecurityOriginData;
+
+class BadgeClient : public RefCounted<BadgeClient> {
+public:
+    virtual ~BadgeClient() = default;
+
+    virtual void setAppBadge(Page*, const SecurityOriginData&, std::optional<uint64_t>) = 0;
+    virtual void setClientBadge(Page&, const SecurityOriginData&, std::optional<uint64_t>) = 0;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/badge/EmptyBadgeClient.h
+++ b/Source/WebCore/Modules/badge/EmptyBadgeClient.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "BadgeClient.h"
+
+namespace WebCore {
+
+class EmptyBadgeClient final : public BadgeClient {
+public:
+    static Ref<EmptyBadgeClient> create()
+    {
+        return adoptRef(*new EmptyBadgeClient);
+    }
+private:
+    void setAppBadge(Page*, const SecurityOriginData&, std::optional<uint64_t>) final { }
+    void setClientBadge(Page&, const SecurityOriginData&, std::optional<uint64_t>) final { }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/badge/Navigator+Badge.idl
+++ b/Source/WebCore/Modules/badge/Navigator+Badge.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=BADGING,
+    EnabledBySetting=ClientBadgeEnabled
+] partial interface Navigator {
+    [SecureContext] Promise<undefined> setClientBadge(optional [EnforceRange] unsigned long long contents);
+    [SecureContext] Promise<undefined> clearClientBadge();
+};

--- a/Source/WebCore/Modules/badge/NavigatorBadge.idl
+++ b/Source/WebCore/Modules/badge/NavigatorBadge.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=BADGING,
+    EnabledBySetting=AppBadgeEnabled
+] interface mixin NavigatorBadge {
+    [SecureContext] Promise<undefined> setAppBadge(optional [EnforceRange] unsigned long long contents);
+    [SecureContext] Promise<undefined> clearAppBadge();
+};

--- a/Source/WebCore/Modules/badge/WorkerBadgeProxy.h
+++ b/Source/WebCore/Modules/badge/WorkerBadgeProxy.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+class WorkerBadgeProxy {
+public:
+    virtual ~WorkerBadgeProxy() = default;
+
+    virtual void setAppBadge(std::optional<uint64_t>) = 0;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -31,6 +31,7 @@
 #include "AppHighlight.h"
 #include "ApplicationCacheStorage.h"
 #include "BackForwardClient.h"
+#include "BadgeClient.h"
 #include "BroadcastChannelRegistry.h"
 #include "CacheStorageProvider.h"
 #include "ColorChooser.h"
@@ -50,6 +51,7 @@
 #include "DummyStorageProvider.h"
 #include "EditorClient.h"
 #include "EmptyAttachmentElementClient.h"
+#include "EmptyBadgeClient.h"
 #include "EmptyFrameLoaderClient.h"
 #include "FormState.h"
 #include "Frame.h"
@@ -1199,7 +1201,8 @@ PageConfiguration pageConfigurationWithEmptyClients(PAL::SessionID sessionID)
         makeUniqueRef<EmptyMediaRecorderProvider>(),
         EmptyBroadcastChannelRegistry::create(),
         makeUniqueRef<DummyStorageProvider>(),
-        makeUniqueRef<DummyModelPlayerProvider>()
+        makeUniqueRef<DummyModelPlayerProvider>(),
+        EmptyBadgeClient::create()
     };
 
     static NeverDestroyed<EmptyChromeClient> dummyChromeClient;

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -23,6 +23,7 @@
 #include "config.h"
 #include "Navigator.h"
 
+#include "BadgeClient.h"
 #include "Chrome.h"
 #include "CookieJar.h"
 #include "DOMMimeType.h"
@@ -382,5 +383,55 @@ GPU* Navigator::gpu()
 
     return m_gpuForWebGPU.get();
 }
+
+#if ENABLE(BADGING)
+
+void Navigator::setAppBadge(std::optional<unsigned long long> badge, Ref<DeferredPromise>&& promise)
+{
+    auto* frame = this->frame();
+    if (!frame) {
+        promise->reject();
+        return;
+    }
+
+    auto* page = frame->page();
+    if (!page) {
+        promise->reject();
+        return;
+    }
+
+    page->badgeClient().setAppBadge(page, SecurityOriginData::fromFrame(frame), badge);
+    promise->resolve();
+}
+
+void Navigator::clearAppBadge(Ref<DeferredPromise>&& promise)
+{
+    setAppBadge(0, WTFMove(promise));
+}
+
+void Navigator::setClientBadge(std::optional<unsigned long long> badge, Ref<DeferredPromise>&& promise)
+{
+    auto* frame = this->frame();
+    if (!frame) {
+        promise->reject();
+        return;
+    }
+
+    auto* page = frame->page();
+    if (!page) {
+        promise->reject();
+        return;
+    }
+
+    page->badgeClient().setClientBadge(*page, SecurityOriginData::fromFrame(frame), badge);
+    promise->resolve();
+}
+
+void Navigator::clearClientBadge(Ref<DeferredPromise>&& promise)
+{
+    setClientBadge(0, WTFMove(promise));
+}
+
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -67,6 +67,14 @@ public:
 
     GPU* gpu();
 
+#if ENABLE(BADGING)
+    void setAppBadge(std::optional<unsigned long long>, Ref<DeferredPromise>&&);
+    void clearAppBadge(Ref<DeferredPromise>&&);
+
+    void setClientBadge(std::optional<unsigned long long>, Ref<DeferredPromise>&&);
+    void clearClientBadge(Ref<DeferredPromise>&&);
+#endif
+
 private:
     void showShareData(ExceptionOr<ShareDataWithParsedURL&>, Ref<DeferredPromise>&&);
     explicit Navigator(ScriptExecutionContext*, DOMWindow&);

--- a/Source/WebCore/page/Navigator.idl
+++ b/Source/WebCore/page/Navigator.idl
@@ -32,6 +32,7 @@
     undefined getStorageUpdates();
 };
 
+Navigator includes NavigatorBadge;
 Navigator includes NavigatorID;
 Navigator includes NavigatorLanguage;
 Navigator includes NavigatorLocks;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -351,6 +351,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
     , m_attachmentElementClient(WTFMove(pageConfiguration.attachmentElementClient))
 #endif
     , m_contentSecurityPolicyModeForExtension(WTFMove(pageConfiguration.contentSecurityPolicyModeForExtension))
+    , m_badgeClient(WTFMove(pageConfiguration.badgeClient))
 {
     updateTimerThrottlingState();
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -22,6 +22,7 @@
 
 #include "ActivityState.h"
 #include "AnimationFrameRate.h"
+#include "BadgeClient.h"
 #include "Color.h"
 #include "ContentSecurityPolicy.h"
 #include "DisabledAdaptations.h"
@@ -994,6 +995,9 @@ public:
 #if ENABLE(IMAGE_ANALYSIS)
     WEBCORE_EXPORT void analyzeImagesForFindInPage(Function<void()>&& callback);
 #endif
+
+    BadgeClient& badgeClient() { return m_badgeClient.get(); }
+
 private:
     struct Navigation {
         RegistrableDomain domain;
@@ -1354,6 +1358,8 @@ private:
 #endif
 
     ContentSecurityPolicyModeForExtension m_contentSecurityPolicyModeForExtension { ContentSecurityPolicyModeForExtension::None };
+
+    Ref<BadgeClient> m_badgeClient;
 };
 
 inline PageGroup& Page::group()

--- a/Source/WebCore/page/PageConfiguration.cpp
+++ b/Source/WebCore/page/PageConfiguration.cpp
@@ -30,6 +30,7 @@
 #include "ApplicationCacheStorage.h"
 #include "AttachmentElementClient.h"
 #include "BackForwardClient.h"
+#include "BadgeClient.h"
 #include "BroadcastChannelRegistry.h"
 #include "CacheStorageProvider.h"
 #include "CookieJar.h"
@@ -63,7 +64,7 @@
 
 namespace WebCore {
 
-PageConfiguration::PageConfiguration(PAL::SessionID sessionID, UniqueRef<EditorClient>&& editorClient, Ref<SocketProvider>&& socketProvider, UniqueRef<WebRTCProvider>&& webRTCProvider, Ref<CacheStorageProvider>&& cacheStorageProvider, Ref<UserContentProvider>&& userContentProvider, Ref<BackForwardClient>&& backForwardClient, Ref<CookieJar>&& cookieJar, UniqueRef<ProgressTrackerClient>&& progressTrackerClient, UniqueRef<FrameLoaderClient>&& loaderClientForMainFrame, UniqueRef<SpeechRecognitionProvider>&& speechRecognitionProvider, UniqueRef<MediaRecorderProvider>&& mediaRecorderProvider, Ref<BroadcastChannelRegistry>&& broadcastChannelRegistry, UniqueRef<StorageProvider>&& storageProvider, UniqueRef<ModelPlayerProvider>&& modelPlayerProvider)
+PageConfiguration::PageConfiguration(PAL::SessionID sessionID, UniqueRef<EditorClient>&& editorClient, Ref<SocketProvider>&& socketProvider, UniqueRef<WebRTCProvider>&& webRTCProvider, Ref<CacheStorageProvider>&& cacheStorageProvider, Ref<UserContentProvider>&& userContentProvider, Ref<BackForwardClient>&& backForwardClient, Ref<CookieJar>&& cookieJar, UniqueRef<ProgressTrackerClient>&& progressTrackerClient, UniqueRef<FrameLoaderClient>&& loaderClientForMainFrame, UniqueRef<SpeechRecognitionProvider>&& speechRecognitionProvider, UniqueRef<MediaRecorderProvider>&& mediaRecorderProvider, Ref<BroadcastChannelRegistry>&& broadcastChannelRegistry, UniqueRef<StorageProvider>&& storageProvider, UniqueRef<ModelPlayerProvider>&& modelPlayerProvider, Ref<BadgeClient>&& badgeClient)
     : sessionID(sessionID)
     , editorClient(WTFMove(editorClient))
     , socketProvider(WTFMove(socketProvider))
@@ -79,6 +80,7 @@ PageConfiguration::PageConfiguration(PAL::SessionID sessionID, UniqueRef<EditorC
     , mediaRecorderProvider(WTFMove(mediaRecorderProvider))
     , storageProvider(WTFMove(storageProvider))
     , modelPlayerProvider(WTFMove(modelPlayerProvider))
+    , badgeClient(WTFMove(badgeClient))
 {
 }
 

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -52,6 +52,7 @@ class ApplicationCacheStorage;
 class AttachmentElementClient;
 class AuthenticatorCoordinatorClient;
 class BackForwardClient;
+class BadgeClient;
 class BroadcastChannelRegistry;
 class CacheStorageProvider;
 class ChromeClient;
@@ -85,7 +86,7 @@ class WebRTCProvider;
 class PageConfiguration {
     WTF_MAKE_NONCOPYABLE(PageConfiguration); WTF_MAKE_FAST_ALLOCATED;
 public:
-    WEBCORE_EXPORT PageConfiguration(PAL::SessionID, UniqueRef<EditorClient>&&, Ref<SocketProvider>&&, UniqueRef<WebRTCProvider>&&, Ref<CacheStorageProvider>&&, Ref<UserContentProvider>&&, Ref<BackForwardClient>&&, Ref<CookieJar>&&, UniqueRef<ProgressTrackerClient>&&, UniqueRef<FrameLoaderClient>&&, UniqueRef<SpeechRecognitionProvider>&&, UniqueRef<MediaRecorderProvider>&&, Ref<BroadcastChannelRegistry>&&, UniqueRef<StorageProvider>&&, UniqueRef<ModelPlayerProvider>&&);
+    WEBCORE_EXPORT PageConfiguration(PAL::SessionID, UniqueRef<EditorClient>&&, Ref<SocketProvider>&&, UniqueRef<WebRTCProvider>&&, Ref<CacheStorageProvider>&&, Ref<UserContentProvider>&&, Ref<BackForwardClient>&&, Ref<CookieJar>&&, UniqueRef<ProgressTrackerClient>&&, UniqueRef<FrameLoaderClient>&&, UniqueRef<SpeechRecognitionProvider>&&, UniqueRef<MediaRecorderProvider>&&, Ref<BroadcastChannelRegistry>&&, UniqueRef<StorageProvider>&&, UniqueRef<ModelPlayerProvider>&&, Ref<BadgeClient>&&);
     WEBCORE_EXPORT ~PageConfiguration();
     PageConfiguration(PageConfiguration&&);
 
@@ -136,7 +137,7 @@ public:
     RefPtr<VisitedLinkStore> visitedLinkStore;
     Ref<BroadcastChannelRegistry> broadcastChannelRegistry;
     WeakPtr<ScreenOrientationManager> screenOrientationManager;
-    
+
 #if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
     RefPtr<DeviceOrientationUpdateProvider> deviceOrientationUpdateProvider;
 #endif
@@ -158,6 +159,8 @@ public:
 #if ENABLE(ATTACHMENT_ELEMENT)
     std::unique_ptr<AttachmentElementClient> attachmentElementClient;
 #endif
+
+    Ref<BadgeClient> badgeClient;
 
     ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension { WebCore::ContentSecurityPolicyModeForExtension::None };
     std::optional<FrameIdentifier> mainFrameIdentifier;

--- a/Source/WebCore/page/WorkerNavigator.cpp
+++ b/Source/WebCore/page/WorkerNavigator.cpp
@@ -27,6 +27,11 @@
 #include "config.h"
 #include "WorkerNavigator.h"
 
+#include "JSDOMPromiseDeferred.h"
+#include "WorkerBadgeProxy.h"
+#include "WorkerGlobalScope.h"
+#include "WorkerThread.h"
+
 namespace WebCore {
 
 WorkerNavigator::WorkerNavigator(ScriptExecutionContext& context, const String& userAgent, bool isOnline)
@@ -51,5 +56,25 @@ GPU* WorkerNavigator::gpu()
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=233622 Implement this.
     return nullptr;
 }
+
+#if ENABLE(BADGING)
+void WorkerNavigator::setAppBadge(std::optional<unsigned long long> badge, Ref<DeferredPromise>&& promise)
+{
+    auto* scope = downcast<WorkerGlobalScope>(scriptExecutionContext());
+    if (!scope) {
+        promise->reject();
+        return;
+    }
+
+    scope->thread().workerBadgeProxy().setAppBadge(badge);
+    promise->resolve();
+}
+
+void WorkerNavigator::clearAppBadge(Ref<DeferredPromise>&& promise)
+{
+    setAppBadge(0, WTFMove(promise));
+}
+#endif
+
 
 } // namespace WebCore

--- a/Source/WebCore/page/WorkerNavigator.h
+++ b/Source/WebCore/page/WorkerNavigator.h
@@ -39,6 +39,11 @@ public:
     bool onLine() const final;
     void setIsOnline(bool isOnline) { m_isOnline = isOnline; }
 
+#if ENABLE(BADGING)
+    void setAppBadge(std::optional<unsigned long long>, Ref<DeferredPromise>&&);
+    void clearAppBadge(Ref<DeferredPromise>&&);
+#endif
+
     GPU* gpu();
 
 private:

--- a/Source/WebCore/page/WorkerNavigator.idl
+++ b/Source/WebCore/page/WorkerNavigator.idl
@@ -34,6 +34,7 @@
     readonly attribute unsigned long long hardwareConcurrency;
 };
 
+WorkerNavigator includes NavigatorBadge;
 WorkerNavigator includes NavigatorID;
 WorkerNavigator includes NavigatorLanguage;
 WorkerNavigator includes NavigatorLocks;

--- a/Source/WebCore/workers/DedicatedWorkerThread.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerThread.cpp
@@ -39,8 +39,8 @@
 
 namespace WebCore {
 
-DedicatedWorkerThread::DedicatedWorkerThread(const WorkerParameters& params, const ScriptBuffer& sourceCode, WorkerLoaderProxy& workerLoaderProxy, WorkerDebuggerProxy& workerDebuggerProxy, WorkerObjectProxy& workerObjectProxy, WorkerThreadStartMode startMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, JSC::RuntimeFlags runtimeFlags)
-    : WorkerThread(params, sourceCode, workerLoaderProxy, workerDebuggerProxy, workerObjectProxy, startMode, topOrigin, connectionProxy, socketProvider, runtimeFlags)
+DedicatedWorkerThread::DedicatedWorkerThread(const WorkerParameters& params, const ScriptBuffer& sourceCode, WorkerLoaderProxy& workerLoaderProxy, WorkerDebuggerProxy& workerDebuggerProxy, WorkerObjectProxy& workerObjectProxy, WorkerBadgeProxy& workerBadgeProxy, WorkerThreadStartMode startMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, JSC::RuntimeFlags runtimeFlags)
+    : WorkerThread(params, sourceCode, workerLoaderProxy, workerDebuggerProxy, workerObjectProxy, workerBadgeProxy, startMode, topOrigin, connectionProxy, socketProvider, runtimeFlags)
     , m_workerObjectProxy(workerObjectProxy)
 {
 }

--- a/Source/WebCore/workers/DedicatedWorkerThread.h
+++ b/Source/WebCore/workers/DedicatedWorkerThread.h
@@ -54,7 +54,7 @@ protected:
     Ref<WorkerGlobalScope> createWorkerGlobalScope(const WorkerParameters&, Ref<SecurityOrigin>&&, Ref<SecurityOrigin>&& topOrigin) override;
 
 private:
-    DedicatedWorkerThread(const WorkerParameters&, const ScriptBuffer& sourceCode, WorkerLoaderProxy&, WorkerDebuggerProxy&, WorkerObjectProxy&, WorkerThreadStartMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, JSC::RuntimeFlags);
+    DedicatedWorkerThread(const WorkerParameters&, const ScriptBuffer& sourceCode, WorkerLoaderProxy&, WorkerDebuggerProxy&, WorkerObjectProxy&, WorkerBadgeProxy&, WorkerThreadStartMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, JSC::RuntimeFlags);
 
     ASCIILiteral threadName() const final { return "WebCore: Worker"_s; }
 

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "WorkerBadgeProxy.h"
 #include "WorkerGlobalScopeProxy.h"
 #include "WorkerDebuggerProxy.h"
 #include "WorkerLoaderProxy.h"
@@ -38,7 +39,7 @@ class DedicatedWorkerThread;
 class WorkerInspectorProxy;
 class WorkerUserGestureForwarder;
 
-class WorkerMessagingProxy final : public ThreadSafeRefCounted<WorkerMessagingProxy>, public WorkerGlobalScopeProxy, public WorkerObjectProxy, public WorkerLoaderProxy, public WorkerDebuggerProxy {
+class WorkerMessagingProxy final : public ThreadSafeRefCounted<WorkerMessagingProxy>, public WorkerGlobalScopeProxy, public WorkerObjectProxy, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit WorkerMessagingProxy(Worker&);
@@ -86,6 +87,9 @@ private:
     void workerGlobalScopeDestroyedInternal();
     Worker* workerObject() const { return m_workerObject; }
 
+    // WorkerBadgeProxy
+    void setAppBadge(std::optional<uint64_t>) final;
+    
     RefPtr<ScriptExecutionContext> m_scriptExecutionContext;
     ScriptExecutionContextIdentifier m_loaderContextIdentifier;
     RefPtr<WorkerInspectorProxy> m_inspectorProxy;
@@ -93,6 +97,7 @@ private:
     Worker* m_workerObject;
     bool m_mayBeDestroyed { false };
     RefPtr<DedicatedWorkerThread> m_workerThread;
+    URL m_scriptURL;
 
     bool m_askedToSuspend { false };
     bool m_askedToTerminate { false };

--- a/Source/WebCore/workers/WorkerThread.cpp
+++ b/Source/WebCore/workers/WorkerThread.cpp
@@ -93,11 +93,12 @@ WorkerThreadStartupData::WorkerThreadStartupData(const WorkerParameters& other, 
 {
 }
 
-WorkerThread::WorkerThread(const WorkerParameters& params, const ScriptBuffer& sourceCode, WorkerLoaderProxy& workerLoaderProxy, WorkerDebuggerProxy& workerDebuggerProxy, WorkerReportingProxy& workerReportingProxy, WorkerThreadStartMode startMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, JSC::RuntimeFlags runtimeFlags)
+WorkerThread::WorkerThread(const WorkerParameters& params, const ScriptBuffer& sourceCode, WorkerLoaderProxy& workerLoaderProxy, WorkerDebuggerProxy& workerDebuggerProxy, WorkerReportingProxy& workerReportingProxy, WorkerBadgeProxy& badgeProxy, WorkerThreadStartMode startMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, JSC::RuntimeFlags runtimeFlags)
     : WorkerOrWorkletThread(params.inspectorIdentifier.isolatedCopy(), params.workerThreadMode)
     , m_workerLoaderProxy(workerLoaderProxy)
     , m_workerDebuggerProxy(workerDebuggerProxy)
     , m_workerReportingProxy(workerReportingProxy)
+    , m_workerBadgeProxy(badgeProxy)
     , m_runtimeFlags(runtimeFlags)
     , m_startupData(makeUnique<WorkerThreadStartupData>(params, sourceCode, startMode, topOrigin))
     , m_idbConnectionProxy(connectionProxy)

--- a/Source/WebCore/workers/WorkerThread.h
+++ b/Source/WebCore/workers/WorkerThread.h
@@ -43,9 +43,11 @@
 namespace WebCore {
 
 class NotificationClient;
+class Page;
 class ScriptBuffer;
 class SecurityOrigin;
 class SocketProvider;
+class WorkerBadgeProxy;
 class WorkerGlobalScope;
 class WorkerLoaderProxy;
 class WorkerDebuggerProxy;
@@ -92,8 +94,9 @@ class WorkerThread : public WorkerOrWorkletThread {
 public:
     virtual ~WorkerThread();
 
-    WorkerLoaderProxy& workerLoaderProxy() final { return m_workerLoaderProxy; }
+    WorkerBadgeProxy& workerBadgeProxy() const { return m_workerBadgeProxy; }
     WorkerDebuggerProxy* workerDebuggerProxy() const final { return &m_workerDebuggerProxy; }
+    WorkerLoaderProxy& workerLoaderProxy() final { return m_workerLoaderProxy; }
     WorkerReportingProxy& workerReportingProxy() const { return m_workerReportingProxy; }
 
     // Number of active worker threads.
@@ -110,7 +113,7 @@ public:
     void setWorkerClient(std::unique_ptr<WorkerClient>&& client) { m_workerClient = WTFMove(client); }
     WorkerClient* workerClient() { return m_workerClient.get(); }
 protected:
-    WorkerThread(const WorkerParameters&, const ScriptBuffer& sourceCode, WorkerLoaderProxy&, WorkerDebuggerProxy&, WorkerReportingProxy&, WorkerThreadStartMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, JSC::RuntimeFlags);
+    WorkerThread(const WorkerParameters&, const ScriptBuffer& sourceCode, WorkerLoaderProxy&, WorkerDebuggerProxy&, WorkerReportingProxy&, WorkerBadgeProxy&, WorkerThreadStartMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, JSC::RuntimeFlags);
 
     // Factory method for creating a new worker context for the thread.
     virtual Ref<WorkerGlobalScope> createWorkerGlobalScope(const WorkerParameters&, Ref<SecurityOrigin>&&, Ref<SecurityOrigin>&& topOrigin) = 0;
@@ -135,6 +138,7 @@ private:
     WorkerLoaderProxy& m_workerLoaderProxy;
     WorkerDebuggerProxy& m_workerDebuggerProxy;
     WorkerReportingProxy& m_workerReportingProxy;
+    WorkerBadgeProxy& m_workerBadgeProxy;
     JSC::RuntimeFlags m_runtimeFlags;
 
     std::unique_ptr<WorkerThreadStartupData> m_startupData;

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -101,8 +101,8 @@ static WorkerParameters generateWorkerParameters(const ServiceWorkerContextData&
     };
 }
 
-ServiceWorkerThread::ServiceWorkerThread(ServiceWorkerContextData&& contextData, ServiceWorkerData&& workerData, String&& userAgent, WorkerThreadMode workerThreadMode, const Settings::Values& settingsValues, WorkerLoaderProxy& loaderProxy, WorkerDebuggerProxy& debuggerProxy, IDBClient::IDBConnectionProxy* idbConnectionProxy, SocketProvider* socketProvider, std::unique_ptr<NotificationClient>&& notificationClient, PAL::SessionID sessionID)
-    : WorkerThread(generateWorkerParameters(contextData, WTFMove(userAgent), workerThreadMode, settingsValues, sessionID), contextData.script, loaderProxy, debuggerProxy, DummyServiceWorkerThreadProxy::shared(), WorkerThreadStartMode::Normal, contextData.registration.key.topOrigin().securityOrigin().get(), idbConnectionProxy, socketProvider, JSC::RuntimeFlags::createAllEnabled())
+ServiceWorkerThread::ServiceWorkerThread(ServiceWorkerContextData&& contextData, ServiceWorkerData&& workerData, String&& userAgent, WorkerThreadMode workerThreadMode, const Settings::Values& settingsValues, WorkerLoaderProxy& loaderProxy, WorkerDebuggerProxy& debuggerProxy, WorkerBadgeProxy& badgeProxy, IDBClient::IDBConnectionProxy* idbConnectionProxy, SocketProvider* socketProvider, std::unique_ptr<NotificationClient>&& notificationClient, PAL::SessionID sessionID)
+    : WorkerThread(generateWorkerParameters(contextData, WTFMove(userAgent), workerThreadMode, settingsValues, sessionID), contextData.script, loaderProxy, debuggerProxy, DummyServiceWorkerThreadProxy::shared(), badgeProxy, WorkerThreadStartMode::Normal, contextData.registration.key.topOrigin().securityOrigin().get(), idbConnectionProxy, socketProvider, JSC::RuntimeFlags::createAllEnabled())
     , m_serviceWorkerIdentifier(contextData.serviceWorkerIdentifier)
     , m_jobDataIdentifier(contextData.jobDataIdentifier)
     , m_contextData(crossThreadCopy(WTFMove(contextData)))

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.h
@@ -91,7 +91,7 @@ protected:
     void runEventLoop() override;
 
 private:
-    WEBCORE_EXPORT ServiceWorkerThread(ServiceWorkerContextData&&, ServiceWorkerData&&, String&& userAgent, WorkerThreadMode, const Settings::Values&, WorkerLoaderProxy&, WorkerDebuggerProxy&, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<NotificationClient>&&, PAL::SessionID);
+    WEBCORE_EXPORT ServiceWorkerThread(ServiceWorkerContextData&&, ServiceWorkerData&&, String&& userAgent, WorkerThreadMode, const Settings::Values&, WorkerLoaderProxy&, WorkerDebuggerProxy&, WorkerBadgeProxy&, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<NotificationClient>&&, PAL::SessionID);
 
     ASCIILiteral threadName() const final { return "WebCore: ServiceWorker"_s; }
     void finishedEvaluatingScript() final;

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -69,7 +69,7 @@ ServiceWorkerThreadProxy::ServiceWorkerThreadProxy(UniqueRef<Page>&& page, Servi
 #if ENABLE(REMOTE_INSPECTOR)
     , m_remoteDebuggable(makeUnique<ServiceWorkerDebuggable>(*this, contextData))
 #endif
-    , m_serviceWorkerThread(ServiceWorkerThread::create(WTFMove(contextData), WTFMove(workerData), WTFMove(userAgent), workerThreadMode, m_document->settingsValues(), *this, *this, idbConnectionProxy(m_document), m_document->socketProvider(), WTFMove(notificationClient), m_page->sessionID()))
+    , m_serviceWorkerThread(ServiceWorkerThread::create(WTFMove(contextData), WTFMove(workerData), WTFMove(userAgent), workerThreadMode, m_document->settingsValues(), *this, *this, *this, idbConnectionProxy(m_document), m_document->socketProvider(), WTFMove(notificationClient), m_page->sessionID()))
     , m_cacheStorageProvider(cacheStorageProvider)
     , m_inspectorProxy(*this)
 {
@@ -421,6 +421,15 @@ void ServiceWorkerThreadProxy::fireNotificationEvent(NotificationData&& data, No
     UNUSED_PARAM(eventType);
     callback(false);
 #endif
+}
+
+void ServiceWorkerThreadProxy::setAppBadge(std::optional<uint64_t> badge)
+{
+    ASSERT(!isMainThread());
+
+    callOnMainRunLoop([badge = WTFMove(badge), this, protectedThis = Ref { *this }] {
+        m_page->badgeClient().setAppBadge(nullptr, SecurityOriginData::fromURL(scriptURL()), badge);
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -37,6 +37,7 @@
 #include "ServiceWorkerInspectorProxy.h"
 #include "ServiceWorkerThread.h"
 #include "StorageBlockingPolicy.h"
+#include "WorkerBadgeProxy.h"
 #include "WorkerDebuggerProxy.h"
 #include "WorkerLoaderProxy.h"
 #include <wtf/HashMap.h>
@@ -53,7 +54,7 @@ class ServiceWorkerInspectorProxy;
 struct ServiceWorkerContextData;
 enum class WorkerThreadMode : bool;
 
-class ServiceWorkerThreadProxy final : public ThreadSafeRefCounted<ServiceWorkerThreadProxy>, public WorkerLoaderProxy, public WorkerDebuggerProxy {
+class ServiceWorkerThreadProxy final : public ThreadSafeRefCounted<ServiceWorkerThreadProxy>, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy {
 public:
     template<typename... Args> static Ref<ServiceWorkerThreadProxy> create(Args&&... args)
     {
@@ -110,6 +111,9 @@ private:
     // WorkerDebuggerProxy
     void postMessageToDebugger(const String&) final;
     void setResourceCachingDisabledByWebInspector(bool) final;
+
+    // WorkerBadgeProxy
+    void setAppBadge(std::optional<uint64_t>) final;
 
     UniqueRef<Page> m_page;
     Ref<Document> m_document;

--- a/Source/WebCore/workers/shared/context/SharedWorkerThread.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThread.cpp
@@ -33,8 +33,8 @@
 
 namespace WebCore {
 
-SharedWorkerThread::SharedWorkerThread(SharedWorkerIdentifier identifier, const WorkerParameters& parameters, const ScriptBuffer& sourceCode, WorkerLoaderProxy& loaderProxy, WorkerDebuggerProxy& debuggerProxy, WorkerObjectProxy& objectProxy, WorkerThreadStartMode startMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, JSC::RuntimeFlags runtimeFlags)
-    : WorkerThread(parameters, sourceCode, loaderProxy, debuggerProxy, objectProxy, startMode, topOrigin, connectionProxy, socketProvider, runtimeFlags)
+SharedWorkerThread::SharedWorkerThread(SharedWorkerIdentifier identifier, const WorkerParameters& parameters, const ScriptBuffer& sourceCode, WorkerLoaderProxy& loaderProxy, WorkerDebuggerProxy& debuggerProxy, WorkerObjectProxy& objectProxy, WorkerBadgeProxy& badgeProxy, WorkerThreadStartMode startMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, JSC::RuntimeFlags runtimeFlags)
+    : WorkerThread(parameters, sourceCode, loaderProxy, debuggerProxy, objectProxy, badgeProxy, startMode, topOrigin, connectionProxy, socketProvider, runtimeFlags)
     , m_identifier(identifier)
     , m_name(parameters.name.isolatedCopy())
 {

--- a/Source/WebCore/workers/shared/context/SharedWorkerThread.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThread.h
@@ -39,7 +39,7 @@ public:
     SharedWorkerIdentifier identifier() const { return m_identifier; }
 
 private:
-    SharedWorkerThread(SharedWorkerIdentifier, const WorkerParameters&, const ScriptBuffer& sourceCode, WorkerLoaderProxy&, WorkerDebuggerProxy&, WorkerObjectProxy&, WorkerThreadStartMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, JSC::RuntimeFlags);
+    SharedWorkerThread(SharedWorkerIdentifier, const WorkerParameters&, const ScriptBuffer& sourceCode, WorkerLoaderProxy&, WorkerDebuggerProxy&, WorkerObjectProxy&, WorkerBadgeProxy&, WorkerThreadStartMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, JSC::RuntimeFlags);
 
     Ref<WorkerGlobalScope> createWorkerGlobalScope(const WorkerParameters&, Ref<SecurityOrigin>&&, Ref<SecurityOrigin>&& topOrigin) final;
     ASCIILiteral threadName() const final { return "WebCore: SharedWorker"_s; }

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
+#include "ClientOrigin.h"
 #include "SharedWorkerIdentifier.h"
+#include "WorkerBadgeProxy.h"
 #include "WorkerDebuggerProxy.h"
 #include "WorkerLoaderProxy.h"
 #include "WorkerObjectProxy.h"
@@ -39,11 +41,10 @@ class Page;
 class SharedWorker;
 class SharedWorkerThread;
 
-struct ClientOrigin;
 struct WorkerFetchResult;
 struct WorkerInitializationData;
 
-class SharedWorkerThreadProxy final : public ThreadSafeRefCounted<SharedWorkerThreadProxy>, public WorkerObjectProxy, public WorkerLoaderProxy, public WorkerDebuggerProxy {
+class SharedWorkerThreadProxy final : public ThreadSafeRefCounted<SharedWorkerThreadProxy>, public WorkerObjectProxy, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy {
 public:
     template<typename... Args> static Ref<SharedWorkerThreadProxy> create(Args&&... args) { return adoptRef(*new SharedWorkerThreadProxy(std::forward<Args>(args)...)); }
     WEBCORE_EXPORT ~SharedWorkerThreadProxy();
@@ -78,6 +79,9 @@ private:
     void postMessageToDebugger(const String&) final;
     void setResourceCachingDisabledByWebInspector(bool) final;
 
+    // WorkerBadgeProxy
+    void setAppBadge(std::optional<uint64_t>) final;
+
     static void networkStateChanged(bool isOnLine);
     void notifyNetworkStateChange(bool isOnline);
 
@@ -90,6 +94,7 @@ private:
     CacheStorageProvider& m_cacheStorageProvider;
     RefPtr<CacheStorageConnection> m_cacheStorageConnection;
     bool m_isTerminatingOrTerminated { false };
+    ClientOrigin m_clientOrigin;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -789,6 +789,7 @@ WebProcess/WebCoreSupport/RemoteWebLockRegistry.cpp
 WebProcess/WebCoreSupport/SessionStateConversion.cpp
 WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
 WebProcess/WebCoreSupport/WebAttachmentElementClient.cpp
+WebProcess/WebCoreSupport/WebBadgeClient.cpp
 WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
 WebProcess/WebCoreSupport/WebChromeClient.cpp
 WebProcess/WebCoreSupport/WebColorChooser.cpp

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -234,6 +234,9 @@ public:
     virtual void startXRSession(WebKit::WebPageProxy&, CompletionHandler<void(RetainPtr<id>)>&& completionHandler) { completionHandler(nil); }
     virtual void endXRSession(WebKit::WebPageProxy&) { }
 #endif
+
+    virtual void updateAppBadge(WebKit::WebPageProxy&, std::optional<uint64_t>) { }
+    virtual void updateClientBadge(WebKit::WebPageProxy&, std::optional<uint64_t>) { }
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -1598,6 +1598,26 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
     return _preferences->mediaPreferredFullscreenWidth();
 }
 
+- (void)_setAppBadgeEnabled:(BOOL)enabled
+{
+    _preferences->setAppBadgeEnabled(enabled);
+}
+
+- (BOOL)_appBadgeEnabled
+{
+    return _preferences->appBadgeEnabled();
+}
+
+- (void)_setClientBadgeEnabled:(BOOL)enabled
+{
+    _preferences->setClientBadgeEnabled(enabled);
+}
+
+- (BOOL)_clientBadgeEnabled
+{
+    return _preferences->clientBadgeEnabled();
+}
+
 @end
 
 @implementation WKPreferences (WKDeprecated)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -182,6 +182,8 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setInteractionRegionInlinePadding:) double _interactionRegionInlinePadding WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, setter=_setRequiresFullscreenToLockScreenOrientation:) BOOL _requiresFullscreenToLockScreenOrientation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, setter=_setMediaPreferredFullscreenWidth:) double _mediaPreferredFullscreenWidth WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, setter=_setAppBadgeEnabled:) BOOL _appBadgeEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, setter=_setClientBadgeEnabled:) BOOL _clientBadgeEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 #if !TARGET_OS_IPHONE
 @property (nonatomic, setter=_setWebGLEnabled:) BOOL _webGLEnabled WK_API_AVAILABLE(macos(10.13.4));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -208,6 +208,9 @@ struct UIEdgeInsets;
 
 - (void)_webView:(WKWebView *)webView decidePolicyForModalContainer:(_WKModalContainerInfo *)containerInfo decisionHandler:(void (^)(_WKModalContainerDecision))decisionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
+- (void)_webView:(WKWebView *)webView updatedAppBadge:(NSNumber *)badge WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+- (void)_webView:(WKWebView *)webView updatedClientBadge:(NSNumber *)badge WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 #if TARGET_OS_IPHONE
 
 - (BOOL)_webView:(WKWebView *)webView shouldIncludeAppLinkActionsForElement:(_WKActivatedElementInfo *)element WK_API_AVAILABLE(ios(9.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h
@@ -40,4 +40,5 @@ WK_API_AVAILABLE(macos(10.15), ios(13.0))
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore openWindow:(NSURL *)url fromServiceWorkerOrigin:(WKSecurityOrigin *)serviceWorkerOrigin completionHandler:(void (^)(WKWebView *newWebView))completionHandler;
 - (NSDictionary<NSString *, NSNumber *> *)notificationPermissionsForWebsiteDataStore:(WKWebsiteDataStore *)dataStore;
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore showNotification:(_WKNotificationData *)notificationData;
+- (void)websiteDataStore:(WKWebsiteDataStore *)dataStore workerOrigin:(WKSecurityOrigin *)workerOrigin updatedAppBadge:(NSNumber *)badge;
 @end

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -189,6 +189,9 @@ private:
         void endXRSession(WebPageProxy&) final;
 #endif
 
+        void updateAppBadge(WebPageProxy&, std::optional<uint64_t>) final;
+        void updateClientBadge(WebPageProxy&, std::optional<uint64_t>) final;
+
         WeakPtr<UIDelegate> m_uiDelegate;
     };
 
@@ -293,6 +296,8 @@ private:
         bool webViewRequestNotificationPermissionForSecurityOriginDecisionHandler : 1;
         bool webViewRequestCookieConsentWithMoreInfoHandlerDecisionHandler : 1;
         bool webViewDecidePolicyForModalContainerDecisionHandler : 1;
+        bool webViewUpdatedAppBadge : 1;
+        bool webViewUpdatedClientBadge : 1;
     } m_delegateMethods;
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -210,6 +210,9 @@ void UIDelegate::setDelegate(id <WKUIDelegate> delegate)
     m_delegateMethods.webViewRequestNotificationPermissionForSecurityOriginDecisionHandler = [delegate respondsToSelector:@selector(_webView:requestNotificationPermissionForSecurityOrigin:decisionHandler:)];
     m_delegateMethods.webViewRequestCookieConsentWithMoreInfoHandlerDecisionHandler = [delegate respondsToSelector:@selector(_webView:requestCookieConsentWithMoreInfoHandler:decisionHandler:)];
     m_delegateMethods.webViewDecidePolicyForModalContainerDecisionHandler = [delegate respondsToSelector:@selector(_webView:decidePolicyForModalContainer:decisionHandler:)];
+
+    m_delegateMethods.webViewUpdatedAppBadge = [delegate respondsToSelector:@selector(_webView:updatedAppBadge:)];
+    m_delegateMethods.webViewUpdatedClientBadge = [delegate respondsToSelector:@selector(_webView:updatedClientBadge:)];
 }
 
 #if ENABLE(CONTEXT_MENUS)
@@ -1885,6 +1888,44 @@ void UIDelegate::UIClient::didDisableInspectorBrowserDomain(WebPageProxy&)
         return;
 
     [delegate _webViewDidDisableInspectorBrowserDomain:m_uiDelegate->m_webView.get().get()];
+}
+
+void UIDelegate::UIClient::updateAppBadge(WebPageProxy&, std::optional<uint64_t> badge)
+{
+    if (!m_uiDelegate)
+        return;
+
+    if (!m_uiDelegate->m_delegateMethods.webViewUpdatedAppBadge)
+        return;
+
+    auto delegate = (id <WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    if (!delegate)
+        return;
+
+    NSNumber *nsBadge = nil;
+    if (badge)
+        nsBadge = @(*badge);
+
+    [delegate _webView:m_uiDelegate->m_webView.get().get() updatedAppBadge:nsBadge];
+}
+
+void UIDelegate::UIClient::updateClientBadge(WebPageProxy&, std::optional<uint64_t> badge)
+{
+    if (!m_uiDelegate)
+        return;
+
+    if (!m_uiDelegate->m_delegateMethods.webViewUpdatedClientBadge)
+        return;
+
+    auto delegate = (id <WKUIDelegatePrivate>)m_uiDelegate->m_delegate.get();
+    if (!delegate)
+        return;
+
+    NSNumber *nsBadge = nil;
+    if (badge)
+        nsBadge = @(*badge);
+
+    [delegate _webView:m_uiDelegate->m_webView.get().get() updatedClientBadge:nsBadge];
 }
 
 #if ENABLE(WEBXR)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -452,6 +452,9 @@ public:
 #endif
     void getNotifications(const URL&, const String&, CompletionHandler<void(Vector<WebCore::NotificationData>&&)>&&);
 
+    void setAppBadge(std::optional<WebPageProxyIdentifier>, const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);
+    void setClientBadge(WebPageProxyIdentifier, const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);
+
     WebCore::CrossOriginMode crossOriginMode() const { return m_crossOriginMode; }
     LockdownMode lockdownMode() const { return m_lockdownMode; }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -88,4 +88,6 @@ messages -> WebProcessProxy LegacyReceiver {
 #endif
 
     GetNotifications(URL registrationURL, String tag) -> (Vector<WebCore::NotificationData> result)
+    SetAppBadge(std::optional<WebKit::WebPageProxyIdentifier> pageIdentifier, struct WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
+    SetClientBadge(WebKit::WebPageProxyIdentifier pageIdentifier, struct WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
 }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2164,6 +2164,11 @@ void WebsiteDataStore::openWindowFromServiceWorker(const String& urlString, cons
     m_client->openWindowFromServiceWorker(urlString, serviceWorkerOrigin, WTFMove(innerCallback));
 }
 
+void WebsiteDataStore::workerUpdatedAppBadge(const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)
+{
+    m_client->workerUpdatedAppBadge(origin, badge);
+}
+
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
 
 void WebsiteDataStore::setEmulatedConditions(std::optional<int64_t>&& bytesPerSecondLimit)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -396,9 +396,6 @@ public:
     static void setManagedDomainsForTesting(HashSet<WebCore::RegistrableDomain>&&, CompletionHandler<void()>&&);
 #endif
 
-
-
-
     void updateBundleIdentifierInNetworkProcess(const String&, CompletionHandler<void()>&&);
     void clearBundleIdentifierInNetworkProcess(CompletionHandler<void()>&&);
 
@@ -410,6 +407,8 @@ public:
     void didDestroyServiceWorkerNotification(const UUID& notificationID);
 
     void openWindowFromServiceWorker(const String& urlString, const WebCore::SecurityOriginData& serviceWorkerOrigin, CompletionHandler<void(std::optional<WebCore::PageIdentifier>)>&&);
+
+    void workerUpdatedAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t>);
 
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     void setEmulatedConditions(std::optional<int64_t>&& bytesPerSecondLimit);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
@@ -68,6 +68,10 @@ public:
     {
         return { };
     }
+
+    virtual void workerUpdatedAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t>)
+    {
+    }
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1016,6 +1016,7 @@
 		512935D81288D19400A4B695 /* WebContextMenuItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 512935D61288D19400A4B695 /* WebContextMenuItem.h */; };
 		512935E41288D97800A4B695 /* InjectedBundlePageContextMenuClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 512935E21288D97800A4B695 /* InjectedBundlePageContextMenuClient.h */; };
 		5129EB1223D0DE7B00AF1CD7 /* ContentWorldShared.h in Headers */ = {isa = PBXBuildFile; fileRef = 5129EB1123D0DE7800AF1CD7 /* ContentWorldShared.h */; };
+		512B6792294B8CB8000C0760 /* WebBadgeClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 512B6790294B8CB8000C0760 /* WebBadgeClient.h */; };
 		512CD6982721EFC800F7F8EC /* WebPushDaemonConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 512CD6972721EFC300F7F8EC /* WebPushDaemonConnection.h */; };
 		512CD69A2721F0A900F7F8EC /* WebPushDaemonConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 512CD6992721F04900F7F8EC /* WebPushDaemonConstants.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		512E34E5130B4D0500ABD19A /* WKApplicationCacheManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 517A33B4130B308C00F80CB5 /* WKApplicationCacheManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5008,6 +5009,8 @@
 		512935E11288D97800A4B695 /* InjectedBundlePageContextMenuClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InjectedBundlePageContextMenuClient.cpp; sourceTree = "<group>"; };
 		512935E21288D97800A4B695 /* InjectedBundlePageContextMenuClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InjectedBundlePageContextMenuClient.h; sourceTree = "<group>"; };
 		5129EB1123D0DE7800AF1CD7 /* ContentWorldShared.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContentWorldShared.h; sourceTree = "<group>"; };
+		512B678F294B8CB8000C0760 /* WebBadgeClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebBadgeClient.cpp; sourceTree = "<group>"; };
+		512B6790294B8CB8000C0760 /* WebBadgeClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebBadgeClient.h; sourceTree = "<group>"; };
 		512CD6962721EFC200F7F8EC /* WebPushDaemonConnection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebPushDaemonConnection.cpp; sourceTree = "<group>"; };
 		512CD6972721EFC300F7F8EC /* WebPushDaemonConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebPushDaemonConnection.h; sourceTree = "<group>"; };
 		512CD6992721F04900F7F8EC /* WebPushDaemonConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebPushDaemonConstants.h; sourceTree = "<group>"; };
@@ -12206,6 +12209,8 @@
 				CEDA12DE152CCAE800D9E08D /* WebAlternativeTextClient.h */,
 				E36D701D27B718EF006531B7 /* WebAttachmentElementClient.cpp */,
 				E36D701A27B709ED006531B7 /* WebAttachmentElementClient.h */,
+				512B678F294B8CB8000C0760 /* WebBadgeClient.cpp */,
+				512B6790294B8CB8000C0760 /* WebBadgeClient.h */,
 				46EE2847269E049B00DD48AB /* WebBroadcastChannelRegistry.cpp */,
 				46EE2848269E049B00DD48AB /* WebBroadcastChannelRegistry.h */,
 				46E9760A2757F6C900ACDD37 /* WebBroadcastChannelRegistry.messages.in */,
@@ -15424,6 +15429,7 @@
 				518D2CAE12D5153B003BB93B /* WebBackForwardListItem.h in Headers */,
 				DDA0A2C527E55E4E005E086E /* WebBackForwardListPrivate.h in Headers */,
 				BC72B9FB11E6476B001EB4EA /* WebBackForwardListProxy.h in Headers */,
+				512B6792294B8CB8000C0760 /* WebBadgeClient.h in Headers */,
 				46EE2849269E04AC00DD48AB /* WebBroadcastChannelRegistry.h in Headers */,
 				DDA0A33F27E55E4F005E086E /* WebCache.h in Headers */,
 				41897ED11F415D680016FA42 /* WebCacheStorageConnection.h in Headers */,

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -38,6 +38,7 @@
 #include "RemoteWorkerInitializationData.h"
 #include "RemoteWorkerLibWebRTCProvider.h"
 #include "ServiceWorkerFetchTaskMessages.h"
+#include "WebBadgeClient.h"
 #include "WebBroadcastChannelRegistry.h"
 #include "WebCacheStorageProvider.h"
 #include "WebCompiledContentRuleListData.h"
@@ -150,7 +151,9 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
     assertIsCurrent(m_queue.get());
 
     callOnMainRunLoopAndWait([this, protectedThis = Ref { *this }, contextData = WTFMove(contextData).isolatedCopy(), workerData = WTFMove(workerData).isolatedCopy(), userAgent = WTFMove(userAgent).isolatedCopy(), workerThreadMode]() mutable {
-    auto pageConfiguration = pageConfigurationWithEmptyClients(WebProcess::singleton().sessionID());
+        auto pageConfiguration = pageConfigurationWithEmptyClients(WebProcess::singleton().sessionID());
+
+        pageConfiguration.badgeClient = WebBadgeClient::create();
         pageConfiguration.databaseProvider = WebDatabaseProvider::getOrCreate(m_pageGroupID);
         pageConfiguration.socketProvider = WebSocketProvider::create(m_webPageProxyID);
         pageConfiguration.broadcastChannelRegistry = WebProcess::singleton().broadcastChannelRegistry();

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -30,6 +30,7 @@
 #include "RemoteWebLockRegistry.h"
 #include "RemoteWorkerFrameLoaderClient.h"
 #include "RemoteWorkerLibWebRTCProvider.h"
+#include "WebBadgeClient.h"
 #include "WebBroadcastChannelRegistry.h"
 #include "WebCacheStorageProvider.h"
 #include "WebCompiledContentRuleListData.h"
@@ -96,6 +97,7 @@ void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::Client
     RELEASE_LOG(SharedWorker, "WebSharedWorkerContextManagerConnection::launchSharedWorker: sharedWorkerIdentifier=%" PRIu64, sharedWorkerIdentifier.toUInt64());
     auto pageConfiguration = WebCore::pageConfigurationWithEmptyClients(WebProcess::singleton().sessionID());
 
+    pageConfiguration.badgeClient = WebBadgeClient::create();
     pageConfiguration.databaseProvider = WebDatabaseProvider::getOrCreate(m_pageGroupID);
     pageConfiguration.socketProvider = WebSocketProvider::create(m_webPageProxyID);
     pageConfiguration.broadcastChannelRegistry = WebProcess::singleton().broadcastChannelRegistry();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebBadgeClient.h"
+
+#include "WebPage.h"
+#include "WebProcess.h"
+#include "WebProcessProxyMessages.h"
+
+using namespace WebCore;
+
+namespace WebKit {
+
+void WebBadgeClient::setAppBadge(Page* page, const SecurityOriginData& origin, std::optional<uint64_t> badge)
+{
+    std::optional<WebPageProxyIdentifier> pageIdentifier;
+    if (page)
+        pageIdentifier = WebPage::fromCorePage(*page).webPageProxyIdentifier();
+
+    WebProcess::singleton().setAppBadge(pageIdentifier, origin, badge);
+}
+
+void WebBadgeClient::setClientBadge(Page& page, const SecurityOriginData& origin, std::optional<uint64_t> badge)
+{
+    WebProcess::singleton().setClientBadge(WebPage::fromCorePage(page).webPageProxyIdentifier(), origin, badge);
+}
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/BadgeClient.h>
+#include <wtf/Ref.h>
+
+namespace WebKit {
+
+class WebBadgeClient final : public WebCore::BadgeClient {
+public:
+    static Ref<WebBadgeClient> create()
+    {
+        return adoptRef(*new WebBadgeClient);
+    }
+
+private:
+    void setAppBadge(WebCore::Page*, const WebCore::SecurityOriginData&, std::optional<uint64_t>) final;
+    void setClientBadge(WebCore::Page&, const WebCore::SecurityOriginData&, std::optional<uint64_t>) final;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
@@ -30,6 +30,7 @@
 #include "RemoteImageBufferProxy.h"
 #include "RemoteRenderingBackendProxy.h"
 #include "WebPage.h"
+#include "WebProcess.h"
 
 #if ENABLE(WEBGL) && ENABLE(GPU_PROCESS)
 #include "RemoteGraphicsContextGLProxy.h"

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -73,6 +73,7 @@
 #include "WebAttachmentElementClient.h"
 #include "WebBackForwardListItem.h"
 #include "WebBackForwardListProxy.h"
+#include "WebBadgeClient.h"
 #include "WebBroadcastChannelRegistry.h"
 #include "WebCacheStorageProvider.h"
 #include "WebChromeClient.h"
@@ -625,8 +626,10 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         makeUniqueRef<MediaRecorderProvider>(*this),
         WebProcess::singleton().broadcastChannelRegistry(),
         makeUniqueRef<WebStorageProvider>(),
-        makeUniqueRef<WebModelPlayerProvider>(*this)
+        makeUniqueRef<WebModelPlayerProvider>(*this),
+        WebProcess::singleton().badgeClient()
     );
+
     pageConfiguration.chromeClient = new WebChromeClient(*this);
 #if ENABLE(CONTEXT_MENUS)
     pageConfiguration.contextMenuClient = new WebContextMenuClient(this);

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -54,6 +54,7 @@
 #include "StorageAreaMap.h"
 #include "UserData.h"
 #include "WebAutomationSessionProxy.h"
+#include "WebBadgeClient.h"
 #include "WebBroadcastChannelRegistry.h"
 #include "WebCacheStorageProvider.h"
 #include "WebConnectionToUIProcess.h"
@@ -287,6 +288,7 @@ WebProcess::WebProcess()
     , m_remoteVideoCodecFactory(*this)
 #endif
     , m_cacheStorageProvider(WebCacheStorageProvider::create())
+    , m_badgeClient(WebBadgeClient::create())
     , m_broadcastChannelRegistry(WebBroadcastChannelRegistry::create())
     , m_cookieJar(WebCookieJar::create())
     , m_dnsPrefetchHystereris([this](PAL::HysteresisState state) { if (state == PAL::HysteresisState::Stopped) m_dnsPrefetchedHosts.clear(); })
@@ -2013,6 +2015,16 @@ bool WebProcess::areAllPagesThrottleable() const
     return WTF::allOf(m_pageMap.values(), [](auto& page) {
         return page->isThrottleable();
     });
+}
+
+void WebProcess::setAppBadge(std::optional<WebPageProxyIdentifier> pageIdentifier, const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)
+{
+    parentProcessConnection()->send(Messages::WebProcessProxy::SetAppBadge(pageIdentifier, origin, badge), 0);
+}
+
+void WebProcess::setClientBadge(WebPageProxyIdentifier pageIdentifier, const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)
+{
+    parentProcessConnection()->send(Messages::WebProcessProxy::SetClientBadge(pageIdentifier, origin, badge), 0);
 }
 
 #if HAVE(CVDISPLAYLINK)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -126,6 +126,7 @@ class RemoteMediaEngineConfigurationFactory;
 class StorageAreaMap;
 class UserData;
 class WebAutomationSessionProxy;
+class WebBadgeClient;
 class WebBroadcastChannelRegistry;
 class WebCacheStorageProvider;
 class WebCookieJar;
@@ -314,6 +315,7 @@ public:
     WebAutomationSessionProxy* automationSessionProxy() { return m_automationSessionProxy.get(); }
 
     WebCacheStorageProvider& cacheStorageProvider() { return m_cacheStorageProvider.get(); }
+    WebBadgeClient& badgeClient() { return m_badgeClient.get(); }
     WebBroadcastChannelRegistry& broadcastChannelRegistry() { return m_broadcastChannelRegistry.get(); }
     WebCookieJar& cookieJar() { return m_cookieJar.get(); }
     WebSocketChannelManager& webSocketChannelManager() { return m_webSocketChannelManager; }
@@ -385,6 +387,9 @@ public:
     bool hadMainFrameMainResourcePrivateRelayed() const { return m_hadMainFrameMainResourcePrivateRelayed; }
 
     void deleteWebsiteDataForOrigins(OptionSet<WebsiteDataType>, const Vector<WebCore::SecurityOriginData>& origins, CompletionHandler<void()>&&);
+
+    void setAppBadge(std::optional<WebPageProxyIdentifier>, const WebCore::SecurityOriginData&, std::optional<uint64_t>);
+    void setClientBadge(WebPageProxyIdentifier, const WebCore::SecurityOriginData&, std::optional<uint64_t>);
 
 private:
     WebProcess();
@@ -645,6 +650,7 @@ private:
 #endif
 #endif
     Ref<WebCacheStorageProvider> m_cacheStorageProvider;
+    Ref<WebBadgeClient> m_badgeClient;
     Ref<WebBroadcastChannelRegistry> m_broadcastChannelRegistry;
     Ref<WebCookieJar> m_cookieJar;
     WebSocketChannelManager m_webSocketChannelManager;

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -154,6 +154,7 @@
 #import <WebCore/DummyStorageProvider.h>
 #import <WebCore/Editing.h>
 #import <WebCore/Editor.h>
+#import <WebCore/EmptyBadgeClient.h>
 #import <WebCore/Event.h>
 #import <WebCore/EventHandler.h>
 #import <WebCore/FocusController.h>
@@ -1539,7 +1540,8 @@ static void WebKitInitializeGamepadProviderIfNecessary()
         makeUniqueRef<WebCore::MediaRecorderProvider>(),
         WebBroadcastChannelRegistry::getOrCreate([[self preferences] privateBrowsingEnabled]),
         makeUniqueRef<WebCore::DummyStorageProvider>(),
-        makeUniqueRef<WebCore::DummyModelPlayerProvider>()
+        makeUniqueRef<WebCore::DummyModelPlayerProvider>(),
+        WebCore::EmptyBadgeClient::create()
     );
 #if !PLATFORM(IOS_FAMILY)
     pageConfiguration.chromeClient = new WebChromeClient(self);
@@ -1819,7 +1821,8 @@ static void WebKitInitializeGamepadProviderIfNecessary()
         makeUniqueRef<WebCore::MediaRecorderProvider>(),
         WebBroadcastChannelRegistry::getOrCreate([[self preferences] privateBrowsingEnabled]),
         makeUniqueRef<WebCore::DummyStorageProvider>(),
-        makeUniqueRef<WebCore::DummyModelPlayerProvider>()
+        makeUniqueRef<WebCore::DummyModelPlayerProvider>(),
+        WebCore::EmptyBadgeClient::create()
     );
     pageConfiguration.chromeClient = new WebChromeClientIOS(self);
 #if ENABLE(DRAG_SUPPORT)

--- a/Source/WebKitLegacy/win/WebView.cpp
+++ b/Source/WebKitLegacy/win/WebView.cpp
@@ -99,6 +99,7 @@
 #include <WebCore/DummySpeechRecognitionProvider.h>
 #include <WebCore/DummyStorageProvider.h>
 #include <WebCore/Editor.h>
+#include <WebCore/EmptyBadgeClient.h>
 #include <WebCore/EventHandler.h>
 #include <WebCore/EventNames.h>
 #include <WebCore/FloatQuad.h>
@@ -2910,7 +2911,8 @@ HRESULT WebView::initWithFrame(RECT frame, _In_ BSTR frameName, _In_ BSTR groupN
         makeUniqueRef<MediaRecorderProvider>(),
         WebBroadcastChannelRegistry::getOrCreate(false),
         makeUniqueRef<WebCore::DummyStorageProvider>(),
-        makeUniqueRef<WebCore::DummyModelPlayerProvider>()
+        makeUniqueRef<WebCore::DummyModelPlayerProvider>(),
+		EmptyBadgeClient::create()
     );
     configuration.chromeClient = new WebChromeClient(this);
 #if ENABLE(CONTEXT_MENUS)

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -54,6 +54,7 @@ Tests/WebKitCocoa/AudioBufferSize.mm
 Tests/WebKitCocoa/AudioRoutingArbitration.mm
 Tests/WebKitCocoa/AutoFillAvailable.mm
 Tests/WebKitCocoa/AutoLayoutIntegration.mm
+Tests/WebKitCocoa/Badging.mm
 Tests/WebKitCocoa/BundleCSSStyleDeclarationHandle.mm
 Tests/WebKitCocoa/BundleEditingDelegate.mm
 Tests/WebKitCocoa/BundleFormDelegate.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2392,6 +2392,7 @@
 		518EE51720A78CDF00E024F3 /* DoubleDefersLoadingPlugin.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DoubleDefersLoadingPlugin.mm; sourceTree = "<group>"; };
 		518EE51A20A78CFB00E024F3 /* DoAfterNextPresentationUpdateAfterCrash.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DoAfterNextPresentationUpdateAfterCrash.mm; sourceTree = "<group>"; };
 		518EE51C20A78D3300E024F3 /* DecidePolicyForNavigationAction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DecidePolicyForNavigationAction.mm; sourceTree = "<group>"; };
+		51A24D10294BE9B300E43A29 /* Badging.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Badging.mm; sourceTree = "<group>"; };
 		51A5877C1D1B3D8D004BA9AF /* IndexedDBMultiProcess-3.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "IndexedDBMultiProcess-3.html"; sourceTree = "<group>"; };
 		51A587821D272EB5004BA9AF /* IndexedDBDatabaseProcessKill-1.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "IndexedDBDatabaseProcessKill-1.html"; sourceTree = "<group>"; };
 		51A587841D272EF3004BA9AF /* IndexedDBDatabaseProcessKill.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IndexedDBDatabaseProcessKill.mm; sourceTree = "<group>"; };
@@ -3804,6 +3805,7 @@
 				754CEC801F6722DC00D0039A /* AutoFillAvailable.mm */,
 				2DD355351BD08378005DF4A7 /* AutoLayoutIntegration.mm */,
 				07CD32F52065B5420064A4BE /* AVFoundationPreference.mm */,
+				51A24D10294BE9B300E43A29 /* Badging.mm */,
 				5C42594422669E9B0039AA7A /* BasicProposedCredentialPlugIn.mm */,
 				9528E5FB279A0337008ADFEF /* BundleCSSStyleDeclarationHandle.mm */,
 				9528E5FC279A0338008ADFEF /* BundleCSSStyleDeclarationHandlePlugIn.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Badging.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Badging.mm
@@ -1,0 +1,465 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(BADGING)
+
+#import "DeprecatedGlobalValues.h"
+#import "HTTPServer.h"
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestNotificationProvider.h"
+#import "TestWKWebView.h"
+#import <WebCore/RegistrationDatabase.h>
+#import <WebKit/WKNotificationProvider.h>
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKUIDelegatePrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <WebKit/_WKNotificationData.h>
+#import <WebKit/_WKWebsiteDataStoreConfiguration.h>
+#import <WebKit/_WKWebsiteDataStoreDelegate.h>
+#import <wtf/HexNumber.h>
+
+static constexpr auto simpleMainBytes = R"SWRESOURCE(
+Hello World!
+)SWRESOURCE"_s;
+
+static constexpr auto checkForBadgeFunctions = R"SWRESOURCE(
+var result = "";
+
+function checkNavigatorProperty(property)
+{
+    if (property in window.navigator) {
+        if (typeof(property in window.navigator) == "function")
+            return 'f ';
+        else
+            return '1 ';
+    }
+    return '0 ';
+}
+
+result += checkNavigatorProperty('setAppBadge');
+result += checkNavigatorProperty('clearAppBadge');
+result += checkNavigatorProperty('setClientBadge');
+result += checkNavigatorProperty('clearClientBadge');
+return result;
+)SWRESOURCE"_s;
+
+static constexpr auto exerciseBadgeFunctions = R"SWRESOURCE(
+window.navigator.setAppBadge(0);
+window.navigator.setAppBadge(1);
+window.navigator.setAppBadge(Number.MAX_SAFE_INTEGER);
+window.navigator.setAppBadge();
+
+window.navigator.setClientBadge(0);
+window.navigator.setClientBadge(1);
+window.navigator.setClientBadge(Number.MAX_SAFE_INTEGER);
+window.navigator.setClientBadge();
+
+window.navigator.clearAppBadge();
+window.navigator.clearClientBadge();
+
+
+window.navigator.setAppBadge(-10).then(() => {
+    window.webkit.messageHandlers.sw.postMessage("SUCCEEDED");
+}).catch((e) => {
+    window.webkit.messageHandlers.sw.postMessage("CAUGHT ERROR");
+});
+window.navigator.setAppBadge('a').then(() => {
+    window.webkit.messageHandlers.sw.postMessage("SUCCEEDED");
+}).catch((e) => {
+    window.webkit.messageHandlers.sw.postMessage("CAUGHT ERROR");
+});
+window.navigator.setClientBadge(-10).then(() => {
+    window.webkit.messageHandlers.sw.postMessage("SUCCEEDED");
+}).catch((e) => {
+    window.webkit.messageHandlers.sw.postMessage("CAUGHT ERROR");
+});
+window.navigator.setClientBadge('a').then(() => {
+    window.webkit.messageHandlers.sw.postMessage("SUCCEEDED");
+}).catch((e) => {
+    window.webkit.messageHandlers.sw.postMessage("CAUGHT ERROR");
+});
+
+
+return "DONE";
+)SWRESOURCE"_s;
+
+@interface BadgeDelegate : NSObject<WKUIDelegatePrivate, _WKWebsiteDataStoreDelegate>
+@property (readwrite) int appBadgeIndex;
+@property (readwrite) int clientBadgeIndex;
+@property (readwrite, copy) NSArray *expectedAppBadgeSequence;
+@property (readwrite, copy) NSArray *expectedClientBadgeSequence;
+@end
+
+@implementation BadgeDelegate
+
+- (void)updatedAppBadge:(NSNumber *)badge
+{
+    id innerBadge = badge;
+    if (!innerBadge)
+        innerBadge = [NSNull null];
+    EXPECT_TRUE([_expectedAppBadgeSequence[_appBadgeIndex++] isEqual:innerBadge]);
+}
+
+- (void)_webView:(WKWebView *)webView updatedAppBadge:(NSNumber *)badge
+{
+    [self updatedAppBadge:badge];
+}
+
+- (void)_webView:(WKWebView *)webView updatedClientBadge:(NSNumber *)badge
+{
+    id innerBadge = badge;
+    if (!innerBadge)
+        innerBadge = [NSNull null];
+    EXPECT_TRUE([_expectedClientBadgeSequence[_clientBadgeIndex++] isEqual :innerBadge]);
+}
+
+- (void)websiteDataStore:(WKWebsiteDataStore *)dataStore workerOrigin:(WKSecurityOrigin *)workerOrigin updatedAppBadge:(NSNumber *)badge
+{
+    [self updatedAppBadge:badge];
+}
+
+@end
+
+TEST(Badging, APIWindow)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { simpleMainBytes } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    static bool messagesDone = false;
+    static int messageCount = 0;
+    static const int expectedMessages = 4;
+
+    auto testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"sw"];
+    [testMessageHandler addMessage:@"SUCCEEDED" withHandler:^{
+        EXPECT_TRUE(false);
+        if (++messageCount == expectedMessages)
+            messagesDone = true;
+    }];
+    [testMessageHandler addMessage:@"CAUGHT ERROR" withHandler:^{
+        EXPECT_TRUE(true);
+        if (++messageCount == expectedMessages)
+            messagesDone = true;
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    auto badgeDelegate = adoptNS([BadgeDelegate new]);
+    badgeDelegate.get().expectedAppBadgeSequence = @[@0, @1, @9007199254740991, [NSNull null], @0];
+    badgeDelegate.get().expectedClientBadgeSequence = @[@0, @1, @9007199254740991, [NSNull null], @0];
+
+    webView.get().UIDelegate = badgeDelegate.get();
+    [webView synchronouslyLoadRequest:server.request("/"_s)];
+
+    NSString *nsCheckForBadgeFunctions = [NSString stringWithUTF8String:checkForBadgeFunctions];
+    static bool done = false;
+    [webView callAsyncJavaScript:nsCheckForBadgeFunctions arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
+        EXPECT_TRUE([result isEqualToString:@"0 0 0 0 "]);
+        EXPECT_NULL(error);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    webView.get().configuration.preferences._appBadgeEnabled = YES;
+    webView.get().configuration.preferences._clientBadgeEnabled = NO;
+    [webView synchronouslyLoadRequest:server.request("/"_s)];
+
+    done = false;
+    [webView callAsyncJavaScript:nsCheckForBadgeFunctions arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
+        EXPECT_TRUE([result isEqualToString:@"1 1 0 0 "]);
+        EXPECT_NULL(error);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    webView.get().configuration.preferences._appBadgeEnabled = NO;
+    webView.get().configuration.preferences._clientBadgeEnabled = YES;
+    [webView synchronouslyLoadRequest:server.request("/"_s)];
+
+    done = false;
+    [webView callAsyncJavaScript:nsCheckForBadgeFunctions arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
+        EXPECT_TRUE([result isEqualToString:@"0 0 1 1 "]);
+        EXPECT_NULL(error);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    webView.get().configuration.preferences._appBadgeEnabled = YES;
+    webView.get().configuration.preferences._clientBadgeEnabled = YES;
+    [webView synchronouslyLoadRequest:server.request("/"_s)];
+
+    done = false;
+    [webView callAsyncJavaScript:nsCheckForBadgeFunctions arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
+        EXPECT_TRUE([result isEqualToString:@"1 1 1 1 "]);
+        EXPECT_NULL(error);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    NSString *nsExerciseBadgeFunctions = [NSString stringWithUTF8String:exerciseBadgeFunctions];
+    done = false;
+    [webView callAsyncJavaScript:nsExerciseBadgeFunctions arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
+        EXPECT_TRUE([result isEqualToString:@"DONE"]);
+        EXPECT_NULL(error);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&messagesDone);
+
+    EXPECT_EQ(badgeDelegate.get().appBadgeIndex, 5);
+    EXPECT_EQ(badgeDelegate.get().clientBadgeIndex, 5);
+}
+
+static constexpr auto workerMainBytes = R"TESTRESOURCE(
+<script>
+window.worker = new Worker('worker.js');
+worker.onerror = (event) => {
+    window.webkit.messageHandlers.testHandler.postMessage(event);
+};
+worker.onmessage = (event) => {
+    window.webkit.messageHandlers.testHandler.postMessage(event.data);
+};
+</script>
+)TESTRESOURCE"_s;
+
+static constexpr auto workerBytes = R"TESTRESOURCE(
+self.onmessage = (event) => {
+    if (event.data != 'updateBadge')
+        return;
+
+    navigator.setAppBadge(10);
+    navigator.clearAppBadge();
+
+    self.postMessage('BADGINGDONE');
+};
+self.postMessage('RUNNING');
+
+)TESTRESOURCE"_s;
+
+TEST(Badging, DedicatedWorker)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { workerMainBytes } },
+        { "/worker.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, workerBytes } }
+    });
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    static bool workerRunning = false;
+    static bool badgingDone = false;
+    static bool javascriptDone = false;
+
+    auto testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"testHandler"];
+    [testMessageHandler addMessage:@"RUNNING" withHandler:^{
+        workerRunning = true;
+    }];
+    [testMessageHandler addMessage:@"BADGINGDONE" withHandler:^{
+        badgingDone = true;
+    }];
+
+    configuration.get().preferences._appBadgeEnabled = YES;
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    auto badgeDelegate = adoptNS([BadgeDelegate new]);
+    badgeDelegate.get().expectedAppBadgeSequence = @[@10, @0];
+    configuration.get().websiteDataStore._delegate = badgeDelegate.get();
+
+    [webView synchronouslyLoadRequest:server.request("/"_s)];
+
+    TestWebKitAPI::Util::run(&workerRunning);
+
+    [webView callAsyncJavaScript:@"window.worker.postMessage('updateBadge');" arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
+        EXPECT_NULL(error);
+        javascriptDone = true;
+    }];
+    TestWebKitAPI::Util::run(&javascriptDone);
+    TestWebKitAPI::Util::run(&badgingDone);
+
+    EXPECT_EQ(badgeDelegate.get().appBadgeIndex, 2);
+    EXPECT_EQ(badgeDelegate.get().clientBadgeIndex, 0);
+}
+
+static constexpr auto sharedWorkerMainBytes = R"TESTRESOURCE(
+<script>
+window.sharedWorker = new SharedWorker('sharedworker.js');
+sharedWorker.port.onmessage = (event) => {
+    window.webkit.messageHandlers.testHandler.postMessage(event.data);
+};
+</script>
+)TESTRESOURCE"_s;
+
+static constexpr auto sharedWorkerBytes = R"TESTRESOURCE(
+onconnect = (e) => {
+    self.port = e.ports[0];
+    self.port.postMessage("RUNNING");
+
+    self.port.onmessage = (event) => {
+        if (event.data != 'updateBadge')
+            return;
+
+        navigator.setAppBadge(10);
+        navigator.clearAppBadge();
+
+        self.port.postMessage('BADGINGDONE');
+    };
+}
+
+)TESTRESOURCE"_s;
+
+TEST(Badging, SharedWorker)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { sharedWorkerMainBytes } },
+        { "/sharedworker.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, sharedWorkerBytes } }
+    });
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    static bool workerRunning = false;
+    static bool badgingDone = false;
+    static bool javascriptDone = false;
+
+    auto testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"testHandler"];
+    [testMessageHandler addMessage:@"RUNNING" withHandler:^{
+        workerRunning = true;
+    }];
+    [testMessageHandler addMessage:@"BADGINGDONE" withHandler:^{
+        badgingDone = true;
+    }];
+
+    configuration.get().preferences._appBadgeEnabled = YES;
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    auto badgeDelegate = adoptNS([BadgeDelegate new]);
+    badgeDelegate.get().expectedAppBadgeSequence = @[@10, @0];
+    configuration.get().websiteDataStore._delegate = badgeDelegate.get();
+
+    [webView synchronouslyLoadRequest:server.request("/"_s)];
+
+    TestWebKitAPI::Util::run(&workerRunning);
+
+    [webView callAsyncJavaScript:@"window.sharedWorker.port.postMessage('updateBadge');" arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
+        EXPECT_NULL(error);
+        javascriptDone = true;
+    }];
+    TestWebKitAPI::Util::run(&javascriptDone);
+    TestWebKitAPI::Util::run(&badgingDone);
+
+    EXPECT_EQ(badgeDelegate.get().appBadgeIndex, 2);
+    EXPECT_EQ(badgeDelegate.get().clientBadgeIndex, 0);
+}
+
+static constexpr auto serviceWorkerMainBytes = R"SWRESOURCE(
+<script>
+const channel = new MessageChannel();
+channel.port1.onmessage = (event) => {
+    window.webkit.messageHandlers.testHandler.postMessage(event.data);
+};
+
+navigator.serviceWorker.register('/sw.js').then((registration) => {
+    if (registration.active) {
+        registration.active.postMessage({port: channel.port2}, [channel.port2]);
+        return;
+    }
+    worker = registration.installing;
+    worker.addEventListener('statechange', function() {
+        if (worker.state == 'activated')
+            worker.postMessage({port: channel.port2}, [channel.port2]);
+    });
+}).catch(function(error) {
+    log("Registration failed with: " + error);
+});
+</script>
+)SWRESOURCE"_s;
+
+//updateBadge
+
+static constexpr auto serviceWorkerScriptBytes = R"SWRESOURCE(
+let port;
+self.addEventListener("message", (event) => {
+    port = event.data.port;
+    port.onmessage = (event) => {
+        if (event.data != 'updateBadge')
+            return;
+
+        navigator.setAppBadge(10);
+        navigator.clearAppBadge();
+
+         port.postMessage('BADGINGDONE');
+    };
+    port.postMessage("RUNNING");
+});
+)SWRESOURCE"_s;
+
+TEST(Badging, ServiceWorker)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { serviceWorkerMainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, serviceWorkerScriptBytes } }
+    });
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    static bool workerRunning = false;
+    static bool badgingDone = false;
+    static bool javascriptDone = false;
+
+    auto testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"testHandler"];
+    [testMessageHandler addMessage:@"RUNNING" withHandler:^{
+        workerRunning = true;
+    }];
+    [testMessageHandler addMessage:@"BADGINGDONE" withHandler:^{
+        badgingDone = true;
+    }];
+
+    configuration.get().preferences._appBadgeEnabled = YES;
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    auto badgeDelegate = adoptNS([BadgeDelegate new]);
+    badgeDelegate.get().expectedAppBadgeSequence = @[@10, @0];
+    configuration.get().websiteDataStore._delegate = badgeDelegate.get();
+
+    [webView synchronouslyLoadRequest:server.request("/"_s)];
+
+    TestWebKitAPI::Util::run(&workerRunning);
+
+    [webView callAsyncJavaScript:@"channel.port1.postMessage('updateBadge');" arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
+        EXPECT_NULL(error);
+        javascriptDone = true;
+    }];
+    TestWebKitAPI::Util::run(&javascriptDone);
+    TestWebKitAPI::Util::run(&badgingDone);
+
+    EXPECT_EQ(badgeDelegate.get().appBadgeIndex, 2);
+    EXPECT_EQ(badgeDelegate.get().clientBadgeIndex, 0);
+}
+#endif // ENABLE(BADGING)


### PR DESCRIPTION
#### 7457143192d5ea0040dfe29917d9af8dcb49feff
<pre>
WebKit engine support for Badging API
<a href="https://bugs.webkit.org/show_bug.cgi?id=223906">https://bugs.webkit.org/show_bug.cgi?id=223906</a>
rdar://76241764

Reviewed by Tim Horton and Chris Dumez.

This patch adds engine support for setAppBadge() and setClientBadge() on Navigator objects.
<a href="https://w3c.github.io/badging/">https://w3c.github.io/badging/</a>

When Javascript updates a badge count it is sent to the embedding application via delegate callbacks.

Engine support does not mean browser support.

The standard explicitly calls out that if the User Agent does not intend to do anything with the updated
badge count then the API should not be exposed to JavaScript.
This allows for the best practice of feature detection, so web page JavaScript can put its badge count
data somewhere else that it knows will be used.

As such, WebKit support remains disabled at runtime, and only clients interested in actually using the
badge count will enable it.

This patch implements the feature by exposing a BadgeClient on Page.

The WebContent process implementation of the BadgeClient sends new badge counts to the UI process to
be forwarded along to a delegate.

For the Cocoa port:
- If the badge count update came from a WindowNavigator object, then the new badge count is sent to the
  WKUIDelegate installed on the WKWebView.
- If the badge count update came from a WorkerNavigator object (dedicated, shared, or service), then
  the new badge count is sent to the WKWebsiteDataStoreDelegate installed on the relevant data store.

Almost the entire patch is a mechanical plumbing task of moving the badge count from JS to the API client.

But an unfortunately large amount of this patch is in service of forwarding the WorkerNavigator calls from
the worker threads to the main thread and then to lookup the appropriate Page object.

C&apos;est la vie.

* Source/WTF/Scripts/Preferences/WebPreferences.yaml:
* Source/WTF/wtf/PlatformEnable.h:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/badge/BadgeClient.h: Copied from Source/WebCore/page/WorkerNavigator.cpp.
* Source/WebCore/Modules/badge/EmptyBadgeClient.h: Copied from Source/WebCore/page/WorkerNavigator.cpp.
* Source/WebCore/Modules/badge/Navigator+Badge.idl: Copied from Source/WebCore/workers/shared/context/SharedWorkerThread.h.
* Source/WebCore/Modules/badge/NavigatorBadge.idl: Copied from Source/WebCore/workers/shared/context/SharedWorkerThread.h.
* Source/WebCore/Modules/badge/WorkerBadgeProxy.h: Copied from Source/WebCore/page/WorkerNavigator.cpp.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::pageConfigurationWithEmptyClients):
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::setAppBadge):
(WebCore::Navigator::clearAppBadge):
(WebCore::Navigator::setClientBadge):
(WebCore::Navigator::clearClientBadge):
* Source/WebCore/page/Navigator.h:
* Source/WebCore/page/Navigator.idl:
* Source/WebCore/page/Page.cpp:
(WebCore::m_badgeClient):
(WebCore::m_contentSecurityPolicyModeForExtension): Deleted.
* Source/WebCore/page/Page.h:
(WebCore::Page::badgeClient):
* Source/WebCore/page/PageConfiguration.cpp:
(WebCore::PageConfiguration::PageConfiguration):
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/page/WorkerNavigator.cpp:
(WebCore::WorkerNavigator::setAppBadge):
(WebCore::WorkerNavigator::clearAppBadge):
* Source/WebCore/page/WorkerNavigator.h:
* Source/WebCore/page/WorkerNavigator.idl:
* Source/WebCore/workers/DedicatedWorkerThread.cpp:
(WebCore::DedicatedWorkerThread::DedicatedWorkerThread):
* Source/WebCore/workers/DedicatedWorkerThread.h:
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):
(WebCore::WorkerMessagingProxy::postTaskToWorkerObject):
(WebCore::WorkerMessagingProxy::setAppBadge):
* Source/WebCore/workers/WorkerMessagingProxy.h:
* Source/WebCore/workers/WorkerThread.cpp:
(WebCore::WorkerThread::WorkerThread):
* Source/WebCore/workers/WorkerThread.h:
(WebCore::WorkerThread::workerBadgeProxy const):
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::ServiceWorkerThread::ServiceWorkerThread):
* Source/WebCore/workers/service/context/ServiceWorkerThread.h:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::ServiceWorkerThreadProxy):
(WebCore::ServiceWorkerThreadProxy::setAppBadge):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/shared/context/SharedWorkerThread.cpp:
(WebCore::SharedWorkerThread::SharedWorkerThread):
* Source/WebCore/workers/shared/context/SharedWorkerThread.h:
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::SharedWorkerThreadProxy::SharedWorkerThreadProxy):
(WebCore::SharedWorkerThreadProxy::setAppBadge):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::updateAppBadge):
(API::UIClient::updateClientBadge):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences _setAppBadgeEnabled:]):
(-[WKPreferences _appBadgeEnabled]):
(-[WKPreferences _setClientBadgeEnabled:]):
(-[WKPreferences _clientBadgeEnabled]):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::setDelegate):
(WebKit::UIDelegate::UIClient::updateAppBadge):
(WebKit::UIDelegate::UIClient::updateClientBadge):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::setAppBadge):
(WebKit::WebProcessProxy::setClientBadge):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::workerUpdatedAppBadge):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h:
(WebKit::WebsiteDataStoreClient::workerUpdatedAppBadge):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::installServiceWorker):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
(WebKit::WebSharedWorkerContextManagerConnection::launchSharedWorker):
* Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.cpp: Copied from Source/WebCore/workers/shared/context/SharedWorkerThread.h.
(WebKit::WebBadgeClient::setAppBadge):
(WebKit::WebBadgeClient::setClientBadge):
* Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.h: Copied from Source/WebCore/workers/shared/context/SharedWorkerThread.h.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::WebProcess):
(WebKit::WebProcess::setAppBadge):
(WebKit::WebProcess::setClientBadge):
* Source/WebKit/WebProcess/WebProcess.h:
(WebKit::WebProcess::badgeClient):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _commonInitializationWithFrameName:groupName:]):
(-[WebView initSimpleHTMLDocumentWithStyle:frame:preferences:groupName:]):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Badging.mm: Added.
(-[BadgeDelegate updatedAppBadge:]):
(-[BadgeDelegate _webView:updatedAppBadge:]):
(-[BadgeDelegate _webView:updatedClientBadge:]):
(-[BadgeDelegate websiteDataStore:workerOrigin:updatedAppBadge:]):

Canonical link: <a href="https://commits.webkit.org/258051@main">https://commits.webkit.org/258051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bbde66e47d301f4dbacf6623fe2c0acd6de612b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100751 "30 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110050 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170324 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/475 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93151 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107896 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34790 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22825 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77762 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91237 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3589 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24349 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87328 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1125 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3613 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/472 "Build is in progress. Recent messages:") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29204 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43848 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90212 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5526 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5390 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20184 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->