### PR TITLE
[git-webkit] Add Publish Command

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.12.2',
+    version='5.13.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 12, 2)
+version = Version(5, 13, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -37,6 +37,7 @@ from .checkout import Checkout
 from .credentials import Credentials
 from .find import Find, Info
 from .pickable import Pickable
+from .publish import Publish
 from .install_git_lfs import InstallGitLFS
 from .land import Land
 from .log import Log
@@ -91,7 +92,7 @@ def main(
         Clean, Find, Info, Land, Log, Pull,
         PullRequest, Revert, Setup, InstallGitLFS,
         Credentials, Commit, DeletePRBranches, Squash,
-        Pickable, CherryPick, Trace, Track, Show,
+        Pickable, CherryPick, Trace, Track, Show, Publish,
     ] + (programs or [])
     if subversion:
         programs.append(SetupGitSvn)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/publish.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/publish.py
@@ -1,0 +1,260 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import collections
+import re
+import sys
+
+from .command import Command
+from .track import Track
+from webkitcorepy import arguments, run, string_utils, Terminal
+from webkitscmpy import log, local
+
+
+class Publish(Command):
+    name = 'publish'
+    help = "Push a specific branch or tag and all its history to a specified remote."
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            'arguments', nargs='+',
+            type=str, default=None,
+            help='String representation(s) of branches or tags to be published',
+        )
+        parser.add_argument(
+            '--remote', dest='remote', type=str, default=None,
+            help='Publish content to the specified remote',
+        )
+
+    @classmethod
+    def branches_on(cls, repository, ref):
+        output = run(
+            [repository.executable(), 'branch', '-a', '--merged', ref],
+            cwd=repository.root_path,
+            capture_output=True,
+            encoding='utf-8',
+        )
+        if output.returncode:
+            sys.stderr.write(output.stderr)
+            return {}
+        result = collections.defaultdict(set)
+        for line in output.stdout.splitlines():
+            split = line.lstrip().split('/', 2)
+            if len(split) < 3 or split[0] != 'remotes':
+                result[None].add('/'.join(split))
+            else:
+                result[split[1]].add(split[2])
+        return result
+
+    @classmethod
+    def tags_on(cls, repository, ref):
+        result = run(
+            [repository.executable(), 'tag', '--merged', ref],
+            cwd=repository.root_path,
+            capture_output=True,
+            encoding='utf-8',
+        )
+        if not result.returncode:
+            return result.stdout.splitlines()
+        sys.stderr.write(result.stderr)
+        return []
+
+    @classmethod
+    def parental_intersection(cls, repository, commit):
+        if commit.branch == repository.default_branch:
+            return None
+        if commit.identifier <= 1:
+            return None
+        try:
+            parent_branch = repository.find('{}~{}'.format(commit.hash, commit.identifier - 1)).branch
+        except (ValueError, repository.Exception):
+            return None
+        if parent_branch == commit.branch:
+            return None
+        remote = repository.remote_for(parent_branch)
+        intersection = repository.merge_base(commit.hash, 'refs/remotes/{}/{}'.format(remote, parent_branch))
+        if intersection.hash == commit.hash:
+            return None
+        return intersection
+
+    @classmethod
+    def _add_branch_ref_to(cls, mapping, repository, branch, commit):
+        if branch not in mapping:
+            mapping[branch] = commit
+        elif mapping[branch].hash != commit.hash and repository.merge_base(
+                mapping[branch].hash, commit.hash,
+                include_log=False, include_identifier=False
+        ).hash == mapping[branch].hash:
+            mapping[branch] = commit
+
+    @classmethod
+    def main(cls, args, repository, **kwargs):
+        if not repository:
+            sys.stderr.write('No repository provided\n')
+            return 1
+        if not isinstance(repository, local.Git):
+            sys.stderr.write("Can only 'publish' branches in a git checkout\n")
+            return 1
+
+        commits = set()
+        branches_to_publish = {}
+        tags_to_publish = set()
+        for ref in args.arguments:
+            try:
+                commit = repository.find(ref)
+                commits.add(commit)
+                if ref in repository.tags():
+                    log.info('    {} is a tag, referencing {}'.format(ref, commit))
+                    tags_to_publish.add(ref)
+                    continue
+                if ref.startswith('ref/remotes/') or ref.startswith('remotes/'):
+                    ref = ref.split('remotes/')[-1].split('/', 1)[-1]
+                if ref in repository.branches:
+                    log.info('    {} is a branch, referencing {}'.format(ref, commit))
+                    cls._add_branch_ref_to(
+                        mapping=branches_to_publish,
+                        repository=repository,
+                        branch=ref, commit=commit,
+                    )
+                else:
+                    log.info('    {} references {}'.format(ref, commit))
+            except (ValueError, repository.Exception):
+                sys.stderr.write("'{}' cannot be found in this repository to be published\n".format(ref))
+
+        if not branches_to_publish and not tags_to_publish and not commits:
+            sys.stderr.write("No branches or tags to publish found\n")
+            return 1
+
+        requested_refs = tags_to_publish | set(branches_to_publish.keys())
+
+        log.warning('User specified {} and {}, request comprises {}'.format(
+            string_utils.pluralize(len(branches_to_publish), 'branch', 'branches'),
+            string_utils.pluralize(len(tags_to_publish), 'tag'),
+            string_utils.pluralize(len(commits), 'commit'),
+        ))
+
+        if not args.remote:
+            for commit in commits:
+                prevailing_remote = None
+                remotes_for = repository.branches_for(hash=commit.hash, remote=None).keys()
+                for candidate in repository.source_remotes():
+                    if candidate in remotes_for:
+                        prevailing_remote = candidate
+                        break
+                for candidate in reversed(repository.source_remotes()):
+                    if candidate == args.remote or candidate == prevailing_remote:
+                        args.remote = prevailing_remote
+                        break
+            if not args.remote:
+                args.remote = repository.default_remote
+            args.remote = repository.source_remotes()[max(repository.source_remotes().index(args.remote) - 1, 0)]
+            log.warning("Inferred '{}' as the target remote".format(args.remote))
+        if args.remote not in repository.source_remotes():
+            sys.stderr.write("'{}' is not a recognized remote\n".format(args.remote))
+            return 1
+
+        existing_tags = set(repository.tags(remote=args.remote))
+        tags_to_publish = tags_to_publish - existing_tags
+        for commit in commits:
+            tags_to_publish |= set(cls.tags_on(repository, commit.hash)) - existing_tags
+            intersection = cls.parental_intersection(repository, commit)
+            if intersection and intersection.branch != repository.default_branch:
+                cls._add_branch_ref_to(
+                    mapping=branches_to_publish,
+                    repository=repository,
+                    branch=intersection.branch, commit=intersection,
+                )
+            for remote, branches in cls.branches_on(repository, commit.hash).items():
+                if remote is not None and remote not in repository.source_remotes():
+                    continue
+                for branch in branches:
+                    commit = repository.find('remotes/{}/{}'.format(remote, branch) if remote else branch)
+                    cls._add_branch_ref_to(
+                        mapping=branches_to_publish,
+                        repository=repository,
+                        branch=branch, commit=commit,
+                    )
+
+        if tags_to_publish - requested_refs:
+            log.warning("Inferred the following tags:")
+            for tag in tags_to_publish - requested_refs:
+                log.warning('    {}'.format(tag))
+            log.warning('')
+
+        if set(branches_to_publish.keys()) - requested_refs:
+            log.warning("Inferred the following branches:")
+            for branch in set(branches_to_publish.keys()) - requested_refs:
+                log.warning('    {} @ {}'.format(branch, branches_to_publish[branch]))
+            log.warning('')
+
+        if tags_to_publish:
+            print("Pushing the following tags to {}:".format(args.remote))
+            for tag in sorted(tags_to_publish):
+                print('    {}'.format(tag))
+            print('')
+        if branches_to_publish:
+            print("Pushing the branches at the following commits to {}:".format(args.remote))
+            for branch in sorted(branches_to_publish.keys()):
+                print('    {} @ {}'.format(branch, branches_to_publish[branch]))
+            print('')
+
+        if Terminal.choose(
+            "Are you sure you would like to publish to '{}' remote?".format(args.remote),
+            default='No',
+        ) == 'No':
+            sys.stderr.write("Publication canceled\n")
+            return 1
+
+        return_code = 0
+        print('Pushing branches to {}...'.format(args.remote))
+        command = [repository.executable(), 'push', '--atomic', args.remote] + [
+            '{}:refs/heads/{}'.format(commit.hash[:commit.HASH_LABEL_SIZE], branch) for branch, commit in branches_to_publish.items()
+        ]
+        log.info("Invoking '{}'".format(' '.join(command)))
+        if run(
+            command,
+            cwd=repository.root_path,
+            capture_output=True,
+            encoding='utf-8',
+        ).returncode:
+            sys.stderr.write('Failed to push branches to {}\n'.format(args.remote))
+            return_code += 1
+
+        if tags_to_publish:
+            print('Pushing tags to {}...'.format(args.remote))
+            command = [repository.executable(), 'push', '--atomic', args.remote] + list(tags_to_publish)
+            log.info("Invoking '{}'".format(' '.join(command)))
+            if run(
+                command,
+                cwd=repository.root_path,
+                capture_output=True,
+                encoding='utf-8',
+            ).returncode:
+                sys.stderr.write('Failed to push tags to {}\n'.format(args.remote))
+                return_code += 1
+
+        if return_code:
+            print('Publication failed.')
+        else:
+            print('Publication succeeded!')
+        return return_code

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -381,7 +381,7 @@ class PullRequest(Command):
                     sys.stderr.write("Failed to create pull request due to unsuitable remote\n")
                     return 1
             else:
-                source_remote = repository.source_remotes()[1]
+                source_remote = repository.source_remotes()[-1]
                 if args.defaults or Terminal.choose(
                     "Would you like to make a pull request against '{}' instead of '{}'? \n".format(source_remote, original_remote),
                     default='Yes',

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/publish_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/publish_unittest.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+import os
+import time
+import sys
+
+from datetime import datetime
+
+from webkitcorepy import OutputCapture, testing
+from webkitcorepy.mocks import Terminal as MockTerminal
+from webkitscmpy import program, mocks
+
+
+class TestPublish(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def setUp(self):
+        super(TestPublish, self).setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        os.mkdir(os.path.join(self.path, '.svn'))
+
+    def test_svn(self):
+        with OutputCapture() as captured, mocks.local.Git(), mocks.local.Svn(self.path):
+            self.assertEqual(1, program.main(
+                args=('publish', 'branch-b'),
+                path=self.path,
+            ))
+
+        self.assertEqual(captured.stderr.getvalue(), "Can only 'publish' branches in a git checkout\n")
+
+    def test_none(self):
+        with OutputCapture() as captured, mocks.local.Git(), mocks.local.Svn():
+            self.assertEqual(1, program.main(
+                args=('publish', 'branch-b'),
+                path=self.path,
+            ))
+
+        self.assertEqual(captured.stderr.getvalue(), 'No repository provided\n')
+
+    def test_git(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path), mocks.local.Svn(), MockTerminal.input('y'):
+            self.assertEqual(0, program.main(
+                args=('publish', 'branch-b', '-v'),
+                path=self.path,
+            ))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Pushing the branches at the following commits to origin:\n'
+            '    branch-b @ 2.3@branch-b\n\n'
+            "Are you sure you would like to publish to 'origin' remote? (Yes/[No]): \n"
+            'Pushing branches to origin...\n'
+            'Publication succeeded!\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                '    branch-b is a branch, referencing 2.3@branch-b',
+                'User specified 1 branch and 0 tags, request comprises 1 commit',
+                "Inferred 'origin' as the target remote",
+                "Invoking '/usr/bin/git push --atomic origin 790725a6d79e:refs/heads/branch-b'",
+            ],
+        )
+
+    def test_git_cancel(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn(), MockTerminal.input('n'):
+            self.assertEqual(1, program.main(
+                args=('publish', 'branch-b'),
+                path=self.path,
+            ))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Pushing the branches at the following commits to origin:\n'
+            '    branch-b @ 2.3@branch-b\n\n'
+            "Are you sure you would like to publish to 'origin' remote? (Yes/[No]): \n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), 'Publication canceled\n')

--- a/metadata/git_config_extension
+++ b/metadata/git_config_extension
@@ -7,8 +7,8 @@
         auto-check = true
 [webkitscmpy "remotes"]
         origin = git@github.com:WebKit/WebKit.git
-        apple = git@github.com:apple/WebKit.git
         security = git@github.com:WebKit/WebKit-security.git
+        apple = git@github.com:apple/WebKit.git
 [webkitscmpy "access"]
         apple = apple/teams/WebKit
         security = WebKit/teams/security


### PR DESCRIPTION
#### 88545c7a87426658674dbab19b43989e947171e6
<pre>
[git-webkit] Add Publish Command
<a href="https://bugs.webkit.org/show_bug.cgi?id=249586">https://bugs.webkit.org/show_bug.cgi?id=249586</a>
&lt;rdar://97397960&gt;

Reviewed by Elliott Williams.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py: Add &apos;git branch -a --merged&apos;
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/publish.py: Added.
(Publish):
(Publish.parser): User provides command a list of refs to publish.
(Publish.branches_on): List all branches that are on the history of a specified ref.
(Publish.tags_on): List all tags that are on the history of a specified ref.
(Publish.parental_intersection): Find the intersection point of the provided commit and the parent
branch of that commit. Note that the provided commit might be on the parent branch, in which case
this function returns nothing.
(Publish._push_branch_ref): Push a branch ref onto the provided mapping. This function takes into
consideration any existing branch ref of the same name, taking the more up to date of the two.
(Publish.main): Given the refs provided by the user, find all refs on that history and push those refs
to the &quot;next&quot; source remote.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.create_pull_request): Prefer the most secret remote.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/publish_unittest.py: Added.
(TestPublish): Added tests.
* metadata/git_config_extension: Sort source remotes.

Canonical link: <a href="https://commits.webkit.org/260044@main">https://commits.webkit.org/260044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbf5ca313ab54707d21cb0a3d07618029a53ac3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106862 "Failed to checkout and rebase branch from PR 7850") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/15898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/39655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/116043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/115601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/110765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/17376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/7096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/112629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/17376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/39655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/99046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/110354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/17376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/39655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/99046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/9049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/39655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/9625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/7096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/105678 "Failed to checkout and rebase branch from PR 7850") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/15216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/39655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/11154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3747 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->