### PR TITLE
White spaces in the 'keyTimes' attribute should be ignored

### DIFF
--- a/LayoutTests/svg/animations/animate-keyTimes-attribute-white-spaces-expected.svg
+++ b/LayoutTests/svg/animations/animate-keyTimes-attribute-white-spaces-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg"> 
+    <rect width="100" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/svg/animations/animate-keyTimes-attribute-white-spaces.svg
+++ b/LayoutTests/svg/animations/animate-keyTimes-attribute-white-spaces.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg"> 
+    <rect x="-100" y="-100" width="100" height="100" fill="green">
+        <animate attributeName="x" dur="50ms" values="-100 ; 0" keyTimes="0 ; 1 " fill="freeze" onend="handleEndEvent()"/>
+        <animate attributeName="y" dur="50ms" values="-100 ; 0" keyTimes="0 ; 1 " fill="freeze" onend="handleEndEvent()"/>
+    </rect>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        var handledEndEvents = 0;
+        function handleEndEvent() {
+            if (++handledEndEvents == 2) {
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }
+        }
+    </script>
+</svg>


### PR DESCRIPTION
#### 5f68aec1b0520e839d1244266b828a3880e8bee0
<pre>
White spaces in the &apos;keyTimes&apos; attribute should be ignored
<a href="https://bugs.webkit.org/show_bug.cgi?id=212162">https://bugs.webkit.org/show_bug.cgi?id=212162</a>
&lt;rdar://problem/63460019&gt;

Reviewed by Nikolas Zimmermann.

See <a href="https://svgwg.org/specs/animations/#KeyTimesAttribute.">https://svgwg.org/specs/animations/#KeyTimesAttribute.</a>

* LayoutTests/svg/animations/animate-keyTimes-attribute-white-spaces-expected.svg: Added.
* LayoutTests/svg/animations/animate-keyTimes-attribute-white-spaces.svg: Added.
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::parseKeyTimes):
(WebCore::SVGAnimationElement::parseAttribute):

Canonical link: <a href="https://commits.webkit.org/258129@main">https://commits.webkit.org/258129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c5a3afe07aced9b6ee962bd01749338d020e7db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110205 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170474 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/922 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93313 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108047 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34923 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77897 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3738 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24481 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/878 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43981 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5581 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5534 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->