### PR TITLE
[WebGPU] GPUCanvasContext does not respect Document::deviceScaleFactor()

### DIFF
--- a/Source/WebCore/html/canvas/GPUCanvasContext.cpp
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.cpp
@@ -45,7 +45,8 @@ namespace WebCore {
 static IntSize getCanvasSizeAsIntSize(const GPUCanvasContext::CanvasType& canvas)
 {
     return WTF::switchOn(canvas, [](const RefPtr<HTMLCanvasElement>& htmlCanvas) -> IntSize {
-        return { static_cast<int>(htmlCanvas->width()), static_cast<int>(htmlCanvas->height()) };
+        auto scaleFactor = htmlCanvas->document().deviceScaleFactor();
+        return { static_cast<int>(scaleFactor * htmlCanvas->width()), static_cast<int>(scaleFactor * htmlCanvas->height()) };
     }
 #if ENABLE(OFFSCREEN_CANVAS)
     , [](const RefPtr<OffscreenCanvas>& offscreenCanvas) -> IntSize {

--- a/Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js
@@ -247,9 +247,18 @@ async function helloCube() {
         }
     };
 
+    const deviceScaleFactor = window.devicePixelRatio || 1;
     const depthTexture = device.createTexture({
-        size: [ canvas.width, canvas.height ],
+        size: [ canvas.width * deviceScaleFactor, canvas.height * deviceScaleFactor ],
         format: 'depth24plus',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+        sampleCount: 4
+    });
+
+    const msaaRenderTarget = device.createTexture({
+        size: [ canvas.width * deviceScaleFactor, canvas.height * deviceScaleFactor ],
+        sampleCount: 4,
+        format: 'bgra8unorm',
         usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
@@ -306,7 +315,8 @@ async function helloCube() {
         
         /* GPURenderPassColorATtachmentDescriptor */
         const colorAttachmentDescriptor = {
-            view: renderAttachment,
+            view: msaaRenderTarget.createView(),
+            resolveTarget: renderAttachment,
             loadOp: "clear",
             storeOp: "store",
             clearColor: darkBlue


### PR DESCRIPTION
#### f8f6a06f6b9a583fdd82365d6a05b68e19b267aa
<pre>
[WebGPU] GPUCanvasContext does not respect Document::deviceScaleFactor()
<a href="https://bugs.webkit.org/show_bug.cgi?id=249605">https://bugs.webkit.org/show_bug.cgi?id=249605</a>
&lt;radar://103528514&gt;

Reviewed by Dean Jackson.

Scale surface width by the device scale factor.

* Source/WebCore/html/canvas/GPUCanvasContext.cpp:
(WebCore::getCanvasSizeAsIntSize):

* Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js:
(async helloCube.frameUpdate):
(async helloCube):
Add a test to ensure this functionality works, also add MSAA support
to this sample which removes all jaggies as the cubes are rotating.

Canonical link: <a href="https://commits.webkit.org/258153@main">https://commits.webkit.org/258153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd5591193c8399484c125ec6127a77112df59a76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110224 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170493 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/941 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93332 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108066 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34934 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90230 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77910 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3757 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24493 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/892 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9888 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43995 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5601 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5553 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->