### PR TITLE
Rename `sanitizeForCopyOrShare` to `sanitizeLookalikeCharacters`

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -292,7 +292,7 @@ void ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::sanitizeDataIfNee
         if (urlStringToSanitize.isEmpty())
             return;
 
-        m_data = { page->sanitizeForCopyOrShare(urlStringToSanitize) };
+        m_data = { page->sanitizeLookalikeCharacters(urlStringToSanitize) };
     }
 
     if (m_type == "text/html"_s) {

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -273,7 +273,7 @@ void DataTransfer::setDataFromItemList(Document& document, const String& type, c
 
     if (type == "text/uri-list"_s || type == textPlainContentTypeAtom()) {
         if (auto* page = document.page())
-            sanitizedData = page->sanitizeForCopyOrShare(sanitizedData);
+            sanitizedData = page->sanitizeLookalikeCharacters(sanitizedData);
     }
 
     if (sanitizedData != data)

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1649,7 +1649,7 @@ void Editor::copyURL(const URL& url, const String& title, Pasteboard& pasteboard
 {
     auto sanitizedURL = url;
     if (auto* page = m_document.page())
-        sanitizedURL = page->sanitizeForCopyOrShare(url);
+        sanitizedURL = page->sanitizeLookalikeCharacters(url);
 
     PasteboardURL pasteboardURL;
     pasteboardURL.url = sanitizedURL;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -547,7 +547,7 @@ public:
     virtual void handlePDFServiceClick(const IntPoint&, HTMLAttachmentElement&) { }
 #endif
 
-    virtual URL sanitizeForCopyOrShare(const URL& url) const { return url; }
+    virtual URL sanitizeLookalikeCharacters(const URL& url) const { return url; }
 
     virtual bool shouldDispatchFakeMouseMoveEvents() const { return true; }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4114,15 +4114,15 @@ ScreenOrientationManager* Page::screenOrientationManager() const
     return m_screenOrientationManager.get();
 }
 
-URL Page::sanitizeForCopyOrShare(const URL& url) const
+URL Page::sanitizeLookalikeCharacters(const URL& url) const
 {
-    return chrome().client().sanitizeForCopyOrShare(url);
+    return chrome().client().sanitizeLookalikeCharacters(url);
 }
 
-String Page::sanitizeForCopyOrShare(const String& urlString) const
+String Page::sanitizeLookalikeCharacters(const String& urlString) const
 {
     if (auto url = URL { urlString }; url.isValid())
-        return sanitizeForCopyOrShare(WTFMove(url)).string();
+        return sanitizeLookalikeCharacters(WTFMove(url)).string();
     return urlString;
 }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -953,8 +953,8 @@ public:
 
     bool httpsUpgradeEnabled() const { return m_httpsUpgradeEnabled; }
 
-    URL sanitizeForCopyOrShare(const URL&) const;
-    String sanitizeForCopyOrShare(const String&) const;
+    URL sanitizeLookalikeCharacters(const URL&) const;
+    String sanitizeLookalikeCharacters(const String&) const;
 
     LoadSchedulingMode loadSchedulingMode() const { return m_loadSchedulingMode; }
     void setLoadSchedulingMode(LoadSchedulingMode);

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -391,7 +391,7 @@ URL HitTestResult::absoluteImageURL() const
         || is<SVGImageElement>(*imageNode)) {
         auto imageURL = imageNode->document().completeURL(downcast<Element>(*imageNode).imageSourceURL());
         if (auto* page = imageNode->document().page())
-            return page->sanitizeForCopyOrShare(imageURL);
+            return page->sanitizeLookalikeCharacters(imageURL);
         return imageURL;
     }
 
@@ -422,7 +422,7 @@ URL HitTestResult::absoluteMediaURL() const
     if (auto* element = mediaElement()) {
         auto sourceURL = element->currentSrc();
         if (auto* page = element->document().page())
-            return page->sanitizeForCopyOrShare(sourceURL);
+            return page->sanitizeLookalikeCharacters(sourceURL);
         return sourceURL;
     }
 #endif
@@ -634,7 +634,7 @@ URL HitTestResult::absoluteLinkURL() const
 
     auto url = m_innerURLElement->absoluteLinkURL();
     if (auto* page = m_innerURLElement->document().page())
-        return page->sanitizeForCopyOrShare(url);
+        return page->sanitizeLookalikeCharacters(url);
 
     return url;
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1519,9 +1519,9 @@ void WebChromeClient::requestTextRecognition(Element& element, TextRecognitionOp
 
 #endif
 
-URL WebChromeClient::sanitizeForCopyOrShare(const URL& url) const
+URL WebChromeClient::sanitizeLookalikeCharacters(const URL& url) const
 {
-    return m_page.sanitizeForCopyOrShare(url);
+    return m_page.sanitizeLookalikeCharacters(url);
 }
 
 #if ENABLE(TEXT_AUTOSIZING)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -455,7 +455,7 @@ private:
     void textAutosizingUsesIdempotentModeChanged() final;
 #endif
 
-    URL sanitizeForCopyOrShare(const URL&) const final;
+    URL sanitizeLookalikeCharacters(const URL&) const final;
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
     void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&) final;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -655,7 +655,7 @@ void WebPage::readSelectionFromPasteboard(const String& pasteboardName, Completi
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WebPageCocoaAdditions.mm>)
 #include <WebKitAdditions/WebPageCocoaAdditions.mm>
 #else
-URL WebPage::sanitizeForCopyOrShare(const URL& url) const
+URL WebPage::sanitizeLookalikeCharacters(const URL& url) const
 {
     return url;
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1492,7 +1492,7 @@ public:
 
     void isPlayingMediaDidChange(WebCore::MediaProducerMediaStateFlags);
 
-    URL sanitizeForCopyOrShare(const URL&) const;
+    URL sanitizeLookalikeCharacters(const URL&) const;
 
 #if ENABLE(IMAGE_ANALYSIS)
     void requestTextRecognition(WebCore::Element&, WebCore::TextRecognitionOptions&&, CompletionHandler<void(RefPtr<WebCore::Element>&&)>&& = { });
@@ -2581,7 +2581,7 @@ inline bool WebPage::shouldAvoidComputingPostLayoutDataForEditorState() const { 
 #endif
 
 #if !PLATFORM(COCOA)
-inline URL WebPage::sanitizeForCopyOrShare(const URL& url) const { return url; }
+inline URL WebPage::sanitizeLookalikeCharacters(const URL& url) const { return url; }
 #endif
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2940,7 +2940,7 @@ static void imagePositionInformation(WebPage& page, Element& element, const Inte
 
     auto& [renderImage, image] = *rendererAndImage;
     info.isImage = true;
-    info.imageURL = page.sanitizeForCopyOrShare(element.document().completeURL(renderImage.cachedImage()->url().string()));
+    info.imageURL = page.sanitizeLookalikeCharacters(element.document().completeURL(renderImage.cachedImage()->url().string()));
     info.imageMIMEType = image.mimeType();
     info.isAnimatedImage = image.isAnimated();
     info.elementContainsImageOverlay = is<HTMLElement>(element) && ImageOverlay::hasOverlay(downcast<HTMLElement>(element));
@@ -2984,7 +2984,7 @@ static void elementPositionInformation(WebPage& page, Element& element, const In
 
     if (linkElement && !info.isImageOverlayText) {
         info.isLink = true;
-        info.url = page.sanitizeForCopyOrShare(linkElement->document().completeURL(stripLeadingAndTrailingHTMLSpaces(linkElement->getAttribute(HTMLNames::hrefAttr))));
+        info.url = page.sanitizeLookalikeCharacters(linkElement->document().completeURL(stripLeadingAndTrailingHTMLSpaces(linkElement->getAttribute(HTMLNames::hrefAttr))));
 
         linkIndicatorPositionInformation(page, *linkElement, request, info);
 #if ENABLE(DATA_DETECTION)
@@ -3007,7 +3007,7 @@ static void elementPositionInformation(WebPage& page, Element& element, const In
             if (request.includeImageData) {
                 if (auto rendererAndImage = imageRendererAndImage(element)) {
                     auto& [renderImage, image] = *rendererAndImage;
-                    info.imageURL = page.sanitizeForCopyOrShare(element.document().completeURL(renderImage.cachedImage()->url().string()));
+                    info.imageURL = page.sanitizeLookalikeCharacters(element.document().completeURL(renderImage.cachedImage()->url().string()));
                     info.imageMIMEType = image.mimeType();
                     info.image = createShareableBitmap(renderImage, { screenSize() * page.corePage()->deviceScaleFactor(), AllowAnimatedImages::Yes, UseSnapshotForTransparentImages::Yes });
                 }


### PR DESCRIPTION
#### 155f7eb85ad8427193c369d549bc15609acfa4a9
<pre>
Rename `sanitizeForCopyOrShare` to `sanitizeLookalikeCharacters`
<a href="https://bugs.webkit.org/show_bug.cgi?id=249559">https://bugs.webkit.org/show_bug.cgi?id=249559</a>

Reviewed by Aditya Keerthi.

Rename `sanitizeForCopyOrShare` to `sanitizeLookalikeCharacters`, in preparation for using this
codepath in contexts that are not limited to copying or sharing links.

No change in behavior.

* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::sanitizeDataIfNeeded):
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::setDataFromItemList):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::copyURL):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::sanitizeLookalikeCharacters const):
(WebCore::ChromeClient::sanitizeForCopyOrShare const): Deleted.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::sanitizeLookalikeCharacters const):
(WebCore::Page::sanitizeForCopyOrShare const): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::absoluteImageURL const):
(WebCore::HitTestResult::absoluteMediaURL const):
(WebCore::HitTestResult::absoluteLinkURL const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::sanitizeLookalikeCharacters const):
(WebKit::WebChromeClient::sanitizeForCopyOrShare const): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::sanitizeLookalikeCharacters const):
(WebKit::WebPage::sanitizeForCopyOrShare const): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::sanitizeLookalikeCharacters const):
(WebKit::WebPage::sanitizeForCopyOrShare const): Deleted.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::imagePositionInformation):
(WebKit::elementPositionInformation):

Canonical link: <a href="https://commits.webkit.org/258068@main">https://commits.webkit.org/258068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aafe4c3243ba214da74975c76ba2442707567b7d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110113 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170389 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104802 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/742 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93219 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107958 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34848 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22883 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77823 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3652 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3672 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43904 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5534 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5450 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->