### PR TITLE
[JSC] WebAssembly.Memory's buffer should not be growable / resizable

### DIFF
--- a/JSTests/wasm/stress/wasm-shared-memory-growable.js
+++ b/JSTests/wasm/stress/wasm-shared-memory-growable.js
@@ -1,0 +1,27 @@
+//@ skip if $architecture == "arm"
+
+import * as assert from "../assert.js";
+
+{
+    let memory = new WebAssembly.Memory({
+        shared: true,
+        initial: 1,
+        maximum: 16,
+    });
+
+    let buffer = memory.buffer;
+    assert.eq(buffer.growable, false);
+    assert.eq(buffer.maxByteLength, 65536);
+    assert.eq(buffer.byteLength, 65536);
+}
+{
+    let memory = new WebAssembly.Memory({
+        shared: false,
+        initial: 1,
+    });
+
+    let buffer = memory.buffer;
+    assert.eq(buffer.resizable, false);
+    assert.eq(buffer.maxByteLength, 65536);
+    assert.eq(buffer.byteLength, 65536);
+}

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -239,10 +239,7 @@ Ref<ArrayBuffer> ArrayBuffer::createFromBytes(const void* data, size_t byteLengt
 
 Ref<ArrayBuffer> ArrayBuffer::createShared(Ref<SharedArrayBufferContents>&& shared)
 {
-    void* memory = shared->data();
-    size_t sizeInBytes = shared->sizeInBytes(std::memory_order_seq_cst);
-    auto maxByteLength = shared->maxByteLength();
-    ArrayBufferContents contents(memory, sizeInBytes, maxByteLength, WTFMove(shared));
+    ArrayBufferContents contents(WTFMove(shared));
     return create(WTFMove(contents));
 }
 


### PR DESCRIPTION
#### d6903a56fc2ae074d2b2ec9900f83f5bbd45edfd
<pre>
[JSC] WebAssembly.Memory&apos;s buffer should not be growable / resizable
<a href="https://bugs.webkit.org/show_bug.cgi?id=249635">https://bugs.webkit.org/show_bug.cgi?id=249635</a>
rdar://103545248

Reviewed by Mark Lam.

While WebAssembly.Memory&apos;s &quot;shared&quot; backing-memory is actually growable,
we should say it is not growable since the integration plan is not defined yet,
and we are not having enough [AllowResizable] annotation in WebCore.

* JSTests/wasm/stress/wasm-shared-memory-growable.js: Added.
(assert.eq):
* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::ArrayBuffer::createShared):
* Source/JavaScriptCore/runtime/ArrayBuffer.h:

Canonical link: <a href="https://commits.webkit.org/258126@main">https://commits.webkit.org/258126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a3b437e46a5b49527b0b4ce7b3cf782755e5ca1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110301 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1025 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93405 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108135 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106780 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91475 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3822 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87575 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1370 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3850 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/29255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/9962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/44069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90466 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5618 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/20240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2922 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->