### PR TITLE
Avoid uint64_t overflow in Decimal::operator/() and fix static MaxCoefficient value

### DIFF
--- a/LayoutTests/fast/forms/range/input-range-progress-indicator-overflow-expected.html
+++ b/LayoutTests/fast/forms/range/input-range-progress-indicator-overflow-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<body>
+    <input id='test' type='range' min="1" max='9999999' />
+</body>
+<script>
+function test() {
+  var x = document.getElementById("test").min = "5000000";
+}
+</script>

--- a/LayoutTests/fast/forms/range/input-range-progress-indicator-overflow.html
+++ b/LayoutTests/fast/forms/range/input-range-progress-indicator-overflow.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<body>
+    <input type='range' min='0' max='9999999' value="5000000" />
+</body>


### PR DESCRIPTION
#### d16c8e20b19ef4903f1dd85056d5f6ad0353d36d
<pre>
Avoid uint64_t overflow in Decimal::operator/() and fix static MaxCoefficient value

Avoid uint64_t overflow in Decimal::operator/() and fix static MaxCoefficient value
<a href="https://bugs.webkit.org/show_bug.cgi?id=248784">https://bugs.webkit.org/show_bug.cgi?id=248784</a>

Reviewed by Darin Adler.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=191294 &amp; <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=174294

This patch changes Decimal::operator/() not to cause uint64_t overflow in
multiplication and addition during calculating quotient. Original code
wrongly assumed each division loop generate at most two digits, by
|MaxCoefficient &lt; 100|, however this assumption is wrong such as
50,000 / 99,9999.

This patch also fixes assertion failure |n&gt; Precision|, where |Precision| == 18, in |scaleUp(x, n)| via |Decimal::ceil()|.
Before this patch, we don&apos;t have 18 digits quotient with 10^-18 exponent from result of division operator.

Additionally, it also update MaxCoefficient static variable value in Decimal.cpp to match the Precision
and the corresponding comment about using 18 as precision.

* Source/WebCore/platform/Decimal.cpp:
- Update &quot;MaxCoefficient&quot; static variable
(Decimal:operator/): Update &quot;divisor&quot; function to account for overflow in multiplication and addition
(Decimal::ceiling): Fixes assertion failure
* LayoutTests/fast/range/input-range-progress-indicator-overflow.html: Add Test Case
* LayoutTests/fast/range/input-range-progress-indicator-overflow-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/258174@main">https://commits.webkit.org/258174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/236b137849e6d5f4f4eff3a681e2342ace4fb379

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110333 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170589 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1059 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93440 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108167 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35027 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78014 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3854 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24595 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/997 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44103 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5612 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5650 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->