### PR TITLE
Support contain-intrinsic-size auto && <length>

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4735,8 +4735,6 @@ webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/floats-aspect-ratio-001.html [ ImageOnlyFailure ]
 
 # contain-intrinsic-size
-webkit.org/b/246338 imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007.html [ Skip ]
-webkit.org/b/246338 imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-009.html [ Skip ]
 webkit.org/b/246283 imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-logical-003.html [ Skip ]
 
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/image-fractional-height-with-wide-aspect-ratio.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-005-expected.txt
@@ -1,4 +1,4 @@
-1
+50
 
-FAIL contain-intrinsic-size: auto assert_equals: expected 50 but got 1
+PASS contain-intrinsic-size: auto
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006-expected.txt
@@ -1,19 +1,19 @@
 
-FAIL Basic usage assert_equals: Using last remembered size - clientWidth expected 100 but got 1
-FAIL Last remembered size can be 0 assert_equals: Using last remembered size - clientWidth expected 0 but got 1
-FAIL Last remembered size can be set to 0 after losing display:none assert_equals: Using the new last remembered size - clientWidth expected 0 but got 1
-FAIL Last remembered size is logical assert_equals: Using last remembered size - clientWidth expected 100 but got 1
-FAIL Last remembered size survives box destruction assert_equals: Using last remembered size - clientWidth expected 100 but got 1
-FAIL Last remembered size survives display type changes assert_equals: Using last remembered size - clientWidth expected 100 but got 1
-FAIL Losing cis:auto removes last remembered size assert_equals: Using last remembered size - clientWidth expected 100 but got 1
+PASS Basic usage
+PASS Last remembered size can be 0
+PASS Last remembered size can be set to 0 after losing display:none
+PASS Last remembered size is logical
+PASS Last remembered size survives box destruction
+PASS Last remembered size survives display type changes
+PASS Losing cis:auto removes last remembered size
 PASS Losing cis:auto removes last remembered size even if size doesn't change
-FAIL Losing cis:auto removes last remembered size immediately assert_equals: Using last remembered size - clientWidth expected 100 but got 1
-FAIL Losing cis:auto during display:none doesn't remove last remembered size assert_equals: Using last remembered size - clientWidth expected 100 but got 1
-FAIL Lack of cis:auto during box creation removes last remembered size assert_equals: Using last remembered size - clientWidth expected 100 but got 1
-FAIL Last remembered size can be removed synchronously assert_equals: Using last remembered size - clientWidth expected 100 but got 1
-FAIL Disconnected element can briefly keep last remembered size assert_equals: Using last remembered size - clientWidth expected 100 but got 1
-FAIL Disconnected element ends up losing last remembered size assert_equals: Using last remembered size - clientWidth expected 100 but got 1
+PASS Losing cis:auto removes last remembered size immediately
+PASS Losing cis:auto during display:none doesn't remove last remembered size
+PASS Lack of cis:auto during box creation removes last remembered size
+PASS Last remembered size can be removed synchronously
+PASS Disconnected element can briefly keep last remembered size
+PASS Disconnected element ends up losing last remembered size
 PASS Disconnected element ends up losing last remembered size even if size was 0x0
-FAIL Last remembered size survives becoming inline assert_equals: Still using previous last remembered size - clientWidth expected 100 but got 1
-FAIL Last remembered size can be set to 0x0 after losing display:inline assert_equals: Last remembered size is now 0x0 - clientWidth expected 0 but got 1
+PASS Last remembered size survives becoming inline
+PASS Last remembered size can be set to 0x0 after losing display:inline
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007-expected.txt
@@ -1,96 +1,54 @@
 
-FAIL .test 1 assert_equals:
-<div class="test auto-width" data-expected-client-width="320" data-expected-client-height="0"></div>
-clientHeight expected 0 but got 240
-FAIL .test 2 assert_equals:
-<div class="test auto-height" data-expected-client-width="0" data-expected-client-height="240"></div>
-clientWidth expected 0 but got 320
+PASS .test 1
+PASS .test 2
 PASS .test 3
-FAIL .test 4 assert_equals:
-<div class="scroll test auto-width" data-expected-client-width="320" data-expected-client-height="0"></div>
-clientHeight expected 0 but got 240
-FAIL .test 5 assert_equals:
-<div class="scroll test auto-height" data-expected-client-width="0" data-expected-client-height="240"></div>
-clientWidth expected 0 but got 320
+PASS .test 4
+PASS .test 5
 PASS .test 6
 FAIL .test 7 assert_equals:
 <div class="columns test auto-width" data-expected-client-width="656" data-expected-client-height="0"></div>
-clientHeight expected 0 but got 120
-FAIL .test 8 assert_equals:
-<div class="columns test auto-height" data-expected-client-width="136" data-expected-client-height="120"></div>
-clientWidth expected 136 but got 656
-PASS .test 9
-FAIL .test 10 assert_equals:
-<div class="grid test auto-width" data-expected-client-width="320" data-expected-client-height="0"></div>
-clientHeight expected 0 but got 240
-FAIL .test 11 assert_equals:
-<div class="grid test auto-height" data-expected-client-width="0" data-expected-client-height="240"></div>
-clientWidth expected 0 but got 320
+clientWidth expected 656 but got 1328
+PASS .test 8
+FAIL .test 9 assert_equals:
+<div class="columns test auto-both" data-expected-client-width="656" data-expected-client-height="120"></div>
+clientWidth expected 656 but got 1328
+PASS .test 10
+PASS .test 11
 PASS .test 12
-FAIL .test 13 assert_equals:
-<div class="flex test auto-width" data-expected-client-width="320" data-expected-client-height="0"></div>
-clientHeight expected 0 but got 240
-FAIL .test 14 assert_equals:
-<div class="flex test auto-height" data-expected-client-width="0" data-expected-client-height="240"></div>
-clientWidth expected 0 but got 320
+PASS .test 13
+PASS .test 14
 PASS .test 15
-FAIL .test 16 assert_equals:
-<fieldset class="test auto-width" data-expected-client-width="344" data-expected-client-height="16"></fieldset>
-clientHeight expected 16 but got 256
-FAIL .test 17 assert_equals:
-<fieldset class="test auto-height" data-expected-client-width="24" data-expected-client-height="256"></fieldset>
-clientWidth expected 24 but got 344
+PASS .test 16
+PASS .test 17
 PASS .test 18
-FAIL .test 19 assert_equals:
-<img src="resources/dice.png" class="test auto-width" data-expected-client-width="320" data-expected-client-height="0">
-clientHeight expected 0 but got 240
-FAIL .test 20 assert_equals:
-<img src="resources/dice.png" class="test auto-height" data-expected-client-width="0" data-expected-client-height="240">
-clientWidth expected 0 but got 320
+PASS .test 19
+PASS .test 20
 PASS .test 21
 FAIL .test 22 assert_equals:
 <svg class="test auto-width" data-expected-client-width="300" data-expected-client-height="0"></svg>
-clientHeight expected 0 but got 150
+clientWidth expected 300 but got 0
 FAIL .test 23 assert_equals:
 <svg class="test auto-height" data-expected-client-width="0" data-expected-client-height="150"></svg>
-clientWidth expected 0 but got 300
-PASS .test 24
-FAIL .test 25 assert_equals:
-<canvas class="test auto-width" data-expected-client-width="300" data-expected-client-height="0"></canvas>
-clientHeight expected 0 but got 150
-FAIL .test 26 assert_equals:
-<canvas class="test auto-height" data-expected-client-width="0" data-expected-client-height="150"></canvas>
-clientWidth expected 0 but got 300
+clientHeight expected 150 but got 0
+FAIL .test 24 assert_equals:
+<svg class="test auto-both" data-expected-client-width="300" data-expected-client-height="150"></svg>
+clientWidth expected 300 but got 0
+PASS .test 25
+PASS .test 26
 PASS .test 27
-FAIL .test 28 assert_equals:
-<iframe class="test auto-width" data-expected-client-width="300" data-expected-client-height="0"></iframe>
-clientHeight expected 0 but got 150
-FAIL .test 29 assert_equals:
-<iframe class="test auto-height" data-expected-client-width="0" data-expected-client-height="150"></iframe>
-clientWidth expected 0 but got 300
+PASS .test 28
+PASS .test 29
 PASS .test 30
-FAIL .test 31 assert_equals:
-<video class="test auto-width" data-expected-client-width="300" data-expected-client-height="0"></video>
-clientHeight expected 0 but got 150
-FAIL .test 32 assert_equals:
-<video class="test auto-height" data-expected-client-width="0" data-expected-client-height="150"></video>
-clientWidth expected 0 but got 300
+PASS .test 31
+PASS .test 32
 PASS .test 33
-FAIL .test 34 assert_equals:
-<button class="test auto-width" data-expected-client-width="332" data-expected-client-height="5"></button>
-clientHeight expected 5 but got 245
-FAIL .test 35 assert_equals:
-<button class="test auto-height" data-expected-client-width="12" data-expected-client-height="245"></button>
-clientWidth expected 12 but got 332
+PASS .test 34
+PASS .test 35
 PASS .test 36
 PASS .test 37
-FAIL .test 38 assert_equals:
-<select class="test auto-height" data-expected-client-width="36" data-expected-client-height="18"><option>Lorem ipsum</option></select>
-clientWidth expected 36 but got 99
+PASS .test 38
 PASS .test 39
 PASS .test 40
-FAIL .test 41 assert_equals:
-<select multiple="" class="test auto-height" data-expected-client-width="4" data-expected-client-height="55"><option>Lorem ipsum</option></select>
-clientWidth expected 4 but got 72
+PASS .test 41
 PASS .test 42
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-008-expected.txt
@@ -1,5 +1,5 @@
 
 PASS requestAnimationFrame
-FAIL Early ResizeObserver assert_equals: Using last remembered size - clientWidth expected 100 but got 40
-FAIL Late ResizeObserver assert_equals: Using last remembered size - clientWidth expected 100 but got 40
+PASS Early ResizeObserver
+PASS Late ResizeObserver
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-009-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-009-expected.txt
@@ -1,6 +1,4 @@
 
-FAIL Only recording last remembered inline size assert_equals: Using last remembered inline size - clientWidth expected 100 but got 2
-FAIL Only recording last remembered block size assert_equals: Using last remembered block size - clientHeight expected 50 but got 1
-FAIL contain:inline-size prevents recording last remembered inline size assert_equals: Size containment for inline axis - clientWidth expected 20 but got 0
-FAIL contain:inline-size can keep previous last remembered inline size assert_equals: Size containment for inline axis - clientWidth expected 20 but got 0
+FAIL Only recording last remembered inline size assert_equals: Using last remembered inline size - clientHeight expected 1 but got 50
+FAIL Only recording last remembered block size assert_equals: Using last remembered block size - clientWidth expected 2 but got 100
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-010-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-010-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Last remembered size supports multiple fragments assert_equals: Using last remembered size - clientWidth expected 50 but got 1
-FAIL Last remembered size is updated when 2nd fragment changes size assert_equals: Using updated last remembered size - clientWidth expected 50 but got 1
+PASS Last remembered size supports multiple fragments
+PASS Last remembered size is updated when 2nd fragment changes size
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-011-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-011-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL contain:size does not prevent recording last remembered size assert_equals: Using last remembered size - clientWidth expected 20 but got 2
+PASS contain:size does not prevent recording last remembered size
 FAIL contain:inline-size does not prevent recording last remembered inline size assert_equals: Size containment for inline axis - clientWidth expected 20 but got 0
 

--- a/LayoutTests/resize-observer/contain-instrinsic-size-should-not-leak-nodes-expected.txt
+++ b/LayoutTests/resize-observer/contain-instrinsic-size-should-not-leak-nodes-expected.txt
@@ -1,0 +1,6 @@
+This tests element is with CIS auto and removing the element from the document.
+The element should become eligible for GC at some point.
+
+PASS Remove nodes after observing
+PASS Remove nodes after skipping content
+

--- a/LayoutTests/resize-observer/contain-instrinsic-size-should-not-leak-nodes.html
+++ b/LayoutTests/resize-observer/contain-instrinsic-size-should-not-leak-nodes.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<style>
+.size-100-50 {
+    width: 100px;
+    height: 50px;
+}
+.cis-auto {
+    contain-intrinsic-size: auto 1px auto 2px;
+}
+
+.skip-contents {
+    content-visibility: hidden;
+}
+
+</style>
+<body>
+    <pre id="log">This tests element is with CIS auto and removing the element from the document.
+The element should become eligible for GC at some point.
+</pre>
+
+<div id="container"></div>
+
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/gc.js"></script>
+<script>
+let initialNodeCount = internals.referencingNodeCount(document);
+const CISCount = 100;
+
+function nextRendering() {
+    return new Promise(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+}
+
+function createNodes() {
+    const parent = document.createElement('div');
+    for (let i = 0; i < CISCount; ++i) {
+        const element = document.createElement('div');
+        element.className = "size-100-50 cis-auto";
+        parent.appendChild(element);
+    }
+
+    container.appendChild(parent);
+}
+
+function removeNodes() {
+    container.removeChild(container.firstChild);
+}
+
+function skipContent() {
+    const elements = container.firstChild.children;
+    for (let i = 0; i < elements.length; i++) {
+        elements[i].classList.add("skip-contents");
+        elements[i].classList.remove("size-100-50");
+    }
+}
+
+promise_test(async function () {
+    createNodes();
+    await nextRendering();
+    removeNodes();
+    await nextRendering();
+    gc();
+    await nextRendering();
+    assert_equals(internals.referencingNodeCount(document) < initialNodeCount + CISCount * 0.8, true, 'More than 20% of nodes should be collected');
+}, "Remove nodes after observing");
+
+promise_test(async function () {
+    let container = document.getElementById("container");
+    createNodes();
+    await nextRendering();
+    skipContent();
+    await nextRendering();
+    removeNodes();
+    await nextRendering();
+    gc();
+    await nextRendering();
+    assert_equals(internals.referencingNodeCount(document) < initialNodeCount + CISCount * 0.8, true, 'More than 20% of nodes should be collected');
+}, "Remove nodes after skipping content");
+</script>
+</body>
+
+</html>

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -677,6 +677,14 @@ ExceptionOr<void> ContainerNode::removeChild(Node& oldChild)
     rebuildSVGExtensionsElementsIfNecessary();
     dispatchSubtreeModifiedEvent();
 
+    auto* element = dynamicDowncast<Element>(oldChild);
+    if (element && element->lastRememberedSize()) {
+        // The disconnected element could be unobserved because of other properties, here we need to make sure it is observed,
+        // so that deliver could be triggered and it would clear lastRememberedSize.
+        document().observeForContainIntrinsicSize(*element);
+        document().resetObservationSizeForContainIntrinsicSize(*element);
+    }
+
     return { };
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -202,6 +202,7 @@
 #include "ReportingScope.h"
 #include "RequestAnimationFrameCallback.h"
 #include "ResizeObserver.h"
+#include "ResizeObserverEntry.h"
 #include "ResourceLoadObserver.h"
 #include "RuntimeApplicationChecks.h"
 #include "SVGDocumentExtensions.h"
@@ -382,6 +383,30 @@ public:
 };
 
 static const Seconds intersectionObserversInitialUpdateDelay { 2000_ms };
+
+static void CallbackForContainIntrinsicSize(const Vector<Ref<ResizeObserverEntry>>& entries, ResizeObserver& observer)
+{
+    for (auto& entry : entries) {
+        if (auto* target = entry->target()) {
+            if (!target->isConnected()) {
+                observer.unobserve(*target);
+                target->clearLastRememberedSize();
+                continue;
+            }
+
+            auto* box = target->renderBox();
+            if (!box) {
+                observer.unobserve(*target);
+                continue;
+            }
+            ASSERT(!box->shouldSkipContent());
+            ASSERT(box->style().hasAutoLengthContainIntrinsicSize());
+
+            auto contentBoxSize = entry->contentBoxSize().at(0);
+            target->setLastRememberedSize(ResizeObserverSize::create(contentBoxSize->inlineSize(), contentBoxSize->blockSize()));
+        }
+    }
+}
 
 // https://www.w3.org/TR/xml/#NT-NameStartChar
 // NameStartChar       ::=       ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
@@ -8467,9 +8492,21 @@ size_t Document::gatherResizeObservations(size_t deeperThan)
     return minDepth;
 }
 
+size_t Document::gatherResizeObservationsForContainIntrinsicSize()
+{
+    if (!m_resizeObserverForContainIntrinsicSize)
+        return ResizeObserver::maxElementDepth();
+
+    LOG_WITH_STREAM(ResizeObserver, stream << "Document " << *this << " gatherResizeObservationsForContainIntrinsicSize");
+    return m_resizeObserverForContainIntrinsicSize->gatherObservations(0);
+}
+
 void Document::deliverResizeObservations()
 {
     LOG_WITH_STREAM(ResizeObserver, stream << "Document " << *this << " deliverResizeObservations");
+    if (m_resizeObserverForContainIntrinsicSize)
+        m_resizeObserverForContainIntrinsicSize->deliverObservations();
+
     auto observersToNotify = m_resizeObservers;
     for (const auto& observer : observersToNotify) {
         if (!observer || !observer->hasActiveObservations())
@@ -8495,14 +8532,17 @@ void Document::setHasSkippedResizeObservations(bool skipped)
 
 void Document::updateResizeObservations(Page& page)
 {
-    if (!hasResizeObservers())
+    if (!hasResizeObservers() && !m_resizeObserverForContainIntrinsicSize)
         return;
 
     // We need layout the whole frame tree here. Because ResizeObserver could observe element in other frame,
     // and it could change other frame in deliverResizeObservations().
     page.layoutIfNeeded();
 
-    // Start check resize obervers;
+    // Start check resize observers;
+    if (gatherResizeObservationsForContainIntrinsicSize() != ResizeObserver::maxElementDepth())
+        deliverResizeObservations();
+
     for (size_t depth = gatherResizeObservations(0); depth != ResizeObserver::maxElementDepth(); depth = gatherResizeObservations(depth)) {
         deliverResizeObservations();
         page.layoutIfNeeded();
@@ -9467,6 +9507,33 @@ void Document::addElementWithLangAttrMatchingDocumentElement(Element& element)
 void Document::removeElementWithLangAttrMatchingDocumentElement(Element& element)
 {
     m_elementsWithLangAttrMatchingDocumentElement.remove(element);
+}
+
+RefPtr<ResizeObserver> Document::ensureResizeObserverForContainIntrinsicSize()
+{
+    if (!m_resizeObserverForContainIntrinsicSize)
+        m_resizeObserverForContainIntrinsicSize = ResizeObserver::createNativeObserver(*this, CallbackForContainIntrinsicSize);
+    return m_resizeObserverForContainIntrinsicSize;
+}
+
+void Document::observeForContainIntrinsicSize(Element& element)
+{
+    auto ro = ensureResizeObserverForContainIntrinsicSize();
+    ro->observe(element);
+}
+
+void Document::unobserveForContainIntrinsicSize(Element& element)
+{
+    if (!m_resizeObserverForContainIntrinsicSize)
+        return;
+    m_resizeObserverForContainIntrinsicSize->unobserve(element);
+}
+
+void Document::resetObservationSizeForContainIntrinsicSize(Element& target)
+{
+    if (!m_resizeObserverForContainIntrinsicSize)
+        return;
+    m_resizeObserverForContainIntrinsicSize->resetObservationSize(target);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1527,6 +1527,11 @@ public:
     void setHasSkippedResizeObservations(bool);
     void updateResizeObservations(Page&);
 
+    size_t gatherResizeObservationsForContainIntrinsicSize();
+    void observeForContainIntrinsicSize(Element&);
+    void unobserveForContainIntrinsicSize(Element&);
+    void resetObservationSizeForContainIntrinsicSize(Element&);
+
 #if ENABLE(MEDIA_STREAM)
     void setHasCaptureMediaStreamTrack() { m_hasHadCaptureMediaStreamTrack = true; }
     bool hasHadCaptureMediaStreamTrack() const { return m_hasHadCaptureMediaStreamTrack; }
@@ -1876,6 +1881,8 @@ private:
     NotificationClient* notificationClient() final;
 
     void updateSleepDisablerIfNeeded();
+
+    RefPtr<ResizeObserver> ensureResizeObserverForContainIntrinsicSize();
 
     const Ref<const Settings> m_settings;
 
@@ -2365,6 +2372,8 @@ private:
     bool m_isDirAttributeDirty { false };
 
     static bool hasEverCreatedAnAXObjectCache;
+
+    RefPtr<ResizeObserver> m_resizeObserverForContainIntrinsicSize;
 };
 
 Element* eventTargetElementForDocument(Document*);

--- a/Source/WebCore/page/ResizeObservation.cpp
+++ b/Source/WebCore/page/ResizeObservation.cpp
@@ -53,6 +53,11 @@ void ResizeObservation::updateObservationSize(const BoxSizes& boxSizes)
     m_lastObservationSizes = boxSizes;
 }
 
+void ResizeObservation::resetObservationSize()
+{
+    m_lastObservationSizes = { LayoutSize(-1, -1), LayoutSize(-1, -1), LayoutSize(-1, -1) };
+}
+
 auto ResizeObservation::computeObservedSizes() const -> std::optional<BoxSizes>
 {
     if (m_target->isSVGElement()) {

--- a/Source/WebCore/page/ResizeObservation.h
+++ b/Source/WebCore/page/ResizeObservation.h
@@ -56,6 +56,7 @@ public:
 
     std::optional<BoxSizes> elementSizeChanged() const;
     void updateObservationSize(const BoxSizes&);
+    void resetObservationSize();
 
     FloatRect computeContentRect() const;
     FloatSize borderBoxSize() const;

--- a/Source/WebCore/page/ResizeObserver.cpp
+++ b/Source/WebCore/page/ResizeObserver.cpp
@@ -42,12 +42,17 @@ namespace WebCore {
 
 Ref<ResizeObserver> ResizeObserver::create(Document& document, Ref<ResizeObserverCallback>&& callback)
 {
-    return adoptRef(*new ResizeObserver(document, WTFMove(callback)));
+    return adoptRef(*new ResizeObserver(document, { RefPtr<ResizeObserverCallback> { WTFMove(callback) } }));
 }
 
-ResizeObserver::ResizeObserver(Document& document, Ref<ResizeObserverCallback>&& callback)
+Ref<ResizeObserver> ResizeObserver::createNativeObserver(Document& document, NativeResizeObserverCallback&& nativeCallback)
+{
+    return adoptRef(*new ResizeObserver(document, { WTFMove(nativeCallback) }));
+}
+
+ResizeObserver::ResizeObserver(Document& document, JSOrNativeResizeObserverCallback&& callback)
     : m_document(document)
-    , m_callback(WTFMove(callback))
+    , m_JSOrNativeCallback(WTFMove(callback))
 {
 }
 
@@ -58,11 +63,9 @@ ResizeObserver::~ResizeObserver()
         m_document->removeResizeObserver(*this);
 }
 
-// https://drafts.csswg.org/resize-observer/#dom-resizeobserver-observe
-void ResizeObserver::observe(Element& target, const ResizeObserverOptions& options)
+void ResizeObserver::observeInternal(Element& target, const ResizeObserverBoxOptions boxOptions)
 {
-    if (!m_callback)
-        return;
+    ASSERT(!m_JSOrNativeCallback.valueless_by_exception());
 
     auto position = m_observations.findIf([&](auto& observation) {
         return observation->target() == &target;
@@ -71,7 +74,7 @@ void ResizeObserver::observe(Element& target, const ResizeObserverOptions& optio
     if (position != notFound) {
         // The spec suggests unconditionally unobserving here, but that causes a test failure:
         // https://github.com/web-platform-tests/wpt/issues/30708
-        if (m_observations[position]->observedBox() == options.box)
+        if (m_observations[position]->observedBox() == boxOptions)
             return;
 
         unobserve(target);
@@ -80,17 +83,28 @@ void ResizeObserver::observe(Element& target, const ResizeObserverOptions& optio
     auto& observerData = target.ensureResizeObserverData();
     observerData.observers.append(*this);
 
-    m_observations.append(ResizeObservation::create(target, options.box));
+    m_observations.append(ResizeObservation::create(target, boxOptions));
 
     // Per the specification, we should dispatch at least one observation for the target. For this reason, we make sure to keep the
     // target alive until this first observation. This, in turn, will keep the ResizeObserver's JS wrapper alive via
     // isReachableFromOpaqueRoots(), so the callback stays alive.
     m_targetsWaitingForFirstObservation.append(target);
 
-    if (m_document) {
+    if (m_document && isJSCallback()) {
         m_document->addResizeObserver(*this);
         m_document->scheduleRenderingUpdate(RenderingUpdateStep::ResizeObservations);
     }
+}
+
+// https://drafts.csswg.org/resize-observer/#dom-resizeobserver-observe
+void ResizeObserver::observe(Element& target, const ResizeObserverOptions& options)
+{
+    observeInternal(target, options.box);
+}
+
+void ResizeObserver::observe(Element& target)
+{
+    observeInternal(target, ResizeObserverBoxOptions::ContentBox);
 }
 
 // https://drafts.csswg.org/resize-observer/#dom-resizeobserver-unobserve
@@ -148,17 +162,24 @@ void ResizeObserver::deliverObservations()
 
     auto targetsWaitingForFirstObservation = std::exchange(m_targetsWaitingForFirstObservation, { });
 
+    if (isNativeCallback()) {
+        std::get<NativeResizeObserverCallback>(m_JSOrNativeCallback)(entries, *this);
+        return;
+    }
+
     // FIXME: The JSResizeObserver wrapper should be kept alive as long as the resize observer can fire events.
-    ASSERT(m_callback->hasCallback());
-    if (!m_callback->hasCallback())
+    ASSERT(isJSCallback());
+    auto jsCallback = std::get<RefPtr<ResizeObserverCallback>>(m_JSOrNativeCallback);
+    ASSERT(jsCallback->hasCallback());
+    if (!jsCallback->hasCallback())
         return;
 
-    auto* context = m_callback->scriptExecutionContext();
+    auto* context = jsCallback->scriptExecutionContext();
     if (!context)
         return;
 
     InspectorInstrumentation::willFireObserverCallback(*context, "ResizeObserver"_s);
-    m_callback->handleEvent(*this, entries, *this);
+    jsCallback->handleEvent(*this, entries, *this);
     InspectorInstrumentation::didFireObserverCallback(*context);
 }
 
@@ -205,6 +226,37 @@ bool ResizeObserver::removeObservation(const Element& target)
     return m_observations.removeFirstMatching([&target](auto& observation) {
         return observation->target() == &target;
     });
+}
+
+bool ResizeObserver::isJSCallback()
+{
+    return std::holds_alternative<RefPtr<ResizeObserverCallback>>(m_JSOrNativeCallback);
+}
+
+bool ResizeObserver::isNativeCallback()
+{
+    return std::holds_alternative<NativeResizeObserverCallback>(m_JSOrNativeCallback);
+}
+
+ResizeObserverCallback* ResizeObserver::callbackConcurrently()
+{
+    return WTF::switchOn(m_JSOrNativeCallback,
+    [] (const RefPtr<ResizeObserverCallback>& jsCallback) -> ResizeObserverCallback* {
+        return jsCallback.get();
+    },
+    [] (const NativeResizeObserverCallback&) -> ResizeObserverCallback* {
+        return nullptr;
+    });
+}
+
+void ResizeObserver::resetObservationSize(Element& target)
+{
+    auto position = m_observations.findIf([&](auto& observation) {
+        return observation->target() == &target;
+    });
+
+    if (position != notFound)
+        m_observations[position]->resetObservationSize();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -608,6 +608,7 @@ public:
     ContainIntrinsicSizeType containIntrinsicHeightType() const { return static_cast<ContainIntrinsicSizeType>(m_nonInheritedData->rareData->containIntrinsicHeightType); }
     std::optional<Length> containIntrinsicWidth() const { return m_nonInheritedData->rareData->containIntrinsicWidth; }
     std::optional<Length> containIntrinsicHeight() const { return m_nonInheritedData->rareData->containIntrinsicHeight; }
+    bool hasAutoLengthContainIntrinsicSize() const { return containIntrinsicWidthType() == ContainIntrinsicSizeType::AutoAndLength || containIntrinsicHeightType() == ContainIntrinsicSizeType::AutoAndLength; }
 
     BoxAlignment boxAlign() const { return static_cast<BoxAlignment>(m_nonInheritedData->miscData->deprecatedFlexibleBox->align); }
     BoxDirection boxDirection() const { return static_cast<BoxDirection>(m_inheritedFlags.boxDirection); }


### PR DESCRIPTION
#### 88587e7bd5451f3504cfc7576d2f7617ab1b7cf8
<pre>
Support contain-intrinsic-size auto &amp;&amp; &lt;length&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=239450">https://bugs.webkit.org/show_bug.cgi?id=239450</a>

Reviewed by Oriol Brufau.

This patch adds support to value auto &amp;&amp; &lt;length&gt; for contain-intrinsic-size. Per [1], with the auto &amp;&amp; &lt;length&gt; value,
the last remembered size is the explicit intrinsic size if the box is skipping its content.
The last remembered size is determined when ResizeObserver events are delivered. m_resizeObserverForContainIntrinsicSize
in Document is created specifically to handle the last remembered size. CallbackForContainIntrinsicSize in Document is
used to handle the lastRememberedSize. Because this ResizeObserver is for inside use, so we create a interface
NativeResizeObserverCallback for native use. Now in ResizeObserver there are two kinds of callbacks:
JSResizeObserverCallback and NativeResizeObserverCallback, only one could be initialized.
The resizeObserver would observe the target if contain-intrinsic-size is valued auto &amp;&amp; &lt;length&gt;, otherwise unobserve
it and clear the lastRememberedSize. If an observed target is hidden or skipping its content, unobserve it. Similarly,
if an observed target is removed from DOM tree, unobserve it and clear the lastRememberedSize.

[1] <a href="https://www.w3.org/TR/css-sizing-4/#valdef-contain-intrinsic-width-auto--length">https://www.w3.org/TR/css-sizing-4/#valdef-contain-intrinsic-width-auto--length</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-008-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-009-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-010-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-011-expected.txt:
* LayoutTests/resize-observer/contain-instrinsic-size-should-not-leak-nodes-expected.txt: Added.
* LayoutTests/resize-observer/contain-instrinsic-size-should-not-leak-nodes.html: Added.
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeChild):
* Source/WebCore/dom/Document.cpp:
(WebCore::CallbackForContainIntrinsicSize):
(WebCore::Document::gatherResizeObservationsForContainIntrinsicSize):
(WebCore::Document::deliverResizeObservations):
(WebCore::Document::updateResizeObservations):
(WebCore::Document::ensureResizeObserverForContainIntrinsicSize):
(WebCore::Document::observeForContainIntrinsicSize):
(WebCore::Document::unobserveForContainIntrinsicSize):
(WebCore::Document::resetObservationSizeForContainIntrinsicSize):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/ResizeObservation.cpp:
(WebCore::ResizeObservation::resetObservationSize):
* Source/WebCore/page/ResizeObservation.h:
* Source/WebCore/page/ResizeObserver.cpp:
(WebCore::ResizeObserver::create):
(WebCore::ResizeObserver::createNativeObserver):
(WebCore::ResizeObserver::ResizeObserver):
(WebCore::ResizeObserver::observeInternal):
(WebCore::ResizeObserver::observe):
(WebCore::ResizeObserver::deliverObservations):
(WebCore::ResizeObserver::isJSCallback):
(WebCore::ResizeObserver::isNativeCallback):
(WebCore::ResizeObserver::callbackConcurrently):
(WebCore::ResizeObserver::resetObservationSize):
* Source/WebCore/page/ResizeObserver.h:
(WebCore::ResizeObserver::callbackConcurrently): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::hasAutoLengthContainIntrinsicSize const):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateElementRenderer):

Canonical link: <a href="https://commits.webkit.org/260535@main">https://commits.webkit.org/260535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eada6ab89059c81db2c8f34d92895b1d95c4a3b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/108161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/17240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/41028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/117285 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/116603 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/112047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/18652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/8529 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/100368 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/113928 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/14073 "Found 6 new test failures: editing/deleting/smart-delete-003.html, editing/pasteboard/smart-paste-003-trailing-whitespace.html, editing/pasteboard/smart-paste-005.html, editing/pasteboard/smart-paste-paragraph-004.html, editing/selection/doubleclick-whitespace-img-crash.html, editing/selection/ios/selection-handles-in-iframe.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/97245 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/41957 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/95983 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/28883 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/83628 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10109 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/30231 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/10832 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/7133 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/16258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/49822 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7281 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/12414 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->