### PR TITLE
[WebGPU] Implement GPUQuerySet

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.h
@@ -58,6 +58,7 @@ public:
     PAL::WebGPU::Buffer& backing() { return m_backing; }
     const PAL::WebGPU::Buffer& backing() const { return m_backing; }
 
+    ~GPUBuffer() { destroy(); }
 private:
     GPUBuffer(Ref<PAL::WebGPU::Buffer>&& backing)
         : m_backing(WTFMove(backing))

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -329,6 +329,7 @@ void Buffer::unmap()
 #endif
 
     m_state = State::Unmapped;
+    m_mappedRanges = MappedRanges();
 }
 
 void Buffer::setLabel(String&& label)

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -69,7 +69,7 @@ public:
     void popDebugGroup();
     void pushDebugGroup(String&& groupLabel);
     void resolveQuerySet(const QuerySet&, uint32_t firstQuery, uint32_t queryCount, const Buffer& destination, uint64_t destinationOffset);
-    void writeTimestamp(const QuerySet&, uint32_t queryIndex);
+    void writeTimestamp(QuerySet&, uint32_t queryIndex);
     void setLabel(String&&);
 
     Device& device() const { return m_device; }

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -31,15 +31,53 @@
 
 namespace WebGPU {
 
-Ref<QuerySet> Device::createQuerySet(const WGPUQuerySetDescriptor& descriptor)
+static id<MTLCounterSet> getCounterSet(MTLCommonCounterSet counterSetName, id<MTLDevice> device)
 {
-    UNUSED_PARAM(descriptor);
-    return QuerySet::createInvalid(*this);
+    for (id<MTLCounterSet> counterSet in device.counterSets) {
+        if ([counterSetName caseInsensitiveCompare:counterSetName] == NSOrderedSame)
+            return counterSet;
+    }
+
+    return nil;
 }
 
-QuerySet::QuerySet(id<MTLCounterSampleBuffer> counterSampleBuffer, Device& device)
-    : m_counterSampleBuffer(counterSampleBuffer)
-    , m_device(device)
+Ref<QuerySet> Device::createQuerySet(const WGPUQuerySetDescriptor& descriptor)
+{
+    if (descriptor.nextInChain)
+        return QuerySet::createInvalid(*this);
+
+    auto queryCount = descriptor.count;
+
+    switch (descriptor.type) {
+    case WGPUQueryType_Timestamp: {
+        ASSERT(queryCount == 4);
+        MTLCounterSampleBufferDescriptor *descriptor = [MTLCounterSampleBufferDescriptor new];
+        descriptor.counterSet = getCounterSet(MTLCommonCounterTimestamp, m_device);
+        descriptor.storageMode = MTLStorageModeShared;
+        descriptor.sampleCount = queryCount;
+        auto timestampBuffer = [m_device newCounterSampleBufferWithDescriptor:descriptor error:nil];
+        return timestampBuffer ? QuerySet::create(timestampBuffer, *this) : QuerySet::createInvalid(*this);
+    }
+    case WGPUQueryType_Occlusion:
+        return QuerySet::create(safeCreateBuffer(sizeof(uint64_t) * queryCount, MTLStorageModeShared), *this);
+    case WGPUQueryType_PipelineStatistics:
+    case WGPUQueryType_Force32:
+        ASSERT_NOT_REACHED("unexpected queryType");
+        return QuerySet::createInvalid(*this);
+    }
+}
+
+QuerySet::QuerySet(id<MTLBuffer> buffer, Device& device)
+    : m_device(device)
+    , m_visibilityBuffer(buffer)
+    , m_queryCount(buffer.length / sizeof(uint64_t))
+{
+}
+
+QuerySet::QuerySet(id<MTLCounterSampleBuffer> buffer, Device& device)
+    : m_device(device)
+    , m_timestampBuffer(buffer)
+    , m_queryCount(buffer.sampleCount)
 {
 }
 
@@ -53,13 +91,31 @@ QuerySet::~QuerySet() = default;
 void QuerySet::destroy()
 {
     // https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-destroy
-
-    m_counterSampleBuffer = nil;
+    m_visibilityBuffer = nil;
+    m_timestampBuffer = nil;
 }
 
-void QuerySet::setLabel(String&&)
+void QuerySet::setLabel(String&& label)
 {
-    // MTLCounterSampleBuffer's labels are read-only.
+    m_visibilityBuffer.label = label;
+}
+
+Vector<MTLTimestamp> QuerySet::resolveTimestamps() const
+{
+    ASSERT(m_timestampBuffer);
+
+    NSData *resolvedData = [m_timestampBuffer resolveCounterRange:NSMakeRange(0, m_queryCount)];
+    ASSERT(resolvedData);
+    Vector<MTLTimestamp> timestamps;
+    size_t timestampCount = resolvedData.length / sizeof(uint64_t);
+    timestamps.resize(timestampCount);
+    auto gpuTimestamps = static_cast<const MTLTimestamp *>(resolvedData.bytes);
+    // FIXME: some devices may require mapping GPU time to CPU time, however
+    // this does not appear to be the case in testing
+    for (size_t i = 0; i < timestampCount; ++i)
+        timestamps[i] = gpuTimestamps[i];
+
+    return timestamps;
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -47,9 +47,9 @@ class RenderPipeline;
 class RenderPassEncoder : public WGPURenderPassEncoderImpl, public RefCounted<RenderPassEncoder>, public CommandsMixin {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RenderPassEncoder> create(id<MTLRenderCommandEncoder> renderCommandEncoder, Device& device)
+    static Ref<RenderPassEncoder> create(id<MTLRenderCommandEncoder> renderCommandEncoder, NSUInteger visibilityResultBufferSize, Device& device)
     {
-        return adoptRef(*new RenderPassEncoder(renderCommandEncoder, device));
+        return adoptRef(*new RenderPassEncoder(renderCommandEncoder, visibilityResultBufferSize, device));
     }
     static Ref<RenderPassEncoder> createInvalid(Device& device)
     {
@@ -86,7 +86,7 @@ public:
     bool isValid() const { return m_renderCommandEncoder; }
 
 private:
-    RenderPassEncoder(id<MTLRenderCommandEncoder>, Device&);
+    RenderPassEncoder(id<MTLRenderCommandEncoder>, NSUInteger, Device&);
     RenderPassEncoder(Device&);
 
     bool validatePopDebugGroup() const;
@@ -102,7 +102,9 @@ private:
     id<MTLBuffer> m_indexBuffer { nil };
     MTLIndexType m_indexType { MTLIndexTypeUInt16 };
     NSUInteger m_indexBufferOffset { 0 };
-    uint32_t m_vertexShaderInputBufferCount { 0 };
+    NSUInteger m_vertexShaderInputBufferCount { 0 };
+    NSUInteger m_visibilityResultBufferOffset { 0 };
+    NSUInteger m_visibilityResultBufferSize { 0 };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -35,9 +35,10 @@
 
 namespace WebGPU {
 
-RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEncoder, Device& device)
+RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEncoder, NSUInteger visibilityResultBufferSize, Device& device)
     : m_renderCommandEncoder(renderCommandEncoder)
     , m_device(device)
+    , m_visibilityResultBufferSize(visibilityResultBufferSize)
 {
 }
 
@@ -54,7 +55,10 @@ RenderPassEncoder::~RenderPassEncoder()
 
 void RenderPassEncoder::beginOcclusionQuery(uint32_t queryIndex)
 {
-    UNUSED_PARAM(queryIndex);
+    if (queryIndex < m_visibilityResultBufferSize) {
+        m_visibilityResultBufferOffset = queryIndex;
+        [m_renderCommandEncoder setVisibilityResultMode:MTLVisibilityResultModeCounting offset:queryIndex];
+    }
 }
 
 void RenderPassEncoder::beginPipelineStatisticsQuery(const QuerySet& querySet, uint32_t queryIndex)
@@ -93,7 +97,7 @@ void RenderPassEncoder::drawIndirect(const Buffer& indirectBuffer, uint64_t indi
 
 void RenderPassEncoder::endOcclusionQuery()
 {
-
+    [m_renderCommandEncoder setVisibilityResultMode:MTLVisibilityResultModeDisabled offset:m_visibilityResultBufferOffset];
 }
 
 void RenderPassEncoder::endPass()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in
@@ -25,7 +25,7 @@
 
 messages -> RemoteBuffer NotRefCounted Stream {
     void GetMappedRange(PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size) -> (std::optional<Vector<uint8_t>> data) Synchronous
-    void MapAsync(PAL::WebGPU::MapModeFlags mapModeFlags, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size) -> (std::optional<Vector<uint8_t>> data) Synchronous
+    void MapAsync(PAL::WebGPU::MapModeFlags mapModeFlags, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size) -> (std::optional<Vector<uint8_t>> data) Synchronous NotStreamEncodableReply
     void Unmap(Vector<uint8_t> data)
     void Destroy()
     void SetLabel(String label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
@@ -92,7 +92,7 @@ void RemoteCommandEncoder::copyBufferToBuffer(
 {
     auto convertedSource = m_objectHeap.convertBufferFromBacking(source);
     ASSERT(convertedSource);
-    auto convertedDestination = m_objectHeap.convertBufferFromBacking(source);
+    auto convertedDestination = m_objectHeap.convertBufferFromBacking(destination);
     ASSERT(convertedDestination);
     if (!convertedSource || !convertedDestination)
         return;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -60,6 +60,9 @@ void RemoteBufferProxy::mapAsync(PAL::WebGPU::MapModeFlags mapModeFlags, PAL::We
 
 auto RemoteBufferProxy::getMappedRange(PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size) -> MappedRange
 {
+    if (m_data.has_value())
+        return { m_data->data() + offset, static_cast<size_t>(size.value_or(m_data->size() - offset)) };
+
     // FIXME: Implement error handling.
     auto sendResult = sendSync(Messages::RemoteBuffer::GetMappedRange(offset, size));
     auto [data] = sendResult.takeReplyOr(std::nullopt);

--- a/Websites/webkit.org/demos/webgpu/query-sets.html
+++ b/Websites/webkit.org/demos/webgpu/query-sets.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=600">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+<title>WebGPU Hello Triangle</title>
+<link rel="stylesheet" href="css/style.css">
+<style>
+body {
+    font-family: system-ui;
+    color: #f7f7ff;
+    background-color: rgb(38, 38, 127);
+    text-align: center;
+}
+canvas {
+    margin: 0 auto;
+}
+</style>
+</head>
+<body>
+<div id="contents">
+    <h1>Simple Triangle</h1>
+    <canvas></canvas>
+</div>
+<div id="error">
+    <h2>WebGPU not available</h2>
+    <p>
+        Make sure you are on a system with WebGPU enabled. In
+        Safari, first make sure the Developer Menu is visible (Preferences >
+        Advanced), then Develop > Experimental Features > WebGPU.
+    </p>
+    <p>
+        In addition, you must be using Safari Technology Preview 92 or above.
+        You can get the latest STP <a href="https://developer.apple.com/safari/download/">here</a>.
+    </p>
+</div>
+<script src="scripts/query-sets.js"></script>
+</body>
+</html>

--- a/Websites/webkit.org/demos/webgpu/scripts/query-sets.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/query-sets.js
@@ -1,0 +1,233 @@
+async function helloTriangle() {
+    if (!navigator.gpu || GPUBufferUsage.COPY_SRC === undefined) {
+        document.body.className = 'error';
+        return;
+    }
+    
+    const adapter = await navigator.gpu.requestAdapter();
+    const device = await adapter.requestDevice();
+    
+    /*** Query Set creation ***/
+    const timestampQueryCount = 4;
+    const timestampQuery = device.createQuerySet({
+        type: 'timestamp',
+        count: timestampQueryCount
+    });
+
+    const timestampQueryBufferSize = timestampQueryCount * 8;
+    const timestampQueryResults = device.createBuffer({
+        size: timestampQueryBufferSize,
+        usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.COPY_SRC
+    });
+    
+    const timestampQueryDisplayResults = device.createBuffer({
+        size: timestampQueryBufferSize,
+        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+    });
+    
+    const occlusionQueryCount = 4;
+    const occlusionQuery = device.createQuerySet({
+        type: 'occlusion',
+        count: occlusionQueryCount
+    });
+    
+    const occlusionQueryBufferSize = 8 * occlusionQueryCount;
+    const occlusionQueryResults = device.createBuffer({
+        size: occlusionQueryBufferSize,
+        usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.COPY_SRC
+    });
+    
+    const occlusionQueryDisplayResults = device.createBuffer({
+        size: occlusionQueryBufferSize,
+        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+    });
+    
+    /*** Vertex Buffer Setup ***/
+    
+    /* Vertex Data */
+    const vertexStride = 8 * 4;
+    const vertexDataSize = vertexStride * 3;
+    
+    /* GPUBufferDescriptor */
+    const vertexDataBufferDescriptor = {
+    size: vertexDataSize,
+    usage: GPUBufferUsage.VERTEX
+    };
+    
+    /* GPUBuffer */
+    const vertexBuffer = device.createBuffer(vertexDataBufferDescriptor);
+    
+    /*** Shader Setup ***/
+    const uniformBindGroupLayout = device.createBindGroupLayout({ entries: [{binding: 0, visibility: GPUShaderStage.VERTEX, buffer: {}}] });
+    const pipelineLayoutDesc = { bindGroupLayouts: [uniformBindGroupLayout] };
+    const layout = device.createPipelineLayout(pipelineLayoutDesc);
+    const uniformBufferSize = 12;
+    const uniformBuffer = device.createBuffer({
+        size: uniformBufferSize,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+
+    const uniformBindGroup = device.createBindGroup({
+        layout: uniformBindGroupLayout,
+        entries: [
+          {
+            binding: 0,
+            resource: {
+              buffer: uniformBuffer,
+              offset: 0
+            },
+          }
+        ]
+    });
+
+    const mslSource = `
+                #include <metal_stdlib>
+                using namespace metal;
+                struct Vertex {
+                   float4 position [[position]];
+                   float4 color;
+                };
+    
+                struct VertexShaderArguments {
+                    device float *time [[id(0)]];
+                };
+
+                vertex Vertex vsmain(const device VertexShaderArguments &values [[buffer(1)]], unsigned VertexIndex [[vertex_id]])
+                {
+                   float2 pos[3] = {
+                       float2( 0.0,  0.5 + .05 * values.time[0]),
+                       float2(-0.5 -  .05 * values.time[1], -0.5 -  .05 * values.time[1]),
+                       float2( 0.5 +  .05 * values.time[2], -0.5 -  .05 * values.time[2]),
+                   };
+    
+                   Vertex vout;
+                   vout.position = float4(pos[VertexIndex], 0.0, 1.0);
+                   vout.color = float4(pos[VertexIndex] + float2(0.5, 0.5), 0.0, 1.0);
+                   return vout;
+                }
+    
+                fragment float4 fsmain(Vertex in [[stage_in]])
+                {
+                    return in.color;
+                }
+    `;
+    
+    const shaderModule = device.createShaderModule({ code: mslSource, isWHLSL: false, hints: [ {layout: "auto" }, ] });
+    
+    /* GPUPipelineStageDescriptors */
+    const vertexStageDescriptor = { module: shaderModule, entryPoint: "vsmain" };
+    
+    const fragmentStageDescriptor = { module: shaderModule, entryPoint: "fsmain", targets: [ {format: "bgra8unorm" }, ],  };
+    
+    /* GPURenderPipelineDescriptor */
+    
+    const renderPipelineDescriptor = {
+        layout: "auto",
+        vertex: vertexStageDescriptor,
+        fragment: fragmentStageDescriptor,
+        primitive: {topology: "triangle-list" },
+    };
+    /* GPURenderPipeline */
+    const renderPipeline = device.createRenderPipeline(renderPipelineDescriptor);
+    
+    /*** Swap Chain Setup ***/
+    
+    const canvas = document.querySelector("canvas");
+    canvas.width = 600;
+    canvas.height = 600;
+    
+    const gpuContext = canvas.getContext("webgpu");
+    
+    /* GPUCanvasConfiguration */
+    const canvasConfiguration = { device: device, format: "bgra8unorm" };
+    gpuContext.configure(canvasConfiguration);
+    
+    /* GPUTexture */
+    async function frameUpdate() {
+        const secondsBuffer = new Float32Array(3);
+        const d = new Date();
+        const seconds = d.getMilliseconds() / 1000 + d.getSeconds();
+        secondsBuffer.set([seconds*10 * (6.28318530718 / 60.0),
+                          seconds*5 * (6.28318530718 / 60.0),
+                          seconds*1 * (6.28318530718 / 60.0)]);
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, 12);
+
+        const currentTexture = gpuContext.getCurrentTexture();
+        
+        /*** Render Pass Setup ***/
+        
+        /* Acquire Texture To Render To */
+        
+        /* GPUTextureView */
+        const renderAttachment = currentTexture.createView();
+        
+        /* GPUColor */
+        const black = { r: 0.0, g: 0.0, b: 0.0, a: 1 };
+        
+        /* GPURenderPassColorATtachmentDescriptor */
+        const colorAttachmentDescriptor = {
+            view: renderAttachment,
+            loadOp: "clear",
+            storeOp: "store",
+            clearValue: black
+        };
+        
+        /* GPURenderPassDescriptor */
+        const renderPassDescriptor = {
+            colorAttachments: [colorAttachmentDescriptor],
+            occlusionQuerySet: occlusionQuery,
+            timestampWrites: [ { querySet: timestampQuery, queryIndex: 0, location: "beginning" },
+                               { querySet: timestampQuery, queryIndex: 1, location: "end" } ]
+        };
+        
+        /*** Rendering ***/
+        
+        /* GPUCommandEncoder */
+        const commandEncoder = device.createCommandEncoder();
+        /* GPURenderPassEncoder */
+        const renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+        
+        renderPassEncoder.setPipeline(renderPipeline);
+        const vertexBufferSlot = 0;
+        renderPassEncoder.setVertexBuffer(vertexBufferSlot, vertexBuffer, 0);
+        renderPassEncoder.setBindGroup(1, uniformBindGroup);
+        renderPassEncoder.beginOcclusionQuery(0);
+        renderPassEncoder.draw(3, 1, 0, 0); // 3 vertices, 1 instance, 0th vertex, 0th instance.
+        renderPassEncoder.endOcclusionQuery();
+        renderPassEncoder.end();
+        
+        commandEncoder.resolveQuerySet(occlusionQuery, 0, occlusionQueryCount, occlusionQueryResults, 0); // querySet, firstQuery, queryCount, destination, destinationOffset
+        commandEncoder.resolveQuerySet(timestampQuery, 0, timestampQueryCount, timestampQueryResults, 0); // querySet, firstQuery, queryCount, destination, destinationOffset
+
+        /* GPUComamndBuffer */
+        const commandBuffer = commandEncoder.finish();
+        
+        /* GPUQueue */
+        const queue = device.queue;
+        queue.submit([commandBuffer]);
+        
+        const copyBufferEncoder = device.createCommandEncoder();
+        copyBufferEncoder.copyBufferToBuffer(occlusionQueryResults, 0, occlusionQueryDisplayResults, 0, occlusionQueryBufferSize);
+        copyBufferEncoder.copyBufferToBuffer(timestampQueryResults, 0, timestampQueryDisplayResults, 0, timestampQueryBufferSize);
+        const copyBufferEncoderCommandBuffe = copyBufferEncoder.finish();
+        queue.submit([copyBufferEncoderCommandBuffe]);
+
+        const waitForWorkCompletion = await queue.onSubmittedWorkDone();
+
+        const occlusionQueryResultsArrayBuffer = await occlusionQueryDisplayResults.mapAsync(GPUMapMode.READ);
+        const occlusionQueryResultsArray = new BigUint64Array(occlusionQueryDisplayResults.getMappedRange());
+        console.log("Occlusion query results: " + occlusionQueryResultsArray);
+        occlusionQueryDisplayResults.unmap();
+        
+        const timestampQueryResultsArrayBuffer = await timestampQueryDisplayResults.mapAsync(GPUMapMode.READ);
+        const timestampQueryResultsArray = new BigUint64Array(timestampQueryDisplayResults.getMappedRange());
+        console.log("Timestamp query results: " + timestampQueryResultsArray);
+        timestampQueryDisplayResults.unmap();
+    
+        requestAnimationFrame(frameUpdate);
+    }
+    
+    requestAnimationFrame(frameUpdate);
+}
+
+window.addEventListener("DOMContentLoaded", helloTriangle);


### PR DESCRIPTION
#### 9ced63bbda6ac9231451b1ca549a16f397e28c78
<pre>
[WebGPU] Implement GPUQuerySet
<a href="https://bugs.webkit.org/show_bug.cgi?id=249356">https://bugs.webkit.org/show_bug.cgi?id=249356</a>
&lt;radar://103379862&gt;

Reviewed by Dean Jackson.

Implement visibility and timestamp queries.

* Source/WebCore/Modules/WebGPU/GPUBuffer.h:
(WebCore::GPUBuffer::~GPUBuffer):
Call the backing&apos;s destroy function so buffer
instances don&apos;t accumulate.

* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::unmap):
Reset the mapped state on unmap.

* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::validateRenderPassDescriptor const):
(WebGPU::CommandEncoder::beginRenderPass):
(WebGPU::CommandEncoder::resolveQuerySet):
Resolve visibility and occlusion queries as needed.

(WebGPU::CommandEncoder::writeTimestamp):
writeTimestamp is not practical to implement on TBDR, the
best we can get is granularity of the render pass.

* Source/WebGPU/WebGPU/QuerySet.h:
(WebGPU::QuerySet::create):
(WebGPU::QuerySet::isValid const):
(WebGPU::QuerySet::queryCount const):
(WebGPU::QuerySet::visibilityBuffer const):
(WebGPU::QuerySet::counterSampleBuffer const):
* Source/WebGPU/WebGPU/QuerySet.mm:
(WebGPU::getCounterSet):
(WebGPU::Device::createQuerySet):
(WebGPU::QuerySet::QuerySet):
(WebGPU::QuerySet::destroy):
(WebGPU::QuerySet::setLabel):
(WebGPU::QuerySet::resolveTimestamps const):
Implement timestamp and visibility queries.

* Source/WebGPU/WebGPU/RenderPassEncoder.h:
(WebGPU::RenderPassEncoder::create):
Use timestamps queries if they are present in the descriptor.

* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::RenderPassEncoder):
(WebGPU::RenderPassEncoder::beginOcclusionQuery):
(WebGPU::RenderPassEncoder::endOcclusionQuery):
Metal calls for visibility queries.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp:
(WebKit::RemoteCommandEncoder::copyBufferToBuffer):
Fix typo where source was being used as the source and destination.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp:
(WebKit::WebGPU::RemoteBufferProxy::getMappedRange):
Return early if the buffer was already mapped by mapAsync.

* Websites/webkit.org/demos/webgpu/query-sets.html: Added.
* Websites/webkit.org/demos/webgpu/scripts/query-sets.js: Added.
(async helloTriangle.async frameUpdate):
(async helloTriangle):
Add a demo test for this work.

Canonical link: <a href="https://commits.webkit.org/258236@main">https://commits.webkit.org/258236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f5f31c6629cb580814cc3bd1fcf3c9c3cd84175

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110583 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105292 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1322 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93701 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108411 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107093 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4091 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24830 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4139 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44313 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5668 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5902 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->