### PR TITLE
[macOS] Unreviewed, non-unified build fixes

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
@@ -27,6 +27,7 @@
 #import "_WKNotificationDataInternal.h"
 
 #import <WebCore/NotificationData.h>
+#import <WebCore/WebCoreObjCExtras.h>
 
 static NSString *iconURLKey = @"iconURL";
 static NSString *tagKey = @"tag";

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationDataInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationDataInternal.h
@@ -25,6 +25,8 @@
 
 #import "_WKNotificationData.h"
 
+#import <WebKit/WKWebsiteDataStore.h>
+
 namespace WebCore {
 struct NotificationData;
 };

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -36,7 +36,8 @@
 #include "WebPageProxyMessages.h"
 #include "WebProcessMessages.h"
 
-using namespace WebCore;
+#include <WebCore/FrameIdentifier.h>
+#include <WebCore/ShouldTreatAsContinuingLoad.h>
 
 namespace WebKit {
 
@@ -63,7 +64,7 @@ ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<WebProces
 
     LoadParameters loadParameters;
     loadParameters.request = request;
-    loadParameters.shouldTreatAsContinuingLoad = ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision;
+    loadParameters.shouldTreatAsContinuingLoad = WebCore::ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision;
     // FIXME: Add more parameters as appropriate.
 
     // FIXME: Do we need a LoadRequestWaitingForProcessLaunch version?
@@ -106,7 +107,7 @@ void ProvisionalFrameProxy::decidePolicyForResponse(WebCore::FrameIdentifier fra
         page->decidePolicyForResponseShared(m_process.copyRef(), m_pageID, frameID, WTFMove(frameInfo), identifier, navigationID, response, request, canShowMIMEType, downloadAttribute, listenerID);
 }
 
-void ProvisionalFrameProxy::didCommitLoadForFrame(FrameIdentifier frameID, FrameInfoData&& frameInfo, ResourceRequest&& request, uint64_t navigationID, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType frameLoadType, const WebCore::CertificateInfo& certificateInfo, bool usedLegacyTLS, bool privateRelayed, bool containsPluginDocument, std::optional<WebCore::HasInsecureContent> forcedHasInsecureContent, WebCore::MouseEventPolicy mouseEventPolicy, const UserData& userData)
+void ProvisionalFrameProxy::didCommitLoadForFrame(WebCore::FrameIdentifier frameID, FrameInfoData&& frameInfo, WebCore::ResourceRequest&& request, uint64_t navigationID, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType frameLoadType, const WebCore::CertificateInfo& certificateInfo, bool usedLegacyTLS, bool privateRelayed, bool containsPluginDocument, std::optional<WebCore::HasInsecureContent> forcedHasInsecureContent, WebCore::MouseEventPolicy mouseEventPolicy, const UserData& userData)
 {
     m_process->removeMessageReceiver(Messages::WebPageProxy::messageReceiverName(), m_pageID);
     m_process->removeMessageReceiver(Messages::WebFrameProxy::messageReceiverName(), m_frame.frameID().object());


### PR DESCRIPTION
#### f68cfcc57ff92ba0d6be77471ae466bad36120da
<pre>
[macOS] Unreviewed, non-unified build fixes

* Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm: Add missing
  header &apos;WebCoreObjCExtras.h&apos;.
* Source/WebKit/UIProcess/API/Cocoa/_WKNotificationDataInternal.h: Add
  missing header &apos;WKWebsiteDataStore.h&apos;.
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp: Add missing headers
  &apos;ShouldTreatAsContinuingLoad.h&apos; and &apos;FrameIdentifier.h&apos;.
(WebKit::ProvisionalFrameProxy::ProvisionalFrameProxy):
(WebKit::ProvisionalFrameProxy::didCommitLoadForFrame):

Canonical link: <a href="https://commits.webkit.org/258124@main">https://commits.webkit.org/258124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33c1161c6dfb6e79fe8513a59a9ea8abe51484f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110289 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1013 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93393 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108125 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106770 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34984 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3812 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3840 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44058 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5608 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2921 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->