### PR TITLE
[Live Range Selection] fast/css/counters/counter-before-content-not-incremented.html times out

### DIFF
--- a/LayoutTests/fast/css/counters/counter-before-content-not-incremented.html
+++ b/LayoutTests/fast/css/counters/counter-before-content-not-incremented.html
@@ -26,7 +26,7 @@
             // We need to use the selection or we cannot reproduce this bug!
             var selection = window.getSelection();
             var container = document.getElementById("container");
-            selection.setPosition(container, 0);
+            selection.setPosition(container.firstChild.firstChild, 0);
             if (selection.rangeCount > 0) {
                 var newElement = document.createElement('div');
                 newElement.id = 'div' + i;


### PR DESCRIPTION
#### 1790015372f92b1243ffc68561d19ff9fab8064c
<pre>
[Live Range Selection] fast/css/counters/counter-before-content-not-incremented.html times out
<a href="https://bugs.webkit.org/show_bug.cgi?id=249524">https://bugs.webkit.org/show_bug.cgi?id=249524</a>

Reviewed by Darin Adler.

The test failure is caused by the test assuming the selection end points to be canonicalized,
which is no longer true once live range selection is enabled. Fixed the test by explicitly
setting selection end points to the canonicalized positions.

* LayoutTests/fast/css/counters/counter-before-content-not-incremented.html:

Canonical link: <a href="https://commits.webkit.org/258042@main">https://commits.webkit.org/258042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ba526fcfbad0cf4dc9922bbcde58c0bfc1b9a80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110031 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170305 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/407 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93133 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107877 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34778 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90075 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77749 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3570 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3594 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43833 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5522 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5372 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->