### PR TITLE
Fix build for "[Xcode] IDECustomBuildProductsPaths starting with "~" are ignored when determining the build location"

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -401,6 +401,7 @@ sub determineBaseProductDir
         if (!defined($baseProductDir)) {
             $baseProductDir = join '', readXcodeUserDefault("IDEApplicationwideBuildSettings");
             $baseProductDir = $1 if $baseProductDir =~ /SYMROOT\s*=\s*\"(.*?)\";/s;
+            undef $baseProductDir if $baseProductDir =~ /{\s*}/;
         }
     }
 


### PR DESCRIPTION
#### 16f48c87bad1617f9bb4a9ec12c918877966c313
<pre>
Fix build for &quot;[Xcode] IDECustomBuildProductsPaths starting with &quot;~&quot; are ignored when determining the build location&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=249442">https://bugs.webkit.org/show_bug.cgi?id=249442</a>

Unreviewed build fix.

That change failed to consider when there is _no_
IDECustomBuildProductsPaths, and someone is building from a directory
_other than_ the WebKit repo root. We check the
IDEApplicationwideBuildSettings defaults key, which may be an empty
dictionary &quot;{ }&quot;, and were treating that as a path, rather than falling
back to using the repo&apos;s root directory to determine the location.

* Tools/Scripts/webkitdirs.pm:
(determineBaseProductDir):
</pre>