### PR TITLE
[JSC] Use MoveZeroToDouble / MoveZeroToFloat in AirIRGenerator

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -2630,6 +2630,11 @@ public:
         m_assembler.fmov<64>(reg, ARM64Registers::zr);
     }
 
+    void moveZeroToFloat(FPRegisterID reg)
+    {
+        m_assembler.fmov<32>(reg, ARM64Registers::zr);
+    }
+
     void moveDoubleTo64(FPRegisterID src, RegisterID dest)
     {
         m_assembler.fmov<64>(dest, src);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -1422,6 +1422,18 @@ public:
             m_assembler.vmov(dest, src);
     }
 
+    void moveZeroToFloat(FPRegisterID reg)
+    {
+        static double zeroConstant = 0.;
+        loadFloat(TrustedImmPtr(&zeroConstant), reg);
+    }
+
+    void loadFloat(TrustedImmPtr address, FPRegisterID dest)
+    {
+        move(address, addressTempRegister);
+        m_assembler.flds(ARMRegisters::asSingle(dest), addressTempRegister, 0);
+    }
+
     void moveZeroToDouble(FPRegisterID reg)
     {
         static double zeroConstant = 0.;

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -2302,6 +2302,14 @@ public:
             m_assembler.xorps_rr(reg, reg);
     }
 
+    void moveZeroToFloat(FPRegisterID reg)
+    {
+        if (supportsAVX())
+            m_assembler.vxorps_rrr(reg, reg, reg);
+        else
+            m_assembler.xorps_rr(reg, reg);
+    }
+
     Jump branchDoubleNonZero(FPRegisterID reg, FPRegisterID scratch)
     {
         if (supportsAVX())

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -770,6 +770,9 @@ MoveDouble U:F:64, D:F:64, S:F:64
 MoveZeroToDouble D:F:64
     Tmp
 
+MoveZeroToFloat D:F:32
+    Tmp
+
 64: Move64ToDouble U:G:64, D:F:64
     Tmp, Tmp
     x86: Addr, Tmp as loadDouble

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
@@ -725,10 +725,7 @@ void AirIRGenerator64::emitZeroInitialize(BasicBlock* block, ExpressionType valu
     }
     case TypeKind::F32:
     case TypeKind::F64: {
-        auto temp = g64();
-        // IEEE 754 "0" is just int32/64 zero.
-        append(block, Move, Arg::imm(0), temp);
-        append(block, type.isF32() ? Move32ToFloat : Move64ToDouble, temp, value);
+        append(block, type.isF32() ? MoveZeroToFloat : MoveZeroToDouble, value);
         break;
     }
     case TypeKind::V128: {
@@ -797,9 +794,13 @@ void AirIRGenerator64::emitMaterializeConstant(BasicBlock* block, Type type, uin
         break;
     case TypeKind::F32:
     case TypeKind::F64: {
-        auto tmp = g64();
-        append(block, Move, Arg::bigImm(value), tmp);
-        append(block, type.isF32() ? Move32ToFloat : Move64ToDouble, tmp, dest);
+        if (value == 0)
+            append(block, type.isF32() ? MoveZeroToFloat : MoveZeroToDouble, dest);
+        else {
+            auto tmp = g64();
+            append(block, Move, Arg::bigImm(value), tmp);
+            append(block, type.isF32() ? Move32ToFloat : Move64ToDouble, tmp, dest);
+        }
         break;
     }
 


### PR DESCRIPTION
#### df8eda6a623bc5b34ebeb991573dc1f61917ad24
<pre>
[JSC] Use MoveZeroToDouble / MoveZeroToFloat in AirIRGenerator
<a href="https://bugs.webkit.org/show_bug.cgi?id=249552">https://bugs.webkit.org/show_bug.cgi?id=249552</a>
rdar://103490579

Reviewed by Mark Lam.

This is silly that we are using Move32ToFloat / Move32ToDouble to
generate zero value Double / Float in AirIRGenerator. We should just
use MoveZeroToDouble. And this patch adds MoveZeroToFloat too.

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::moveZeroToFloat):
* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
(JSC::MacroAssemblerARMv7::moveZeroToFloat):
(JSC::MacroAssemblerARMv7::loadFloat):
* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h:
(JSC::MacroAssemblerX86Common::moveZeroToFloat):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::emitZeroInitialize):
(JSC::Wasm::AirIRGenerator64::emitMaterializeConstant):

Canonical link: <a href="https://commits.webkit.org/258063@main">https://commits.webkit.org/258063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3aa30ea7620e3d8a173d68d1133df61d580d9993

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100790 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110088 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170363 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/614 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93192 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107935 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91468 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34827 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90124 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22862 "Failed to checkout and rebase branch from PR 7824") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77801 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91275 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3627 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24385 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87365 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1162 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3650 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29216 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9761 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43884 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90252 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5428 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20199 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2899 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->