### PR TITLE
Fix handling of grid-template-columns / grid-template-rows in CSS Typed OM

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
@@ -17,7 +17,6 @@ PASS Can set 'grid-auto-columns' to a percent: 3.14%
 PASS Can set 'grid-auto-columns' to a percent: calc(0% + 0%)
 PASS Can set 'grid-auto-columns' to a flexible length: 0fr
 PASS Can set 'grid-auto-columns' to a flexible length: 1fr
-FAIL Can set 'grid-auto-columns' to a flexible length: -3.14fr Invalid values
 PASS Setting 'grid-auto-columns' to a time: 0s throws TypeError
 PASS Setting 'grid-auto-columns' to a time: -3.14ms throws TypeError
 PASS Setting 'grid-auto-columns' to a time: 3.14s throws TypeError
@@ -26,6 +25,7 @@ PASS Setting 'grid-auto-columns' to an angle: 0deg throws TypeError
 PASS Setting 'grid-auto-columns' to an angle: 3.14rad throws TypeError
 PASS Setting 'grid-auto-columns' to an angle: -3.14deg throws TypeError
 PASS Setting 'grid-auto-columns' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'grid-auto-columns' to a flexible length: -3.14fr throws TypeError
 FAIL Setting 'grid-auto-columns' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'grid-auto-columns' to a number: -3.14 throws TypeError
 PASS Setting 'grid-auto-columns' to a number: 3.14 throws TypeError
@@ -53,7 +53,6 @@ PASS Can set 'grid-auto-rows' to a percent: 3.14%
 PASS Can set 'grid-auto-rows' to a percent: calc(0% + 0%)
 PASS Can set 'grid-auto-rows' to a flexible length: 0fr
 PASS Can set 'grid-auto-rows' to a flexible length: 1fr
-FAIL Can set 'grid-auto-rows' to a flexible length: -3.14fr Invalid values
 PASS Setting 'grid-auto-rows' to a time: 0s throws TypeError
 PASS Setting 'grid-auto-rows' to a time: -3.14ms throws TypeError
 PASS Setting 'grid-auto-rows' to a time: 3.14s throws TypeError
@@ -62,6 +61,7 @@ PASS Setting 'grid-auto-rows' to an angle: 0deg throws TypeError
 PASS Setting 'grid-auto-rows' to an angle: 3.14rad throws TypeError
 PASS Setting 'grid-auto-rows' to an angle: -3.14deg throws TypeError
 PASS Setting 'grid-auto-rows' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'grid-auto-rows' to a flexible length: -3.14fr throws TypeError
 FAIL Setting 'grid-auto-rows' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'grid-auto-rows' to a number: -3.14 throws TypeError
 PASS Setting 'grid-auto-rows' to a number: 3.14 throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt
@@ -5,14 +5,16 @@ PASS Can set 'grid-template-columns' to CSS-wide keywords: unset
 PASS Can set 'grid-template-columns' to CSS-wide keywords: revert
 PASS Can set 'grid-template-columns' to var() references:  var(--A)
 PASS Can set 'grid-template-columns' to the 'none' keyword: none
-FAIL Setting 'grid-template-columns' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'grid-template-columns' to a length: -3.14em throws TypeError
-FAIL Setting 'grid-template-columns' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'grid-template-columns' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'grid-template-columns' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'grid-template-columns' to a percent: -3.14% throws TypeError
-FAIL Setting 'grid-template-columns' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'grid-template-columns' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Can set 'grid-template-columns' to a length: 0px
+PASS Can set 'grid-template-columns' to a length: -3.14em
+PASS Can set 'grid-template-columns' to a length: 3.14cm
+PASS Can set 'grid-template-columns' to a length: calc(0px + 0em)
+PASS Can set 'grid-template-columns' to a percent: 0%
+FAIL Can set 'grid-template-columns' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'grid-template-columns' to a percent: 3.14%
+PASS Can set 'grid-template-columns' to a percent: calc(0% + 0%)
+PASS Can set 'grid-template-columns' to a flexible length: 0fr
+PASS Can set 'grid-template-columns' to a flexible length: 1fr
 PASS Setting 'grid-template-columns' to a time: 0s throws TypeError
 PASS Setting 'grid-template-columns' to a time: -3.14ms throws TypeError
 PASS Setting 'grid-template-columns' to a time: 3.14s throws TypeError
@@ -21,8 +23,6 @@ PASS Setting 'grid-template-columns' to an angle: 0deg throws TypeError
 PASS Setting 'grid-template-columns' to an angle: 3.14rad throws TypeError
 PASS Setting 'grid-template-columns' to an angle: -3.14deg throws TypeError
 PASS Setting 'grid-template-columns' to an angle: calc(0rad + 0deg) throws TypeError
-FAIL Setting 'grid-template-columns' to a flexible length: 0fr throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'grid-template-columns' to a flexible length: 1fr throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'grid-template-columns' to a flexible length: -3.14fr throws TypeError
 FAIL Setting 'grid-template-columns' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'grid-template-columns' to a number: -3.14 throws TypeError
@@ -39,14 +39,16 @@ PASS Can set 'grid-template-rows' to CSS-wide keywords: unset
 PASS Can set 'grid-template-rows' to CSS-wide keywords: revert
 PASS Can set 'grid-template-rows' to var() references:  var(--A)
 PASS Can set 'grid-template-rows' to the 'none' keyword: none
-FAIL Setting 'grid-template-rows' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'grid-template-rows' to a length: -3.14em throws TypeError
-FAIL Setting 'grid-template-rows' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'grid-template-rows' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'grid-template-rows' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'grid-template-rows' to a percent: -3.14% throws TypeError
-FAIL Setting 'grid-template-rows' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'grid-template-rows' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Can set 'grid-template-rows' to a length: 0px
+PASS Can set 'grid-template-rows' to a length: -3.14em
+PASS Can set 'grid-template-rows' to a length: 3.14cm
+PASS Can set 'grid-template-rows' to a length: calc(0px + 0em)
+PASS Can set 'grid-template-rows' to a percent: 0%
+FAIL Can set 'grid-template-rows' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'grid-template-rows' to a percent: 3.14%
+PASS Can set 'grid-template-rows' to a percent: calc(0% + 0%)
+PASS Can set 'grid-template-rows' to a flexible length: 0fr
+PASS Can set 'grid-template-rows' to a flexible length: 1fr
 PASS Setting 'grid-template-rows' to a time: 0s throws TypeError
 PASS Setting 'grid-template-rows' to a time: -3.14ms throws TypeError
 PASS Setting 'grid-template-rows' to a time: 3.14s throws TypeError
@@ -55,8 +57,6 @@ PASS Setting 'grid-template-rows' to an angle: 0deg throws TypeError
 PASS Setting 'grid-template-rows' to an angle: 3.14rad throws TypeError
 PASS Setting 'grid-template-rows' to an angle: -3.14deg throws TypeError
 PASS Setting 'grid-template-rows' to an angle: calc(0rad + 0deg) throws TypeError
-FAIL Setting 'grid-template-rows' to a flexible length: 0fr throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'grid-template-rows' to a flexible length: 1fr throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'grid-template-rows' to a flexible length: -3.14fr throws TypeError
 FAIL Setting 'grid-template-rows' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'grid-template-rows' to a number: -3.14 throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows.html
@@ -16,6 +16,18 @@
 for (const suffix of ['columns', 'rows']) {
   runPropertyTests(`grid-template-${suffix}`, [
     { syntax: 'none' },
+    {
+      syntax: '<length>',
+      specified: assert_is_equal_with_range_handling
+    },
+    {
+      syntax: '<percentage>',
+      specified: assert_is_equal_with_range_handling
+    },
+    {
+      syntax: '<flex>',
+      specified: assert_is_equal_with_range_handling
+    }
   ]);
 
   runUnsupportedPropertyTests(`grid-template-${suffix}`, [

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resources/testsuite.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resources/testsuite.js
@@ -193,12 +193,17 @@ const gTestSyntaxExamples = {
         description: "one fraction",
         input: new CSSUnitValue(1, 'fr')
       },
+      // TODO(https://github.com/w3c/css-houdini-drafts/issues/734):
+      // Add calc tests involving 'fr' when that is spec'd in CSS.
+    ],
+  },
+  '<negative-flex>': {
+    description: 'a flexible length',
+    examples: [
       {
         description: "negative fraction",
         input: new CSSUnitValue(-3.14, 'fr')
       },
-      // TODO(https://github.com/w3c/css-houdini-drafts/issues/734):
-      // Add calc tests involving 'fr' when that is spec'd in CSS.
     ],
   },
   '<number>': {

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -227,6 +227,8 @@ static bool isValueOutOfRangeForProperty(CSSPropertyID propertyID, double value,
     case CSSPropertyFontStretch:
     case CSSPropertyGridAutoColumns:
     case CSSPropertyGridAutoRows:
+    case CSSPropertyGridTemplateColumns:
+    case CSSPropertyGridTemplateRows:
     case CSSPropertyInlineSize:
     case CSSPropertyLineHeight:
     case CSSPropertyMaxBlockSize:

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1051,6 +1051,7 @@ inline GridTrackSize BuilderConverter::createGridTrackSize(const CSSValue& value
 
 inline bool BuilderConverter::createGridTrackList(const CSSValue& value, GridTrackList& trackList, BuilderState& builderState)
 {
+    RefPtr<const CSSValueList> valueList;
     // Handle 'none' or 'masonry'.
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (primitiveValue->valueID() == CSSValueMasonry) {
@@ -1058,14 +1059,22 @@ inline bool BuilderConverter::createGridTrackList(const CSSValue& value, GridTra
             trackList.append(GridTrackEntryMasonry());
             return true;
         }
-        return primitiveValue->valueID() == CSSValueNone;
-    }
+        // Values coming from CSS Typed OM may not have been converted to a CSSValueList yet.
+        if (primitiveValue->valueID() == CSSValueNone)
+            return true;
 
-    if (!is<CSSValueList>(value))
+        auto newList = CSSValueList::createSpaceSeparated();
+        newList->append(const_cast<CSSValue&>(value));
+        valueList = WTFMove(newList);
+    } else if (is<CSSValueList>(value))
+        valueList = &downcast<CSSValueList>(value);
+    else
         return false;
 
+    ASSERT(valueList);
+
     bool isSubgrid = false;
-    if (is<CSSSubgridValue>(value)) {
+    if (is<CSSSubgridValue>(*valueList)) {
         isSubgrid = true;
         trackList.append(GridTrackEntrySubgrid());
     }
@@ -1097,7 +1106,7 @@ inline bool BuilderConverter::createGridTrackList(const CSSValue& value, GridTra
             ensureLineNames(repeatList);
     };
 
-    for (auto& currentValue : downcast<CSSValueList>(value)) {
+    for (auto& currentValue : *valueList) {
         if (is<CSSGridLineNamesValue>(currentValue)) {
             Vector<String> names;
             for (auto& namedGridLineValue : downcast<CSSGridLineNamesValue>(currentValue.get()))


### PR DESCRIPTION
#### a5f4bb317a21ecac43636ca62237877d6627f83b
<pre>
Fix handling of grid-template-columns / grid-template-rows in CSS Typed OM
<a href="https://bugs.webkit.org/show_bug.cgi?id=249601">https://bugs.webkit.org/show_bug.cgi?id=249601</a>

Reviewed by Simon Fraser.

Fix handling of grid-template-columns / grid-template-rows in CSS Typed OM.

I updated the grid-template-columns-rows.html WPT test to allow &lt;length&gt;,
&lt;percentage&gt; and &lt;flex&gt;, as per the specification:
- <a href="https://w3c.github.io/csswg-drafts/css-grid/#auto-tracks">https://w3c.github.io/csswg-drafts/css-grid/#auto-tracks</a>
- <a href="https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-size">https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-size</a>
- <a href="https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-breadth">https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-breadth</a>

In doing so, I found several issues with our implementation:
- While we allowed setting such values, the returned computed value after
  setting would always be &quot;none&quot;. This was due to a bug in our style builder
  converter where we assumed that the value was the &quot;none&quot; keyword if its
  type was a CSSPrimitiveValue. However, when coming from CSS-Typed-OM (and
  not the CSS parser), the input CSSPrimitiveValue may not have been converted
  to a CSSValueList yet. As a result, I updated the style builder converter
  to create the CSSValueList on the fly if needed.
- Per the specification, negative values are not allowed. However, those
  properties were not handled in isValueOutOfRangeForProperty() and we would
  thus fail to wrap the negative values into a `calc()`.

Finally, I updated the tests to separate the testing of positive and negative
&lt;flex&gt; values (&apos;fr&apos; unit). The reason for this is that these properties allow
&lt;flex&gt; values but do not allow negative &lt;flex&gt; values. Normally, such values
would get wrapped into a `calc()` so they could be set without throwing an
exception. However, &lt;flex&gt; values are currently invalid inside a calc(), as
per:
- <a href="https://w3c.github.io/csswg-drafts/css-grid/#fr-unit">https://w3c.github.io/csswg-drafts/css-grid/#fr-unit</a>
&quot;Note: &lt;flex&gt; values are not &lt;length&gt;s (nor are they compatible with &lt;length&gt;s,
 like some &lt;percentage&gt; values), so they cannot be represented in or combined
 with other unit types in calc() expressions.&quot;

As a result, we throw a TypeError when trying to set a negative &lt;flex&gt; value
for these 2 properties, which I believe is the expected behavior.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/resources/testsuite.js:
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::isValueOutOfRangeForProperty):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::createGridTrackList):

Canonical link: <a href="https://commits.webkit.org/258102@main">https://commits.webkit.org/258102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49efc890bc5d9e8183768f7bf7b34c94988c2fa4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110207 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170476 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/924 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93315 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108049 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34921 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90213 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77898 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3740 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24480 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3759 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/877 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43980 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5562 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5536 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->