### PR TITLE
css rendering bug : fixed-position-element and 'left'

### DIFF
--- a/LayoutTests/fast/css/css-properties-position-relative-as-parent-fixed.html
+++ b/LayoutTests/fast/css/css-properties-position-relative-as-parent-fixed.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        h5 {
+            margin: 0;
+        }
+
+        div {
+            font-family: monospace;
+        }
+
+        .container {
+            position: relative;
+            left: 150px;
+            font-size: 0.8em;
+        }
+
+        .main {
+            width: 400px;
+        }
+
+        .relative {
+            position: relative;
+        }
+
+        .fixed {
+            position: fixed;
+        }
+
+        .green {
+            background-color: lime;
+        }
+
+        .blue {
+            background-color: cyan;
+        }
+
+        .grey {
+            background-color: silver;
+        }
+
+        .rtl {
+            direction: rtl;
+        }
+    </style>
+</head>
+<body>
+    <h3>Test for chromium bug : <a href="https://code.google.com/p/chromium/issues/detail?id=31286">31286</a>. css rendering bug : fixed-position-element and 'left'.</h3>
+    <p>If fixed position inline element does not have left and/or right position then it should render as normal flow.</p>
+
+    <h5>Case 1: fixed text box (blue) should be just after relative text box (green).</h5>
+    <div class="container">
+        <div class="main relative green" style="left: 100px;">
+            relative
+            <span class="fixed blue">
+                fixed
+            </span>
+        </div>
+    </div>
+
+    <h5>Case 2: fixed text box (blue) should be just before relative text box (green).</h5>
+    <div class="container">
+        <div class="main relative green rtl" style="left: 100px;">
+            relative
+            <span class="fixed blue">
+                fixed
+            </span>
+        </div>
+    </div>
+
+    <h5>Case 3: fixed text box (blue) should be just after relative text box (green).</h5>
+    <div class="container">
+        <div class="main relative green" style="right: 100px;">
+            relative
+            <span class="fixed blue">
+                fixed
+            </span>
+        </div>
+    </div>
+
+    <h5>Case 4: fixed text box (blue) should be just before relative text box (green).</h5>
+    <div class="container">
+        <div class="main relative green rtl" style="right: 100px;">
+            relative
+            <span class="fixed blue">
+                fixed
+            </span>
+        </div>
+    </div>
+
+    <h5>Case 5: fixed text box (blue) should be just after relative2 text box (green).</h5>
+    <div class="container">
+        <div class="main relative grey" style="left: 100px;">
+            relative
+            <span class="relative green" style="left: 100px;">
+                relative2
+                <span class="fixed blue">
+                    fixed
+                </span>
+            </span>
+        </div>
+    </div>
+
+    <h5>Case 6: fixed text box (blue) should be after relative text box (grey) in some distance and before the other relative2 text box (green) in some distance.</h5>
+    <div class="container">
+        <div class="main relative grey rtl" style="left: 100px;">
+            relative
+            <span class="relative green" style="left: 100px;">
+                relative2
+                <span class="fixed blue">
+                    fixed
+                </span>
+            </span>
+        </div>
+    </div>
+
+    <h5>Case 7: fixed text box (blue) should be just after relative2 text box (green).</h5>
+    <div class="container">
+        <div class="main relative grey" style="left: 100px;">
+            relative
+            <span class="relative green" style="right: 100px;">
+                relative2
+                <span class="fixed blue">
+                    fixed
+                </span>
+            </span>
+        </div>
+    </div>
+
+    <h5>Case 8: fixed text box (blue) should be before relative2 text box (green) in some distance.</h5>
+    <div class="container">
+        <div class="main relative grey rtl" style="left: 100px;">
+            relative
+            <span class="relative green" style="right: 100px;">
+                relative2
+                <span class="fixed blue">
+                    fixed
+                </span>
+            </span>
+        </div>
+    </div>
+
+    <h5>Case 9: fixed text box (blue) should be just after relative2 text box (green).</h5>
+    <div class="container">
+        <div class="main relative grey" style="right: 100px;">
+            relative
+            <span class="relative green" style="left: 100px;">
+                relative2
+                <span class="fixed blue">
+                    fixed
+                </span>
+            </span>
+        </div>
+    </div>
+
+    <h5>Case 10: fixed text box (blue) should be after relative text box (grey) in some distance and before other relative2 text box (green) in some distance.</h5>
+    <div class="container">
+        <div class="main relative grey rtl" style="right: 100px;">
+            relative
+            <span class="relative green" style="left: 100px;">
+                relative2
+                <span class="fixed blue">
+                    fixed
+                </span>
+            </span>
+        </div>
+    </div>
+
+    <h5>Case 11: fixed text box (blue) should be just after relative2 text box (green).</h5>
+    <div class="container">
+        <div class="main relative grey" style="right: 100px;">
+            relative
+            <span class="relative green" style="right: 100px;">
+                relative2
+                <span class="fixed blue">
+                    fixed
+                </span>
+            </span>
+        </div>
+    </div>
+
+    <h5>Case 12: fixed text box (blue) should be before relative2 text box (green) in some distance.</h5>
+    <div class="container">
+        <div class="main relative grey rtl" style="right: 100px;">
+            relative
+            <span class="relative green" style="right: 100px;">
+                relative2
+                <span class="fixed blue">
+                    fixed
+                </span>
+            </span>
+        </div>
+    </div>
+
+    <h5>Case 13: fixed text box (blue) should be just after relative2 text box (green).</h5>
+    <div class="container">
+        <div class="main relative grey" style="left: 100px;">
+            relative
+            <span class="relative green" style="left: 25%;">
+                relative2
+                <span class="fixed blue">
+                    fixed
+                </span>
+            </span>
+        </div>
+    </div>
+
+    <h5>Case 14: fixed text box (blue) should be after relative text box (grey) in some distance and before the other relative2 text box (green) in some distance.</h5>
+    <div class="container">
+        <div class="main relative grey rtl" style="left: 100px;">
+            relative
+            <span class="relative green" style="left: 25%;">
+                relative2
+                <span class="fixed blue">
+                    fixed
+                </span>
+            </span>
+        </div>
+    </div>
+
+</body>
+</html>


### PR DESCRIPTION
<pre>
css rendering bug : fixed-position-element and 'left'
<a href="https://bugs.webkit.org/show_bug.cgi?id=122878">https://bugs.webkit.org/show_bug.cgi?id=122878</a>

Reviewed by NOBODY (OOPS!).

This patch is to align Webkit with Gecko / Firefox and Blink / Chromium.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/771dc814b28496295ded1ac67346d774f4ebd608">https://chromium.googlesource.com/chromium/blink/+/771dc814b28496295ded1ac67346d774f4ebd608</a>

Fixed position element was rendered as normal flow irrespective of it's relative-position
parents.

If fixed position element does not have left and/or right position then it should render
as normal flow with respect to it's parent. So fixed position element is shifted with the
value of relative position of its parent.

* Source/WebCore/rendering/RenderBox.cpp: (computeInlineStaticDistance): Update logic to
account for left/right position in reference to relative position
* LayoutTests/fast/css/css-properties-relative-as-parent-fixed.html: Add Test Case
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c7bb438f9037f7490a2ca794d37cc0fba1d0bd6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103364 "1 style error") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12485 "Hash 2c7bb438 for PR 7813 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36329 "Hash 2c7bb438 for PR 7813 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112600 "Hash 2c7bb438 for PR 7813 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172805 "Hash 2c7bb438 for PR 7813 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107317 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13514 "Hash 2c7bb438 for PR 7813 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3390 "Hash 2c7bb438 for PR 7813 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95581 "Hash 2c7bb438 for PR 7813 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/111416 "Hash 2c7bb438 for PR 7813 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109139 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/13514 "Hash 2c7bb438 for PR 7813 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/36329 "Hash 2c7bb438 for PR 7813 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/95581 "Hash 2c7bb438 for PR 7813 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/13514 "Hash 2c7bb438 for PR 7813 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/36329 "Hash 2c7bb438 for PR 7813 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/95581 "Hash 2c7bb438 for PR 7813 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5876 "Hash 2c7bb438 for PR 7813 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/36329 "Hash 2c7bb438 for PR 7813 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6048 "Hash 2c7bb438 for PR 7813 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/3390 "Hash 2c7bb438 for PR 7813 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12031 "Hash 2c7bb438 for PR 7813 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/36329 "Hash 2c7bb438 for PR 7813 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7807 "Hash 2c7bb438 for PR 7813 does not build (failure)") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->