### PR TITLE
HTMLOptionElement::defaultSelected should affect selection state of other option elements

### DIFF
--- a/LayoutTests/fast/forms/select/option-defaultselected-expected.txt
+++ b/LayoutTests/fast/forms/select/option-defaultselected-expected.txt
@@ -1,0 +1,21 @@
+Tests for HTMLOptionElement::defaultSelected
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS option1.defaultSelected is false
+PASS option1.defaultSelected = true; option1.hasAttribute("selected") is true
+PASS option1.selected is true
+PASS option1.selected = false; option1.defaultSelected is true
+PASS option1.defaultSelected = false; option1.hasAttribute("selected") is false
+PASS option1.setAttribute("selected", "no"); option1.defaultSelected is true
+PASS option1.removeAttribute("selected"); option1.defaultSelected is false
+PASS selectionMap(select1) is "100"
+PASS select1[2].defaultSelected = true; selectionMap(select1) is "001"
+PASS select1[1].defaultSelected = true; selectionMap(select1) is "010"
+PASS select1[1].defaultSelected = false; selectionMap(select1) is "100"
+PASS select1[2].selected = true; selectionMap(select1) is "001"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/select/option-defaultselected.html
+++ b/LayoutTests/fast/forms/select/option-defaultselected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script>
+function selectionMap(select) {
+    var result = '';
+    var options = select.options;
+    for (var i = 0; i < options.length; ++i)
+        result += options[i].selected ? '1' : '0';
+    return result;
+}
+
+description('Tests for HTMLOptionElement::defaultSelected');
+
+var option1 = document.createElement('option');
+shouldBeFalse('option1.defaultSelected');
+shouldBeTrue('option1.defaultSelected = true; option1.hasAttribute("selected")');
+shouldBeTrue('option1.selected');
+shouldBeTrue('option1.selected = false; option1.defaultSelected');
+shouldBeFalse('option1.defaultSelected = false; option1.hasAttribute("selected")');
+shouldBeTrue('option1.setAttribute("selected", "no"); option1.defaultSelected');
+shouldBeFalse('option1.removeAttribute("selected"); option1.defaultSelected');
+
+var select1 = document.createElement('select');
+select1.innerHTML = '<option>1<option>2<option>3';
+shouldBeEqualToString('selectionMap(select1)', '100');
+
+shouldBeEqualToString('select1[2].defaultSelected = true; selectionMap(select1)', '001');
+shouldBeEqualToString('select1[1].defaultSelected = true; selectionMap(select1)', '010');
+shouldBeEqualToString('select1[1].defaultSelected = false; selectionMap(select1)', '100');
+shouldBeEqualToString('select1[2].selected = true; selectionMap(select1)', '001');
+</script>
+</body>

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -3,8 +3,8 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2015 Google Inc. All rights reserved.
  * Copyright (C) 2011 Motorola Mobility, Inc.  All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -174,7 +174,7 @@ int HTMLOptionElement::index() const
     return 0;
 }
 
-void HTMLOptionElement::parseAttribute(const QualifiedName& name, const AtomString& value)
+void HTMLOptionElement::parseAttribute(const QualifiedName& name, const AtomString& oldValue, const AtomString& value)
 {
 #if ENABLE(DATALIST_ELEMENT)
     if (name == valueAttr) {
@@ -195,11 +195,9 @@ void HTMLOptionElement::parseAttribute(const QualifiedName& name, const AtomStri
         Style::PseudoClassChangeInvalidation defaultInvalidation(*this, CSSSelector::PseudoClassDefault, !value.isNull());
         m_isDefault = !value.isNull();
 
-        // FIXME: This doesn't match what the HTML specification says.
-        // The specification implies that removing the selected attribute or
-        // changing the value of a selected attribute that is already present
-        // has no effect on whether the element is selected.
-        setSelectedState(!value.isNull());
+        // https://html.spec.whatwg.org/multipage/forms.html#concept-option-selectedness
+        if (oldValue.isNull() != value.isNull())
+            setSelected(!value.isNull());
     } else
         HTMLElement::parseAttribute(name, value);
 }

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -2,8 +2,8 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -74,7 +74,7 @@ private:
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
     bool matchesDefaultPseudoClass() const final;
 
-    void parseAttribute(const QualifiedName&, const AtomString&) final;
+    virtual void parseAttribute(const QualifiedName&, const AtomString&, const AtomString&);
 
     bool accessKeyAction(bool) final;
 


### PR DESCRIPTION
<pre>
HTMLOptionElement::defaultSelected should affect selection state of other option elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=119291">https://bugs.webkit.org/show_bug.cgi?id=119291</a>

Reviewed by NOBODY (OOPS!).

Partial Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/e8f0337fdc86554b48cf81d7ed8c286f251d2405">https://chromium.googlesource.com/chromium/blink/+/e8f0337fdc86554b48cf81d7ed8c286f251d2405</a>

According to the standard, we should set selectedness to true if defaultSelected is set to
true, and we should not set selectedness to false if defaultSelected is set to false
because the standard says nothing about it.

[1]
> Whenever an option element's selected attribute is added, its selectedness
> must be set to true.

When the selectedness of an option is udpated, other options's selectedness should become
false.

[2]
> If the multiple attribute is absent, whenever an option element in the select
> element's list of options has its selectedness set to true, and whenever an
> option element with its selectedness set to true is added to the select
> element's list of options, the user agent must set the selectedness of all the
> other option elements in its list of options to false.

The old behavior doesn't match to the standard and any other browsers. The new behavior
matches to IE10, Chrome, Gecko and the standard.

* Source/WebCore/html/HTMLOptionElement.cpp
(HTMLOptionElement::parseAttribute): Add 'if' logic over bool with value, which will be
used for "setSelectedState" and also remove FIXME
* LayoutTests/fast/forms/select/option-defaultselected-expected.txt: Added Expectations
* LayoutTests/fast/forms/select/option-defaultselected.html: Added
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/691185ca71c81e432608cf7e94dd94cfb0b20271

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100827 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9975 "Hash 691185ca for PR 7817 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33872 "Hash 691185ca for PR 7817 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110129 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170403 "Found 60 new test failures: accessibility/selection-states.html, accessibility/text-alternative-calculation-from-listbox.html, dom/html/level2/html/HTMLSelectElement02.html, dom/html/level2/html/HTMLSelectElement04.html, dom/html/level2/html/HTMLSelectElement17.html, dom/html/level2/html/HTMLSelectElement18.html, dom/html/level2/html/HTMLSelectElement19.html, dom/xhtml/level2/html/HTMLSelectElement02.xhtml, dom/xhtml/level2/html/HTMLSelectElement04.xhtml, dom/xhtml/level2/html/HTMLSelectElement17.xhtml ... (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104816 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10908 "Hash 691185ca for PR 7817 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/739 "Hash 691185ca for PR 7817 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93235 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107974 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106610 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/10908 "Hash 691185ca for PR 7817 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/33872 "Hash 691185ca for PR 7817 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34860 "Found 60 new test failures: accessibility/multiselect-list-reports-active-option.html, accessibility/selection-states.html, accessibility/text-alternative-calculation-from-listbox.html, dom/html/level2/html/HTMLSelectElement02.html, dom/html/level2/html/HTMLSelectElement04.html, dom/html/level2/html/HTMLSelectElement17.html, dom/html/level2/html/HTMLSelectElement18.html, dom/html/level2/html/HTMLSelectElement19.html, dom/xhtml/level2/html/HTMLSelectElement02.xhtml, dom/xhtml/level2/html/HTMLSelectElement04.xhtml ... (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/10908 "Hash 691185ca for PR 7817 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/33872 "Hash 691185ca for PR 7817 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77835 "Found 4 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-simple, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-groups (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3667 "Hash 691185ca for PR 7817 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/33872 "Hash 691185ca for PR 7817 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3686 "Hash 691185ca for PR 7817 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/739 "Hash 691185ca for PR 7817 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9797 "Hash 691185ca for PR 7817 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/33872 "Hash 691185ca for PR 7817 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5464 "Hash 691185ca for PR 7817 does not build (failure)") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->