### PR TITLE
The MacCatalyst build shouldn't install a redundant copy of `webpushtool`

### DIFF
--- a/Source/WebKit/Configurations/webpushtool.xcconfig
+++ b/Source/WebKit/Configurations/webpushtool.xcconfig
@@ -25,6 +25,9 @@
 
 PRODUCT_NAME = webpushtool;
 
+SKIP_INSTALL = $(SKIP_INSTALL_$(WK_PLATFORM_NAME));
+SKIP_INSTALL_maccatalyst = YES;
+
 EXCLUDED_SOURCE_FILE_NAMES[sdk=appletv*] = *;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=watch*] = *;
 


### PR DESCRIPTION
#### 311b537dbda0bc38487c66b9fcedfe8821afdf6a
<pre>
The MacCatalyst build shouldn&apos;t install a redundant copy of `webpushtool`
<a href="https://bugs.webkit.org/show_bug.cgi?id=249606">https://bugs.webkit.org/show_bug.cgi?id=249606</a>

Reviewed by Brady Eidson.

Avoid installing a second copy of `webpushtool` when building WebKit for Catalyst, by skipping
installation for `webpushtool` (the original copy is already installed when building for macOS
proper).

* Source/WebKit/Configurations/webpushtool.xcconfig:

Canonical link: <a href="https://commits.webkit.org/258091@main">https://commits.webkit.org/258091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/606ac300d0c3c4b8a7f54ce5fcf08828229b04d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10064 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/33961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/110218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/935 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/108060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106694 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/33961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/93326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/33961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/33961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/3770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/33961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2908 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->