### PR TITLE
[JSC] Use ExtendedOffsetAddr if normal Addr with SP/FP failed for Patch

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
@@ -126,6 +126,10 @@ void lowerStackArgs(Code& code)
                         result = Arg::addr(Air::Tmp(MacroAssembler::stackPointerRegister), offsetFromSP);
                         if (result.isValidForm(width))
                             return result;
+
+                        if (inst.kind.opcode == Patch)
+                            return Arg::extendedOffsetAddr(offsetFromFP);
+
 #if CPU(ARM64) || CPU(RISCV64)
                         Air::Tmp tmp = Air::Tmp(extendedOffsetAddrRegister());
 


### PR DESCRIPTION
#### 87ae77e616dd6d6cfeb1bece78f2ac9482e132fa
<pre>
[JSC] Use ExtendedOffsetAddr if normal Addr with SP/FP failed for Patch
<a href="https://bugs.webkit.org/show_bug.cgi?id=249553">https://bugs.webkit.org/show_bug.cgi?id=249553</a>
rdar://103492366

Reviewed by Justin Michaud.

Patchpoint requires that all stack arguments needs to be represented as &quot;SP + offset&quot; or &quot;FP + offset&quot;.
But in AirLowerStackArgs, we are incorrectly lowering this to &quot;LR + offset&quot; if offset is too large.
We should use a bit suboptimal ExtendedOffsetAddr for that case to ensure that they are still &quot;FP + offset&quot; form.
This fixes debug assertion failure in call.wast.js, happening after 257974@main.

* Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp:
(JSC::B3::Air::lowerStackArgs):

Canonical link: <a href="https://commits.webkit.org/258083@main">https://commits.webkit.org/258083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ab25a6904fa9e3f23840dda92a9c07e0293640e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110091 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170366 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/756 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93195 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107938 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91471 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34829 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77803 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91278 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3630 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24388 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87368 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1165 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/722 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29218 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9764 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43887 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90255 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5431 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20201 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2904 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->