### PR TITLE
Fix :out-of-range pseudo class matching for empty input[type=number]

### DIFF
--- a/LayoutTests/fast/css/pseudo-in-range-expected.txt
+++ b/LayoutTests/fast/css/pseudo-in-range-expected.txt
@@ -3,6 +3,10 @@ Tests that we find controls if they have a range limitation and are in-range.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+==> :in-range should match to an INPUT without a value:
+PASS document.querySelector("input[type=number]:in-range").id is "number1"
+
+==> :in-range should match to an INPUT with an in-range value:
 PASS document.querySelector("input[type=number]:in-range").id is "number1"
 PASS document.querySelector("input[type=range]:in-range").id is "range1"
 PASS document.querySelectorAll(":in-range").length is 2

--- a/LayoutTests/fast/css/pseudo-in-range.html
+++ b/LayoutTests/fast/css/pseudo-in-range.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -9,12 +9,17 @@ description('Tests that we find controls if they have a range limitation and are
 
 var parentDiv = document.createElement('div');
 document.body.appendChild(parentDiv);
-parentDiv.innerHTML = '<input id="number1" type="number" min=0 max=10 value=5><input id="range1" type="range" min=0 max=10 value=5><input id="text1" type="text" min=0 max=10 value=5><input id="checkbox1" type="checkbox">    <input id="radio1" type="radio">';
+parentDiv.innerHTML = '<input id="number1" type="number" min=0 max=10><input id="range1" type="range" min=0 max=10 value=5><input id="text1" type="text" min=0 max=10 value=5><input id="checkbox1" type="checkbox">    <input id="radio1" type="radio">';
 
-shouldBe('document.querySelector("input[type=number]:in-range").id', '"number1"');
-shouldBe('document.querySelector("input[type=range]:in-range").id', '"range1"');
+debug('==> :in-range should match to an INPUT without a value:');
+shouldBeEqualToString('document.querySelector("input[type=number]:in-range").id', 'number1');
+
+debug('');
+debug('==> :in-range should match to an INPUT with an in-range value:');
+parentDiv.firstChild.value = '5';
+shouldBeEqualToString('document.querySelector("input[type=number]:in-range").id', 'number1');
+shouldBeEqualToString('document.querySelector("input[type=range]:in-range").id', 'range1');
 shouldBe('document.querySelectorAll(":in-range").length', '2');
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/css/pseudo-out-of-range-expected.txt
+++ b/LayoutTests/fast/css/pseudo-out-of-range-expected.txt
@@ -3,10 +3,14 @@ Tests that we find controls if they have a range limitation and are out-of-range
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+==> :out-of-range doesn't match to an INPUT without a value:
+PASS document.querySelector("input[type=number]:out-of-range") is null
+
+==> :out-of-range should match to an INPUT with an out-of-range value:
 PASS document.querySelector("input[type=number]:out-of-range").id is "number1"
 PASS document.querySelectorAll(":out-of-range").length is 1
 
-When the value becomes in-range dynamically, we do not find the control anymore
+==> When the value becomes in-range dynamically, we do not find the control anymore:
 PASS document.querySelector("input[type=number]:out-of-range") is null
 PASS document.querySelectorAll(":out-of-range").length is 0
 PASS successfullyParsed is true

--- a/LayoutTests/fast/css/pseudo-out-of-range.html
+++ b/LayoutTests/fast/css/pseudo-out-of-range.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -9,18 +9,23 @@ description('Tests that we find controls if they have a range limitation and are
 
 var parentDiv = document.createElement('div');
 document.body.appendChild(parentDiv);
-parentDiv.innerHTML = '<input id="number1" type="number" min=0 max=10 value=50><input id="text1" type="text" min=0 max=10 value=50><input id="checkbox1" type="checkbox"><input id="radio1" type="radio">';
+parentDiv.innerHTML = '<input id="number1" type="number" min=0 max=10><input id="text1" type="text" min=0 max=10 value=50><input id="checkbox1" type="checkbox"><input id="radio1" type="radio">';
 
+debug('==> :out-of-range doesn\'t match to an INPUT without a value:');
+shouldBeNull('document.querySelector("input[type=number]:out-of-range")');
+
+debug('');
+debug('==> :out-of-range should match to an INPUT with an out-of-range value:');
+parentDiv.firstChild.value = '50';
 shouldBe('document.querySelector("input[type=number]:out-of-range").id', '"number1"');
 shouldBe('document.querySelectorAll(":out-of-range").length', '1');
 
-debug("");
-debug("When the value becomes in-range dynamically, we do not find the control anymore");
+debug('');
+debug('==> When the value becomes in-range dynamically, we do not find the control anymore:');
 document.getElementById("number1").value = 5;
 
 shouldBe('document.querySelector("input[type=number]:out-of-range")', 'null');
 shouldBe('document.querySelectorAll(":out-of-range").length', '0');
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -2,10 +2,10 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  * Copyright (C) 2007 Samuel Weinig (sam@webkit.org)
- * Copyright (C) 2009, 2010, 2011, 2012 Google Inc. All rights reserved.
+ * Copyright (C) 2009-2015 Google Inc. All rights reserved.
  * Copyright (C) 2012 Samsung Electronics. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -509,7 +509,9 @@ bool InputType::isInRange(const String& value) const
     StepRange stepRange(createStepRange(AnyStepHandling::Reject));
     if (!stepRange.hasRangeLimitations())
         return false;
-    
+
+    // This function should return true if both of validity.rangeUnderflow and
+    // validity.rangeOverflow are false. If the INPUT has no value, they are false.
     const Decimal numericValue = parseToNumberOrNaN(value);
     if (!numericValue.isFinite())
         return true;
@@ -526,9 +528,11 @@ bool InputType::isOutOfRange(const String& value) const
     if (!stepRange.hasRangeLimitations())
         return false;
 
+    // This function should return true if both of validity.rangeUnderflow and
+    // validity.rangeOverflow are true. If the INPUT has no value, they are false.
     const Decimal numericValue = parseToNumberOrNaN(value);
     if (!numericValue.isFinite())
-        return true;
+        return false;
 
     return numericValue < stepRange.minimum() || numericValue > stepRange.maximum();
 }


### PR DESCRIPTION
#### c427ef22b3af7c014053c01382a8113d06e9f6e8
<pre>
Fix :out-of-range pseudo class matching for empty input[type=number]

Fix :out-of-range pseudo class matching for empty input[type=number]
<a href="https://bugs.webkit.org/show_bug.cgi?id=249642">https://bugs.webkit.org/show_bug.cgi?id=249642</a>

Reviewed by Aditya Keerthi.

This patch is to align WebKit behavior with Gecko / Firefox, Blink / Chromium and Web-Specification.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/37a451a5e2b2b571871560111eb164ced3df1240">https://chromium.googlesource.com/chromium/blink/+/37a451a5e2b2b571871560111eb164ced3df1240</a>

The definition of :out-of-range is &apos;either rangeUnderflow or rangeOverflow.&apos;  If
an INPUT has no value, neither rangeUnderflow nor rangeOverflow is true.

* Source/WebCore/html/InputType.cpp:
(InputType::isInRange): Add comment for return value
(InputType::isOutOfRange): Add comment for return value and also change it to &quot;false&quot;
* LayoutTests/fast/css/pseudo-out-of-range.html: Updated
* LayoutTests/fast/css/pseudo-out-of-range-expected.txt: Ditto
* LayoutTests/fast/css/pseudo-in-range.html: Ditto
* LayoutTests/fast/css/pseudo-in-range-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/258165@main">https://commits.webkit.org/258165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8165d8164f8bb8042361a91b13da1f3bee7d9d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110311 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170567 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1036 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93417 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108145 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91661 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35005 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90303 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77994 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3832 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24572 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/974 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9972 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44080 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5606 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5628 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->