### PR TITLE
Refactor caret animation handling logic when scrolling/zooming

### DIFF
--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -333,6 +333,8 @@ private:
     void uppercaseWord() final { }
     void lowercaseWord() final { }
     void capitalizeWord() final { }
+
+    void setCaretDecorationVisibility(bool) final { }
 #endif
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -154,6 +154,8 @@ public:
     virtual void uppercaseWord() = 0;
     virtual void lowercaseWord() = 0;
     virtual void capitalizeWord() = 0;
+
+    virtual void setCaretDecorationVisibility(bool) = 0;
 #endif
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4126,4 +4126,18 @@ String Page::sanitizeLookalikeCharacters(const String& urlString) const
     return urlString;
 }
 
+void Page::willBeginScrolling()
+{
+#if USE(APPKIT)
+    editorClient().setCaretDecorationVisibility(false);
+#endif
+}
+
+void Page::didFinishScrolling()
+{
+#if USE(APPKIT)
+    editorClient().setCaretDecorationVisibility(true);
+#endif
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -998,6 +998,9 @@ public:
 
     BadgeClient& badgeClient() { return m_badgeClient.get(); }
 
+    void willBeginScrolling();
+    void didFinishScrolling();
+
 private:
     struct Navigation {
         RegistrableDomain domain;

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "pal/HysteresisActivity.h"
 #if ENABLE(ASYNC_SCROLLING)
 
 #include "ScrollingCoordinator.h"
@@ -160,14 +161,21 @@ private:
     
     void applyScrollPositionUpdate(ScrollUpdate&&, ScrollType);
     void updateScrollPositionAfterAsyncScroll(ScrollingNodeID, const FloatPoint&, std::optional<FloatPoint> layoutViewportOrigin, ScrollingLayerPositionAction, ScrollType);
+    void animatedScrollWillStartForNode(ScrollingNodeID);
     void animatedScrollDidEndForNode(ScrollingNodeID);
+    void wheelEventScrollWillStartForNode(ScrollingNodeID);
+    void wheelEventScrollDidEndForNode(ScrollingNodeID);
 
     FrameView* frameViewForScrollingNode(ScrollingNodeID) const;
+
+    void hysterisisTimerFired(PAL::HysteresisState);
 
     std::unique_ptr<ScrollingStateTree> m_scrollingStateTree;
     RefPtr<ScrollingTree> m_scrollingTree;
 
     bool m_eventTrackingRegionsDirty { false };
+
+    PAL::HysteresisActivity m_hysterisisActivity;
 };
 
 #if ENABLE(SCROLLING_THREAD)

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
@@ -136,4 +136,16 @@ TextStream& operator<<(TextStream& ts, WheelEventProcessingSteps steps)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, ScrollUpdateType type)
+{
+    switch (type) {
+    case ScrollUpdateType::PositionUpdate: ts << "position update"; break;
+    case ScrollUpdateType::AnimatedScrollWillStart: ts << "animated scroll will start"; break;
+    case ScrollUpdateType::AnimatedScrollDidEnd: ts << "animated scroll did end"; break;
+    case ScrollUpdateType::WheelEventScrollWillStart: ts << "wheel event scroll will start"; break;
+    case ScrollUpdateType::WheelEventScrollDidEnd: ts << "wheel event scroll did end"; break;
+    }
+    return ts;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -151,7 +151,10 @@ struct RequestedKeyboardScrollData {
 
 enum class ScrollUpdateType : uint8_t {
     PositionUpdate,
-    AnimatedScrollDidEnd
+    AnimatedScrollWillStart,
+    AnimatedScrollDidEnd,
+    WheelEventScrollWillStart,
+    WheelEventScrollDidEnd,
 };
 
 struct ScrollUpdate {
@@ -205,6 +208,7 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollingLayerPosit
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollableAreaParameters);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ViewportRectStability);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, WheelEventProcessingSteps);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollUpdateType);
 
 } // namespace WebCore
 

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -117,7 +117,10 @@ public:
     // Called after a scrolling tree node has handled a scroll and updated its layers.
     // Updates FrameView/RenderLayer scrolling state and GraphicsLayers.
     virtual void scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode&, ScrollingLayerPositionAction = ScrollingLayerPositionAction::Sync) = 0;
+    virtual void scrollingTreeNodeWillStartAnimatedScroll(ScrollingTreeScrollingNode&) { }
     virtual void scrollingTreeNodeDidStopAnimatedScroll(ScrollingTreeScrollingNode&) { }
+    virtual void scrollingTreeNodeWillStartWheelEventScroll(ScrollingTreeScrollingNode&) { }
+    virtual void scrollingTreeNodeDidStopWheelEventScroll(ScrollingTreeScrollingNode&) { }
 
     // Called for requested scroll position updates. Returns true if handled.
     virtual bool scrollingTreeNodeRequestsScroll(ScrollingNodeID, const RequestedScrollData&) { return false; }

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -236,10 +236,25 @@ void ScrollingTreeScrollingNode::setScrollSnapInProgress(bool isSnapping)
     scrollingTree().setNodeScrollSnapInProgress(scrollingNodeID(), isSnapping);
 }
 
+void ScrollingTreeScrollingNode::willStartAnimatedScroll()
+{
+    scrollingTree().scrollingTreeNodeWillStartAnimatedScroll(*this);
+}
+
 void ScrollingTreeScrollingNode::didStopAnimatedScroll()
 {
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeScrollingNode " << scrollingNodeID() << " didStopAnimatedScroll");
     scrollingTree().scrollingTreeNodeDidStopAnimatedScroll(*this);
+}
+
+void ScrollingTreeScrollingNode::willStartWheelEventScroll()
+{
+    scrollingTree().scrollingTreeNodeWillStartWheelEventScroll(*this);
+}
+
+void ScrollingTreeScrollingNode::didStopWheelEventScroll()
+{
+    scrollingTree().scrollingTreeNodeDidStopWheelEventScroll(*this);
 }
 
 bool ScrollingTreeScrollingNode::startAnimatedScrollToPosition(FloatPoint destinationPosition)

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -141,7 +141,10 @@ protected:
     virtual bool startAnimatedScrollToPosition(FloatPoint);
     virtual void stopAnimatedScroll();
 
+    void willStartAnimatedScroll();
     void didStopAnimatedScroll();
+    void willStartWheelEventScroll();
+    void didStopWheelEventScroll();
 
     void setScrollAnimationInProgress(bool);
 

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -259,14 +259,14 @@ void ThreadedScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNod
     });
 }
 
-void ThreadedScrollingTree::scrollingTreeNodeDidStopAnimatedScroll(ScrollingTreeScrollingNode& node)
+void ThreadedScrollingTree::scrollingTreeNodeScrollUpdated(ScrollingTreeScrollingNode& node, const ScrollUpdateType& scrollUpdateType)
 {
     if (!m_scrollingCoordinator)
         return;
 
-    LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingTree::scrollingTreeNodeDidStopAnimatedScroll " << node.scrollingNodeID());
+    LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingTree::scrollingTreeNodeScrollUpdated " << node.scrollingNodeID() << " update type " << scrollUpdateType);
 
-    auto scrollUpdate = ScrollUpdate { node.scrollingNodeID(), { }, { }, ScrollUpdateType::AnimatedScrollDidEnd };
+    auto scrollUpdate = ScrollUpdate { node.scrollingNodeID(), { }, { }, scrollUpdateType };
 
     if (RunLoop::isMain()) {
         m_scrollingCoordinator->applyScrollUpdate(WTFMove(scrollUpdate));
@@ -279,6 +279,26 @@ void ThreadedScrollingTree::scrollingTreeNodeDidStopAnimatedScroll(ScrollingTree
         if (auto* scrollingCoordinator = strongThis->m_scrollingCoordinator.get())
             scrollingCoordinator->scrollingThreadAddedPendingUpdate();
     });
+}
+
+void ThreadedScrollingTree::scrollingTreeNodeWillStartAnimatedScroll(ScrollingTreeScrollingNode& node)
+{
+    scrollingTreeNodeScrollUpdated(node, ScrollUpdateType::AnimatedScrollWillStart);
+}
+
+void ThreadedScrollingTree::scrollingTreeNodeDidStopAnimatedScroll(ScrollingTreeScrollingNode& node)
+{
+    scrollingTreeNodeScrollUpdated(node, ScrollUpdateType::AnimatedScrollDidEnd);
+}
+
+void ThreadedScrollingTree::scrollingTreeNodeWillStartWheelEventScroll(ScrollingTreeScrollingNode& node)
+{
+    scrollingTreeNodeScrollUpdated(node, ScrollUpdateType::WheelEventScrollWillStart);
+}
+
+void ThreadedScrollingTree::scrollingTreeNodeDidStopWheelEventScroll(ScrollingTreeScrollingNode& node)
+{
+    scrollingTreeNodeScrollUpdated(node, ScrollUpdateType::WheelEventScrollDidEnd);
 }
 
 void ThreadedScrollingTree::reportSynchronousScrollingReasonsChanged(MonotonicTime timestamp, OptionSet<SynchronousScrollingReason> reasons)

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
@@ -71,7 +71,10 @@ protected:
     explicit ThreadedScrollingTree(AsyncScrollingCoordinator&);
 
     void scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode&, ScrollingLayerPositionAction = ScrollingLayerPositionAction::Sync) override;
+    void scrollingTreeNodeWillStartAnimatedScroll(ScrollingTreeScrollingNode&) override;
     void scrollingTreeNodeDidStopAnimatedScroll(ScrollingTreeScrollingNode&) override;
+    void scrollingTreeNodeWillStartWheelEventScroll(ScrollingTreeScrollingNode&) override;
+    void scrollingTreeNodeDidStopWheelEventScroll(ScrollingTreeScrollingNode&) override;
     bool scrollingTreeNodeRequestsScroll(ScrollingNodeID, const RequestedScrollData&) override WTF_REQUIRES_LOCK(m_treeLock);
 
 #if PLATFORM(MAC)
@@ -122,6 +125,8 @@ private:
 
     void lockLayersForHitTesting() final WTF_ACQUIRES_LOCK(m_layerHitTestMutex);
     void unlockLayersForHitTesting() final WTF_RELEASES_LOCK(m_layerHitTestMutex);
+
+    void scrollingTreeNodeScrollUpdated(ScrollingTreeScrollingNode&, const ScrollUpdateType&);
 
     enum class SynchronizationState : uint8_t {
         Idle,

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
@@ -146,9 +146,24 @@ float ThreadedScrollingTreeScrollingNodeDelegate::pageScaleFactor() const
     return 1;
 }
 
+void ThreadedScrollingTreeScrollingNodeDelegate::willStartAnimatedScroll()
+{
+    scrollingNode().willStartAnimatedScroll();
+}
+
 void ThreadedScrollingTreeScrollingNodeDelegate::didStopAnimatedScroll()
 {
     scrollingNode().didStopAnimatedScroll();
+}
+
+void ThreadedScrollingTreeScrollingNodeDelegate::willStartWheelEventScroll()
+{
+    scrollingNode().willStartWheelEventScroll();
+}
+
+void ThreadedScrollingTreeScrollingNodeDelegate::didStopWheelEventScroll()
+{
+    scrollingNode().didStopWheelEventScroll();
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::willStartScrollSnapAnimation()

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h
@@ -72,7 +72,10 @@ protected:
     FloatPoint scrollOffset() const override;
     float pageScaleFactor() const override;
 
+    void willStartAnimatedScroll() override;
     void didStopAnimatedScroll() override;
+    void willStartWheelEventScroll() override;
+    void didStopWheelEventScroll() override;
     void willStartScrollSnapAnimation() override;
     void didStopScrollSnapAnimation() override;
 

--- a/Source/WebCore/platform/ScrollingEffectsController.cpp
+++ b/Source/WebCore/platform/ScrollingEffectsController.cpp
@@ -518,6 +518,8 @@ void ScrollingEffectsController::scrollAnimationWillStart(ScrollAnimation& anima
     UNUSED_PARAM(animation);
 #endif
 
+    m_client.willStartAnimatedScroll();
+
     if (is<ScrollAnimationKeyboard>(animation)) {
         willBeginKeyboardScrolling();
         startDeferringWheelEventTestCompletion(WheelEventTestMonitor::ScrollAnimationInProgress);

--- a/Source/WebCore/platform/ScrollingEffectsController.h
+++ b/Source/WebCore/platform/ScrollingEffectsController.h
@@ -115,6 +115,9 @@ public:
     virtual void willStartAnimatedScroll() { }
     virtual void didStopAnimatedScroll() { }
 
+    virtual void willStartWheelEventScroll() { }
+    virtual void didStopWheelEventScroll() { }
+
     virtual void willStartScrollSnapAnimation() { }
     virtual void didStopScrollSnapAnimation() { }
 

--- a/Source/WebCore/platform/mac/ScrollingEffectsController.mm
+++ b/Source/WebCore/platform/mac/ScrollingEffectsController.mm
@@ -119,6 +119,11 @@ bool ScrollingEffectsController::handleWheelEvent(const PlatformWheelEvent& whee
     if (wheelEvent.phase() == PlatformWheelEventPhase::MayBegin || wheelEvent.phase() == PlatformWheelEventPhase::Cancelled)
         return false;
 
+    if (wheelEvent.isEndOfNonMomentumScroll() || wheelEvent.isEndOfMomentumScroll())
+        m_client.didStopWheelEventScroll();
+    else if (wheelEvent.isGestureStart() || wheelEvent.isTransitioningToMomentumScroll())
+        m_client.willStartWheelEventScroll();
+
     if (wheelEvent.phase() == PlatformWheelEventPhase::Began) {
         // FIXME: Trying to decide if a gesture is horizontal or vertical at the "began" phase is very error-prone.
         auto horizontalSide = ScrollableArea::targetSideForScrollDelta(-wheelEvent.delta(), ScrollEventAxis::Horizontal);

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -458,6 +458,8 @@ public:
     virtual void registerInsertionUndoGrouping() = 0;
 
     virtual void setEditableElementIsFocused(bool) = 0;
+
+    virtual void setCaretDecorationVisibility(bool) = 0;
 #endif // PLATFORM(MAC)
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9742,6 +9742,11 @@ void WebPageProxy::setEditableElementIsFocused(bool editableElementIsFocused)
     pageClient().setEditableElementIsFocused(editableElementIsFocused);
 }
 
+void WebPageProxy::setCaretDecorationVisibility(bool visibility)
+{
+    pageClient().setCaretDecorationVisibility(visibility);
+}
+
 #endif // PLATFORM(MAC)
 
 #if PLATFORM(COCOA) || PLATFORM(GTK)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2174,6 +2174,11 @@ public:
     void disconnectFramesFromPage();
 
     void didCommitLoadForFrame(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, uint64_t navigationID, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool wasPrivateRelayed, bool containsPluginDocument, std::optional<WebCore::HasInsecureContent> forcedHasInsecureContent, WebCore::MouseEventPolicy, const UserData&);
+
+#if PLATFORM(MAC)
+    void setCaretDecorationVisibility(bool);
+#endif
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -368,6 +368,8 @@ messages -> WebPageProxy {
 
     SetEditableElementIsFocused(bool editableElementIsFocused)
 
+    SetCaretDecorationVisibility(bool visibility)
+
     HandleAcceptsFirstMouse(bool acceptsFirstMouse)
 #endif
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -197,6 +197,8 @@ private:
 
     void setEditableElementIsFocused(bool) override;
 
+    void setCaretDecorationVisibility(bool) override;
+
     void registerInsertionUndoGrouping() override;
 
 #if ENABLE(UI_PROCESS_PDF_HUD)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -755,6 +755,11 @@ void PageClientImpl::setEditableElementIsFocused(bool editableElementIsFocused)
     m_impl->setEditableElementIsFocused(editableElementIsFocused);
 }
 
+void PageClientImpl::setCaretDecorationVisibility(bool visibility)
+{
+    m_impl->setCaretDecorationVisibility(visibility);
+}
+
 #if ENABLE(FULLSCREEN_API)
 
 WebFullScreenManagerProxyClient& PageClientImpl::fullScreenManagerProxyClient()

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -119,6 +119,12 @@ void ViewGestureController::handleMagnificationGestureEvent(NSEvent *event, Floa
 
     ASSERT(m_activeGestureType == ViewGestureType::None || m_activeGestureType == ViewGestureType::Magnification);
 
+    if (event.phase == NSEventPhaseBegan)
+        m_webPageProxy.setCaretDecorationVisibility(false);
+
+    if (event.phase == NSEventPhaseEnded || event.phase == NSEventPhaseCancelled)
+        m_webPageProxy.setCaretDecorationVisibility(true);
+
     if (m_activeGestureType == ViewGestureType::None) {
         if (event.phase != NSEventPhaseBegan)
             return;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -376,6 +376,8 @@ public:
     bool validateUserInterfaceItem(id <NSValidatedUserInterfaceItem>);
     void setEditableElementIsFocused(bool);
 
+    void setCaretDecorationVisibility(bool);
+
     void startSpeaking();
     void stopSpeaking(id);
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5790,6 +5790,12 @@ void WebViewImpl::setEditableElementIsFocused(bool editableElementIsFocused)
 
 #endif // HAVE(TOUCH_BAR)
 
+#if !USE(APPLE_INTERNAL_SDK)
+void WebViewImpl::setCaretDecorationVisibility(bool)
+{
+}
+#endif
+
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
 void WebViewImpl::setMediaSessionCoordinatorForTesting(MediaSessionCoordinatorProxyPrivate* coordinator)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -124,6 +124,8 @@ private:
     void uppercaseWord() final;
     void lowercaseWord() final;
     void capitalizeWord() final;
+
+    void setCaretDecorationVisibility(bool) final;
 #endif
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
@@ -179,6 +179,11 @@ void WebEditorClient::toggleAutomaticSpellingCorrection()
 
 #endif // USE(AUTOMATIC_TEXT_REPLACEMENT)
 
+void WebEditorClient::setCaretDecorationVisibility(bool visibility)
+{
+    m_page->send(Messages::WebPageProxy::SetCaretDecorationVisibility(visibility));
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
@@ -89,6 +89,8 @@ private:
     void uppercaseWord() final;
     void lowercaseWord() final;
     void capitalizeWord() final;
+
+    void setCaretDecorationVisibility(bool) final { };
 #endif
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)


### PR DESCRIPTION
#### f7697e1e0fab24855f25a56a0512c7bbdffdc108
<pre>
Refactor caret animation handling logic when scrolling/zooming
<a href="https://bugs.webkit.org/show_bug.cgi?id=249511">https://bugs.webkit.org/show_bug.cgi?id=249511</a>
rdar://102938633

Reviewed by Simon Fraser.

* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/EditorClient.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::AsyncScrollingCoordinator):
(WebCore::AsyncScrollingCoordinator::hysterisisTimerFired):
(WebCore::AsyncScrollingCoordinator::applyScrollPositionUpdate):
(WebCore::AsyncScrollingCoordinator::animatedScrollWillStartForNode):
(WebCore::AsyncScrollingCoordinator::animatedScrollDidEndForNode):
(WebCore::AsyncScrollingCoordinator::wheelEventScrollWillStartForNode):
(WebCore::AsyncScrollingCoordinator::wheelEventScrollDidEndForNode):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::scrollingTreeNodeWillStartAnimatedScroll):
(WebCore::ScrollingTree::scrollingTreeNodeWillStartWheelEventScroll):
(WebCore::ScrollingTree::scrollingTreeNodeDidStopWheelEventScroll):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::willStartAnimatedScroll):
(WebCore::ScrollingTreeScrollingNode::willStartWheelEventScroll):
(WebCore::ScrollingTreeScrollingNode::didStopWheelEventScroll):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::scrollingTreeNodeScrollUpdated):
(WebCore::ThreadedScrollingTree::scrollingTreeNodeWillStartAnimatedScroll):
(WebCore::ThreadedScrollingTree::scrollingTreeNodeDidStopAnimatedScroll):
(WebCore::ThreadedScrollingTree::scrollingTreeNodeWillStartWheelEventScroll):
(WebCore::ThreadedScrollingTree::scrollingTreeNodeDidStopWheelEventScroll):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp:
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::willStartAnimatedScroll):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::willStartWheelEventScroll):
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::didStopWheelEventScroll):
* Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h:
* Source/WebCore/platform/ScrollingEffectsController.cpp:
(WebCore::ScrollingEffectsController::scrollAnimationWillStart):
* Source/WebCore/platform/ScrollingEffectsController.h:
(WebCore::ScrollingEffectsControllerClient::willStartWheelEventScroll):
(WebCore::ScrollingEffectsControllerClient::didStopWheelEventScroll):
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::handleWheelEvent):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setCaretDecorationVisibility):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::setCaretDecorationVisibility):
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::handleMagnificationGestureEvent):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::setCaretDecorationVisibility):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::setCaretDecorationVisibility):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h:

Canonical link: <a href="https://commits.webkit.org/258201@main">https://commits.webkit.org/258201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7de16a76cb29b7ad5aa391b83cbd4c5d14aba59b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110481 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170762 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1217 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93598 "Updated gtk dependencies (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108313 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8574 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/93598 "Updated gtk dependencies (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23224 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/93598 "Updated gtk dependencies (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3992 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24739 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1162 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44225 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5634 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5793 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->