### PR TITLE
Don't use Vector<UChar> to build strings

### DIFF
--- a/Source/WebCore/platform/text/LocaleICU.cpp
+++ b/Source/WebCore/platform/text/LocaleICU.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011,2012 Google Inc. All rights reserved.
+ * Copyright (C) 2011-2013 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -36,6 +36,7 @@
 #include <unicode/udatpg.h>
 #include <unicode/uloc.h>
 #include <wtf/DateMath.h>
+#include <wtf/text/StringBuffer.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
@@ -73,9 +74,9 @@ String LocaleICU::decimalSymbol(UNumberFormatSymbol symbol)
     ASSERT(U_SUCCESS(status) || needsToGrowToProduceBuffer(status));
     if (U_FAILURE(status) && !needsToGrowToProduceBuffer(status))
         return String();
-    Vector<UChar> buffer(bufferLength);
+    StringBuffer<UChar> buffer(bufferLength);
     status = U_ZERO_ERROR;
-    unum_getSymbol(m_numberFormat, symbol, buffer.data(), bufferLength, &status);
+    unum_getSymbol(m_numberFormat, symbol, buffer.characters(), bufferLength, &status);
     if (U_FAILURE(status))
         return String();
     return String::adopt(WTFMove(buffer));
@@ -88,9 +89,9 @@ String LocaleICU::decimalTextAttribute(UNumberFormatTextAttribute tag)
     ASSERT(U_SUCCESS(status) || needsToGrowToProduceBuffer(status));
     if (U_FAILURE(status) && !needsToGrowToProduceBuffer(status))
         return String();
-    Vector<UChar> buffer(bufferLength);
+    StringBuffer<UChar> buffer(bufferLength);
     status = U_ZERO_ERROR;
-    unum_getTextAttribute(m_numberFormat, tag, buffer.data(), bufferLength, &status);
+    unum_getTextAttribute(m_numberFormat, tag, buffer.characters(), bufferLength, &status);
     ASSERT(U_SUCCESS(status));
     if (U_FAILURE(status))
         return String();
@@ -153,9 +154,9 @@ static String getDateFormatPattern(const UDateFormat* dateFormat)
     int32_t length = udat_toPattern(dateFormat, TRUE, 0, 0, &status);
     if (!needsToGrowToProduceBuffer(status) || !length)
         return emptyString();
-    Vector<UChar> buffer(length);
+    StringBuffer<UChar> buffer(length);
     status = U_ZERO_ERROR;
-    udat_toPattern(dateFormat, TRUE, buffer.data(), length, &status);
+    udat_toPattern(dateFormat, TRUE, buffer.characters(), length, &status);
     if (U_FAILURE(status))
         return emptyString();
     return String::adopt(WTFMove(buffer));
@@ -175,9 +176,9 @@ std::unique_ptr<Vector<String>> LocaleICU::createLabelVector(const UDateFormat* 
         int32_t length = udat_getSymbols(dateFormat, type, startIndex + i, 0, 0, &status);
         if (!needsToGrowToProduceBuffer(status))
             return makeUnique<Vector<String>>();
-        Vector<UChar> buffer(length);
+        StringBuffer<UChar> buffer(length);
         status = U_ZERO_ERROR;
-        udat_getSymbols(dateFormat, type, startIndex + i, buffer.data(), length, &status);
+        udat_getSymbols(dateFormat, type, startIndex + i, buffer.characters(), length, &status);
         if (U_FAILURE(status))
             return makeUnique<Vector<String>>();
         labels->uncheckedAppend(String::adopt(WTFMove(buffer)));
@@ -262,9 +263,9 @@ static String getFormatForSkeleton(const char* locale, const UChar* skeleton, in
     status = U_ZERO_ERROR;
     int32_t length = udatpg_getBestPattern(patternGenerator, skeleton, skeletonLength, 0, 0, &status);
     if (needsToGrowToProduceBuffer(status) && length) {
-        Vector<UChar> buffer(length);
+        StringBuffer<UChar> buffer(length);
         status = U_ZERO_ERROR;
-        udatpg_getBestPattern(patternGenerator, skeleton, skeletonLength, buffer.data(), length, &status);
+        udatpg_getBestPattern(patternGenerator, skeleton, skeletonLength, buffer.characters(), length, &status);
         if (U_SUCCESS(status))
             format = String::adopt(WTFMove(buffer));
     }


### PR DESCRIPTION
#### 6b1eb391bf3d0bf4fa2b3834e61df0a4dfa95c11
<pre>
Don&apos;t use Vector&lt;UChar&gt; to build strings

Don&apos;t use Vector&lt;UChar&gt; to build strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=119319">https://bugs.webkit.org/show_bug.cgi?id=119319</a>

Reviewed by Darin Adler.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/9fda929af533c3c1aa3961c4818ea30ed7499021">https://chromium.googlesource.com/chromium/blink/+/9fda929af533c3c1aa3961c4818ea30ed7499021</a>

This patch replaces a bunch of sites which were using Vector&lt;UChar&gt;
to construct string with StringBuffer.

* Source/WebCore/platform/text/LocaleICU.cpp:
(WebCore::LocaleICU::decimalSymbol):
(WebCore::LocaleICU::decimalTextAttribute):
(WebCore::getDateFormatPattern):
(WebCore::LocaleICU::createLabelVector):
(WebCore::getFormatForSkeleton):

Canonical link: <a href="https://commits.webkit.org/258081@main">https://commits.webkit.org/258081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58243541659f928e64390ffc6d86d7d4ab5d1e9f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110149 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170423 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/855 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93257 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107994 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34875 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77849 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3686 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24434 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3705 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/814 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43934 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5542 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5483 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->