### PR TITLE
[Tools] built-product-archive shouldn't pass 'jsc' as port name for 'jsc-only'

### DIFF
--- a/Tools/CISupport/built-product-archive
+++ b/Tools/CISupport/built-product-archive
@@ -60,7 +60,7 @@ def main():
         parser.error("Action is required")
         return 1
 
-    genericPlatform = options.platform.split('-', 1)[0]
+    genericPlatform = 'jsc-only' if options.platform.startswith('jsc') else options.platform.split('-', 1)[0]
     determineWebKitBuildDirectories(genericPlatform, options.platform, options.configuration)
     if not _topLevelBuildDirectory:
         print('Could not determine top-level build directory', file=sys.stderr)
@@ -215,7 +215,7 @@ def dirContainsdwo(directory):
 MINIFIED_EXCLUDED_PATTERNS = ('*.a', '*.dSYM', 'DerivedSources')
 
 def archiveBuiltProduct(configuration, platform, fullPlatform, minify=False):
-    assert platform in ('gtk', 'ios', 'jsc', 'mac', 'tvos', 'watchos', 'win', 'wincairo', 'wpe')
+    assert platform in ('gtk', 'ios', 'jsc-only', 'mac', 'tvos', 'watchos', 'win', 'wincairo', 'wpe')
     global _configurationBuildDirectory
 
     if platform in ['ios', 'tvos', 'watchos']:
@@ -255,7 +255,7 @@ def archiveBuiltProduct(configuration, platform, fullPlatform, minify=False):
 
         shutil.rmtree(thinDirectory)
 
-    elif platform in ('gtk', 'jsc', 'wpe'):
+    elif platform in ('gtk', 'jsc-only', 'wpe'):
         # On GTK+/WPE/JSC we don't need the intermediate step of creating a thinDirectory
         # to be compressed in a ZIP file, because we can create the ZIP directly.
         # This is faster and requires less disk resources.
@@ -329,7 +329,7 @@ def unzipArchive(directoryToExtractTo, configuration):
 
 
 def extractBuiltProduct(configuration, platform):
-    assert platform in ('gtk', 'ios', 'jsc', 'mac', 'tvos', 'watchos', 'win', 'wincairo', 'wpe')
+    assert platform in ('gtk', 'ios', 'jsc-only', 'mac', 'tvos', 'watchos', 'win', 'wincairo', 'wpe')
 
     archiveFile = os.path.join(_topLevelBuildDirectory, configuration + '.zip')
 
@@ -338,7 +338,7 @@ def extractBuiltProduct(configuration, platform):
 
     if platform in ('mac', 'ios', 'tvos', 'watchos'):
         return unzipArchive(_topLevelBuildDirectory, configuration)
-    elif platform in ('gtk', 'jsc', 'win', 'wincairo', 'wpe'):
+    elif platform in ('gtk', 'jsc-only', 'win', 'wincairo', 'wpe'):
         print('Extracting: {}'.format(_configurationBuildDirectory))
         if unzipArchive(_configurationBuildDirectory, configuration):
             return 1


### PR DESCRIPTION
#### 428d184a46a4b75ab06d3a0b7721b00f90b52d6e
<pre>
[Tools] built-product-archive shouldn&apos;t pass &apos;jsc&apos; as port name for &apos;jsc-only&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=249644">https://bugs.webkit.org/show_bug.cgi?id=249644</a>

Reviewed by Michael Catanzaro.

&apos;jsc&apos; is not a valid port name, so built-product-archive ends calling
webkit-build-directory to determine the build directories with an unknown
port name, which returns the default directory layout.

This works by accident for the general use case, but it should be calling
webkit-build-directory script with the right port name.

Fix it to use and pass &apos;jsc-only&apos; for the case of the JSCOnly port.

* Tools/CISupport/built-product-archive:

Canonical link: <a href="https://commits.webkit.org/258147@main">https://commits.webkit.org/258147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cca13c782b54b217c40c9782af964dcb8fa03596

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110317 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170573 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1042 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93424 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108151 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8402 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35018 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23062 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78008 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3838 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24579 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/981 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9978 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44087 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5634 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2932 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->