### PR TITLE
Workaround `[AllowShared] BufferSource`

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUQueue.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.idl
@@ -44,13 +44,13 @@ interface GPUQueue {
     undefined writeBuffer(
         GPUBuffer buffer,
         GPUSize64 bufferOffset,
-        [AllowShared] BufferSource data,
+        [AllowShared] (ArrayBufferView or ArrayBuffer) data,
         optional GPUSize64 dataOffset = 0,
         optional GPUSize64 size);
 
     undefined writeTexture(
         GPUImageCopyTexture destination,
-        [AllowShared] BufferSource data,
+        [AllowShared] (ArrayBufferView or ArrayBuffer) data,
         GPUImageDataLayout dataLayout,
         GPUExtent3D size);
 

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.idl
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.idl
@@ -33,8 +33,8 @@
     Promise<unsigned long long> getSize();
     Promise<undefined> flush();
     Promise<undefined> close();
-    unsigned long long read([AllowShared] BufferSource buffer, FilesystemReadWriteOptions options);
-    unsigned long long write([AllowShared] BufferSource buffer, FilesystemReadWriteOptions options);
+    unsigned long long read([AllowShared] (ArrayBufferView or ArrayBuffer) buffer, FilesystemReadWriteOptions options);
+    unsigned long long write([AllowShared] (ArrayBufferView or ArrayBuffer) buffer, FilesystemReadWriteOptions options);
 };
 
 dictionary FilesystemReadWriteOptions {

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl
@@ -36,7 +36,7 @@
   readonly attribute unsigned long long? duration;
   readonly attribute unsigned long byteLength;
 
-  undefined copyTo([AllowShared] BufferSource destination);
+  undefined copyTo([AllowShared] (ArrayBufferView or ArrayBuffer) destination);
 };
 
 typedef [EnforceRange] long long WebCodecsEncodedVideoChunkInitTimestamp;
@@ -48,5 +48,5 @@ typedef [EnforceRange] unsigned long long WebCodecsEncodedVideoChunkInitDuration
   required WebCodecsEncodedVideoChunkType type;
   WebCodecsEncodedVideoChunkInitTimestamp timestamp;
   WebCodecsEncodedVideoChunkInitDuration duration;
-  required [AllowShared] BufferSource data;
+  required [AllowShared] (ArrayBufferView or ArrayBuffer) data;
 };

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoderConfig.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoderConfig.idl
@@ -31,7 +31,7 @@ typedef [EnforceRange] unsigned long long WebCodecsVideoDecoderConfigSize;
     JSGenerateToJSObject,
 ] dictionary WebCodecsVideoDecoderConfig {
     required DOMString codec;
-    [AllowShared] BufferSource description;
+    [AllowShared] (ArrayBufferView or ArrayBuffer) description;
     WebCodecsVideoDecoderConfigSize codedWidth;
     WebCodecsVideoDecoderConfigSize codedHeight;
     WebCodecsVideoDecoderConfigSize displayAspectWidth;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
@@ -44,7 +44,7 @@ typedef (HTMLImageElement or HTMLCanvasElement or ImageBitmap
 ] interface WebCodecsVideoFrame {
     [CallWith=CurrentScriptExecutionContext] constructor(CanvasImageSource image, optional VideoFrameInit init = {});
     [CallWith=CurrentScriptExecutionContext] constructor(WebCodecsVideoFrame image, optional VideoFrameInit init = {});
-    [CallWith=CurrentScriptExecutionContext] constructor([AllowShared] BufferSource data, VideoFrameBufferInit init);
+    [CallWith=CurrentScriptExecutionContext] constructor([AllowShared] (ArrayBufferView or ArrayBuffer) data, VideoFrameBufferInit init);
 
     readonly attribute VideoPixelFormat? format;
     readonly attribute unsigned long codedWidth;
@@ -58,7 +58,7 @@ typedef (HTMLImageElement or HTMLCanvasElement or ImageBitmap
     readonly attribute VideoColorSpace colorSpace;
 
     unsigned long allocationSize(optional VideoFrameCopyToOptions options = {});
-    Promise<sequence<PlaneLayout>> copyTo([AllowShared] BufferSource destination, optional VideoFrameCopyToOptions options = {});
+    Promise<sequence<PlaneLayout>> copyTo([AllowShared] (ArrayBufferView or ArrayBuffer) destination, optional VideoFrameCopyToOptions options = {});
     [CallWith=CurrentScriptExecutionContext] WebCodecsVideoFrame clone();
     undefined close();
 };

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -595,8 +595,9 @@ sub AddToIncludesForIDLType
         return;
     }
 
-    if ($codeGenerator->IsBufferSourceType($type)) {
+    if ($codeGenerator->IsBufferSourceType($type) || $type->extendedAttributes->{AllowShared}) {
         AddToIncludes("JSDOMConvertBufferSource.h", $includesRef, $conditional);
+        AddToIncludes("JSDOMConvertUnion.h", $includesRef, $conditional);
         return;
     }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -32,6 +32,7 @@
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertSerializedScriptValue.h"
 #include "JSDOMConvertStrings.h"
+#include "JSDOMConvertUnion.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMGlobalObject.h"
 #include "JSDOMGlobalObjectInlines.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.cpp
@@ -31,6 +31,7 @@
 #include "JSDOMConvertInterface.h"
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertStrings.h"
+#include "JSDOMConvertUnion.h"
 #include "JSDOMConvertVariadic.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMGlobalObjectInlines.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
@@ -31,6 +31,7 @@
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertSerializedScriptValue.h"
 #include "JSDOMConvertStrings.h"
+#include "JSDOMConvertUnion.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMGlobalObject.h"
 #include "JSTestNode.h"

--- a/Source/WebCore/dom/TextDecoder.idl
+++ b/Source/WebCore/dom/TextDecoder.idl
@@ -40,5 +40,5 @@ dictionary TextDecodeOptions {
     readonly attribute DOMString encoding;
     readonly attribute boolean fatal;
     readonly attribute boolean ignoreBOM;
-    USVString decode(optional [AllowShared] BufferSource? input, optional TextDecodeOptions options);
+    USVString decode(optional [AllowShared] (ArrayBufferView or ArrayBuffer)? input, optional TextDecodeOptions options);
 };

--- a/Source/WebCore/dom/TextDecoderStreamDecoder.idl
+++ b/Source/WebCore/dom/TextDecoderStreamDecoder.idl
@@ -31,6 +31,6 @@
     constructor(DOMString label, boolean fatal, boolean ignoreBOM);
 
     [PrivateIdentifier] DOMString encoding();
-    [PrivateIdentifier] DOMString decode([AllowShared] BufferSource source);
+    [PrivateIdentifier] DOMString decode([AllowShared] (ArrayBufferView or ArrayBuffer) source);
     [PrivateIdentifier] DOMString flush();
 };


### PR DESCRIPTION
#### 02a7ddd1949f734535c90d93a6d10eea06afcdce
<pre>
Workaround `[AllowShared] BufferSource`
<a href="https://bugs.webkit.org/show_bug.cgi?id=249632">https://bugs.webkit.org/show_bug.cgi?id=249632</a>
rdar://103543109

Reviewed by Mark Lam.

BufferSource is typedef ArrayBuffer or ArrayBufferView. However, WebCore is implementing it as one class instead
of using Variant. As a result IDL AllowShared annotation is not applied correctly to each of variant&apos;s type.
We already hit this issue in WebGL and we workaround this by using ([AllowShared] ArrayBufferView or [AllowShared] ArrayBuffer).
We should do that in all the other IDL files too.

* Source/WebCore/Modules/WebGPU/GPUQueue.idl:
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.idl:
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoderConfig.idl:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(AddToIncludesForIDLType):
* Source/WebCore/dom/TextDecoder.idl:
* Source/WebCore/dom/TextDecoderStreamDecoder.idl:

Canonical link: <a href="https://commits.webkit.org/258137@main">https://commits.webkit.org/258137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dddc45bb74a0d8cee3da745f637f96ae4867c25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110302 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170557 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1026 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108136 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91650 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34999 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77990 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3823 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24564 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3851 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/966 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44072 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5619 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2930 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->