### PR TITLE
Update CSS-Typed-OM tests to more consistently add range checks for properties not allowing negative values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'animation-duration' to CSS-wide keywords: unset
 PASS Can set 'animation-duration' to CSS-wide keywords: revert
 PASS Can set 'animation-duration' to var() references:  var(--A)
 PASS Can set 'animation-duration' to a time: 0s
-FAIL Can set 'animation-duration' to a time: -3.14ms assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'animation-duration' to a time: -3.14ms assert_approx_equals: expected -0.00314 +/- 0.000001 but got 0
 PASS Can set 'animation-duration' to a time: 3.14s
 PASS Can set 'animation-duration' to a time: calc(0s + 0ms)
 PASS Setting 'animation-duration' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration.html
@@ -13,7 +13,10 @@
 'use strict';
 
 runListValuedPropertyTests('animation-duration', [
-  { syntax: '<time>' },
+  {
+    syntax: '<time>',
+    specified: assert_is_equal_with_range_handling
+  },
 ]);
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt
@@ -6,7 +6,7 @@ PASS Can set 'animation-iteration-count' to CSS-wide keywords: revert
 PASS Can set 'animation-iteration-count' to var() references:  var(--A)
 PASS Can set 'animation-iteration-count' to the 'infinite' keyword: infinite
 PASS Can set 'animation-iteration-count' to a number: 0
-FAIL Can set 'animation-iteration-count' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'animation-iteration-count' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'animation-iteration-count' to a number: 3.14
 PASS Can set 'animation-iteration-count' to a number: calc(2 + 3)
 PASS Setting 'animation-iteration-count' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count.html
@@ -15,7 +15,10 @@
 
 runListValuedPropertyTests('animation-iteration-count', [
   { syntax: 'infinite' },
-  { syntax: '<number>' },
+  {
+    syntax: '<number>',
+    specified: assert_is_equal_with_range_handling
+  },
 ]);
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt
@@ -5,11 +5,11 @@ PASS Can set 'background-size' to CSS-wide keywords: unset
 PASS Can set 'background-size' to CSS-wide keywords: revert
 PASS Can set 'background-size' to var() references:  var(--A)
 PASS Can set 'background-size' to a length: 0px
-FAIL Can set 'background-size' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'background-size' to a length: -3.14em
 PASS Can set 'background-size' to a length: 3.14cm
 PASS Can set 'background-size' to a length: calc(0px + 0em)
 PASS Can set 'background-size' to a percent: 0%
-FAIL Can set 'background-size' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'background-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'background-size' to a percent: 3.14%
 PASS Can set 'background-size' to a percent: calc(0% + 0%)
 PASS Can set 'background-size' to the 'auto' keyword: auto

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size.html
@@ -14,8 +14,14 @@
 'use strict';
 
 runListValuedPropertyTests('background-size', [
-  { syntax: '<length>' },
-  { syntax: '<percentage>' },
+  {
+    syntax: '<length>',
+    specified: assert_is_equal_with_range_handling
+  },
+  {
+    syntax: '<percentage>',
+    specified: assert_is_equal_with_range_handling
+  },
   { syntax: 'auto' },
   { syntax: 'cover' },
   { syntax: 'contain' },

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset-expected.txt
@@ -5,11 +5,11 @@ PASS Can set 'border-image-outset' to CSS-wide keywords: unset
 PASS Can set 'border-image-outset' to CSS-wide keywords: revert
 PASS Can set 'border-image-outset' to var() references:  var(--A)
 PASS Can set 'border-image-outset' to a length: 0px
-FAIL Can set 'border-image-outset' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-image-outset' to a length: -3.14em
 PASS Can set 'border-image-outset' to a length: 3.14cm
 PASS Can set 'border-image-outset' to a length: calc(0px + 0em)
 PASS Can set 'border-image-outset' to a number: 0
-FAIL Can set 'border-image-outset' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-image-outset' to a number: -3.14
 PASS Can set 'border-image-outset' to a number: 3.14
 PASS Can set 'border-image-outset' to a number: calc(2 + 3)
 PASS Setting 'border-image-outset' to a percent: 0% throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset.html
@@ -18,10 +18,12 @@ runPropertyTests('border-image-outset', [
   // Typed OM level 1.
   {
     syntax: '<length>',
+    specified: assert_is_equal_with_range_handling,
     computed: (_, result) => assert_is_unsupported(result)
   },
   {
     syntax: '<number>',
+    specified: assert_is_equal_with_range_handling,
     computed: (_, result) => assert_is_unsupported(result)
   },
 ]);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice-expected.txt
@@ -5,11 +5,11 @@ PASS Can set 'border-image-slice' to CSS-wide keywords: unset
 PASS Can set 'border-image-slice' to CSS-wide keywords: revert
 PASS Can set 'border-image-slice' to var() references:  var(--A)
 PASS Can set 'border-image-slice' to a number: 0
-FAIL Can set 'border-image-slice' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-image-slice' to a number: -3.14
 PASS Can set 'border-image-slice' to a number: 3.14
 PASS Can set 'border-image-slice' to a number: calc(2 + 3)
 PASS Can set 'border-image-slice' to a percent: 0%
-FAIL Can set 'border-image-slice' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-image-slice' to a percent: -3.14%
 PASS Can set 'border-image-slice' to a percent: 3.14%
 PASS Can set 'border-image-slice' to a percent: calc(0% + 0%)
 PASS Setting 'border-image-slice' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice.html
@@ -18,10 +18,12 @@ runPropertyTests('border-image-slice', [
   // Typed OM level 1.
   {
     syntax: '<number>',
+    specified: assert_is_equal_with_range_handling,
     computed: (_, result) => assert_is_unsupported(result)
   },
   {
     syntax: '<percentage>',
+    specified: assert_is_equal_with_range_handling,
     computed: (_, result) => assert_is_unsupported(result)
   },
 ]);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width-expected.txt
@@ -5,15 +5,15 @@ PASS Can set 'border-image-width' to CSS-wide keywords: unset
 PASS Can set 'border-image-width' to CSS-wide keywords: revert
 PASS Can set 'border-image-width' to var() references:  var(--A)
 PASS Can set 'border-image-width' to a length: 0px
-FAIL Can set 'border-image-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-image-width' to a length: -3.14em
 PASS Can set 'border-image-width' to a length: 3.14cm
 PASS Can set 'border-image-width' to a length: calc(0px + 0em)
 PASS Can set 'border-image-width' to a percent: 0%
-FAIL Can set 'border-image-width' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-image-width' to a percent: -3.14%
 PASS Can set 'border-image-width' to a percent: 3.14%
 PASS Can set 'border-image-width' to a percent: calc(0% + 0%)
 PASS Can set 'border-image-width' to a number: 0
-FAIL Can set 'border-image-width' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-image-width' to a number: -3.14
 PASS Can set 'border-image-width' to a number: 3.14
 PASS Can set 'border-image-width' to a number: calc(2 + 3)
 PASS Can set 'border-image-width' to the 'auto' keyword: auto

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width.html
@@ -18,14 +18,17 @@ runPropertyTests('border-image-width', [
   // Typed OM level 1.
   {
     syntax: '<length>',
+    specified: assert_is_equal_with_range_handling,
     computed: (_, result) => assert_is_unsupported(result)
   },
   {
     syntax: '<percentage>',
+    specified: assert_is_equal_with_range_handling,
     computed: (_, result) => assert_is_unsupported(result)
   },
   {
     syntax: '<number>',
+    specified: assert_is_equal_with_range_handling,
     computed: (_, result) => assert_is_unsupported(result)
   },
   {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt
@@ -5,11 +5,11 @@ PASS Can set 'border-top-left-radius' to CSS-wide keywords: unset
 PASS Can set 'border-top-left-radius' to CSS-wide keywords: revert
 PASS Can set 'border-top-left-radius' to var() references:  var(--A)
 PASS Can set 'border-top-left-radius' to a length: 0px
-FAIL Can set 'border-top-left-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-top-left-radius' to a length: -3.14em
 PASS Can set 'border-top-left-radius' to a length: 3.14cm
 PASS Can set 'border-top-left-radius' to a length: calc(0px + 0em)
 PASS Can set 'border-top-left-radius' to a percent: 0%
-FAIL Can set 'border-top-left-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-top-left-radius' to a percent: -3.14%
 PASS Can set 'border-top-left-radius' to a percent: 3.14%
 PASS Can set 'border-top-left-radius' to a percent: calc(0% + 0%)
 PASS Setting 'border-top-left-radius' to a time: 0s throws TypeError
@@ -36,11 +36,11 @@ PASS Can set 'border-top-right-radius' to CSS-wide keywords: unset
 PASS Can set 'border-top-right-radius' to CSS-wide keywords: revert
 PASS Can set 'border-top-right-radius' to var() references:  var(--A)
 PASS Can set 'border-top-right-radius' to a length: 0px
-FAIL Can set 'border-top-right-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-top-right-radius' to a length: -3.14em
 PASS Can set 'border-top-right-radius' to a length: 3.14cm
 PASS Can set 'border-top-right-radius' to a length: calc(0px + 0em)
 PASS Can set 'border-top-right-radius' to a percent: 0%
-FAIL Can set 'border-top-right-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-top-right-radius' to a percent: -3.14%
 PASS Can set 'border-top-right-radius' to a percent: 3.14%
 PASS Can set 'border-top-right-radius' to a percent: calc(0% + 0%)
 PASS Setting 'border-top-right-radius' to a time: 0s throws TypeError
@@ -67,11 +67,11 @@ PASS Can set 'border-bottom-left-radius' to CSS-wide keywords: unset
 PASS Can set 'border-bottom-left-radius' to CSS-wide keywords: revert
 PASS Can set 'border-bottom-left-radius' to var() references:  var(--A)
 PASS Can set 'border-bottom-left-radius' to a length: 0px
-FAIL Can set 'border-bottom-left-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-bottom-left-radius' to a length: -3.14em
 PASS Can set 'border-bottom-left-radius' to a length: 3.14cm
 PASS Can set 'border-bottom-left-radius' to a length: calc(0px + 0em)
 PASS Can set 'border-bottom-left-radius' to a percent: 0%
-FAIL Can set 'border-bottom-left-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-bottom-left-radius' to a percent: -3.14%
 PASS Can set 'border-bottom-left-radius' to a percent: 3.14%
 PASS Can set 'border-bottom-left-radius' to a percent: calc(0% + 0%)
 PASS Setting 'border-bottom-left-radius' to a time: 0s throws TypeError
@@ -98,11 +98,11 @@ PASS Can set 'border-bottom-right-radius' to CSS-wide keywords: unset
 PASS Can set 'border-bottom-right-radius' to CSS-wide keywords: revert
 PASS Can set 'border-bottom-right-radius' to var() references:  var(--A)
 PASS Can set 'border-bottom-right-radius' to a length: 0px
-FAIL Can set 'border-bottom-right-radius' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-bottom-right-radius' to a length: -3.14em
 PASS Can set 'border-bottom-right-radius' to a length: 3.14cm
 PASS Can set 'border-bottom-right-radius' to a length: calc(0px + 0em)
 PASS Can set 'border-bottom-right-radius' to a percent: 0%
-FAIL Can set 'border-bottom-right-radius' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-bottom-right-radius' to a percent: -3.14%
 PASS Can set 'border-bottom-right-radius' to a percent: 3.14%
 PASS Can set 'border-bottom-right-radius' to a percent: calc(0% + 0%)
 PASS Setting 'border-bottom-right-radius' to a time: 0s throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius.html
@@ -19,10 +19,12 @@ for (const suffix of ['top-left', 'top-right', 'bottom-left', 'bottom-right']) {
   runPropertyTests('border-' + suffix + '-radius', [
     {
       syntax: '<length>',
+      specified: assert_is_equal_with_range_handling,
       computed: (_, result) => assert_is_unsupported(result)
     },
     {
       syntax: '<percentage>',
+      specified: assert_is_equal_with_range_handling,
       computed: (_, result) => assert_is_unsupported(result)
     },
   ]);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt
@@ -8,7 +8,7 @@ PASS Can set 'font-weight' to the 'normal' keyword: normal
 PASS Can set 'font-weight' to the 'bold' keyword: bold
 PASS Can set 'font-weight' to the 'bolder' keyword: bolder
 PASS Can set 'font-weight' to the 'lighter' keyword: lighter
-FAIL Can set 'font-weight' to a number: 0 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'font-weight' to a number: 0
 FAIL Can set 'font-weight' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 FAIL Can set 'font-weight' to a number: 3.14 assert_approx_equals: expected 3.14 +/- 0.000001 but got 3
 PASS Can set 'font-weight' to a number: calc(2 + 3)

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight.html
@@ -38,7 +38,7 @@ runPropertyTests('font-weight', [
     syntax: '<number>',
     specified: (input, result) => {
       if (input instanceof CSSUnitValue &&
-          (input.value < 0 || input.value > 1000))
+          (input.value < 1 || input.value > 1000))
         assert_style_value_equals(result, new CSSMathSum(input));
       else
         assert_style_value_equals(result, input);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
@@ -8,11 +8,11 @@ PASS Can set 'grid-auto-columns' to the 'min-content' keyword: min-content
 PASS Can set 'grid-auto-columns' to the 'max-content' keyword: max-content
 PASS Can set 'grid-auto-columns' to the 'auto' keyword: auto
 PASS Can set 'grid-auto-columns' to a length: 0px
-FAIL Can set 'grid-auto-columns' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'grid-auto-columns' to a length: -3.14em
 PASS Can set 'grid-auto-columns' to a length: 3.14cm
 PASS Can set 'grid-auto-columns' to a length: calc(0px + 0em)
 PASS Can set 'grid-auto-columns' to a percent: 0%
-FAIL Can set 'grid-auto-columns' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'grid-auto-columns' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'grid-auto-columns' to a percent: 3.14%
 PASS Can set 'grid-auto-columns' to a percent: calc(0% + 0%)
 PASS Can set 'grid-auto-columns' to a flexible length: 0fr
@@ -44,11 +44,11 @@ PASS Can set 'grid-auto-rows' to the 'min-content' keyword: min-content
 PASS Can set 'grid-auto-rows' to the 'max-content' keyword: max-content
 PASS Can set 'grid-auto-rows' to the 'auto' keyword: auto
 PASS Can set 'grid-auto-rows' to a length: 0px
-FAIL Can set 'grid-auto-rows' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'grid-auto-rows' to a length: -3.14em
 PASS Can set 'grid-auto-rows' to a length: 3.14cm
 PASS Can set 'grid-auto-rows' to a length: calc(0px + 0em)
 PASS Can set 'grid-auto-rows' to a percent: 0%
-FAIL Can set 'grid-auto-rows' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'grid-auto-rows' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'grid-auto-rows' to a percent: 3.14%
 PASS Can set 'grid-auto-rows' to a percent: calc(0% + 0%)
 PASS Can set 'grid-auto-rows' to a flexible length: 0fr

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows.html
@@ -20,8 +20,14 @@ for (const suffix of ['columns', 'rows']) {
     { syntax: 'min-content' },
     { syntax: 'max-content' },
     { syntax: 'auto' },
-    { syntax: '<length>' },
-    { syntax: '<percentage>' },
+    {
+      syntax: '<length>',
+      specified: assert_is_equal_with_range_handling
+    },
+    {
+      syntax: '<percentage>',
+      specified: assert_is_equal_with_range_handling
+    },
     { syntax: '<flex>' },
   ]);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
@@ -185,6 +185,192 @@ PASS Setting 'margin-inline' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'margin-inline' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'margin-inline' to a transform: perspective(10em) throws TypeError
 PASS Setting 'margin-inline' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS Can set 'padding-block-start' to CSS-wide keywords: initial
+PASS Can set 'padding-block-start' to CSS-wide keywords: inherit
+PASS Can set 'padding-block-start' to CSS-wide keywords: unset
+PASS Can set 'padding-block-start' to CSS-wide keywords: revert
+PASS Can set 'padding-block-start' to var() references:  var(--A)
+PASS Can set 'padding-block-start' to a percent: 0%
+FAIL Can set 'padding-block-start' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-block-start' to a percent: 3.14%
+PASS Can set 'padding-block-start' to a percent: calc(0% + 0%)
+PASS Can set 'padding-block-start' to a length: 0px
+PASS Can set 'padding-block-start' to a length: -3.14em
+PASS Can set 'padding-block-start' to a length: 3.14cm
+PASS Can set 'padding-block-start' to a length: calc(0px + 0em)
+PASS Setting 'padding-block-start' to a time: 0s throws TypeError
+PASS Setting 'padding-block-start' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-block-start' to a time: 3.14s throws TypeError
+PASS Setting 'padding-block-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-block-start' to an angle: 0deg throws TypeError
+PASS Setting 'padding-block-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-block-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-block-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-block-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-block-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-block-start' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-block-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-block-start' to a number: -3.14 throws TypeError
+PASS Setting 'padding-block-start' to a number: 3.14 throws TypeError
+PASS Setting 'padding-block-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-block-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-block-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-block-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS Can set 'padding-block-end' to CSS-wide keywords: initial
+PASS Can set 'padding-block-end' to CSS-wide keywords: inherit
+PASS Can set 'padding-block-end' to CSS-wide keywords: unset
+PASS Can set 'padding-block-end' to CSS-wide keywords: revert
+PASS Can set 'padding-block-end' to var() references:  var(--A)
+PASS Can set 'padding-block-end' to a percent: 0%
+FAIL Can set 'padding-block-end' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-block-end' to a percent: 3.14%
+PASS Can set 'padding-block-end' to a percent: calc(0% + 0%)
+PASS Can set 'padding-block-end' to a length: 0px
+PASS Can set 'padding-block-end' to a length: -3.14em
+PASS Can set 'padding-block-end' to a length: 3.14cm
+PASS Can set 'padding-block-end' to a length: calc(0px + 0em)
+PASS Setting 'padding-block-end' to a time: 0s throws TypeError
+PASS Setting 'padding-block-end' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-block-end' to a time: 3.14s throws TypeError
+PASS Setting 'padding-block-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-block-end' to an angle: 0deg throws TypeError
+PASS Setting 'padding-block-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-block-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-block-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-block-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-block-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-block-end' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-block-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-block-end' to a number: -3.14 throws TypeError
+PASS Setting 'padding-block-end' to a number: 3.14 throws TypeError
+PASS Setting 'padding-block-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-block-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-block-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-block-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS Can set 'padding-inline-start' to CSS-wide keywords: initial
+PASS Can set 'padding-inline-start' to CSS-wide keywords: inherit
+PASS Can set 'padding-inline-start' to CSS-wide keywords: unset
+PASS Can set 'padding-inline-start' to CSS-wide keywords: revert
+PASS Can set 'padding-inline-start' to var() references:  var(--A)
+PASS Can set 'padding-inline-start' to a percent: 0%
+FAIL Can set 'padding-inline-start' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-inline-start' to a percent: 3.14%
+PASS Can set 'padding-inline-start' to a percent: calc(0% + 0%)
+PASS Can set 'padding-inline-start' to a length: 0px
+PASS Can set 'padding-inline-start' to a length: -3.14em
+PASS Can set 'padding-inline-start' to a length: 3.14cm
+PASS Can set 'padding-inline-start' to a length: calc(0px + 0em)
+PASS Setting 'padding-inline-start' to a time: 0s throws TypeError
+PASS Setting 'padding-inline-start' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-inline-start' to a time: 3.14s throws TypeError
+PASS Setting 'padding-inline-start' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-inline-start' to an angle: 0deg throws TypeError
+PASS Setting 'padding-inline-start' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-inline-start' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-inline-start' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-inline-start' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-inline-start' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-inline-start' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-inline-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-inline-start' to a number: -3.14 throws TypeError
+PASS Setting 'padding-inline-start' to a number: 3.14 throws TypeError
+PASS Setting 'padding-inline-start' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-inline-start' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-inline-start' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-inline-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS Can set 'padding-inline-end' to CSS-wide keywords: initial
+PASS Can set 'padding-inline-end' to CSS-wide keywords: inherit
+PASS Can set 'padding-inline-end' to CSS-wide keywords: unset
+PASS Can set 'padding-inline-end' to CSS-wide keywords: revert
+PASS Can set 'padding-inline-end' to var() references:  var(--A)
+PASS Can set 'padding-inline-end' to a percent: 0%
+FAIL Can set 'padding-inline-end' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-inline-end' to a percent: 3.14%
+PASS Can set 'padding-inline-end' to a percent: calc(0% + 0%)
+PASS Can set 'padding-inline-end' to a length: 0px
+PASS Can set 'padding-inline-end' to a length: -3.14em
+PASS Can set 'padding-inline-end' to a length: 3.14cm
+PASS Can set 'padding-inline-end' to a length: calc(0px + 0em)
+PASS Setting 'padding-inline-end' to a time: 0s throws TypeError
+PASS Setting 'padding-inline-end' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-inline-end' to a time: 3.14s throws TypeError
+PASS Setting 'padding-inline-end' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-inline-end' to an angle: 0deg throws TypeError
+PASS Setting 'padding-inline-end' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-inline-end' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-inline-end' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-inline-end' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-inline-end' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-inline-end' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-inline-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-inline-end' to a number: -3.14 throws TypeError
+PASS Setting 'padding-inline-end' to a number: 3.14 throws TypeError
+PASS Setting 'padding-inline-end' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-inline-end' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-inline-end' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-inline-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL Can set 'padding-block' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'padding-block' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to a percent: -3.14% Bad value for shorthand CSS property
+FAIL Can set 'padding-block' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to a percent: calc(0% + 0%) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to a length: -3.14em Bad value for shorthand CSS property
+FAIL Can set 'padding-block' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-block' to a length: calc(0px + 0em) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+PASS Setting 'padding-block' to a time: 0s throws TypeError
+PASS Setting 'padding-block' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-block' to a time: 3.14s throws TypeError
+PASS Setting 'padding-block' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-block' to an angle: 0deg throws TypeError
+PASS Setting 'padding-block' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-block' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-block' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-block' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-block' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-block' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-block' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-block' to a number: -3.14 throws TypeError
+PASS Setting 'padding-block' to a number: 3.14 throws TypeError
+PASS Setting 'padding-block' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-block' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-block' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-block' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL Can set 'padding-inline' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to var() references:  var(--A) assert_equals: expected 2 but got 1
+FAIL Can set 'padding-inline' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to a percent: -3.14% Bad value for shorthand CSS property
+FAIL Can set 'padding-inline' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to a percent: calc(0% + 0%) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to a length: -3.14em Bad value for shorthand CSS property
+FAIL Can set 'padding-inline' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+FAIL Can set 'padding-inline' to a length: calc(0px + 0em) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
+PASS Setting 'padding-inline' to a time: 0s throws TypeError
+PASS Setting 'padding-inline' to a time: -3.14ms throws TypeError
+PASS Setting 'padding-inline' to a time: 3.14s throws TypeError
+PASS Setting 'padding-inline' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'padding-inline' to an angle: 0deg throws TypeError
+PASS Setting 'padding-inline' to an angle: 3.14rad throws TypeError
+PASS Setting 'padding-inline' to an angle: -3.14deg throws TypeError
+PASS Setting 'padding-inline' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'padding-inline' to a flexible length: 0fr throws TypeError
+PASS Setting 'padding-inline' to a flexible length: 1fr throws TypeError
+PASS Setting 'padding-inline' to a flexible length: -3.14fr throws TypeError
+FAIL Setting 'padding-inline' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-inline' to a number: -3.14 throws TypeError
+PASS Setting 'padding-inline' to a number: 3.14 throws TypeError
+PASS Setting 'padding-inline' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'padding-inline' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'padding-inline' to a transform: perspective(10em) throws TypeError
+PASS Setting 'padding-inline' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 PASS Can set 'inset-block-start' to CSS-wide keywords: initial
 PASS Can set 'inset-block-start' to CSS-wide keywords: inherit
 PASS Can set 'inset-block-start' to CSS-wide keywords: unset
@@ -371,192 +557,6 @@ PASS Setting 'inset-inline' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'inset-inline' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'inset-inline' to a transform: perspective(10em) throws TypeError
 PASS Setting 'inset-inline' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-PASS Can set 'padding-block-start' to CSS-wide keywords: initial
-PASS Can set 'padding-block-start' to CSS-wide keywords: inherit
-PASS Can set 'padding-block-start' to CSS-wide keywords: unset
-PASS Can set 'padding-block-start' to CSS-wide keywords: revert
-PASS Can set 'padding-block-start' to var() references:  var(--A)
-PASS Can set 'padding-block-start' to a percent: 0%
-FAIL Can set 'padding-block-start' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-PASS Can set 'padding-block-start' to a percent: 3.14%
-PASS Can set 'padding-block-start' to a percent: calc(0% + 0%)
-PASS Can set 'padding-block-start' to a length: 0px
-FAIL Can set 'padding-block-start' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-PASS Can set 'padding-block-start' to a length: 3.14cm
-PASS Can set 'padding-block-start' to a length: calc(0px + 0em)
-PASS Setting 'padding-block-start' to a time: 0s throws TypeError
-PASS Setting 'padding-block-start' to a time: -3.14ms throws TypeError
-PASS Setting 'padding-block-start' to a time: 3.14s throws TypeError
-PASS Setting 'padding-block-start' to a time: calc(0s + 0ms) throws TypeError
-PASS Setting 'padding-block-start' to an angle: 0deg throws TypeError
-PASS Setting 'padding-block-start' to an angle: 3.14rad throws TypeError
-PASS Setting 'padding-block-start' to an angle: -3.14deg throws TypeError
-PASS Setting 'padding-block-start' to an angle: calc(0rad + 0deg) throws TypeError
-PASS Setting 'padding-block-start' to a flexible length: 0fr throws TypeError
-PASS Setting 'padding-block-start' to a flexible length: 1fr throws TypeError
-PASS Setting 'padding-block-start' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'padding-block-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-block-start' to a number: -3.14 throws TypeError
-PASS Setting 'padding-block-start' to a number: 3.14 throws TypeError
-PASS Setting 'padding-block-start' to a number: calc(2 + 3) throws TypeError
-PASS Setting 'padding-block-start' to a transform: translate(50%, 50%) throws TypeError
-PASS Setting 'padding-block-start' to a transform: perspective(10em) throws TypeError
-PASS Setting 'padding-block-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-PASS Can set 'padding-block-end' to CSS-wide keywords: initial
-PASS Can set 'padding-block-end' to CSS-wide keywords: inherit
-PASS Can set 'padding-block-end' to CSS-wide keywords: unset
-PASS Can set 'padding-block-end' to CSS-wide keywords: revert
-PASS Can set 'padding-block-end' to var() references:  var(--A)
-PASS Can set 'padding-block-end' to a percent: 0%
-FAIL Can set 'padding-block-end' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-PASS Can set 'padding-block-end' to a percent: 3.14%
-PASS Can set 'padding-block-end' to a percent: calc(0% + 0%)
-PASS Can set 'padding-block-end' to a length: 0px
-FAIL Can set 'padding-block-end' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-PASS Can set 'padding-block-end' to a length: 3.14cm
-PASS Can set 'padding-block-end' to a length: calc(0px + 0em)
-PASS Setting 'padding-block-end' to a time: 0s throws TypeError
-PASS Setting 'padding-block-end' to a time: -3.14ms throws TypeError
-PASS Setting 'padding-block-end' to a time: 3.14s throws TypeError
-PASS Setting 'padding-block-end' to a time: calc(0s + 0ms) throws TypeError
-PASS Setting 'padding-block-end' to an angle: 0deg throws TypeError
-PASS Setting 'padding-block-end' to an angle: 3.14rad throws TypeError
-PASS Setting 'padding-block-end' to an angle: -3.14deg throws TypeError
-PASS Setting 'padding-block-end' to an angle: calc(0rad + 0deg) throws TypeError
-PASS Setting 'padding-block-end' to a flexible length: 0fr throws TypeError
-PASS Setting 'padding-block-end' to a flexible length: 1fr throws TypeError
-PASS Setting 'padding-block-end' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'padding-block-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-block-end' to a number: -3.14 throws TypeError
-PASS Setting 'padding-block-end' to a number: 3.14 throws TypeError
-PASS Setting 'padding-block-end' to a number: calc(2 + 3) throws TypeError
-PASS Setting 'padding-block-end' to a transform: translate(50%, 50%) throws TypeError
-PASS Setting 'padding-block-end' to a transform: perspective(10em) throws TypeError
-PASS Setting 'padding-block-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-PASS Can set 'padding-inline-start' to CSS-wide keywords: initial
-PASS Can set 'padding-inline-start' to CSS-wide keywords: inherit
-PASS Can set 'padding-inline-start' to CSS-wide keywords: unset
-PASS Can set 'padding-inline-start' to CSS-wide keywords: revert
-PASS Can set 'padding-inline-start' to var() references:  var(--A)
-PASS Can set 'padding-inline-start' to a percent: 0%
-FAIL Can set 'padding-inline-start' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-PASS Can set 'padding-inline-start' to a percent: 3.14%
-PASS Can set 'padding-inline-start' to a percent: calc(0% + 0%)
-PASS Can set 'padding-inline-start' to a length: 0px
-FAIL Can set 'padding-inline-start' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-PASS Can set 'padding-inline-start' to a length: 3.14cm
-PASS Can set 'padding-inline-start' to a length: calc(0px + 0em)
-PASS Setting 'padding-inline-start' to a time: 0s throws TypeError
-PASS Setting 'padding-inline-start' to a time: -3.14ms throws TypeError
-PASS Setting 'padding-inline-start' to a time: 3.14s throws TypeError
-PASS Setting 'padding-inline-start' to a time: calc(0s + 0ms) throws TypeError
-PASS Setting 'padding-inline-start' to an angle: 0deg throws TypeError
-PASS Setting 'padding-inline-start' to an angle: 3.14rad throws TypeError
-PASS Setting 'padding-inline-start' to an angle: -3.14deg throws TypeError
-PASS Setting 'padding-inline-start' to an angle: calc(0rad + 0deg) throws TypeError
-PASS Setting 'padding-inline-start' to a flexible length: 0fr throws TypeError
-PASS Setting 'padding-inline-start' to a flexible length: 1fr throws TypeError
-PASS Setting 'padding-inline-start' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'padding-inline-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-inline-start' to a number: -3.14 throws TypeError
-PASS Setting 'padding-inline-start' to a number: 3.14 throws TypeError
-PASS Setting 'padding-inline-start' to a number: calc(2 + 3) throws TypeError
-PASS Setting 'padding-inline-start' to a transform: translate(50%, 50%) throws TypeError
-PASS Setting 'padding-inline-start' to a transform: perspective(10em) throws TypeError
-PASS Setting 'padding-inline-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-PASS Can set 'padding-inline-end' to CSS-wide keywords: initial
-PASS Can set 'padding-inline-end' to CSS-wide keywords: inherit
-PASS Can set 'padding-inline-end' to CSS-wide keywords: unset
-PASS Can set 'padding-inline-end' to CSS-wide keywords: revert
-PASS Can set 'padding-inline-end' to var() references:  var(--A)
-PASS Can set 'padding-inline-end' to a percent: 0%
-FAIL Can set 'padding-inline-end' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-PASS Can set 'padding-inline-end' to a percent: 3.14%
-PASS Can set 'padding-inline-end' to a percent: calc(0% + 0%)
-PASS Can set 'padding-inline-end' to a length: 0px
-FAIL Can set 'padding-inline-end' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
-PASS Can set 'padding-inline-end' to a length: 3.14cm
-PASS Can set 'padding-inline-end' to a length: calc(0px + 0em)
-PASS Setting 'padding-inline-end' to a time: 0s throws TypeError
-PASS Setting 'padding-inline-end' to a time: -3.14ms throws TypeError
-PASS Setting 'padding-inline-end' to a time: 3.14s throws TypeError
-PASS Setting 'padding-inline-end' to a time: calc(0s + 0ms) throws TypeError
-PASS Setting 'padding-inline-end' to an angle: 0deg throws TypeError
-PASS Setting 'padding-inline-end' to an angle: 3.14rad throws TypeError
-PASS Setting 'padding-inline-end' to an angle: -3.14deg throws TypeError
-PASS Setting 'padding-inline-end' to an angle: calc(0rad + 0deg) throws TypeError
-PASS Setting 'padding-inline-end' to a flexible length: 0fr throws TypeError
-PASS Setting 'padding-inline-end' to a flexible length: 1fr throws TypeError
-PASS Setting 'padding-inline-end' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'padding-inline-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-inline-end' to a number: -3.14 throws TypeError
-PASS Setting 'padding-inline-end' to a number: 3.14 throws TypeError
-PASS Setting 'padding-inline-end' to a number: calc(2 + 3) throws TypeError
-PASS Setting 'padding-inline-end' to a transform: translate(50%, 50%) throws TypeError
-PASS Setting 'padding-inline-end' to a transform: perspective(10em) throws TypeError
-PASS Setting 'padding-inline-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL Can set 'padding-block' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'padding-block' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'padding-block' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'padding-block' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'padding-block' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Can set 'padding-block' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'padding-block' to a percent: -3.14% Bad value for shorthand CSS property
-FAIL Can set 'padding-block' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'padding-block' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-FAIL Can set 'padding-block' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'padding-block' to a length: -3.14em Bad value for shorthand CSS property
-FAIL Can set 'padding-block' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'padding-block' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-PASS Setting 'padding-block' to a time: 0s throws TypeError
-PASS Setting 'padding-block' to a time: -3.14ms throws TypeError
-PASS Setting 'padding-block' to a time: 3.14s throws TypeError
-PASS Setting 'padding-block' to a time: calc(0s + 0ms) throws TypeError
-PASS Setting 'padding-block' to an angle: 0deg throws TypeError
-PASS Setting 'padding-block' to an angle: 3.14rad throws TypeError
-PASS Setting 'padding-block' to an angle: -3.14deg throws TypeError
-PASS Setting 'padding-block' to an angle: calc(0rad + 0deg) throws TypeError
-PASS Setting 'padding-block' to a flexible length: 0fr throws TypeError
-PASS Setting 'padding-block' to a flexible length: 1fr throws TypeError
-PASS Setting 'padding-block' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'padding-block' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-block' to a number: -3.14 throws TypeError
-PASS Setting 'padding-block' to a number: 3.14 throws TypeError
-PASS Setting 'padding-block' to a number: calc(2 + 3) throws TypeError
-PASS Setting 'padding-block' to a transform: translate(50%, 50%) throws TypeError
-PASS Setting 'padding-block' to a transform: perspective(10em) throws TypeError
-PASS Setting 'padding-block' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL Can set 'padding-inline' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'padding-inline' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'padding-inline' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'padding-inline' to CSS-wide keywords: revert assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
-FAIL Can set 'padding-inline' to var() references:  var(--A) assert_equals: expected 2 but got 1
-FAIL Can set 'padding-inline' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'padding-inline' to a percent: -3.14% Bad value for shorthand CSS property
-FAIL Can set 'padding-inline' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'padding-inline' to a percent: calc(0% + 0%) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-FAIL Can set 'padding-inline' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'padding-inline' to a length: -3.14em Bad value for shorthand CSS property
-FAIL Can set 'padding-inline' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'padding-inline' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-PASS Setting 'padding-inline' to a time: 0s throws TypeError
-PASS Setting 'padding-inline' to a time: -3.14ms throws TypeError
-PASS Setting 'padding-inline' to a time: 3.14s throws TypeError
-PASS Setting 'padding-inline' to a time: calc(0s + 0ms) throws TypeError
-PASS Setting 'padding-inline' to an angle: 0deg throws TypeError
-PASS Setting 'padding-inline' to an angle: 3.14rad throws TypeError
-PASS Setting 'padding-inline' to an angle: -3.14deg throws TypeError
-PASS Setting 'padding-inline' to an angle: calc(0rad + 0deg) throws TypeError
-PASS Setting 'padding-inline' to a flexible length: 0fr throws TypeError
-PASS Setting 'padding-inline' to a flexible length: 1fr throws TypeError
-PASS Setting 'padding-inline' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'padding-inline' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'padding-inline' to a number: -3.14 throws TypeError
-PASS Setting 'padding-inline' to a number: 3.14 throws TypeError
-PASS Setting 'padding-inline' to a number: calc(2 + 3) throws TypeError
-PASS Setting 'padding-inline' to a transform: translate(50%, 50%) throws TypeError
-PASS Setting 'padding-inline' to a transform: perspective(10em) throws TypeError
-PASS Setting 'padding-inline' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 FAIL Can set 'border-block-start' to CSS-wide keywords: initial assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-start' to CSS-wide keywords: inherit assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-start' to CSS-wide keywords: unset assert_equals: expected "CSSKeywordValue" but got "CSSStyleValue"
@@ -598,7 +598,7 @@ FAIL Can set 'border-block-start-width' to the 'thin' keyword: thin assert_equal
 FAIL Can set 'border-block-start-width' to the 'medium' keyword: medium assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-block-start-width' to the 'thick' keyword: thick assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 PASS Can set 'border-block-start-width' to a length: 0px
-FAIL Can set 'border-block-start-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-block-start-width' to a length: -3.14em
 PASS Can set 'border-block-start-width' to a length: 3.14cm
 PASS Can set 'border-block-start-width' to a length: calc(0px + 0em)
 PASS Setting 'border-block-start-width' to a percent: 0% throws TypeError
@@ -729,7 +729,7 @@ FAIL Can set 'border-block-end-width' to the 'thin' keyword: thin assert_equals:
 FAIL Can set 'border-block-end-width' to the 'medium' keyword: medium assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-block-end-width' to the 'thick' keyword: thick assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 PASS Can set 'border-block-end-width' to a length: 0px
-FAIL Can set 'border-block-end-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-block-end-width' to a length: -3.14em
 PASS Can set 'border-block-end-width' to a length: 3.14cm
 PASS Can set 'border-block-end-width' to a length: calc(0px + 0em)
 PASS Setting 'border-block-end-width' to a percent: 0% throws TypeError
@@ -860,7 +860,7 @@ FAIL Can set 'border-inline-start-width' to the 'thin' keyword: thin assert_equa
 FAIL Can set 'border-inline-start-width' to the 'medium' keyword: medium assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-inline-start-width' to the 'thick' keyword: thick assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 PASS Can set 'border-inline-start-width' to a length: 0px
-FAIL Can set 'border-inline-start-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-inline-start-width' to a length: -3.14em
 PASS Can set 'border-inline-start-width' to a length: 3.14cm
 PASS Can set 'border-inline-start-width' to a length: calc(0px + 0em)
 PASS Setting 'border-inline-start-width' to a percent: 0% throws TypeError
@@ -991,7 +991,7 @@ FAIL Can set 'border-inline-end-width' to the 'thin' keyword: thin assert_equals
 FAIL Can set 'border-inline-end-width' to the 'medium' keyword: medium assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 FAIL Can set 'border-inline-end-width' to the 'thick' keyword: thick assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 PASS Can set 'border-inline-end-width' to a length: 0px
-FAIL Can set 'border-inline-end-width' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'border-inline-end-width' to a length: -3.14em
 PASS Can set 'border-inline-end-width' to a length: 3.14cm
 PASS Can set 'border-inline-end-width' to a length: calc(0px + 0em)
 PASS Setting 'border-inline-end-width' to a percent: 0% throws TypeError
@@ -1124,7 +1124,7 @@ FAIL Can set 'border-block-width' to the 'thick' keyword: thick assert_equals: e
 FAIL Can set 'border-block-width' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'border-block-width' to a length: -3.14em Bad value for shorthand CSS property
 FAIL Can set 'border-block-width' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-block-width' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-block-width' to a length: calc(0px + 0em) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
 PASS Setting 'border-block-width' to a percent: 0% throws TypeError
 PASS Setting 'border-block-width' to a percent: -3.14% throws TypeError
 PASS Setting 'border-block-width' to a percent: 3.14% throws TypeError
@@ -1255,7 +1255,7 @@ FAIL Can set 'border-inline-width' to the 'thick' keyword: thick assert_equals: 
 FAIL Can set 'border-inline-width' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
 FAIL Can set 'border-inline-width' to a length: -3.14em Bad value for shorthand CSS property
 FAIL Can set 'border-inline-width' to a length: 3.14cm assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-inline-width' to a length: calc(0px + 0em) assert_class_string: specified calc must be a CSSMathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
+FAIL Can set 'border-inline-width' to a length: calc(0px + 0em) assert_equals: expected "CSSMathSum" but got "CSSStyleValue"
 PASS Setting 'border-inline-width' to a percent: 0% throws TypeError
 PASS Setting 'border-inline-width' to a percent: -3.14% throws TypeError
 PASS Setting 'border-inline-width' to a percent: 3.14% throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical.html
@@ -19,14 +19,34 @@ const logical = {
   corners: ['start-start', 'start-end', 'end-start', 'end-end'],
 };
 
-for (const prefix of ['margin-', 'inset-', 'padding-']) {
-  for (const side of [...logical.sides, ...logical.axes]) {
-    runPropertyTests(prefix + side, [
-      // TODO: Test 'auto'
-      { syntax: '<percentage>' },
-      { syntax: '<length>' },
-    ]);
-  }
+for (const side of [...logical.sides, ...logical.axes]) {
+  runPropertyTests('margin-' + side, [
+    // TODO: Test 'auto'
+    { syntax: '<percentage>' },
+    { syntax: '<length>' }
+  ]);
+}
+
+for (const side of [...logical.sides, ...logical.axes]) {
+  runPropertyTests('padding-' + side, [
+    // TODO: Test 'auto'
+    {
+      syntax: '<percentage>',
+      specified: assert_is_equal_with_range_handling
+    },
+    {
+      syntax: '<length>',
+      specified: assert_is_equal_with_range_handling
+    },
+  ]);
+}
+
+for (const side of [...logical.sides, ...logical.axes]) {
+  runPropertyTests('inset-' + side, [
+    // TODO: Test 'auto'
+    { syntax: '<percentage>' },
+    { syntax: '<length>' }
+  ]);
 }
 
 // BORDERS
@@ -42,7 +62,10 @@ for (const side of [...logical.sides, ...logical.axes]) {
     { syntax: 'thin' },
     { syntax: 'medium' },
     { syntax: 'thick' },
-    { syntax: '<length>' },
+    {
+      syntax: '<length>',
+      specified: assert_is_equal_with_range_handling
+    },
   ]);
 
   runPropertyTests(`border-${side}-color`, [
@@ -59,8 +82,14 @@ for (const side of [...logical.sides, ...logical.axes]) {
 // border radius
 for (const side of logical.corners) {
   runPropertyTests(`border-${side}-radius`, [
-    { syntax: '<percentage>' },
-    { syntax: '<length>' },
+    {
+      syntax: '<percentage>',
+      specified: assert_is_equal_with_range_handling
+    },
+    {
+      syntax: '<length>',
+      specified: assert_is_equal_with_range_handling
+    },
   ]);
 }
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt
@@ -5,11 +5,11 @@ PASS Can set 'scroll-padding-top' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-top' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-top' to var() references:  var(--A)
 PASS Can set 'scroll-padding-top' to a percent: 0%
-FAIL Can set 'scroll-padding-top' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-top' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'scroll-padding-top' to a percent: 3.14%
 PASS Can set 'scroll-padding-top' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-top' to a length: 0px
-FAIL Can set 'scroll-padding-top' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-top' to a length: -3.14em
 PASS Can set 'scroll-padding-top' to a length: 3.14cm
 PASS Can set 'scroll-padding-top' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-top' to a time: 0s throws TypeError
@@ -36,11 +36,11 @@ PASS Can set 'scroll-padding-left' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-left' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-left' to var() references:  var(--A)
 PASS Can set 'scroll-padding-left' to a percent: 0%
-FAIL Can set 'scroll-padding-left' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-left' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'scroll-padding-left' to a percent: 3.14%
 PASS Can set 'scroll-padding-left' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-left' to a length: 0px
-FAIL Can set 'scroll-padding-left' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-left' to a length: -3.14em
 PASS Can set 'scroll-padding-left' to a length: 3.14cm
 PASS Can set 'scroll-padding-left' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-left' to a time: 0s throws TypeError
@@ -67,11 +67,11 @@ PASS Can set 'scroll-padding-right' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-right' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-right' to var() references:  var(--A)
 PASS Can set 'scroll-padding-right' to a percent: 0%
-FAIL Can set 'scroll-padding-right' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-right' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'scroll-padding-right' to a percent: 3.14%
 PASS Can set 'scroll-padding-right' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-right' to a length: 0px
-FAIL Can set 'scroll-padding-right' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-right' to a length: -3.14em
 PASS Can set 'scroll-padding-right' to a length: 3.14cm
 PASS Can set 'scroll-padding-right' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-right' to a time: 0s throws TypeError
@@ -98,11 +98,11 @@ PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-bottom' to var() references:  var(--A)
 PASS Can set 'scroll-padding-bottom' to a percent: 0%
-FAIL Can set 'scroll-padding-bottom' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-bottom' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'scroll-padding-bottom' to a percent: 3.14%
 PASS Can set 'scroll-padding-bottom' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-bottom' to a length: 0px
-FAIL Can set 'scroll-padding-bottom' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-bottom' to a length: -3.14em
 PASS Can set 'scroll-padding-bottom' to a length: 3.14cm
 PASS Can set 'scroll-padding-bottom' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-bottom' to a time: 0s throws TypeError
@@ -129,11 +129,11 @@ PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-inline-start' to var() references:  var(--A)
 PASS Can set 'scroll-padding-inline-start' to a percent: 0%
-FAIL Can set 'scroll-padding-inline-start' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-inline-start' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'scroll-padding-inline-start' to a percent: 3.14%
 PASS Can set 'scroll-padding-inline-start' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-inline-start' to a length: 0px
-FAIL Can set 'scroll-padding-inline-start' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-inline-start' to a length: -3.14em
 PASS Can set 'scroll-padding-inline-start' to a length: 3.14cm
 PASS Can set 'scroll-padding-inline-start' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-inline-start' to a time: 0s throws TypeError
@@ -160,11 +160,11 @@ PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-block-start' to var() references:  var(--A)
 PASS Can set 'scroll-padding-block-start' to a percent: 0%
-FAIL Can set 'scroll-padding-block-start' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-block-start' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'scroll-padding-block-start' to a percent: 3.14%
 PASS Can set 'scroll-padding-block-start' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-block-start' to a length: 0px
-FAIL Can set 'scroll-padding-block-start' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-block-start' to a length: -3.14em
 PASS Can set 'scroll-padding-block-start' to a length: 3.14cm
 PASS Can set 'scroll-padding-block-start' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-block-start' to a time: 0s throws TypeError
@@ -191,11 +191,11 @@ PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-inline-end' to var() references:  var(--A)
 PASS Can set 'scroll-padding-inline-end' to a percent: 0%
-FAIL Can set 'scroll-padding-inline-end' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-inline-end' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'scroll-padding-inline-end' to a percent: 3.14%
 PASS Can set 'scroll-padding-inline-end' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-inline-end' to a length: 0px
-FAIL Can set 'scroll-padding-inline-end' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-inline-end' to a length: -3.14em
 PASS Can set 'scroll-padding-inline-end' to a length: 3.14cm
 PASS Can set 'scroll-padding-inline-end' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-inline-end' to a time: 0s throws TypeError
@@ -222,11 +222,11 @@ PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-block-end' to var() references:  var(--A)
 PASS Can set 'scroll-padding-block-end' to a percent: 0%
-FAIL Can set 'scroll-padding-block-end' to a percent: -3.14% assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'scroll-padding-block-end' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'scroll-padding-block-end' to a percent: 3.14%
 PASS Can set 'scroll-padding-block-end' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-block-end' to a length: 0px
-FAIL Can set 'scroll-padding-block-end' to a length: -3.14em assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+PASS Can set 'scroll-padding-block-end' to a length: -3.14em
 PASS Can set 'scroll-padding-block-end' to a length: 3.14cm
 PASS Can set 'scroll-padding-block-end' to a length: calc(0px + 0em)
 PASS Setting 'scroll-padding-block-end' to a time: 0s throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding.html
@@ -15,15 +15,27 @@
 
 for (const suffix of ['top', 'left', 'right', 'bottom']) {
   runPropertyTests('scroll-padding-' + suffix, [
-    { syntax: '<percentage>' },
-    { syntax: '<length>' },
+    {
+      syntax: '<percentage>',
+      specified: assert_is_equal_with_range_handling
+    },
+    {
+      syntax: '<length>',
+      specified: assert_is_equal_with_range_handling
+    },
   ]);
 }
 
 for (const suffix of ['inline-start', 'block-start', 'inline-end', 'block-end']) {
   runPropertyTests('scroll-padding-' + suffix, [
-    { syntax: '<percentage>' },
-    { syntax: '<length>' },
+    {
+      syntax: '<percentage>',
+      specified: assert_is_equal_with_range_handling
+    },
+    {
+      syntax: '<length>',
+      specified: assert_is_equal_with_range_handling
+    },
   ]);
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'stroke-miterlimit' to CSS-wide keywords: unset
 PASS Can set 'stroke-miterlimit' to CSS-wide keywords: revert
 PASS Can set 'stroke-miterlimit' to var() references:  var(--A)
 PASS Can set 'stroke-miterlimit' to a number: 0
-FAIL Can set 'stroke-miterlimit' to a number: -3.14 assert_equals: expected "CSSUnitValue" but got "CSSMathSum"
+FAIL Can set 'stroke-miterlimit' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
 PASS Can set 'stroke-miterlimit' to a number: 3.14
 PASS Can set 'stroke-miterlimit' to a number: calc(2 + 3)
 PASS Setting 'stroke-miterlimit' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit.html
@@ -14,7 +14,10 @@
 'use strict';
 
 runPropertyTests('stroke-miterlimit', [
-  { syntax: '<number>' },
+  {
+    syntax: '<number>',
+    specified: assert_is_equal_with_range_handling
+  },
 ]);
 
 </script>


### PR DESCRIPTION
#### 21f9d871d4533f03577c76ee90ef17bba39604d2
<pre>
Update CSS-Typed-OM tests to more consistently add range checks for properties not allowing negative values
<a href="https://bugs.webkit.org/show_bug.cgi?id=249582">https://bugs.webkit.org/show_bug.cgi?id=249582</a>

Reviewed by Simon Fraser.

Update CSS-Typed-OM tests to more consistently add range checks for properties
not allowing negative values:

- animation-duration
<a href="https://w3c.github.io/csswg-drafts/css-animations/#animation-duration">https://w3c.github.io/csswg-drafts/css-animations/#animation-duration</a>

- animation-iteration-count
<a href="https://w3c.github.io/csswg-drafts/css-animations/#animation-iteration-count">https://w3c.github.io/csswg-drafts/css-animations/#animation-iteration-count</a>
<a href="https://w3c.github.io/csswg-drafts/css-animations/#typedef-single-animation-iteration-count">https://w3c.github.io/csswg-drafts/css-animations/#typedef-single-animation-iteration-count</a>

- background-size
<a href="https://w3c.github.io/csswg-drafts/css-backgrounds/#the-background-size">https://w3c.github.io/csswg-drafts/css-backgrounds/#the-background-size</a>
<a href="https://w3c.github.io/csswg-drafts/css-backgrounds/#typedef-bg-size">https://w3c.github.io/csswg-drafts/css-backgrounds/#typedef-bg-size</a>

- border-image-outset
<a href="https://w3c.github.io/csswg-drafts/css-backgrounds/#the-border-image-outset">https://w3c.github.io/csswg-drafts/css-backgrounds/#the-border-image-outset</a>

- border-image-slice
<a href="https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-slice">https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-slice</a>

- border-image-width
<a href="https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-width">https://w3c.github.io/csswg-drafts/css-backgrounds/#border-image-width</a>

- border-top-left-radius, border-top-right-radius, border-bottom-right-radius, border-bottom-left-radius
<a href="https://w3c.github.io/csswg-drafts/css-backgrounds/#border-radius">https://w3c.github.io/csswg-drafts/css-backgrounds/#border-radius</a>

- font-weight
<a href="https://w3c.github.io/csswg-drafts/css-fonts/#font-weight-prop">https://w3c.github.io/csswg-drafts/css-fonts/#font-weight-prop</a>
<a href="https://w3c.github.io/csswg-drafts/css-fonts/#font-weight-absolute-values">https://w3c.github.io/csswg-drafts/css-fonts/#font-weight-absolute-values</a>

- grid-auto-columns, grid-auto-rows
<a href="https://w3c.github.io/csswg-drafts/css-grid/#auto-tracks">https://w3c.github.io/csswg-drafts/css-grid/#auto-tracks</a>
<a href="https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-size">https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-size</a>
<a href="https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-breadth">https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-breadth</a>

- padding-block-start, padding-block-end, padding-inline-start, padding-inline-end
<a href="https://w3c.github.io/csswg-drafts/css-logical/#padding-properties">https://w3c.github.io/csswg-drafts/css-logical/#padding-properties</a>
<a href="https://w3c.github.io/csswg-drafts/css-box-4/#propdef-padding-top">https://w3c.github.io/csswg-drafts/css-box-4/#propdef-padding-top</a>

- border-block-start-width, border-block-end-width, border-inline-start-width, border-inline-end-width
<a href="https://w3c.github.io/csswg-drafts/css-logical/#border-width">https://w3c.github.io/csswg-drafts/css-logical/#border-width</a>
<a href="https://w3c.github.io/csswg-drafts/css-backgrounds-3/#propdef-border-top-width">https://w3c.github.io/csswg-drafts/css-backgrounds-3/#propdef-border-top-width</a>
<a href="https://w3c.github.io/csswg-drafts/css-backgrounds-3/#typedef-line-width">https://w3c.github.io/csswg-drafts/css-backgrounds-3/#typedef-line-width</a>

- scroll-padding-top, scroll-padding-right, scroll-padding-bottom, scroll-padding-left
<a href="https://w3c.github.io/csswg-drafts/css-scroll-snap/#padding-longhands-physical">https://w3c.github.io/csswg-drafts/css-scroll-snap/#padding-longhands-physical</a>

- scroll-padding-inline-start, scroll-padding-block-start, scroll-padding-inline-end, scroll-padding-block-end
<a href="https://w3c.github.io/csswg-drafts/css-scroll-snap/#padding-longhands-logical">https://w3c.github.io/csswg-drafts/css-scroll-snap/#padding-longhands-logical</a>

- stroke-miterlimit
<a href="https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty">https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-duration.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-iteration-count.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit.html:

Canonical link: <a href="https://commits.webkit.org/258100@main">https://commits.webkit.org/258100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2aa1167acb037779c31cdd920cc87fb022d901be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110177 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170451 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/886 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93285 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108020 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91545 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34898 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90197 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77873 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3712 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24462 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3729 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/847 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43958 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5507 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2913 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->