### PR TITLE
Fix canvas fallback content focusability computation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/canvas-descendants-focusability-003.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/canvas-descendants-focusability-003.tentative-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL <button hidden="" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <section hidden="" tabindex="-1" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <div tabindex="-1" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <span tabindex="-1" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <a href="#" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <button style="display: contents" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <section style="display: contents" tabindex="-1" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <div style="display: contents" tabindex="-1" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <span style="display: contents" tabindex="-1" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <a style="display: contents" href="#" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
+PASS <button hidden="" data-focusable="false">
+PASS <section hidden="" tabindex="-1" data-focusable="false">
+PASS <div tabindex="-1" data-focusable="false">
+PASS <span tabindex="-1" data-focusable="false">
+PASS <a href="#" data-focusable="false">
+PASS <button style="display: contents" data-focusable="false">
+PASS <section style="display: contents" tabindex="-1" data-focusable="false">
+PASS <div style="display: contents" tabindex="-1" data-focusable="false">
+PASS <span style="display: contents" tabindex="-1" data-focusable="false">
+PASS <a style="display: contents" href="#" data-focusable="false">
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/canvas-descendants-focusability-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/canvas-descendants-focusability-005-expected.txt
@@ -5,9 +5,9 @@ PASS <section tabindex="-1" data-focusable="true">
 PASS <div tabindex="-1" data-focusable="true">
 PASS <span tabindex="-1" data-focusable="true">
 PASS <a href="#" data-focusable="true">
-FAIL <button hidden="" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <section tabindex="-1" hidden="" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <div tabindex="-1" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <span tabindex="-1" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
-FAIL <a href="#" data-focusable="false"> assert_true: Shouldn't be focused expected true got false
+PASS <button hidden="" data-focusable="false">
+PASS <section tabindex="-1" hidden="" data-focusable="false">
+PASS <div tabindex="-1" data-focusable="false">
+PASS <span tabindex="-1" data-focusable="false">
+PASS <a href="#" data-focusable="false">
 

--- a/LayoutTests/imported/w3c/web-platform-tests/inert/inert-canvas-fallback-content-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/inert/inert-canvas-fallback-content-expected.txt
@@ -8,41 +8,31 @@ PASS
 PASS
       normal `a`
 
-FAIL
+PASS
       `div` in `display: none`
-     assert_not_equals: got disallowed value Element node <div tabindex="-1" data-focusable="false">
-      `div` in...
-FAIL
+
+PASS
       `span` in `display: none`
-     assert_not_equals: got disallowed value Element node <span tabindex="-1" data-focusable="false">
-      `span` ...
-FAIL
+
+PASS
       `a` in `display: none`
-     assert_not_equals: got disallowed value Element node <a href="#" data-focusable="false">
-      `a` in `display...
-FAIL
+
+PASS
       inert `div`
-     assert_not_equals: got disallowed value Element node <div tabindex="-1" data-focusable="false">
-      inert `d...
-FAIL
+
+PASS
       inert `span`
-     assert_not_equals: got disallowed value Element node <span tabindex="-1" data-focusable="false">
-      inert `...
-FAIL
+
+PASS
       inert `a`
-     assert_not_equals: got disallowed value Element node <a href="#" data-focusable="false">
-      inert `a`
-    </a>
-FAIL
+
+PASS
       inert `div` in `display: none`
-     assert_not_equals: got disallowed value Element node <div tabindex="-1" data-focusable="false">
-      inert `d...
-FAIL
+
+PASS
       inert `span` in `display: none`
-     assert_not_equals: got disallowed value Element node <span tabindex="-1" data-focusable="false">
-      inert `...
-FAIL
+
+PASS
       inert `a` in `display: none`
-     assert_not_equals: got disallowed value Element node <a href="#" data-focusable="false">
-      inert `a` in `d...
+
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -377,6 +377,7 @@ public:
 
     std::optional<int> tabIndexSetExplicitly() const;
     bool shouldBeIgnoredInSequentialFocusNavigation() const { return defaultTabIndex() < 0 && !supportsFocus(); }
+    bool hasFocusableStyle() const;
     virtual bool supportsFocus() const;
     virtual bool isFocusable() const;
     virtual bool isKeyboardFocusable(KeyboardEvent*) const;
@@ -402,8 +403,6 @@ public:
     const RenderStyle* computedStyleForEditability();
 
     bool needsStyleInvalidation() const;
-
-    bool isFocusableWithoutResolvingFullStyle() const;
 
     // Methods for indicating the style is affected by dynamic updates (e.g., children changing, our position changing in our sibling list, etc.)
     bool styleAffectedByEmpty() const { return hasStyleFlag(NodeStyleFlag::StyleAffectedByEmpty); }

--- a/Source/WebCore/html/HTMLAreaElement.cpp
+++ b/Source/WebCore/html/HTMLAreaElement.cpp
@@ -211,7 +211,7 @@ bool HTMLAreaElement::isMouseFocusable() const
 bool HTMLAreaElement::isFocusable() const
 {
     RefPtr<HTMLImageElement> image = imageElement();
-    if (!image || !image->isFocusableWithoutResolvingFullStyle())
+    if (!image || !image->hasFocusableStyle())
         return false;
 
     return supportsFocus() && tabIndexSetExplicitly().value_or(0) >= 0;


### PR DESCRIPTION
#### 40332c5701cc30c1b1be025aaa3e454e2faf81b0
<pre>
Fix canvas fallback content focusability computation
<a href="https://bugs.webkit.org/show_bug.cgi?id=239017">https://bugs.webkit.org/show_bug.cgi?id=239017</a>
rdar://91830204

Reviewed by Ryosuke Niwa.

Fallback content for canvas should go through all the normal checks for focusability. The only thing that differs is
that the fallback content should not be focusable if the canvas isn&apos;t.

Rename `isFocusableWithoutResolvingFullStyle` to `hasFocusableStyle` since the old name was misleading (suggests that it
is the same as `isFocusable` without resolving the full style, which isn&apos;t true).

* LayoutTests/imported/w3c/web-platform-tests/inert/inert-canvas-fallback-content-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isFocusable const):
(WebCore::Element::isFocusableWithoutResolvingFullStyle const): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/HTMLAreaElement.cpp:
(WebCore::HTMLAreaElement::isFocusable const):

Canonical link: <a href="https://commits.webkit.org/258043@main">https://commits.webkit.org/258043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea4107455e0adcd30d06761ef7da5ce4acd8aee1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110019 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170293 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/444 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93121 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107865 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34768 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90068 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77739 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3558 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24325 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3582 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43821 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5518 "Found 1 new test failure: imported/w3c/web-platform-tests/webstorage/event_case_sensitive.html (failure)") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5361 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2887 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->