### PR TITLE
REGRESSION(257823@main): 4X Test262-test are constant failures

### DIFF
--- a/JSTests/stress/regexp-lookbehind.js
+++ b/JSTests/stress/regexp-lookbehind.js
@@ -79,6 +79,20 @@ function testRegExp(re, str, exp)
         print(dumpValue(str) +".match(" + re.toString() + "), FAILED test #" + testNumber + ", Expected ", dumpValue(exp), " got ", dumpValue(actual));
 }
 
+function testRegExpSyntaxError(reString, flags, expError)
+{
+    testNumber++;
+
+    try {
+        let re = new RegExp(reString, flags);
+    } catch (e) {
+        if (e != expError)
+            print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\" got \"" + e + "\"");
+        else if (verbose)
+            print("/" + reString + "/" + flags + "passed, it threw \"" + expError + "\" as expected");
+    }
+}
+
 // Test 1
 testRegExp(/(?<= )Dog/, " Dog", ["Dog"]);
 testRegExp(/(?<=A )Dog/, "Walk A Dog", ["Dog"]);
@@ -201,3 +215,4 @@ testRegExp(/(?<=(^(?:A|\u{10400}|\u{10401}|\u{10406})*))x/u, "\u{10401}A\u{10400
 // Test 86
 testRegExp(/(?<=(\d{2})(\d{2}))X/, "34121234X", ["X", "12", "34"]);
 testRegExp(/(?<=\2\1(\d{2})(\d{2}))X/, "34121234X", ["X", "12", "34"]);
+testRegExpSyntaxError(".(?<=.)?", "", "SyntaxError: Invalid regular expression: invalid quantifier");

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -952,7 +952,3 @@ skip:
 
     # Skip while https://bugs.webkit.org/show_bug.cgi?id=249330 is being investigated
     - test/built-ins/RegExp/named-groups/lookbehind.js 
-    - test/language/literals/regexp/invalid-optional-lookbehind.js 
-    - test/language/literals/regexp/invalid-optional-negative-lookbehind.js 
-    - test/language/literals/regexp/invalid-range-lookbehind.js 
-    - test/language/literals/regexp/invalid-range-negative-lookbehind.js 

--- a/Source/JavaScriptCore/yarr/YarrErrorCode.cpp
+++ b/Source/JavaScriptCore/yarr/YarrErrorCode.cpp
@@ -41,6 +41,7 @@ ASCIILiteral errorMessage(ErrorCode error)
         REGEXP_ERROR_PREFIX "nothing to repeat"_s,                                    // QuantifierWithoutAtom
         REGEXP_ERROR_PREFIX "number too large in {} quantifier"_s,                    // QuantifierTooLarge
         REGEXP_ERROR_PREFIX "incomplete {} quantifier for Unicode pattern"_s,         // QuantifierIncomplete
+        REGEXP_ERROR_PREFIX "invalid quantifier"_s,                                   // CantQuantifyAtom
         REGEXP_ERROR_PREFIX "missing )"_s,                                            // MissingParentheses
         REGEXP_ERROR_PREFIX "unmatched ] or } bracket for Unicode pattern"_s,         // BracketUnmatched
         REGEXP_ERROR_PREFIX "unmatched parentheses"_s,                                // ParenthesesUnmatched
@@ -78,6 +79,7 @@ JSObject* errorToThrow(JSGlobalObject* globalObject, ErrorCode error)
     case ErrorCode::QuantifierWithoutAtom:
     case ErrorCode::QuantifierTooLarge:
     case ErrorCode::QuantifierIncomplete:
+    case ErrorCode::CantQuantifyAtom:
     case ErrorCode::MissingParentheses:
     case ErrorCode::BracketUnmatched:
     case ErrorCode::ParenthesesUnmatched:

--- a/Source/JavaScriptCore/yarr/YarrErrorCode.h
+++ b/Source/JavaScriptCore/yarr/YarrErrorCode.h
@@ -42,6 +42,7 @@ enum class ErrorCode : uint8_t {
     QuantifierWithoutAtom,
     QuantifierTooLarge,
     QuantifierIncomplete,
+    CantQuantifyAtom,
     MissingParentheses,
     BracketUnmatched,
     ParenthesesUnmatched,

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -45,6 +45,12 @@ private:
 
     enum class UnicodeParseContext : uint8_t { PatternCodePoint, GroupName };
 
+    enum class TokenType : uint8_t {
+        NotAtom = 0,
+        Atom = 1,
+        Lookbehind = 2
+    };
+
     /*
      * CharacterClassParserDelegate:
      *
@@ -263,7 +269,7 @@ private:
      * interpreted as assertions).
      */
     template<bool inCharacterClass, class EscapeDelegate>
-    bool parseEscape(EscapeDelegate& delegate)
+    TokenType parseEscape(EscapeDelegate& delegate)
     {
         ASSERT(!hasError(m_errorCode));
         ASSERT(peek() == '\\');
@@ -271,7 +277,7 @@ private:
 
         if (atEndOfPattern()) {
             m_errorCode = ErrorCode::EscapeUnterminated;
-            return false;
+            return TokenType::NotAtom;
         }
 
         switch (peek()) {
@@ -282,7 +288,7 @@ private:
                 delegate.atomPatternCharacter('\b');
             else {
                 delegate.assertionWordBoundary(false);
-                return false;
+                return TokenType::NotAtom;
             }
             break;
         case 'B':
@@ -294,7 +300,7 @@ private:
                 delegate.atomPatternCharacter('B');
             } else {
                 delegate.assertionWordBoundary(true);
-                return false;
+                return TokenType::NotAtom;
             }
             break;
 
@@ -531,7 +537,7 @@ private:
             delegate.atomPatternCharacter(consume());
         }
         
-        return true;
+        return TokenType::Atom;
     }
 
     template<UnicodeParseContext context>
@@ -558,7 +564,7 @@ private:
      *
      * These methods alias to parseEscape().
      */
-    bool parseAtomEscape()
+    TokenType parseAtomEscape()
     {
         return parseEscape<false>(m_delegate);
     }
@@ -659,13 +665,13 @@ private:
                 } else {
                     if (tryConsume('=')) {
                         m_delegate.atomParentheticalAssertionBegin(false, Backward);
-                        type = ParenthesesType::Assertion;
+                        type = ParenthesesType::LookbehindAssertion;
                         break;
                     }
 
                     if (tryConsume('!')) {
                         m_delegate.atomParentheticalAssertionBegin(true, Backward);
-                        type = ParenthesesType::Assertion;
+                        type = ParenthesesType::LookbehindAssertion;
                         break;
                     }
                     m_errorCode = ErrorCode::InvalidGroupName;
@@ -695,7 +701,7 @@ private:
      * was either an Atom or, for web compatibility reasons, QuantifiableAssertion
      * in non-Unicode pattern.
      */
-    bool parseParenthesesEnd()
+    TokenType parseParenthesesEnd()
     {
         ASSERT(!hasError(m_errorCode));
         ASSERT(peek() == ')');
@@ -703,12 +709,18 @@ private:
 
         if (m_parenthesesStack.isEmpty()) {
             m_errorCode = ErrorCode::ParenthesesUnmatched;
-            return false;
+            return TokenType::NotAtom;
         }
 
         m_delegate.atomParenthesesEnd();
         auto type = m_parenthesesStack.takeLast();
-        return type == ParenthesesType::Subpattern || !m_isUnicode;
+        if (type == ParenthesesType::LookbehindAssertion)
+            return TokenType::Lookbehind;
+
+        if (type == ParenthesesType::Subpattern || !m_isUnicode)
+            return TokenType::Atom;
+
+        return TokenType::NotAtom;
     }
 
     /*
@@ -716,7 +728,7 @@ private:
      *
      * Helper for parseTokens(); checks for parse errors and non-greedy quantifiers.
      */
-    void parseQuantifier(bool lastTokenWasAnAtom, unsigned min, unsigned max)
+    void parseQuantifier(TokenType lastTokenType, unsigned min, unsigned max)
     {
         ASSERT(!hasError(m_errorCode));
         ASSERT(min <= max);
@@ -726,8 +738,10 @@ private:
             return;
         }
 
-        if (lastTokenWasAnAtom)
+        if (lastTokenType == TokenType::Atom)
             m_delegate.quantifyAtom(min, max, !tryConsume('?'));
+        else if (lastTokenType == TokenType::Lookbehind)
+            m_errorCode = ErrorCode::CantQuantifyAtom;
         else
             m_errorCode = ErrorCode::QuantifierWithoutAtom;
     }
@@ -743,46 +757,46 @@ private:
      */
     void parseTokens()
     {
-        bool lastTokenWasAnAtom = false;
+        TokenType lastTokenType = TokenType::NotAtom;
 
         while (!atEndOfPattern()) {
             switch (peek()) {
             case '|':
                 consume();
                 m_delegate.disjunction();
-                lastTokenWasAnAtom = false;
+                lastTokenType = TokenType::NotAtom;
                 break;
 
             case '(':
                 parseParenthesesBegin();
-                lastTokenWasAnAtom = false;
+                lastTokenType = TokenType::NotAtom;
                 break;
 
             case ')':
-                lastTokenWasAnAtom = parseParenthesesEnd();
+                lastTokenType = parseParenthesesEnd();
                 break;
 
             case '^':
                 consume();
                 m_delegate.assertionBOL();
-                lastTokenWasAnAtom = false;
+                lastTokenType = TokenType::NotAtom;
                 break;
 
             case '$':
                 consume();
                 m_delegate.assertionEOL();
-                lastTokenWasAnAtom = false;
+                lastTokenType = TokenType::NotAtom;
                 break;
 
             case '.':
                 consume();
                 m_delegate.atomBuiltInCharacterClass(BuiltInCharacterClassID::DotClassID, false);
-                lastTokenWasAnAtom = true;
+                lastTokenType = TokenType::Atom;
                 break;
 
             case '[':
                 parseCharacterClass();
-                lastTokenWasAnAtom = true;
+                lastTokenType = TokenType::Atom;
                 break;
 
             case ']':
@@ -793,29 +807,29 @@ private:
                 }
 
                 m_delegate.atomPatternCharacter(consume());
-                lastTokenWasAnAtom = true;
+                lastTokenType = TokenType::Atom;
                 break;
 
             case '\\':
-                lastTokenWasAnAtom = parseAtomEscape();
+                lastTokenType = parseAtomEscape();
                 break;
 
             case '*':
                 consume();
-                parseQuantifier(lastTokenWasAnAtom, 0, quantifyInfinite);
-                lastTokenWasAnAtom = false;
+                parseQuantifier(lastTokenType, 0, quantifyInfinite);
+                lastTokenType = TokenType::NotAtom;
                 break;
 
             case '+':
                 consume();
-                parseQuantifier(lastTokenWasAnAtom, 1, quantifyInfinite);
-                lastTokenWasAnAtom = false;
+                parseQuantifier(lastTokenType, 1, quantifyInfinite);
+                lastTokenType = TokenType::NotAtom;
                 break;
 
             case '?':
                 consume();
-                parseQuantifier(lastTokenWasAnAtom, 0, 1);
-                lastTokenWasAnAtom = false;
+                parseQuantifier(lastTokenType, 0, 1);
+                lastTokenType = TokenType::NotAtom;
                 break;
 
             case '{': {
@@ -831,10 +845,10 @@ private:
 
                     if (tryConsume('}')) {
                         if (min <= max)
-                            parseQuantifier(lastTokenWasAnAtom, min, max);
+                            parseQuantifier(lastTokenType, min, max);
                         else
                             m_errorCode = ErrorCode::QuantifierOutOfOrder;
-                        lastTokenWasAnAtom = false;
+                        lastTokenType = TokenType::NotAtom;
                         break;
                     }
                 }
@@ -851,7 +865,7 @@ private:
 
             default:
                 m_delegate.atomPatternCharacter(consumePossibleSurrogatePair<UnicodeParseContext::PatternCodePoint>());
-                lastTokenWasAnAtom = true;
+                lastTokenType = TokenType::Atom;
             }
 
             if (hasError(m_errorCode))
@@ -1214,7 +1228,7 @@ private:
         return std::nullopt;
     }
 
-    enum class ParenthesesType : uint8_t { Subpattern, Assertion };
+    enum class ParenthesesType : uint8_t { Subpattern, Assertion, LookbehindAssertion };
 
     Delegate& m_delegate;
     ErrorCode m_errorCode { ErrorCode::NoError };


### PR DESCRIPTION
#### cc3bdd6f9825b5eff922b0d912f5cdbdcdd54646
<pre>
REGRESSION(257823@main): 4X Test262-test are constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=249624">https://bugs.webkit.org/show_bug.cgi?id=249624</a>
rdar://103537619

Reviewed by Yusuke Suzuki.

As specified, RegExp lookbehinds do not allow for quantifiers.
This change fixes the Yarr parser to disallow Quantifiers for Lookbehinds and adds a new error if one
is specified.  The error message has the same text as V8.

Added a new test case and re-enabled the corresponding Test262 tests.

* JSTests/stress/regexp-lookbehind.js:
(testRegExpSyntaxError):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/yarr/YarrErrorCode.cpp:
(JSC::Yarr::errorMessage):
(JSC::Yarr::errorToThrow):
* Source/JavaScriptCore/yarr/YarrErrorCode.h:
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::parseEscape):
(JSC::Yarr::Parser::parseAtomEscape):
(JSC::Yarr::Parser::parseParenthesesBegin):
(JSC::Yarr::Parser::parseParenthesesEnd):
(JSC::Yarr::Parser::parseQuantifier):
(JSC::Yarr::Parser::parseTokens):

Canonical link: <a href="https://commits.webkit.org/258139@main">https://commits.webkit.org/258139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d18a1d2c6d463ddbfe091f7b9624dd079fc44ea0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100972 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110276 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170536 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/997 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93379 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108112 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106755 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8367 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34977 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90275 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77968 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91451 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3799 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24569 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87549 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1343 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/943 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29251 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44077 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90439 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5588 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5595 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20236 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->