### PR TITLE
user-select: initial content within user-select: none should be copied

### DIFF
--- a/LayoutTests/editing/pasteboard/copy-content-with-user-select-none-expected.txt
+++ b/LayoutTests/editing/pasteboard/copy-content-with-user-select-none-expected.txt
@@ -6,19 +6,38 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS getSelection().toString().includes("hello") is true
 PASS getSelection().toString().includes("world") is false
+PASS getSelection().toString().includes("WebKit") is true
+PASS getSelection().toString().includes("rocks") is false
+PASS getSelection().toString().includes("because") is false
 PASS getSelection().toString().includes("foo") is false
 PASS getSelection().toString().includes("bar") is true
 PASS event.clipboardData.getData("text/plain").includes("hello") is true
 PASS event.clipboardData.getData("text/plain").includes("world") is false
+PASS event.clipboardData.getData("text/plain").includes("WebKit") is true
+PASS event.clipboardData.getData("text/plain").includes("rocks") is false
+PASS event.clipboardData.getData("text/plain").includes("beacuse") is false
 PASS event.clipboardData.getData("text/plain").includes("foo") is false
 PASS event.clipboardData.getData("text/plain").includes("bar") is true
 PASS event.clipboardData.getData("text/html").includes("hello") is true
 PASS event.clipboardData.getData("text/html").includes("world") is false
+PASS event.clipboardData.getData("text/html").includes("<i") is false
+PASS event.clipboardData.getData("text/html").includes("</i>") is false
+PASS event.clipboardData.getData("text/html").includes("WebKit") is true
+PASS event.clipboardData.getData("text/html").includes("<b ") is true
+PASS event.clipboardData.getData("text/html").includes("</b>") is true
+PASS event.clipboardData.getData("text/html").includes("rocks") is false
+PASS event.clipboardData.getData("text/html").includes("<q>") is false
+PASS event.clipboardData.getData("text/html").includes("</q>") is false
+PASS event.clipboardData.getData("text/html").includes("because") is false
+PASS event.clipboardData.getData("text/html").includes("<s>") is false
+PASS event.clipboardData.getData("text/html").includes("</s>") is false
+PASS event.clipboardData.getData("text/html").includes("<em>") is false
+PASS event.clipboardData.getData("text/html").includes("</em>") is false
 PASS event.clipboardData.getData("text/html").includes("foo") is false
 PASS event.clipboardData.getData("text/html").includes("bar") is true
 PASS successfullyParsed is true
 
 TEST COMPLETE
-hello world foo bar
-hello bar
+hello world WebKit rocks because foo bar
+hello WebKit bar
 

--- a/LayoutTests/editing/pasteboard/copy-content-with-user-select-none.html
+++ b/LayoutTests/editing/pasteboard/copy-content-with-user-select-none.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html>
 <body>
-<div id="source">hello <span style="-webkit-user-select: none; user-select: none;">world </span><span inert>foo </span>bar</div>
+<div id="source">hello <span style="-webkit-user-select: none; user-select: none;"><i>world </i><b style="-webkit-user-select: initial;
+user-select: initial;">WebKit <span style="-webkit-user-select: none; user-select: none;"><q>rocks </q></span></b><font color="green" style="-webkit-user-select: none;
+user-select: none;"><s>because </s></font></span><span inert><em>foo </em></span></span>bar</div>
 <div id="destination" contenteditable></div>
 <pre id="output"></pre>
 </body>
@@ -17,6 +19,9 @@ getSelection().setBaseAndExtent(source, 0, source, source.childNodes.length);
 source.addEventListener("copy", () => {
     shouldBeTrue('getSelection().toString().includes("hello")');
     shouldBeFalse('getSelection().toString().includes("world")');
+    shouldBeTrue('getSelection().toString().includes("WebKit")');
+    shouldBeFalse('getSelection().toString().includes("rocks")');
+    shouldBeFalse('getSelection().toString().includes("because")');
     shouldBeFalse('getSelection().toString().includes("foo")');
     shouldBeTrue('getSelection().toString().includes("bar")');
 });
@@ -24,17 +29,32 @@ source.addEventListener("copy", () => {
 destination.addEventListener("paste", () => {
     shouldBeTrue('event.clipboardData.getData("text/plain").includes("hello")');
     shouldBeFalse('event.clipboardData.getData("text/plain").includes("world")');
+    shouldBeTrue('event.clipboardData.getData("text/plain").includes("WebKit")');
+    shouldBeFalse('event.clipboardData.getData("text/plain").includes("rocks")');
+    shouldBeFalse('event.clipboardData.getData("text/plain").includes("beacuse")');
     shouldBeFalse('event.clipboardData.getData("text/plain").includes("foo")');
     shouldBeTrue('event.clipboardData.getData("text/plain").includes("bar")');
     shouldBeTrue('event.clipboardData.getData("text/html").includes("hello")');
     shouldBeFalse('event.clipboardData.getData("text/html").includes("world")');
+    shouldBeFalse('event.clipboardData.getData("text/html").includes("<i")');
+    shouldBeFalse('event.clipboardData.getData("text/html").includes("</i>")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("WebKit")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("<b ")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("</b>")');
+    shouldBeFalse('event.clipboardData.getData("text/html").includes("rocks")');
+    shouldBeFalse('event.clipboardData.getData("text/html").includes("<q>")');
+    shouldBeFalse('event.clipboardData.getData("text/html").includes("</q>")');
+    shouldBeFalse('event.clipboardData.getData("text/html").includes("because")');
+    shouldBeFalse('event.clipboardData.getData("text/html").includes("<s>")');
+    shouldBeFalse('event.clipboardData.getData("text/html").includes("</s>")');
+    shouldBeFalse('event.clipboardData.getData("text/html").includes("<em>")');
+    shouldBeFalse('event.clipboardData.getData("text/html").includes("</em>")');
     shouldBeFalse('event.clipboardData.getData("text/html").includes("foo")');
     shouldBeTrue('event.clipboardData.getData("text/html").includes("bar")');
     finishJSTest();
 });
 
-if (window.testRunner && window.internals) {
-    testRunner.dumpAsText();
+if (window.testRunner) {
     testRunner.execCommand("Copy");
     destination.focus();
     testRunner.execCommand("Paste");

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -477,7 +477,7 @@ void TextIterator::advance()
         if (!m_handledNode) {
             if (!isRendererVisible(renderer, m_behaviors)) {
                 m_handledNode = true;
-                m_handledChildren = !hasDisplayContents(*m_node);
+                m_handledChildren = !hasDisplayContents(*m_node) && !renderer;
             } else {
                 // handle current node according to its type
                 if (renderer->isText() && m_node->isTextNode())

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -59,6 +59,24 @@ enum class MSOListQuirks : bool { CheckIfNeeded, Disabled };
 String sanitizeMarkup(const String&, MSOListQuirks = MSOListQuirks::Disabled, std::optional<Function<void(DocumentFragment&)>> fragmentSanitizer = std::nullopt);
 String sanitizedMarkupForFragmentInDocument(Ref<DocumentFragment>&&, Document&, MSOListQuirks, const String& originalMarkup);
 
+class UserSelectNoneStateCache {
+public:
+    explicit UserSelectNoneStateCache(TreeType);
+
+    bool nodeOnlyContainsUserSelectNone(Node& node) { return computeState(node) == State::OnlyUserSelectNone; }
+
+private:
+    ContainerNode* parentNode(Node&);
+    Node* firstChild(Node&);
+    Node* nextSibling(Node&);
+
+    enum class State : uint8_t { NotUserSelectNone, Mixed, OnlyUserSelectNone };
+    State computeState(Node&);
+
+    HashMap<Ref<Node>, State> m_cache;
+    bool m_useComposedTree;
+};
+
 WEBCORE_EXPORT Ref<DocumentFragment> createFragmentFromText(const SimpleRange& context, const String& text);
 WEBCORE_EXPORT Ref<DocumentFragment> createFragmentFromMarkup(Document&, const String& markup, const String& baseURL, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
 ExceptionOr<Ref<DocumentFragment>> createFragmentForInnerOuterHTML(Element&, const String& markup, OptionSet<ParserContentPolicy>);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm
@@ -165,9 +165,11 @@ TEST(CopyRTF, StripsDataDetectorsLinks)
 
 TEST(CopyRTF, StripsUserSelectNone)
 {
-    auto attributedString = copyAttributedStringFromHTML(@"hello <span style='-webkit-user-select: none'>world </span><span inert>foo </span>bar", false);
+    auto attributedString = copyAttributedStringFromHTML(@"hello <span style='-webkit-user-select: none; user-select: none;'>world "
+        "<span style='-webkit-user-select: initial; user-select: initial;'>WebKit </span></span>"
+        "<div style='-webkit-user-select: none; user-select: none;'>some<br>user-select-none<br>content</div><span inert>foo </span>bar", false);
 
-    EXPECT_WK_STREQ([attributedString string].UTF8String, "hello bar");
+    EXPECT_WK_STREQ([attributedString string].UTF8String, "hello WebKit bar");
 }
 
 #endif // PLATFORM(COCOA)


### PR DESCRIPTION
#### 3837614ab70da684405b3f6f704694b6a5ff6bf5
<pre>
user-select: initial content within user-select: none should be copied
<a href="https://bugs.webkit.org/show_bug.cgi?id=249507">https://bugs.webkit.org/show_bug.cgi?id=249507</a>

Reviewed by Darin Adler.

Allow content inside user-select: none to be copyable if it&apos;s not user-select: none.

The fix is simple for TextIterator where we can set m_handledChildren to be false when
ignoring user-select: none content so that if there is any visible content we won&apos;t skip.

The fix is more involved for StyledMarkupAccumulator (for HTML) and HTMLConverter (RTFD).
These classes need to decide whether the whole element should be skipped or not based on
if an element with user-select: none contains any content that is not user-select: none or not.

If it does, then we need to traverse through these elements with appropriate block/paragraph
styling and emit string for those content that is not user-select: none.

* LayoutTests/editing/pasteboard/copy-content-with-user-select-none-expected.txt:
* LayoutTests/editing/pasteboard/copy-content-with-user-select-none.html:

* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::advance):

* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::HTMLConverter):
(HTMLConverter::_enterElement):
(HTMLConverter::_processText):

* Source/WebCore/editing/markup.cpp:
(WebCore::UserSelectNoneStateCache::UserSelectNoneStateCache): Added.
(WebCore::UserSelectNoneStateCache::parentNode): Added.
(WebCore::UserSelectNoneStateCache::firstChild): Added.
(WebCore::UserSelectNoneStateCache::nextSibling): Added.
(WebCore::UserSelectNoneStateCache::computeState): Added.
(WebCore::StyledMarkupAccumulator::traverseNodesForSerialization):

* Source/WebCore/editing/markup.h:
(WebCore::UserSelectNoneStateCache::nodeOnlyContainsUserSelectNone): Added.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm:
(CopyRTF.StripsUserSelectNone):

Canonical link: <a href="https://commits.webkit.org/258054@main">https://commits.webkit.org/258054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8c58b06845472f8949a34172efb5d5cccae0c13

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110027 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170301 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/400 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93129 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107873 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91416 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34774 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77745 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3566 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24332 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/398 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43829 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5368 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2895 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->