### PR TITLE
FileSystemSyncAccessHandle::{read,write}'s option should be optional

### DIFF
--- a/LayoutTests/storage/filesystemaccess/sync-access-handle-read-write-worker-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/sync-access-handle-read-write-worker-expected.txt
@@ -14,6 +14,11 @@ PASS [Worker] readSize is readBuffer.byteLength
 PASS [Worker] readText is "This is second sentence."
 PASS [Worker] readSize is readBuffer.byteLength
 PASS [Worker] readText is "This is first sentence.This is second sentence."
+PASS [Worker] writeSize is writeBuffer.byteLength
+PASS [Worker] readSize is readBuffer.byteLength
+PASS [Worker] readText is "This is first sentence.This is second sentence."
+PASS [Worker] readSize is readBuffer.byteLength
+PASS [Worker] readText is "This is third sentence."
 PASS [Worker] accessHandle.read(new ArrayBuffer(1), { "at" : Number.MAX_SAFE_INTEGER }) threw exception InvalidStateError: Failed to read at offset.
 PASS [Worker] accessHandle.write(new ArrayBuffer(1), { "at" : Number.MAX_SAFE_INTEGER }) threw exception InvalidStateError: Failed to write at offset.
 [Worker] test flush():

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp
@@ -211,11 +211,13 @@ ExceptionOr<unsigned long long> FileSystemSyncAccessHandle::read(BufferSource&& 
     if (!m_pendingPromises.isEmpty())
         return Exception { InvalidStateError, "Access handle has unfinished operation"_s };
 
-    int result = FileSystem::seekFile(m_file.handle(), options.at, FileSystem::FileSeekOrigin::Beginning);
-    if (result == -1)
-        return Exception { InvalidStateError, "Failed to read at offset"_s };
+    if (options.at) {
+        int result = FileSystem::seekFile(m_file.handle(), options.at.value(), FileSystem::FileSeekOrigin::Beginning);
+        if (result == -1)
+            return Exception { InvalidStateError, "Failed to read at offset"_s };
+    }
 
-    result = FileSystem::readFromFile(m_file.handle(), buffer.mutableData(), buffer.length());
+    int result = FileSystem::readFromFile(m_file.handle(), buffer.mutableData(), buffer.length());
     if (result == -1)
         return Exception { InvalidStateError, "Failed to read from file"_s };
 
@@ -232,11 +234,13 @@ ExceptionOr<unsigned long long> FileSystemSyncAccessHandle::write(BufferSource&&
     if (!m_pendingPromises.isEmpty())
         return Exception { InvalidStateError, "Access handle has unfinished operation"_s };
 
-    int result = FileSystem::seekFile(m_file.handle(), options.at, FileSystem::FileSeekOrigin::Beginning);
-    if (result == -1)
-        return Exception { InvalidStateError, "Failed to write at offset"_s };
+    if (options.at) {
+        int result = FileSystem::seekFile(m_file.handle(), options.at.value(), FileSystem::FileSeekOrigin::Beginning);
+        if (result == -1)
+            return Exception { InvalidStateError, "Failed to write at offset"_s };
+    }
 
-    result = FileSystem::writeToFile(m_file.handle(), buffer.data(), buffer.length());
+    int result = FileSystem::writeToFile(m_file.handle(), buffer.data(), buffer.length());
     if (result == -1)
         return Exception { InvalidStateError, "Failed to write to file"_s };
 

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h
@@ -43,7 +43,7 @@ template<typename> class DOMPromiseDeferred;
 class FileSystemSyncAccessHandle : public ActiveDOMObject, public RefCounted<FileSystemSyncAccessHandle>, public CanMakeWeakPtr<FileSystemSyncAccessHandle> {
 public:
     struct FilesystemReadWriteOptions {
-        unsigned long long at;
+        std::optional<unsigned long long> at;
     };
 
     static Ref<FileSystemSyncAccessHandle> create(ScriptExecutionContext&, FileSystemFileHandle&, FileSystemSyncAccessHandleIdentifier, FileHandle&&);

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.idl
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.idl
@@ -33,8 +33,8 @@
     Promise<unsigned long long> getSize();
     Promise<undefined> flush();
     Promise<undefined> close();
-    unsigned long long read([AllowShared] (ArrayBufferView or ArrayBuffer) buffer, FilesystemReadWriteOptions options);
-    unsigned long long write([AllowShared] (ArrayBufferView or ArrayBuffer) buffer, FilesystemReadWriteOptions options);
+    unsigned long long read([AllowShared] (ArrayBufferView or ArrayBuffer) buffer, optional FilesystemReadWriteOptions options = {});
+    unsigned long long write([AllowShared] (ArrayBufferView or ArrayBuffer) buffer, optional FilesystemReadWriteOptions options = {});
 };
 
 dictionary FilesystemReadWriteOptions {


### PR DESCRIPTION
#### 08343037ad9b7c9a6c75d6c51a791755a7522e4c
<pre>
FileSystemSyncAccessHandle::{read,write}&apos;s option should be optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=249631">https://bugs.webkit.org/show_bug.cgi?id=249631</a>
rdar://103541719

Reviewed by Justin Michaud.

The current FileSystemSyncAccessHandle::{read,write} implementation has a bug that `options` parameter is specified as mandatory.
As a result, these APIs throw errors because it is using `read` / `write` functions without options.
This patch fixes the implementation to make them optional.

When optional `at` is not found, then the behavior is using the current file position&apos;s cursor. Thus, we just skip seekFile if
it is not specified.

* LayoutTests/storage/filesystemaccess/resources/sync-access-handle-read-write.js:
(write):
(read):
(async test):
* LayoutTests/storage/filesystemaccess/sync-access-handle-read-write-worker-expected.txt:
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp:
(WebCore::FileSystemSyncAccessHandle::read):
(WebCore::FileSystemSyncAccessHandle::write):
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.idl:

Canonical link: <a href="https://commits.webkit.org/258160@main">https://commits.webkit.org/258160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e90371a64faf49e8a9073958dd02c6cc71d9e33d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110343 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170600 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1070 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108177 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8428 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35043 "layout-tests (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23086 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3864 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24603 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3892 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1007 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10004 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44111 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5660 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2940 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->