### PR TITLE
[libpas] remove unused variable in ThingyAndUtilityHeapAllocationTests

### DIFF
--- a/Source/bmalloc/libpas/src/test/ThingyAndUtilityHeapAllocationTests.cpp
+++ b/Source/bmalloc/libpas/src/test/ThingyAndUtilityHeapAllocationTests.cpp
@@ -782,11 +782,9 @@ void testFreeListRefillSpans(unsigned prewarmObjectSize,
     CHECK_EQUAL(objects.size(), numberOfSpans);
     CHECK_EQUAL(actualNumberOfObjects, numberOfObjects);
     
-    unsigned numberOfSpansFreed = 0;
     unsigned numberOfObjectsFreed = 0;
     set<void*> freedObject;
     for (unsigned span = firstSpanToFree; span < objects.size(); span += 2) {
-        numberOfSpansFreed++;
         for (void* object : objects[span]) {
             thingy_deallocate(object);
             freedObject.insert(object);


### PR DESCRIPTION
#### eee1c52ab0d27f20389ba4b4a1738a43d8c026f7
<pre>
[libpas] remove unused variable in ThingyAndUtilityHeapAllocationTests
<a href="https://bugs.webkit.org/show_bug.cgi?id=249542">https://bugs.webkit.org/show_bug.cgi?id=249542</a>

Reviewed by Yusuke Suzuki.

Removing an unused variable in test file.

* Source/bmalloc/libpas/src/test/ThingyAndUtilityHeapAllocationTests.cpp:
(std::testFreeListRefillSpans):

Canonical link: <a href="https://commits.webkit.org/258058@main">https://commits.webkit.org/258058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3ff148a450b6896857e35dda162613fd3e177b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110069 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170344 "Found 1 new test failure: svg/as-image/svg-as-image-canvas.html (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/522 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93173 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107916 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34810 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77783 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91256 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3608 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24367 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87347 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1144 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3632 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29212 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43866 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90233 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5530 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5409 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20195 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->