### PR TITLE
[web-animations] add an AnimatableProperty type to encapsulate either a standard or custom property

### DIFF
--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -25,10 +25,13 @@
 
 #pragma once
 
+#include "CSSPropertyNames.h"
 #include "CSSValue.h"
 #include <wtf/HashMap.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/Markable.h>
+#include <wtf/text/AtomString.h>
+#include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {
 
@@ -64,6 +67,45 @@ using AnimationEvents = Vector<Ref<AnimationEventBase>>;
 using PropertyToTransitionMap = HashMap<CSSPropertyID, RefPtr<CSSTransition>>;
 using CSSAnimationCollection = ListHashSet<RefPtr<CSSAnimation>>;
 
+using AnimatableProperty = std::variant<CSSPropertyID, AtomString>;
+using AnimatablePropertyToTransitionMap = HashMap<AnimatableProperty, RefPtr<CSSTransition>>;
+
 } // namespace WebCore
 
+namespace WTF {
 
+template<> struct DefaultHash<WebCore::AnimatableProperty> {
+    static unsigned hash(const WebCore::AnimatableProperty& key) {
+        return WTF::switchOn(key,
+            [] (WebCore::CSSPropertyID property) {
+                return DefaultHash<WebCore::CSSPropertyID>::hash(property);
+            },
+            [] (const AtomString& string) {
+                return DefaultHash<AtomString>::hash(string);
+            }
+        );
+    }
+    static bool equal(const WebCore::AnimatableProperty& a, const WebCore::AnimatableProperty& b) { return a == b; }
+    static const bool safeToCompareToEmptyOrDeleted = true;
+};
+
+template<> struct HashTraits<WebCore::AnimatableProperty> : GenericHashTraits<WebCore::AnimatableProperty> {
+    static const bool emptyValueIsZero = true;
+    static void constructDeletedValue(WebCore::AnimatableProperty& slot) {
+        WebCore::CSSPropertyID property;
+        HashTraits<WebCore::CSSPropertyID>::constructDeletedValue(property);
+        new (NotNull, &slot) WebCore::AnimatableProperty(property);
+    }
+    static bool isDeletedValue(const WebCore::AnimatableProperty& value) {
+        return WTF::switchOn(value,
+            [] (WebCore::CSSPropertyID property) {
+                return HashTraits<WebCore::CSSPropertyID>::isDeletedValue(property);
+            },
+            [] (const AtomString&) {
+                return false;
+            }
+        );
+    }
+};
+
+} // namespace WTF


### PR DESCRIPTION
#### ea7b3989b369d140fcf55e9962380d663a79d905
<pre>
[web-animations] add an AnimatableProperty type to encapsulate either a standard or custom property
<a href="https://bugs.webkit.org/show_bug.cgi?id=249498">https://bugs.webkit.org/show_bug.cgi?id=249498</a>

Reviewed by Darin Adler.

The animation code is currently heavily biased towards dealing with &quot;standard&quot; CSS properties, represented
by the CSSPropertyID enum. However, with the work to add interpolation support for custom properties (see
bug 249293) and to support CSS Transitions for custom properties (see bug 249399), we really need to deal
with both custom properties and standard properties everywhere we currently deal with only standard
properties.

In this patch we&apos;re adding a new type, AnimatableProperty, which is an std::variant&lt;CSSPropertyID, AtomString&gt;.
We currently use CSSPropertyID as a value for property lists which are HashSet&lt;&gt; and as keys to HashMap&lt;&gt;,
so we must add the relevant traits to support this use for AnimatableProperty.

* Source/WebCore/animation/WebAnimationTypes.h:
(WTF::DefaultHash&lt;WebCore::AnimatableProperty&gt;::hash):
(WTF::DefaultHash&lt;WebCore::AnimatableProperty&gt;::equal):
(WTF::HashTraits&lt;WebCore::AnimatableProperty&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebCore::AnimatableProperty&gt;::isDeletedValue):

Canonical link: <a href="https://commits.webkit.org/258040@main">https://commits.webkit.org/258040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0e984bc3b8e6b8618539529ef3a95c1dfa0b3ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100738 "Failed to checkout and rebase branch from PR 7780") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33780 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/110037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170311 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/104727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/431 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107883 "Built successfully") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/106521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/93139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/3600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5378 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2886 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->