### PR TITLE
Revert [258128@main] CSSRule.type should not return values greater than 15

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom-expected.txt
@@ -12,7 +12,7 @@ PASS Rule for --syntax-only has expected cssText
 PASS Rule for --inherits-only has expected cssText
 PASS Rule for --initial-value-only has expected cssText
 PASS Rule for --tab	tab has expected cssText
-PASS CSSRule.type returns 0
+FAIL CSSRule.type returns 0 assert_equals: expected 0 but got 21
 PASS Rule for --valid returns expected value for CSSPropertyRule.name
 PASS Rule for --valid-reverse returns expected value for CSSPropertyRule.name
 PASS Rule for --valid-universal returns expected value for CSSPropertyRule.name

--- a/Source/WebCore/css/CSSRule.cpp
+++ b/Source/WebCore/css/CSSRule.cpp
@@ -36,17 +36,6 @@ struct SameSizeAsCSSRule : public RefCounted<SameSizeAsCSSRule> {
 
 static_assert(sizeof(CSSRule) == sizeof(SameSizeAsCSSRule), "CSSRule should stay small");
 
-unsigned short CSSRule::typeForCSSOM() const
-{
-    // "This enumeration is thus frozen in its current state, and no new new values will be
-    // added to reflect additional at-rules; all at-rules beyond the ones listed above will return 0."
-    // https://drafts.csswg.org/cssom/#the-cssrule-interface
-    if (styleRuleType() >= firstUnexposedStyleRuleType)
-        return 0;
-
-    return static_cast<unsigned short>(styleRuleType());
-}
-
 ExceptionOr<void> CSSRule::setCssText(const String&)
 {
     return { };

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -37,7 +37,7 @@ class CSSRule : public RefCounted<CSSRule> {
 public:
     virtual ~CSSRule() = default;
 
-    WEBCORE_EXPORT unsigned short typeForCSSOM() const;
+    unsigned short type() const { return static_cast<unsigned short>(styleRuleType()); }
 
     virtual StyleRuleType styleRuleType() const = 0;
     virtual String cssText() const = 0;

--- a/Source/WebCore/css/CSSRule.idl
+++ b/Source/WebCore/css/CSSRule.idl
@@ -31,7 +31,7 @@
     readonly attribute CSSRule? parentRule;
     readonly attribute CSSStyleSheet? parentStyleSheet;
 
-    [ImplementedAs=typeForCSSOM] readonly attribute unsigned short type;
+    readonly attribute unsigned short type;
     
     [ImplementedAs=Unknown] const unsigned short UNKNOWN_RULE = 0;
     [ImplementedAs=Style] const unsigned short STYLE_RULE = 1;

--- a/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
+++ b/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
@@ -397,7 +397,7 @@ Ref<MutableStyleProperties> PropertySetCSSStyleDeclaration::copyProperties() con
 StyleRuleCSSStyleDeclaration::StyleRuleCSSStyleDeclaration(MutableStyleProperties& propertySet, CSSRule& parentRule)
     : PropertySetCSSStyleDeclaration(propertySet)
     , m_refCount(1)
-    , m_parentRuleType(parentRule.styleRuleType())
+    , m_parentRuleType(static_cast<StyleRuleType>(parentRule.type()))
     , m_parentRule(&parentRule)
 {
     m_propertySet->ref();

--- a/Source/WebCore/css/StyleRuleType.h
+++ b/Source/WebCore/css/StyleRuleType.h
@@ -44,15 +44,13 @@ enum class StyleRuleType : uint8_t {
     CounterStyle = 11,
     Supports = 12,
     FontFeatureValues = 14,
-    // Numbers above 15 are not exposed to the web.
     LayerBlock = 16,
-    LayerStatement,
-    Container,
-    FontPaletteValues,
+    LayerStatement = 17,
+    Container = 18,
+    FontPaletteValues = 19,
+    // Those at-rules (@swash, @annotation,...) don't have a specified number in the spec.
     FontFeatureValuesBlock,
     Property,
 };
-
-static constexpr auto firstUnexposedStyleRuleType = StyleRuleType::LayerBlock;
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMCSSRule.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMCSSRule.cpp
@@ -196,7 +196,7 @@ gushort webkit_dom_css_rule_get_rule_type(WebKitDOMCSSRule* self)
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_CSS_RULE(self), 0);
     WebCore::CSSRule* item = WebKit::core(self);
-    gushort result = item->typeForCSSOM();
+    gushort result = item->type();
     return result;
 }
 

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSRule.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSRule.mm
@@ -56,7 +56,7 @@
 - (unsigned short)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->typeForCSSOM();
+    return static_cast<unsigned short>(IMPL->type());
 }
 
 - (NSString *)cssText


### PR DESCRIPTION
#### 6f48cdedc5b41b6b9c6043f161e43fdfcf23c83b
<pre>
Revert [258128@main] CSSRule.type should not return values greater than 15
<a href="https://bugs.webkit.org/show_bug.cgi?id=249560">https://bugs.webkit.org/show_bug.cgi?id=249560</a>
rdar://103531316

Unreviewed revert
This reverts because it broke the build on the bots.

Explanation of why this fixes the bug (OOPS!).

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom-expected.txt:
* Source/WebCore/css/CSSRule.cpp:
(WebCore::CSSRule::typeForCSSOM const): Deleted.
* Source/WebCore/css/CSSRule.h:
(WebCore::CSSRule::type const):
* Source/WebCore/css/CSSRule.idl:
* Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp:
(WebCore::StyleRuleCSSStyleDeclaration::StyleRuleCSSStyleDeclaration):
* Source/WebCore/css/StyleRuleType.h:
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMCSSRule.cpp:
(webkit_dom_css_rule_get_rule_type):
* Source/WebKitLegacy/mac/DOM/DOMCSSRule.mm:
(-[DOMCSSRule type]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f48cdedc5b41b6b9c6043f161e43fdfcf23c83b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/101018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110321 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170577 "Built successfully and passed tests") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/105005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1047 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93428 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108155 "Built successfully") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/106801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3842 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3870 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9982 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/44091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5638 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2924 "Commit message contains (OOPS!) and no reviewer found") | | | | 
<!--EWS-Status-Bubble-End-->