### PR TITLE
Revert [257989@main] [WebAuthn] Handle security keys with a full key store because it broke the build for the bots

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https-expected.txt
@@ -4,7 +4,6 @@ CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'na
 CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
-CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 
 PASS PublicKeyCredential's [[create]] with timeout in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with malicious payload in a mock hid authenticator.
@@ -13,5 +12,4 @@ PASS PublicKeyCredential's [[create]] with unsupported options in a mock hid aut
 PASS PublicKeyCredential's [[create]] with mixed options in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with mixed options in a mock hid authenticator. 2
 PASS PublicKeyCredential's [[create]] with InvalidStateError in a mock hid authenticator.
-PASS PublicKeyCredential's [[create]] with full key store.
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
@@ -159,27 +159,4 @@
             internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", payloadBase64: [testCtapErrCredentialExcludedOnlyResponseBase64] } });
         return promiseRejects(t, "InvalidStateError", navigator.credentials.create(options), "At least one credential matches an entry of the excludeCredentials list in the authenticator.");
     }, "PublicKeyCredential's [[create]] with InvalidStateError in a mock hid authenticator.");
-
-        promise_test(function(t) {
-        const options = {
-            publicKey: {
-                rp: {
-                    name: "example.com"
-                },
-                user: {
-                    name: "John Appleseed",
-                    id: asciiToUint8Array("123456"),
-                    displayName: "John",
-                },
-                challenge: asciiToUint8Array("123456"),
-                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
-                authenticatorSelection: { residentKey: "required" },
-                timeout: 10 // We wait for another authenticator upon full.
-            }
-        };
-
-        if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", payloadBase64: [testCreateMessageFullKeyStoreBase64] } });
-        return promiseRejects(t, "NotAllowedError", navigator.credentials.create(options), "Operation timed out.");
-    }, "PublicKeyCredential's [[create]] with full key store.");
 </script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
@@ -18,5 +18,4 @@ PASS PublicKeyCredential's [[create]] with direct attestation in a mock hid auth
 PASS PublicKeyCredential's [[create]] with indirect attestation in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with googleLegacyAppidSupport extension in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with googleLegacyAppidSupport and appid extensions in a mock hid authenticator.
-PASS PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform', 'preferred' } in a mock hid authenticator with a full key store.
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
@@ -424,29 +424,4 @@
             checkCtapMakeCredentialResult(credential);
         });
     }, "PublicKeyCredential's [[create]] with googleLegacyAppidSupport and appid extensions in a mock hid authenticator.");
-
-    promise_test(t => {
-        const options = {
-            publicKey: {
-                rp: {
-                    name: "localhost",
-                },
-                user: {
-                    name: "John Appleseed",
-                    id: Base64URL.parse(testUserhandleBase64),
-                    displayName: "Appleseed",
-                },
-                challenge: Base64URL.parse("MTIzNDU2"),
-                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
-                authenticatorSelection: { authenticatorAttachment: "cross-platform", residentKey: "preferred" },
-                extensions: { credProps: true }
-            }
-        };
-
-        if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreateMessageFullKeyStoreBase64, testCreationMessageBase64] } });
-        return navigator.credentials.create(options).then(credential => {
-            checkCtapMakeCredentialResult(credential);
-        });
-    }, "PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform', 'preferred' } in a mock hid authenticator with a full key store.");
 </script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https-expected.txt
@@ -6,5 +6,4 @@ PASS PublicKeyCredential's [[create]] with U2F in a mock nfc authenticator.
 PASS PublicKeyCredential's [[create]] with multiple physical tags in a mock nfc authenticator.
 PASS PublicKeyCredential's [[create]] with service restart in a mock nfc authenticator.
 PASS PublicKeyCredential's [[create]] with legacy U2F keys in a mock nfc authenticator.
-PASS PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform', 'preferred' } in a mock nfc authenticator with a full key store based on getInfo
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https.html
@@ -166,31 +166,4 @@
             checkCtapMakeCredentialResult(credential);
         });
     }, "PublicKeyCredential's [[create]] with legacy U2F keys in a mock nfc authenticator.");
-
-
-
-    promise_test(t => {
-        const options = {
-            publicKey: {
-                rp: {
-                    name: "localhost",
-                },
-                user: {
-                    name: "John Appleseed",
-                    id: Base64URL.parse(testUserhandleBase64),
-                    displayName: "Appleseed",
-                },
-                challenge: Base64URL.parse("MTIzNDU2"),
-                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
-                authenticatorSelection: { authenticatorAttachment: "cross-platform", residentKey: "preferred" }
-            }
-        };
-
-        if (window.internals)
-        internals.setMockWebAuthenticationConfiguration({ nfc: { error: "success", payloadBase64: [testNfcCtapVersionBase64, testGetInfoResponseApduNoRemainingDiscoverableBase64, testCreationMessageApduBase64] } });
-
-        return navigator.credentials.create(options).then(credential => {
-            checkCtapMakeCredentialResult(credential);
-        });
-    }, "PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform', 'preferred' } in a mock nfc authenticator with a full key store based on getInfo");
 </script>

--- a/LayoutTests/http/wpt/webauthn/resources/util.js
+++ b/LayoutTests/http/wpt/webauthn/resources/util.js
@@ -112,8 +112,6 @@ const testNfcCtapVersionBase64 = "RklET18yXzCQAA==";
 const testGetInfoResponseApduBase64 =
     "AKYBgmZVMkZfVjJoRklET18yXzACgWtobWFjLXNlY3JldANQbUS6m/bsLkm5MAyP" +
     "6SDLcwSkYnJr9WJ1cPVkcGxhdPRpY2xpZW50UGlu9AUZBLAGgQGQAA==";
-const testGetInfoResponseApduNoRemainingDiscoverableBase64 =
-    "AKcBgmZVMkZfVjJoRklET18yXzACgWtobWFjLXNlY3JldANQbUS6m/bsLkm5MAyP6SDLcwSkYnJr9WJ1cPVkcGxhdPRpY2xpZW50UGlu9AUZBLAGgQEUAJAA";
 const testCreationMessageApduBase64 =
     "AKMBZnBhY2tlZAJYxEbMf7lnnVWy25CS4cjZ5eHQK3WA8LSBLHcJYuHkj1rYQQAA" +
     "AE74oBHzjApNFYAGFxEfntx9AEAoCK3O6P5OyXN6V/f+9nAga0NA2Cgp4V3mgSJ5" +
@@ -145,7 +143,6 @@ const testAssertionMessageApduBase64 =
     "QoJ1L7Fe64G9uBeQAA==";
 const testCcidNoUidBase64 = "aIE=";
 const testCcidValidUidBase64 = "CH+d1ZAA";
-const testCreateMessageFullKeyStoreBase64 = "KA==";
 
 const RESOURCES_DIR = "/WebKit/webauthn/resources/";
 

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
@@ -83,12 +83,6 @@ AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setTransports(Vector
     return *this;
 }
 
-AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setRemainingDiscoverableCredentials(uint32_t remainingDiscoverableCredentials)
-{
-    m_remainingDiscoverableCredentials = remainingDiscoverableCredentials;
-    return *this;
-}
-
 static String toString(WebCore::AuthenticatorTransport transport)
 {
     switch (transport) {
@@ -144,9 +138,6 @@ Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse& response)
         auto transports = *response.transports();
         deviceInfoMap.emplace(CBORValue(7), toArrayValue(transports.map(toString)));
     }
-
-    if (response.remainingDiscoverableCredentials())
-        deviceInfoMap.emplace(CBORValue(8), CBORValue(static_cast<int64_t>(*response.maxMsgSize())));
 
     auto encodedBytes = CBORWriter::write(CBORValue(WTFMove(deviceInfoMap)));
     ASSERT(encodedBytes);

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h
@@ -54,7 +54,6 @@ public:
     AuthenticatorGetInfoResponse& setExtensions(Vector<String>&&);
     AuthenticatorGetInfoResponse& setOptions(AuthenticatorSupportedOptions&&);
     AuthenticatorGetInfoResponse& setTransports(Vector<WebCore::AuthenticatorTransport>&&);
-    AuthenticatorGetInfoResponse& setRemainingDiscoverableCredentials(uint32_t);
 
     const StdSet<ProtocolVersion>& versions() const { return m_versions; }
     const Vector<uint8_t>& aaguid() const { return m_aaguid; }
@@ -63,7 +62,6 @@ public:
     const std::optional<Vector<String>>& extensions() const { return m_extensions; }
     const AuthenticatorSupportedOptions& options() const { return m_options; }
     const std::optional<Vector<WebCore::AuthenticatorTransport>>& transports() const { return m_transports; }
-    const std::optional<uint32_t>& remainingDiscoverableCredentials() const { return m_remainingDiscoverableCredentials; }
 
 private:
     StdSet<ProtocolVersion> m_versions;
@@ -73,7 +71,6 @@ private:
     std::optional<Vector<String>> m_extensions;
     AuthenticatorSupportedOptions m_options;
     std::optional<Vector<WebCore::AuthenticatorTransport>> m_transports;
-    std::optional<uint32_t> m_remainingDiscoverableCredentials;
 };
 
 WEBCORE_EXPORT Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse&);

--- a/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
@@ -360,14 +360,6 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
         response.setTransports(WTFMove(transports));
     }
 
-    it = responseMap.find(CBOR(20));
-    if (it != responseMap.end()) {
-        if (!it->second.isUnsigned())
-            return std::nullopt;
-
-        response.setRemainingDiscoverableCredentials(it->second.getUnsigned());
-    }
-
     return WTFMove(response);
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
@@ -51,7 +51,6 @@ typedef NS_ENUM(NSInteger, _WKWebAuthenticationPanelUpdate) {
     _WKWebAuthenticationPanelUpdateLAError,
     _WKWebAuthenticationPanelUpdateLAExcludeCredentialsMatched,
     _WKWebAuthenticationPanelUpdateLANoCredential,
-    _WKWebAuthenticationPanelUpdateKeyStoreFull,
 } WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 
 typedef NS_ENUM(NSInteger, _WKWebAuthenticationResult) {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
@@ -76,8 +76,6 @@ static _WKWebAuthenticationPanelUpdate wkWebAuthenticationPanelUpdate(WebAuthent
         return _WKWebAuthenticationPanelUpdateLAExcludeCredentialsMatched;
     if (status == WebAuthenticationStatus::LANoCredential)
         return _WKWebAuthenticationPanelUpdateLANoCredential;
-    if (status == WebAuthenticationStatus::KeyStoreFull)
-        return _WKWebAuthenticationPanelUpdateKeyStoreFull;
     ASSERT_NOT_REACHED();
     return _WKWebAuthenticationPanelUpdateMultipleNFCTagsPresent;
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h
@@ -49,7 +49,6 @@ enum class WebAuthenticationStatus : uint8_t {
     LAError,
     LAExcludeCredentialsMatched,
     LANoCredential,
-    KeyStoreFull,
 };
 
 enum class LocalAuthenticatorPolicy : bool {

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -98,13 +98,6 @@ void CtapAuthenticator::makeCredential()
     auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
     auto internalUVAvailability = m_info.options().userVerificationAvailability();
     auto residentKeyAvailability = m_info.options().residentKeyAvailability();
-    if (m_isKeyStoreFull || (m_info.remainingDiscoverableCredentials() && !m_info.remainingDiscoverableCredentials())) {
-        if (options.authenticatorSelection && (options.authenticatorSelection->requireResidentKey || options.authenticatorSelection->residentKey == ResidentKeyRequirement::Required)) {
-            observer()->authenticatorStatusUpdated(WebAuthenticationStatus::KeyStoreFull);
-            return;
-        }
-        residentKeyAvailability = AuthenticatorSupportedOptions::ResidentKeyAvailability::kNotSupported;
-    }
     // If UV is required, then either built-in uv or a pin will work.
     if (internalUVAvailability == UVAvailability::kSupportedAndConfigured && (!options.authenticatorSelection || options.authenticatorSelection->userVerification != UserVerificationRequirement::Discouraged) && m_pinAuth.isEmpty())
         cborCmd = encodeMakeCredenitalRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability);
@@ -135,16 +128,6 @@ void CtapAuthenticator::continueMakeCredentialAfterResponseReceived(Vector<uint8
             receiveRespond(ExceptionData { InvalidStateError, "At least one credential matches an entry of the excludeCredentials list in the authenticator."_s });
             return;
         }
-        if (error == CtapDeviceResponseCode::kCtap2ErrKeyStoreFull) {
-            auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
-            if (options.authenticatorSelection->requireResidentKey || options.authenticatorSelection->residentKey == ResidentKeyRequirement::Required) {
-                observer()->authenticatorStatusUpdated(WebAuthenticationStatus::KeyStoreFull);
-            } else if (!m_isKeyStoreFull) {
-                m_isKeyStoreFull = true;
-                makeCredential();
-            }
-            return;
-        }
 
         if (isPinError(error)) {
             if (!m_pinAuth.isEmpty() && observer()) // Skip the very first command that acts like wink.
@@ -162,7 +145,7 @@ void CtapAuthenticator::continueMakeCredentialAfterResponseReceived(Vector<uint8
         
         auto rkSupported = m_info.options().residentKeyAvailability() == AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported;
         auto rkRequested = options.authenticatorSelection && ((options.authenticatorSelection->residentKey && options.authenticatorSelection->residentKey != ResidentKeyRequirement::Discouraged) || options.authenticatorSelection->requireResidentKey);
-        extensionOutputs.credProps = AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput { rkSupported && rkRequested && !m_isKeyStoreFull };
+        extensionOutputs.credProps = AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput { rkSupported && rkRequested };
         response->setExtensions(WTFMove(extensionOutputs));
     }
     receiveRespond(response.releaseNonNull());

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -74,7 +74,6 @@ private:
 
     fido::AuthenticatorGetInfoResponse m_info;
     bool m_isDowngraded { false };
-    bool m_isKeyStoreFull { false };
     size_t m_remainingAssertionResponses { 0 };
     Vector<Ref<WebCore::AuthenticatorAssertionResponse>> m_assertionResponses;
     Vector<uint8_t> m_pinAuth;


### PR DESCRIPTION
#### f7fba6d71160d9d9a00c1f658e1fec416113f28f
<pre>
Revert [257989@main] [WebAuthn] Handle security keys with a full key store because it broke the build for the bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=247339">https://bugs.webkit.org/show_bug.cgi?id=247339</a>
rdar://100241655

Unreviewed build fix.

* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https.html:
* LayoutTests/http/wpt/webauthn/resources/util.js:
* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp:
(fido::encodeAsCBOR):
(fido::AuthenticatorGetInfoResponse::setRemainingDiscoverableCredentials): Deleted.
* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h:
* Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp:
(fido::readCTAPGetInfoResponse):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm:
(WebKit::wkWebAuthenticationPanelUpdate):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterResponseReceived):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h:

Canonical link: <a href="https://commits.webkit.org/258056@main">https://commits.webkit.org/258056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9647a6ae3f621a64f3d44a480a06aeb93f21ae3d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110074 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170349 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/546 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93178 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107921 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106559 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3613 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3637 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9748 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5414 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2896 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->