### PR TITLE
Cherry-pick 252432.777@safari-7614-branch (907f9f00adcc). rdar://100915554

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/CARingBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CARingBuffer.cpp
@@ -144,6 +144,29 @@ TEST_F(CARingBufferTest, Basics)
     EXPECT_EQ(fetchBounds, makeBounds(capacity - 1, capacity - 1 + capacity));
 }
 
+TEST_F(CARingBufferTest, SmallBufferListForFetch)
+{
+    const int capacity = 32;
+    const int halfCapacity = capacity / 2;
+    setup(44100, 1, CAAudioStreamDescription::PCMFormat::Float32, true, capacity);
+
+    float sourceBuffer[capacity];
+    for (int i = 0; i < capacity; i++)
+        sourceBuffer[i] = i + 0.5;
+    setListDataBuffer(reinterpret_cast<uint8_t*>(sourceBuffer), capacity);
+    CARingBuffer::Error err = ringBuffer().store(&bufferList(), capacity, 0);
+    EXPECT_EQ(err, CARingBuffer::Error::Ok);
+
+    float destinationBuffer[halfCapacity];
+    setListDataBuffer(reinterpret_cast<uint8_t*>(destinationBuffer), halfCapacity);
+    int bufferCount = bufferList().mNumberBuffers;
+    EXPECT_GE(bufferCount, 1);
+    size_t listDataByteSizeBeforeFetch = bufferList().mBuffers[0].mDataByteSize;
+
+    ringBuffer().fetch(&bufferList(), capacity, 0);
+    EXPECT_LE(bufferList().mBuffers[0].mDataByteSize, listDataByteSizeBeforeFetch);
+}
+
 template <typename type>
 class MixingTest {
 public:


### PR DESCRIPTION
#### 03b0d03cceae2c081da42c1aa7969b9a89782956
<pre>
Cherry-pick 252432.777@safari-7614-branch (907f9f00adcc). rdar://100915554

    CARingBuffer::fetch should not increase buffer data byte size of AudioBufferList
    rdar://100915554

    Reviewed by Jer Noble.

    CARingBuffer::fetchInternal() sets mDataByteSize to nbytes unconditionally, but it won&apos;t be able fill that much if
    (nbytes + offset) is bigger than existing mDataByteSize; FetchABL() calculates the real number of bytes that can be
    filled.

    * Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
    (WebCore::FetchABL):
    (WebCore::CARingBuffer::fetchInternal):
    * Tools/TestWebKitAPI/Tests/WebCore/CARingBuffer.cpp:
    (TestWebKitAPI::TEST_F):

    Canonical link: <a href="https://commits.webkit.org/252432.777@safari-7614-branch">https://commits.webkit.org/252432.777@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/258115@main">https://commits.webkit.org/258115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4688c28e2ba552d52574fc2ee247d6267f2ef3d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110252 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170501 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/952 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93341 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108074 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91584 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34941 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77918 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3765 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24501 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3785 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/904 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44002 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5570 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5561 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->