### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/fill-opacity.html to match the latest specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity-expected.txt
@@ -8,14 +8,14 @@ PASS Can set 'fill-opacity' to a number: 0
 PASS Can set 'fill-opacity' to a number: -3.14
 PASS Can set 'fill-opacity' to a number: 3.14
 PASS Can set 'fill-opacity' to a number: calc(2 + 3)
+PASS Can set 'fill-opacity' to a percent: 0%
+PASS Can set 'fill-opacity' to a percent: -3.14%
+PASS Can set 'fill-opacity' to a percent: 3.14%
+PASS Can set 'fill-opacity' to a percent: calc(0% + 0%)
 PASS Setting 'fill-opacity' to a length: 0px throws TypeError
 PASS Setting 'fill-opacity' to a length: -3.14em throws TypeError
 PASS Setting 'fill-opacity' to a length: 3.14cm throws TypeError
 PASS Setting 'fill-opacity' to a length: calc(0px + 0em) throws TypeError
-FAIL Setting 'fill-opacity' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'fill-opacity' to a percent: -3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'fill-opacity' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'fill-opacity' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'fill-opacity' to a time: 0s throws TypeError
 PASS Setting 'fill-opacity' to a time: -3.14ms throws TypeError
 PASS Setting 'fill-opacity' to a time: 3.14s throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity.html
@@ -13,7 +13,7 @@
 <script>
 'use strict';
 
-function assert_is_equal_with_clamping(input, result) {
+function assert_is_equal_with_clamping_number(input, result) {
   const number = input.to('number');
 
   if (number.value < 0)
@@ -24,11 +24,27 @@ function assert_is_equal_with_clamping(input, result) {
     assert_style_value_equals(result, input);
 }
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const number = input.to('percent');
+  const value = number.value / 100.;
+
+  if (value < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'number'));
+  else if (value > 1)
+    assert_style_value_equals(result, new CSSUnitValue(1, 'number'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(value, 'number'));
+}
+
 runPropertyTests('fill-opacity', [
   {
     syntax: '<number>',
-    computed: assert_is_equal_with_clamping
+    computed: assert_is_equal_with_clamping_number
   },
+  {
+    syntax: '<percentage>',
+    computed: assert_is_equal_with_clamping_percentage
+  }
 ]);
 
 </script>


### PR DESCRIPTION
#### 422c18c5dba37299622f8634c99d776ec1b017f9
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/fill-opacity.html to match the latest specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=249588">https://bugs.webkit.org/show_bug.cgi?id=249588</a>

Reviewed by Cameron McCormack.

Fix css/css-typed-om/the-stylepropertymap/properties/fill-opacity.html to match
the latest specification:
- <a href="https://svgwg.org/svg2-draft/painting.html#FillOpacity">https://svgwg.org/svg2-draft/painting.html#FillOpacity</a>

The specification allows percentages, not just numbers.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/fill-opacity.html:

Canonical link: <a href="https://commits.webkit.org/258096@main">https://commits.webkit.org/258096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5755493b9715d43d8da901fc3acecaa951bd31cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110187 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170461 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/899 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108030 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91549 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34908 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90200 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77883 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3722 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24466 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/860 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43962 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5557 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5517 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->