### PR TITLE
JetStream3 harness: reset seed of Math.random() on every benchmark iteration

### DIFF
--- a/PerformanceTests/JetStream3/simple/file-system.js
+++ b/PerformanceTests/JetStream3/simple/file-system.js
@@ -25,25 +25,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-let seed;
-function resetSeed() {
-    seed = 49734321;
-}
-resetSeed();
-
-Math.random = (function() {
-    return function() {
-        // Robert Jenkins' 32 bit integer hash function.
-        seed = ((seed + 0x7ed55d16) + (seed << 12))  & 0xffffffff;
-        seed = ((seed ^ 0xc761c23c) ^ (seed >>> 19)) & 0xffffffff;
-        seed = ((seed + 0x165667b1) + (seed << 5))   & 0xffffffff;
-        seed = ((seed + 0xd3a2646c) ^ (seed << 9))   & 0xffffffff;
-        seed = ((seed + 0xfd7046c5) + (seed << 3))   & 0xffffffff;
-        seed = ((seed ^ 0xb55a4f09) ^ (seed >>> 16)) & 0xffffffff;
-        return (seed & 0xfffffff) / 0x10000000;
-    };
-})();
-
 function computeIsLittleEndian() {
     let buf = new ArrayBuffer(4);
     let dv = new DataView(buf);
@@ -185,8 +166,6 @@ async function setupDirectory() {
 
 class Benchmark {
     async runIteration() {
-        resetSeed();
-
         try {
             const fs = await setupDirectory();
 


### PR DESCRIPTION
#### 7bca60ef1a1704e00bd8ca90c006793f0556cb0d
<pre>
JetStream3 harness: reset seed of Math.random() on every benchmark iteration
<a href="https://bugs.webkit.org/show_bug.cgi?id=249592">https://bugs.webkit.org/show_bug.cgi?id=249592</a>

Reviewed by Yusuke Suzuki.

This change extracts Math.random() implementation, which resets its seed on every iteration,
from simple/file-system.js to be used for all other tests, including newly-added BigInt crypto
tests that heavily rely on Math.random().

* PerformanceTests/JetStream3/JetStreamDriver.js:
(prototype.get runnerCode):
(prototype.get preiterationCode):
(prototype.async run):
(AsyncBenchmark.get runnerCode.return.async doRun):
(AsyncBenchmark.prototype.get runnerCode):
(AsyncBenchmark):
* PerformanceTests/JetStream3/simple/file-system.js:
(Benchmark.prototype.async runIteration):
(Benchmark):
(resetSeed): Deleted.
(Math.random): Deleted.

Canonical link: <a href="https://commits.webkit.org/258213@main">https://commits.webkit.org/258213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e35def308d6280321e611c96c1fb7c3e401ef49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110196 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/911 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93304 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108038 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91555 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34911 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22952 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77886 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3730 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24472 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/868 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43968 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5526 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2963 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->