### PR TITLE
[Live Range Selection] image overlay tests fail

### DIFF
--- a/LayoutTests/fast/images/text-recognition/image-overlay-block-with-newlines-expected.txt
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-block-with-newlines-expected.txt
@@ -1,4 +1,4 @@
-PASS getSelection().toString() is "Hello\nworld"
+PASS textarea.value is "Hello\nworld"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/images/text-recognition/image-overlay-block-with-newlines.html
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-block-with-newlines.html
@@ -9,7 +9,8 @@ body, html {
 </style>
 </head>
 <body>
-<img src="../resources/green-400x400.png"></img>
+<img src="../resources/green-400x400.png">
+<textarea id="textarea"></textarea>
 <script>
 addEventListener("load", () => {
     let image = document.querySelector("img");
@@ -22,9 +23,14 @@ addEventListener("load", () => {
             text : "Hello\nworld",
         }
     ]);
-    const overlay = internals.shadowRoot(image).getElementById("image-overlay");
-    getSelection().selectAllChildren(overlay);
-    shouldBeEqualToString("getSelection().toString()", "Hello\nworld");
+    const imageOverlay = internals.shadowRoot(image).getElementById("image-overlay");
+    internals.setSelectionWithoutValidation(imageOverlay, 0, imageOverlay, imageOverlay.childNodes.length);
+    testRunner.execCommand("Copy");
+
+    textarea.focus();
+    testRunner.execCommand("Paste");
+
+    shouldBeEqualToString("textarea.value", "Hello\nworld");
 });
 </script>
 </body>

--- a/LayoutTests/fast/images/text-recognition/image-overlay-line-wrapping.html
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-line-wrapping.html
@@ -82,7 +82,8 @@ addEventListener("load", () => {
         }
     ]);
 
-    getSelection().selectAllChildren(internals.shadowRoot(image).getElementById("image-overlay"));
+    const imageOverlay = internals.shadowRoot(image).getElementById("image-overlay");
+    internals.setSelectionWithoutValidation(imageOverlay, 0, imageOverlay, imageOverlay.childNodes.length);
     document.execCommand("Copy");
 
     textarea = document.querySelector("textarea");

--- a/LayoutTests/fast/images/text-recognition/image-overlay-reversed-range-expected.txt
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-reversed-range-expected.txt
@@ -1,5 +1,5 @@
 
-PASS getSelection().toString() is "foo bar"
+PASS textarea.value is "foo bar"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/images/text-recognition/image-overlay-reversed-range.html
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-reversed-range.html
@@ -13,7 +13,7 @@ img {
 </style>
 </head>
 <body>
-<textarea></textarea>
+<textarea id="textarea"></textarea>
 <img src="../resources/green-400x400.png"></img>
 <pre id="console"></pre>
 <script>
@@ -52,8 +52,14 @@ addEventListener("load", () => {
         }
     ]);
 
-    getSelection().selectAllChildren(internals.shadowRoot(image).getElementById("image-overlay"));
-    shouldBeEqualToString("getSelection().toString()", "foo bar")
+    const imageOverlay = internals.shadowRoot(image).getElementById("image-overlay");
+    internals.setSelectionWithoutValidation(imageOverlay, 0, imageOverlay, imageOverlay.childNodes.length);
+    document.execCommand("Copy");
+
+    textarea.focus();
+    document.execCommand("Paste");
+
+    shouldBeEqualToString("textarea.value", "foo bar")
 });
 </script>
 </body>

--- a/LayoutTests/fast/images/text-recognition/image-overlay-text-without-leading-whitespace.html
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-text-without-leading-whitespace.html
@@ -50,7 +50,8 @@ addEventListener("load", () => {
         }
     ]);
 
-    getSelection().selectAllChildren(internals.shadowRoot(image).getElementById("image-overlay"));
+    const imageOverlay = internals.shadowRoot(image).getElementById("image-overlay");
+    internals.setSelectionWithoutValidation(imageOverlay, 0, imageOverlay, imageOverlay.childNodes.length);
     testRunner.execCommand("Copy");
 
     input = document.querySelector("input");


### PR DESCRIPTION
#### 2ad3dff89d32c62d36ddb3e93b18cfd5be580fa9
<pre>
[Live Range Selection] image overlay tests fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=249529">https://bugs.webkit.org/show_bug.cgi?id=249529</a>

Reviewed by Darin Adler.

These image overlay tests start fail when enabling live range selection because they rely on
getSelection().selectAllChildren to be able to select contents within user-agent shadow roots.

Some tests also rely on getSelection().toString() to include the same selected content.

Fixed these tests by using internals.setSelectionWithoutValidation to select the contents
within user-agent shadow roots, and copying &amp; pasting it to textarea / input element
to extract the selected txt.

* LayoutTests/fast/images/text-recognition/image-overlay-block-with-newlines-expected.txt:
* LayoutTests/fast/images/text-recognition/image-overlay-block-with-newlines.html:
* LayoutTests/fast/images/text-recognition/image-overlay-line-wrapping.html:
* LayoutTests/fast/images/text-recognition/image-overlay-reversed-range-expected.txt:
* LayoutTests/fast/images/text-recognition/image-overlay-reversed-range.html:
* LayoutTests/fast/images/text-recognition/image-overlay-text-without-leading-whitespace.html:

Canonical link: <a href="https://commits.webkit.org/258041@main">https://commits.webkit.org/258041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8c7205a3426642cbe5f412157395c42002586ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110035 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170309 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/428 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93137 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107881 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34781 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77752 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3574 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3598 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43836 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5521 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5376 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->