### PR TITLE
Align `stroke-dasharray` CSS property parsing with the specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt
@@ -5,14 +5,18 @@ PASS Can set 'stroke-dasharray' to CSS-wide keywords: unset
 PASS Can set 'stroke-dasharray' to CSS-wide keywords: revert
 PASS Can set 'stroke-dasharray' to var() references:  var(--A)
 PASS Can set 'stroke-dasharray' to the 'none' keyword: none
-FAIL Setting 'stroke-dasharray' to a length: 0px throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'stroke-dasharray' to a length: -3.14em throws TypeError
-FAIL Setting 'stroke-dasharray' to a length: 3.14cm throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stroke-dasharray' to a length: calc(0px + 0em) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stroke-dasharray' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'stroke-dasharray' to a percent: -3.14% throws TypeError
-FAIL Setting 'stroke-dasharray' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stroke-dasharray' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Can set 'stroke-dasharray' to a length: 0px
+FAIL Can set 'stroke-dasharray' to a length: -3.14em assert_equals: unit expected "px" but got "em"
+FAIL Can set 'stroke-dasharray' to a length: 3.14cm assert_equals: unit expected "px" but got "cm"
+PASS Can set 'stroke-dasharray' to a length: calc(0px + 0em)
+PASS Can set 'stroke-dasharray' to a percent: 0%
+FAIL Can set 'stroke-dasharray' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'stroke-dasharray' to a percent: 3.14%
+PASS Can set 'stroke-dasharray' to a percent: calc(0% + 0%)
+PASS Can set 'stroke-dasharray' to a number: 0
+PASS Can set 'stroke-dasharray' to a number: -3.14
+PASS Can set 'stroke-dasharray' to a number: 3.14
+PASS Can set 'stroke-dasharray' to a number: calc(2 + 3)
 PASS Setting 'stroke-dasharray' to a time: 0s throws TypeError
 PASS Setting 'stroke-dasharray' to a time: -3.14ms throws TypeError
 PASS Setting 'stroke-dasharray' to a time: 3.14s throws TypeError
@@ -24,10 +28,6 @@ PASS Setting 'stroke-dasharray' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'stroke-dasharray' to a flexible length: 0fr throws TypeError
 PASS Setting 'stroke-dasharray' to a flexible length: 1fr throws TypeError
 PASS Setting 'stroke-dasharray' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'stroke-dasharray' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-PASS Setting 'stroke-dasharray' to a number: -3.14 throws TypeError
-FAIL Setting 'stroke-dasharray' to a number: 3.14 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stroke-dasharray' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'stroke-dasharray' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'stroke-dasharray' to a transform: perspective(10em) throws TypeError
 PASS Setting 'stroke-dasharray' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray.html
@@ -14,7 +14,20 @@
 'use strict';
 
 runPropertyTests('stroke-dasharray', [
-  { syntax: 'none' }
+  { syntax: 'none' },
+  {
+    syntax: '<length>',
+    specified: assert_is_equal_with_range_handling,
+  },
+  {
+    syntax: '<percentage>',
+    specified: assert_is_equal_with_range_handling,
+  },
+  {
+    syntax: '<number>',
+    specified: assert_is_equal_with_range_handling,
+    computed: (_, result) => assert_is_unit('px', result)
+  },
 ]);
 
 runUnsupportedPropertyTests('stroke-dasharray', [

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dasharray-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dasharray-invalid-expected.txt
@@ -4,6 +4,6 @@ PASS e.style['stroke-dasharray'] = "none 10px" should not set the property value
 PASS e.style['stroke-dasharray'] = "20px / 30px" should not set the property value
 PASS e.style['stroke-dasharray'] = "-40px" should not set the property value
 PASS e.style['stroke-dasharray'] = "calc(2px + 3)" should not set the property value
-FAIL e.style['stroke-dasharray'] = "calc(10% + 5)" should not set the property value assert_equals: expected "" but got "calc(5 + 10%)"
+PASS e.style['stroke-dasharray'] = "calc(10% + 5)" should not set the property value
 PASS e.style['stroke-dasharray'] = "calc(40 + calc(3px + 6%))" should not set the property value
 

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -108,7 +108,7 @@ RefPtr<CSSPrimitiveValue> consumeNumber(CSSParserTokenRange&, ValueRange);
 RefPtr<CSSPrimitiveValue> consumeNumberOrPercent(CSSParserTokenRange&, ValueRange);
 
 RefPtr<CSSPrimitiveValue> consumeLength(CSSParserTokenRange&, CSSParserMode, ValueRange, UnitlessQuirk = UnitlessQuirk::Forbid);
-RefPtr<CSSPrimitiveValue> consumeLengthOrPercent(CSSParserTokenRange&, CSSParserMode, ValueRange, UnitlessQuirk = UnitlessQuirk::Forbid, NegativePercentagePolicy = NegativePercentagePolicy::Forbid);
+RefPtr<CSSPrimitiveValue> consumeLengthOrPercent(CSSParserTokenRange&, CSSParserMode, ValueRange, UnitlessQuirk = UnitlessQuirk::Forbid, UnitlessZeroQuirk = UnitlessZeroQuirk::Allow, NegativePercentagePolicy = NegativePercentagePolicy::Forbid);
 
 RefPtr<CSSPrimitiveValue> consumePercent(CSSParserTokenRange&, ValueRange);
 RefPtr<CSSPrimitiveValue> consumePercentWorkerSafe(CSSParserTokenRange&, ValueRange, CSSValuePool&);

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -251,6 +251,7 @@ static bool isValueOutOfRangeForProperty(CSSPropertyID propertyID, double value,
     case CSSPropertyScrollPaddingLeft:
     case CSSPropertyScrollPaddingRight:
     case CSSPropertyScrollPaddingTop:
+    case CSSPropertyStrokeDasharray:
     case CSSPropertyStrokeMiterlimit:
     case CSSPropertyStrokeWidth:
         return value < 0;

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -237,10 +237,13 @@ SVGLengthValue SVGLengthValue::blend(const SVGLengthValue& from, const SVGLength
     return { WebCore::blend(fromValue.releaseReturnValue(), toValue, { progress }), to.lengthType() };
 }
 
-SVGLengthValue SVGLengthValue::fromCSSPrimitiveValue(const CSSPrimitiveValue& value)
+SVGLengthValue SVGLengthValue::fromCSSPrimitiveValue(const CSSPrimitiveValue& value, ShouldConvertNumberToPxLength shouldConvertNumberToPxLength)
 {
     // FIXME: This needs to call value.computeLength() so it can correctly resolve non-absolute units (webkit.org/b/204826).
-    SVGLengthType lengthType = primitiveTypeToLengthType(value.primitiveType());
+    auto primitiveType = value.primitiveType();
+    if (primitiveType == CSSUnitType::CSS_NUMBER && shouldConvertNumberToPxLength == ShouldConvertNumberToPxLength::Yes)
+        primitiveType = CSSUnitType::CSS_PX;
+    SVGLengthType lengthType = primitiveTypeToLengthType(primitiveType);
     return lengthType == SVGLengthType::Unknown ? SVGLengthValue() : SVGLengthValue(value.floatValue(), lengthType);
 }
 

--- a/Source/WebCore/svg/SVGLengthValue.h
+++ b/Source/WebCore/svg/SVGLengthValue.h
@@ -56,6 +56,8 @@ enum class SVGLengthNegativeValuesMode : uint8_t {
     Forbid
 };
 
+enum class ShouldConvertNumberToPxLength : bool { No, Yes };
+
 class SVGLengthValue {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -67,7 +69,7 @@ public:
     static SVGLengthValue construct(SVGLengthMode, StringView, SVGParsingError&, SVGLengthNegativeValuesMode = SVGLengthNegativeValuesMode::Allow);
     static SVGLengthValue blend(const SVGLengthValue& from, const SVGLengthValue& to, float progress);
 
-    static SVGLengthValue fromCSSPrimitiveValue(const CSSPrimitiveValue&);
+    static SVGLengthValue fromCSSPrimitiveValue(const CSSPrimitiveValue&, ShouldConvertNumberToPxLength = ShouldConvertNumberToPxLength::No);
     Ref<CSSPrimitiveValue> toCSSPrimitiveValue(const Element* = nullptr) const;
 
     SVGLengthType lengthType() const { return m_lengthType; }


### PR DESCRIPTION
#### 36071c56fa58a4258963e403263ab1e3d984f82c
<pre>
Align `stroke-dasharray` CSS property parsing with the specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=249615">https://bugs.webkit.org/show_bug.cgi?id=249615</a>

Reviewed by Simon Fraser.

Align `stroke-dasharray` CSS property parsing with the specification:
- <a href="https://svgwg.org/svg2-draft/painting.html#StrokeDashing">https://svgwg.org/svg2-draft/painting.html#StrokeDashing</a>
- <a href="https://svgwg.org/svg2-draft/painting.html#DataTypeDasharray">https://svgwg.org/svg2-draft/painting.html#DataTypeDasharray</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray.html:
Update stroke-dasharray css-typed-on WPT test to match the specification. In
particular, &lt;length&gt; | &lt;percentage&gt; | &lt;number&gt; should be allowed. Negative
values shouldn&apos;t be allowed. Also, computed values should be converted to
lengths if numbers were provided.

* LayoutTests/imported/w3c/web-platform-tests/svg/painting/parsing/stroke-dasharray-invalid-expected.txt:
Rebaseline WPT test now that more checks are passing.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
Update LengthRawKnownTokenTypeNumberConsumer::consume() to stop ignoring the
UnitlessZeroQuirk parameter. Previously, no matter what value the caller was
passing for this parameter, we were allowing unitless zero. Update call sites
to pass UnitlessZeroQuirk::Allow to maintain pre-existing behavior for now.
However, I made sure to pass UnitlessZeroQuirk::Forbid in
consumeStrokeDasharray() since we want to make sure &quot;0&quot; gets parsed as a
&lt;number&gt;, not a &lt;length&gt; (covered by stroke-dasharray-valid.html WPT test).

(WebCore::CSSPropertyParserHelpers::consumeStrokeDasharray):
Fallback to parsing input as a &lt;number&gt; if parsing it as a &lt;length-percentage&gt;,
as per the specification.

* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::isValueOutOfRangeForProperty):
Update isValueOutOfRangeForProperty() to properly indicate that stroke-dasharray
doesn&apos;t allow negative values.

* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertSVGLengthValue):
(WebCore::Style::BuilderConverter::convertSVGLengthVector):
(WebCore::Style::BuilderConverter::convertStrokeDashArray):
Update our style builder converter to:
- Deal with stroke-dasharray values coming from CSS-Typed-OM, which may not have
  been converted to a CSSValueList yet (unlike values coming from the CSS parser).
- Request that numbers get converted to lengths (by using &apos;px&apos; unit), now that we
  allow numbers at parser level (per the specification).

* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::SVGLengthValue::fromCSSPrimitiveValue):
* Source/WebCore/svg/SVGLengthValue.h:

Canonical link: <a href="https://commits.webkit.org/258136@main">https://commits.webkit.org/258136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92827d66d42f79575de197d5a8733ad81b613073

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110266 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170529 "Found 1 new test failure: js/dom/Promise-reject-large-string.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/987 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93370 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108103 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34969 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90268 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77953 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3792 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24535 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/935 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44039 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5588 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2929 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->