### PR TITLE
Ensure WebKit survey results are always visible in the admin

### DIFF
--- a/Websites/webkit.org/wp-content/plugins/webkit-survey/plugin.php
+++ b/Websites/webkit.org/wp-content/plugins/webkit-survey/plugin.php
@@ -86,7 +86,7 @@ class WebKit_Survey {
         </style>
         <?php
         include(dirname(__FILE__) . '/results.php');
-        echo "$total Total Votes";
+        echo '<strong>' . number_format($total) . '</strong> Total Votes';
     }
 
     public function process_vote() {

--- a/Websites/webkit.org/wp-content/plugins/webkit-survey/results.php
+++ b/Websites/webkit.org/wp-content/plugins/webkit-survey/results.php
@@ -61,7 +61,7 @@
     foreach ($SurveyResults->survey as $id => $Entry): $total = isset($Entry->scores['total']) ? $Entry->scores['total'] : 1; 
     
     $results_classes = ['webkit-survey-results'];
-    if ($SurveyResults->status == 'closed' || $SurveyResults->results == 'visible' || WebKit_Survey::responded()) 
+    if ($SurveyResults->status == 'closed' || $SurveyResults->results == 'visible' || WebKit_Survey::responded() || is_admin()) 
         $results_classes[] = 'visible';
 ?>
 <div class="<?php esc_attr_e(join(' ', $results_classes)); ?>">


### PR DESCRIPTION
#### 07d853d3a9e7bbec0cf740412ea0bc089e2af3af
<pre>
Ensure WebKit survey results are always visible in the admin
<a href="https://bugs.webkit.org/show_bug.cgi?id=249584">https://bugs.webkit.org/show_bug.cgi?id=249584</a>

Reviewed by Tim Nguyen.

* Websites/webkit.org/wp-content/plugins/webkit-survey/plugin.php:
* Websites/webkit.org/wp-content/plugins/webkit-survey/results.php:

Canonical link: <a href="https://commits.webkit.org/258086@main">https://commits.webkit.org/258086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dba6a17ab1d834691f182accabe5a082b99f735d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110180 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/892 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93288 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108023 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34902 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77877 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3715 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3732 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/850 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9845 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43965 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5510 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2905 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->