### PR TITLE
[GPU Process] [FormControls] Add a ControlPart for TextField

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1740,6 +1740,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/controls/ControlStyle.h
     platform/graphics/controls/MeterPart.h
     platform/graphics/controls/PlatformControl.h
+    platform/graphics/controls/TextFieldPart.h
 
     platform/graphics/displaylists/DisplayList.h
     platform/graphics/displaylists/DisplayListDrawingContext.h

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -935,6 +935,7 @@
 		5CB898B1286274FA00CA3485 /* QuarantineSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QuarantineSPI.h; sourceTree = "<group>"; };
 		63E369F921AFA83F001C14BC /* NSProgressSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSProgressSPI.h; sourceTree = "<group>"; };
 		71B1141F26823ACD004D6701 /* SystemPreviewSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemPreviewSPI.h; sourceTree = "<group>"; };
+		72BA2A872951462500678507 /* NSTextFieldCellSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSTextFieldCellSPI.h; sourceTree = "<group>"; };
 		7A36D0F8223AD9AB00B0522E /* CommonCryptoSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommonCryptoSPI.h; sourceTree = "<group>"; };
 		7A3A6A7F20CADB4600317AAE /* NSImageSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSImageSPI.h; sourceTree = "<group>"; };
 		7B47F2A128587B9700E793C8 /* CoreGraphicsSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreGraphicsSoftLink.h; sourceTree = "<group>"; };
@@ -1210,6 +1211,7 @@
 				0C77857F1F45130F00F4EBB6 /* NSSharingServicePickerSPI.h */,
 				0C7785801F45130F00F4EBB6 /* NSSharingServiceSPI.h */,
 				0C7785811F45130F00F4EBB6 /* NSSpellCheckerSPI.h */,
+				72BA2A872951462500678507 /* NSTextFieldCellSPI.h */,
 				0C7785821F45130F00F4EBB6 /* NSTextFinderSPI.h */,
 				93DB7D3624626BCC004BD8A3 /* NSTextInputContextSPI.h */,
 				93DB7D3924626F86004BD8A3 /* NSUndoManagerSPI.h */,

--- a/Source/WebCore/PAL/pal/spi/mac/NSTextFieldCellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSTextFieldCellSPI.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <AppKit/NSTextFieldCell.h>
+
+@interface NSTextFieldCell ()
+- (CFDictionaryRef)_coreUIDrawOptionsWithFrame:(NSRect)cellFrame inView:(NSView *)controlView includeFocus:(BOOL)includeFocus;
+- (CFDictionaryRef)_coreUIDrawOptionsWithFrame:(NSRect)cellFrame inView:(NSView *)controlView includeFocus:(BOOL)includeFocus maskOnly:(BOOL)maskOnly;
+@end

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -465,6 +465,7 @@ platform/graphics/mac/WebLayer.mm
 platform/graphics/mac/controls/ControlFactoryMac.mm
 platform/graphics/mac/controls/ControlMac.mm
 platform/graphics/mac/controls/MeterMac.mm
+platform/graphics/mac/controls/TextFieldMac.mm
 platform/graphics/mac/controls/WebControlView.mm
 platform/graphics/opentype/OpenTypeCG.cpp
 platform/image-decoders/avif/AVIFImageDecoder.cpp

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class MeterPart;
 class PlatformControl;
+class TextFieldPart;
 
 class ControlFactory {
     WTF_MAKE_FAST_ALLOCATED;
@@ -40,6 +41,7 @@ public:
     static ControlFactory& sharedControlFactory();
 
     virtual std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) = 0;
+    virtual std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/ControlPart.h
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.h
@@ -42,14 +42,14 @@ public:
 
     ControlPartType type() const { return m_type; }
 
-    ControlFactory& controlFactory() const;
+    WEBCORE_EXPORT ControlFactory& controlFactory() const;
     void setControlFactory(ControlFactory* controlFactory) { m_controlFactory = controlFactory; }
 
     FloatSize sizeForBounds(const FloatRect& bounds, const ControlStyle&);
     void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) const;
 
 protected:
-    ControlPart(ControlPartType);
+    WEBCORE_EXPORT ControlPart(ControlPartType);
 
     PlatformControl* platformControl() const;
     virtual std::unique_ptr<PlatformControl> createPlatformControl() = 0;

--- a/Source/WebCore/platform/graphics/controls/ControlStyle.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlStyle.cpp
@@ -75,6 +75,15 @@ TextStream& operator<<(TextStream& ts, ControlStyle::State state)
     case ControlStyle::State::LargeControls:
         ts << "large-controls";
         break;
+    case ControlStyle::State::ReadOnly:
+        ts << "read-only";
+        break;
+    case ControlStyle::State::ListButton:
+        ts << "list-button";
+        break;
+    case ControlStyle::State::ListButtonPressed:
+        ts << "list-button-pressed";
+        break;
     }
     return ts;
 }

--- a/Source/WebCore/platform/graphics/controls/ControlStyle.h
+++ b/Source/WebCore/platform/graphics/controls/ControlStyle.h
@@ -34,7 +34,7 @@ class TextStream;
 namespace WebCore {
 
 struct ControlStyle {
-    enum class State : uint16_t {
+    enum class State {
         Hovered             = 1 << 0,
         Pressed             = 1 << 1,
         Focused             = 1 << 2,
@@ -49,6 +49,9 @@ struct ControlStyle {
         DarkAppearance      = 1 << 11,
         RightToLeft         = 1 << 12,
         LargeControls       = 1 << 13,
+        ReadOnly            = 1 << 14,
+        ListButton          = 1 << 15,
+        ListButtonPressed   = 1 << 16,
     };
     OptionSet<State> states;
     unsigned fontSize { 12 };

--- a/Source/WebCore/platform/graphics/controls/TextFieldPart.h
+++ b/Source/WebCore/platform/graphics/controls/TextFieldPart.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class TextFieldPart : public ControlPart {
+public:
+    static Ref<TextFieldPart> create()
+    {
+        return adoptRef(*new TextFieldPart());
+    }
+
+private:
+    TextFieldPart()
+        : ControlPart(ControlPartType::TextField)
+    {
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() override
+    {
+        return controlFactory().createPlatformTextField(*this);
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -39,12 +39,16 @@ public:
     NSView *drawingView(const FloatRect&, const ControlStyle&) const;
 
     std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) override;
+    std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) override;
 
 private:
     NSLevelIndicatorCell* levelIndicatorCell() const;
+    NSTextFieldCell* textFieldCell() const;
 
     mutable RetainPtr<WebControlView> m_drawingView;
+
     mutable RetainPtr<NSLevelIndicatorCell> m_levelIndicatorCell;
+    mutable RetainPtr<NSTextFieldCell> m_textFieldCell;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
@@ -42,13 +42,17 @@ public:
     ControlMac(ControlPart&, ControlFactoryMac&);
 
 protected:
-    using PlatformControl::draw;
+    static bool userPrefersContrast();
 
     void setFocusRingClipRect(const FloatRect& clipBounds) override;
 
     void updateCellStates(const FloatRect&, const ControlStyle&) override;
 
-    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *, NSView *, bool drawCell = true);
+    void drawCell(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&, NSCell *, NSView *, bool drawCell = true);
+
+#if ENABLE(DATALIST_ELEMENT)
+    void drawListButton(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&);
+#endif
 
     ControlFactoryMac& m_controlFactory;
 };

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.mm
@@ -94,7 +94,7 @@ void MeterMac::draw(GraphicsContext& context, const FloatRect& rect, float devic
 
     auto *view = m_controlFactory.drawingView(rect, style);
 
-    ControlMac::draw(context, rect, deviceScaleFactor, style, m_levelIndicatorCell.get(), view);
+    drawCell(context, rect, deviceScaleFactor, style, m_levelIndicatorCell.get(), view);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ControlMac.h"
+
+namespace WebCore {
+
+class TextFieldMac final : public ControlMac {
+public:
+    TextFieldMac(TextFieldPart& owningPart, ControlFactoryMac&, NSTextFieldCell *);
+
+private:
+    static bool shouldPaintCustomTextField(const ControlStyle&);
+
+    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) final;
+
+    RetainPtr<NSTextFieldCell> m_textFieldCell;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.mm
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "TextFieldMac.h"
+
+#if PLATFORM(MAC)
+
+#import "ControlFactoryMac.h"
+#import "LocalCurrentGraphicsContext.h"
+#import "TextFieldPart.h"
+#import "WebControlView.h"
+
+namespace WebCore {
+
+TextFieldMac::TextFieldMac(TextFieldPart& owningPart, ControlFactoryMac& controlFactory, NSTextFieldCell* textFieldCell)
+    : ControlMac(owningPart, controlFactory)
+    , m_textFieldCell(textFieldCell)
+{
+    ASSERT(m_textFieldCell);
+}
+
+bool TextFieldMac::shouldPaintCustomTextField(const ControlStyle& style)
+{
+    // <rdar://problem/88948646> Prevent AppKit from painting text fields in the light appearance
+    // with increased contrast, as the border is not painted, rendering the control invisible.
+    return userPrefersContrast() && !style.states.contains(ControlStyle::State::DarkAppearance);
+}
+
+void TextFieldMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+{
+    const auto& states = style.states;
+    auto enabled = states.contains(ControlStyle::State::Enabled) && !states.contains(ControlStyle::State::ReadOnly);
+
+    LocalCurrentGraphicsContext localContext(context);
+    GraphicsContextStateSaver stateSaver(context);
+
+    FloatRect paintRect(rect);
+
+    if (shouldPaintCustomTextField(style)) {
+        constexpr int strokeThickness = 1;
+
+        FloatRect strokeRect(paintRect);
+        strokeRect.inflate(-strokeThickness / 2.0f);
+
+        context.setStrokeColor(enabled ? Color::black : Color::darkGray);
+        context.setStrokeStyle(SolidStroke);
+        context.strokeRect(strokeRect, strokeThickness);
+    } else {
+        // <rdar://problem/22896977> We adjust the paint rect here to account for how AppKit draws the text
+        // field cell slightly smaller than the rect we pass to drawWithFrame.
+        AffineTransform transform = context.getCTM();
+        if (transform.xScale() > 1 || transform.yScale() > 1) {
+            paintRect.inflateX(1 / transform.xScale());
+            paintRect.inflateY(2 / transform.yScale());
+            paintRect.move(0, -1 / transform.yScale());
+        }
+        
+        auto *view = m_controlFactory.drawingView(rect, style);
+        
+        [m_textFieldCell.get() setEnabled:enabled];
+        [m_textFieldCell.get() drawWithFrame:NSRect(paintRect) inView:view];
+        [m_textFieldCell.get() setControlView:nil];
+    }
+
+#if ENABLE(DATALIST_ELEMENT)
+    if (states.contains(ControlStyle::State::ListButton))
+        drawListButton(context, rect, deviceScaleFactor, style);
+#endif
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/WebControlView.h
+++ b/Source/WebCore/platform/graphics/mac/controls/WebControlView.h
@@ -37,4 +37,7 @@
 @property (class) NSRect clipBounds;
 @end
 
+@interface WebControlTextFieldCell : NSTextFieldCell
+@end
+
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -541,7 +541,8 @@ public:
     bool pushContentsClip(PaintInfo&, const LayoutPoint& accumulatedOffset);
     void popContentsClip(PaintInfo&, PaintPhase originalPhase, const LayoutPoint& accumulatedOffset);
 
-    ControlPart* ensureControlPart();
+    ControlPart* ensureControlPartForRenderer();
+    ControlPart* ensureControlPartForBorderOnly();
 
     virtual void paintObject(PaintInfo&, const LayoutPoint&) { ASSERT_NOT_REACHED(); }
     virtual void paintBoxDecorations(PaintInfo&, const LayoutPoint&);

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -70,7 +70,8 @@ public:
     void adjustStyle(RenderStyle&, const Element*, const RenderStyle* userAgentAppearanceStyle);
 
     virtual bool canCreateControlPartForRenderer(const RenderObject&) const { return false; }
-    RefPtr<ControlPart> createControlPartForRenderer(const RenderObject&) const;
+    virtual bool canCreateControlPartForBorderOnly(const RenderObject&) const { return false; }
+    RefPtr<ControlPart> createControlPart(const RenderObject&) const;
 
     OptionSet<ControlStyle::State> extractControlStyleStatesForRenderer(const RenderObject&) const;
     ControlStyle extractControlStyleForRenderer(const RenderObject&) const;
@@ -396,6 +397,10 @@ public:
     bool isPresenting(const RenderObject&) const;
     bool isReadOnlyControl(const RenderObject&) const;
     bool isDefault(const RenderObject&) const;
+#if ENABLE(DATALIST_ELEMENT)
+    bool hasListButton(const RenderObject&) const;
+    bool hasListButtonPressed(const RenderObject&) const;
+#endif
 
 protected:
     struct ColorCache {

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -102,11 +102,11 @@ private:
 
     bool canPaint(const PaintInfo&, const Settings&, ControlPartType) const final;
     bool canCreateControlPartForRenderer(const RenderObject&) const final;
+    bool canCreateControlPartForBorderOnly(const RenderObject&) const final;
 
     bool useFormSemanticContext() const final;
     bool supportsLargeFormControls() const final;
 
-    bool paintTextField(const RenderObject&, const PaintInfo&, const FloatRect&) final;
     void adjustTextFieldStyle(RenderStyle&, const Element*) const final;
 
     bool paintTextArea(const RenderObject&, const PaintInfo&, const FloatRect&) final;
@@ -159,8 +159,6 @@ private:
 private:
     String fileListNameForWidth(const FileList*, const FontCascade&, int width, bool multipleFilesAllowed) const final;
 
-    bool shouldPaintCustomTextField(const RenderObject&) const;
-
     Color systemColor(CSSValueID, OptionSet<StyleColorOptions>) const final;
 
     // Get the control size based off the font. Used by some of the controls (like buttons).
@@ -199,7 +197,6 @@ private:
     NSMenu *searchMenuTemplate() const;
     NSSliderCell *sliderThumbHorizontal() const;
     NSSliderCell *sliderThumbVertical() const;
-    NSTextFieldCell *textField() const;
 #if ENABLE(DATALIST_ELEMENT)
     NSCell *listButton() const;
 #endif
@@ -221,7 +218,6 @@ private:
     mutable RetainPtr<NSMenu> m_searchMenuTemplate;
     mutable RetainPtr<NSSliderCell> m_sliderThumbHorizontal;
     mutable RetainPtr<NSSliderCell> m_sliderThumbVertical;
-    mutable RetainPtr<NSTextFieldCell> m_textField;
 #if ENABLE(SERVICE_CONTROLS)
     mutable RetainPtr<NSServicesRolloverButtonCell> m_servicesRolloverButton;
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -109,6 +109,7 @@
 #include <WebCore/SystemImage.h>
 #include <WebCore/TestReportBody.h>
 #include <WebCore/TextCheckerClient.h>
+#include <WebCore/TextFieldPart.h>
 #include <WebCore/TextIndicator.h>
 #include <WebCore/TransformOperation.h>
 #include <WebCore/TransformationMatrix.h>
@@ -1625,7 +1626,11 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
     case WebCore::ControlPartType::BorderlessAttachment:
 #endif
     case WebCore::ControlPartType::TextArea:
+        break;
+
     case WebCore::ControlPartType::TextField:
+        return WebCore::TextFieldPart::create();
+
     case WebCore::ControlPartType::CapsLockIndicator:
 #if ENABLE(INPUT_TYPE_COLOR)
     case WebCore::ControlPartType::ColorWell:

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2331,7 +2331,7 @@ enum class WebCore::FetchHeadersGuard : uint8_t {
     Response
 };
 
-[Nested OptionSet] enum class WebCore::ControlStyle::State : uint16_t {
+[Nested OptionSet] enum class WebCore::ControlStyle::State : unsigned {
     Hovered,
     Pressed,
     Focused,
@@ -2345,7 +2345,10 @@ enum class WebCore::FetchHeadersGuard : uint8_t {
     FormSemanticContext,
     DarkAppearance,
     RightToLeft,
-    LargeControls
+    LargeControls,
+    ReadOnly,
+    ListButton,
+    ListButtonPressed
 };
 
 [AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ControlStyle {


### PR DESCRIPTION
#### 8209e22dca2cc1df925cf2aae58a982a66a93dde
<pre>
[GPU Process] [FormControls] Add a ControlPart for TextField
<a href="https://bugs.webkit.org/show_bug.cgi?id=249573">https://bugs.webkit.org/show_bug.cgi?id=249573</a>
rdar://103508637

Reviewed by Simon Fraser and Aditya Keerthi.

NSTextFieldCell is used draw a border around the text field. CoreUI is used to
draw a list button if the text field has a data list.

* Source/WebCore/Headers.cmake:
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/spi/mac/NSTextFieldCellSPI.h: Added.
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/ControlPart.h:
* Source/WebCore/platform/graphics/controls/ControlStyle.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/controls/ControlStyle.h:
* Source/WebCore/platform/graphics/controls/TextFieldPart.h: Copied from Source/WebCore/platform/graphics/controls/ControlFactory.h.
(WebCore::TextFieldPart::create):
(WebCore::TextFieldPart::TextFieldPart):
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::levelIndicatorCell const):
(WebCore::ControlFactoryMac::textFieldCell const):
(WebCore::ControlFactoryMac::createPlatformTextField):
* Source/WebCore/platform/graphics/mac/controls/ControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::ControlMac::userPrefersContrast):
(WebCore::drawCellOrFocusRing):
(WebCore::ControlMac::drawCell):
(WebCore::ControlMac::drawListButton):
(WebCore::ControlMac::draw): Deleted.
* Source/WebCore/platform/graphics/mac/controls/MeterMac.mm:
(WebCore::MeterMac::draw):
* Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h: Copied from Source/WebCore/platform/graphics/controls/ControlFactory.h.
* Source/WebCore/platform/graphics/mac/controls/TextFieldMac.mm: Added.
(WebCore::TextFieldMac::TextFieldMac):
(WebCore::TextFieldMac::shouldPaintCustomTextField):
(WebCore::TextFieldMac::draw):
* Source/WebCore/platform/graphics/mac/controls/WebControlView.h:
* Source/WebCore/platform/graphics/mac/controls/WebControlView.mm:
(-[WebControlTextFieldCell _adjustedCoreUIDrawOptionsForDrawingBordersOnly:]):
(-[WebControlTextFieldCell _coreUIDrawOptionsWithFrame:inView:includeFocus:]):
(-[WebControlTextFieldCell _coreUIDrawOptionsWithFrame:inView:includeFocus:maskOnly:]):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::ensureControlPartForRenderer):
(WebCore::RenderBox::ensureControlPartForBorderOnly):
(WebCore::RenderBox::paintBoxDecorations):
(WebCore::RenderBox::ensureControlPart): Deleted.
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::createControlPart const):
(WebCore::RenderTheme::extractControlStyleStatesForRenderer const):
(WebCore::RenderTheme::hasListButton const):
(WebCore::RenderTheme::hasListButtonPressed const):
(WebCore::RenderTheme::createControlPartForRenderer const): Deleted.
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::canCreateControlPartForBorderOnly const):
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::canCreateControlPartForBorderOnly const):
(WebCore::RenderThemeMac::meterSizeForBounds const):
(WebCore::RenderThemeMac::shouldPaintCustomTextField const): Deleted.
(WebCore::RenderThemeMac::paintTextField): Deleted.
(WebCore::RenderThemeMac::textField const): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/258125@main">https://commits.webkit.org/258125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b89ef51cb89e6392a17e19e798c8464c2839eb4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110278 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170538 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/999 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93381 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108114 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34971 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23025 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3801 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24542 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/944 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44046 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5578 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5597 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->