### PR TITLE
[GPU Process] [FormControls] Add a ControlPart for ToggleButton

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1744,6 +1744,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/controls/PlatformControl.h
     platform/graphics/controls/TextAreaPart.h
     platform/graphics/controls/TextFieldPart.h
+    platform/graphics/controls/ToggleButtonPart.h
 
     platform/graphics/displaylists/DisplayList.h
     platform/graphics/displaylists/DisplayListDrawingContext.h

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -462,11 +462,13 @@ platform/graphics/mac/SimpleFontDataCoreText.cpp
 platform/graphics/mac/SwitchingGPUClient.cpp
 platform/graphics/mac/WebKitNSImageExtras.mm
 platform/graphics/mac/WebLayer.mm
+platform/graphics/mac/controls/ButtonControlMac.mm
 platform/graphics/mac/controls/ControlFactoryMac.mm
 platform/graphics/mac/controls/ControlMac.mm
 platform/graphics/mac/controls/MeterMac.mm
 platform/graphics/mac/controls/TextAreaMac.mm
 platform/graphics/mac/controls/TextFieldMac.mm
+platform/graphics/mac/controls/ToggleButtonMac.mm
 platform/graphics/mac/controls/WebControlView.mm
 platform/graphics/opentype/OpenTypeCG.cpp
 platform/image-decoders/avif/AVIFImageDecoder.cpp

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -31,6 +31,7 @@ class MeterPart;
 class PlatformControl;
 class TextAreaPart;
 class TextFieldPart;
+class ToggleButtonPart;
 
 class ControlFactory {
     WTF_MAKE_FAST_ALLOCATED;
@@ -44,6 +45,7 @@ public:
     virtual std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) = 0;
+    virtual std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/ToggleButtonPart.h
+++ b/Source/WebCore/platform/graphics/controls/ToggleButtonPart.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class ToggleButtonPart final : public ControlPart {
+public:
+    static Ref<ToggleButtonPart> create(ControlPartType type)
+    {
+        return adoptRef(*new ToggleButtonPart(type));
+    }
+
+private:
+    ToggleButtonPart(ControlPartType type)
+        : ControlPart(type)
+    {
+        ASSERT(type == ControlPartType::Checkbox || type == ControlPartType::Radio);
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformToggleButton(*this);
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ControlMac.h"
+
+namespace WebCore {
+
+class ButtonControlMac : public ControlMac {
+public:
+    ButtonControlMac(ControlPart&, ControlFactoryMac&, NSButtonCell *);
+
+protected:
+    void updateCellStates(const FloatRect&, const ControlStyle&) override;
+
+    RetainPtr<NSButtonCell> m_buttonCell;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ButtonControlMac.h"
+
+#if PLATFORM(MAC)
+
+#import <pal/spi/cocoa/NSButtonCellSPI.h>
+
+namespace WebCore {
+
+ButtonControlMac::ButtonControlMac(ControlPart& part, ControlFactoryMac& controlFactory, NSButtonCell *buttonCell)
+    : ControlMac(part, controlFactory)
+    , m_buttonCell(buttonCell)
+{
+    ASSERT(m_buttonCell);
+}
+
+void ButtonControlMac::updateCellStates(const FloatRect& rect, const ControlStyle& style)
+{
+    const auto& states = style.states;
+
+    // Pressed state
+    bool oldPressed = [m_buttonCell isHighlighted];
+    bool pressed = states.contains(ControlStyle::State::Pressed);
+    if (pressed != oldPressed)
+        [m_buttonCell _setHighlighted:pressed animated:false];
+
+    // Enabled state
+    bool oldEnabled = [m_buttonCell isEnabled];
+    bool enabled = states.contains(ControlStyle::State::Enabled);
+    if (oldEnabled != enabled)
+        [m_buttonCell setEnabled:enabled];
+
+    // Checked and Indeterminate
+    bool oldIndeterminate = [m_buttonCell state] == NSControlStateValueMixed;
+    bool oldChecked = [m_buttonCell state] == NSControlStateValueOn;
+    bool indeterminate = states.contains(ControlStyle::State::Indeterminate);
+    bool checked = states.contains(ControlStyle::State::Checked);
+    if (oldIndeterminate != indeterminate || checked != oldChecked) {
+        NSControlStateValue newState = indeterminate ? NSControlStateValueMixed : (checked ? NSControlStateValueOn : NSControlStateValueOff);
+        [m_buttonCell _setState:newState animated:false];
+    }
+
+    // Presenting state
+    if (states.contains(ControlStyle::State::Presenting))
+        [m_buttonCell _setHighlighted:YES animated:NO];
+
+    // Window inactive state does not need to be checked explicitly, since we paint parented to
+    // a view in a window whose key state can be detected.
+
+    // Only update if we have to, since AppKit does work even if the size is the same.
+    auto controlSize = calculateControlSize(rect.size(), style);
+    if (controlSize != [m_buttonCell controlSize])
+        [m_buttonCell setControlSize:controlSize];
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -41,13 +41,18 @@ public:
     std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) override;
     std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) override;
     std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) override;
+    std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) override;
 
 private:
+    NSButtonCell *checkboxCell() const;
+    NSButtonCell *radioCell() const;
     NSLevelIndicatorCell* levelIndicatorCell() const;
     NSTextFieldCell* textFieldCell() const;
 
     mutable RetainPtr<WebControlView> m_drawingView;
 
+    mutable RetainPtr<NSButtonCell> m_checkboxCell;
+    mutable RetainPtr<NSButtonCell> m_radioCell;
     mutable RetainPtr<NSLevelIndicatorCell> m_levelIndicatorCell;
     mutable RetainPtr<NSTextFieldCell> m_textFieldCell;
 };

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -31,6 +31,8 @@
 #import "MeterMac.h"
 #import "TextAreaMac.h"
 #import "TextFieldMac.h"
+#import "ToggleButtonMac.h"
+#import "ToggleButtonPart.h"
 #import <pal/spi/mac/NSViewSPI.h>
 #import <wtf/BlockObjCExceptions.h>
 
@@ -58,6 +60,37 @@ NSView *ControlFactoryMac::drawingView(const FloatRect& rect, const ControlStyle
     UNUSED_PARAM(style);
 #endif
     return m_drawingView.get();
+}
+
+static RetainPtr<NSButtonCell> createToggleButtonCell()
+{
+    auto buttonCell = adoptNS([[NSButtonCell alloc] init]);
+    [buttonCell setTitle:nil];
+    [buttonCell setFocusRingType:NSFocusRingTypeExterior];
+    return buttonCell;
+}
+
+NSButtonCell* ControlFactoryMac::checkboxCell() const
+{
+    if (!m_checkboxCell) {
+        BEGIN_BLOCK_OBJC_EXCEPTIONS
+        m_checkboxCell = createToggleButtonCell();
+        [m_checkboxCell setButtonType:NSButtonTypeSwitch];
+        [m_checkboxCell setAllowsMixedState:YES];
+        END_BLOCK_OBJC_EXCEPTIONS
+    }
+    return m_checkboxCell.get();
+}
+
+NSButtonCell* ControlFactoryMac::radioCell() const
+{
+    if (!m_radioCell) {
+        BEGIN_BLOCK_OBJC_EXCEPTIONS
+        m_radioCell = createToggleButtonCell();
+        [m_radioCell setButtonType:NSButtonTypeRadio];
+        END_BLOCK_OBJC_EXCEPTIONS
+    }
+    return m_radioCell.get();
 }
 
 NSLevelIndicatorCell* ControlFactoryMac::levelIndicatorCell() const
@@ -101,6 +134,11 @@ std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformTextArea(TextA
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformTextField(TextFieldPart& part)
 {
     return makeUnique<TextFieldMac>(part, *this, textFieldCell());
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformToggleButton(ToggleButtonPart& part)
+{
+    return makeUnique<ToggleButtonMac>(part, *this, part.type() == ControlPartType::Checkbox ? checkboxCell() : radioCell());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
@@ -44,6 +44,11 @@ public:
 protected:
     static bool userPrefersContrast();
 
+    virtual IntSize cellSize(NSControlSize, const ControlStyle&) const { return { }; };
+    virtual IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const { return { }; };
+
+    NSControlSize calculateControlSize(const FloatSize&, const ControlStyle&) const;
+
     void setFocusRingClipRect(const FloatRect& clipBounds) override;
 
     void updateCellStates(const FloatRect&, const ControlStyle&) override;

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -57,6 +57,24 @@ void ControlMac::setFocusRingClipRect(const FloatRect& clipBounds)
     [WebControlView setClipBounds:clipBounds];
 }
 
+NSControlSize ControlMac::calculateControlSize(const FloatSize& size, const ControlStyle& style) const
+{
+    if (style.states.contains(ControlStyle::State::LargeControls)
+        && size.width() >= static_cast<int>(cellSize(NSControlSizeLarge, style).width() * style.zoomFactor)
+        && size.height() >= static_cast<int>(cellSize(NSControlSizeLarge, style).height() * style.zoomFactor))
+        return NSControlSizeLarge;
+
+    if (size.width() >= static_cast<int>(cellSize(NSControlSizeRegular, style).width() * style.zoomFactor)
+        && size.height() >= static_cast<int>(cellSize(NSControlSizeRegular, style).height() * style.zoomFactor))
+        return NSControlSizeRegular;
+
+    if (size.width() >= static_cast<int>(cellSize(NSControlSizeSmall, style).width() * style.zoomFactor)
+        && size.height() >= static_cast<int>(cellSize(NSControlSizeSmall, style).height() * style.zoomFactor))
+        return NSControlSizeSmall;
+
+    return NSControlSizeMini;
+}
+
 void ControlMac::updateCellStates(const FloatRect&, const ControlStyle& style)
 {
     [WebControlWindow setHasKeyAppearance:!style.states.contains(ControlStyle::State::WindowInactive)];

--- a/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ButtonControlMac.h"
+#import "ToggleButtonPart.h"
+
+namespace WebCore {
+
+class ToggleButtonMac final : public ButtonControlMac {
+public:
+    ToggleButtonMac(ToggleButtonPart& owningPart, ControlFactoryMac&, NSButtonCell *);
+
+private:
+    IntSize cellSize(NSControlSize, const ControlStyle&) const final;
+    IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const final;
+
+    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) final;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)
+

--- a/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ToggleButtonMac.h"
+
+#if PLATFORM(MAC)
+
+#import "ControlFactoryMac.h"
+#import "GraphicsContext.h"
+#import "LocalDefaultSystemAppearance.h"
+#import "ToggleButtonPart.h"
+#import <pal/spi/cocoa/NSButtonCellSPI.h>
+#import <wtf/BlockObjCExceptions.h>
+
+namespace WebCore {
+
+ToggleButtonMac::ToggleButtonMac(ToggleButtonPart& owningPart, ControlFactoryMac& controlFactory, NSButtonCell *buttonCell)
+    : ButtonControlMac(owningPart, controlFactory, buttonCell)
+{
+    ASSERT(m_owningPart.type() == ControlPartType::Checkbox || m_owningPart.type() == ControlPartType::Radio);
+}
+
+IntSize ToggleButtonMac::cellSize(NSControlSize controlSize, const ControlStyle& style) const
+{
+    static const std::array<IntSize, 4> checkboxSizes =
+    {
+        IntSize { 14, 14 },
+        IntSize { 12, 12 },
+        IntSize { 10, 10 },
+        IntSize { 16, 16 }
+    };
+    static const std::array<IntSize, 4> radioSizes =
+    {
+        IntSize { 16, 16 },
+        IntSize { 12, 12 },
+        IntSize { 10, 10 },
+        IntSize { 0, 0 }
+    };
+    static const std::array<IntSize, 4> largeRadioSizes =
+    {
+        IntSize { 14, 14 },
+        IntSize { 12, 12 },
+        IntSize { 10, 10 },
+        IntSize { 16, 16 }
+    };
+
+    if (m_owningPart.type() == ControlPartType::Checkbox)
+        return checkboxSizes[controlSize];
+
+    if (style.states.contains(ControlStyle::State::LargeControls))
+        return largeRadioSizes[controlSize];
+
+    return radioSizes[controlSize];
+}
+
+IntOutsets ToggleButtonMac::cellOutsets(NSControlSize controlSize, const ControlStyle&) const
+{
+    static const IntOutsets checkboxOutsets[] = {
+        // top right bottom left
+        { 2, 2, 2, 2 },
+        { 2, 1, 2, 1 },
+        { 0, 0, 1, 0 },
+        { 2, 2, 2, 2 },
+    };
+    static const IntOutsets radioOutsets[] = {
+        // top right bottom left
+        { 1, 0, 1, 2 },
+        { 1, 1, 2, 1 },
+        { 0, 0, 1, 1 },
+        { 1, 0, 1, 2 },
+    };
+    return (m_owningPart.type() == ControlPartType::Checkbox ? checkboxOutsets : radioOutsets)[controlSize];
+}
+
+void ToggleButtonMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+
+    GraphicsContextStateSaver stateSaver(context);
+
+    auto controlSize = [m_buttonCell controlSize];
+
+    auto zoomedSize = cellSize(controlSize, style);
+    zoomedSize.scale(style.zoomFactor);
+
+    auto outsets = cellOutsets(controlSize, style);
+    auto zoomedOutsets = FloatBoxExtent {
+        outsets.top() * style.zoomFactor,
+        outsets.right() * style.zoomFactor,
+        outsets.bottom() * style.zoomFactor,
+        outsets.left() * style.zoomFactor
+    };
+
+    auto logicalRect = rect;
+    logicalRect.setSize(zoomedSize);
+    logicalRect.expand(zoomedOutsets);
+
+    if (style.zoomFactor != 1) {
+        logicalRect.scale(1 / style.zoomFactor);
+        context.scale(style.zoomFactor);
+    }
+
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+
+    auto *view = m_controlFactory.drawingView(rect, style);
+
+    if ([m_buttonCell _stateAnimationRunning]) {
+        context.translate(logicalRect.location());
+        context.scale(FloatSize(1, -1));
+        context.translate(0, -logicalRect.height());
+
+        [m_buttonCell _renderCurrentAnimationFrameInContext:context.platformContext() atLocation:NSMakePoint(0, 0)];
+
+        if (![m_buttonCell _stateAnimationRunning] && style.states.contains(ControlStyle::State::Focused))
+            drawCell(context, logicalRect, deviceScaleFactor, style, m_buttonCell.get(), view, false);
+    } else
+        drawCell(context, logicalRect, deviceScaleFactor, style, m_buttonCell.get(), view, true);
+
+    END_BLOCK_OBJC_EXCEPTIONS
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -57,6 +57,7 @@
 #include "TextAreaPart.h"
 #include "TextControlInnerElements.h"
 #include "TextFieldPart.h"
+#include "ToggleButtonPart.h"
 #include <wtf/FileSystem.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringConcatenateNumbers.h>
@@ -493,6 +494,8 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
 
     case ControlPartType::Checkbox:
     case ControlPartType::Radio:
+        return ToggleButtonPart::create(type);
+
     case ControlPartType::PushButton:
     case ControlPartType::SquareButton:
     case ControlPartType::Button:

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -266,8 +266,10 @@ bool RenderThemeMac::canPaint(const PaintInfo& paintInfo, const Settings&, Contr
 #if ENABLE(APPLE_PAY)
     case ControlPartType::ApplePayButton:
 #endif
+    case ControlPartType::Checkbox:
     case ControlPartType::Listbox:
     case ControlPartType::Meter:
+    case ControlPartType::Radio:
     case ControlPartType::TextArea:
     case ControlPartType::TextField:
         return true;
@@ -285,13 +287,16 @@ RenderThemeMac::RenderThemeMac()
 bool RenderThemeMac::canCreateControlPartForRenderer(const RenderObject& renderer) const
 {
     ControlPartType type = renderer.style().effectiveAppearance();
-    return type == ControlPartType::Meter;
+    return type == ControlPartType::Checkbox
+        || type == ControlPartType::Meter
+        || type == ControlPartType::Radio;
 }
 
 bool RenderThemeMac::canCreateControlPartForBorderOnly(const RenderObject& renderer) const
 {
     ControlPartType type = renderer.style().effectiveAppearance();
-    return type == ControlPartType::TextArea
+    return type == ControlPartType::Listbox
+        || type == ControlPartType::TextArea
         || type == ControlPartType::TextField;
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -112,6 +112,7 @@
 #include <WebCore/TextCheckerClient.h>
 #include <WebCore/TextFieldPart.h>
 #include <WebCore/TextIndicator.h>
+#include <WebCore/ToggleButtonPart.h>
 #include <WebCore/TransformOperation.h>
 #include <WebCore/TransformationMatrix.h>
 #include <WebCore/TranslateTransformOperation.h>
@@ -1598,6 +1599,8 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
 
     case WebCore::ControlPartType::Checkbox:
     case WebCore::ControlPartType::Radio:
+        return WebCore::ToggleButtonPart::create(*type);
+
     case WebCore::ControlPartType::PushButton:
     case WebCore::ControlPartType::SquareButton:
     case WebCore::ControlPartType::Button:


### PR DESCRIPTION
#### a5f12d1b9232202fd842ed8b615d2baed86aa271
<pre>
[GPU Process] [FormControls] Add a ControlPart for ToggleButton
<a href="https://bugs.webkit.org/show_bug.cgi?id=249638">https://bugs.webkit.org/show_bug.cgi?id=249638</a>
rdar://103548470

Reviewed by Aditya Keerthi.

It will handle drawing the checkbox and the radio buttons. ButtonControlMac will
be introduced as the base class of ToggleButtonMac. It will also be the base class
of the ButtonMac which will be submitted in a future patch.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/ToggleButtonPart.h: Copied from Source/WebCore/platform/graphics/controls/ControlFactory.h.
* Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.h: Copied from Source/WebCore/platform/graphics/controls/ControlFactory.h.
* Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm: Added.
(WebCore::ButtonControlMac::ButtonControlMac):
(WebCore::ButtonControlMac::updateCellStates):
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::createToggleButtonCell):
(WebCore::ControlFactoryMac::checkboxCell const):
(WebCore::ControlFactoryMac::radioCell const):
(WebCore::ControlFactoryMac::createPlatformToggleButton):
* Source/WebCore/platform/graphics/mac/controls/ControlMac.h:
(WebCore::ControlMac::cellSize const):
(WebCore::ControlMac::cellOutsets const):
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::ControlMac::calculateControlSize const):
* Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h: Copied from Source/WebCore/platform/graphics/controls/ControlFactory.h.
* Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm: Added.
(WebCore::ToggleButtonMac::ToggleButtonMac):
(WebCore::ToggleButtonMac::cellSize const):
(WebCore::ToggleButtonMac::cellOutsets const):
(WebCore::ToggleButtonMac::draw):
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::ThemeMac::paint):
(WebCore::paintToggleButton): Deleted.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::createControlPart const):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
(WebCore::RenderThemeMac::canCreateControlPartForBorderOnly const):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/258177@main">https://commits.webkit.org/258177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68b4a7a201f1def90476faa9fe87e4df251f9a04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110381 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170636 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1112 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93496 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108213 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8458 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35063 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78055 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3899 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24639 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3931 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10041 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44147 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5610 "Found 1 new test failure: media/video-playback-quality.html (failure)") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5696 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2947 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->