### PR TITLE
Avoid CompactPtr expansion if unnecessary

### DIFF
--- a/Source/WTF/wtf/HashTraits.h
+++ b/Source/WTF/wtf/HashTraits.h
@@ -248,8 +248,8 @@ template<typename P> struct HashTraits<Packed<P*>> : SimpleClassHashTraits<Packe
     static Packed<P*> emptyValue() { return nullptr; }
     static bool isEmptyValue(const TargetType& value) { return value.get() == nullptr; }
 
-    using PeekType = P*;
-    static PeekType peek(const TargetType& value) { return value.get(); }
+    using PeekType = Packed<P*>;
+    static PeekType peek(const TargetType& value) { return value; }
     static PeekType peek(P* value) { return value; }
 };
 
@@ -260,8 +260,8 @@ template<typename P> struct HashTraits<CompactPtr<P>> : SimpleClassHashTraits<Co
     static CompactPtr<P> emptyValue() { return nullptr; }
     static bool isEmptyValue(const TargetType& value) { return !value; }
 
-    using PeekType = P*;
-    static PeekType peek(const TargetType& value) { return value.get(); }
+    using PeekType = CompactPtr<P>;
+    static PeekType peek(const TargetType& value) { return value; }
     static PeekType peek(P* value) { return value; }
 };
 

--- a/Source/WTF/wtf/Packed.h
+++ b/Source/WTF/wtf/Packed.h
@@ -263,6 +263,42 @@ struct IsSmartPtr<PackedPtr<T>> {
     static constexpr bool value = true;
 };
 
+template<typename T, typename U>
+inline bool operator==(const PackedPtr<T>& a, const PackedPtr<U>& b)
+{
+    return a.get() == b.get();
+}
+
+template<typename T, typename U>
+inline bool operator!=(const PackedPtr<T>& a, const PackedPtr<U>& b)
+{
+    return a.get() != b.get();
+}
+
+template<typename T, typename U>
+inline bool operator==(const PackedPtr<T>& a, U* b)
+{
+    return a.get() == b;
+}
+
+template<typename T, typename U>
+inline bool operator==(T* a, const PackedPtr<U>& b)
+{
+    return a == b.get();
+}
+
+template<typename T, typename U>
+inline bool operator!=(const PackedPtr<T>& a, U* b)
+{
+    return !(a == b);
+}
+
+template<typename T, typename U>
+inline bool operator!=(T* a, const PackedPtr<U>& b)
+{
+    return !(a == b);
+}
+
 template<typename T>
 struct PackedPtrTraits {
     template<typename U> using RebindTraits = PackedPtrTraits<U>;

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -110,6 +110,13 @@ private:
     friend RefPtr adoptRef<T, PtrTraits, RefDerefTraits>(T*);
     template<typename X, typename Y, typename Z> friend class RefPtr;
 
+    template<typename T1, typename U, typename V, typename X, typename Y, typename Z>
+    friend bool operator==(const RefPtr<T1, U, V>&, const RefPtr<X, Y, Z>&);
+    template<typename T1, typename U, typename V, typename X>
+    friend bool operator==(const RefPtr<T1, U, V>&, X*);
+    template<typename T1, typename X, typename Y, typename Z>
+    friend bool operator==(T1*, const RefPtr<X, Y, Z>&);
+
     enum AdoptTag { Adopt };
     RefPtr(T* ptr, AdoptTag) : m_ptr(ptr) { }
 
@@ -205,38 +212,38 @@ inline void swap(RefPtr<T, U, V>& a, RefPtr<T, U, V>& b)
 
 template<typename T, typename U, typename V, typename X, typename Y, typename Z>
 inline bool operator==(const RefPtr<T, U, V>& a, const RefPtr<X, Y, Z>& b)
-{ 
-    return a.get() == b.get();
+{
+    return a.m_ptr == b.m_ptr;
 }
 
 template<typename T, typename U, typename V, typename X>
 inline bool operator==(const RefPtr<T, U, V>& a, X* b)
-{ 
-    return a.get() == b; 
+{
+    return a.m_ptr == b;
 }
 
 template<typename T, typename X, typename Y, typename Z>
 inline bool operator==(T* a, const RefPtr<X, Y, Z>& b)
 {
-    return a == b.get(); 
+    return a == b.m_ptr;
 }
 
 template<typename T, typename U, typename V, typename X, typename Y, typename Z>
 inline bool operator!=(const RefPtr<T, U, V>& a, const RefPtr<X, Y, Z>& b)
-{ 
-    return a.get() != b.get(); 
+{
+    return !(a == b);
 }
 
 template<typename T, typename U, typename V, typename X>
 inline bool operator!=(const RefPtr<T, U, V>& a, X* b)
 {
-    return a.get() != b; 
+    return !(a == b);
 }
 
 template<typename T, typename X, typename Y, typename Z>
 inline bool operator!=(T* a, const RefPtr<X, Y, Z>& b)
-{ 
-    return a != b.get(); 
+{
+    return !(a == b);
 }
 
 template<typename T, typename U, typename V>

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -445,7 +445,7 @@ Ref<AtomStringImpl> AtomStringImpl::addSlowCase(AtomStringTable& stringTable, St
 // When removing a string from the table, we know it's already the one in the table, so no need for a string equality check.
 struct AtomStringTableRemovalHashTranslator {
     static unsigned hash(AtomStringImpl* string) { return string->hash(); }
-    static bool equal(const AtomStringTable::StringEntry& a, AtomStringImpl* b) { return a.get() == b; }
+    static bool equal(const AtomStringTable::StringEntry& a, AtomStringImpl* b) { return a == b; }
 };
 
 void AtomStringImpl::remove(AtomStringImpl* string)


### PR DESCRIPTION
#### 36ff06c62fdb1c3f88d3360e6833bb2e840b0480
<pre>
Avoid CompactPtr expansion if unnecessary
<a href="https://bugs.webkit.org/show_bug.cgi?id=249572">https://bugs.webkit.org/show_bug.cgi?id=249572</a>
rdar://103506006

Reviewed by Justin Michaud.

This patch adds operator== etc. for CompactPtr and adjust HashTraits for CompactPtr so that
we can avoid pointer expansion while using CompactPtr in HashTable: comparison of CompactPtrs
and hash computation don&apos;t need pointer expansion.

* Source/WTF/wtf/CompactPtr.h:
(WTF::CompactPtr::operator==):
(WTF::CompactPtr::operator!=):
(WTF::CompactPtr::storage const):
(WTF::operator==):
(WTF::operator!=):
(WTF::DefaultHash&lt;CompactPtr&lt;P&gt;&gt;::hash):
(WTF::DefaultHash&lt;CompactPtr&lt;P&gt;&gt;::equal):
* Source/WTF/wtf/HashTraits.h:
(WTF::HashTraits&lt;CompactPtr&lt;P&gt;&gt;::peek):
* Source/WTF/wtf/Packed.h:
(WTF::operator==):
(WTF::operator!=):
* Source/WTF/wtf/RefPtr.h:
(WTF::operator==):
(WTF::operator!=):
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::AtomStringTableRemovalHashTranslator::equal):

Canonical link: <a href="https://commits.webkit.org/258271@main">https://commits.webkit.org/258271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b87717300fb4435c3335b5391eb48cb0a6203485

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110142 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170416 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/862 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93249 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107987 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34873 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90161 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77847 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91325 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3679 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24427 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87413 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1209 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3698 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/830 "Found 60 new test failures: animations/additive-transform-animations.html, animations/duplicate-keys.html, animations/stop-animation-on-suspend.html, compositing/background-color/background-color-alpha-with-opacity.html, compositing/backing/non-composited-visibility-change.html, compositing/backing/solid-color-with-paints-into-ancestor.html, compositing/clipping/nested-overflow-with-border-radius.html, compositing/contents-scale/hidpi-tests/rasterization-scale.html, compositing/iframes/border-radius-composited-frame.html, compositing/overflow/overflow-change-reposition-descendants.html ... (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29229 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43927 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90301 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5476 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20213 "Passed tests") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2986 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->