### PR TITLE
AirDisassembler: fix printing of entrypoints

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
@@ -564,12 +564,12 @@ void GenerateAndAllocateRegisters::generate(CCallHelpers& jit)
         if (std::optional<unsigned> entrypointIndex = m_code.entrypointIndex(block)) {
             ASSERT(m_code.isEntrypoint(block));
             if (disassembler)
-                disassembler->startEntrypoint(*m_jit); 
+                disassembler->startEntrypoint(*m_jit, block);
 
             m_code.prologueGeneratorForEntrypoint(*entrypointIndex)->run(*m_jit, m_code);
 
             if (disassembler)
-                disassembler->endEntrypoint(*m_jit); 
+                disassembler->endEntrypoint(*m_jit, block);
         } else
             ASSERT(!m_code.isEntrypoint(block));
 

--- a/Source/JavaScriptCore/b3/air/AirDisassembler.cpp
+++ b/Source/JavaScriptCore/b3/air/AirDisassembler.cpp
@@ -37,14 +37,14 @@
 
 namespace JSC { namespace B3 { namespace Air {
 
-void Disassembler::startEntrypoint(CCallHelpers& jit)
+void Disassembler::startEntrypoint(CCallHelpers& jit, BasicBlock* block)
 {
-    m_entrypointStart = jit.labelIgnoringWatchpoints();
+    m_entrypointStarts.add(block->index() + 1, jit.labelIgnoringWatchpoints());
 }
 
-void Disassembler::endEntrypoint(CCallHelpers& jit)
+void Disassembler::endEntrypoint(CCallHelpers& jit, BasicBlock* block)
 {
-    m_entrypointEnd = jit.labelIgnoringWatchpoints();
+    m_entrypointEnds.add(block->index() + 1, jit.labelIgnoringWatchpoints());
 }
 
 void Disassembler::startLatePath(CCallHelpers& jit)
@@ -86,7 +86,7 @@ void Disassembler::dump(Code& code, PrintStream& out, LinkBuffer& linkBuffer, co
     for (BasicBlock* block : m_blocks) {
         block->dumpHeader(out);
         if (code.isEntrypoint(block))
-            dumpAsmRange(m_entrypointStart, m_entrypointEnd);
+            dumpAsmRange(m_entrypointStarts.get(block->index() + 1), m_entrypointEnds.get(block->index() + 1));
 
         for (Inst& inst : *block) {
             doToEachInst(inst);

--- a/Source/JavaScriptCore/b3/air/AirDisassembler.h
+++ b/Source/JavaScriptCore/b3/air/AirDisassembler.h
@@ -45,8 +45,8 @@ class Disassembler {
 public:
     Disassembler() = default;
 
-    void startEntrypoint(CCallHelpers&);
-    void endEntrypoint(CCallHelpers&);
+    void startEntrypoint(CCallHelpers&, BasicBlock*);
+    void endEntrypoint(CCallHelpers&, BasicBlock*);
     void startLatePath(CCallHelpers&);
     void endLatePath(CCallHelpers&);
     void startBlock(BasicBlock*, CCallHelpers&);
@@ -57,8 +57,8 @@ public:
 private:
     HashMap<Inst*, std::pair<MacroAssembler::Label, MacroAssembler::Label>> m_instToRange;
     Vector<BasicBlock*> m_blocks;
-    MacroAssembler::Label m_entrypointStart;
-    MacroAssembler::Label m_entrypointEnd;
+    HashMap<int, MacroAssembler::Label> m_entrypointStarts;
+    HashMap<int, MacroAssembler::Label> m_entrypointEnds;
     MacroAssembler::Label m_latePathStart;
     MacroAssembler::Label m_latePathEnd;
 };

--- a/Source/JavaScriptCore/b3/air/AirGenerate.cpp
+++ b/Source/JavaScriptCore/b3/air/AirGenerate.cpp
@@ -240,12 +240,12 @@ static void generateWithAlreadyAllocatedRegisters(Code& code, CCallHelpers& jit)
             ASSERT(code.isEntrypoint(block));
 
             if (disassembler)
-                disassembler->startEntrypoint(jit); 
+                disassembler->startEntrypoint(jit, block);
 
             code.prologueGeneratorForEntrypoint(*entrypointIndex)->run(jit, code);
 
             if (disassembler)
-                disassembler->endEntrypoint(jit); 
+                disassembler->endEntrypoint(jit, block);
         } else
             ASSERT(!code.isEntrypoint(block));
         


### PR DESCRIPTION
#### d3ef4373b20bc4d86d347e5ec626438a83b8024b
<pre>
 AirDisassembler repeats a single entrypoint when printing

https://bugs.webkit.org/show_bug.cgi?id=249646

Reviewed by NOBODY (OOPS!).

The entry points may be cloned, but they are at different addresses.
Keep them in a map so that we can print them out properly.

This is useful for being able to add a breakpoint at the appropriate
address.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
(JSC::B3::Air::GenerateAndAllocateRegisters::generate):
* Source/JavaScriptCore/b3/air/AirDisassembler.cpp:
(JSC::B3::Air::Disassembler::startEntrypoint):
(JSC::B3::Air::Disassembler::endEntrypoint):
(JSC::B3::Air::Disassembler::dump):
* Source/JavaScriptCore/b3/air/AirDisassembler.h:
* Source/JavaScriptCore/b3/air/AirGenerate.cpp:
(JSC::B3::Air::generateWithAlreadyAllocatedRegisters):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f37c32204ee48092c725d81fad14cdbe1494ba7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110324 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170580 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1050 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93431 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108158 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8408 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35021 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78010 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91498 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3845 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24586 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87600 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1393 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/990 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29260 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44094 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90491 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5641 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20245 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->