### PR TITLE
[css-transitions] support transitions of custom properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-angle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-angle-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A custom property of type <angle> can yield a CSS Transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-angle.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-angle.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<angle>",
+  from: "100deg",
+  to: "200deg",
+  expected: "150deg"
+}, 'A custom property of type <angle> can yield a CSS Transition');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-color-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A custom property of type <color> can yield a CSS Transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-color.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<color>",
+  from: "rgb(100, 100, 100)",
+  to: "rgb(200, 200, 200)",
+  expected: "rgb(150, 150, 150)"
+}, 'A custom property of type <color> can yield a CSS Transition');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-custom-ident-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-custom-ident-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A custom property of type <custom-ident> cannot yield a CSS Transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-custom-ident.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-custom-ident.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+no_transition_test({
+  syntax: "<custom-ident>",
+  from: "from",
+  to: "to",
+}, 'A custom property of type <custom-ident> cannot yield a CSS Transition');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-image-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A custom property of type <image> cannot yield a CSS Transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-image.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-image.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+no_transition_test({
+  syntax: "<image>",
+  from: 'url("https://example.com/from")',
+  to: 'url("https://example.com/to")',
+}, 'A custom property of type <image> cannot yield a CSS Transition');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Running a transition an inherited CSS variable is reflected on a standard property using that variable as a value assert_equals: expected "150px" but got "100px"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="container">
+    <div id="target"></div>
+</div>
+<script>
+
+test(() => {
+  const customProperty = "--my-length";
+
+  CSS.registerProperty({
+    name: customProperty,
+    syntax: "<length>",
+    inherits: true,
+    initialValue: "100px"
+  });
+
+  target.style.marginLeft = `var(${customProperty})`;
+  assert_equals(getComputedStyle(target).marginLeft, "100px");
+  assert_equals(getComputedStyle(target).getPropertyValue(customProperty), "100px");
+
+  container.style.transition = `${customProperty} 1s -500ms linear`;
+  container.style.setProperty(customProperty, "200px");
+
+  assert_equals(getComputedStyle(target).marginLeft, "150px");
+}, "Running a transition an inherited CSS variable is reflected on a standard property using that variable as a value");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-integer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-integer-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A custom property of type <integer> can yield a CSS Transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-integer.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-integer.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<integer>",
+  from: "100",
+  to: "200",
+  expected: "150"
+}, 'A custom property of type <integer> can yield a CSS Transition');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-length-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-length-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A custom property of type <length> can yield a CSS Transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-length-percentage-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-length-percentage-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A custom property of type <length-percentage> can yield a CSS Transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-length-percentage.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-length-percentage.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<length-percentage>",
+  from: "100px",
+  to: "100%",
+  expected: "calc(50% + 50px)"
+}, 'A custom property of type <length-percentage> can yield a CSS Transition');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-length.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-length.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<length>",
+  from: "100px",
+  to: "200px",
+  expected: "150px"
+}, 'A custom property of type <length> can yield a CSS Transition');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-list-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-list-expected.txt
@@ -1,0 +1,26 @@
+
+PASS A custom property of type <angle># does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <angle>+ does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <color># does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <color>+ does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <custom-ident># does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <custom-ident>+ does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <image># does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <image>+ does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <integer># does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <integer>+ does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <length-percentage># does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <length-percentage>+ does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <length># does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <length>+ does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <number># does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <number>+ does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <percentage># does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <percentage>+ does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <resolution># does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <resolution>+ does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <time># does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <time>+ does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <url># does not yield a CSS Transition if the lists do not contain the same number of values
+PASS A custom property of type <url>+ does not yield a CSS Transition if the lists do not contain the same number of values
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-list.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-list.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+no_transition_test({
+  syntax: "<angle>#",
+  from: '100deg, 200deg',
+  to: '300deg',
+}, 'A custom property of type <angle># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<angle>+",
+  from: '100deg 200deg',
+  to: '300deg',
+}, 'A custom property of type <angle>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<color>#",
+  from: 'rgb(100, 100, 100), rgb(150, 150, 150)',
+  to: 'rgb(200, 200, 200)',
+}, 'A custom property of type <color># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<color>+",
+  from: 'rgb(100, 100, 100) rgb(150, 150, 150)',
+  to: 'rgb(200, 200, 200)',
+}, 'A custom property of type <color>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<custom-ident>#",
+  from: 'foo, bar',
+  to: 'baz',
+}, 'A custom property of type <custom-ident># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<custom-ident>+",
+  from: 'foo bar',
+  to: 'baz',
+}, 'A custom property of type <custom-ident>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<image>#",
+  from: 'url("https://example.com/foo"), url("https://example.com/bar")',
+  to: 'url("https://example.com/to")',
+}, 'A custom property of type <image># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<image>+",
+  from: 'url("https://example.com/foo") url("https://example.com/bar")',
+  to: 'url("https://example.com/to")',
+}, 'A custom property of type <image>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<integer>#",
+  from: '100, 200',
+  to: '300',
+}, 'A custom property of type <integer># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<integer>+",
+  from: '100 200',
+  to: '300',
+}, 'A custom property of type <integer>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<length-percentage>#",
+  from: '100px, 200px',
+  to: '300%',
+}, 'A custom property of type <length-percentage># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<length-percentage>+",
+  from: '100px 200px',
+  to: '300%',
+}, 'A custom property of type <length-percentage>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<length>#",
+  from: '100px, 200px',
+  to: '300px',
+}, 'A custom property of type <length># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<length>+",
+  from: '100px 200px',
+  to: '300px',
+}, 'A custom property of type <length>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<number>#",
+  from: '100, 200',
+  to: '300',
+}, 'A custom property of type <number># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<number>+",
+  from: '100 200',
+  to: '300',
+}, 'A custom property of type <number>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<percentage>#",
+  from: '100%, 200%',
+  to: '300%',
+}, 'A custom property of type <percentage># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<percentage>+",
+  from: '100% 200%',
+  to: '300%',
+}, 'A custom property of type <percentage>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<resolution>#",
+  from: '100dppx, 200dppx',
+  to: '300dppx',
+}, 'A custom property of type <resolution># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<resolution>+",
+  from: '100dppx 200dppx',
+  to: '300dppx',
+}, 'A custom property of type <resolution>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<time>#",
+  from: '100s, 200s',
+  to: '300s',
+}, 'A custom property of type <time># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<time>+",
+  from: '100s 200s',
+  to: '300s',
+}, 'A custom property of type <time>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<url>#",
+  from: 'url("https://example.com/foo"), url("https://example.com/bar")',
+  to: 'url("https://example.com/to")',
+}, 'A custom property of type <url># does not yield a CSS Transition if the lists do not contain the same number of values');
+
+no_transition_test({
+  syntax: "<url>+",
+  from: 'url("https://example.com/foo") url("https://example.com/bar")',
+  to: 'url("https://example.com/to")',
+}, 'A custom property of type <url>+ does not yield a CSS Transition if the lists do not contain the same number of values');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-non-inherited-used-by-standard-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-non-inherited-used-by-standard-property-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Running a transition a non-inherited CSS variable is reflected on a standard property using that variable as a value assert_equals: expected "150px" but got "200px"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-non-inherited-used-by-standard-property.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-non-inherited-used-by-standard-property.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+test(() => {
+  const customProperty = "--my-length";
+
+  CSS.registerProperty({
+    name: customProperty,
+    syntax: "<length>",
+    inherits: false,
+    initialValue: "100px"
+  });
+
+  target.style.marginLeft = `var(${customProperty})`;
+  assert_equals(getComputedStyle(target).marginLeft, "100px");
+
+  target.style.transition = `${customProperty} 1s -500ms linear`;
+  target.style.setProperty(customProperty, "200px");
+
+  assert_equals(getComputedStyle(target).marginLeft, "150px");
+}, "Running a transition a non-inherited CSS variable is reflected on a standard property using that variable as a value");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-number-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-number-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A custom property of type <number> can yield a CSS Transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-number.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-number.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<number>",
+  from: "100",
+  to: "200",
+  expected: "150"
+}, 'A custom property of type <number> can yield a CSS Transition');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-percentage-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-percentage-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A custom property of type <percentage> can yield a CSS Transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-percentage.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-percentage.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<percentage>",
+  from: "100%",
+  to: "200%",
+  expected: "150%"
+}, 'A custom property of type <percentage> can yield a CSS Transition');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-resolution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-resolution-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A custom property of type <resolution> can yield a CSS Transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-resolution.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-resolution.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<resolution>",
+  from: "100dppx",
+  to: "200dppx",
+  expected: "150dppx"
+}, 'A custom property of type <resolution> can yield a CSS Transition');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-time-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-time-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A custom property of type <time> can yield a CSS Transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-time.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-time.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<time>",
+  from: "100s",
+  to: "200s",
+  expected: "150s"
+}, 'A custom property of type <time> can yield a CSS Transition');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A custom property of type <transform-function> can yield a CSS Transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<transform-function>",
+  from: "translateX(100px)",
+  to: "translateX(200px)",
+  expected: "translateX(150px)"
+}, 'A custom property of type <transform-function> can yield a CSS Transition');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-list-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-list-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A custom property of type <transform-list> can yield a CSS Transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-list.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-list.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+transition_test({
+  syntax: "<transform-list>",
+  from: "translateX(100px) scale(2)",
+  to: "translateX(200px) scale(4)",
+  expected: "translateX(150px) scale(3)"
+}, 'A custom property of type <transform-list> can yield a CSS Transition');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-url-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-url-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A custom property of type <url> cannot yield a CSS Transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-url.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-url.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+no_transition_test({
+  syntax: "<url>",
+  from: 'url("https://example.com/from")',
+  to: 'url("https://example.com/to")',
+}, 'A custom property of type <url> cannot yield a CSS Transition');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt
@@ -6,8 +6,8 @@ PASS Ongoing animation matches new keyframes against the current registration
 FAIL Ongoing animation picks up redeclared intial value assert_equals: expected "250px" but got "200px"
 FAIL Ongoing animation picks up redeclared inherits flag assert_equals: expected "250px" but got "200px"
 FAIL Ongoing animation picks up redeclared meaning of 'unset' assert_equals: expected "250px" but got "200px"
-FAIL Transitioning from initial value assert_equals: expected "rgb(128, 0, 128)" but got "rgb(0, 0, 255)"
-FAIL Transitioning from specified value assert_equals: expected "rgb(0, 64, 128)" but got "rgb(0, 128, 0)"
+PASS Transitioning from initial value
+PASS Transitioning from specified value
 FAIL Transition triggered by initial value change assert_equals: expected "150px" but got "200px"
 PASS No transition when changing types
 FAIL No transition when removing @property rule assert_equals: expected " 100px" but got "100px"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/resources/utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/resources/utils.js
@@ -178,3 +178,60 @@ function discrete_animation_test(syntax, fromValue, toValue, description) {
     checkAtProgress(1, toValue);
   }, description || `Animating a custom property of type ${syntax} is discrete`);
 }
+
+function transition_test(options, description) {
+  promise_test(async () => {
+    const customProperty = generate_name();
+
+    CSS.registerProperty({
+      name: customProperty,
+      syntax: options.syntax,
+      inherits: false,
+      initialValue: options.from
+    });
+
+    assert_equals(getComputedStyle(target).getPropertyValue(customProperty), options.from, "Element has the expected initial value");
+
+    const transitionEventPromise = new Promise(resolve => {
+      target.addEventListener("transitionrun", event => {
+          assert_equals(event.propertyName, customProperty, "TransitionEvent has the expected property name");
+          resolve();
+      });
+    });
+
+    target.style.transition = `${customProperty} 1s -500ms linear`;
+    target.style.setProperty(customProperty, options.to);
+
+    const animations = target.getAnimations();
+    assert_equals(animations.length, 1, "A single animation is running");
+
+    const transition = animations[0];
+    assert_class_string(transition, "CSSTransition", "A CSSTransition is running");
+
+    transition.pause();
+    assert_equals(getComputedStyle(target).getPropertyValue(customProperty), options.expected, "Element has the expected animated value");
+
+    await transitionEventPromise;
+  }, description);
+}
+
+function no_transition_test(options, description) {
+  test(() => {
+    const customProperty = generate_name();
+
+    CSS.registerProperty({
+      name: customProperty,
+      syntax: options.syntax,
+      inherits: false,
+      initialValue: options.from
+    });
+
+    assert_equals(getComputedStyle(target).getPropertyValue(customProperty), options.from, "Element has the expected initial value");
+
+    target.style.transition = `${customProperty} 1s -500ms linear`;
+    target.style.setProperty(customProperty, options.to);
+
+    assert_equals(target.getAnimations().length, 0, "No animation was created");
+    assert_equals(getComputedStyle(target).getPropertyValue(customProperty), options.to, "Element has the expected final value");
+  }, description);
+};

--- a/Source/WebCore/animation/CSSPropertyAnimation.h
+++ b/Source/WebCore/animation/CSSPropertyAnimation.h
@@ -46,8 +46,8 @@ public:
     static bool isPropertyAdditiveOrCumulative(AnimatableProperty);
     static bool propertyRequiresBlendingForAccumulativeIteration(const CSSPropertyBlendingClient&, AnimatableProperty, const RenderStyle& a, const RenderStyle& b);
     static bool animationOfPropertyIsAccelerated(AnimatableProperty);
-    static bool propertiesEqual(AnimatableProperty, const RenderStyle& a, const RenderStyle& b);
-    static bool canPropertyBeInterpolated(AnimatableProperty, const RenderStyle& a, const RenderStyle& b);
+    static bool propertiesEqual(AnimatableProperty, const RenderStyle& a, const RenderStyle& b, const Document&);
+    static bool canPropertyBeInterpolated(AnimatableProperty, const RenderStyle& a, const RenderStyle& b, const Document&);
     static CSSPropertyID getPropertyAtIndex(int, std::optional<bool>& isShorthand);
     static int getNumProperties();
 

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -165,7 +165,8 @@ OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle
         auto inheritedPropertyChanged = [&]() {
             if (previousLastStyleChangeEventStyle) {
                 for (auto property : effect->inheritedProperties()) {
-                    if (!CSSPropertyAnimation::propertiesEqual(property, *previousLastStyleChangeEventStyle, targetStyle))
+                    ASSERT(effect->target());
+                    if (!CSSPropertyAnimation::propertiesEqual(property, *previousLastStyleChangeEventStyle, targetStyle, effect->target()->document()))
                         return true;
                 }
             }

--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -83,8 +83,8 @@ String CSSCustomPropertyValue::customCSSText() const
             return serializeURL(value.string());
         }, [&](const String& value) {
             return value;
-        }, [&](const RefPtr<TransformOperation>& value) {
-            auto cssValue = transformOperationAsCSSValue(*value, RenderStyle::defaultStyle());
+        }, [&](const TransformSyntaxValue& value) {
+            auto cssValue = transformOperationAsCSSValue(*value.transform, RenderStyle::defaultStyle());
             if (!cssValue)
                 return emptyString();
             return cssValue->cssText();

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -32,6 +32,7 @@
 #include "StyleColor.h"
 #include "StyleImage.h"
 #include "TransformOperation.h"
+#include <wtf/PointerComparison.h>
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -47,7 +48,12 @@ public:
         bool operator==(const NumericSyntaxValue& other) const { return value == other.value && unitType == other.unitType; }
     };
 
-    using SyntaxValue = std::variant<Length, NumericSyntaxValue, StyleColor, RefPtr<StyleImage>, URL, String, RefPtr<TransformOperation>>;
+    struct TransformSyntaxValue {
+        RefPtr<TransformOperation> transform;
+        bool operator==(const TransformSyntaxValue& other) const { return arePointingToEqualData(transform, other.transform); }
+    };
+
+    using SyntaxValue = std::variant<Length, NumericSyntaxValue, StyleColor, RefPtr<StyleImage>, URL, String, TransformSyntaxValue>;
 
     struct SyntaxValueList {
         Vector<SyntaxValue> values;

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -36,6 +36,7 @@
 #include "CSSImageValue.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPrimitiveValueMappings.h"
+#include "CSSPropertyParser.h"
 #include "CSSTimingFunctionValue.h"
 #include "CSSValueKeywords.h"
 #include "CompositeOperation.h"
@@ -438,8 +439,12 @@ void CSSToStyleMap::mapAnimationProperty(Animation& animation, const CSSValue& v
         return;
     }
     if (primitiveValue.propertyID() == CSSPropertyInvalid) {
-        animation.setProperty({ Animation::TransitionMode::UnknownProperty, CSSPropertyInvalid });
-        animation.setUnknownProperty(primitiveValue.stringValue());
+        auto stringValue = primitiveValue.stringValue();
+        if (isCustomPropertyName(stringValue))
+            animation.setProperty({ Animation::TransitionMode::CustomProperty, CSSPropertyCustom });
+        else
+            animation.setProperty({ Animation::TransitionMode::UnknownProperty, CSSPropertyInvalid });
+        animation.setCustomOrUnknownProperty(stringValue);
         return;
     }
 

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1304,8 +1304,9 @@ static Ref<CSSValue> createTransitionPropertyValue(const Animation& animation)
         return CSSValuePool::singleton().createIdentifierValue(CSSValueAll);
     case Animation::TransitionMode::SingleProperty:
         return CSSValuePool::singleton().createCustomIdent(nameString(animation.property().id));
+    case Animation::TransitionMode::CustomProperty:
     case Animation::TransitionMode::UnknownProperty:
-        return CSSValuePool::singleton().createCustomIdent(animation.unknownProperty());
+        return CSSValuePool::singleton().createCustomIdent(animation.customOrUnknownProperty());
     }
     ASSERT_NOT_REACHED();
     return CSSValuePool::singleton().createIdentifierValue(CSSValueNone);

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -494,9 +494,8 @@ RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(
         case CSSCustomPropertySyntax::Type::TransformFunction:
         case CSSCustomPropertySyntax::Type::TransformList:
             if (auto transform = transformForValue(value, builderState.cssToLengthConversionData()))
-                return { transform };
+                return { CSSCustomPropertyValue::TransformSyntaxValue { transform } };
             return { };
-    
         case CSSCustomPropertySyntax::Type::Unknown:
             return { };
         }

--- a/Source/WebCore/platform/animation/Animation.cpp
+++ b/Source/WebCore/platform/animation/Animation.cpp
@@ -65,6 +65,7 @@ Animation::Animation(const Animation& o)
     : RefCounted<Animation>()
     , m_property(o.m_property)
     , m_name(o.m_name)
+    , m_customOrUnknownProperty(o.m_customOrUnknownProperty)
     , m_iterationCount(o.m_iterationCount)
     , m_delay(o.m_delay)
     , m_duration(o.m_duration)
@@ -105,6 +106,7 @@ bool Animation::animationsMatch(const Animation& other, bool matchProperties) co
         && m_playState == other.m_playState
         && m_compositeOperation == other.m_compositeOperation
         && m_playStateSet == other.m_playStateSet
+        && m_customOrUnknownProperty == other.m_customOrUnknownProperty
         && m_iterationCount == other.m_iterationCount
         && m_delay == other.m_delay
         && m_duration == other.m_duration
@@ -140,6 +142,7 @@ TextStream& operator<<(TextStream& ts, Animation::TransitionProperty transitionP
     case Animation::TransitionMode::All: ts << "all"; break;
     case Animation::TransitionMode::None: ts << "none"; break;
     case Animation::TransitionMode::SingleProperty: ts << nameLiteral(transitionProperty.id); break;
+    case Animation::TransitionMode::CustomProperty: ts << "custom property"; break;
     case Animation::TransitionMode::UnknownProperty: ts << "unknown property"; break;
     }
     return ts;

--- a/Source/WebCore/platform/animation/Animation.h
+++ b/Source/WebCore/platform/animation/Animation.h
@@ -101,6 +101,7 @@ public:
         All,
         None,
         SingleProperty,
+        CustomProperty,
         UnknownProperty
     };
 
@@ -135,7 +136,7 @@ public:
     Style::ScopeOrdinal nameStyleScopeOrdinal() const { return m_nameStyleScopeOrdinal; }
     AnimationPlayState playState() const { return static_cast<AnimationPlayState>(m_playState); }
     TransitionProperty property() const { return m_property; }
-    const String& unknownProperty() const { return m_unknownProperty; }
+    const String& customOrUnknownProperty() const { return m_customOrUnknownProperty; }
     TimingFunction* timingFunction() const { return m_timingFunction.get(); }
     TimingFunction* defaultTimingFunctionForKeyframes() const { return m_defaultTimingFunctionForKeyframes.get(); }
 
@@ -153,7 +154,7 @@ public:
     }
     void setPlayState(AnimationPlayState d) { m_playState = static_cast<unsigned>(d); m_playStateSet = true; }
     void setProperty(TransitionProperty t) { m_property = t; m_propertySet = true; }
-    void setUnknownProperty(const String& property) { m_unknownProperty = property; }
+    void setCustomOrUnknownProperty(const String& property) { m_customOrUnknownProperty = property; }
     void setTimingFunction(RefPtr<TimingFunction>&& function) { m_timingFunction = WTFMove(function); m_timingFunctionSet = true; }
     void setDefaultTimingFunctionForKeyframes(RefPtr<TimingFunction>&& function) { m_defaultTimingFunctionForKeyframes = WTFMove(function); }
 
@@ -200,7 +201,7 @@ private:
     TransitionProperty m_property { TransitionMode::All, CSSPropertyInvalid };
 
     Name m_name;
-    String m_unknownProperty;
+    String m_customOrUnknownProperty;
     double m_iterationCount;
     double m_delay;
     double m_duration;


### PR DESCRIPTION
#### 56d4a17a7f6bb0043f4c1f320a5eaf748ac03835
<pre>
[css-transitions] support transitions of custom properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=249399">https://bugs.webkit.org/show_bug.cgi?id=249399</a>
rdar://103404742

Reviewed by Antti Koivisto.

We now account for custom properties when considering what properties are eligible to run
a transition under Styleable::updateCSSTransitions().

The first task to make this possible was to add new mode for custom properties to the
Animation object representing a transition on RenderStyle. We leverage the same mechanism
previously used for unknown properties and make it so we can track a custom property as well.

Then we had to finish the implementation of two CSSPropertyAnimation methods to deal with
custom properties. As we consider properties for a transition in Styleable::updateCSSTransitions(),
we call CSSPropertyAnimation::canPropertyBeInterpolated() and CSSPropertyAnimation::propertiesEqual()
to determine we can even transition between two values of a given property or whether the underlying
value of a property has changed while a transition is in-flight.

We now fully implement the custom property path of these CSSPropertyAnimation methods. This required
a little extra work. First, we had to provide a Document to these methods to access initial values
in the case where explicit values for custom properties are not set on RenderStyle.

Then, we had to determine which syntax value types support interpolation, which is most except for
&lt;custom-ident&gt;, &lt;image&gt; and &lt;url&gt;.

Finally, we had to introduce a new TransformSyntaxValue wrapper for RefPtr&lt;TransformOperation&gt; values
to provide a custom operator== to not run simply pointer equality but actually compare the transform
operations.

We added comprehensive tests for CSS Transitions and custom properties, with two notable new failures
tracked by bugs 249640 and bugs 249641.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-angle-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-angle.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-color-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-color.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-custom-ident-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-custom-ident.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-image-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-image.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-integer-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-integer.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-length-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-length-percentage-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-length-percentage.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-length.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-list-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-mismatched-list.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-non-inherited-used-by-standard-property-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-non-inherited-used-by-standard-property.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-number-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-number.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-percentage-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-percentage.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-resolution-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-resolution.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-time-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-time.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-list-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-list.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-url-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-url.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/resources/utils.js:
(async no_transition_test):
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendSyntaxValues):
(WebCore::firstValueInSyntaxValueLists):
(WebCore::blendSyntaxValueLists):
(WebCore::blendCustomProperty):
(WebCore::CSSPropertyAnimation::propertyRequiresBlendingForAccumulativeIteration):
(WebCore::CSSPropertyAnimation::propertiesEqual):
(WebCore::typeOfSyntaxValueCanBeInterpolated):
(WebCore::CSSPropertyAnimation::canPropertyBeInterpolated):
* Source/WebCore/animation/CSSPropertyAnimation.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::applyKeyframeEffects):
* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::customCSSText const):
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapAnimationProperty):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::createTransitionPropertyValue):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue):
* Source/WebCore/platform/animation/Animation.cpp:
(WebCore::Animation::Animation):
(WebCore::Animation::animationsMatch const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/animation/Animation.h:
(WebCore::Animation::customOrUnknownProperty const):
(WebCore::Animation::setCustomOrUnknownProperty):
(WebCore::Animation::unknownProperty const): Deleted.
(WebCore::Animation::setUnknownProperty): Deleted.
* Source/WebCore/style/Styleable.cpp:
(WebCore::propertyInStyleMatchesValueForTransitionInMap):
(WebCore::transitionMatchesProperty):
(WebCore::compileTransitionPropertiesInStyle):
(WebCore::updateCSSTransitionsForStyleableAndProperty):
(WebCore::Styleable::updateCSSTransitions const):

Canonical link: <a href="https://commits.webkit.org/258134@main">https://commits.webkit.org/258134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cb7ec2f35b60c931218894670c86ae2e81fc8fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110314 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170570 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1039 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93421 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108148 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8398 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35009 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23058 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3835 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24575 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3863 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/978 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9975 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44083 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5631 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2926 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->