### PR TITLE
[@property] Add @property rule parsing and CSSOM

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-CSSStyleDeclaration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-CSSStyleDeclaration-expected.txt
@@ -981,9 +981,9 @@ PASS image-rendering: _camel_cased_attribute v. CSS.supports
 PASS image-rendering: _dashed_attribute v. CSS.supports
 PASS ime-mode: _camel_cased_attribute v. CSS.supports
 PASS ime-mode: _dashed_attribute v. CSS.supports
-PASS inherits: _camel_cased_attribute v. CSS.supports
-PASS initial-value: _camel_cased_attribute v. CSS.supports
-PASS initial-value: _dashed_attribute v. CSS.supports
+FAIL inherits: _camel_cased_attribute v. CSS.supports assert_equals: expected true but got false
+FAIL initial-value: _camel_cased_attribute v. CSS.supports assert_equals: expected true but got false
+FAIL initial-value: _dashed_attribute v. CSS.supports assert_equals: expected true but got false
 PASS inline-size: _camel_cased_attribute v. CSS.supports
 PASS inline-size: _dashed_attribute v. CSS.supports
 PASS inset: _camel_cased_attribute v. CSS.supports
@@ -1357,7 +1357,7 @@ PASS stroke-width: _camel_cased_attribute v. CSS.supports
 PASS stroke-width: _dashed_attribute v. CSS.supports
 PASS supported-color-schemes: _camel_cased_attribute v. CSS.supports
 PASS supported-color-schemes: _dashed_attribute v. CSS.supports
-PASS syntax: _camel_cased_attribute v. CSS.supports
+FAIL syntax: _camel_cased_attribute v. CSS.supports assert_equals: expected true but got false
 PASS tab-size: _camel_cased_attribute v. CSS.supports
 PASS tab-size: _dashed_attribute v. CSS.supports
 PASS table-layout: _camel_cased_attribute v. CSS.supports

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom-expected.txt
@@ -1,64 +1,64 @@
 
-FAIL Rule for --valid has expected cssText assert_true: expected true got false
-FAIL Rule for --valid-reverse has expected cssText assert_true: expected true got false
-FAIL Rule for --valid-universal has expected cssText assert_true: expected true got false
-FAIL Rule for --valid-whitespace has expected cssText assert_true: expected true got false
-FAIL Rule for --vALId has expected cssText assert_true: expected true got false
-FAIL Rule for --no-descriptors has expected cssText assert_true: expected true got false
-FAIL Rule for --no-syntax has expected cssText assert_true: expected true got false
-FAIL Rule for --no-inherits has expected cssText assert_true: expected true got false
-FAIL Rule for --no-initial-value has expected cssText assert_true: expected true got false
-FAIL Rule for --syntax-only has expected cssText assert_true: expected true got false
-FAIL Rule for --inherits-only has expected cssText assert_true: expected true got false
-FAIL Rule for --initial-value-only has expected cssText assert_true: expected true got false
-FAIL Rule for --tab	tab has expected cssText assert_true: expected true got false
-FAIL CSSRule.type returns 0 null is not an object (evaluating 'rule.type')
-FAIL Rule for --valid returns expected value for CSSPropertyRule.name assert_true: expected true got false
-FAIL Rule for --valid-reverse returns expected value for CSSPropertyRule.name assert_true: expected true got false
-FAIL Rule for --valid-universal returns expected value for CSSPropertyRule.name assert_true: expected true got false
-FAIL Rule for --valid-whitespace returns expected value for CSSPropertyRule.name assert_true: expected true got false
-FAIL Rule for --vALId returns expected value for CSSPropertyRule.name assert_true: expected true got false
-FAIL Rule for --no-descriptors returns expected value for CSSPropertyRule.name assert_true: expected true got false
-FAIL Rule for --no-syntax returns expected value for CSSPropertyRule.name assert_true: expected true got false
-FAIL Rule for --no-inherits returns expected value for CSSPropertyRule.name assert_true: expected true got false
-FAIL Rule for --no-initial-value returns expected value for CSSPropertyRule.name assert_true: expected true got false
-FAIL Rule for --syntax-only returns expected value for CSSPropertyRule.name assert_true: expected true got false
-FAIL Rule for --inherits-only returns expected value for CSSPropertyRule.name assert_true: expected true got false
-FAIL Rule for --initial-value-only returns expected value for CSSPropertyRule.name assert_true: expected true got false
-FAIL Rule for --valid returns expected value for CSSPropertyRule.syntax assert_true: expected true got false
-FAIL Rule for --valid-reverse returns expected value for CSSPropertyRule.syntax assert_true: expected true got false
-FAIL Rule for --valid-universal returns expected value for CSSPropertyRule.syntax assert_true: expected true got false
-FAIL Rule for --valid-whitespace returns expected value for CSSPropertyRule.syntax assert_true: expected true got false
-FAIL Rule for --vALId returns expected value for CSSPropertyRule.syntax assert_true: expected true got false
-FAIL Rule for --no-descriptors returns expected value for CSSPropertyRule.syntax assert_true: expected true got false
-FAIL Rule for --no-syntax returns expected value for CSSPropertyRule.syntax assert_true: expected true got false
-FAIL Rule for --no-inherits returns expected value for CSSPropertyRule.syntax assert_true: expected true got false
-FAIL Rule for --no-initial-value returns expected value for CSSPropertyRule.syntax assert_true: expected true got false
-FAIL Rule for --syntax-only returns expected value for CSSPropertyRule.syntax assert_true: expected true got false
-FAIL Rule for --inherits-only returns expected value for CSSPropertyRule.syntax assert_true: expected true got false
-FAIL Rule for --initial-value-only returns expected value for CSSPropertyRule.syntax assert_true: expected true got false
-FAIL Rule for --valid returns expected value for CSSPropertyRule.inherits assert_true: expected true got false
-FAIL Rule for --valid-reverse returns expected value for CSSPropertyRule.inherits assert_true: expected true got false
-FAIL Rule for --valid-universal returns expected value for CSSPropertyRule.inherits assert_true: expected true got false
-FAIL Rule for --valid-whitespace returns expected value for CSSPropertyRule.inherits assert_true: expected true got false
-FAIL Rule for --vALId returns expected value for CSSPropertyRule.inherits assert_true: expected true got false
-FAIL Rule for --no-descriptors returns expected value for CSSPropertyRule.inherits assert_true: expected true got false
-FAIL Rule for --no-syntax returns expected value for CSSPropertyRule.inherits assert_true: expected true got false
-FAIL Rule for --no-inherits returns expected value for CSSPropertyRule.inherits assert_true: expected true got false
-FAIL Rule for --no-initial-value returns expected value for CSSPropertyRule.inherits assert_true: expected true got false
-FAIL Rule for --syntax-only returns expected value for CSSPropertyRule.inherits assert_true: expected true got false
-FAIL Rule for --inherits-only returns expected value for CSSPropertyRule.inherits assert_true: expected true got false
-FAIL Rule for --initial-value-only returns expected value for CSSPropertyRule.inherits assert_true: expected true got false
-FAIL Rule for --valid returns expected value for CSSPropertyRule.initialValue assert_true: expected true got false
-FAIL Rule for --valid-reverse returns expected value for CSSPropertyRule.initialValue assert_true: expected true got false
-FAIL Rule for --valid-universal returns expected value for CSSPropertyRule.initialValue assert_true: expected true got false
-FAIL Rule for --valid-whitespace returns expected value for CSSPropertyRule.initialValue assert_true: expected true got false
-FAIL Rule for --vALId returns expected value for CSSPropertyRule.initialValue assert_true: expected true got false
-FAIL Rule for --no-descriptors returns expected value for CSSPropertyRule.initialValue assert_true: expected true got false
-FAIL Rule for --no-syntax returns expected value for CSSPropertyRule.initialValue assert_true: expected true got false
-FAIL Rule for --no-inherits returns expected value for CSSPropertyRule.initialValue assert_true: expected true got false
-FAIL Rule for --no-initial-value returns expected value for CSSPropertyRule.initialValue assert_true: expected true got false
-FAIL Rule for --syntax-only returns expected value for CSSPropertyRule.initialValue assert_true: expected true got false
-FAIL Rule for --inherits-only returns expected value for CSSPropertyRule.initialValue assert_true: expected true got false
-FAIL Rule for --initial-value-only returns expected value for CSSPropertyRule.initialValue assert_true: expected true got false
+PASS Rule for --valid has expected cssText
+PASS Rule for --valid-reverse has expected cssText
+PASS Rule for --valid-universal has expected cssText
+PASS Rule for --valid-whitespace has expected cssText
+PASS Rule for --vALId has expected cssText
+PASS Rule for --no-descriptors has expected cssText
+PASS Rule for --no-syntax has expected cssText
+PASS Rule for --no-inherits has expected cssText
+PASS Rule for --no-initial-value has expected cssText
+PASS Rule for --syntax-only has expected cssText
+PASS Rule for --inherits-only has expected cssText
+PASS Rule for --initial-value-only has expected cssText
+PASS Rule for --tab	tab has expected cssText
+FAIL CSSRule.type returns 0 assert_equals: expected 0 but got 21
+PASS Rule for --valid returns expected value for CSSPropertyRule.name
+PASS Rule for --valid-reverse returns expected value for CSSPropertyRule.name
+PASS Rule for --valid-universal returns expected value for CSSPropertyRule.name
+PASS Rule for --valid-whitespace returns expected value for CSSPropertyRule.name
+PASS Rule for --vALId returns expected value for CSSPropertyRule.name
+PASS Rule for --no-descriptors returns expected value for CSSPropertyRule.name
+PASS Rule for --no-syntax returns expected value for CSSPropertyRule.name
+PASS Rule for --no-inherits returns expected value for CSSPropertyRule.name
+PASS Rule for --no-initial-value returns expected value for CSSPropertyRule.name
+PASS Rule for --syntax-only returns expected value for CSSPropertyRule.name
+PASS Rule for --inherits-only returns expected value for CSSPropertyRule.name
+PASS Rule for --initial-value-only returns expected value for CSSPropertyRule.name
+PASS Rule for --valid returns expected value for CSSPropertyRule.syntax
+PASS Rule for --valid-reverse returns expected value for CSSPropertyRule.syntax
+PASS Rule for --valid-universal returns expected value for CSSPropertyRule.syntax
+PASS Rule for --valid-whitespace returns expected value for CSSPropertyRule.syntax
+PASS Rule for --vALId returns expected value for CSSPropertyRule.syntax
+PASS Rule for --no-descriptors returns expected value for CSSPropertyRule.syntax
+PASS Rule for --no-syntax returns expected value for CSSPropertyRule.syntax
+PASS Rule for --no-inherits returns expected value for CSSPropertyRule.syntax
+PASS Rule for --no-initial-value returns expected value for CSSPropertyRule.syntax
+PASS Rule for --syntax-only returns expected value for CSSPropertyRule.syntax
+PASS Rule for --inherits-only returns expected value for CSSPropertyRule.syntax
+PASS Rule for --initial-value-only returns expected value for CSSPropertyRule.syntax
+PASS Rule for --valid returns expected value for CSSPropertyRule.inherits
+PASS Rule for --valid-reverse returns expected value for CSSPropertyRule.inherits
+PASS Rule for --valid-universal returns expected value for CSSPropertyRule.inherits
+PASS Rule for --valid-whitespace returns expected value for CSSPropertyRule.inherits
+PASS Rule for --vALId returns expected value for CSSPropertyRule.inherits
+PASS Rule for --no-descriptors returns expected value for CSSPropertyRule.inherits
+PASS Rule for --no-syntax returns expected value for CSSPropertyRule.inherits
+PASS Rule for --no-inherits returns expected value for CSSPropertyRule.inherits
+PASS Rule for --no-initial-value returns expected value for CSSPropertyRule.inherits
+PASS Rule for --syntax-only returns expected value for CSSPropertyRule.inherits
+PASS Rule for --inherits-only returns expected value for CSSPropertyRule.inherits
+PASS Rule for --initial-value-only returns expected value for CSSPropertyRule.inherits
+FAIL Rule for --valid returns expected value for CSSPropertyRule.initialValue assert_equals: expected " red" but got "red"
+FAIL Rule for --valid-reverse returns expected value for CSSPropertyRule.initialValue assert_equals: expected " 0px" but got "0px"
+PASS Rule for --valid-universal returns expected value for CSSPropertyRule.initialValue
+FAIL Rule for --valid-whitespace returns expected value for CSSPropertyRule.initialValue assert_equals: expected " red, blue" but got "red, blue"
+FAIL Rule for --vALId returns expected value for CSSPropertyRule.initialValue assert_equals: expected " red" but got "red"
+PASS Rule for --no-descriptors returns expected value for CSSPropertyRule.initialValue
+FAIL Rule for --no-syntax returns expected value for CSSPropertyRule.initialValue assert_equals: expected " red" but got "red"
+FAIL Rule for --no-inherits returns expected value for CSSPropertyRule.initialValue assert_equals: expected " red" but got "red"
+PASS Rule for --no-initial-value returns expected value for CSSPropertyRule.initialValue
+PASS Rule for --syntax-only returns expected value for CSSPropertyRule.initialValue
+PASS Rule for --inherits-only returns expected value for CSSPropertyRule.initialValue
+FAIL Rule for --initial-value-only returns expected value for CSSPropertyRule.initialValue assert_equals: expected " red" but got "red"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-expected.txt
@@ -1,28 +1,28 @@
 
-FAIL Attribute 'syntax' returns expected value for ["<color>"] undefined is not an object (evaluating 'rule.syntax')
-FAIL Attribute 'syntax' returns expected value for ["<color> | none"] undefined is not an object (evaluating 'rule.syntax')
-FAIL Attribute 'syntax' returns expected value for ["<color># | <image> | none"] undefined is not an object (evaluating 'rule.syntax')
-FAIL Attribute 'syntax' returns expected value for ["foo | bar | baz"] undefined is not an object (evaluating 'rule.syntax')
-FAIL Attribute 'syntax' returns expected value for ["*"] undefined is not an object (evaluating 'rule.syntax')
-FAIL Attribute 'syntax' returns expected value for ["notasyntax"] undefined is not an object (evaluating 'rule.syntax')
-FAIL Attribute 'syntax' returns expected value for [red] undefined is not an object (evaluating 'rule.syntax')
-FAIL Attribute 'syntax' returns expected value for [rgb(255, 0, 0)] undefined is not an object (evaluating 'rule.syntax')
-FAIL Attribute 'syntax' returns expected value for [<color>] undefined is not an object (evaluating 'rule.syntax')
-FAIL Attribute 'syntax' returns expected value for [foo | bar] undefined is not an object (evaluating 'rule.syntax')
-FAIL Attribute 'initial-value' returns expected value for [10px] undefined is not an object (evaluating 'rule.initialValue')
-FAIL Attribute 'initial-value' returns expected value for [rgb(1, 2, 3)] undefined is not an object (evaluating 'rule.initialValue')
-FAIL Attribute 'initial-value' returns expected value for [red] undefined is not an object (evaluating 'rule.initialValue')
-FAIL Attribute 'initial-value' returns expected value for [foo] undefined is not an object (evaluating 'rule.initialValue')
-FAIL Attribute 'initial-value' returns expected value for [if(){}] undefined is not an object (evaluating 'rule.initialValue')
-FAIL Attribute 'initial-value' returns expected value for [var(--x)] undefined is not an object (evaluating 'rule.initialValue')
-FAIL Attribute 'inherits' returns expected value for [true] undefined is not an object (evaluating 'rule.inherits')
-FAIL Attribute 'inherits' returns expected value for [false] undefined is not an object (evaluating 'rule.inherits')
-FAIL Attribute 'inherits' returns expected value for [none] undefined is not an object (evaluating 'rule.inherits')
-FAIL Attribute 'inherits' returns expected value for [0] undefined is not an object (evaluating 'rule.inherits')
-FAIL Attribute 'inherits' returns expected value for [1] undefined is not an object (evaluating 'rule.inherits')
-FAIL Attribute 'inherits' returns expected value for ["true"] undefined is not an object (evaluating 'rule.inherits')
-FAIL Attribute 'inherits' returns expected value for ["false"] undefined is not an object (evaluating 'rule.inherits')
-FAIL Attribute 'inherits' returns expected value for [calc(0)] undefined is not an object (evaluating 'rule.inherits')
+PASS Attribute 'syntax' returns expected value for ["<color>"]
+PASS Attribute 'syntax' returns expected value for ["<color> | none"]
+PASS Attribute 'syntax' returns expected value for ["<color># | <image> | none"]
+PASS Attribute 'syntax' returns expected value for ["foo | bar | baz"]
+PASS Attribute 'syntax' returns expected value for ["*"]
+PASS Attribute 'syntax' returns expected value for ["notasyntax"]
+PASS Attribute 'syntax' returns expected value for [red]
+PASS Attribute 'syntax' returns expected value for [rgb(255, 0, 0)]
+PASS Attribute 'syntax' returns expected value for [<color>]
+PASS Attribute 'syntax' returns expected value for [foo | bar]
+PASS Attribute 'initial-value' returns expected value for [10px]
+PASS Attribute 'initial-value' returns expected value for [rgb(1, 2, 3)]
+PASS Attribute 'initial-value' returns expected value for [red]
+PASS Attribute 'initial-value' returns expected value for [foo]
+PASS Attribute 'initial-value' returns expected value for [if(){}]
+PASS Attribute 'initial-value' returns expected value for [var(--x)]
+PASS Attribute 'inherits' returns expected value for [true]
+PASS Attribute 'inherits' returns expected value for [false]
+PASS Attribute 'inherits' returns expected value for [none]
+PASS Attribute 'inherits' returns expected value for [0]
+PASS Attribute 'inherits' returns expected value for [1]
+PASS Attribute 'inherits' returns expected value for ["true"]
+PASS Attribute 'inherits' returns expected value for ["false"]
+PASS Attribute 'inherits' returns expected value for [calc(0)]
 PASS Invalid property name does not parse [foo]
 PASS Invalid property name does not parse [-foo]
 FAIL Rule applied [*, if(){}, false] assert_equals: expected "if(){}" but got ""

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/idlharness-expected.txt
@@ -3,16 +3,16 @@ PASS idl_test setup
 PASS idl_test validation
 PASS Partial namespace CSS: original namespace defined
 PASS Partial namespace CSS: member names are unique
-FAIL CSSPropertyRule interface: existence and properties of interface object assert_own_property: self does not have own property "CSSPropertyRule" expected property "CSSPropertyRule" missing
-FAIL CSSPropertyRule interface object length assert_own_property: self does not have own property "CSSPropertyRule" expected property "CSSPropertyRule" missing
-FAIL CSSPropertyRule interface object name assert_own_property: self does not have own property "CSSPropertyRule" expected property "CSSPropertyRule" missing
-FAIL CSSPropertyRule interface: existence and properties of interface prototype object assert_own_property: self does not have own property "CSSPropertyRule" expected property "CSSPropertyRule" missing
-FAIL CSSPropertyRule interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "CSSPropertyRule" expected property "CSSPropertyRule" missing
-FAIL CSSPropertyRule interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "CSSPropertyRule" expected property "CSSPropertyRule" missing
-FAIL CSSPropertyRule interface: attribute name assert_own_property: self does not have own property "CSSPropertyRule" expected property "CSSPropertyRule" missing
-FAIL CSSPropertyRule interface: attribute syntax assert_own_property: self does not have own property "CSSPropertyRule" expected property "CSSPropertyRule" missing
-FAIL CSSPropertyRule interface: attribute inherits assert_own_property: self does not have own property "CSSPropertyRule" expected property "CSSPropertyRule" missing
-FAIL CSSPropertyRule interface: attribute initialValue assert_own_property: self does not have own property "CSSPropertyRule" expected property "CSSPropertyRule" missing
+PASS CSSPropertyRule interface: existence and properties of interface object
+PASS CSSPropertyRule interface object length
+PASS CSSPropertyRule interface object name
+PASS CSSPropertyRule interface: existence and properties of interface prototype object
+PASS CSSPropertyRule interface: existence and properties of interface prototype object's "constructor" property
+PASS CSSPropertyRule interface: existence and properties of interface prototype object's @@unscopables property
+PASS CSSPropertyRule interface: attribute name
+PASS CSSPropertyRule interface: attribute syntax
+PASS CSSPropertyRule interface: attribute inherits
+PASS CSSPropertyRule interface: attribute initialValue
 PASS CSS namespace: operation escape(CSSOMString)
 PASS CSS namespace: operation registerProperty(PropertyDefinition)
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-CSSStyleDeclaration-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-CSSStyleDeclaration-expected.txt
@@ -981,9 +981,9 @@ PASS image-rendering: _camel_cased_attribute v. CSS.supports
 PASS image-rendering: _dashed_attribute v. CSS.supports
 PASS ime-mode: _camel_cased_attribute v. CSS.supports
 PASS ime-mode: _dashed_attribute v. CSS.supports
-PASS inherits: _camel_cased_attribute v. CSS.supports
-PASS initial-value: _camel_cased_attribute v. CSS.supports
-PASS initial-value: _dashed_attribute v. CSS.supports
+FAIL inherits: _camel_cased_attribute v. CSS.supports assert_equals: expected true but got false
+FAIL initial-value: _camel_cased_attribute v. CSS.supports assert_equals: expected true but got false
+FAIL initial-value: _dashed_attribute v. CSS.supports assert_equals: expected true but got false
 PASS inline-size: _camel_cased_attribute v. CSS.supports
 PASS inline-size: _dashed_attribute v. CSS.supports
 PASS inset: _camel_cased_attribute v. CSS.supports
@@ -1357,7 +1357,7 @@ PASS stroke-width: _camel_cased_attribute v. CSS.supports
 PASS stroke-width: _dashed_attribute v. CSS.supports
 PASS supported-color-schemes: _camel_cased_attribute v. CSS.supports
 PASS supported-color-schemes: _dashed_attribute v. CSS.supports
-PASS syntax: _camel_cased_attribute v. CSS.supports
+FAIL syntax: _camel_cased_attribute v. CSS.supports assert_equals: expected true but got false
 PASS tab-size: _camel_cased_attribute v. CSS.supports
 PASS tab-size: _dashed_attribute v. CSS.supports
 PASS table-layout: _camel_cased_attribute v. CSS.supports

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -842,6 +842,7 @@ set(WebCore_NON_SVG_IDL_FILES
     css/CSSPaintCallback.idl
     css/CSSPaintSize.idl
     css/CSSPageRule.idl
+    css/CSSPropertyRule.idl
     css/CSSRule.idl
     css/CSSRuleList.idl
     css/CSSStyleDeclaration.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -961,6 +961,7 @@ $(PROJECT_DIR)/css/CSSPageRule.idl
 $(PROJECT_DIR)/css/CSSPaintCallback.idl
 $(PROJECT_DIR)/css/CSSPaintSize.idl
 $(PROJECT_DIR)/css/CSSProperties.json
+$(PROJECT_DIR)/css/CSSPropertyRule.idl
 $(PROJECT_DIR)/css/CSSRule.idl
 $(PROJECT_DIR)/css/CSSRuleList.idl
 $(PROJECT_DIR)/css/CSSStyleDeclaration.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -411,6 +411,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSPaintSize.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSPaintSize.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSPerspective.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSPerspective.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSPropertyRule.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSPropertyRule.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSRGB.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSRGB.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSRotate.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -838,6 +838,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/css/CSSPageRule.idl \
     $(WebCore)/css/CSSPaintCallback.idl \
     $(WebCore)/css/CSSPaintSize.idl \
+    $(WebCore)/css/CSSPropertyRule.idl \
     $(WebCore)/css/CSSRule.idl \
     $(WebCore)/css/CSSRuleList.idl \
     $(WebCore)/css/CSSStyleDeclaration.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -786,6 +786,7 @@ css/CSSPageRule.cpp
 css/CSSPaintImageValue.cpp
 css/CSSPrimitiveValue.cpp
 css/CSSProperty.cpp
+css/CSSPropertyRule.cpp
 css/CSSPropertySourceData.cpp
 css/CSSRayValue.cpp
 css/CSSReflectValue.cpp
@@ -3087,6 +3088,7 @@ JSCSSNamespaceRule.cpp
 JSCSSPageRule.cpp
 JSCSSPaintCallback.cpp
 JSCSSPaintSize.cpp
+JSCSSPropertyRule.cpp
 JSCSSRule.cpp
 JSCSSRuleList.cpp
 JSCSSStyleDeclaration.cpp

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3701,7 +3701,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyInternalTextAutosizingStatus:
 #endif
         case CSSPropertyWebkitTextZoom:
-        case CSSPropertyAdditiveSymbols:
         case CSSPropertyAlignmentBaseline:
         case CSSPropertyAlt:
         case CSSPropertyAnimation:
@@ -3715,7 +3714,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyAnimationPlayState:
         case CSSPropertyAnimationTimingFunction:
         case CSSPropertyAppearance:
-        case CSSPropertyBasePalette:
         case CSSPropertyBorderBlock: // logical shorthand
         case CSSPropertyBorderBlockColor: // logical shorthand
         case CSSPropertyBorderBlockStyle: // logical shorthand
@@ -3733,10 +3731,8 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyContainerName:
         case CSSPropertyContainerType:
         case CSSPropertyContentVisibility:
-        case CSSPropertyFallback:
         case CSSPropertyFlex:
         case CSSPropertyFlexFlow:
-        case CSSPropertyFontDisplay:
         case CSSPropertyGap:
         case CSSPropertyGlyphOrientationHorizontal:
         case CSSPropertyGlyphOrientationVertical:
@@ -3762,23 +3758,18 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyMarker:
         case CSSPropertyMasonryAutoFlow:
         case CSSPropertyMathStyle:
-        case CSSPropertyNegative:
         case CSSPropertyOverflow:
-        case CSSPropertyOverrideColors:
         case CSSPropertyOverscrollBehavior:
         case CSSPropertyOverscrollBehaviorBlock:
         case CSSPropertyOverscrollBehaviorInline:
         case CSSPropertyOverscrollBehaviorX:
         case CSSPropertyOverscrollBehaviorY:
-        case CSSPropertyPad:
         case CSSPropertyPaddingBlock: // logical shorthand
         case CSSPropertyPaddingInline: // logical shorthand
         case CSSPropertyPage:
         case CSSPropertyPlaceContent:
         case CSSPropertyPlaceItems:
         case CSSPropertyPlaceSelf:
-        case CSSPropertyPrefix:
-        case CSSPropertyRange:
         case CSSPropertyScrollMargin:
         case CSSPropertyScrollMarginBlock:
         case CSSPropertyScrollMarginBlockEnd:
@@ -3807,11 +3798,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyTextEdge:
         case CSSPropertySize:
         case CSSPropertySpeakAs:
-        case CSSPropertySrc:
         case CSSPropertyStrokeColor:
-        case CSSPropertySuffix:
-        case CSSPropertySymbols:
-        case CSSPropertySystem:
         case CSSPropertyTextCombineUpright:
         case CSSPropertyTextDecoration:
         case CSSPropertyTextDecorationSkip:
@@ -3822,7 +3809,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyTransitionProperty:
         case CSSPropertyTransitionTimingFunction:
         case CSSPropertyUnicodeBidi:
-        case CSSPropertyUnicodeRange:
         case CSSPropertyWillChange:
 #if ENABLE(APPLE_PAY)
         case CSSPropertyApplePayButtonStyle:
@@ -3895,6 +3881,9 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyWebkitUserSelect:
             continue;
         default:
+            if (CSSProperty::isDescriptorOnly(property))
+                continue;
+
             auto resolvedProperty = CSSProperty::resolveDirectionAwareProperty(property, RenderStyle::initialDirection(), RenderStyle::initialWritingMode());
             ASSERT_UNUSED(resolvedProperty, wrapperForProperty(resolvedProperty));
             break;

--- a/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
@@ -39,6 +39,7 @@
 #include "CSSMediaRule.h"
 #include "CSSNamespaceRule.h"
 #include "CSSPageRule.h"
+#include "CSSPropertyRule.h"
 #include "CSSStyleRule.h"
 #include "CSSSupportsRule.h"
 #include "JSCSSContainerRule.h"
@@ -54,6 +55,7 @@
 #include "JSCSSMediaRule.h"
 #include "JSCSSNamespaceRule.h"
 #include "JSCSSPageRule.h"
+#include "JSCSSPropertyRule.h"
 #include "JSCSSStyleRule.h"
 #include "JSCSSSupportsRule.h"
 #include "JSNode.h"
@@ -105,6 +107,8 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<C
         return createWrapper<CSSLayerStatementRule>(globalObject, WTFMove(rule));
     case StyleRuleType::Container:
         return createWrapper<CSSContainerRule>(globalObject, WTFMove(rule));
+    case StyleRuleType::Property:
+        return createWrapper<CSSPropertyRule>(globalObject, WTFMove(rule));
     case StyleRuleType::Unknown:
     case StyleRuleType::Charset:
     case StyleRuleType::Margin:

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -8746,6 +8746,42 @@
                 "category": "css-round-display",
                 "url": "https://www.w3.org/TR/css-round-display-1/#border-boundary-property"
             }
+        },
+        "syntax": {
+            "codegen-properties": {
+                "descriptor-only": true,
+                "settings-flag": "cssCustomPropertiesAndValuesEnabled",
+                "skip-builder": true,
+                "custom-parser": true
+            },
+            "specification": {
+                "category": "css-properties-and-values",
+                "url": "https://drafts.css-houdini.org/css-properties-values-api/#the-syntax-descriptor"
+            }
+        },
+        "inherits": {
+            "codegen-properties": {
+                "descriptor-only": true,
+                "settings-flag": "cssCustomPropertiesAndValuesEnabled",
+                "skip-builder": true,
+                "custom-parser": true
+            },
+            "specification": {
+                "category": "css-properties-and-values",
+                "url": "https://drafts.css-houdini.org/css-properties-values-api/#inherits-descriptor"
+            }
+        },
+        "initial-value": {
+            "codegen-properties": {
+                "descriptor-only": true,
+                "settings-flag": "cssCustomPropertiesAndValuesEnabled",
+                "skip-builder": true,
+                "custom-parser": true
+            },
+            "specification": {
+                "category": "css-properties-and-values",
+                "url": "https://drafts.css-houdini.org/css-properties-values-api/#initial-value-descriptor"
+            }
         }
     },
     "categories": {
@@ -8906,6 +8942,11 @@
             "shortname": "CSS Paged Media",
             "longname": "CSS Paged Media Module",
             "url": "https://www.w3.org/TR/css3-page/"
+        },
+        "css-properties-and-values": {
+            "shortname": "CSS Properties and Values API",
+            "longname": "CSS Properties and Values API",
+            "url": "https://drafts.css-houdini.org/css-properties-values-api"
         },
         "css-round-display": {
             "shortname": "CSS Round Display",

--- a/Source/WebCore/css/CSSPropertyRule.cpp
+++ b/Source/WebCore/css/CSSPropertyRule.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSPropertyRule.h"
+
+#include "CSSMarkup.h"
+#include "CSSStyleSheet.h"
+#include "StyleRule.h"
+#include <wtf/text/StringBuilder.h>
+
+namespace WebCore {
+
+CSSPropertyRule::CSSPropertyRule(StyleRuleProperty& rule, CSSStyleSheet* parent)
+    : CSSRule(parent)
+    , m_propertyRule(rule)
+{
+}
+
+Ref<CSSPropertyRule> CSSPropertyRule::create(StyleRuleProperty& rule, CSSStyleSheet* parent)
+{
+    return adoptRef(*new CSSPropertyRule(rule, parent));
+}
+
+CSSPropertyRule::~CSSPropertyRule() = default;
+
+String CSSPropertyRule::name() const
+{
+    return m_propertyRule->descriptor().name;
+}
+
+String CSSPropertyRule::syntax() const
+{
+    return m_propertyRule->descriptor().syntax;
+}
+
+bool CSSPropertyRule::inherits() const
+{
+    return m_propertyRule->descriptor().inherits.value_or(false);
+}
+
+String CSSPropertyRule::initialValue() const
+{
+    return m_propertyRule->descriptor().initialValue;
+}
+
+String CSSPropertyRule::cssText() const
+{
+    StringBuilder builder;
+
+    auto& descriptor = m_propertyRule->descriptor();
+
+    builder.append("@property ");
+    serializeIdentifier(descriptor.name, builder);
+    builder.append(" { ");
+
+    if (!descriptor.syntax.isNull()) {
+        builder.append("syntax: ");
+        serializeString(syntax(), builder);
+        builder.append("; ");
+    }
+
+    if (descriptor.inherits)
+        builder.append("inherits: ", *descriptor.inherits ? "true" : "false", "; ");
+
+    if (!descriptor.initialValue.isNull())
+        builder.append("initial-value: ", descriptor.initialValue, "; ");
+
+    builder.append("}");
+
+    return builder.toString();
+}
+
+void CSSPropertyRule::reattach(StyleRuleBase& rule)
+{
+    m_propertyRule = downcast<StyleRuleProperty>(rule);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSPropertyRule.h
+++ b/Source/WebCore/css/CSSPropertyRule.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSRule.h"
+
+namespace WebCore {
+
+class StyleRuleProperty;
+
+class CSSPropertyRule final : public CSSRule {
+public:
+    static Ref<CSSPropertyRule> create(StyleRuleProperty&, CSSStyleSheet* parent);
+    virtual ~CSSPropertyRule();
+
+    String name() const;
+    String syntax() const;
+    bool inherits() const;
+    String initialValue() const;
+
+    String cssText() const final;
+
+private:
+    CSSPropertyRule(StyleRuleProperty&, CSSStyleSheet*);
+    StyleRuleType styleRuleType() const final { return StyleRuleType::Property; }
+    void reattach(StyleRuleBase&) final;
+
+    Ref<StyleRuleProperty> m_propertyRule;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_RULE(CSSPropertyRule, StyleRuleType::Property)

--- a/Source/WebCore/css/CSSPropertyRule.idl
+++ b/Source/WebCore/css/CSSPropertyRule.idl
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+typedef USVString CSSOMString;
+
+[
+    Exposed=Window
+]
+interface CSSPropertyRule : CSSRule {
+    readonly attribute CSSOMString name;
+    readonly attribute CSSOMString syntax;
+    readonly attribute boolean inherits;
+    readonly attribute CSSOMString? initialValue;
+};

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1640,3 +1640,7 @@ only
 // overflow-anchor
 // none
 // auto
+
+// inherits
+true
+false

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -4300,6 +4300,12 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyAdditiveSymbols:
         return nullptr;
 
+    // @property descriptors.
+    case CSSPropertyInherits:
+    case CSSPropertyInitialValue:
+    case CSSPropertySyntax:
+        return nullptr;
+
     /* Unimplemented @font-face properties */
     case CSSPropertySrc:
     case CSSPropertyUnicodeRange:

--- a/Source/WebCore/css/DOMCSSCustomPropertyDescriptor.h
+++ b/Source/WebCore/css/DOMCSSCustomPropertyDescriptor.h
@@ -32,7 +32,7 @@ namespace WebCore {
 struct DOMCSSCustomPropertyDescriptor {
     AtomString name;
     String syntax { "*"_s };
-    bool inherits;
+    bool inherits { true };
     String initialValue;
 };
 

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -36,6 +36,7 @@
 #include "CSSMediaRule.h"
 #include "CSSNamespaceRule.h"
 #include "CSSPageRule.h"
+#include "CSSPropertyRule.h"
 #include "CSSStyleRule.h"
 #include "CSSSupportsRule.h"
 #include "MediaList.h"
@@ -104,6 +105,8 @@ template<typename Visitor> constexpr decltype(auto) StyleRuleBase::visitDerived(
         return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleLayer>(*this));
     case StyleRuleType::Container:
         return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleContainer>(*this));
+    case StyleRuleType::Property:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleProperty>(*this));
     case StyleRuleType::Margin:
         break;
     case StyleRuleType::Unknown:
@@ -184,6 +187,9 @@ Ref<CSSRule> StyleRuleBase::createCSSOMWrapper(CSSStyleSheet* parentSheet, CSSGr
         },
         [&](StyleRuleContainer& rule) -> Ref<CSSRule> {
             return CSSContainerRule::create(rule, parentSheet);
+        },
+        [&](StyleRuleProperty& rule) -> Ref<CSSRule> {
+            return CSSPropertyRule::create(rule, parentSheet);
         },
         [](StyleRuleCharset&) -> Ref<CSSRule> {
             RELEASE_ASSERT_NOT_REACHED();
@@ -451,6 +457,17 @@ StyleRuleContainer::StyleRuleContainer(CQ::ContainerQuery&& query, Vector<RefPtr
 Ref<StyleRuleContainer> StyleRuleContainer::create(CQ::ContainerQuery&& query, Vector<RefPtr<StyleRuleBase>>&& rules)
 {
     return adoptRef(*new StyleRuleContainer(WTFMove(query), WTFMove(rules)));
+}
+
+StyleRuleProperty::StyleRuleProperty(Descriptor&& descriptor)
+    : StyleRuleBase(StyleRuleType::Property)
+    , m_descriptor(WTFMove(descriptor))
+{
+}
+
+Ref<StyleRuleProperty> StyleRuleProperty::create(Descriptor&& descriptor)
+{
+    return adoptRef(*new StyleRuleProperty(WTFMove(descriptor)));
 }
 
 StyleRuleCharset::StyleRuleCharset()

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -68,6 +68,7 @@ public:
     bool isImportRule() const { return type() == StyleRuleType::Import; }
     bool isLayerRule() const { return type() == StyleRuleType::LayerBlock || type() == StyleRuleType::LayerStatement; }
     bool isContainerRule() const { return type() == StyleRuleType::Container; }
+    bool isPropertyRule() const { return type() == StyleRuleType::Property; }
 
     Ref<StyleRuleBase> copy() const;
 
@@ -326,6 +327,26 @@ private:
     CQ::ContainerQuery m_containerQuery;
 };
 
+class StyleRuleProperty final : public StyleRuleBase {
+public:
+    struct Descriptor {
+        AtomString name;
+        String syntax { };
+        std::optional<bool> inherits { };
+        String initialValue { };
+    };
+    static Ref<StyleRuleProperty> create(Descriptor&&);
+    Ref<StyleRuleProperty> copy() const { return adoptRef(*new StyleRuleProperty(*this)); }
+
+    const Descriptor& descriptor() const { return m_descriptor; }
+
+private:
+    StyleRuleProperty(Descriptor&&);
+    StyleRuleProperty(const StyleRuleProperty&) = default;
+
+    Descriptor m_descriptor;
+};
+
 // This is only used by the CSS parser.
 class StyleRuleCharset final : public StyleRuleBase {
 public:
@@ -443,3 +464,8 @@ SPECIALIZE_TYPE_TRAITS_END()
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleContainer)
     static bool isType(const WebCore::StyleRuleBase& rule) { return rule.isContainerRule(); }
 SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleProperty)
+    static bool isType(const WebCore::StyleRuleBase& rule) { return rule.isPropertyRule(); }
+SPECIALIZE_TYPE_TRAITS_END()
+

--- a/Source/WebCore/css/StyleRuleType.h
+++ b/Source/WebCore/css/StyleRuleType.h
@@ -49,7 +49,8 @@ enum class StyleRuleType : uint8_t {
     Container = 18,
     FontPaletteValues = 19,
     // Those at-rules (@swash, @annotation,...) don't have a specified number in the spec.
-    FontFeatureValuesBlock = 20,
+    FontFeatureValuesBlock,
+    Property,
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -521,6 +521,7 @@ bool StyleSheetContents::traverseSubresources(const Function<bool(const CachedRe
         case StyleRuleType::FontFeatureValuesBlock:
         case StyleRuleType::FontPaletteValues:
         case StyleRuleType::Margin:
+        case StyleRuleType::Property:
             return false;
         };
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/parser/CSSAtRuleID.cpp
+++ b/Source/WebCore/css/parser/CSSAtRuleID.cpp
@@ -53,6 +53,7 @@ CSSAtRuleID cssAtRuleID(StringView name)
         { "namespace", CSSAtRuleNamespace },
         { "ornaments", CSSAtRuleOrnaments },
         { "page", CSSAtRulePage },
+        { "property", CSSAtRuleProperty },
         { "styleset", CSSAtRuleStyleset },
         { "stylistic", CSSAtRuleStylistic },
         { "supports", CSSAtRuleSupports },

--- a/Source/WebCore/css/parser/CSSAtRuleID.h
+++ b/Source/WebCore/css/parser/CSSAtRuleID.h
@@ -50,6 +50,7 @@ enum CSSAtRuleID {
     CSSAtRuleCounterStyle,
     CSSAtRuleLayer,
     CSSAtRuleContainer,
+    CSSAtRuleProperty,
 
     CSSAtRuleFontFeatureValues,
     CSSAtRuleStylistic,

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -142,6 +142,7 @@ private:
     RefPtr<StyleRuleCounterStyle> consumeCounterStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleLayer> consumeLayerRule(CSSParserTokenRange prelude, std::optional<CSSParserTokenRange> block);
     RefPtr<StyleRuleContainer> consumeContainerRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
+    RefPtr<StyleRuleProperty> consumePropertyRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
 
     RefPtr<StyleRuleKeyframe> consumeKeyframeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRule> consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -76,6 +76,7 @@ private:
     bool parseFontPaletteValuesDescriptor(CSSPropertyID);
     bool parseCounterStyleDescriptor(CSSPropertyID, const CSSParserContext&);
     bool parseKeyframeDescriptor(CSSPropertyID, bool important);
+    bool parsePropertyDescriptor(CSSPropertyID);
 
     void addProperty(CSSPropertyID longhand, CSSPropertyID shorthand, Ref<CSSValue>&&, bool important, bool implicit = false);
     void addPropertyWithImplicitDefault(CSSPropertyID longhand, CSSPropertyID shorthand, RefPtr<CSSValue>&&, Ref<CSSValue>&& implicitDefault, bool important);

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -113,6 +113,7 @@ static RuleFlatteningStrategy flatteningStrategyForStyleRuleType(StyleRuleType s
     case StyleRuleType::FontFeatureValues:
     case StyleRuleType::FontFeatureValuesBlock:
     case StyleRuleType::FontPaletteValues:
+    case StyleRuleType::Property:
         // These rule types do not contain rules that apply directly to an element (i.e. these rules should not appear
         // in the Styles details sidebar of the Elements tab in Web Inspector).
         return RuleFlatteningStrategy::Ignore;


### PR DESCRIPTION
#### 8c6f3e96197beab5fd3a56bbf50678b20becb0c1
<pre>
[@property] Add @property rule parsing and CSSOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=249554">https://bugs.webkit.org/show_bug.cgi?id=249554</a>
rdar://103493363

Reviewed by Cameron McCormack.

<a href="https://drafts.css-houdini.org/css-properties-values-api/#at-property-rule">https://drafts.css-houdini.org/css-properties-values-api/#at-property-rule</a>

The properties defined by @property rules are not yet registered with this patch.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-CSSStyleDeclaration-expected.txt:

The CSS property code generator adds all properties unconditionally to CSSStyleDeclaration interface.
However descriptors should in most cases be omitted. That&apos;s why these newly added descriptors turn into fails in this test.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/idlharness-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):

Use isDescriptorOnly to reduce need for special casing. Descriptors are never animatable.

* Source/WebCore/bindings/js/JSCSSRuleCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/css/CSSProperties.json:

Add &apos;syntax&apos;, &apos;inherits&apos; and &apos;initial-value&apos; descriptors

* Source/WebCore/css/CSSPropertyRule.cpp: Added.
(WebCore::CSSPropertyRule::CSSPropertyRule):
(WebCore::CSSPropertyRule::create):
(WebCore::CSSPropertyRule::name const):
(WebCore::CSSPropertyRule::syntax const):
(WebCore::CSSPropertyRule::inherits const):
(WebCore::CSSPropertyRule::initialValue const):
(WebCore::CSSPropertyRule::cssText const):
(WebCore::CSSPropertyRule::reattach):
* Source/WebCore/css/CSSPropertyRule.h: Added.
* Source/WebCore/css/CSSPropertyRule.idl: Added.

Add a CSSOM wrapper.

* Source/WebCore/css/CSSValueKeywords.in:

Add &apos;true&apos; and &apos;false&apos;.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/css/DOMCSSCustomPropertyDescriptor.h:
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::visitDerived):
(WebCore::StyleRuleBase::createCSSOMWrapper const):
(WebCore::StyleRuleProperty::StyleRuleProperty):
(WebCore::StyleRuleProperty::create):

Add StyleRuleProperty type for representing @property in stylesheets.

* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleBase::isPropertyRule const):
(isType):
* Source/WebCore/css/StyleRuleType.h:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::traverseSubresources const):
* Source/WebCore/css/parser/CSSAtRuleID.cpp:
(WebCore::cssAtRuleID):
* Source/WebCore/css/parser/CSSAtRuleID.h:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeAtRule):
(WebCore::CSSParserImpl::consumePropertyRule):
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseValue):
(WebCore::CSSPropertyParser::parsePropertyDescriptor):
* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::flatteningStrategyForStyleRuleType):

Canonical link: <a href="https://commits.webkit.org/258067@main">https://commits.webkit.org/258067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fe6e5aad6147fad11dfda2ef2640322d20c594f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110115 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170391 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/712 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107960 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34850 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77825 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91301 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3654 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24408 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87388 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1185 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3673 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/686 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29224 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43907 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90276 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5533 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5451 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20208 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->