### PR TITLE
Add API for getting and setting cookie policy used in WKWebView

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h
@@ -31,6 +31,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class WKHTTPCookieStore;
 
+typedef NS_ENUM(NSInteger, WKCookiePolicy) {
+    WKCookiePolicyAllow,
+    WKCookiePolicyDisallow,
+} NS_SWIFT_NAME(WKHTTPCookieStore.CookiePolicy) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 WK_API_AVAILABLE(macos(10.13), ios(11.0))
 @protocol WKHTTPCookieStoreObserver <NSObject>
 @optional
@@ -72,6 +77,17 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
  @param observer The observer to remove.
  */
 - (void)removeObserver:(id<WKHTTPCookieStoreObserver>)observer;
+
+/*! @abstract Set whether cookies are allowed.
+ @param policy A value indicating whether cookies are allowed. The default value is WKCookiePolicyAllow.
+ @param completionHandler A block to invoke once the cookie policy has been set.
+ */
+- (void)setCookiePolicy:(WKCookiePolicy)policy completionHandler:(nullable void (^)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+/*! @abstract Get whether cookies are allowed.
+ @param completionHandler A block to invoke with the value of whether cookies are allowed.
+ */
+- (void)getCookiePolicy:(void (^)(WKCookiePolicy))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA)) NS_SWIFT_ASYNC_NAME(getter:cookiePolicy());
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
@@ -125,6 +125,23 @@ private:
     _cookieStore->unregisterObserver(*result);
 }
 
+- (void)setCookiePolicy:(WKCookiePolicy)policy completionHandler:(void (^)(void))completionHandler
+{
+    auto corePolicy = policy == WKCookiePolicyAllow ? WebCore::HTTPCookieAcceptPolicy::AlwaysAccept : WebCore::HTTPCookieAcceptPolicy::Never;
+    _cookieStore->setHTTPCookieAcceptPolicy(corePolicy, [completionHandler = makeBlockPtr(completionHandler)] {
+        if (completionHandler)
+            completionHandler.get()();
+    });
+}
+
+- (void)getCookiePolicy:(void (^)(WKCookiePolicy))completionHandler
+{
+    _cookieStore->getHTTPCookieAcceptPolicy([completionHandler = makeBlockPtr(completionHandler)] (WebCore::HTTPCookieAcceptPolicy policy) {
+        ASSERT(policy == WebCore::HTTPCookieAcceptPolicy::Never || policy == WebCore::HTTPCookieAcceptPolicy::AlwaysAccept);
+        completionHandler(policy == WebCore::HTTPCookieAcceptPolicy::Never ? WKCookiePolicyDisallow : WKCookiePolicyAllow);
+    });
+}
+
 #pragma mark WKObject protocol implementation
 
 - (API::Object&)_apiObject


### PR DESCRIPTION
#### f8d7c32068649dae490685756e9797417cbec045
<pre>
Add API for getting and setting cookie policy used in WKWebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=249508">https://bugs.webkit.org/show_bug.cgi?id=249508</a>
rdar://21391448

Reviewed by NOBODY (OOPS!).

* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
(-[WKHTTPCookieStore setCookiePolicy:completionHandler:]):
(-[WKHTTPCookieStore getCookiePolicy:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm:
(TEST):
</pre>