### PR TITLE
Align `stroke-width` & `stroke-dashoffset` CSS property parsing with the specification

### DIFF
--- a/LayoutTests/fast/css/parsing-stroke-width-expected.txt
+++ b/LayoutTests/fast/css/parsing-stroke-width-expected.txt
@@ -10,7 +10,7 @@ PASS testComputedStyle(";") is "1px"
 PASS test("stroke-width: 4px;") is "4px"
 PASS test("stroke-width: 0.01em;") is "0.01em"
 PASS test("stroke-width: 10%;") is "10%"
-PASS test("stroke-width: 4;") is "4px"
+PASS test("stroke-width: 4;") is "4"
 PASS test("stroke-width: em;") is ""
 PASS test("stroke-width: %;") is ""
 PASS successfullyParsed is true

--- a/LayoutTests/fast/css/parsing-stroke-width.html
+++ b/LayoutTests/fast/css/parsing-stroke-width.html
@@ -54,7 +54,7 @@
             shouldBe('test("stroke-width: 0.01em;")', '"0.01em"');
             shouldBe('test("stroke-width: 10%;")', '"10%"');
             
-            shouldBeEqualToString('test("stroke-width: 4;")', '4px');
+            shouldBeEqualToString('test("stroke-width: 4;")', '4');
             shouldBeEqualToString('test("stroke-width: em;")', '');
             shouldBeEqualToString('test("stroke-width: %;")', '');
         </script>

--- a/LayoutTests/fast/css/stroke-dashoffset-parsing-expected.txt
+++ b/LayoutTests/fast/css/stroke-dashoffset-parsing-expected.txt
@@ -1,0 +1,26 @@
+Tests the parsing of the stroke-dashoffset CSS property.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getComputedStyle(target).strokeDashoffset is "0px"
+target.style.strokeDashoffset = '3px';
+PASS target.style.strokeDashoffset is "3px"
+PASS getComputedStyle(target).strokeDashoffset is "3px"
+target.style.strokeDashoffset = '10%';
+PASS target.style.strokeDashoffset is "10%"
+PASS getComputedStyle(target).strokeDashoffset is "10%"
+target.style.strokeDashoffset = '20';
+PASS target.style.strokeDashoffset is "20"
+PASS getComputedStyle(target).strokeDashoffset is "20px"
+target.style.strokeDashoffset = '0';
+FAIL target.style.strokeDashoffset should be 0. Was 0px.
+PASS getComputedStyle(target).strokeDashoffset is "0px"
+target.style.strokeDashoffset = '-30px';
+PASS target.style.strokeDashoffset is "-30px"
+PASS getComputedStyle(target).strokeDashoffset is "-30px"
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/stroke-dashoffset-parsing.html
+++ b/LayoutTests/fast/css/stroke-dashoffset-parsing.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<div id="target"></div>
+<script>
+description("Tests the parsing of the stroke-dashoffset CSS property.");
+
+const target = document.getElementById("target");
+
+// Initial value.
+shouldBeEqualToString("getComputedStyle(target).strokeDashoffset", "0px");
+
+// Valid length.
+evalAndLog("target.style.strokeDashoffset = '3px';");
+shouldBeEqualToString("target.style.strokeDashoffset", "3px");
+shouldBeEqualToString("getComputedStyle(target).strokeDashoffset", "3px");
+
+// Valid percentage.
+evalAndLog("target.style.strokeDashoffset = '10%';");
+shouldBeEqualToString("target.style.strokeDashoffset", "10%");
+shouldBeEqualToString("getComputedStyle(target).strokeDashoffset", "10%");
+
+// Valid number.
+evalAndLog("target.style.strokeDashoffset = '20';");
+shouldBeEqualToString("target.style.strokeDashoffset", "20"); // Gecko says 20%, Blink says 20.
+shouldBeEqualToString("getComputedStyle(target).strokeDashoffset", "20px");
+
+// Zero value.
+evalAndLog("target.style.strokeDashoffset = '0';");
+shouldBeEqualToString("target.style.strokeDashoffset", "0"); // Gecko says 0px, specification and Blink say 0.
+shouldBeEqualToString("getComputedStyle(target).strokeDashoffset", "0px");
+
+// Negative value.
+target.style.strokeDashoffset = "";
+evalAndLog("target.style.strokeDashoffset = '-30px';");
+shouldBeEqualToString("target.style.strokeDashoffset", "-30px");
+shouldBeEqualToString("getComputedStyle(target).strokeDashoffset", "-30px");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/stroke-width-parsing-expected.txt
+++ b/LayoutTests/fast/css/stroke-width-parsing-expected.txt
@@ -1,0 +1,26 @@
+Tests the parsing of the stroke-width CSS property.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getComputedStyle(target).strokeWidth is "1px"
+target.style.strokeWidth = '3px';
+PASS target.style.strokeWidth is "3px"
+PASS getComputedStyle(target).strokeWidth is "3px"
+target.style.strokeWidth = '10%';
+PASS target.style.strokeWidth is "10%"
+PASS getComputedStyle(target).strokeWidth is "10%"
+target.style.strokeWidth = '20';
+PASS target.style.strokeWidth is "20"
+PASS getComputedStyle(target).strokeWidth is "20px"
+target.style.strokeWidth = '0';
+FAIL target.style.strokeWidth should be 0. Was 0px.
+PASS getComputedStyle(target).strokeWidth is "0px"
+target.style.strokeWidth = '-30px';
+PASS target.style.strokeWidth is ""
+PASS getComputedStyle(target).strokeWidth is "1px"
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/stroke-width-parsing.html
+++ b/LayoutTests/fast/css/stroke-width-parsing.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<div id="target"></div>
+<script>
+description("Tests the parsing of the stroke-width CSS property.");
+
+const target = document.getElementById("target");
+
+// Initial value.
+shouldBeEqualToString("getComputedStyle(target).strokeWidth", "1px");
+
+// Valid length.
+evalAndLog("target.style.strokeWidth = '3px';");
+shouldBeEqualToString("target.style.strokeWidth", "3px");
+shouldBeEqualToString("getComputedStyle(target).strokeWidth", "3px");
+
+// Valid percentage.
+evalAndLog("target.style.strokeWidth = '10%';");
+shouldBeEqualToString("target.style.strokeWidth", "10%");
+shouldBeEqualToString("getComputedStyle(target).strokeWidth", "10%");
+
+// Valid number.
+evalAndLog("target.style.strokeWidth = '20';");
+shouldBeEqualToString("target.style.strokeWidth", "20"); // Gecko says 20%, Blink says 20.
+shouldBeEqualToString("getComputedStyle(target).strokeWidth", "20px");
+
+// Zero value.
+evalAndLog("target.style.strokeWidth = '0';");
+shouldBeEqualToString("target.style.strokeWidth", "0"); // Gecko says 0px, specification and Blink say 0.
+shouldBeEqualToString("getComputedStyle(target).strokeWidth", "0px");
+
+// Negative value.
+target.style.strokeWidth = "";
+evalAndLog("target.style.strokeWidth = '-30px';");
+shouldBeEqualToString("target.style.strokeWidth", "");
+shouldBeEqualToString("getComputedStyle(target).strokeWidth", "1px");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset-expected.txt
@@ -12,6 +12,10 @@ PASS Can set 'stroke-dashoffset' to a percent: 0%
 PASS Can set 'stroke-dashoffset' to a percent: -3.14%
 PASS Can set 'stroke-dashoffset' to a percent: 3.14%
 PASS Can set 'stroke-dashoffset' to a percent: calc(0% + 0%)
+PASS Can set 'stroke-dashoffset' to a number: 0
+PASS Can set 'stroke-dashoffset' to a number: -3.14
+PASS Can set 'stroke-dashoffset' to a number: 3.14
+PASS Can set 'stroke-dashoffset' to a number: calc(2 + 3)
 PASS Setting 'stroke-dashoffset' to a time: 0s throws TypeError
 PASS Setting 'stroke-dashoffset' to a time: -3.14ms throws TypeError
 PASS Setting 'stroke-dashoffset' to a time: 3.14s throws TypeError
@@ -23,10 +27,6 @@ PASS Setting 'stroke-dashoffset' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'stroke-dashoffset' to a flexible length: 0fr throws TypeError
 PASS Setting 'stroke-dashoffset' to a flexible length: 1fr throws TypeError
 PASS Setting 'stroke-dashoffset' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'stroke-dashoffset' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stroke-dashoffset' to a number: -3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stroke-dashoffset' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stroke-dashoffset' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'stroke-dashoffset' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'stroke-dashoffset' to a transform: perspective(10em) throws TypeError
 PASS Setting 'stroke-dashoffset' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset.html
@@ -15,7 +15,11 @@
 
 runPropertyTests('stroke-dashoffset', [
   { syntax: '<length>' },
-  { syntax: '<percentage>' }
+  { syntax: '<percentage>' },
+  {
+    syntax: '<number>',
+    computed: (_, result) => assert_is_unit('px', result)
+  },
 ]);
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt
@@ -5,13 +5,17 @@ PASS Can set 'stroke-width' to CSS-wide keywords: unset
 PASS Can set 'stroke-width' to CSS-wide keywords: revert
 PASS Can set 'stroke-width' to var() references:  var(--A)
 PASS Can set 'stroke-width' to a length: 0px
-FAIL Can set 'stroke-width' to a length: -3.14em assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
+PASS Can set 'stroke-width' to a length: -3.14em
 PASS Can set 'stroke-width' to a length: 3.14cm
 PASS Can set 'stroke-width' to a length: calc(0px + 0em)
 PASS Can set 'stroke-width' to a percent: 0%
-FAIL Can set 'stroke-width' to a percent: -3.14% assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
+FAIL Can set 'stroke-width' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'stroke-width' to a percent: 3.14%
 PASS Can set 'stroke-width' to a percent: calc(0% + 0%)
+PASS Can set 'stroke-width' to a number: 0
+PASS Can set 'stroke-width' to a number: -3.14
+PASS Can set 'stroke-width' to a number: 3.14
+PASS Can set 'stroke-width' to a number: calc(2 + 3)
 PASS Setting 'stroke-width' to a time: 0s throws TypeError
 PASS Setting 'stroke-width' to a time: -3.14ms throws TypeError
 PASS Setting 'stroke-width' to a time: 3.14s throws TypeError
@@ -23,10 +27,6 @@ PASS Setting 'stroke-width' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'stroke-width' to a flexible length: 0fr throws TypeError
 PASS Setting 'stroke-width' to a flexible length: 1fr throws TypeError
 PASS Setting 'stroke-width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'stroke-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stroke-width' to a number: -3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stroke-width' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stroke-width' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'stroke-width' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'stroke-width' to a transform: perspective(10em) throws TypeError
 PASS Setting 'stroke-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width.html
@@ -22,6 +22,11 @@ runListValuedPropertyTests('stroke-width', [
     syntax: '<percentage>',
     specified: assert_is_equal_with_range_handling
   },
+  {
+    syntax: '<number>',
+    specified: assert_is_equal_with_range_handling,
+    computed: (_, result) => assert_is_unit('px', result)
+  },
 ]);
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dashoffset-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dashoffset-invalid-expected.txt
@@ -4,6 +4,6 @@ PASS e.style['stroke-dashoffset'] = "-10.px" should not set the property value
 PASS e.style['stroke-dashoffset'] = "30deg" should not set the property value
 PASS e.style['stroke-dashoffset'] = "40px 50%" should not set the property value
 PASS e.style['stroke-dashoffset'] = "calc(2px + 3)" should not set the property value
-FAIL e.style['stroke-dashoffset'] = "calc(10% + 5)" should not set the property value assert_equals: expected "" but got "calc(5 + 10%)"
+PASS e.style['stroke-dashoffset'] = "calc(10% + 5)" should not set the property value
 PASS e.style['stroke-dashoffset'] = "calc(40 + calc(3px + 6%))" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dashoffset-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dashoffset-valid-expected.txt
@@ -1,5 +1,5 @@
 
-PASS e.style['stroke-dashoffset'] = "0" should set the property value
+FAIL e.style['stroke-dashoffset'] = "0" should set the property value assert_equals: serialization should be canonical expected "0" but got "0px"
 PASS e.style['stroke-dashoffset'] = "10px" should set the property value
 PASS e.style['stroke-dashoffset'] = "-20%" should set the property value
 PASS e.style['stroke-dashoffset'] = "30" should set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dashoffset-valid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dashoffset-valid.svg
@@ -13,10 +13,10 @@
   <h:script src="/css/support/parsing-testcommon.js"/>
   <script><![CDATA[
 
-test_valid_value("stroke-dashoffset", "0", "0px");
+test_valid_value("stroke-dashoffset", "0");
 test_valid_value("stroke-dashoffset", "10px");
 test_valid_value("stroke-dashoffset", "-20%");
-test_valid_value("stroke-dashoffset", "30", "30px");
+test_valid_value("stroke-dashoffset", "30");
 test_valid_value("stroke-dashoffset", "40Q", "40q");
 test_valid_value("stroke-dashoffset", "calc(2em + 3ex)");
 test_valid_value("stroke-dashoffset", "calc(3)");

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-computed-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Property stroke-width value '10'
 PASS Property stroke-width value 'calc(10px + 0.5em)'
-FAIL Property stroke-width value 'calc(10px - 0.5em)' assert_equals: expected "0px" but got "-10px"
+PASS Property stroke-width value 'calc(10px - 0.5em)'
 PASS Property stroke-width value '40%'
 PASS Property stroke-width value 'calc(50% + 60px)'
 PASS stroke-width computes em lengths

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-invalid-expected.txt
@@ -1,9 +1,9 @@
 
 PASS e.style['stroke-width'] = "auto" should not set the property value
 PASS e.style['stroke-width'] = "10px 20px" should not set the property value
-FAIL e.style['stroke-width'] = "-1px" should not set the property value assert_equals: expected "" but got "-1px"
-FAIL e.style['stroke-width'] = "-10%" should not set the property value assert_equals: expected "" but got "-10%"
+PASS e.style['stroke-width'] = "-1px" should not set the property value
+PASS e.style['stroke-width'] = "-10%" should not set the property value
 PASS e.style['stroke-width'] = "calc(2px + 3)" should not set the property value
-FAIL e.style['stroke-width'] = "calc(10% + 5)" should not set the property value assert_equals: expected "" but got "calc(5 + 10%)"
+PASS e.style['stroke-width'] = "calc(10% + 5)" should not set the property value
 PASS e.style['stroke-width'] = "calc(40 + calc(3px + 6%))" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-valid-expected.txt
@@ -1,5 +1,5 @@
 
-PASS e.style['stroke-width'] = "0" should set the property value
+FAIL e.style['stroke-width'] = "0" should set the property value assert_equals: serialization should be canonical expected "0" but got "0px"
 PASS e.style['stroke-width'] = "10" should set the property value
 PASS e.style['stroke-width'] = "1px" should set the property value
 PASS e.style['stroke-width'] = "calc(2em + 3ex)" should set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-valid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-valid.svg
@@ -13,8 +13,8 @@
   <h:script src="/css/support/parsing-testcommon.js"/>
   <script><![CDATA[
 
-test_valid_value("stroke-width", "0", "0px");
-test_valid_value("stroke-width", "10", "10px");
+test_valid_value("stroke-width", "0");
+test_valid_value("stroke-width", "10");
 test_valid_value("stroke-width", "1px");
 test_valid_value("stroke-width", "calc(2em + 3ex)");
 test_valid_value("stroke-width", "4%");

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4888,12 +4888,12 @@
             "codegen-properties": {
                 "initial": "initialZeroLength",
                 "name-for-methods": "StrokeDashOffset",
-                "converter": "Length",
-                "parser-grammar": "<length-percentage svg>"
+                "converter": "LengthAllowingNumber",
+                "parser-grammar": "<length-percentage> | <number>"
             },
             "specification": {
                 "category": "svg",
-                "url": "https://www.w3.org/TR/SVG11/painting.html#StrokeDashoffsetProperty"
+                "url": "https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty"
             }
         },
         "stroke-linecap": {
@@ -4978,8 +4978,8 @@
             "codegen-properties": {
                 "custom": "Value",
                 "initial": "initialOneLength",
-                "converter": "Length",
-                "parser-grammar": "<length-percentage svg>"
+                "converter": "LengthAllowingNumber",
+                "parser-grammar": "<length-percentage [0,inf]> | <number [0,inf]>"
             },
             "status": "supported",
             "specification": {

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -252,6 +252,7 @@ static bool isValueOutOfRangeForProperty(CSSPropertyID propertyID, double value,
     case CSSPropertyScrollPaddingRight:
     case CSSPropertyScrollPaddingTop:
     case CSSPropertyStrokeMiterlimit:
+    case CSSPropertyStrokeWidth:
         return value < 0;
     case CSSPropertyFontWeight:
         return value < 1 || value > 1000;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -78,6 +78,7 @@ public:
     static Length convertLengthOrAutoOrContent(const BuilderState&, const CSSValue&);
     static Length convertLengthSizing(const BuilderState&, const CSSValue&);
     static Length convertLengthMaxSizing(const BuilderState&, const CSSValue&);
+    static Length convertLengthAllowingNumber(const BuilderState&, const CSSValue&); // Assumes unit is 'px' if input is a number.
     static TabSize convertTabSize(const BuilderState&, const CSSValue&);
     template<typename T> static T convertComputedLength(BuilderState&, const CSSValue&);
     template<typename T> static T convertLineWidth(BuilderState&, const CSSValue&);
@@ -227,6 +228,14 @@ inline Length BuilderConverter::convertLength(const BuilderState& builderState, 
 
     ASSERT_NOT_REACHED();
     return Length(0, LengthType::Fixed);
+}
+
+inline Length BuilderConverter::convertLengthAllowingNumber(const BuilderState& builderState, const CSSValue& value)
+{
+    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
+    if (primitiveValue.isNumberOrInteger())
+        return convertLength(builderState, CSSPrimitiveValue::create(primitiveValue.doubleValue(), CSSUnitType::CSS_PX));
+    return convertLength(builderState, value);
 }
 
 inline Length BuilderConverter::convertLengthOrAuto(const BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -2107,7 +2107,7 @@ inline void BuilderCustom::applyValueWillChange(BuilderState& builderState, CSSV
 
 inline void BuilderCustom::applyValueStrokeWidth(BuilderState& builderState, CSSValue& value)
 {
-    builderState.style().setStrokeWidth(BuilderConverter::convertLength(builderState, value));
+    builderState.style().setStrokeWidth(BuilderConverter::convertLengthAllowingNumber(builderState, value));
     builderState.style().setHasExplicitlySetStrokeWidth(true);
 }
 


### PR DESCRIPTION
#### 77685f21f584083f4170cb835c0d517448e46912
<pre>
Align `stroke-width` &amp; `stroke-dashoffset` CSS property parsing with the specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=249510">https://bugs.webkit.org/show_bug.cgi?id=249510</a>

Reviewed by Cameron McCormack.

Align `stroke-width` &amp; `stroke-dashoffset` CSS property parsing with the specification:
- <a href="https://svgwg.org/svg2-draft/painting.html#StrokeWidth">https://svgwg.org/svg2-draft/painting.html#StrokeWidth</a>
- <a href="https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty">https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty</a>

For stroke-width:
- Use `&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt;` parser grammar instead of
  `&lt;length-percentage svg&gt;`. The specification actually says
  `&lt;length-percentage&gt; | &lt;number&gt;` but carries on to say that negative values are
  invalid.

For stroke-dashoffset:
- Use `&lt;length-percentage&gt; | &lt;number&gt;` parser grammar instead of
  `&lt;length-percentage svg&gt;`, as per the specification.

* LayoutTests/fast/css/parsing-stroke-width-expected.txt:
* LayoutTests/fast/css/parsing-stroke-width.html:
Update existing test to reflect behavior change.

* LayoutTests/fast/css/stroke-dashoffset-parsing-expected.txt: Added.
* LayoutTests/fast/css/stroke-dashoffset-parsing.html: Added.
* LayoutTests/fast/css/stroke-width-parsing-expected.txt: Added.
* LayoutTests/fast/css/stroke-width-parsing.html: Added.
Extend layout test coverage. Those 2 tests are passing in both Chrome and
Firefox.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dashoffset.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width.html:
Update existing CSS-Typed-OM tests to match the specification for `stroke-width`
and `stroke-dashoffset`. The tests incorrectly didn&apos;t allow &lt;number&gt; for these
properties.

* LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dashoffset-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-width-invalid-expected.txt:
Rebaseline WPT tests now that more checks are passing.

* Source/WebCore/css/CSSProperties.json:
- Update parser grammar to match the specification.
- Use convertLengthAllowingNumber() instead of convertLength() since we now allow numbers which need
  to be converted to a length by adding &apos;px&apos; (as per spec).

* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::isValueOutOfRangeForProperty):
Update function to correctly report that `stroke-width` doesn&apos;t allow negative values.

* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertLength):
Introduce a new convertLengthAllowingNumber() function which mostly behaves like
convertLength() but also allows numbers, which it silently converts a lengths
by assuming they are pixels. This behavior is used by `stroke-width` and
`stroke-dashoffset`, and mandated by the specification.

Canonical link: <a href="https://commits.webkit.org/258107@main">https://commits.webkit.org/258107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ff47882d05af6c09c5478628997b83fc9dbaf45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110237 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/956 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93344 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108077 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106715 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34943 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3789 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9901 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44012 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5561 "Built successfully and passed tests") | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5564 "Failed to checkout and rebase branch from PR 7800") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->