### PR TITLE
Move WheelEventProcessingSteps to ScrollingCoordinatorTypes.h

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
@@ -125,4 +125,15 @@ TextStream& operator<<(TextStream& ts, ViewportRectStability stability)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, WheelEventProcessingSteps steps)
+{
+    switch (steps) {
+    case WheelEventProcessingSteps::ScrollingThread: ts << "scrolling thread"; break;
+    case WheelEventProcessingSteps::MainThreadForScrolling: ts << "main thread scrolling"; break;
+    case WheelEventProcessingSteps::MainThreadForNonBlockingDOMEventDispatch: ts << "main thread non-blocking DOM event dispatch"; break;
+    case WheelEventProcessingSteps::MainThreadForBlockingDOMEventDispatch: ts << "main thread blocking DOM event dispatch"; break;
+    }
+    return ts;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -58,25 +58,6 @@ enum class EventListenerRegionType : uint8_t;
 using FramesPerSecond = unsigned;
 using PlatformDisplayID = uint32_t;
 
-struct WheelEventHandlingResult {
-    OptionSet<WheelEventProcessingSteps> steps;
-    bool wasHandled { false };
-    bool needsMainThreadProcessing() const { return steps.containsAny({ WheelEventProcessingSteps::MainThreadForScrolling, WheelEventProcessingSteps::MainThreadForNonBlockingDOMEventDispatch, WheelEventProcessingSteps::MainThreadForBlockingDOMEventDispatch }); }
-
-    static WheelEventHandlingResult handled(OptionSet<WheelEventProcessingSteps> steps = { })
-    {
-        return { steps, true };
-    }
-    static WheelEventHandlingResult unhandled(OptionSet<WheelEventProcessingSteps> steps = { })
-    {
-        return { steps, false };
-    }
-    static WheelEventHandlingResult result(bool handled)
-    {
-        return { { }, handled };
-    }
-};
-
 enum class EventTargeting : uint8_t { NodeOnly, Propagate };
 
 class ScrollingTree : public ThreadSafeRefCounted<ScrollingTree> {

--- a/Source/WebCore/platform/PlatformWheelEvent.cpp
+++ b/Source/WebCore/platform/PlatformWheelEvent.cpp
@@ -110,17 +110,6 @@ TextStream& operator<<(TextStream& ts, const PlatformWheelEvent& event)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, WheelEventProcessingSteps steps)
-{
-    switch (steps) {
-    case WheelEventProcessingSteps::ScrollingThread: ts << "scrolling thread"; break;
-    case WheelEventProcessingSteps::MainThreadForScrolling: ts << "main thread scrolling"; break;
-    case WheelEventProcessingSteps::MainThreadForNonBlockingDOMEventDispatch: ts << "main thread non-blocking DOM event dispatch"; break;
-    case WheelEventProcessingSteps::MainThreadForBlockingDOMEventDispatch: ts << "main thread blocking DOM event dispatch"; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, EventHandling steps)
 {
     switch (steps) {

--- a/Source/WebCore/platform/PlatformWheelEvent.h
+++ b/Source/WebCore/platform/PlatformWheelEvent.h
@@ -38,13 +38,6 @@ namespace WebCore {
 
 class PlatformGestureEvent;
 
-enum class WheelEventProcessingSteps : uint8_t {
-    ScrollingThread                             = 1 << 0,
-    MainThreadForScrolling                      = 1 << 1,
-    MainThreadForNonBlockingDOMEventDispatch    = 1 << 2,
-    MainThreadForBlockingDOMEventDispatch       = 1 << 3,
-};
-
 enum class WheelScrollGestureState : uint8_t {
     Blocking,
     NonBlocking
@@ -288,7 +281,6 @@ inline FloatSize PlatformWheelEvent::swipeVelocity() const
 #endif // ENABLE(KINETIC_SCROLLING)
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PlatformWheelEvent&);
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, WheelEventProcessingSteps);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, EventHandling);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, WheelScrollGestureState);
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -767,6 +767,7 @@ def headers_for_type(type):
         'WebCore::UsedLegacyTLS': ['<WebCore/ResourceResponseBase.h>'],
         'WebCore::VideoPresetData': ['<WebCore/VideoPreset.h>'],
         'WebCore::ViewportAttributes': ['<WebCore/ViewportArguments.h>'],
+        'WebCore::WheelEventProcessingSteps': ['<WebCore/ScrollingCoordinatorTypes.h>'],
         'WebCore::WillContinueLoading': ['<WebCore/FrameLoaderTypes.h>'],
         'WebKit::ActivityStateChangeID': ['"DrawingAreaInfo.h"'],
         'WebKit::AllowOverwrite': ['"DownloadID.h"'],

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -30,6 +30,7 @@
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/PlatformWheelEvent.h>
 #include <WebCore/RectEdges.h>
+#include <WebCore/ScrollingCoordinatorTypes.h>
 #include <WebCore/WheelEventDeltaFilter.h>
 #include <memory>
 #include <wtf/HashMap.h>


### PR DESCRIPTION
#### ebc5f3efb4bdb408c9fd67e7c2a4f1e0c8168c74
<pre>
Move WheelEventProcessingSteps to ScrollingCoordinatorTypes.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=249519">https://bugs.webkit.org/show_bug.cgi?id=249519</a>
rdar://103471270

Reviewed by Cameron McCormack.

WheelEventProcessingSteps and WheelEventHandlingResult are going to be used in more places;
move them into ScrollingCoordinatorTypes.h.

Prepare messages.py for WheelEventProcessingSteps being used in IPC messages.

* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
(WebCore::WheelEventHandlingResult::needsMainThreadProcessing const):
(WebCore::WheelEventHandlingResult::handled):
(WebCore::WheelEventHandlingResult::unhandled):
(WebCore::WheelEventHandlingResult::result):
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::WheelEventHandlingResult::needsMainThreadProcessing const): Deleted.
(WebCore::WheelEventHandlingResult::handled): Deleted.
(WebCore::WheelEventHandlingResult::unhandled): Deleted.
(WebCore::WheelEventHandlingResult::result): Deleted.
* Source/WebCore/platform/PlatformWheelEvent.cpp:
* Source/WebCore/platform/PlatformWheelEvent.h:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:

Canonical link: <a href="https://commits.webkit.org/258037@main">https://commits.webkit.org/258037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b5f4bb65454caafe58ac4c7a8d9c882cccb3ef9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110017 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170291 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/374 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93119 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107863 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34767 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/104240 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3556 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3580 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43820 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5516 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5360 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->