### PR TITLE
[GPU Process] [FormControls] Add a ControlPart for TextArea

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1742,6 +1742,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/controls/ControlStyle.h
     platform/graphics/controls/MeterPart.h
     platform/graphics/controls/PlatformControl.h
+    platform/graphics/controls/TextAreaPart.h
     platform/graphics/controls/TextFieldPart.h
 
     platform/graphics/displaylists/DisplayList.h

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -465,6 +465,7 @@ platform/graphics/mac/WebLayer.mm
 platform/graphics/mac/controls/ControlFactoryMac.mm
 platform/graphics/mac/controls/ControlMac.mm
 platform/graphics/mac/controls/MeterMac.mm
+platform/graphics/mac/controls/TextAreaMac.mm
 platform/graphics/mac/controls/TextFieldMac.mm
 platform/graphics/mac/controls/WebControlView.mm
 platform/graphics/opentype/OpenTypeCG.cpp

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class MeterPart;
 class PlatformControl;
+class TextAreaPart;
 class TextFieldPart;
 
 class ControlFactory {
@@ -41,6 +42,7 @@ public:
     static ControlFactory& sharedControlFactory();
 
     virtual std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) = 0;
+    virtual std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) = 0;
 };
 

--- a/Source/WebCore/platform/graphics/controls/TextAreaPart.h
+++ b/Source/WebCore/platform/graphics/controls/TextAreaPart.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class TextAreaPart final : public ControlPart {
+public:
+    static Ref<TextAreaPart> create(ControlPartType type)
+    {
+        return adoptRef(*new TextAreaPart(type));
+    }
+
+private:
+    TextAreaPart(ControlPartType type)
+        : ControlPart(type)
+    {
+        ASSERT(type == ControlPartType::Listbox || type == ControlPartType::TextArea);
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformTextArea(*this);
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/TextFieldPart.h
+++ b/Source/WebCore/platform/graphics/controls/TextFieldPart.h
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-class TextFieldPart : public ControlPart {
+class TextFieldPart final : public ControlPart {
 public:
     static Ref<TextFieldPart> create()
     {
@@ -43,7 +43,7 @@ private:
     {
     }
 
-    std::unique_ptr<PlatformControl> createPlatformControl() override
+    std::unique_ptr<PlatformControl> createPlatformControl() final
     {
         return controlFactory().createPlatformTextField(*this);
     }

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -39,6 +39,7 @@ public:
     NSView *drawingView(const FloatRect&, const ControlStyle&) const;
 
     std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) override;
+    std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) override;
     std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) override;
 
 private:

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import "MeterMac.h"
+#import "TextAreaMac.h"
 #import "TextFieldMac.h"
 #import <pal/spi/mac/NSViewSPI.h>
 #import <wtf/BlockObjCExceptions.h>
@@ -90,6 +91,11 @@ NSTextFieldCell* ControlFactoryMac::textFieldCell() const
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformMeter(MeterPart& part)
 {
     return makeUnique<MeterMac>(part, *this, levelIndicatorCell());
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformTextArea(TextAreaPart& part)
+{
+    return makeUnique<TextAreaMac>(part);
 }
 
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformTextField(TextFieldPart& part)

--- a/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "PlatformControl.h"
+
+namespace WebCore {
+
+class TextAreaPart;
+
+class TextAreaMac final : public PlatformControl {
+public:
+    TextAreaMac(TextAreaPart&);
+
+private:
+    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) final;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/TextAreaMac.mm
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "TextAreaMac.h"
+
+#if PLATFORM(MAC)
+
+#import "LocalCurrentGraphicsContext.h"
+#import "TextAreaPart.h"
+#import <pal/spi/mac/NSCellSPI.h>
+
+namespace WebCore {
+
+TextAreaMac::TextAreaMac(TextAreaPart& owningPart)
+    : PlatformControl(owningPart)
+{
+    ASSERT(owningPart.type() == ControlPartType::Listbox || owningPart.type() == ControlPartType::TextArea);
+}
+
+void TextAreaMac::draw(GraphicsContext& context, const FloatRect& rect, float, const ControlStyle& style)
+{
+    LocalCurrentGraphicsContext localContext(context);
+
+    bool enabled = style.states.contains(ControlStyle::State::Enabled);
+    bool readOnly = style.states.contains(ControlStyle::State::ReadOnly);
+
+    _NSDrawCarbonThemeListBox(rect, enabled && !readOnly, YES, YES);
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -54,6 +54,7 @@
 #include "SliderThumbElement.h"
 #include "SpinButtonElement.h"
 #include "StringTruncator.h"
+#include "TextAreaPart.h"
 #include "TextControlInnerElements.h"
 #include "TextFieldPart.h"
 #include <wtf/FileSystem.h>
@@ -496,7 +497,6 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
     case ControlPartType::SquareButton:
     case ControlPartType::Button:
     case ControlPartType::DefaultButton:
-    case ControlPartType::Listbox:
     case ControlPartType::Menulist:
     case ControlPartType::MenulistButton:
         break;
@@ -515,8 +515,11 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
     case ControlPartType::Attachment:
     case ControlPartType::BorderlessAttachment:
 #endif
-    case ControlPartType::TextArea:
         break;
+
+    case ControlPartType::Listbox:
+    case ControlPartType::TextArea:
+        return TextAreaPart::create(type);
 
     case ControlPartType::TextField:
         return TextFieldPart::create();

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -109,7 +109,6 @@ private:
 
     void adjustTextFieldStyle(RenderStyle&, const Element*) const final;
 
-    bool paintTextArea(const RenderObject&, const PaintInfo&, const FloatRect&) final;
     void adjustTextAreaStyle(RenderStyle&, const Element*) const final;
 
     bool paintMenuList(const RenderObject&, const PaintInfo&, const FloatRect&) final;

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -262,12 +262,13 @@ bool RenderThemeMac::canPaint(const PaintInfo& paintInfo, const Settings&, Contr
 #if ENABLE(ATTACHMENT_ELEMENT)
     case ControlPartType::Attachment:
     case ControlPartType::BorderlessAttachment:
-        return true;
 #endif
 #if ENABLE(APPLE_PAY)
     case ControlPartType::ApplePayButton:
-        return true;
 #endif
+    case ControlPartType::Listbox:
+    case ControlPartType::Meter:
+    case ControlPartType::TextArea:
     case ControlPartType::TextField:
         return true;
     default:
@@ -290,7 +291,8 @@ bool RenderThemeMac::canCreateControlPartForRenderer(const RenderObject& rendere
 bool RenderThemeMac::canCreateControlPartForBorderOnly(const RenderObject& renderer) const
 {
     ControlPartType type = renderer.style().effectiveAppearance();
-    return type == ControlPartType::TextField;
+    return type == ControlPartType::TextArea
+        || type == ControlPartType::TextField;
 }
 
 bool RenderThemeMac::useFormSemanticContext() const
@@ -1131,13 +1133,6 @@ void RenderThemeMac::adjustImageControlsButtonStyle(RenderStyle& style, const El
 
 void RenderThemeMac::adjustTextFieldStyle(RenderStyle&, const Element*) const
 {
-}
-
-bool RenderThemeMac::paintTextArea(const RenderObject& o, const PaintInfo& paintInfo, const FloatRect& r)
-{
-    LocalCurrentGraphicsContext localContext(paintInfo.context());
-    _NSDrawCarbonThemeListBox(r, isEnabled(o) && !isReadOnlyControl(o), YES, YES);
-    return false;
 }
 
 void RenderThemeMac::adjustTextAreaStyle(RenderStyle&, const Element*) const

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -108,6 +108,7 @@
 #include <WebCore/SkewTransformOperation.h>
 #include <WebCore/SystemImage.h>
 #include <WebCore/TestReportBody.h>
+#include <WebCore/TextAreaPart.h>
 #include <WebCore/TextCheckerClient.h>
 #include <WebCore/TextFieldPart.h>
 #include <WebCore/TextIndicator.h>
@@ -1601,7 +1602,6 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
     case WebCore::ControlPartType::SquareButton:
     case WebCore::ControlPartType::Button:
     case WebCore::ControlPartType::DefaultButton:
-    case WebCore::ControlPartType::Listbox:
     case WebCore::ControlPartType::Menulist:
     case WebCore::ControlPartType::MenulistButton:
         break;
@@ -1625,8 +1625,11 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
     case WebCore::ControlPartType::Attachment:
     case WebCore::ControlPartType::BorderlessAttachment:
 #endif
-    case WebCore::ControlPartType::TextArea:
         break;
+
+    case WebCore::ControlPartType::Listbox:
+    case WebCore::ControlPartType::TextArea:
+        return WebCore::TextAreaPart::create(*type);
 
     case WebCore::ControlPartType::TextField:
         return WebCore::TextFieldPart::create();


### PR DESCRIPTION
#### 9fa141672fb9121359edf625906088ce8aa40843
<pre>
[GPU Process] [FormControls] Add a ControlPart for TextArea
<a href="https://bugs.webkit.org/show_bug.cgi?id=249629">https://bugs.webkit.org/show_bug.cgi?id=249629</a>
rdar://103541252

Reviewed by Aditya Keerthi.

This ControlPart will draw a border around the TextArea and ListBox form controls.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/TextAreaPart.h: Copied from Source/WebCore/platform/graphics/controls/TextFieldPart.h.
* Source/WebCore/platform/graphics/controls/TextFieldPart.h:
(WebCore::TextFieldPart::create): Deleted.
(WebCore::TextFieldPart::TextFieldPart): Deleted.
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::createPlatformTextArea):
* Source/WebCore/platform/graphics/mac/controls/TextAreaMac.h: Copied from Source/WebCore/platform/graphics/controls/TextFieldPart.h.
* Source/WebCore/platform/graphics/mac/controls/TextAreaMac.mm: Copied from Source/WebCore/platform/graphics/controls/TextFieldPart.h.
(WebCore::TextAreaMac::TextAreaMac):
(WebCore::TextAreaMac::draw):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::createControlPart const):
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::canCreateControlPartForBorderOnly const):
(WebCore::RenderThemeMac::paintTextArea): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/258150@main">https://commits.webkit.org/258150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dd7adc05bd60c358e2ca681be4934b6a5b3e7d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110346 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170602 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1084 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93454 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108179 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8426 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23088 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3867 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24605 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3895 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44113 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5595 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5663 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->