### PR TITLE
[web-animations] adopt AnimatableProperty instead of CSSPropertyAnimation::Property

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.h
+++ b/Source/WebCore/animation/CSSPropertyAnimation.h
@@ -31,6 +31,7 @@
 #include "CSSPropertyNames.h"
 #include "CompositeOperation.h"
 #include "IterationCompositeOperation.h"
+#include "WebAnimationTypes.h"
 #include <wtf/HashSet.h>
 
 namespace WebCore {
@@ -40,18 +41,16 @@ class RenderStyle;
 
 class CSSPropertyAnimation {
 public:
-    using Property = std::variant<CSSPropertyID, AtomString>;
-
     static bool isPropertyAnimatable(CSSPropertyID);
-    static bool isPropertyAdditiveOrCumulative(Property);
-    static bool propertyRequiresBlendingForAccumulativeIteration(const CSSPropertyBlendingClient&, Property, const RenderStyle& a, const RenderStyle& b);
+    static bool isPropertyAdditiveOrCumulative(AnimatableProperty);
+    static bool propertyRequiresBlendingForAccumulativeIteration(const CSSPropertyBlendingClient&, AnimatableProperty, const RenderStyle& a, const RenderStyle& b);
     static bool animationOfPropertyIsAccelerated(CSSPropertyID);
     static bool propertiesEqual(CSSPropertyID, const RenderStyle& a, const RenderStyle& b);
     static bool canPropertyBeInterpolated(CSSPropertyID, const RenderStyle& a, const RenderStyle& b);
     static CSSPropertyID getPropertyAtIndex(int, std::optional<bool>& isShorthand);
     static int getNumProperties();
 
-    static void blendProperty(const CSSPropertyBlendingClient&, Property, RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, double progress, CompositeOperation, IterationCompositeOperation = IterationCompositeOperation::Replace, double currentIteration = 0);
+    static void blendProperty(const CSSPropertyBlendingClient&, AnimatableProperty, RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, double progress, CompositeOperation, IterationCompositeOperation = IterationCompositeOperation::Replace, double currentIteration = 0);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -61,6 +61,7 @@
 #include "StyledElement.h"
 #include "TimingFunction.h"
 #include "TranslateTransformOperation.h"
+#include "WebAnimationTypes.h"
 #include "WillChangeData.h"
 #include <JavaScriptCore/Exception.h>
 #include <wtf/UUID.h>
@@ -1417,14 +1418,14 @@ void KeyframeEffect::setAnimatedPropertiesInStyle(RenderStyle& targetStyle, doub
     KeyframeValue propertySpecificKeyframeWithZeroOffset(0, RenderStyle::clonePtr(targetStyle));
     KeyframeValue propertySpecificKeyframeWithOneOffset(1, RenderStyle::clonePtr(targetStyle));
 
-    auto keyframeContainsProperty = [](const KeyframeValue& keyframe, CSSPropertyAnimation::Property property) {
+    auto keyframeContainsProperty = [](const KeyframeValue& keyframe, AnimatableProperty property) {
         return WTF::switchOn(property,
             [&] (CSSPropertyID propertyId) { return keyframe.containsProperty(propertyId); },
-            [&] (AtomString customProperty) { return keyframe.containsCustomProperty(customProperty); }
+            [&] (const AtomString& customProperty) { return keyframe.containsCustomProperty(customProperty); }
         );
     };
 
-    auto blendProperty = [&](CSSPropertyAnimation::Property property) {
+    auto blendProperty = [&](AnimatableProperty property) {
         // 1. If iteration progress is unresolved abort this procedure.
         // 2. Let target property be the longhand property for which the effect value is to be calculated.
         // 3. If animation type of the target property is not animatable abort this procedure since the effect cannot be applied.

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -53,6 +53,7 @@
 #include "StylePropertyShorthand.h"
 #include "StyleResolver.h"
 #include "StyledElement.h"
+#include "WebAnimationTypes.h"
 #include "WebAnimationUtilities.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/NeverDestroyed.h>
@@ -1560,14 +1561,14 @@ ExceptionOr<void> WebAnimation::commitStyles()
 
     auto& keyframeStack = styledElement.ensureKeyframeEffectStack(PseudoId::None);
 
-    auto effectAnimatesProperty = [](KeyframeEffect& effect, CSSPropertyAnimation::Property property) {
+    auto effectAnimatesProperty = [](KeyframeEffect& effect, AnimatableProperty property) {
         return WTF::switchOn(property,
             [&] (CSSPropertyID propertyId) { return effect.animatedProperties().contains(propertyId); },
-            [&] (AtomString customProperty) { return effect.animatedCustomProperties().contains(customProperty); }
+            [&] (const AtomString& customProperty) { return effect.animatedCustomProperties().contains(customProperty); }
         );
     };
 
-    auto commitProperty = [&](CSSPropertyAnimation::Property property) {
+    auto commitProperty = [&](AnimatableProperty property) {
         // 1. Let partialEffectStack be a copy of the effect stack for property on target.
         // 2. If animation's replace state is removed, add all animation effects associated with animation whose effect target is target and which include
         // property as a target property to partialEffectStack.
@@ -1596,7 +1597,7 @@ ExceptionOr<void> WebAnimation::commitStyles()
                     return inlineStyle->setProperty(propertyId, cssValue->cssText(), false, { styledElement.document() });
                 return false;
             },
-            [&] (AtomString customProperty) {
+            [&] (const AtomString& customProperty) {
                 if (auto cssValue = computedStyleExtractor.customPropertyValue(customProperty))
                     return inlineStyle->setCustomProperty(&styledElement.document(), customProperty, cssValue->cssText(), false, { styledElement.document() });
                 return false;


### PR DESCRIPTION
#### 6cb1d999a152484588e500d4d95e83f65652c72b
<pre>
[web-animations] adopt AnimatableProperty instead of CSSPropertyAnimation::Property
<a href="https://bugs.webkit.org/show_bug.cgi?id=249533">https://bugs.webkit.org/show_bug.cgi?id=249533</a>

Reviewed by Simon Fraser.

We introduced the AnimatableProperty type in bug 249498, which removes the need
for CSSPropertyAnimation::Property. We also fix switchOn statements where we used
the AtomString variant to use const AtomString&amp;.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyBlendingContext::CSSPropertyBlendingContext):
(WebCore::CSSPropertyAnimation::blendProperty):
(WebCore::CSSPropertyAnimation::isPropertyAdditiveOrCumulative):
(WebCore::CSSPropertyAnimation::propertyRequiresBlendingForAccumulativeIteration):
* Source/WebCore/animation/CSSPropertyAnimation.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setAnimatedPropertiesInStyle):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::commitStyles):

Canonical link: <a href="https://commits.webkit.org/258050@main">https://commits.webkit.org/258050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcf3e5f56838172738ba030074988624bad2ba82

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110040 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170314 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/445 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93142 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107886 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91426 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34784 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90085 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77755 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3579 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24343 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3603 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/445 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43842 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5381 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2892 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->