### PR TITLE
Cherry-pick 252432.749@safari-7614-branch (5281fc90d6f3). rdar://100515218

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -543,6 +543,12 @@ RefPtr<AudioBus> AudioFileReader::createBus(float sampleRate, bool mixToMono)
     if (!inFormat)
         return nullptr;
 
+    // Block loading of the Audible Audio codec.
+    // FIXME: convert this to a WebPreference deny-list of codecIDs
+    if (inFormat->mFormatID == kAudioFormatAudible
+        || inFormat->mFormatID == kCMAudioCodecType_AAC_AudibleProtected)
+        return nullptr;
+
     AudioStreamBasicDescription outFormat = clientDataFormat(*inFormat, sampleRate);
     size_t numberOfChannels = inFormat->mChannelsPerFrame;
     double fileSampleRate = inFormat->mSampleRate;


### PR DESCRIPTION
#### 7f45f505dc7e58f399b2303ec8080bc6f9c55753
<pre>
Cherry-pick 252432.749@safari-7614-branch (5281fc90d6f3). rdar://100515218

    [Cocoa] Disable Audible codec in WebAudio
    <a href="https://bugs.webkit.org/show_bug.cgi?id=247337">https://bugs.webkit.org/show_bug.cgi?id=247337</a>
    rdar://100515218

    Reviewed by Darin Adler and John Wilander.

    * Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
    (WebCore::AudioFileReader::createBus):

    Canonical link: <a href="https://commits.webkit.org/252432.749@safari-7614-branch">https://commits.webkit.org/252432.749@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/258090@main">https://commits.webkit.org/258090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/058e930004d71ba7f0606f1be975c06555fbd8e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110186 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170460 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104868 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/898 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93294 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108029 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34907 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77882 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3721 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24464 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3738 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/858 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43960 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5549 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5516 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->