### PR TITLE
WIP patch (doesn't build yet) to fire a webNavigation event when a frame navigates.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -34,9 +34,12 @@
 
 #import "CocoaHelpers.h"
 #import "SandboxUtilities.h"
+#import "WebExtensionContext.h"
 #import "WebExtensionContextMessages.h"
+#import "WebExtensionContextProxyMessages.h"
 #import "WebExtensionControllerMessages.h"
 #import "WebExtensionControllerProxyMessages.h"
+#import "WebExtensionEventListenerType.h"
 #import "WebPageProxy.h"
 #import "WebProcessPool.h"
 #import <wtf/FileSystem.h>
@@ -231,6 +234,21 @@ WebExtensionController::WebExtensionSet WebExtensionController::extensions() con
     for (auto& extensionContext : m_extensionContexts)
         extensions.addVoid(extensionContext->extension());
     return extensions;
+}
+
+// MARK: WebNavigation support
+
+void WebExtensionController::didStartProvisionalLoadForFrame(WebCore::PageIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
+{
+    WebExtensionContext::EventListenerTypeSet listenerTypes;
+    listenerTypes.add(WebExtensionEventListenerType::WebNavigationOnBeforeNavigate);
+
+    for (auto& context : m_extensionContexts) {
+//        context->fireEvents(listenerTypes, [context, pageID, frameID, targetURL]{
+        context->fireEvents(listenerTypes, []{
+//            context->sendToProcessesForEvent(WebExtensionEventListenerType::WebNavigationOnBeforeNavigate, Messages::WebExtensionContextProxy::DispatchWebNavigationOnBeforeNavigateEvent(pageID, frameID, targetURL));
+        });
+    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -225,6 +225,8 @@ public:
     void addInjectedContent(WebUserContentControllerProxy&);
     void removeInjectedContent(WebUserContentControllerProxy&);
 
+    void fireEvents(EventListenerTypeSet, CompletionHandler<void()>&&);
+
     template<typename T>
     void sendToProcessesForEvent(WebExtensionEventListenerType, const T& message);
 
@@ -263,7 +265,6 @@ private:
     uint64_t loadBackgroundPageListenersVersionNumberFromStorage();
     void loadBackgroundPageListenersFromStorage();
     void saveBackgroundPageListenersToStorage();
-    void fireEvents(EventListenerTypeSet, CompletionHandler<void()>&&);
     void queueEventToFireAfterBackgroundContentLoads(CompletionHandler<void()>&&);
 
     void performTasksAfterBackgroundContentLoads();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -121,6 +121,9 @@ private:
     void addUserContentController(WebUserContentControllerProxy&);
     void removeUserContentController(WebUserContentControllerProxy&);
 
+    // MARK: webNavigation support.
+    void didStartProvisionalLoadForFrame(WebCore::PageIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL);
+
     Ref<WebExtensionControllerConfiguration> m_configuration;
     WebExtensionControllerIdentifier m_identifier;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
@@ -27,6 +27,9 @@
 
 messages -> WebExtensionController {
 
+    // webNavigation support.
+    DidStartProvisionalLoadForFrame(WebCore::PageIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
+
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -288,7 +288,7 @@ void RemoteScrollingCoordinatorProxy::reportSynchronousScrollingReasonsChanged(M
 
 void RemoteScrollingCoordinatorProxy::startMonitoringWheelEventsForTesting()
 {
-    m_scrollingTree->setIsMonitoringWheelEvents(true);
+//    m_scrollingTree->setIsMonitoringWheelEvents(true);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
@@ -36,8 +36,10 @@
 #include "JSWebExtensionWrapper.h"
 #include "WebExtensionAPINamespace.h"
 #include "WebExtensionContextProxy.h"
+#include "WebExtensionControllerMessages.h"
 #include "WebFrame.h"
 #include "WebPage.h"
+#include "WebProcess.h"
 
 namespace WebKit {
 
@@ -98,6 +100,11 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
 
     JSObjectSetProperty(context, globalObject, toJSString("browser").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
     JSObjectSetProperty(context, globalObject, toJSString("chrome").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+}
+
+void WebExtensionControllerProxy::didStartProvisionalLoadForFrame(WebPage& page, WebFrame& frame, const URL& url)
+{
+    WebProcess::singleton().send(Messages::WebExtensionController::DidStartProvisionalLoadForFrame(page.identifier(), frame.frameID(), url), identifier());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -110,6 +110,14 @@ void WebExtensionContextProxy::enumerateNamespaceObjects(const Function<void(Web
     }
 }
 
+// MARK: webNavigation support
+
+void WebExtensionContextProxy::dispatchWebNavigationOnBeforeNavigateEvent(WebCore::PageIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
+{
+
+}
+
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -30,6 +30,8 @@
 #include "MessageReceiver.h"
 #include "WebExtensionContextParameters.h"
 #include <WebCore/DOMWrapperWorld.h>
+#include <WebCore/FrameIdentifier.h>
+#include <WebCore/PageIdentifier.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakHashSet.h>
 
@@ -75,6 +77,9 @@ public:
 
 private:
     explicit WebExtensionContextProxy(WebExtensionContextParameters);
+
+    // webNavigation support
+    void dispatchWebNavigationOnBeforeNavigateEvent(WebCore::PageIdentifier, WebCore::FrameIdentifier, URL);
 
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -27,6 +27,9 @@
 
 messages -> WebExtensionContextProxy {
 
+    // webNavigation support
+    DispatchWebNavigationOnBeforeNavigateEvent(WebCore::PageIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
+
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -63,6 +63,9 @@ public:
 #if PLATFORM(COCOA)
     void globalObjectIsAvailableForFrame(WebPage&, WebFrame&, WebCore::DOMWrapperWorld&);
     void serviceWorkerGlobalObjectIsAvailableForFrame(WebPage&, WebFrame&, WebCore::DOMWrapperWorld&);
+
+    // webNavigation support.
+    void didStartProvisionalLoadForFrame(WebPage&, WebFrame&, const URL&);
 #endif
 
 private:

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -531,7 +531,6 @@ void WebFrameLoaderClient::dispatchDidStartProvisionalLoad()
     webPage->findController().hideFindUI();
     webPage->sandboxExtensionTracker().didStartProvisionalLoad(m_frame.ptr());
 
-
     RefPtr<API::Object> userData;
 
     // Notify the bundle client.
@@ -543,6 +542,13 @@ void WebFrameLoaderClient::dispatchDidStartProvisionalLoad()
     
     auto& url = provisionalLoader->url();
     auto& unreachableURL = provisionalLoader->unreachableURL();
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    // Notify the extensions controller.
+    if (auto* extensionControllerProxy = webPage->webExtensionControllerProxy())
+        extensionControllerProxy->didStartProvisionalLoadForFrame(*webPage, m_frame, url);
+#endif
+
     // Notify the UIProcess.
     webPage->send(Messages::WebPageProxy::DidStartProvisionalLoadForFrame(m_frame->frameID(), m_frame->info(), provisionalLoader->request(), provisionalLoader->navigationID(), url, unreachableURL, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
 }


### PR DESCRIPTION
#### 331f9d237c69528126d1421a0b06dd1e18da258a
<pre>
WIP patch (doesn&apos;t build yet) to fire a webNavigation event when a frame navigates.
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::didStartProvisionalLoadForFrame):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::startMonitoringWheelEventsForTesting):
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm:
(WebKit::WebExtensionControllerProxy::didStartProvisionalLoadForFrame):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::dispatchWebNavigationOnBeforeNavigateEvent):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDidStartProvisionalLoad):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/331f9d237c69528126d1421a0b06dd1e18da258a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100709 "check-webkit-style running") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110010 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/363 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93112 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107854 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34764 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77735 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3549 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24319 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/366 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43814 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5353 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->