### PR TITLE
[web-animations] adopt AnimatableProperty in ElementRareAnimationData and CSSTransition

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.h
+++ b/Source/WebCore/animation/CSSPropertyAnimation.h
@@ -37,6 +37,7 @@
 namespace WebCore {
 
 class CSSPropertyBlendingClient;
+class Document;
 class RenderStyle;
 
 class CSSPropertyAnimation {
@@ -45,8 +46,8 @@ public:
     static bool isPropertyAdditiveOrCumulative(AnimatableProperty);
     static bool propertyRequiresBlendingForAccumulativeIteration(const CSSPropertyBlendingClient&, AnimatableProperty, const RenderStyle& a, const RenderStyle& b);
     static bool animationOfPropertyIsAccelerated(AnimatableProperty);
-    static bool propertiesEqual(CSSPropertyID, const RenderStyle& a, const RenderStyle& b);
-    static bool canPropertyBeInterpolated(CSSPropertyID, const RenderStyle& a, const RenderStyle& b);
+    static bool propertiesEqual(AnimatableProperty, const RenderStyle& a, const RenderStyle& b);
+    static bool canPropertyBeInterpolated(AnimatableProperty, const RenderStyle& a, const RenderStyle& b);
     static CSSPropertyID getPropertyAtIndex(int, std::optional<bool>& isShorthand);
     static int getNumProperties();
 

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSTransition);
 
-Ref<CSSTransition> CSSTransition::create(const Styleable& owningElement, CSSPropertyID property, MonotonicTime generationTime, const Animation& backingAnimation, const RenderStyle& oldStyle, const RenderStyle& newStyle, Seconds delay, Seconds duration, const RenderStyle& reversingAdjustedStartStyle, double reversingShorteningFactor)
+Ref<CSSTransition> CSSTransition::create(const Styleable& owningElement, AnimatableProperty property, MonotonicTime generationTime, const Animation& backingAnimation, const RenderStyle& oldStyle, const RenderStyle& newStyle, Seconds delay, Seconds duration, const RenderStyle& reversingAdjustedStartStyle, double reversingShorteningFactor)
 {
     auto result = adoptRef(*new CSSTransition(owningElement, property, generationTime, backingAnimation, oldStyle, newStyle, reversingAdjustedStartStyle, reversingShorteningFactor));
     result->initialize(&oldStyle, newStyle, { nullptr });
@@ -49,7 +49,7 @@ Ref<CSSTransition> CSSTransition::create(const Styleable& owningElement, CSSProp
     return result;
 }
 
-CSSTransition::CSSTransition(const Styleable& styleable, CSSPropertyID property, MonotonicTime generationTime, const Animation& backingAnimation, const RenderStyle& oldStyle, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double reversingShorteningFactor)
+CSSTransition::CSSTransition(const Styleable& styleable, AnimatableProperty property, MonotonicTime generationTime, const Animation& backingAnimation, const RenderStyle& oldStyle, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double reversingShorteningFactor)
     : DeclarativeAnimation(styleable, backingAnimation)
     , m_property(property)
     , m_generationTime(generationTime)
@@ -95,7 +95,19 @@ void CSSTransition::setTimingProperties(Seconds delay, Seconds duration)
 
 Ref<DeclarativeAnimationEvent> CSSTransition::createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId)
 {
-    return CSSTransitionEvent::create(eventType, this, scheduledTime, elapsedTime, pseudoId, nameString(m_property));
+    return CSSTransitionEvent::create(eventType, this, scheduledTime, elapsedTime, pseudoId, transitionProperty());
+}
+
+const AtomString CSSTransition::transitionProperty() const
+{
+    return WTF::switchOn(m_property,
+        [] (CSSPropertyID cssProperty) {
+            return nameString(cssProperty);
+        },
+        [] (const AtomString& customProperty) {
+            return customProperty;
+        }
+    );
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CSSTransition.h
+++ b/Source/WebCore/animation/CSSTransition.h
@@ -28,6 +28,7 @@
 #include "CSSPropertyNames.h"
 #include "DeclarativeAnimation.h"
 #include "Styleable.h"
+#include "WebAnimationTypes.h"
 #include <wtf/Markable.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Ref.h>
@@ -41,11 +42,11 @@ class RenderStyle;
 class CSSTransition final : public DeclarativeAnimation {
     WTF_MAKE_ISO_ALLOCATED(CSSTransition);
 public:
-    static Ref<CSSTransition> create(const Styleable&, CSSPropertyID, MonotonicTime generationTime, const Animation&, const RenderStyle& oldStyle, const RenderStyle& newStyle, Seconds delay, Seconds duration, const RenderStyle& reversingAdjustedStartStyle, double);
+    static Ref<CSSTransition> create(const Styleable&, AnimatableProperty, MonotonicTime generationTime, const Animation&, const RenderStyle& oldStyle, const RenderStyle& newStyle, Seconds delay, Seconds duration, const RenderStyle& reversingAdjustedStartStyle, double);
     ~CSSTransition() = default;
 
-    const AtomString& transitionProperty() const { return nameString(m_property); }
-    CSSPropertyID property() const { return m_property; }
+    const AtomString transitionProperty() const;
+    AnimatableProperty property() const { return m_property; }
     MonotonicTime generationTime() const { return m_generationTime; }
     std::optional<Seconds> timelineTimeAtCreation() const { return m_timelineTimeAtCreation; }
     const RenderStyle& targetStyle() const { return *m_targetStyle; }
@@ -54,14 +55,14 @@ public:
     double reversingShorteningFactor() const { return m_reversingShorteningFactor; }
 
 private:
-    CSSTransition(const Styleable&, CSSPropertyID, MonotonicTime generationTime, const Animation&, const RenderStyle& oldStyle, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double);
+    CSSTransition(const Styleable&, AnimatableProperty, MonotonicTime generationTime, const Animation&, const RenderStyle& oldStyle, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double);
     void setTimingProperties(Seconds delay, Seconds duration);
     Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId) final;
     void resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds>) final;
     void animationDidFinish() final;
     bool isCSSTransition() const final { return true; }
 
-    CSSPropertyID m_property;
+    AnimatableProperty m_property;
     MonotonicTime m_generationTime;
     Markable<Seconds, Seconds::MarkableTraits> m_timelineTimeAtCreation;
     std::unique_ptr<RenderStyle> m_targetStyle;

--- a/Source/WebCore/animation/CSSTransitionEvent.cpp
+++ b/Source/WebCore/animation/CSSTransitionEvent.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSTransitionEvent);
 
-CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId, const String& propertyName)
+CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId, const String propertyName)
     : DeclarativeAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoId)
     , m_propertyName(propertyName)
 {

--- a/Source/WebCore/animation/CSSTransitionEvent.h
+++ b/Source/WebCore/animation/CSSTransitionEvent.h
@@ -33,7 +33,7 @@ namespace WebCore {
 class CSSTransitionEvent final : public DeclarativeAnimationEvent {
     WTF_MAKE_ISO_ALLOCATED(CSSTransitionEvent);
 public:
-    static Ref<CSSTransitionEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime,  double elapsedTime, PseudoId pseudoId, const String& propertyName)
+    static Ref<CSSTransitionEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime,  double elapsedTime, PseudoId pseudoId, const String propertyName)
     {
         return adoptRef(*new CSSTransitionEvent(type, animation, scheduledTime, elapsedTime, pseudoId, propertyName));
     }
@@ -58,7 +58,7 @@ public:
     EventInterface eventInterface() const override { return CSSTransitionEventInterfaceType; }
 
 private:
-    CSSTransitionEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId, const String& propertyName);
+    CSSTransitionEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId, const String propertyName);
     CSSTransitionEvent(const AtomString& type, const Init& initializer, IsTrusted);
 
     String m_propertyName;

--- a/Source/WebCore/animation/ElementAnimationRareData.h
+++ b/Source/WebCore/animation/ElementAnimationRareData.h
@@ -50,8 +50,8 @@ public:
     AnimationCollection& animations() { return m_animations; }
     CSSAnimationCollection& animationsCreatedByMarkup() { return m_animationsCreatedByMarkup; }
     void setAnimationsCreatedByMarkup(CSSAnimationCollection&&);
-    PropertyToTransitionMap& completedTransitionsByProperty() { return m_completedTransitionsByProperty; }
-    PropertyToTransitionMap& runningTransitionsByProperty() { return m_runningTransitionsByProperty; }
+    AnimatablePropertyToTransitionMap& completedTransitionsByProperty() { return m_completedTransitionsByProperty; }
+    AnimatablePropertyToTransitionMap& runningTransitionsByProperty() { return m_runningTransitionsByProperty; }
     const RenderStyle* lastStyleChangeEventStyle() const { return m_lastStyleChangeEventStyle.get(); }
     void setLastStyleChangeEventStyle(std::unique_ptr<const RenderStyle>&&);
     void cssAnimationsDidUpdate() { m_hasPendingKeyframesUpdate = false; }
@@ -64,8 +64,8 @@ private:
     std::unique_ptr<const RenderStyle> m_lastStyleChangeEventStyle;
     AnimationCollection m_animations;
     CSSAnimationCollection m_animationsCreatedByMarkup;
-    PropertyToTransitionMap m_completedTransitionsByProperty;
-    PropertyToTransitionMap m_runningTransitionsByProperty;
+    AnimatablePropertyToTransitionMap m_completedTransitionsByProperty;
+    AnimatablePropertyToTransitionMap m_runningTransitionsByProperty;
     PseudoId m_pseudoId;
     bool m_hasPendingKeyframesUpdate { false };
 };

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -155,7 +155,7 @@ public:
     const KeyframeList& blendingKeyframes() const { return m_blendingKeyframes; }
     const HashSet<AnimatableProperty>& animatedProperties();
     const HashSet<CSSPropertyID>& inheritedProperties() const { return m_inheritedProperties; }
-    bool animatesProperty(CSSPropertyID) const;
+    bool animatesProperty(AnimatableProperty) const;
     bool animatesDirectionAwareProperty() const;
 
     bool computeExtentOfTransformAnimation(LayoutRect&) const;

--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -64,7 +64,6 @@ using MarkableDouble = Markable<double, WebAnimationsMarkableDoubleTraits>;
 
 using AnimationCollection = ListHashSet<RefPtr<WebAnimation>>;
 using AnimationEvents = Vector<Ref<AnimationEventBase>>;
-using PropertyToTransitionMap = HashMap<CSSPropertyID, RefPtr<CSSTransition>>;
 using CSSAnimationCollection = ListHashSet<RefPtr<CSSAnimation>>;
 
 using AnimatableProperty = std::variant<CSSPropertyID, AtomString>;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4311,14 +4311,14 @@ const AnimationCollection* Element::animations(PseudoId pseudoId) const
     return nullptr;
 }
 
-bool Element::hasCompletedTransitionForProperty(PseudoId pseudoId, CSSPropertyID property) const
+bool Element::hasCompletedTransitionForProperty(PseudoId pseudoId, AnimatableProperty property) const
 {
     if (auto* animationData = animationRareData(pseudoId))
         return animationData->completedTransitionsByProperty().contains(property);
     return false;
 }
 
-bool Element::hasRunningTransitionForProperty(PseudoId pseudoId, CSSPropertyID property) const
+bool Element::hasRunningTransitionForProperty(PseudoId pseudoId, AnimatableProperty property) const
 {
     if (auto* animationData = animationRareData(pseudoId))
         return animationData->runningTransitionsByProperty().contains(property);
@@ -4349,12 +4349,12 @@ void Element::setAnimationsCreatedByMarkup(PseudoId pseudoId, CSSAnimationCollec
     ensureAnimationRareData(pseudoId).setAnimationsCreatedByMarkup(WTFMove(animations));
 }
 
-PropertyToTransitionMap& Element::ensureCompletedTransitionsByProperty(PseudoId pseudoId)
+AnimatablePropertyToTransitionMap& Element::ensureCompletedTransitionsByProperty(PseudoId pseudoId)
 {
     return ensureAnimationRareData(pseudoId).completedTransitionsByProperty();
 }
 
-PropertyToTransitionMap& Element::ensureRunningTransitionsByProperty(PseudoId pseudoId)
+AnimatablePropertyToTransitionMap& Element::ensureRunningTransitionsByProperty(PseudoId pseudoId)
 {
     return ensureAnimationRareData(pseudoId).runningTransitionsByProperty();
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -543,13 +543,13 @@ public:
     bool hasKeyframeEffects(PseudoId) const;
 
     const AnimationCollection* animations(PseudoId) const;
-    bool hasCompletedTransitionForProperty(PseudoId, CSSPropertyID) const;
-    bool hasRunningTransitionForProperty(PseudoId, CSSPropertyID) const;
+    bool hasCompletedTransitionForProperty(PseudoId, AnimatableProperty) const;
+    bool hasRunningTransitionForProperty(PseudoId, AnimatableProperty) const;
     bool hasRunningTransitions(PseudoId) const;
     AnimationCollection& ensureAnimations(PseudoId);
 
-    PropertyToTransitionMap& ensureCompletedTransitionsByProperty(PseudoId);
-    PropertyToTransitionMap& ensureRunningTransitionsByProperty(PseudoId);
+    AnimatablePropertyToTransitionMap& ensureCompletedTransitionsByProperty(PseudoId);
+    AnimatablePropertyToTransitionMap& ensureRunningTransitionsByProperty(PseudoId);
     CSSAnimationCollection& animationsCreatedByMarkup(PseudoId);
     void setAnimationsCreatedByMarkup(PseudoId, CSSAnimationCollection&&);
 

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -108,12 +108,12 @@ struct Styleable {
         return element.animations(pseudoId);
     }
 
-    bool hasCompletedTransitionForProperty(CSSPropertyID property) const
+    bool hasCompletedTransitionForProperty(AnimatableProperty property) const
     {
         return element.hasCompletedTransitionForProperty(pseudoId, property);
     }
 
-    bool hasRunningTransitionForProperty(CSSPropertyID property) const
+    bool hasRunningTransitionForProperty(AnimatableProperty property) const
     {
         return element.hasRunningTransitionForProperty(pseudoId, property);
     }
@@ -128,12 +128,12 @@ struct Styleable {
         return element.ensureAnimations(pseudoId);
     }
 
-    PropertyToTransitionMap& ensureCompletedTransitionsByProperty() const
+    AnimatablePropertyToTransitionMap& ensureCompletedTransitionsByProperty() const
     {
         return element.ensureCompletedTransitionsByProperty(pseudoId);
     }
 
-    PropertyToTransitionMap& ensureRunningTransitionsByProperty() const
+    AnimatablePropertyToTransitionMap& ensureRunningTransitionsByProperty() const
     {
         return element.ensureRunningTransitionsByProperty(pseudoId);
     }


### PR DESCRIPTION
#### 79a040808a384ca5d6de0bc72078284a8b8d1e5b
<pre>
[web-animations] adopt AnimatableProperty in ElementRareAnimationData and CSSTransition
<a href="https://bugs.webkit.org/show_bug.cgi?id=249589">https://bugs.webkit.org/show_bug.cgi?id=249589</a>

Reviewed by Dean Jackson.

ElementRareAnimationData and CSSTransition still used CSSPropertyID instead of AnimatableProperty,
as well as Styleable which deals with data structures exposed through ElementRareAnimationData.

We make those adopt AnimatableProperty as a final refactoring step to support CSS Transitions
of custom properties (see bug 249399).

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimation::propertiesEqual):
(WebCore::CSSPropertyAnimation::canPropertyBeInterpolated):
* Source/WebCore/animation/CSSPropertyAnimation.h:
* Source/WebCore/animation/CSSTransition.cpp:
(WebCore::CSSTransition::create):
(WebCore::CSSTransition::CSSTransition):
(WebCore::CSSTransition::createEvent):
(WebCore::CSSTransition::transitionProperty const):
* Source/WebCore/animation/CSSTransition.h:
* Source/WebCore/animation/CSSTransitionEvent.cpp:
(WebCore::CSSTransitionEvent::CSSTransitionEvent):
* Source/WebCore/animation/CSSTransitionEvent.h:
* Source/WebCore/animation/ElementAnimationRareData.h:
(WebCore::ElementAnimationRareData::completedTransitionsByProperty):
(WebCore::ElementAnimationRareData::runningTransitionsByProperty):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animatesProperty const):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/WebAnimationTypes.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::hasCompletedTransitionForProperty const):
(WebCore::Element::hasRunningTransitionForProperty const):
(WebCore::Element::ensureCompletedTransitionsByProperty):
(WebCore::Element::ensureRunningTransitionsByProperty):
* Source/WebCore/dom/Element.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::removeCSSTransitionFromMap):
(WebCore::Styleable::animationWasRemoved const):
(WebCore::keyframeEffectForElementAndProperty):
(WebCore::propertyInStyleMatchesValueForTransitionInMap):
(WebCore::transitionMatchesProperty):
(WebCore::compileTransitionPropertiesInStyle):
(WebCore::updateCSSTransitionsForStyleableAndProperty):
(WebCore::Styleable::updateCSSTransitions const):
* Source/WebCore/style/Styleable.h:
(WebCore::Styleable::hasCompletedTransitionForProperty const):
(WebCore::Styleable::hasRunningTransitionForProperty const):
(WebCore::Styleable::ensureCompletedTransitionsByProperty const):
(WebCore::Styleable::ensureRunningTransitionsByProperty const):

Canonical link: <a href="https://commits.webkit.org/258120@main">https://commits.webkit.org/258120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82c9db07c46783c5c4be564811e78bcbe3e0fb19

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110219 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170488 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/936 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93327 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108061 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34931 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77906 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3752 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24494 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3771 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/889 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43994 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5548 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2920 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->