### PR TITLE
Split descriptors out of properties dictionary in CSSProperties.json

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -112,10 +112,6 @@
         "   (https://drafts.csswg.org/css-logical-1/#mapping-logic).",
         "   Examples: \"top-left\", \"block-start\", \"horizontal\".",
         "",
-        "* descriptor-only:",
-        "Indicates that this CSS property is descriptor only (populates.",
-        "CSSProperty::isDescriptorOnly().",
-        "",
         "* font-property:",
         "Indicates that this CSS property is font-related. It must have corresponding",
         "methods on the FontDescription class.",
@@ -417,7 +413,7 @@
             "codegen-properties": {
                 "custom": "All",
                 "high-priority": true,
-                "custom-parser": true
+                "parser-function": "consumeFontFamily"
             },
             "specification": {
                 "category": "css-fonts",
@@ -461,9 +457,9 @@
                 "custom": "All",
                 "font-property": true,
                 "high-priority": true,
-                "custom-parser": true,
                 "parser-requires-context-mode": true,
-                "parser-requires-value-pool": true
+                "parser-requires-value-pool": true,
+                "parser-function": "consumeFontStyle"
             },
             "specification": {
                 "category": "css-fonts",
@@ -477,7 +473,7 @@
                 "font-property": true,
                 "high-priority": true,
                 "converter": "FontWeight",
-                "custom-parser": true
+                "parser-function": "consumeFontWeight"
             },
             "specification": {
                 "category": "css-fonts",
@@ -502,8 +498,8 @@
                 "font-property": true,
                 "high-priority": true,
                 "converter": "FontStretch",
-                "custom-parser": true,
-                "parser-requires-value-pool": true
+                "parser-requires-value-pool": true,
+                "parser-function": "consumeFontStretch"
             },
             "specification": {
                 "category": "css-fonts",
@@ -547,7 +543,7 @@
                 "custom": "Initial|Inherit",
                 "font-property": true,
                 "high-priority": true,
-                "custom-parser": true,
+                "parser-function": "consumeFontFeatureSettings",
                 "parser-requires-value-pool": true
             },
             "specification": {
@@ -625,7 +621,7 @@
                 "custom": "All",
                 "font-property": true,
                 "high-priority": true,
-                "custom-parser": true
+                "parser-function": "consumeFontVariantLigatures"
             },
             "specification": {
                 "category": "css-fonts",
@@ -683,7 +679,7 @@
                 "custom": "All",
                 "font-property": true,
                 "high-priority": true,
-                "custom-parser": true
+                "parser-function": "consumeFontVariantNumeric"
             },
             "specification": {
                 "category": "css-fonts",
@@ -697,7 +693,7 @@
                 "custom": "All",
                 "font-property": true,
                 "high-priority": true,
-                "custom-parser": true
+                "parser-function": "consumeFontVariantAlternates"
             },
             "specification": {
                 "category": "css-fonts",
@@ -711,7 +707,7 @@
                 "custom": "All",
                 "font-property": true,
                 "high-priority": true,
-                "custom-parser": true
+                "parser-function": "consumeFontVariantEastAsian"
             },
             "specification": {
                 "category": "css-fonts",
@@ -1027,18 +1023,6 @@
             "specification": {
                 "category": "css-ruby",
                 "url": "https://www.w3.org/TR/css-ruby-1/#rubypos"
-            }
-        },
-        "additive-symbols": {
-            "codegen-properties": {
-                "descriptor-only": true,
-                "settings-flag": "cssCounterStyleAtRulesEnabled",
-                "skip-builder": true,
-                "custom-parser": true
-            },
-            "specification": {
-                "category": "css-counter-styles",
-                "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-symbols"
             }
         },
         "alignment-baseline": {
@@ -2947,18 +2931,6 @@
                 "url": "https://www.w3.org/TR/CSS2/tables.html#empty-cells"
             }
         },
-        "fallback": {
-            "codegen-properties": {
-                "descriptor-only": true,
-                "settings-flag": "cssCounterStyleAtRulesEnabled",
-                "skip-builder": true,
-                "custom-parser": true
-            },
-            "specification": {
-                "category": "css-counter-styles",
-                "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-fallback"
-            }
-        },
         "fill": {
             "inherited": true,
             "codegen-properties": {
@@ -4478,18 +4450,6 @@
                 "url": "https://drafts.csswg.org/css-overscroll-1/#propdef-overscroll-behavior-x"
             }
         },
-        "pad": {
-            "codegen-properties": {
-                "descriptor-only": true,
-                "settings-flag": "cssCounterStyleAtRulesEnabled",
-                "skip-builder": true,
-                "custom-parser": true
-            },
-            "specification": {
-                "category": "css-counter-styles",
-                "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-pad"
-            }
-        },
         "padding": {
             "codegen-properties": {
                 "longhands": [
@@ -4879,39 +4839,6 @@
                 "url": "https://www.w3.org/TR/css3-page/#page-size-prop"
             }
         },
-        "src": {
-            "codegen-properties": {
-                "skip-builder": true,
-                "descriptor-only": true,
-                "custom-parser": true
-            },
-            "specification": {
-                "category": "css-fonts",
-                "url": "https://www.w3.org/TR/css-fonts-3/#src-desc"
-            }
-        },
-        "base-palette": {
-            "codegen-properties": {
-                "skip-builder": true,
-                "descriptor-only": true,
-                "custom-parser": true
-            },
-            "specification": {
-                "category": "css-fonts",
-                "url": "https://drafts.csswg.org/css-fonts-4/#base-palette-desc"
-            }
-        },
-        "override-colors": {
-            "codegen-properties": {
-                "skip-builder": true,
-                "descriptor-only": true,
-                "custom-parser": true
-            },
-            "specification": {
-                "category": "css-fonts",
-                "url": "https://drafts.csswg.org/css-fonts-4/#override-color"
-            }
-        },
         "stop-color": {
             "codegen-properties": {
                 "svg": true,
@@ -5071,23 +4998,11 @@
             "inherited": true,
             "codegen-properties": {
                 "converter": "SpeakAs",
-                "custom-parser": true
+                "parser-function": "consumeSpeakAs"
             },
             "specification": {
                 "category": "css-speech",
                 "url": "https://www.w3.org/TR/css3-speech/#speak-as"
-            }
-        },
-        "symbols": {
-            "codegen-properties": {
-                "descriptor-only": true,
-                "settings-flag": "cssCounterStyleAtRulesEnabled",
-                "skip-builder": true,
-                "custom-parser": true
-            },
-            "specification": {
-                "category": "css-counter-styles",
-                "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-symbols"
             }
         },
         "table-layout": {
@@ -5605,34 +5520,6 @@
             "specification": {
                 "category": "css-22",
                 "url": "https://www.w3.org/TR/CSS22/visuren.html#propdef-unicode-bidi"
-            }
-        },
-        "unicode-range": {
-            "codegen-properties": {
-                "skip-builder": true,
-                "descriptor-only": true,
-                "custom-parser": true
-            },
-            "specification": {
-                "category": "css-fonts",
-                "url": "https://www.w3.org/TR/css-fonts-3/#descdef-unicode-range"
-            }
-        },
-        "font-display": {
-            "values": [
-                "auto",
-                "block",
-                "swap",
-                "fallback",
-                "optional"
-            ],
-            "codegen-properties": {
-                "skip-builder": true,
-                "descriptor-only": true
-            },
-            "specification": {
-                "category": "css-fonts-4",
-                "url": "https://drafts.csswg.org/css-fonts-4/#font-display-desc"
             }
         },
         "vector-effect": {
@@ -7434,18 +7321,6 @@
             },
             "status": "non-standard"
         },
-        "negative": {
-            "codegen-properties": {
-                "descriptor-only": true,
-                "settings-flag": "cssCounterStyleAtRulesEnabled",
-                "skip-builder": true,
-                "custom-parser": true
-            },
-            "specification": {
-                "category": "css-counter-styles",
-                "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-negative"
-            }
-        },
         "color-scheme": {
             "inherited": true,
             "values": [
@@ -7556,18 +7431,6 @@
                 "url": "https://www.w3.org/TR/css-transforms-1/#propdef-perspective-origin"
             }
         },
-        "prefix": {
-            "codegen-properties": {
-                "descriptor-only": true,
-                "settings-flag": "cssCounterStyleAtRulesEnabled",
-                "skip-builder": true,
-                "custom-parser": true
-            },
-            "specification": {
-                "category": "css-counter-styles",
-                "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-prefix"
-            }
-        },
         "print-color-adjust": {
             "inherited": true,
             "values": [
@@ -7585,18 +7448,6 @@
                 "url": "https://www.w3.org/TR/css-color-adjust/#print-color-adjust"
             }
         },
-        "range": {
-            "codegen-properties": {
-                "descriptor-only": true,
-                "settings-flag": "cssCounterStyleAtRulesEnabled",
-                "skip-builder": true,
-                "custom-parser": true
-            },
-            "specification": {
-                "category": "css-counter-styles",
-                "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-range"
-            }
-        },
         "-webkit-rtl-ordering": {
             "inherited": true,
             "values": [
@@ -7608,18 +7459,6 @@
                 "setter": "setRTLOrdering"
             },
             "status": "non-standard"
-        },
-        "suffix": {
-            "codegen-properties": {
-                "descriptor-only": true,
-                "settings-flag": "cssCounterStyleAtRulesEnabled",
-                "skip-builder": true,
-                "custom-parser": true
-            },
-            "specification": {
-                "category": "css-counter-styles",
-                "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-suffix"
-            }
         },
         "-webkit-text-combine": {
             "inherited": true,
@@ -8552,18 +8391,6 @@
                 "url": "https://www.w3.org/TR/css-shapes/#propdef-shape-image-threshold"
             }
         },
-        "system": {
-            "codegen-properties": {
-                "descriptor-only": true,
-                "settings-flag": "cssCounterStyleAtRulesEnabled",
-                "skip-builder": true,
-                "custom-parser": true
-            },
-            "specification": {
-                "category": "css-counter-styles",
-                "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-system"
-            }
-        },
         "-webkit-tap-highlight-color": {
             "inherited": true,
             "codegen-properties": {
@@ -8746,41 +8573,387 @@
                 "category": "css-round-display",
                 "url": "https://www.w3.org/TR/css-round-display-1/#border-boundary-property"
             }
-        },
-        "syntax": {
-            "codegen-properties": {
-                "descriptor-only": true,
-                "settings-flag": "cssCustomPropertiesAndValuesEnabled",
-                "skip-builder": true,
-                "custom-parser": true
+        }
+    },
+    "descriptors": {
+        "@counter-style": {
+            "additive-symbols": {
+                "codegen-properties": {
+                    "settings-flag": "cssCounterStyleAtRulesEnabled",
+                    "parser-function": "consumeCounterStyleAdditiveSymbols",
+                    "parser-requires-context": true
+                },
+                "specification": {
+                    "category": "css-counter-styles",
+                    "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-symbols"
+                }
             },
-            "specification": {
-                "category": "css-properties-and-values",
-                "url": "https://drafts.css-houdini.org/css-properties-values-api/#the-syntax-descriptor"
+            "fallback": {
+                "codegen-properties": {
+                    "settings-flag": "cssCounterStyleAtRulesEnabled",
+                    "parser-function": "consumeCounterStyleName"
+                },
+                "specification": {
+                    "category": "css-counter-styles",
+                    "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-fallback"
+                }
+            },
+            "negative": {
+                "codegen-properties": {
+                    "settings-flag": "cssCounterStyleAtRulesEnabled",
+                    "parser-function": "consumeCounterStyleNegative",
+                    "parser-requires-context": true
+                },
+                "specification": {
+                    "category": "css-counter-styles",
+                    "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-negative"
+                }
+            },
+            "pad": {
+                "codegen-properties": {
+                    "settings-flag": "cssCounterStyleAtRulesEnabled",
+                    "parser-function": "consumeCounterStylePad",
+                    "parser-requires-context": true
+                },
+                "specification": {
+                    "category": "css-counter-styles",
+                    "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-pad"
+                }
+            },
+            "prefix": {
+                "codegen-properties": {
+                    "settings-flag": "cssCounterStyleAtRulesEnabled",
+                    "parser-function": "consumeCounterStyleSymbol",
+                    "parser-requires-context": true
+                },
+                "specification": {
+                    "category": "css-counter-styles",
+                    "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-prefix"
+                }
+            },
+            "range": {
+                "codegen-properties": {
+                    "settings-flag": "cssCounterStyleAtRulesEnabled",
+                    "parser-function": "consumeCounterStyleRange"
+                },
+                "specification": {
+                    "category": "css-counter-styles",
+                    "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-range"
+                }
+            },
+            "suffix": {
+                "codegen-properties": {
+                    "settings-flag": "cssCounterStyleAtRulesEnabled",
+                    "parser-function": "consumeCounterStyleSymbol",
+                    "parser-requires-context": true
+                },
+                "specification": {
+                    "category": "css-counter-styles",
+                    "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-suffix"
+                }
+            },
+            "system": {
+                "codegen-properties": {
+                    "settings-flag": "cssCounterStyleAtRulesEnabled",
+                    "parser-function": "consumeCounterStyleSystem"
+                },
+                "specification": {
+                    "category": "css-counter-styles",
+                    "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-system"
+                }
+            },
+            "speak-as": {
+                "codegen-properties": {
+                    "settings-flag": "cssCounterStyleAtRulesEnabled",
+                    "parser-function": "consumeCounterStyleSpeakAs"
+                },
+                "specification": {
+                    "category": "css-counter-styles",
+                    "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-speak-as"
+                }
+            },
+            "symbols": {
+                "codegen-properties": {
+                    "settings-flag": "cssCounterStyleAtRulesEnabled",
+                    "parser-function": "consumeCounterStyleSymbols",
+                    "parser-requires-context": true
+                },
+                "specification": {
+                    "category": "css-counter-styles",
+                    "url": "https://www.w3.org/TR/css-counter-styles-3/#counter-style-symbols"
+                }
             }
         },
-        "inherits": {
-            "codegen-properties": {
-                "descriptor-only": true,
-                "settings-flag": "cssCustomPropertiesAndValuesEnabled",
-                "skip-builder": true,
-                "custom-parser": true
+        "@font-face": {
+            "font-family": {
+                "codegen-properties": {
+                    "parser-function": "consumeFontFaceFontFamily"
+                },
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://www.w3.org/TR/css-fonts-4/#font-family-desc"
+                }
             },
-            "specification": {
-                "category": "css-properties-and-values",
-                "url": "https://drafts.css-houdini.org/css-properties-values-api/#inherits-descriptor"
+            "font-display": {
+                "values": [
+                    "auto",
+                    "block",
+                    "swap",
+                    "fallback",
+                    "optional"
+                ],
+                "codegen-properties": {
+                    "parser-exported": true
+                },
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://drafts.csswg.org/css-fonts-4/#font-display-desc"
+                }
+            },
+            "font-feature-settings": {
+                "codegen-properties": {
+                    "parser-function": "consumeFontFeatureSettings",
+                    "parser-requires-value-pool": true
+                },
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://www.w3.org/TR/css-fonts-4/#descdef-font-face-font-feature-settings"
+                }
+            },
+            "font-stretch": {
+                "values": [
+                    "normal",
+                    "ultra-condensed",
+                    "extra-condensed",
+                    "condensed",
+                    "semi-condensed",
+                    "semi-expanded",
+                    "expanded",
+                    "extra-expanded",
+                    "ultra-expanded"
+                ],
+                "codegen-properties": [
+                    {
+                        "enable-if": "ENABLE_VARIATION_FONTS",
+                        "parser-requires-value-pool": true,
+                        "parser-function": "consumeFontStretchRange"
+                    },
+                    {
+                        "enable-if": "!ENABLE_VARIATION_FONTS",
+                        "parser-requires-value-pool": true,
+                        "parser-function": "consumeFontStretch"
+                    }
+                ],
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://www.w3.org/TR/css-fonts-4/#descdef-font-face-font-stretch"
+                }
+            },
+            "font-style": {
+                "values": [
+                    {
+                        "value": "auto",
+                        "status": "unimplemented"
+                    },
+                    "normal",
+                    "italic",
+                    "oblique"
+                ],
+                "codegen-properties": [
+                    {
+                        "enable-if": "ENABLE_VARIATION_FONTS",
+                        "parser-requires-context-mode": true,
+                        "parser-requires-value-pool": true,
+                        "parser-function": "consumeFontStyleRange"
+                    },
+                    {
+                        "enable-if": "!ENABLE_VARIATION_FONTS",
+                        "parser-requires-context-mode": true,
+                        "parser-requires-value-pool": true,
+                        "parser-function": "consumeFontStyle"
+                    }
+                ],
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://www.w3.org/TR/css-fonts-4/#descdef-font-face-font-style"
+                }
+            },
+            "font-variant": {
+                "codegen-properties": {
+                    "longhands": [
+                        "font-variant-ligatures",
+                        "font-variant-caps",
+                        "font-variant-alternates",
+                        "font-variant-numeric",
+                        "font-variant-east-asian",
+                        "font-variant-position"
+                    ]
+                },
+                "specification": {
+                    "category": "css-fonts",
+                    "url": "https://www.w3.org/TR/css-fonts-3/#propdef-font-variant"
+                }
+            },
+            "font-variant-alternates": {
+                "codegen-properties": {
+                    "parser-function": "consumeFontVariantAlternates"
+                },
+                "specification": {
+                    "category": "css-fonts",
+                    "url": "https://drafts.csswg.org/css-fonts-3/#font-variant-alternates-prop"
+                }
+            },
+            "font-variant-caps": {
+                "values": [
+                    "normal",
+                    "small-caps",
+                    "all-small-caps",
+                    "petite-caps",
+                    "all-petite-caps",
+                    "unicase",
+                    "titling-caps"
+                ],
+                "specification": {
+                    "category": "css-fonts",
+                    "url": "https://drafts.csswg.org/css-fonts-3/#font-variant-caps-prop"
+                }
+            },
+            "font-variant-east-asian": {
+                "codegen-properties": {
+                    "parser-function": "consumeFontVariantEastAsian"
+                },
+                "specification": {
+                    "category": "css-fonts",
+                    "url": "https://drafts.csswg.org/css-fonts-3/#font-variant-east-asian-prop"
+                }
+            },
+            "font-variant-ligatures": {
+                "codegen-properties": {
+                    "parser-function": "consumeFontVariantLigatures"
+                },
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://drafts.csswg.org/css-fonts-4/#font-variant-ligatures-prop"
+                }
+            },
+            "font-variant-numeric": {
+                "codegen-properties": {
+                    "parser-function": "consumeFontVariantNumeric"
+                },
+                "specification": {
+                    "category": "css-fonts",
+                    "url": "https://drafts.csswg.org/css-fonts-3/#font-variant-numeric-prop"
+                }
+            },
+            "font-variant-position": {
+                "values": [
+                    "normal",
+                    "sub",
+                    "super"
+                ],
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-position"
+                }
+            },
+            "font-weight": {
+                "codegen-properties": [
+                    {
+                        "enable-if": "ENABLE_VARIATION_FONTS",
+                        "parser-requires-value-pool": true,
+                        "parser-function": "consumeFontWeightAbsoluteRange"
+                    },
+                    {
+                        "enable-if": "!ENABLE_VARIATION_FONTS",
+                        "parser-requires-value-pool": true,
+                        "parser-function": "consumeFontWeightAbsolute"
+                    }
+                ],
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://www.w3.org/TR/css-fonts-4/#descdef-font-face-font-weight"
+                }
+            },
+            "src": {
+                "codegen-properties": {
+                    "parser-function": "consumeFontFaceSrc",
+                    "parser-requires-context": true
+                },
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://www.w3.org/TR/css-fonts-4/#src-desc"
+                }
+            },
+            "unicode-range": {
+                "codegen-properties": {
+                    "parser-function": "consumeFontFaceUnicodeRange"
+                },
+                "specification": {
+                    "category": "css-fonts",
+                    "url": "https://www.w3.org/TR/css-fonts-3/#descdef-unicode-range"
+                }
             }
         },
-        "initial-value": {
-            "codegen-properties": {
-                "descriptor-only": true,
-                "settings-flag": "cssCustomPropertiesAndValuesEnabled",
-                "skip-builder": true,
-                "custom-parser": true
+        "@font-palette-values": {
+            "font-family": {
+                "codegen-properties": {
+                    "parser-function": "consumeFamilyName"
+                },
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://www.w3.org/TR/css-fonts-4/#font-family-2-desc"
+                }
             },
-            "specification": {
-                "category": "css-properties-and-values",
-                "url": "https://drafts.css-houdini.org/css-properties-values-api/#initial-value-descriptor"
+            "base-palette": {
+                "codegen-properties": {
+                    "parser-grammar": "light | dark | <integer [0,inf]>"
+                },
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://www.w3.org/TR/css-fonts-4/#font-family-2-desc"
+                }
+            },
+            "override-colors": {
+                "codegen-properties": {
+                    "parser-function": "consumeFontPaletteValuesOverrideColors",
+                    "parser-requires-context": true
+                },
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://www.w3.org/TR/css-fonts-4/#override-color"
+                }
+            }
+        },
+        "@property": {
+            "syntax": {
+                "codegen-properties": {
+                    "settings-flag": "cssCustomPropertiesAndValuesEnabled",
+                    "parser-grammar": "<string>"
+                },
+                "specification": {
+                    "category": "css-properties-and-values",
+                    "url": "https://drafts.css-houdini.org/css-properties-values-api/#the-syntax-descriptor"
+                }
+            },
+            "inherits": {
+                "codegen-properties": {
+                    "settings-flag": "cssCustomPropertiesAndValuesEnabled",
+                    "parser-grammar": "true | false"
+                },
+                "specification": {
+                    "category": "css-properties-and-values",
+                    "url": "https://drafts.css-houdini.org/css-properties-values-api/#inherits-descriptor"
+                }
+            },
+            "initial-value": {
+                "codegen-properties": {
+                    "settings-flag": "cssCustomPropertiesAndValuesEnabled",
+                    "parser-function": "consumePropertyInitialValue"
+                },
+                "specification": {
+                    "category": "css-properties-and-values",
+                    "url": "https://drafts.css-houdini.org/css-properties-values-api/#initial-value-descriptor"
+                }
             }
         }
     },

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -586,14 +586,14 @@ std::optional<SRGBA<uint8_t>> CSSParserFastPaths::parseNamedColor(StringView str
     return parseNamedColorInternal(string.characters16(), string.length());
 }
 
-bool CSSParserFastPaths::isValidKeywordPropertyAndValue(CSSPropertyID property, CSSValueID value, const CSSParserContext& context)
+bool CSSParserFastPaths::isKeywordValidForStyleProperty(CSSPropertyID property, CSSValueID value, const CSSParserContext& context)
 {
-    return CSSPropertyParsing::isKeywordValidForProperty(property, value, context);
+    return CSSPropertyParsing::isKeywordValidForStyleProperty(property, value, context);
 }
 
-bool CSSParserFastPaths::isKeywordPropertyID(CSSPropertyID property)
+bool CSSParserFastPaths::isKeywordFastPathEligibleStyleProperty(CSSPropertyID property)
 {
-    return CSSPropertyParsing::isKeywordProperty(property);
+    return CSSPropertyParsing::isKeywordFastPathEligibleStyleProperty(property);
 }
 
 static bool isUniversalKeyword(StringView string)
@@ -614,7 +614,7 @@ static RefPtr<CSSValue> parseKeywordValue(CSSPropertyID propertyId, StringView s
     // FIXME: The "!context.enclosingRuleType" is suspicious.
     ASSERT(!CSSProperty::isDescriptorOnly(propertyId) || parsingDescriptor || !context.enclosingRuleType);
 
-    if (!CSSParserFastPaths::isKeywordPropertyID(propertyId)) {
+    if (!CSSParserFastPaths::isKeywordFastPathEligibleStyleProperty(propertyId)) {
         // All properties, including non-keyword properties, accept the CSS-wide keywords.
         if (!isUniversalKeyword(string))
             return nullptr;
@@ -636,7 +636,7 @@ static RefPtr<CSSValue> parseKeywordValue(CSSPropertyID propertyId, StringView s
     if (!parsingDescriptor && isCSSWideKeyword(valueID))
         return CSSValuePool::singleton().createIdentifierValue(valueID);
 
-    if (CSSParserFastPaths::isValidKeywordPropertyAndValue(propertyId, valueID, context))
+    if (CSSParserFastPaths::isKeywordValidForStyleProperty(propertyId, valueID, context))
         return CSSValuePool::singleton().createIdentifierValue(valueID);
     return nullptr;
 }

--- a/Source/WebCore/css/parser/CSSParserFastPaths.h
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.h
@@ -47,8 +47,8 @@ public:
     static RefPtr<CSSValue> maybeParseValue(CSSPropertyID, StringView, const CSSParserContext&);
 
     // Properties handled here shouldn't be explicitly handled in CSSPropertyParser.
-    static bool isKeywordPropertyID(CSSPropertyID);
-    static bool isValidKeywordPropertyAndValue(CSSPropertyID, CSSValueID, const CSSParserContext&);
+    static bool isKeywordFastPathEligibleStyleProperty(CSSPropertyID);
+    static bool isKeywordValidForStyleProperty(CSSPropertyID, CSSValueID, const CSSParserContext&);
 
     // Parses numeric and named colors.
     static std::optional<SRGBA<uint8_t>> parseSimpleColor(StringView, bool strict = false);

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -71,11 +71,20 @@ private:
 
     bool inQuirksMode() const { return m_context.mode == HTMLQuirksMode; }
 
-    bool parseViewportDescriptor(CSSPropertyID propId, bool important);
+    // @font-face descriptors.
     bool parseFontFaceDescriptor(CSSPropertyID);
+    bool parseFontFaceDescriptorShorthand(CSSPropertyID);
+
+    // @font-palette-values descriptors.
     bool parseFontPaletteValuesDescriptor(CSSPropertyID);
-    bool parseCounterStyleDescriptor(CSSPropertyID, const CSSParserContext&);
+
+    // @counter-style descriptors.
+    bool parseCounterStyleDescriptor(CSSPropertyID);
+    
+    // @keyframe descriptors.
     bool parseKeyframeDescriptor(CSSPropertyID, bool important);
+
+    // @property descriptors.
     bool parsePropertyDescriptor(CSSPropertyID);
 
     void addProperty(CSSPropertyID longhand, CSSPropertyID shorthand, Ref<CSSValue>&&, bool important, bool implicit = false);

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -234,7 +234,6 @@ RefPtr<CSSValue> consumeFontVariantNumeric(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeFontWeight(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeFamilyName(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeFontFamily(CSSParserTokenRange&);
-RefPtr<CSSValue> consumeFontFamilyDescriptor(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeCounterIncrement(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeCounterReset(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeSize(CSSParserTokenRange&, CSSParserMode);
@@ -317,6 +316,30 @@ RefPtr<CSSValue> consumeTextEmphasisPosition(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeColorScheme(CSSParserTokenRange&);
 #endif
 RefPtr<CSSValue> consumeOffsetRotate(CSSParserTokenRange&, CSSParserMode);
+
+
+// @font-face descriptor consumers:
+
+RefPtr<CSSValue> consumeFontFaceFontFamily(CSSParserTokenRange&);
+
+// @font-palette-values descriptor consumers:
+
+RefPtr<CSSValue> consumeFontPaletteValuesOverrideColors(CSSParserTokenRange&, const CSSParserContext&);
+
+// @counter-style descriptor consumers:
+
+RefPtr<CSSValue> consumeCounterStyleSystem(CSSParserTokenRange&);
+RefPtr<CSSValue> consumeCounterStyleSymbol(CSSParserTokenRange&, const CSSParserContext&);
+RefPtr<CSSValue> consumeCounterStyleNegative(CSSParserTokenRange&, const CSSParserContext&);
+RefPtr<CSSValue> consumeCounterStyleRange(CSSParserTokenRange&);
+RefPtr<CSSValue> consumeCounterStylePad(CSSParserTokenRange&, const CSSParserContext&);
+RefPtr<CSSValue> consumeCounterStyleSymbols(CSSParserTokenRange&, const CSSParserContext&);
+RefPtr<CSSValue> consumeCounterStyleAdditiveSymbols(CSSParserTokenRange&, const CSSParserContext&);
+RefPtr<CSSValue> consumeCounterStyleSpeakAs(CSSParserTokenRange&);
+
+// @property descriptor consumers:
+
+RefPtr<CSSValue> consumePropertyInitialValue(CSSParserTokenRange&);
 
 
 // Template and inline implementations are at the bottom of the file for readability.

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -275,7 +275,7 @@ static RefPtr<CSSPrimitiveValue> consumeFontStyleAngle(CSSParserTokenRange& rang
     return angle;
 }
 
-RefPtr<CSSFontStyleRangeValue> consumeFontStyleRange(CSSParserTokenRange& range, CSSParserMode mode, CSSValuePool& pool)
+RefPtr<CSSValue> consumeFontStyleRange(CSSParserTokenRange& range, CSSParserMode mode, CSSValuePool& pool)
 {
     auto keyword = CSSPropertyParserHelpers::consumeIdentWorkerSafe<CSSValueNormal, CSSValueItalic, CSSValueOblique>(range, pool);
     if (!keyword)

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h
@@ -32,7 +32,6 @@
 
 namespace WebCore {
 
-class CSSFontStyleRangeValue;
 class CSSPrimitiveValue;
 class CSSValue;
 class CSSValueList;
@@ -65,7 +64,7 @@ RefPtr<CSSValue> consumeFontFeatureSettings(CSSParserTokenRange&, CSSValuePool&)
 RefPtr<CSSPrimitiveValue> consumeFontFaceFontDisplay(CSSParserTokenRange&, CSSValuePool&);
 
 #if ENABLE(VARIATION_FONTS)
-RefPtr<CSSFontStyleRangeValue> consumeFontStyleRange(CSSParserTokenRange&, CSSParserMode, CSSValuePool&);
+RefPtr<CSSValue> consumeFontStyleRange(CSSParserTokenRange&, CSSParserMode, CSSValuePool&);
 RefPtr<CSSValue> consumeFontWeightAbsoluteRange(CSSParserTokenRange&, CSSValuePool&);
 RefPtr<CSSValue> consumeFontStretchRange(CSSParserTokenRange&, CSSValuePool&);
 #endif

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -866,10 +866,10 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::CSS::CSSPropertyInfo>>> Insp
                 property->setLonghands(WTFMove(longhands));
         }
 
-        if (CSSParserFastPaths::isKeywordPropertyID(propertyID)) {
+        if (CSSParserFastPaths::isKeywordFastPathEligibleStyleProperty(propertyID)) {
             auto values = JSON::ArrayOf<String>::create();
             for (auto valueID : allCSSValueKeywords()) {
-                if (CSSParserFastPaths::isValidKeywordPropertyAndValue(propertyID, valueID, strictCSSParserContext()))
+                if (CSSParserFastPaths::isKeywordValidForStyleProperty(propertyID, valueID, strictCSSParserContext()))
                     values->addItem(nameString(valueID));
             }
             if (values->length())


### PR DESCRIPTION
#### 229a3a2d8a276a217a5fb2b3910a12edd3d78d02
<pre>
Split descriptors out of properties dictionary in CSSProperties.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=249558">https://bugs.webkit.org/show_bug.cgi?id=249558</a>
rdar://103497902

Reviewed by Antti Koivisto.

Adds a new top level object to CSSProperties.json, &quot;descriptors&quot;, which contains
mappings from CSS rule types (e.g. @font-face, @counter-style) to a map of the
descriptors that rule type supports. This allows us to remove the &apos;descriptor-only&apos;
properties from the main &apos;properties&apos; map, and also accurately specify the
descriptors that shared names with properties. This is important as some descriptors
share a name with a property but have different grammars.

With the new data in CSSProperties.json, we now generate parse functions for
the new rule types specified: @counter-style, @font-face, @font-palette-values.
and @property. While not too many of the descriptors can be generated right now,
the main &quot;parse...Descriptor&quot; functions can be, and this adds the foundation for
generating more as we add more capabilities to the parser.

To differentiate between style properties and descriptors when exporting consumer
functions, descriptors have a prefix based on their rule type added. For example,
@font-face defines a &quot;font-display&quot; descriptor, which is needed elsewhere, so we
export a function called `CSSPropertyParsing::consumeFontFaceFontDisplay()`.

* Source/WebCore/css/CSSProperties.json:
Move/copy descriptors to new section. Remove support for descriptor-only now
that it can be inferred.

* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::CSSParserFastPaths::isKeywordValidForStyleProperty):
(WebCore::CSSParserFastPaths::isKeywordFastPathEligibleStyleProperty):
(WebCore::parseKeywordValue):
(WebCore::CSSParserFastPaths::isValidKeywordPropertyAndValue): Deleted.
(WebCore::CSSParserFastPaths::isKeywordPropertyID): Deleted.
* Source/WebCore/css/parser/CSSParserFastPaths.h:
Update for more precise names that differentiate between properties
and descriptors.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseValue):
Remove unnecessary passing of the CSSParserContext to a member
function. It can access it via *this.

(WebCore::CSSPropertyParser::parseSingleValue):
Update for rename from parse() to parseStyleProperty().

(WebCore::CSSPropertyParser::parseCounterStyleDescriptor):
(WebCore::CSSPropertyParser::parseFontFaceDescriptor):
(WebCore::CSSPropertyParser::parseFontFaceDescriptorShorthand):
(WebCore::CSSPropertyParser::parseFontPaletteValuesDescriptor):
Call through to the new generated parsers.

(WebCore::consumeCounterStyleSystem): Deleted.
(WebCore::consumeCounterStyleSymbol): Deleted.
(WebCore::consumeCounterStyleNegative): Deleted.
(WebCore::consumeCounterStyleRangeBound): Deleted.
(WebCore::consumeCounterStyleRange): Deleted.
(WebCore::consumeCounterStylePad): Deleted.
(WebCore::consumeCounterStyleSymbols): Deleted.
(WebCore::consumeCounterStyleAdditiveSymbols): Deleted.
(WebCore::consumeCounterStyleSpeakAs): Deleted.
(WebCore::consumeBasePaletteDescriptor): Deleted.
(WebCore::consumeOverrideColorsDescriptor): Deleted.
Moved to CSSPropertyParserHelpers.cpp for consistency.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeBackgroundSize):
(WebCore::CSSPropertyParserHelpers::consumeFontFaceFontFamily):
(WebCore::CSSPropertyParserHelpers::consumeFontPaletteValuesOverrideColors):
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleSystem):
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleSymbol):
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleNegative):
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleRangeBound):
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleRange):
(WebCore::CSSPropertyParserHelpers::consumeCounterStylePad):
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleSymbols):
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleAdditiveSymbols):
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleSpeakAs):
(WebCore::CSSPropertyParserHelpers::consumeFontFamilyDescriptor): Deleted.
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
Moved functions from CSSPropertyParser. Renamed consumeFontFamilyDescriptor
to consumeFontFaceFontFamily to better align with naming convention.

* Source/WebCore/css/process-css-properties.py:
Adds support for the new &apos;descriptors&apos; top level object and generalizes
parser code generation to support them.

* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::getSupportedCSSProperties):
Update for renames.

* Tools/Scripts/webkitpy/style/checkers/jsonchecker.py:
Add checker support for the new sections. Remove support for descriptor-only.

Canonical link: <a href="https://commits.webkit.org/258084@main">https://commits.webkit.org/258084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a29649e64b05fd542a04c2dceea76935a79573d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100859 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110163 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170444 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/916 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93278 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108007 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8274 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34891 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/104383 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90183 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegateReload (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77866 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3700 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24453 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3717 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43948 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5544 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5495 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->