### PR TITLE
[run-webkit-tests] Strip allows*HTTPS* logging messages

### DIFF
--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2019 Apple Inc. All rights reserved.
+# Copyright (C) 2014-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,6 +22,7 @@
 
 import logging
 import os
+import re
 import time
 
 from webkitpy.common.memoized import memoized
@@ -281,3 +282,9 @@ class DarwinPort(ApplePort):
         for name in ['DYLD_LIBRARY_PATH', '__XPC_DYLD_LIBRARY_PATH', 'DYLD_FRAMEWORK_PATH', '__XPC_DYLD_FRAMEWORK_PATH']:
             self._append_value_colon_separated(environment, name, build_root_path)
         return environment
+
+    def stderr_patterns_to_strip(self):
+        worthless_patterns = super(DarwinPort, self).stderr_patterns_to_strip()
+        # Suppress log message from <rdar://56920527>
+        worthless_patterns.append((re.compile('.*nil host used in call to allows.+HTTPSCertificateForHost.*\n'), ''))
+        return worthless_patterns

--- a/Tools/Scripts/webkitpy/port/darwin_testcase.py
+++ b/Tools/Scripts/webkitpy/port/darwin_testcase.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2020 Apple Inc. All rights reserved.
+# Copyright (C) 2014-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
+import re
 import time
 
 from webkitpy.port import port_testcase
@@ -154,3 +155,19 @@ class DarwinTest(port_testcase.PortTestCase):
     def test_get_crash_log(self):
         port = self.make_port(port_name=self.port_name)
         port._get_crash_log('DumpRenderTree', 1234, None, None, time.time(), wait_for_log=False)
+
+    def test_stderr_patterns_to_strip(self):
+        content = '\n'.join([
+            'Some log line',
+            'nil host used in call to allowsAnyHTTPSCertificateForHost',
+            'nil host used in call to allowsSpecificHTTPSCertificateForHost',
+            'Some other log line',
+            '',
+        ])
+        port = self.make_port(port_name=self.port_name)
+        for pattern in port.stderr_patterns_to_strip():
+            content = re.sub(pattern[0], pattern[1], content)
+
+        self.assertEqual(
+            content, 'Some log line\nSome other log line\n'
+        )

--- a/Tools/Scripts/webkitpy/port/ios_simulator.py
+++ b/Tools/Scripts/webkitpy/port/ios_simulator.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2018 Apple Inc. All rights reserved.
+# Copyright (C) 2014-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -106,12 +106,6 @@ class IOSSimulatorPort(IOSPort):
     @memoized
     def developer_dir(self):
         return self._executive.run_command(['xcode-select', '--print-path']).rstrip()
-
-    def logging_patterns_to_strip(self):
-        return []
-
-    def stderr_patterns_to_strip(self):
-        return []
 
 
 class IPhoneSimulatorPort(IOSSimulatorPort):

--- a/Tools/Scripts/webkitpy/port/mac.py
+++ b/Tools/Scripts/webkitpy/port/mac.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2011 Google Inc. All rights reserved.
-# Copyright (C) 2012-2019 Apple Inc. All rights reserved.
+# Copyright (C) 2012-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -287,7 +287,7 @@ class MacPort(DarwinPort):
                     raise e
 
     def logging_patterns_to_strip(self):
-        logging_patterns = []
+        logging_patterns = super(MacPort, self).logging_patterns_to_strip()
 
         # FIXME: Remove this after <rdar://problem/35954459> is fixed.
         logging_patterns.append(('AVDCreateGPUAccelerator: Error loading GPU renderer\n', ''))
@@ -315,7 +315,7 @@ class MacPort(DarwinPort):
         return logging_detectors
 
     def stderr_patterns_to_strip(self):
-        worthless_patterns = []
+        worthless_patterns = super(MacPort, self).stderr_patterns_to_strip()
         worthless_patterns.append((re.compile('.*(Fig|fig|itemasync|vt|mv_|PullParamSetSPS|ccrp_|client).* signalled err=.*\n'), ''))
         worthless_patterns.append((re.compile('.*<<<< FigFilePlayer >>>>.*\n'), ''))
         worthless_patterns.append((re.compile('.*<<<< FigFile >>>>.*\n'), ''))

--- a/Tools/Scripts/webkitpy/port/watch_simulator.py
+++ b/Tools/Scripts/webkitpy/port/watch_simulator.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 Apple Inc. All rights reserved.
+# Copyright (C) 2018-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -95,9 +95,3 @@ class WatchSimulatorPort(WatchPort):
     @memoized
     def developer_dir(self):
         return self._executive.run_command(['xcode-select', '--print-path']).rstrip()
-
-    def logging_patterns_to_strip(self):
-        return []
-
-    def stderr_patterns_to_strip(self):
-        return []


### PR DESCRIPTION
#### 08b7126fcf9f0bba94141fc1afd4b87a628329c5
<pre>
[run-webkit-tests] Strip allows*HTTPS* logging messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=249658">https://bugs.webkit.org/show_bug.cgi?id=249658</a>
rdar://56920527

Reviewed by Alexey Proskuryakov.

* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort.stderr_patterns_to_strip): Strip allows*HTTPS* logging messages.
* Tools/Scripts/webkitpy/port/darwin_testcase.py:
* Tools/Scripts/webkitpy/port/ios_simulator.py:
(IOSSimulatorPort.logging_patterns_to_strip): Deleted.
(IOSSimulatorPort.stderr_patterns_to_strip): Deleted.
* Tools/Scripts/webkitpy/port/mac.py:
(MacPort.stderr_patterns_to_strip): Invoke base class&apos;s stderr_patterns_to_strip.
* Tools/Scripts/webkitpy/port/watch_simulator.py:
(WatchSimulatorPort.logging_patterns_to_strip): Deleted.
(WatchSimulatorPort.stderr_patterns_to_strip): Deleted.

Canonical link: <a href="https://commits.webkit.org/258197@main">https://commits.webkit.org/258197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a41b6edfcd77cec66b0e006d7a5fdbe9afa9cd2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/101215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/10368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/34268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/110498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/105202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/11305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/1235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/108330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/106998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/11305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/34268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/93619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/104735 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/11305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/34268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/34268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/4059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/1235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/10160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/34268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2955 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->