### PR TITLE
[ Gardening ] REBASELINE REGRESSION(257759@main): [ Mac wk1 ] imported/w3c/web-platform-t ests/css/css-typed-om/the-s tylepropertymap/properties/ scroll-behavior.html is a constant text failure (249506)

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2586,8 +2586,5 @@ webkit.org/b/248493 http/tests/security/contentSecurityPolicy/script-src-parsing
 [ Ventura+ ] compositing/fixed-with-main-thread-scrolling.html [ ImageOnlyFailure ]
 [ BigSur+ Debug x86_64 ] editing/execCommand/delete-non-editable-range-crash.html [ Pass Timeout ]
 
-# webkit.org/b/249506 REGRESSION(257759@main): [ Mac wk1 ] imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-behavior.html is a constant text failure
-imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-behavior.html [ Failure ]
-
 # https://bugs.webkit.org/show_bug.cgi?id=249544 Permissions::query does not support geolocation API
 imported/w3c/web-platform-tests/geolocation-API/permission.https.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-behavior-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-behavior-expected.txt
@@ -1,14 +1,35 @@
 
-FAIL Can set 'scroll-behavior' to CSS-wide keywords Invalid property scroll-behavior
-FAIL Can set 'scroll-behavior' to var() references Invalid property scroll-behavior
-FAIL Can set 'scroll-behavior' to the 'auto' keyword Invalid property scroll-behavior
-FAIL Can set 'scroll-behavior' to the 'smooth' keyword Invalid property scroll-behavior
-PASS Setting 'scroll-behavior' to a length throws TypeError
-PASS Setting 'scroll-behavior' to a percent throws TypeError
-PASS Setting 'scroll-behavior' to a time throws TypeError
-PASS Setting 'scroll-behavior' to an angle throws TypeError
-PASS Setting 'scroll-behavior' to a flexible length throws TypeError
-PASS Setting 'scroll-behavior' to a number throws TypeError
-PASS Setting 'scroll-behavior' to a URL throws TypeError
-PASS Setting 'scroll-behavior' to a transform throws TypeError
+FAIL Can set 'scroll-behavior' to CSS-wide keywords: initial Invalid property scroll-behavior
+FAIL Can set 'scroll-behavior' to CSS-wide keywords: inherit Invalid property scroll-behavior
+FAIL Can set 'scroll-behavior' to CSS-wide keywords: unset Invalid property scroll-behavior
+FAIL Can set 'scroll-behavior' to CSS-wide keywords: revert Invalid property scroll-behavior
+FAIL Can set 'scroll-behavior' to var() references:  var(--A) Invalid property scroll-behavior
+FAIL Can set 'scroll-behavior' to the 'auto' keyword: auto Invalid property scroll-behavior
+FAIL Can set 'scroll-behavior' to the 'smooth' keyword: smooth Invalid property scroll-behavior
+PASS Setting 'scroll-behavior' to a length: 0px throws TypeError
+PASS Setting 'scroll-behavior' to a length: -3.14em throws TypeError
+PASS Setting 'scroll-behavior' to a length: 3.14cm throws TypeError
+PASS Setting 'scroll-behavior' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'scroll-behavior' to a percent: 0% throws TypeError
+PASS Setting 'scroll-behavior' to a percent: -3.14% throws TypeError
+PASS Setting 'scroll-behavior' to a percent: 3.14% throws TypeError
+PASS Setting 'scroll-behavior' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'scroll-behavior' to a time: 0s throws TypeError
+PASS Setting 'scroll-behavior' to a time: -3.14ms throws TypeError
+PASS Setting 'scroll-behavior' to a time: 3.14s throws TypeError
+PASS Setting 'scroll-behavior' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'scroll-behavior' to an angle: 0deg throws TypeError
+PASS Setting 'scroll-behavior' to an angle: 3.14rad throws TypeError
+PASS Setting 'scroll-behavior' to an angle: -3.14deg throws TypeError
+PASS Setting 'scroll-behavior' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'scroll-behavior' to a flexible length: 0fr throws TypeError
+PASS Setting 'scroll-behavior' to a flexible length: 1fr throws TypeError
+PASS Setting 'scroll-behavior' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'scroll-behavior' to a number: 0 throws TypeError
+PASS Setting 'scroll-behavior' to a number: -3.14 throws TypeError
+PASS Setting 'scroll-behavior' to a number: 3.14 throws TypeError
+PASS Setting 'scroll-behavior' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'scroll-behavior' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'scroll-behavior' to a transform: perspective(10em) throws TypeError
+PASS Setting 'scroll-behavior' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
 


### PR DESCRIPTION
#### 72824dd77286e1e9b4dead502ea8b202cb8eba95
<pre>
[ Gardening ] REBASELINE REGRESSION(257759@main): [ Mac wk1 ] imported/w3c/web-platform-t ests/css/css-typed-om/the-s tylepropertymap/properties/ scroll-behavior.html is a constant text failure (249506)
<a href="https://bugs.webkit.org/show_bug.cgi?id=249506">https://bugs.webkit.org/show_bug.cgi?id=249506</a>
rdar://103464702

Unreviewed test gardening.

* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-behavior-expected.txt:

Canonical link: <a href="https://commits.webkit.org/258094@main">https://commits.webkit.org/258094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a82e0b95277aa50780d5d612eb4d0e92e8a0c3d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100922 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/10075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33972 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/110229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11006 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/946 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/108071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/106705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/93338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/3762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/3781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/946 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/44007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2909 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->