### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/flood-opacity.html to match the latest specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity-expected.txt
@@ -8,14 +8,14 @@ PASS Can set 'flood-opacity' to a number: 0
 PASS Can set 'flood-opacity' to a number: -3.14
 PASS Can set 'flood-opacity' to a number: 3.14
 PASS Can set 'flood-opacity' to a number: calc(2 + 3)
+PASS Can set 'flood-opacity' to a percent: 0%
+PASS Can set 'flood-opacity' to a percent: -3.14%
+PASS Can set 'flood-opacity' to a percent: 3.14%
+PASS Can set 'flood-opacity' to a percent: calc(0% + 0%)
 PASS Setting 'flood-opacity' to a length: 0px throws TypeError
 PASS Setting 'flood-opacity' to a length: -3.14em throws TypeError
 PASS Setting 'flood-opacity' to a length: 3.14cm throws TypeError
 PASS Setting 'flood-opacity' to a length: calc(0px + 0em) throws TypeError
-FAIL Setting 'flood-opacity' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'flood-opacity' to a percent: -3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'flood-opacity' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'flood-opacity' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'flood-opacity' to a time: 0s throws TypeError
 PASS Setting 'flood-opacity' to a time: -3.14ms throws TypeError
 PASS Setting 'flood-opacity' to a time: 3.14s throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity.html
@@ -13,7 +13,7 @@
 <script>
 'use strict';
 
-function assert_is_equal_with_clamping(input, result) {
+function assert_is_equal_with_clamping_number(input, result) {
   const number = input.to('number');
 
   if (number.value < 0)
@@ -24,11 +24,27 @@ function assert_is_equal_with_clamping(input, result) {
     assert_style_value_equals(result, input);
 }
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const number = input.to('percent');
+  const value = number.value / 100.;
+
+  if (value < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'number'));
+  else if (value > 1)
+    assert_style_value_equals(result, new CSSUnitValue(1, 'number'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(value, 'number'));
+}
+
 runPropertyTests('flood-opacity', [
   {
     syntax: '<number>',
-    computed: assert_is_equal_with_clamping
+    computed: assert_is_equal_with_clamping_number
   },
+  {
+    syntax: '<percentage>',
+    computed: assert_is_equal_with_clamping_percentage
+  }
 ]);
 
 </script>


### PR DESCRIPTION
#### 7764885ca2ebcaccb786509fed3c8309fc138137
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/flood-opacity.html to match the latest specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=249590">https://bugs.webkit.org/show_bug.cgi?id=249590</a>

Reviewed by Cameron McCormack.

Fix css/css-typed-om/the-stylepropertymap/properties/flood-opacity.html to
match the latest specification:
- <a href="https://drafts.fxtf.org/filter-effects/#FloodOpacityProperty">https://drafts.fxtf.org/filter-effects/#FloodOpacityProperty</a>
- <a href="https://drafts.csswg.org/css-color-5/#typedef-alpha-value">https://drafts.csswg.org/css-color-5/#typedef-alpha-value</a>

The specification allows percentages.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flood-opacity.html:

Canonical link: <a href="https://commits.webkit.org/258099@main">https://commits.webkit.org/258099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1eab9c3fd36b2512fbd6e26841f2b6505e9a1940

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110194 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170465 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/909 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93302 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108036 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34909 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90203 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77884 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3728 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24470 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3746 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/866 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43966 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5524 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2912 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->