### PR TITLE
[Live Range Selection] accessibility/gtk/caret-browsing-select-focus.html fails

### DIFF
--- a/LayoutTests/accessibility/gtk/caret-browsing-select-focus.html
+++ b/LayoutTests/accessibility/gtk/caret-browsing-select-focus.html
@@ -29,7 +29,7 @@ if (window.testRunner && window.internals) {
     // Check roles and initial states
     // Move the caret once to force the focus onto this toplevel
     var par1 = document.getElementById("par1");
-    window.getSelection().setPosition(par1, 10);
+    window.getSelection().setPosition(par1, 1);
     eventSender.keyDown("rightArrow");
     shouldBe("axCombo.role", "'AXRole: AXComboBox'");
     shouldBe("axMenuItemFoo.role", "'AXRole: AXMenuItem'");


### PR DESCRIPTION
#### 2077152ab0049efb0a700ca0d613a76d2efd662d
<pre>
[Live Range Selection] accessibility/gtk/caret-browsing-select-focus.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=249634">https://bugs.webkit.org/show_bug.cgi?id=249634</a>

Reviewed by Carlos Garcia Campos.

The failure was caused by the test using an invalid offset of 10.
Use the equivalent valid offset of 1 instead.

* LayoutTests/accessibility/gtk/caret-browsing-select-focus.html:

Canonical link: <a href="https://commits.webkit.org/258157@main">https://commits.webkit.org/258157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02a8f7c24b56cc3161aedca5061687c6b2f78116

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110290 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170549 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1014 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93394 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108126 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34988 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77979 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3813 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24553 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/955 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44059 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5609 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2939 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->