### PR TITLE
REGRESSION: LayoutTest fast/scrolling/arrow-key-scroll-in-rtl-document.html is a flaky failure

### DIFF
--- a/LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document-expected.txt
+++ b/LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document-expected.txt
@@ -1,1 +1,1 @@
-scrollLeft is -40
+PASS: scrollLeft is -120

--- a/LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document.html
+++ b/LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document.html
@@ -28,8 +28,12 @@
 
         function checkForScroll()
         {
+            var expectedScrollLeft = -120;
             var scrollLeft = document.scrollingElement.scrollLeft;
-            document.getElementById('result').textContent = "scrollLeft is " + scrollLeft;
+            if (scrollLeft != expectedScrollLeft)
+                document.getElementById('result').textContent = "FAIL: scrollLeft is " + scrollLeft +  ", expected " + expectedScrollLeft;
+             else
+                document.getElementById('result').textContent = "PASS: scrollLeft is " + scrollLeft;
 
             if (window.testRunner)
                 testRunner.notifyDone();

--- a/LayoutTests/fast/scrolling/keyboard-scrolling-distance-downArrow.html
+++ b/LayoutTests/fast/scrolling/keyboard-scrolling-distance-downArrow.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ScrollAnimatorEnabled=true ] -->
 
 <html>
 

--- a/LayoutTests/fast/scrolling/keyboard-scrolling-distance-pageDown.html
+++ b/LayoutTests/fast/scrolling/keyboard-scrolling-distance-pageDown.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ScrollAnimatorEnabled=true ] -->
 
 <html>
 

--- a/LayoutTests/fast/scrolling/unfocusing-page-while-keyboard-scrolling.html
+++ b/LayoutTests/fast/scrolling/unfocusing-page-while-keyboard-scrolling.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ScrollAnimatorEnabled=true ] -->
 <html>
 <head>
     <script src="../../resources/ui-helper.js"></script>

--- a/LayoutTests/platform/mac-wk1/fast/scrolling/arrow-key-scroll-in-rtl-document-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/scrolling/arrow-key-scroll-in-rtl-document-expected.txt
@@ -1,1 +1,0 @@
-scrollLeft is -120

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4527,7 +4527,7 @@ bool EventHandler::focusedScrollableAreaShouldUseSmoothKeyboardScrolling()
 
 bool EventHandler::shouldUseSmoothKeyboardScrollingForFocusedScrollableArea()
 {
-    return m_frame.settings().eventHandlerDrivenSmoothKeyboardScrollingEnabled() && focusedScrollableAreaShouldUseSmoothKeyboardScrolling();
+    return m_frame.settings().eventHandlerDrivenSmoothKeyboardScrollingEnabled() && focusedScrollableAreaShouldUseSmoothKeyboardScrolling() && m_frame.settings().scrollAnimatorEnabled();
 }
 
 bool EventHandler::keyboardScrollRecursively(std::optional<ScrollDirection> direction, std::optional<ScrollGranularity> granularity, Node* startingNode)


### PR DESCRIPTION
#### be42dd0621a716f17ba71dc6961e0b611497f133
<pre>
REGRESSION: LayoutTest fast/scrolling/arrow-key-scroll-in-rtl-document.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=249565">https://bugs.webkit.org/show_bug.cgi?id=249565</a>
rdar://103502192

Reviewed by Simon Fraser.

The disabling of the scroll animator in this test wasn&apos;t actually doing anything.
Although that keyboard smooth scrolling defaults to whatever the initial setting
of `ScrollAnimatorEnabled` is, changing this flag at runtime in a test didn&apos;t
change the setting of smooth keyboard scrolling.

Now, smooth scrolling will always consult this setting, and so this test can now
be changed back to the way it was pre-keyboard smooth scrolling, which was not
flaky because the scroll animator was actually disabled and so everything happened
instantly.

* LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document-expected.txt:
* LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document.html:
* LayoutTests/platform/mac-wk1/fast/scrolling/arrow-key-scroll-in-rtl-document-expected.txt: Removed.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::shouldUseSmoothKeyboardScrollingForFocusedScrollableArea):
* LayoutTests/fast/scrolling/keyboard-scrolling-distance-pageDown.html:
* LayoutTests/fast/scrolling/unfocusing-page-while-keyboard-scrolling.html:

Canonical link: <a href="https://commits.webkit.org/258095@main">https://commits.webkit.org/258095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dccca31a7b45dbefbbe2cfc7da053943f3851707

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110183 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170457 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104865 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/895 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93291 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108026 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91548 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34904 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77879 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3718 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24465 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/856 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43961 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5556 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5513 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->