### PR TITLE
[web-animations] adopt AnimatableProperty in more places

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.h
+++ b/Source/WebCore/animation/CSSPropertyAnimation.h
@@ -41,10 +41,10 @@ class RenderStyle;
 
 class CSSPropertyAnimation {
 public:
-    static bool isPropertyAnimatable(CSSPropertyID);
+    static bool isPropertyAnimatable(AnimatableProperty);
     static bool isPropertyAdditiveOrCumulative(AnimatableProperty);
     static bool propertyRequiresBlendingForAccumulativeIteration(const CSSPropertyBlendingClient&, AnimatableProperty, const RenderStyle& a, const RenderStyle& b);
-    static bool animationOfPropertyIsAccelerated(CSSPropertyID);
+    static bool animationOfPropertyIsAccelerated(AnimatableProperty);
     static bool propertiesEqual(CSSPropertyID, const RenderStyle& a, const RenderStyle& b);
     static bool canPropertyBeInterpolated(CSSPropertyID, const RenderStyle& a, const RenderStyle& b);
     static CSSPropertyID getPropertyAtIndex(int, std::optional<bool>& isShorthand);

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -153,8 +153,7 @@ public:
 
     void computeDeclarativeAnimationBlendingKeyframes(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     const KeyframeList& blendingKeyframes() const { return m_blendingKeyframes; }
-    const HashSet<CSSPropertyID>& animatedProperties();
-    const HashSet<AtomString>& animatedCustomProperties();
+    const HashSet<AnimatableProperty>& animatedProperties();
     const HashSet<CSSPropertyID>& inheritedProperties() const { return m_inheritedProperties; }
     bool animatesProperty(CSSPropertyID) const;
     bool animatesDirectionAwareProperty() const;
@@ -244,8 +243,7 @@ private:
 
     AtomString m_keyframesName;
     KeyframeList m_blendingKeyframes { emptyAtom() };
-    HashSet<CSSPropertyID> m_animatedProperties;
-    HashSet<AtomString> m_animatedCustomProperties;
+    HashSet<AnimatableProperty> m_animatedProperties;
     HashSet<CSSPropertyID> m_inheritedProperties;
     Vector<ParsedKeyframe> m_parsedKeyframes;
     Vector<AcceleratedAction> m_pendingAcceleratedActions;

--- a/Source/WebCore/rendering/style/KeyframeList.h
+++ b/Source/WebCore/rendering/style/KeyframeList.h
@@ -24,8 +24,8 @@
 
 #pragma once
 
-#include "CSSPropertyNames.h"
 #include "CompositeOperation.h"
+#include "WebAnimationTypes.h"
 #include <wtf/Vector.h>
 #include <wtf/HashSet.h>
 #include <wtf/text/AtomString.h>
@@ -49,13 +49,9 @@ public:
     {
     }
 
-    void addProperty(CSSPropertyID prop) { m_properties.add(prop); }
-    bool containsProperty(CSSPropertyID prop) const { return m_properties.contains(prop); }
-    const HashSet<CSSPropertyID>& properties() const { return m_properties; }
-
-    void addCustomProperty(const AtomString& customProperty) { m_customProperties.add(customProperty); }
-    bool containsCustomProperty(const AtomString& customProperty) const { return m_customProperties.contains(customProperty); }
-    const HashSet<AtomString>& customProperties() const { return m_customProperties; }
+    void addProperty(AnimatableProperty);
+    bool containsProperty(AnimatableProperty) const;
+    const HashSet<AnimatableProperty>& properties() const { return m_properties; }
 
     double key() const { return m_key; }
     void setKey(double key) { m_key = key; }
@@ -74,8 +70,7 @@ public:
 
 private:
     double m_key;
-    HashSet<CSSPropertyID> m_properties; // The properties specified in this keyframe.
-    HashSet<AtomString> m_customProperties; // The custom properties being animated.
+    HashSet<AnimatableProperty> m_properties; // The properties specified in this keyframe.
     std::unique_ptr<RenderStyle> m_style;
     RefPtr<TimingFunction> m_timingFunction;
     std::optional<CompositeOperation> m_compositeOperation;
@@ -98,14 +93,12 @@ public:
     
     void insert(KeyframeValue&&);
     
-    bool containsProperty(CSSPropertyID prop) const { return m_properties.contains(prop); }
-    const HashSet<CSSPropertyID>& properties() const { return m_properties; }
+    void addProperty(AnimatableProperty);
+    bool containsProperty(AnimatableProperty) const;
+    const HashSet<AnimatableProperty>& properties() const { return m_properties; }
+
     bool containsAnimatableProperty() const;
     bool containsDirectionAwareProperty() const;
-
-    void addCustomProperty(const AtomString& customProperty) { m_customProperties.add(customProperty); }
-    bool containsCustomProperty(const AtomString& customProperty) const { return m_customProperties.contains(customProperty); }
-    const HashSet<AtomString>& customProperties() const { return m_customProperties; }
 
     void clear();
     bool isEmpty() const { return m_keyframes.isEmpty(); }
@@ -124,8 +117,7 @@ public:
 private:
     AtomString m_animationName;
     Vector<KeyframeValue> m_keyframes; // Kept sorted by key.
-    HashSet<CSSPropertyID> m_properties; // The properties being animated.
-    HashSet<AtomString> m_customProperties; // The custom properties being animated.
+    HashSet<AnimatableProperty> m_properties; // The properties being animated.
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### eee69004092ae8ec6127d7a22449f326e0070060
<pre>
[web-animations] adopt AnimatableProperty in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=249541">https://bugs.webkit.org/show_bug.cgi?id=249541</a>

Reviewed by Antti Koivisto.

We continue the adoption of the new AnimatableProperty types which holds either a
CSSPropertyID for standard CSS properties or an AtomString for custom CSS properties.

We start with KeyframeValue and KeyframeList which is the central place we store
properties. We remove the two separate property lists to have a single
HashSet&lt;AnimatableProperty&gt; and make all remaining methods relying on CSSPropertyID
now make no assumption on the property type it&apos;s dealing with.

We also ensure we never pass in CSSPropertyCustom as a CSSPropertyID, changing
Style::Resolver::styleForKeyframe() to have separate KeyframeValue::addKeyframe()
calls, one for custom properties and one for standard properties.

The rest of this change is pretty straightforward refactoring to deal with
AnimatableProperty where we&apos;d previously only deal with CSSPropertyID.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimation::isPropertyAnimatable):
(WebCore::CSSPropertyAnimation::animationOfPropertyIsAccelerated):
* Source/WebCore/animation/CSSPropertyAnimation.h:
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::animationCanBeRemoved):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::getKeyframes):
(WebCore::KeyframeEffect::processKeyframes):
(WebCore::KeyframeEffect::animatedProperties):
(WebCore::KeyframeEffect::setBlendingKeyframes):
(WebCore::KeyframeEffect::computeStackingContextImpact):
(WebCore::KeyframeEffect::computeAcceleratedPropertiesState):
(WebCore::KeyframeEffect::setAnimatedPropertiesInStyle):
(WebCore::KeyframeEffect::computeHasImplicitKeyframeForAcceleratedProperty):
(WebCore::KeyframeEffect::animatedCustomProperties): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::commitStyles):
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::buildObjectForKeyframes):
* Source/WebCore/rendering/style/KeyframeList.cpp:
(WebCore::KeyframeList::insert):
(WebCore::KeyframeList::copyKeyframes):
(WebCore::KeyframeList::fillImplicitKeyframes):
(WebCore::KeyframeList::containsAnimatableProperty const):
(WebCore::KeyframeList::addProperty):
(WebCore::KeyframeList::containsProperty const):
(WebCore::KeyframeValue::addProperty):
(WebCore::KeyframeValue::containsProperty const):
* Source/WebCore/rendering/style/KeyframeList.h:
(WebCore::KeyframeValue::properties const):
(WebCore::KeyframeList::properties const):
(WebCore::KeyframeValue::addProperty): Deleted.
(WebCore::KeyframeValue::containsProperty const): Deleted.
(WebCore::KeyframeValue::addCustomProperty): Deleted.
(WebCore::KeyframeValue::containsCustomProperty const): Deleted.
(WebCore::KeyframeValue::customProperties const): Deleted.
(WebCore::KeyframeList::containsProperty const): Deleted.
(WebCore::KeyframeList::addCustomProperty): Deleted.
(WebCore::KeyframeList::containsCustomProperty const): Deleted.
(WebCore::KeyframeList::customProperties const): Deleted.
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe):

Canonical link: <a href="https://commits.webkit.org/258075@main">https://commits.webkit.org/258075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b43f7355b9cebe538f835779c45120b5b5e4a7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110143 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170417 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104829 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10921 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/822 "Failed to checkout and rebase branch from PR 7839") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93250 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107988 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8253 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34872 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77846 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3680 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24428 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3699 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/765 "Unable to confirm if test failures are introduced by change, retrying build") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43928 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5477 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2901 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->