### PR TITLE
Live Text is visible after hovering on images in gentlemencoders.com

### DIFF
--- a/LayoutTests/fast/images/text-recognition/image-overlay-with-text-fill-and-stroke-expected.html
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-with-text-fill-and-stroke-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+img {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+</style>
+</head>
+<body>
+<img src="../resources/green-400x400.png"></img>
+</body>
+</html>

--- a/LayoutTests/fast/images/text-recognition/image-overlay-with-text-fill-and-stroke.html
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-with-text-fill-and-stroke.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    color: red;
+    -webkit-text-stroke-color: red;
+    -webkit-text-fill-color: red;
+}
+</style>
+</head>
+<body>
+<img src="../resources/green-400x400.png"></img>
+<script>
+addEventListener("load", () => {
+    internals.installImageOverlay(document.querySelector("img"), [
+        {
+            topLeft : new DOMPointReadOnly(0, 0),
+            topRight : new DOMPointReadOnly(1, 0),
+            bottomRight : new DOMPointReadOnly(1, 0.5),
+            bottomLeft : new DOMPointReadOnly(0, 0.5),
+            children: [
+                {
+                    text : "foo",
+                    topLeft : new DOMPointReadOnly(0, 0),
+                    topRight : new DOMPointReadOnly(0.5, 0),
+                    bottomRight : new DOMPointReadOnly(0.5, 0.5),
+                    bottomLeft : new DOMPointReadOnly(0, 0.5),
+                },
+                {
+                    text : "bar",
+                    topLeft : new DOMPointReadOnly(0.5, 0),
+                    topRight : new DOMPointReadOnly(1, 0),
+                    bottomRight : new DOMPointReadOnly(1, 0.5),
+                    bottomLeft : new DOMPointReadOnly(0.5, 0.5),
+                }
+            ],
+        }
+    ]);
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/shadow/imageOverlay.css
+++ b/Source/WebCore/html/shadow/imageOverlay.css
@@ -28,6 +28,8 @@ div#image-overlay {
     position: relative;
     overflow: hidden;
     color: transparent;
+    -webkit-text-stroke-color: currentcolor;
+    -webkit-text-fill-color: currentcolor;
     text-shadow: none;
     text-indent: 0;
     text-align: center;


### PR DESCRIPTION
#### 4112008b949ffffd7238a40e23674f621983c5e1
<pre>
Live Text is visible after hovering on images in gentlemencoders.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=249540">https://bugs.webkit.org/show_bug.cgi?id=249540</a>
rdar://102196692

Reviewed by Ryosuke Niwa.

Make a small adjustment to the image overlay stylesheet, to prevent explicitly set
`-webkit-text-{fill|stroke}-color` in image elements from causing injected Live Text to show up as
non-transparent text.

Note that we use `currentcolor` here instead of `transparent`, so that text in image overlays for
visual translation *will* continue to show up as visible text (against semi-transparent backdrop
containers).

* LayoutTests/fast/images/text-recognition/image-overlay-with-text-fill-and-stroke-expected.html: Added.
* LayoutTests/fast/images/text-recognition/image-overlay-with-text-fill-and-stroke.html: Added.
* Source/WebCore/html/shadow/imageOverlay.css:
(div#image-overlay):

Canonical link: <a href="https://commits.webkit.org/258057@main">https://commits.webkit.org/258057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1fcda4b4b104734b26478141c147c43f2f3c26a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110067 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170342 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/515 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93171 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107914 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106552 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34809 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22839 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3606 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24364 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3630 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9741 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43863 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5529 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5407 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->