### PR TITLE
Do not use std::optional for optional dictionary parameters

### DIFF
--- a/Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.cpp
+++ b/Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.cpp
@@ -37,12 +37,12 @@
 
 namespace WebCore {
 
-void NavigatorCookieConsent::requestCookieConsent(Navigator& navigator, std::optional<RequestCookieConsentOptions>&& options, Ref<DeferredPromise>&& promise)
+void NavigatorCookieConsent::requestCookieConsent(Navigator& navigator, RequestCookieConsentOptions&& options, Ref<DeferredPromise>&& promise)
 {
     from(navigator).requestCookieConsent(WTFMove(options), WTFMove(promise));
 }
 
-void NavigatorCookieConsent::requestCookieConsent(std::optional<RequestCookieConsentOptions>&& options, Ref<DeferredPromise>&& promise)
+void NavigatorCookieConsent::requestCookieConsent(RequestCookieConsentOptions&& options, Ref<DeferredPromise>&& promise)
 {
     // FIXME: Support the 'More info' option.
     UNUSED_PARAM(options);

--- a/Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.h
+++ b/Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.h
@@ -45,13 +45,13 @@ public:
     {
     }
 
-    static void requestCookieConsent(Navigator&, std::optional<RequestCookieConsentOptions>&&, Ref<DeferredPromise>&&);
+    static void requestCookieConsent(Navigator&, RequestCookieConsentOptions&&, Ref<DeferredPromise>&&);
 
 private:
     static NavigatorCookieConsent& from(Navigator&);
     static const char* supplementName() { return "NavigatorCookieConsent"; }
 
-    void requestCookieConsent(std::optional<RequestCookieConsentOptions>&&, Ref<DeferredPromise>&&);
+    void requestCookieConsent(RequestCookieConsentOptions&&, Ref<DeferredPromise>&&);
 
     Navigator& m_navigator;
 };

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
@@ -49,13 +49,12 @@ FileSystemDirectoryHandle::FileSystemDirectoryHandle(ScriptExecutionContext& con
 {
 }
 
-void FileSystemDirectoryHandle::getFileHandle(const String& name, std::optional<FileSystemDirectoryHandle::GetFileOptions> options, DOMPromiseDeferred<IDLInterface<FileSystemFileHandle>>&& promise)
+void FileSystemDirectoryHandle::getFileHandle(const String& name, const FileSystemDirectoryHandle::GetFileOptions& options, DOMPromiseDeferred<IDLInterface<FileSystemFileHandle>>&& promise)
 {
     if (isClosed())
         return promise.reject(Exception { InvalidStateError, "Handle is closed"_s });
 
-    bool createIfNecessary = options ? options->create : false;
-    connection().getFileHandle(identifier(), name, createIfNecessary, [weakThis = ThreadSafeWeakPtr { *this }, connection = Ref { connection() }, name, promise = WTFMove(promise)](auto result) mutable {
+    connection().getFileHandle(identifier(), name, options.create, [weakThis = ThreadSafeWeakPtr { *this }, connection = Ref { connection() }, name, promise = WTFMove(promise)](auto result) mutable {
         if (result.hasException())
             return promise.reject(result.releaseException());
 
@@ -70,13 +69,12 @@ void FileSystemDirectoryHandle::getFileHandle(const String& name, std::optional<
     });
 }
 
-void FileSystemDirectoryHandle::getDirectoryHandle(const String& name, std::optional<FileSystemDirectoryHandle::GetDirectoryOptions> options, DOMPromiseDeferred<IDLInterface<FileSystemDirectoryHandle>>&& promise)
+void FileSystemDirectoryHandle::getDirectoryHandle(const String& name, const FileSystemDirectoryHandle::GetDirectoryOptions& options, DOMPromiseDeferred<IDLInterface<FileSystemDirectoryHandle>>&& promise)
 {
     if (isClosed())
         return promise.reject(Exception { InvalidStateError, "Handle is closed"_s });
 
-    bool createIfNecessary = options ? options->create : false;
-    connection().getDirectoryHandle(identifier(), name, createIfNecessary, [weakThis = ThreadSafeWeakPtr { *this }, connection = Ref { connection() }, name, promise = WTFMove(promise)](auto result) mutable {
+    connection().getDirectoryHandle(identifier(), name, options.create, [weakThis = ThreadSafeWeakPtr { *this }, connection = Ref { connection() }, name, promise = WTFMove(promise)](auto result) mutable {
         if (result.hasException())
             return promise.reject(result.releaseException());
 
@@ -91,13 +89,12 @@ void FileSystemDirectoryHandle::getDirectoryHandle(const String& name, std::opti
     });
 }
 
-void FileSystemDirectoryHandle::removeEntry(const String& name, std::optional<FileSystemDirectoryHandle::RemoveOptions> options, DOMPromiseDeferred<void>&& promise)
+void FileSystemDirectoryHandle::removeEntry(const String& name, const FileSystemDirectoryHandle::RemoveOptions& options, DOMPromiseDeferred<void>&& promise)
 {
     if (isClosed())
         return promise.reject(Exception { InvalidStateError, "Handle is closed"_s });
 
-    bool deleteRecursively = options ? options->recursive : false;
-    connection().removeEntry(identifier(), name, deleteRecursively, [promise = WTFMove(promise)](auto result) mutable {
+    connection().removeEntry(identifier(), name, options.recursive, [promise = WTFMove(promise)](auto result) mutable {
         promise.settle(WTFMove(result));
     });
 }

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.h
@@ -48,9 +48,9 @@ public:
     };
 
     WEBCORE_EXPORT static Ref<FileSystemDirectoryHandle> create(ScriptExecutionContext&, String&&, FileSystemHandleIdentifier, Ref<FileSystemStorageConnection>&&);
-    void getFileHandle(const String& name, std::optional<GetFileOptions>, DOMPromiseDeferred<IDLInterface<FileSystemFileHandle>>&&);
-    void getDirectoryHandle(const String& name, std::optional<GetDirectoryOptions>, DOMPromiseDeferred<IDLInterface<FileSystemDirectoryHandle>>&&);
-    void removeEntry(const String& name, std::optional<RemoveOptions>, DOMPromiseDeferred<void>&&);
+    void getFileHandle(const String& name, const GetFileOptions&, DOMPromiseDeferred<IDLInterface<FileSystemFileHandle>>&&);
+    void getDirectoryHandle(const String& name, const GetDirectoryOptions&, DOMPromiseDeferred<IDLInterface<FileSystemDirectoryHandle>>&&);
+    void removeEntry(const String& name, const RemoveOptions&, DOMPromiseDeferred<void>&&);
     void resolve(const FileSystemHandle&, DOMPromiseDeferred<IDLSequence<IDLUSVString>>&&);
 
     void getHandleNames(CompletionHandler<void(ExceptionOr<Vector<String>>&&)>&&);


### PR DESCRIPTION
#### 03d50508e4139e54f59354d08552b4f2e95831c4
<pre>
Do not use std::optional for optional dictionary parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=249639">https://bugs.webkit.org/show_bug.cgi?id=249639</a>
rdar://103549528

Reviewed by Chris Dumez.

In our current implementation, generated code will always create a dictionary (struct) and pass it as parameter, so
the parameter will never be std::nullopt.

* Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.cpp:
(WebCore::NavigatorCookieConsent::requestCookieConsent):
* Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp:
(WebCore::FileSystemDirectoryHandle::getFileHandle):
(WebCore::FileSystemDirectoryHandle::getDirectoryHandle):
(WebCore::FileSystemDirectoryHandle::removeEntry):
* Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.h:

Canonical link: <a href="https://commits.webkit.org/258140@main">https://commits.webkit.org/258140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e10140770983075d6843b2646e8ecd98a626520

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110309 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170565 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1033 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93414 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108143 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8392 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35007 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90300 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77997 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3830 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24570 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/972 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44078 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5590 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5626 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->