### PR TITLE
Facebook.com: Text overlaps in videos up next sidebar

### DIFF
--- a/LayoutTests/compositing/transforms/clipping-layer-and-flattening-layer-expected.html
+++ b/LayoutTests/compositing/transforms/clipping-layer-and-flattening-layer-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .expected {
+        height: 200px;
+        width: 100px;
+        background-color: red;
+    }
+</style>
+</head>
+<body>
+    <div class="expected"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/transforms/clipping-layer-and-flattening-layer.html
+++ b/LayoutTests/compositing/transforms/clipping-layer-and-flattening-layer.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .perspective-layer {
+        perspective: 1px;
+        will-change: transform;
+    }
+    .scroll-clip {
+        overflow-y: scroll;
+    }
+    .intermediate {
+        height: 200px;
+    }
+    .clipped-layer {
+        height: 300px;
+        width: 100px;
+        background-color: red;
+        position: relative;
+        will-change: transform;
+    }
+    ::-webkit-scrollbar { 
+        display: none;
+    }
+</style>
+</head>
+<body>
+    <div class="perspective-layer">
+        <div class="scroll-clip">
+            <div class="intermediate">
+                <div class="clipped-layer"></div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1684,9 +1684,6 @@ void RenderLayerBacking::updateInternalHierarchy()
     constexpr size_t maxOrderedLayers = 6;
     Vector<GraphicsLayer*, maxOrderedLayers> orderedLayers;
 
-    if (m_transformFlatteningLayer)
-        orderedLayers.append(m_transformFlatteningLayer.get());
-
     if (lastClippingLayer)
         orderedLayers.append(lastClippingLayer);
 
@@ -1704,6 +1701,15 @@ void RenderLayerBacking::updateInternalHierarchy()
     }
 
     orderedLayers.append(m_graphicsLayer.get());
+
+    // The transform flattening layer is outside the clipping stack, so we need
+    // to make sure we add the first layer in the clipping stack as its child.
+    if (m_transformFlatteningLayer) {
+        if (lastClippingLayer)
+            m_transformFlatteningLayer->addChild(*m_ancestorClippingStack->firstLayer());
+        else
+            m_transformFlatteningLayer->addChild(*orderedLayers[0]);
+    }
 
     if (m_childContainmentLayer)
         orderedLayers.append(m_childContainmentLayer.get());


### PR DESCRIPTION
#### 3028133f11d61758e687f07e3c5b7a8ee0dd30b3
<pre>
Facebook.com: Text overlaps in videos up next sidebar
<a href="https://bugs.webkit.org/show_bug.cgi?id=249566">https://bugs.webkit.org/show_bug.cgi?id=249566</a>
&lt;rdar://problem/103502243&gt;

Reviewed by Simon Fraser.

The transform flattening layer was being attached as the parent of the last clipping layer in the
stack, not the first. This meant that any clipping layers before the last ended up orphaned.

* LayoutTests/compositing/transforms/clipping-layer-and-flattening-layer-expected.html: Added.
* LayoutTests/compositing/transforms/clipping-layer-and-flattening-layer.html: Added.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateInternalHierarchy):

Canonical link: <a href="https://commits.webkit.org/258093@main">https://commits.webkit.org/258093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87dec3567b6666337bb92c0abb34a53b41d8a7e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110135 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170409 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/861 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93241 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107980 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91505 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34866 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77840 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3672 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24420 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3691 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/828 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43920 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5552 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5469 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->