### PR TITLE
Make MacroAssemblerARMv7 scratch regs available to Air

### DIFF
--- a/Source/JavaScriptCore/b3/B3Common.cpp
+++ b/Source/JavaScriptCore/b3/B3Common.cpp
@@ -72,10 +72,12 @@ bool shouldSaveIRBeforePhase()
 
 GPRReg extendedOffsetAddrRegister()
 {
-    RELEASE_ASSERT(isARM64() || isRISCV64());
+    RELEASE_ASSERT(isARM64() || isRISCV64() || isARM());
 #if CPU(ARM64) || CPU(RISCV64)
     return MacroAssembler::linkRegister;
-#elif CPU(X86_64) || CPU(ARM)
+#elif CPU(ARM)
+    return MacroAssembler::dataTempRegister;
+#elif CPU(X86_64)
     return GPRReg::InvalidGPRReg;
 #else
 #error Unhandled architecture.

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -551,7 +551,9 @@ private:
     template<typename Int, typename = Value::IsLegalOffset<Int>>
     Arg effectiveAddr(Value* address, Int offset, Width width)
     {
-        ASSERT(Arg::isValidAddrForm(offset, width));
+        // This function currently is currently only used for loads/stores, so
+        // using Air::Move is appropriate.
+        ASSERT(Arg::isValidAddrForm(Air::Move, offset, width));
         
         auto fallback = [&] () -> Arg {
             return Arg::addr(tmp(address), offset);
@@ -642,7 +644,7 @@ private:
         Width width = value->accessWidth();
 
         Arg result = effectiveAddr(value->lastChild(), offset, width);
-        RELEASE_ASSERT(result.isValidForm(width));
+        RELEASE_ASSERT(result.isValidForm(Air::Move, width));
 
         return result;
     }
@@ -1146,11 +1148,11 @@ private:
                 default:
                     break;
                 case Air::Move32:
-                    if (isValidForm(Store32, Arg::ZeroReg, dest.kind()) && dest.isValidForm(Width32))
+                    if (isValidForm(Store32, Arg::ZeroReg, dest.kind()) && dest.isValidForm(Move, Width32))
                         return Inst(Store32, m_value, zeroReg(), dest);
                     break;
                 case Air::Move:
-                    if (isValidForm(Store64, Arg::ZeroReg, dest.kind()) && dest.isValidForm(Width64))
+                    if (isValidForm(Store64, Arg::ZeroReg, dest.kind()) && dest.isValidForm(Move, Width64))
                         return Inst(Store64, m_value, zeroReg(), dest);
                     break;
                 }

--- a/Source/JavaScriptCore/b3/B3MemoryValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3MemoryValueInlines.h
@@ -28,6 +28,7 @@
 #if ENABLE(B3_JIT)
 
 #include "AirArg.h"
+#include "AirOpcode.h"
 #include "B3AtomicValue.h"
 
 namespace JSC { namespace B3 {
@@ -39,8 +40,10 @@ inline bool MemoryValue::isLegalOffsetImpl(int32_t offset) const
     // So far only X86 allows exotic loads to have an offset.
     if (requiresSimpleAddr())
         return !offset;
-    
-    return Air::Arg::isValidAddrForm(offset, accessWidth());
+
+    // The opcode is only used on ARM and Air::Move is appropriate for
+    // loads/stores.
+    return Air::Arg::isValidAddrForm(Air::Move, offset, accessWidth());
 }
 
 inline bool MemoryValue::requiresSimpleAddr() const

--- a/Source/JavaScriptCore/b3/air/AirCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCode.cpp
@@ -88,9 +88,7 @@ Code::Code(Procedure& proc)
                     all.remove(reg);
             }
 #endif
-            // FIXME https://bugs.webkit.org/show_bug.cgi?id=243890
-            // Our use of DisallowMacroScratchRegisterUsage is not quite right, so for now...
-            all.exclude(RegisterSetBuilder::macroClobberedRegisters());
+            all.remove(MacroAssembler::fpTempRegister);
 #endif // CPU(ARM)
             auto calleeSave = RegisterSetBuilder::calleeSaveRegisters();
             all.buildAndValidate().forEach(
@@ -116,6 +114,10 @@ Code::Code(Procedure& proc)
             setRegsInPriorityOrder(bank, result);
         });
 
+#if CPU(ARM_THUMB2)
+    if (auto reg = extendedOffsetAddrRegister())
+        pinRegister(reg);
+#endif
     m_pinnedRegs.add(MacroAssembler::framePointerRegister, IgnoreVectors);
 }
 

--- a/Source/JavaScriptCore/b3/air/AirHelpers.h
+++ b/Source/JavaScriptCore/b3/air/AirHelpers.h
@@ -37,7 +37,6 @@ inline Air::Opcode moveForType(Type type)
     case Int32:
         return Move32;
     case Int64:
-        RELEASE_ASSERT(is64Bit());
         return Move;
     case Float:
         return MoveFloat;

--- a/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
@@ -120,11 +120,11 @@ void lowerStackArgs(Code& code)
                         }
 
                         Arg result = Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), offsetFromFP);
-                        if (result.isValidForm(width))
+                        if (result.isValidForm(Move, width))
                             return result;
 
                         result = Arg::addr(Air::Tmp(MacroAssembler::stackPointerRegister), offsetFromSP);
-                        if (result.isValidForm(width))
+                        if (result.isValidForm(Move, width))
                             return result;
 
                         if (inst.kind.opcode == Patch)
@@ -139,7 +139,7 @@ void lowerStackArgs(Code& code)
                         result = Arg::addr(tmp, 0);
                         return result;
 #elif CPU(ARM)
-                        // We solve this from the macro assembler for now
+                        // We solve this in AirAllocateRegistersAndStackAndGenerateCode.cpp.
                         UNUSED_PARAM(instIndex);
                         return result;
 #elif CPU(X86_64)

--- a/Source/JavaScriptCore/b3/air/opcode_generator.rb
+++ b/Source/JavaScriptCore/b3/air/opcode_generator.rb
@@ -918,7 +918,7 @@ writeH("OpcodeGenerated") {
                         outp.puts "if (args[#{index}].isStack() && args[#{index}].stackSlot()->isSpill())"
                         outp.puts "OPGEN_RETURN(false);"
                     end
-                    outp.puts "if (!Arg::isValidAddrForm(args[#{index}].offset()))"
+                    outp.puts "if (!Arg::isValidAddrForm(this->kind.opcode, args[#{index}].offset()))"
                     outp.puts "OPGEN_RETURN(false);"
                 when "ExtendedOffsetAddr"
                     if arg.role == "UA"

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
@@ -641,7 +641,7 @@ private:
 
     B3::Air::Arg materializeAddrArg(Tmp base, size_t offset, Width width)
     {
-        if (Arg::isValidAddrForm(offset, width))
+        if (Arg::isValidAddrForm(Move, offset, width))
             return Arg::addr(base, offset);
 
         auto temp = g64();


### PR DESCRIPTION
#### 67d43c36bbf9f2111a98316b5bd4a7ea1a539761
<pre>
Make MacroAssemblerARMv7 scratch regs available to Air
<a href="https://bugs.webkit.org/show_bug.cgi?id=249648">https://bugs.webkit.org/show_bug.cgi?id=249648</a>

Reviewed by Justin Michaud.

Make addressTempRegister/dataTempRegister available for use in Air. We
still need to reserve one of the two as the extendedOffsetAddrRegister,
so this results in one extra usable register in Air.

Legal load offsets on ARM differ between words and doubles, so we need
to thread the Air opcode all the way to isValidAddrForm.

We also make calls to MacroAssemblerARMv7::short_move (which make use of
the cachedAddressTempRegister) conditional on m_allowScratchRegister, so
that we don&apos;t accidentally try to use a cached value.

The trickiest part is in the use of the extendedOffsetAddrRegister in
Air. The register allocator in
AirAllocateRegistersAndStackAndGenerateCode.cpp assumes that it can
flush a register value without needing any extra registers. This is not
the case on ARM when the offset relative to the callFrameRegister is too
large. It used to be the case before this patch, because
MacroAssemblerARMv7 was privately reserving a register.

However, the extendedOffsetAddrRegister may have already been allocated
by lowerStackArgs, so we can&apos;t rely on it being available when we later
need to spill a value.

Instead, we move the lowering of the extended offset to
GenerateAndAllocateRegisters::generate, which becomes the sole user of
extendedOffsetAddrRegister.

Note that this is not a pure win on ARMv7. We lose the reuse of
previously computed addresess in MacroAssemblerARMv7, which results in
larger code size overall. We can hopefully claim those back by
implementing the same caching logic generically in Air. This is a wash
on the total score for JetStream2 but the corresponding code size is 18%
larger.

* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
(JSC::MacroAssemblerARMv7::store32):
(JSC::MacroAssemblerARMv7::cachedRegisterGetValue):
(JSC::MacroAssemblerARMv7::cachedRegisterSetValue):
(JSC::MacroAssemblerARMv7::short_move):
(JSC::MacroAssemblerARMv7::move):
(JSC::MacroAssemblerARMv7::setupArmAddress):
(JSC::MacroAssemblerARMv7::absoluteAddressWithinShortOffset):
(JSC::MacroAssemblerARMv7::moveFixedWidthEncoding):
* Source/JavaScriptCore/b3/B3Common.cpp:
(JSC::B3::extendedOffsetAddrRegister):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3MemoryValueInlines.h:
(JSC::B3::MemoryValue::isLegalOffsetImpl const):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
(JSC::B3::Air::callFrameAddr):
(JSC::B3::Air::GenerateAndAllocateRegisters::flush):
(JSC::B3::Air::GenerateAndAllocateRegisters::alloc):
(JSC::B3::Air::GenerateAndAllocateRegisters::generate):
* Source/JavaScriptCore/b3/air/AirArg.h:
(JSC::B3::Air::Arg::isValidAddrForm):
(JSC::B3::Air::Arg::isValidForm const):
* Source/JavaScriptCore/b3/air/AirCode.cpp:
(JSC::B3::Air::Code::Code):
* Source/JavaScriptCore/b3/air/AirHelpers.h:
(JSC::B3::Air::moveForType):
* Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp:
(JSC::B3::Air::lowerStackArgs):
* Source/JavaScriptCore/b3/air/opcode_generator.rb:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator32_64.cpp:
(JSC::Wasm::AirIRGenerator32::emitZeroInitialize):
(JSC::Wasm::AirIRGenerator32::emitLoad):
(JSC::Wasm::AirIRGenerator32::emitStore):
(JSC::Wasm::isFPLoadOp):
(JSC::Wasm::AirIRGenerator32::emitLoadOp):
(JSC::Wasm::isFPStoreOp):
(JSC::Wasm::AirIRGenerator32::emitStoreOp):
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::materializeAddrArg):
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::AirIRGeneratorBase::emitPatchpoint):
(JSC::Wasm::ExpressionType&gt;::restoreWebAssemblyGlobalState):
(JSC::Wasm::ExpressionType&gt;::addCurrentMemory):
(JSC::Wasm::ExpressionType&gt;::getGlobal):
(JSC::Wasm::ExpressionType&gt;::setGlobal):
(JSC::Wasm::ExpressionType&gt;::fixupPointerPlusOffsetForAtomicOps):
(JSC::Wasm::ExpressionType&gt;::addCallIndirect):

Canonical link: <a href="https://commits.webkit.org/258279@main">https://commits.webkit.org/258279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14f68f718c9e4e2e4246e45d17410267a4dd7b3b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110329 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170585 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1055 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93436 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108163 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35022 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90319 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78011 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91502 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3850 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24591 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87605 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1397 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3878 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/994 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29261 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44099 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90496 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5646 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20247 "Passed tests") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2993 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->