### PR TITLE
REGRESSION (257084@main): Mitigate crashes when calling into `WebPageProxy::loadAlternateHTML` with nil data

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2561,7 +2561,7 @@ static void convertAndAddHighlight(Vector<Ref<WebKit::SharedMemory>>& buffers, N
 - (void)_loadAlternateHTMLString:(NSString *)string baseURL:(NSURL *)baseURL forUnreachableURL:(NSURL *)unreachableURL
 {
     THROW_IF_SUSPENDED;
-    NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
+    auto *data = [string dataUsingEncoding:NSUTF8StringEncoding] ?: NSData.data;
     _page->loadAlternateHTML(WebCore::DataSegment::create((__bridge CFDataRef)data), "UTF-8"_s, baseURL, unreachableURL);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
@@ -128,6 +128,19 @@ TEST(WKWebView, LoadAlternateHTMLStringNoFileSystemPath)
     [webView loadHTMLString:@"<html>hi</html>" baseURL:[NSURL URLWithString:@"file:///.file/id="]];
 }
 
+TEST(WKWebView, LoadNilAlternateHTMLStringDoesNotCrash)
+{
+    auto webView = adoptNS([[WKWebView alloc] init]);
+    auto controller = adoptNS([LoadAlternateHTMLStringFromProvisionalLoadErrorController new]);
+    [webView setNavigationDelegate:controller.get()];
+
+    IGNORE_NULL_CHECK_WARNINGS_BEGIN
+    [webView _loadAlternateHTMLString:nil baseURL:nil forUnreachableURL:[NSURL URLWithString:@"https://www.example.com"]];
+    IGNORE_NULL_CHECK_WARNINGS_END
+
+    TestWebKitAPI::Util::run(&isDone);
+}
+
 TEST(WKWebView, LoadAlternateHTMLStringFromProvisionalLoadErrorReload)
 {
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);


### PR DESCRIPTION
#### 2b837edd2587d41faa63c8611720ca388405e6fa
<pre>
REGRESSION (257084@main): Mitigate crashes when calling into `WebPageProxy::loadAlternateHTML` with nil data
<a href="https://bugs.webkit.org/show_bug.cgi?id=249622">https://bugs.webkit.org/show_bug.cgi?id=249622</a>
rdar://103459912

Reviewed by Aditya Keerthi.

Prior to the changes in 257084@main, attempting to call into `WebPageProxy::loadAlternateHTML` with
a nil `NSString` would trigger a load with what was (effectively) empty data, whether it&apos;s because
the WebKit client passed in `nil` for the HTML string, or if Foundation returned a nil `NSData` from
`-[NSString dataUsingEncoding:]`, whose return type is a `nullable NSData *`.

After 257084@main, this now results in a crash underneath `DataSegment::size()` when attempting to
call `CFDataGetLength` on `0x0`, after we send `AddAllowedFirstPartyForCookies` to the network
process and get a response.

While this could potentially be a client error, it&apos;s probably a good idea to apply a mitigation
within WebKit in this scenario, since:

-   This keeps behavior in line with shipping WebKit, and
-   `-[NSString dataUsingEncoding:]` is technically allowed to return a `nil` `NSData` from
    nullability annotations, though it&apos;s (admittedly) unclear how this would occur when passing in a
    UTF-8 string encoding.

Test: WKWebView.LoadNilAlternateHTMLStringDoesNotCrash

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _loadAlternateHTMLString:baseURL:forUnreachableURL:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/258156@main">https://commits.webkit.org/258156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e1a17b3b1e058040c93769536d2007fed3122d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110264 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170527 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/985 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93368 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108101 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34959 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90263 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77947 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3790 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24531 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/932 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44034 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5598 "'git push ...'") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5586 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->