### PR TITLE
Escape '&' in javascript URLs for innerHTML/outerHTML

### DIFF
--- a/LayoutTests/fast/innerHTML/javascript-url-expected.txt
+++ b/LayoutTests/fast/innerHTML/javascript-url-expected.txt
@@ -1,13 +1,12 @@
-Test that innerHTML does not mangle javascript: urls.
-r.innerHTML = r.innerHTML.replace(/&37;3C!--D--&37;3E/g, 123)
-PASS: r.innerHTML.indexOf('javascript:test(123)') > -1 should be true and is.
-r.firstChild.setAttribute('href', 'javascript:test("text<")')
-PASS: r.innerHTML.indexOf('javascript:test("text<")') > -1 should be true and is.
-r.firstChild.setAttribute("href", "javascript:test('text>')")
-PASS: r.innerHTML.indexOf("javascript:test('text>')") > -1 should be true and is.
-testString = javascript:test('text&',"test2&")
-r.firstChild.setAttribute("href", testString)
-PASS: r.innerHTML.indexOf("javascript:test('text&',&quot;test2&&quot;)") > 1 should be true and is.
-r.firstChild.setAttribute('href', 'http://www.google.fi/search?q=scarlett johansson&meta=&btnG=Google-haku')
-<a href="http://www.google.fi/search?q=scarlett johansson&amp;meta=&amp;btnG=Google-haku">link</a>
+Test that innerHTML/outerHTML does not mangle javascript: urls.
+PASS r.innerHTML is "<a href=\"javascript:test(123)\">link</a>"
+PASS r.innerHTML is "<a href='javascript:test(\"text<\")'>link</a>"
+PASS r.innerHTML is "<a href=\"javascript:test('text>')\">link</a>"
+PASS r.innerHTML is "<a href=\"javascript:test('text&amp;',&quot;test2&amp;&quot;)\">link</a>"
+PASS r.firstChild.outerHTML is "<a href=\"javascript:window.location='?x&amp;y'\">link</a>"
+PASS r.firstChild.outerHTML is "<a href=\"javascript:window.location='?x&amp;amp;y'\">link</a>"
+PASS r.firstChild.outerHTML is "<a href=\"javascript:window.location='?x&amp;y'\">link</a>"
+PASS successfullyParsed is true
+
+TEST COMPLETE
 link

--- a/LayoutTests/fast/innerHTML/javascript-url.html
+++ b/LayoutTests/fast/innerHTML/javascript-url.html
@@ -1,62 +1,25 @@
-<head>
-<script>
-if (window.testRunner)
-    testRunner.dumpAsText();
-    
-function print(message, color) 
-{
-    var paragraph = document.createElement("div");
-    paragraph.appendChild(document.createTextNode(message));
-    paragraph.style.fontFamily = "monospace";
-    if (color)
-        paragraph.style.color = color;
-    document.getElementById("console").appendChild(paragraph);
-}
-
-function run(a)
-{
-    print(a);
-    try {
-        eval(a);
-    } catch(e) {
-        print(e);
-    }
-}
-
-function shouldBe(a, b)
-{
-    var evalA;
-    try {
-        evalA = eval(a);
-    } catch(e) {
-        evalA = e;
-    }
-    
-    if (evalA == b)
-        print("PASS: " + a + " should be " + b + " and is.", "green");
-    else
-        print("FAIL: " + a + " should be " + b + " but instead is " + evalA + ".", "red");
-}
-</script>
-</head>
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
 <body>
-Test that innerHTML does not mangle javascript: urls.
+Test that innerHTML/outerHTML does not mangle javascript: urls.
 <div id=console></div>
-<div id=jsurltest><a href='
- javascript:test(&37;3C!--D--&37;3E)'>link</a></div>
+<div id=jsurltest><a href='javascript:test(&37;3C!--D--&37;3E)'>link</a></div>
 <script>
 var r = document.getElementById('jsurltest');
-run("r.innerHTML = r.innerHTML.replace(/&37;3C!--D--&37;3E/g, 123)");
-shouldBe("r.innerHTML.indexOf('javascript:test(123)') > -1", true);
-run("r.firstChild.setAttribute('href', 'javascript:test(\"text<\")')");
-shouldBe("r.innerHTML.indexOf('javascript:test(\"text<\")') > -1", true);
-run('r.firstChild.setAttribute("href", "javascript:test(\'text>\')")');
-shouldBe('r.innerHTML.indexOf("javascript:test(\'text>\')") > -1', true);
+r.innerHTML = r.innerHTML.replace('&amp;37;3C!--D--&amp;37;3E', 123);
+shouldBeEqualToString('r.innerHTML', '<a href="javascript:test(123)">link</a>');
+r.firstChild.setAttribute('href', 'javascript:test(\"text<\")');
+shouldBeEqualToString('r.innerHTML', '<a href=\'javascript:test("text<")\'>link</a>');
+r.firstChild.setAttribute('href', 'javascript:test(\'text>\')');
+shouldBeEqualToString("r.innerHTML", '<a href="javascript:test(\'text>\')">link</a>');
 testString = 'javascript:test(\'text&\',"test2&")';
-print("testString = " + testString);
-run('r.firstChild.setAttribute("href", testString)');
-shouldBe('r.innerHTML.indexOf("javascript:test(\'text&\',&quot;test2&&quot;)") > 1', true);
-
-run("r.firstChild.setAttribute('href', 'http://www.google.fi/search?q=scarlett johansson&meta=&btnG=Google-haku')");
-print(r.innerHTML);
+r.firstChild.setAttribute('href', testString);
+shouldBeEqualToString('r.innerHTML', '<a href="javascript:test(\'text&amp;\',&quot;test2&amp;&quot;)">link</a>');
+r.firstChild.href = 'javascript:window.location=\'?x&y\'';
+shouldBeEqualToString("r.firstChild.outerHTML", '<a href="javascript:window.location=\'?x&amp;y\'">link</a>');
+// Behavior is same as FF
+r.firstChild.href = 'javascript:window.location=\'?x&amp;y\'';
+shouldBeEqualToString('r.firstChild.outerHTML', '<a href="javascript:window.location=\'?x&amp;amp;y\'">link</a>');
+r.innerHTML = '<a href="javascript:window.location=\'?x&amp;y\'">link</a>';
+shouldBeEqualToString('r.firstChild.outerHTML', '<a href="javascript:window.location=\'?x&amp;y\'">link</a>');
 </script>

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2009-2022 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -312,6 +312,9 @@ void MarkupAccumulator::appendQuotedURLAttributeValue(StringBuilder& result, con
     char quoteChar = '"';
     if (WTF::protocolIsJavaScript(resolvedURLString)) {
         // minimal escaping for javascript urls
+        if (resolvedURLString.contains('&'))
+            resolvedURLString = makeStringByReplacingAll(resolvedURLString, '&', "&amp;"_s);
+
         if (resolvedURLString.contains('"')) {
             if (resolvedURLString.contains('\''))
                 resolvedURLString = makeStringByReplacingAll(resolvedURLString, '"', "&quot;"_s);


### PR DESCRIPTION
#### aff702358ff43fa9220b4e72da9bc3bab8c117b7
<pre>
Escape &apos;&amp;&apos; in javascript URLs for innerHTML/outerHTML

Escape &apos;&amp;&apos; in javascript URLs for innerHTML/outerHTML
<a href="https://bugs.webkit.org/show_bug.cgi?id=249576">https://bugs.webkit.org/show_bug.cgi?id=249576</a>

Reviewed by Ryosuke Niwa.

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://src.chromium.org/viewvc/blink?revision=192539&amp">https://src.chromium.org/viewvc/blink?revision=192539&amp</a>;view=revision

It is to add special handling with HTML escape when serializing URL is already
implemented for quote. Added implementation to replace &apos;&amp;&apos; by &apos;&amp;amp;&apos;.

* Source/WebCore/editing/MarkupAccumulator.cpp:
(MarkupAccumulator::appendQuotedURLAttributeValue): Add condition to escape &quot;&amp;&quot;
* LayoutTests/fast/innerHTML/javascript-url.html: Updated
* LayoutTests/fast/innerHTML/javascript-url-expected.txt: Updated Expectations

Canonical link: <a href="https://commits.webkit.org/258112@main">https://commits.webkit.org/258112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32d6e0e231e783685741a0f805f9c42c48be10f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110199 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170469 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/914 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93306 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108041 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34913 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22955 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77888 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3732 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24475 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/869 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9863 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43971 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5569 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5528 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->