### PR TITLE
Add regression testing for CSP inheritance via meta tag containing newline characters

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/blob-inherits-from-meta-http-equiv-with-invalid-characters-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/blob-inherits-from-meta-http-equiv-with-invalid-characters-expected.txt
@@ -1,0 +1,4 @@
+ALERT: PASS executed blob URL script.
+
+PASS blob: URL inherits CSP from a meta tag whose contents have newline characters.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/blob-inherits-from-meta-http-equiv-with-invalid-characters.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/blob-inherits-from-meta-http-equiv-with-invalid-characters.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="
+    default-src 'none';
+    script-src blob: 'nonce-abc'">
+<script nonce="abc" src="/resources/testharness.js"></script>
+<script nonce="abc" src="/resources/testharnessreport.js"></script>
+</head>
+<script nonce="abc">
+    async_test(t => {
+        var script = document.createElement("script");
+        script.onerror = () => assert_unreached("FAIL should not have fired error event.");
+        script.onload = () => t.done();
+        script.src = URL.createObjectURL(new Blob(["alert('PASS executed blob URL script.');"]));
+        document.head.appendChild(script);
+    }, "blob: URL inherits CSP from a meta tag whose contents have newline characters.");
+</script>
+</html>


### PR DESCRIPTION
#### 8df840f39f29393e105f1baf471b1bdda069f848
<pre>
Add regression testing for CSP inheritance via meta tag containing newline characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=249616">https://bugs.webkit.org/show_bug.cgi?id=249616</a>
rdar://103535066

Reviewed by Brent Fulgham.

This adds a test for blob URL inheriting a CSP delivered via a meta tag when the content attirbute
contains newlines. The fix for this landed in 258110@main

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/blob-inherits-from-meta-http-equiv-with-invalid-characters-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/blob-inherits-from-meta-http-equiv-with-invalid-characters.html: Added.

Canonical link: <a href="https://commits.webkit.org/258146@main">https://commits.webkit.org/258146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/579841061ab72fe4b9b5e1dda424e6043da40c27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110342 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1069 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108176 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8424 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35035 "layout-tests (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23083 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3863 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24600 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3891 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1005 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44108 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5591 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5659 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->