### PR TITLE
[WK2] Polish and utilize encoding, decoding of Span<T, Extent>

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h
+++ b/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h
@@ -80,16 +80,16 @@ private:
 template<class Encoder>
 void CAAudioStreamDescription::encode(Encoder& encoder) const
 {
-    encoder.encodeFixedLengthData(reinterpret_cast<const uint8_t*>(&m_streamDescription), sizeof(m_streamDescription), 1);
+    encoder.encodeObject(m_streamDescription);
 }
 
 template<class Decoder>
 std::optional<CAAudioStreamDescription> CAAudioStreamDescription::decode(Decoder& decoder)
 {
-    AudioStreamBasicDescription asbd { };
-    if (!decoder.decodeFixedLengthData(reinterpret_cast<uint8_t*>(&asbd), sizeof(asbd), 1))
+    auto asbd = decoder.template decodeObject<AudioStreamBasicDescription>();
+    if (!asbd)
         return std::nullopt;
-    return CAAudioStreamDescription { asbd };
+    return CAAudioStreamDescription { *asbd };
 }
 
 inline CAAudioStreamDescription toCAAudioStreamDescription(const AudioStreamDescription& description)

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -62,12 +62,12 @@ template<typename T> struct SimpleArgumentCoder {
     template<typename Encoder>
     static void encode(Encoder& encoder, const T& t)
     {
-        encoder.encodeFixedLengthData(reinterpret_cast<const uint8_t*>(&t), sizeof(T), alignof(T));
+        encoder.encodeObject(t);
     }
 
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, T& t)
+    static std::optional<T> decode(Decoder& decoder)
     {
-        return decoder.decodeFixedLengthData(reinterpret_cast<uint8_t*>(&t), sizeof(T), alignof(T));
+        return decoder.decodeObject<T>();
     }
 };
 

--- a/Source/WebKit/Platform/IPC/Decoder.cpp
+++ b/Source/WebKit/Platform/IPC/Decoder.cpp
@@ -153,17 +153,6 @@ std::unique_ptr<Decoder> Decoder::unwrapForTesting(Decoder& decoder)
     return wrappedDecoder;
 }
 
-const uint8_t* Decoder::decodeFixedLengthReference(size_t size, size_t alignment)
-{
-    if (!alignBufferPosition(alignment, size))
-        return nullptr;
-
-    const uint8_t* data = m_bufferPos;
-    m_bufferPos += size;
-
-    return data;
-}
-
 std::optional<Attachment> Decoder::takeLastAttachment()
 {
     if (m_attachments.isEmpty()) {

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -96,6 +96,9 @@ public:
     WARN_UNUSED_RETURN Span<const T> decodeSpan(size_t);
 
     template<typename T>
+    WARN_UNUSED_RETURN std::optional<T> decodeObject();
+
+    template<typename T>
     WARN_UNUSED_RETURN bool decode(T& t)
     {
         using Impl = ArgumentCoder<std::remove_cvref_t<T>, void>;
@@ -242,6 +245,20 @@ inline Span<const T> Decoder::decodeSpan(size_t size)
 
     m_bufferPos = alignedPosition + size * sizeof(T);
     return { reinterpret_cast<const T*>(alignedPosition), size };
+}
+
+template<typename T>
+inline std::optional<T> Decoder::decodeObject()
+{
+    static_assert(std::is_trivially_copyable_v<T>);
+
+    auto data = decodeSpan<T>(1);
+    if (!data.data())
+        return std::nullopt;
+
+    T object { };
+    memcpy(&object, data.data(), sizeof(T));
+    return object;
 }
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -87,11 +87,8 @@ public:
     WARN_UNUSED_RETURN bool isValid() const { return m_bufferPos != nullptr; }
     void markInvalid() { m_bufferPos = nullptr; }
 
-    WARN_UNUSED_RETURN bool decodeFixedLengthData(uint8_t* data, size_t, size_t alignment);
-
     // The data in the returned pointer here will only be valid for the lifetime of the Decoder object.
     // Returns nullptr on failure.
-    WARN_UNUSED_RETURN const uint8_t* decodeFixedLengthReference(size_t, size_t alignment);
     template<typename T>
     WARN_UNUSED_RETURN Span<const T> decodeSpan(size_t);
 
@@ -145,26 +142,12 @@ public:
         }
     }
 
-    template<typename T>
-    bool bufferIsLargeEnoughToContain(size_t numElements) const
-    {
-        static_assert(std::is_arithmetic<T>::value, "Type T must have a fixed, known encoded size!");
-
-        if (numElements > std::numeric_limits<size_t>::max() / sizeof(T))
-            return false;
-
-        return bufferIsLargeEnoughToContain(alignof(T), numElements * sizeof(T));
-    }
-
     std::optional<Attachment> takeLastAttachment();
 
     static constexpr bool isIPCDecoder = true;
 
 private:
     Decoder(const uint8_t* buffer, size_t bufferSize, BufferDeallocator&&, Vector<Attachment>&&);
-
-    bool alignBufferPosition(size_t alignment, size_t);
-    bool bufferIsLargeEnoughToContain(size_t alignment, size_t) const;
 
     const uint8_t* m_buffer;
     const uint8_t* m_bufferPos;
@@ -184,15 +167,6 @@ private:
 #endif
 };
 
-inline const uint8_t* roundUpToAlignment(const uint8_t* ptr, size_t alignment)
-{
-    // Assert that the alignment is a power of 2.
-    ASSERT(alignment && !(alignment & (alignment - 1)));
-
-    uintptr_t alignmentMask = alignment - 1;
-    return reinterpret_cast<uint8_t*>((reinterpret_cast<uintptr_t>(ptr) + alignmentMask) & ~alignmentMask);
-}
-
 inline bool alignedBufferIsLargeEnoughToContain(const uint8_t* alignedPosition, const uint8_t* bufferStart, const uint8_t* bufferEnd, size_t size)
 {
     // When size == 0 for the last argument and it's a variable length byte array,
@@ -200,35 +174,6 @@ inline bool alignedBufferIsLargeEnoughToContain(const uint8_t* alignedPosition, 
     // is not an off-by-one error since (static_cast<size_t>(bufferEnd - alignedPosition) >= size)
     // will catch issues when size != 0.
     return bufferEnd >= alignedPosition && bufferStart <= alignedPosition && static_cast<size_t>(bufferEnd - alignedPosition) >= size;
-}
-
-inline bool Decoder::alignBufferPosition(size_t alignment, size_t size)
-{
-    const uint8_t* alignedPosition = roundUpToAlignment(m_bufferPos, alignment);
-    if (UNLIKELY(!alignedBufferIsLargeEnoughToContain(alignedPosition, m_buffer, m_bufferEnd, size))) {
-        // We've walked off the end of this buffer.
-        markInvalid();
-        return false;
-    }
-
-    m_bufferPos = alignedPosition;
-    return true;
-}
-
-inline bool Decoder::bufferIsLargeEnoughToContain(size_t alignment, size_t size) const
-{
-    return alignedBufferIsLargeEnoughToContain(roundUpToAlignment(m_bufferPos, alignment), m_buffer, m_bufferEnd, size);
-}
-
-inline bool Decoder::decodeFixedLengthData(uint8_t* data, size_t size, size_t alignment)
-{
-    if (!alignBufferPosition(alignment, size))
-        return false;
-
-    memcpy(data, m_bufferPos, size);
-    m_bufferPos += size;
-
-    return true;
 }
 
 template<typename T>

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -70,6 +70,8 @@ public:
     void encodeFixedLengthData(const uint8_t* data, size_t, size_t alignment);
     template<typename T, size_t Extent>
     void encodeSpan(const Span<T, Extent>&);
+    template<typename T>
+    void encodeObject(const T&);
 
     template<typename T>
     Encoder& operator<<(T&& t)
@@ -114,6 +116,13 @@ template<typename T, size_t Extent>
 inline void Encoder::encodeSpan(const Span<T, Extent>& data)
 {
     encodeFixedLengthData(reinterpret_cast<const uint8_t*>(data.data()), data.size_bytes(), alignof(T));
+}
+
+template<typename T>
+inline void Encoder::encodeObject(const T& object)
+{
+    static_assert(std::is_trivially_copyable_v<T>);
+    encodeSpan(Span { std::addressof(object), 1 });
 }
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -67,7 +67,6 @@ public:
 
     void wrapForTesting(UniqueRef<Encoder>&&);
 
-    void encodeFixedLengthData(const uint8_t* data, size_t, size_t alignment);
     template<typename T, size_t Extent>
     void encodeSpan(const Span<T, Extent>&);
     template<typename T>
@@ -90,6 +89,7 @@ public:
     static constexpr bool isIPCEncoder = true;
 
 private:
+    void encodeFixedLengthData(const uint8_t* data, size_t, size_t alignment);
     uint8_t* grow(size_t alignment, size_t);
 
     bool hasAttachments() const;

--- a/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
@@ -76,6 +76,13 @@ public:
     }
 
     template<typename T>
+    bool encodeObject(const T& object)
+    {
+        static_assert(std::is_trivially_copyable_v<T>);
+        return encodeSpan(Span { std::addressof(object), 1 });
+    }
+
+    template<typename T>
     StreamConnectionEncoder& operator<<(T&& t)
     {
         ArgumentCoder<std::remove_cvref_t<T>, void>::encode(*this, std::forward<T>(t));

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -261,9 +261,9 @@ void ArgumentCoder<RectEdges<bool>>::encode(Encoder& encoder, const RectEdges<bo
     SimpleArgumentCoder<RectEdges<bool>>::encode(encoder, boxEdges);
 }
     
-bool ArgumentCoder<RectEdges<bool>>::decode(Decoder& decoder, RectEdges<bool>& boxEdges)
+std::optional<RectEdges<bool>> ArgumentCoder<RectEdges<bool>>::decode(Decoder& decoder)
 {
-    return SimpleArgumentCoder<RectEdges<bool>>::decode(decoder, boxEdges);
+    return SimpleArgumentCoder<RectEdges<bool>>::decode(decoder);
 }
 
 #if ENABLE(META_VIEWPORT)
@@ -272,17 +272,9 @@ void ArgumentCoder<ViewportArguments>::encode(Encoder& encoder, const ViewportAr
     SimpleArgumentCoder<ViewportArguments>::encode(encoder, viewportArguments);
 }
 
-bool ArgumentCoder<ViewportArguments>::decode(Decoder& decoder, ViewportArguments& viewportArguments)
-{
-    return SimpleArgumentCoder<ViewportArguments>::decode(decoder, viewportArguments);
-}
-
 std::optional<ViewportArguments> ArgumentCoder<ViewportArguments>::decode(Decoder& decoder)
 {
-    ViewportArguments viewportArguments;
-    if (!SimpleArgumentCoder<ViewportArguments>::decode(decoder, viewportArguments))
-        return std::nullopt;
-    return viewportArguments;
+    return SimpleArgumentCoder<ViewportArguments>::decode(decoder);
 }
 
 #endif // ENABLE(META_VIEWPORT)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -223,13 +223,12 @@ template<> struct ArgumentCoder<WebCore::DOMCacheEngine::Record> {
 
 template<> struct ArgumentCoder<WebCore::RectEdges<bool>> {
     static void encode(Encoder&, const WebCore::RectEdges<bool>&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::RectEdges<bool>&);
+    static std::optional<WebCore::RectEdges<bool>> decode(Decoder&);
 };
 
 #if ENABLE(META_VIEWPORT)
 template<> struct ArgumentCoder<WebCore::ViewportArguments> {
     static void encode(Encoder&, const WebCore::ViewportArguments&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ViewportArguments&);
     static std::optional<WebCore::ViewportArguments> decode(Decoder&);
 };
 #endif

--- a/Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp
+++ b/Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp
@@ -39,14 +39,11 @@ using namespace WebCore;
 template<> struct ArgumentCoder<LOGFONT> {
     static void encode(Encoder& encoder, const LOGFONT& logFont)
     {
-        encoder.encodeFixedLengthData(reinterpret_cast<const uint8_t*>(&logFont), sizeof logFont, 1);
+        encoder.encodeObject(logFont);
     }
     static std::optional<LOGFONT> decode(Decoder& decoder)
     {
-        LOGFONT logFont;
-        if (!decoder.decodeFixedLengthData(reinterpret_cast<uint8_t*>(&logFont), sizeof(logFont), 1))
-            return std::nullopt;
-        return logFont;
+        return decoder.decodeObject<LOGFONT>();
     }
 };
 

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -1884,7 +1884,7 @@ static bool encodeTypedArray(IPC::Encoder& encoder, JSContextRef context, JSValu
     if (!data.buffer)
         return false;
 
-    encoder.encodeFixedLengthData(reinterpret_cast<const uint8_t*>(data.buffer), data.length, 1);
+    encoder.encodeSpan(Span<const uint8_t> { reinterpret_cast<const uint8_t*>(data.buffer), data.length });
     return true;
 }
 


### PR DESCRIPTION
#### 052814cd7d8fb7e816ee514909b00282fda25052
<pre>
[WK2] Polish and utilize encoding, decoding of Span&lt;T, Extent&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=249603">https://bugs.webkit.org/show_bug.cgi?id=249603</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WTF/wtf/ArgumentCoder.h:
(IPC::ArgumentCoder&lt;bool&gt;::encode):
(IPC::ArgumentCoder&lt;bool&gt;::decode):
* Source/WebCore/Modules/highlight/AppHighlight.h:
(WebCore::AppHighlight::encode const):
(WebCore::AppHighlight::decode):
* Source/WebCore/Modules/webauthn/AuthenticatorResponseData.h:
(WebCore::encodeArrayBuffer):
(WebCore::decodeArrayBuffer):
* Source/WebCore/bindings/js/BufferSource.h:
(WebCore::BufferSource::encode const):
(WebCore::BufferSource::decode):
* Source/WebCore/bindings/js/SerializedScriptValue.h:
(WebCore::SerializedScriptValue::encode const):
(WebCore::SerializedScriptValue::decode):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::FragmentedSharedBuffer::create):
* Source/WebCore/platform/SharedBuffer.h:
(WebCore::FragmentedSharedBuffer::FragmentedSharedBuffer):
* Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h:
(WebCore::CAAudioStreamDescription::encode const):
(WebCore::CAAudioStreamDescription::decode):
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp:
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h:
(WebCore::ByteArrayPixelBuffer::encode const):
(WebCore::ByteArrayPixelBuffer::decode):
* Source/WebCore/platform/graphics/Model.h:
(WebCore::Model::encode const):
(WebCore::Model::decode):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h:
(WebCore::CapabilityValueOrRange::encode const):
(WebCore::CapabilityValueOrRange::decode):
* Source/WebKit/Platform/IPC/ArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;CString&gt;::encode):
(IPC::ArgumentCoder&lt;CString&gt;::decode):
(IPC::ArgumentCoder&lt;String&gt;::encode):
(IPC::decodeStringText):
(IPC::ArgumentCoder&lt;StringView&gt;::encode):
(IPC::ArgumentCoder&lt;SHA1::Digest&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;SHA1::Digest&gt;::decode): Deleted.
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
(IPC::SimpleArgumentCoder::encode):
(IPC::SimpleArgumentCoder::decode):
(IPC::ArgumentCoder&lt;SHA1::Digest&gt;::encode):
(IPC::ArgumentCoder&lt;SHA1::Digest&gt;::decode):
* Source/WebKit/Platform/IPC/Decoder.cpp:
(IPC::Decoder::decodeFixedLengthReference): Deleted.
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::decodeSpan):
(IPC::Decoder::decodeObject):
(IPC::Decoder::bufferIsLargeEnoughToContain const): Deleted.
(IPC::roundUpToAlignment): Deleted.
(IPC::Decoder::alignBufferPosition): Deleted.
(IPC::Decoder::decodeFixedLengthData): Deleted.
* Source/WebKit/Platform/IPC/Encoder.h:
(IPC::Encoder::encodeSpan):
(IPC::Encoder::encodeObject):
* Source/WebKit/Platform/IPC/StreamConnectionEncoder.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::FragmentedSharedBuffer&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::FragmentedSharedBuffer&gt;::decode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d5794f1846477c40f00a9f1ce00acfa62955ec1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/104063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/13158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/36992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/113275 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/173582 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/108007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/14218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/4070 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/96299 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/112355 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/109833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/94022 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/38636 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/25634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/80294 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/94139 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/6527 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/27010 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/90647 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/4306 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/6672 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/3549 "Found 1 new test failure: fast/images/avif-heif-container-as-image.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29902 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/12669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/46545 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/99258 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/8449 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/24971 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->