### PR TITLE
webkitcorepy.tests.file_lock_unittest.FileLockTestCase.test_locked_timeout is randomly failing

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/file_lock_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/file_lock_unittest.py
@@ -85,14 +85,14 @@ class FileLockTestCase(unittest.TestCase):
             self.assertFalse(lock_a.acquired)
             self.assertFalse(lock_b.acquired)
 
-            start_time = int(time.time())
+            start_time = time.time()
             with lock_a:
-                self.assertEqual(start_time, int(time.time()))
+                self.assertAlmostEqual(start_time, time.time(), places=1)
                 self.assertTrue(lock_a.acquired)
                 self.assertFalse(lock_b.acquired)
 
                 with lock_b:
-                    self.assertEqual(start_time + 30, int(time.time()))
+                    self.assertAlmostEqual(start_time + 30, time.time(), places=1)
                     self.assertTrue(lock_a.acquired)
                     self.assertFalse(lock_b.acquired)
 


### PR DESCRIPTION
#### 81d0d71c7efa6a94a80ffe93bdbea89c8b3314e0
<pre>
webkitcorepy.tests.file_lock_unittest.FileLockTestCase.test_locked_timeout is randomly failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=249608">https://bugs.webkit.org/show_bug.cgi?id=249608</a>

Reviewed by Jonathan Bedard.

test_locked_timeout was randomly failing because it compared two time
values by truncating fraction parts. For example, two time values
53.99 and 54.00 are enough close, but don&apos;t match in the comparison.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/file_lock_unittest.py:
(FileLockTestCase.test_locked_timeout):
Use assertAlmostEqual to compare time values.

Canonical link: <a href="https://commits.webkit.org/258154@main">https://commits.webkit.org/258154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc4589291e8c8246c3450d0a7f9288287b9912a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110316 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170572 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1041 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93423 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108150 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8399 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91666 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35012 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/104537 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78002 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3837 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24576 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3865 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/980 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/99938 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44084 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5599 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5633 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->