### PR TITLE
Make URL lookalike character sanitization work with navigation

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -95,10 +95,6 @@
 #include "IPCTesterMessages.h"
 #endif
 
-#if PLATFORM(COCOA)
-#include "NetworkConnectionIntegrityHelpers.h"
-#endif
-
 #define CONNECTION_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [webProcessIdentifier=%" PRIu64 "] NetworkConnectionToWebProcess::" fmt, this, webProcessIdentifier().toUInt64(), ##__VA_ARGS__)
 #define CONNECTION_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [webProcessIdentifier=%" PRIu64 "] NetworkConnectionToWebProcess::" fmt, this, webProcessIdentifier().toUInt64(), ##__VA_ARGS__)
 
@@ -1441,15 +1437,6 @@ void NetworkConnectionToWebProcess::installMockContentFilter(WebCore::MockConten
 {
     MockContentFilterSettings::singleton() = WTFMove(settings);
 }
-#endif
-
-#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
-
-void NetworkConnectionToWebProcess::requestLookalikeCharacterStrings(CompletionHandler<void(const HashSet<String>&)>&& completionHandler)
-{
-    WebKit::requestLookalikeCharacterStrings(WTFMove(completionHandler));
-}
-
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -297,10 +297,6 @@ private:
     void getProcessDisplayName(audit_token_t, CompletionHandler<void(const String&)>&&);
 #endif
 
-#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
-    void requestLookalikeCharacterStrings(CompletionHandler<void(const HashSet<String>&)>&&);
-#endif
-
 #if USE(LIBWEBRTC)
     NetworkRTCProvider& rtcProvider();
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -116,8 +116,4 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
 #if ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
     InstallMockContentFilter(WebCore::MockContentFilterSettings settings)
 #endif
-
-#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
-    RequestLookalikeCharacterStrings() -> (HashSet<String> strings)
-#endif
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -106,6 +106,7 @@
 #if PLATFORM(COCOA)
 #include "CookieStorageUtilsCF.h"
 #include "LaunchServicesDatabaseObserver.h"
+#include "NetworkConnectionIntegrityHelpers.h"
 #include "NetworkSessionCocoa.h"
 #include <wtf/cocoa/Entitlements.h>
 #endif
@@ -2861,5 +2862,14 @@ void NetworkProcess::countNonDefaultSessionSets(PAL::SessionID sessionID, Comple
     auto* session = networkSession(sessionID);
     completionHandler(session ? session->countNonDefaultSessionSets() : 0);
 }
+
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+
+void NetworkProcess::requestLookalikeCharacterStrings(CompletionHandler<void(const Vector<String>&)>&& completionHandler)
+{
+    WebKit::requestLookalikeCharacterStrings(WTFMove(completionHandler));
+}
+
+#endif
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -493,6 +493,10 @@ private:
     void registerURLSchemeAsNoAccess(const String&) const;
     void registerURLSchemeAsCORSEnabled(const String&) const;
 
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+    void requestLookalikeCharacterStrings(CompletionHandler<void(const Vector<String>&)>&&);
+#endif
+
 #if PLATFORM(IOS_FAMILY)
     void setIsHoldingLockedFiles(bool);
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -228,4 +228,8 @@ messages -> NetworkProcess LegacyReceiver {
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     SetEmulatedConditions(PAL::SessionID sessionID, std::optional<int64_t> bytesPerSecondLimit)
 #endif
+
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+    RequestLookalikeCharacterStrings() -> (Vector<String> strings)
+#endif
 }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkConnectionIntegrityHelpers.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkConnectionIntegrityHelpers.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #import <wtf/CompletionHandler.h>
-#import <wtf/HashSet.h>
+#import <wtf/Vector.h>
 #import <wtf/text/WTFString.h>
 
 OBJC_CLASS NSURLSession;
@@ -36,7 +36,7 @@ namespace WebKit {
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
 
 void configureForNetworkConnectionIntegrity(NSURLSession *);
-void requestLookalikeCharacterStrings(CompletionHandler<void(const HashSet<String>&)>&&);
+void requestLookalikeCharacterStrings(CompletionHandler<void(const Vector<String>&)>&&);
 
 #endif
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebPageCreationParameters.cpp
@@ -200,6 +200,10 @@ void WebPageCreationParameters::encode(IPC::Encoder& encoder) const
 
     encoder << contentSecurityPolicyModeForExtension;
     encoder << mainFrameIdentifier;
+
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+    encoder << lookalikeCharacterStrings;
+#endif
 }
 
 std::optional<WebPageCreationParameters> WebPageCreationParameters::decode(IPC::Decoder& decoder)
@@ -634,6 +638,14 @@ std::optional<WebPageCreationParameters> WebPageCreationParameters::decode(IPC::
 
     if (!decoder.decode(parameters.mainFrameIdentifier))
         return std::nullopt;
+
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+    std::optional<Vector<String>> lookalikeCharacterStrings;
+    decoder >> lookalikeCharacterStrings;
+    if (!lookalikeCharacterStrings)
+        return std::nullopt;
+    parameters.lookalikeCharacterStrings = WTFMove(*lookalikeCharacterStrings);
+#endif
 
     return { WTFMove(parameters) };
 }

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -281,6 +281,10 @@ struct WebPageCreationParameters {
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension { WebCore::ContentSecurityPolicyModeForExtension::None };
 
     std::optional<WebCore::FrameIdentifier> mainFrameIdentifier;
+
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+    Vector<String> lookalikeCharacterStrings;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1847,6 +1847,15 @@ void NetworkProcessProxy::setEmulatedConditions(PAL::SessionID sessionID, std::o
 
 #endif // ENABLE(INSPECTOR_NETWORK_THROTTLING)
 
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+
+void NetworkProcessProxy::requestLookalikeCharacterStrings(CompletionHandler<void(Vector<String>&&)>&& completion)
+{
+    sendWithAsyncReply(Messages::NetworkProcess::RequestLookalikeCharacterStrings(), WTFMove(completion), 0);
+}
+
+#endif // ENABLE(NETWORK_CONNECTION_INTEGRITY)
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -213,6 +213,8 @@ public:
     void setDomainsWithCrossPageStorageAccess(HashMap<TopFrameDomain, SubResourceDomain>&&, CompletionHandler<void()>&&);
 #endif
 
+    void requestLookalikeCharacterStrings(CompletionHandler<void(Vector<String>&&)>&&);
+
     void setPrivateClickMeasurementDebugMode(PAL::SessionID, bool);
     
     void synthesizeAppIsBackground(bool background);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2713,6 +2713,11 @@ private:
     static bool isInHardwareKeyboardMode();
 #endif
 
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+    static Vector<String>& cachedLookalikeStrings();
+    void updateLookalikeCharacterStringsIfNeeded();
+#endif
+
 #if USE(RUNNINGBOARD)
     void clearAudibleActivity();
 #endif
@@ -3322,6 +3327,10 @@ private:
     bool m_isRunningModalJavaScriptDialog { false };
     bool m_isSuspended { false };
     bool m_isLockdownModeExplicitlySet { false };
+
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+    bool m_shouldUpdateLookalikeCharacterStrings { false };
+#endif
 
     std::optional<PrivateClickMeasurementAndMetadata> m_privateClickMeasurement;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1654,7 +1654,7 @@ private:
 #endif
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
-    void updateLookalikeCharacterStringsIfNeeded();
+    void setLookalikeCharacterStrings(Vector<String>&&);
 #endif
 
 #if ENABLE(META_VIEWPORT)
@@ -2559,8 +2559,6 @@ private:
 #endif
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
-    bool m_sanitizeLookalikeCharactersInLinksEnabled { false };
-    bool m_shouldUpdateLookalikeCharacterStrings { true };
     HashSet<String> m_lookalikeCharacterStrings;
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -710,4 +710,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 #endif
 
     GenerateTestReport(String message, String group);
+
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+    SetLookalikeCharacterStrings(Vector<String> strings);
+#endif
 }


### PR DESCRIPTION
#### 4ad38bf6ac68c303cf131eb31793098cfaeb38a1
<pre>
Make URL lookalike character sanitization work with navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=249578">https://bugs.webkit.org/show_bug.cgi?id=249578</a>

Reviewed by Tim Horton.

Make URL lookalike character sanitization apply to URLs upon top-level navigation. See below for
more details.

* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::sanitizeLookalikeCharactersIfNecessary):
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):

Hook into content extension code to redirect to the new URL, in the case where we applied lookalike
sanitization. This is similar to how HTTPS upgrade logic works (under the call to
`makeSecureIfNecessary`, above).

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::requestLookalikeCharacterStrings): Deleted.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:

Move this existing code out of `NetworkConnectionToWebProcess`, and into `NetworkProcess` instead.
See comments below for more details.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::requestLookalikeCharacterStrings):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:

Add a method to `NetworkProcess(Proxy)` that can be used to request lookalike character strings.
This logic was previously on `NetworkConnectionToWebProcess`, since the web process directly
requested this information from the network process; however, since we now cache these strings UI-
process-side before delivering them to the web process, it makes more sense for this functionality
to move to the IPC boundaries between the UI and network processes (i.e. `NetworkProcessProxy` and
`NetworkProcess`).

* Source/WebKit/NetworkProcess/cocoa/NetworkConnectionIntegrityHelpers.h:
* Source/WebKit/Shared/WebPageCreationParameters.cpp:
(WebKit::WebPageCreationParameters::encode const):
(WebKit::WebPageCreationParameters::decode):
* Source/WebKit/Shared/WebPageCreationParameters.h:

Add a list of lookalike character strings to creation parameters, so that if we&apos;ve previously
requested and cached them in the UI process, they can become available in the web process
immediately upon process initialization.

* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::requestLookalikeCharacterStrings):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::didCommitLoadForFrame):

See below for more details.

(WebKit::WebPageProxy::createNewPage):
(WebKit::WebPageProxy::creationParameters):

Pass in `cachedLookalikeStrings()` when putting together creation parameters for the new page.

(WebKit::WebPageProxy::cachedLookalikeStrings):

Maintain a cached list of lookalike strings in the UI process.

(WebKit::WebPageProxy::updateLookalikeCharacterStringsIfNeeded):
* Source/WebKit/UIProcess/WebPageProxy.h:

Add a flag to indicate whether the list of lookalike strings needs to be updated after we begin
loading the web page. This is set when creating a new web page, only if the list of strings was not
already cached in the UI process upon page creation. In this case, we pass an empty `Vector&lt;String&gt;`
to the web process via creation parameters; after committing the load, we update the cached list in
the UI process, and send the updated results to the web page.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):
(WebKit::WebPage::updatePreferences):
(WebKit::WebPage::didCommitLoad):
(WebKit::WebPage::setLookalikeCharacterStrings):

Add an IPC message to the web page, to update the list of lookalike strings.

(WebKit::WebPage::updateLookalikeCharacterStringsIfNeeded): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/258169@main">https://commits.webkit.org/258169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef3c16f10922526284ba3ee0f671f7f1fb788abb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110390 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1120 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108219 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106873 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/93502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3939 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10048 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/44148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5608 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5702 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->