### PR TITLE
CSSRule.type should not return values greater than 15

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom-expected.txt
@@ -12,7 +12,7 @@ PASS Rule for --syntax-only has expected cssText
 PASS Rule for --inherits-only has expected cssText
 PASS Rule for --initial-value-only has expected cssText
 PASS Rule for --tab	tab has expected cssText
-FAIL CSSRule.type returns 0 assert_equals: expected 0 but got 21
+PASS CSSRule.type returns 0
 PASS Rule for --valid returns expected value for CSSPropertyRule.name
 PASS Rule for --valid-reverse returns expected value for CSSPropertyRule.name
 PASS Rule for --valid-universal returns expected value for CSSPropertyRule.name

--- a/Source/WebCore/css/CSSRule.cpp
+++ b/Source/WebCore/css/CSSRule.cpp
@@ -36,6 +36,17 @@ struct SameSizeAsCSSRule : public RefCounted<SameSizeAsCSSRule> {
 
 static_assert(sizeof(CSSRule) == sizeof(SameSizeAsCSSRule), "CSSRule should stay small");
 
+unsigned short CSSRule::typeForCSSOM() const
+{
+    // "This enumeration is thus frozen in its current state, and no new new values will be
+    // added to reflect additional at-rules; all at-rules beyond the ones listed above will return 0."
+    // https://drafts.csswg.org/cssom/#the-cssrule-interface
+    if (styleRuleType() >= firstUnexposedStyleRuleType)
+        return 0;
+
+    return static_cast<unsigned short>(styleRuleType());
+}
+
 ExceptionOr<void> CSSRule::setCssText(const String&)
 {
     return { };

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -37,7 +37,7 @@ class CSSRule : public RefCounted<CSSRule> {
 public:
     virtual ~CSSRule() = default;
 
-    unsigned short type() const { return static_cast<unsigned short>(styleRuleType()); }
+    WEBCORE_EXPORT unsigned short typeForCSSOM() const;
 
     virtual StyleRuleType styleRuleType() const = 0;
     virtual String cssText() const = 0;

--- a/Source/WebCore/css/CSSRule.idl
+++ b/Source/WebCore/css/CSSRule.idl
@@ -31,7 +31,7 @@
     readonly attribute CSSRule? parentRule;
     readonly attribute CSSStyleSheet? parentStyleSheet;
 
-    readonly attribute unsigned short type;
+    [ImplementedAs=typeForCSSOM] readonly attribute unsigned short type;
     
     [ImplementedAs=Unknown] const unsigned short UNKNOWN_RULE = 0;
     [ImplementedAs=Style] const unsigned short STYLE_RULE = 1;

--- a/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
+++ b/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
@@ -397,7 +397,7 @@ Ref<MutableStyleProperties> PropertySetCSSStyleDeclaration::copyProperties() con
 StyleRuleCSSStyleDeclaration::StyleRuleCSSStyleDeclaration(MutableStyleProperties& propertySet, CSSRule& parentRule)
     : PropertySetCSSStyleDeclaration(propertySet)
     , m_refCount(1)
-    , m_parentRuleType(static_cast<StyleRuleType>(parentRule.type()))
+    , m_parentRuleType(parentRule.styleRuleType())
     , m_parentRule(&parentRule)
 {
     m_propertySet->ref();

--- a/Source/WebCore/css/StyleRuleType.h
+++ b/Source/WebCore/css/StyleRuleType.h
@@ -44,13 +44,15 @@ enum class StyleRuleType : uint8_t {
     CounterStyle = 11,
     Supports = 12,
     FontFeatureValues = 14,
+    // Numbers above 15 are not exposed to the web.
     LayerBlock = 16,
-    LayerStatement = 17,
-    Container = 18,
-    FontPaletteValues = 19,
-    // Those at-rules (@swash, @annotation,...) don't have a specified number in the spec.
+    LayerStatement,
+    Container,
+    FontPaletteValues,
     FontFeatureValuesBlock,
     Property,
 };
+
+static constexpr auto firstUnexposedStyleRuleType = StyleRuleType::LayerBlock;
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMCSSRule.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMCSSRule.cpp
@@ -196,7 +196,7 @@ gushort webkit_dom_css_rule_get_rule_type(WebKitDOMCSSRule* self)
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_CSS_RULE(self), 0);
     WebCore::CSSRule* item = WebKit::core(self);
-    gushort result = item->type();
+    gushort result = item->typeForCSSOM();
     return result;
 }
 

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSRule.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSRule.mm
@@ -56,7 +56,7 @@
 - (unsigned short)type
 {
     WebCore::JSMainThreadNullState state;
-    return static_cast<unsigned short>(IMPL->type());
+    return IMPL->typeForCSSOM();
 }
 
 - (NSString *)cssText


### PR DESCRIPTION
#### f34b82d5e7cb29e73606d63e4b1b39539c4b90b1
<pre>
CSSRule.type should not return values greater than 15
<a href="https://bugs.webkit.org/show_bug.cgi?id=249560">https://bugs.webkit.org/show_bug.cgi?id=249560</a>
rdar://103531316

Reviewed by Sam Weinig.

&quot;This enumeration is thus frozen in its current state, and no new new values will be added to
reflect additional at-rules; all at-rules beyond the ones listed above will return 0.&quot;

<a href="https://w3c.github.io/csswg-drafts/cssom/#the-cssrule-interface">https://w3c.github.io/csswg-drafts/cssom/#the-cssrule-interface</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom-expected.txt:
* Source/WebCore/css/CSSRule.cpp:
(WebCore::CSSRule::typeForCSSOM const):

Return 0 for unexposed types.
Rename for clarity.

* Source/WebCore/css/CSSRule.h:
(WebCore::CSSRule::type const): Deleted.
* Source/WebCore/css/CSSRule.idl:
* Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp:
(WebCore::StyleRuleCSSStyleDeclaration::StyleRuleCSSStyleDeclaration):
* Source/WebCore/css/StyleRuleType.h:
* Source/WebKitLegacy/mac/DOM/DOMCSSRule.mm:
(-[DOMCSSRule type]):

Canonical link: <a href="https://commits.webkit.org/258128@main">https://commits.webkit.org/258128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c0cc4195be0de7be187a07e19df2cc4b45f78d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110300 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1024 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108134 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106779 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34993 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3821 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3849 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44068 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5579 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5617 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->