### PR TITLE
[WebGPU] Support vertex shader input buffers

### DIFF
--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -102,6 +102,7 @@ private:
     id<MTLBuffer> m_indexBuffer { nil };
     MTLIndexType m_indexType { MTLIndexTypeUInt16 };
     NSUInteger m_indexBufferOffset { 0 };
+    uint32_t m_vertexShaderInputBufferCount { 0 };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -171,7 +171,7 @@ void RenderPassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& group
     for (const auto& resource : group.resources())
         [m_renderCommandEncoder useResource:resource.mtlResource usage:resource.usage stages:resource.renderStages];
 
-    [m_renderCommandEncoder setVertexBuffer:group.vertexArgumentBuffer() offset:0 atIndex:groupIndex];
+    [m_renderCommandEncoder setVertexBuffer:group.vertexArgumentBuffer() offset:0 atIndex:groupIndex + m_vertexShaderInputBufferCount];
     [m_renderCommandEncoder setFragmentBuffer:group.fragmentArgumentBuffer() offset:0 atIndex:groupIndex];
 }
 
@@ -193,6 +193,7 @@ void RenderPassEncoder::setPipeline(const RenderPipeline& pipeline)
     // FIXME: validation according to
     // https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-setpipeline.
     m_primitiveType = pipeline.primitiveType();
+    m_vertexShaderInputBufferCount = pipeline.vertexShaderInputBufferCount();
 
     [m_renderCommandEncoder setRenderPipelineState:pipeline.renderPipelineState()];
     if (pipeline.depthStencilState())

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -41,9 +41,9 @@ class Device;
 class RenderPipeline : public WGPURenderPipelineImpl, public RefCounted<RenderPipeline> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, id<MTLDepthStencilState> depthStencilState, Device& device)
+    static Ref<RenderPipeline> create(id<MTLRenderPipelineState> renderPipelineState, MTLPrimitiveType primitiveType, std::optional<MTLIndexType> indexType, MTLWinding frontFace, MTLCullMode cullMode, id<MTLDepthStencilState> depthStencilState, uint32_t vertexShaderInputBufferCount, Device& device)
     {
-        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthStencilState, device));
+        return adoptRef(*new RenderPipeline(renderPipelineState, primitiveType, indexType, frontFace, cullMode, depthStencilState, vertexShaderInputBufferCount, device));
     }
 
     static Ref<RenderPipeline> createInvalid(Device& device)
@@ -65,9 +65,10 @@ public:
     MTLCullMode cullMode() const { return m_cullMode; }
 
     Device& device() const { return m_device; }
+    uint32_t vertexShaderInputBufferCount() const { return m_vertexShaderInputBufferCount; }
 
 private:
-    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, id<MTLDepthStencilState>, Device&);
+    RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, id<MTLDepthStencilState>, uint32_t, Device&);
     RenderPipeline(Device&);
 
     const id<MTLRenderPipelineState> m_renderPipelineState { nil };
@@ -78,6 +79,7 @@ private:
     MTLWinding m_frontFace;
     MTLCullMode m_cullMode;
     id<MTLDepthStencilState> m_depthStencilState;
+    uint32_t m_vertexShaderInputBufferCount { 0 };
 };
 
 } // namespace WebGPU

--- a/Websites/webkit.org/demos/webgpu/scripts/textured-cube-vs-input-buffers.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/textured-cube-vs-input-buffers.js
@@ -1,0 +1,318 @@
+async function helloCube() {
+    if (!navigator.gpu || GPUBufferUsage.COPY_SRC === undefined) {
+        document.body.className = 'error';
+        return;
+    }
+
+    const canvas = document.querySelector("canvas");
+    canvas.width = 600;
+    canvas.height = 600;
+    
+    const adapter = await navigator.gpu.requestAdapter();
+    const device = await adapter.requestDevice();
+    
+    /*** Vertex Buffer Setup ***/
+    
+    /* Vertex Data */
+    const vertexStride = 10 * 4;
+    const vertexDataSize = vertexStride * 36;
+    
+    /* GPUBufferDfescriptor */
+    const vertexDataBufferDescriptor = {
+        size: vertexDataSize,
+        usage: GPUBufferUsage.VERTEX,
+        mappedAtCreation: true
+    };
+
+    /* GPUBuffer */
+    const vertexBuffer = device.createBuffer(vertexDataBufferDescriptor);
+    const vertexWriteArray = new Float32Array(vertexBuffer.getMappedRange());
+    vertexWriteArray.set([
+        // float4 position, float4 color, float2 uv
+        .5, -.5, .5, 1,   1, 0, 1, 1,  1, 1,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  0, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,  0, 0,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  1, 0,
+        .5, -.5, .5, 1,   1, 0, 1, 1,  1, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,  0, 0,
+
+        .5, .5, .5, 1,    1, 1, 1, 1,  1, 1,
+        .5, -.5, .5, 1,   1, 0, 1, 1,  0, 1,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  0, 0,
+        .5, .5, -.5, 1,   1, 1, 0, 1,  1, 0,
+        .5, .5, .5, 1,    1, 1, 1, 1,  1, 1,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  0, 0,
+
+        -.5, .5, .5, 1,   0, 1, 1, 1,  1, 1,
+        .5, .5, .5, 1,    1, 1, 1, 1,  0, 1,
+        .5, .5, -.5, 1,   1, 1, 0, 1,  0, 0,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  1, 0,
+        -.5, .5, .5, 1,   0, 1, 1, 1,  1, 1,
+        .5, .5, -.5, 1,   1, 1, 0, 1,  0, 0,
+
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  1, 1,
+        -.5, .5, .5, 1,   0, 1, 1, 1,  0, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  0, 0,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,  1, 0,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  1, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  0, 0,
+
+        .5, .5, .5, 1,    1, 1, 1, 1,  1, 1,
+        -.5, .5, .5, 1,   0, 1, 1, 1,  0, 1,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  0, 0,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  0, 0,
+        .5, -.5, .5, 1,   1, 0, 1, 1,  1, 0,
+        .5, .5, .5, 1,    1, 1, 1, 1,  1, 1,
+    
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  1, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,  0, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  0, 0,
+        .5, .5, -.5, 1,   1, 1, 0, 1,  1, 0,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  1, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  0, 0,
+    ]);
+    vertexBuffer.unmap();
+    
+    const uniformBufferSize = 12;
+    const uniformBuffer = device.createBuffer({
+        size: uniformBufferSize,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    
+    /* GPUTexture */
+    const image = new Image();
+    const imageLoadPromise = new Promise(resolve => {
+        image.onload = () => resolve();
+        image.src = "resources/webkit-logo.png"
+    });
+    await Promise.resolve(imageLoadPromise);
+
+    const textureSize = {
+        width: image.width,
+        height: image.height,
+        depth: 1
+    };
+
+    const textureDescriptor = {
+        size: textureSize,
+        arrayLayerCount: 1,
+        mipLevelCount: 1,
+        sampleCount: 1,
+        dimension: "2d",
+        format: "bgra8unorm",
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST
+    };
+    const texture = device.createTexture(textureDescriptor);
+    
+    const imageBitmap = await createImageBitmap(image);
+
+    device.queue.copyExternalImageToTexture(
+        { source: imageBitmap },
+        { texture: texture },
+        [image.width, image.height]
+    );
+
+    const sampler = device.createSampler({
+        magFilter: "linear",
+        minFilter: "linear"
+    });
+
+    /*** Shader Setup ***/
+    
+    const uniformBindGroupLayout = device.createBindGroupLayout({ entries: [
+        { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: {} },
+        { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: {} },
+        { binding: 2, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
+    ] });
+
+    const uniformBindGroup = device.createBindGroup({
+        layout: uniformBindGroupLayout,
+        entries: [
+          {
+            binding: 0,
+            resource: {
+              buffer: uniformBuffer,
+              offset: 0
+            },
+          },
+          {
+            binding: 1,
+            resource: texture.createView(),
+          },
+          {
+            binding: 2,
+            resource: sampler,
+          },
+        ],
+      });
+
+    const mslSource = `
+                #define vertexInputPackedFloatSize 10
+                #include <metal_stdlib>
+                using namespace metal;
+                struct VertexIn {
+                   float4 position [[attribute(0)]];
+                   float4 color [[attribute(1)]];
+                   float2 uv [[attribute(2)]];
+                };
+    
+                struct VertexOut {
+                   float4 position [[position]];
+                   float4 color;
+                   float2 uv;
+                };
+    
+                struct VertexShaderArguments {
+                    device float *time [[id(0)]];
+                };
+    
+                struct FragmentShaderArguments {
+                    texture2d<half> colorTexture;
+                    sampler textureSampler;
+                };
+    
+                vertex VertexOut vsmain(VertexIn vin [[stage_in]], const device VertexShaderArguments &values [[buffer(1)]])
+                {
+                    VertexOut vout;
+                    float alpha = values.time[0];
+                    float beta = values.time[1];
+                    float gamma = values.time[2];
+                    float cA = cos(alpha);
+                    float sA = sin(alpha);
+                    float cB = cos(beta);
+                    float sB = sin(beta);
+                    float cG = cos(gamma);
+                    float sG = sin(gamma);
+    
+                    float4x4 m = float4x4(cA * cB,  sA * cB,   -sB, 0,
+                                          cA*sB*sG - sA*cG,  sA*sB*sG + cA*cG,   cB * sG, 0,
+                                          cA*sB*cG + sA*sG, sA*sB*cG - cA*sG, cB * cG, 0,
+                                          0,     0,     0, 1);
+                    vout.position = vin.position * m;
+                    vout.position.z = (vout.position.z + 0.5) * 0.5;
+                    vout.color = vin.color;
+                    vout.uv = vin.uv;
+                    return vout;
+                }
+
+                fragment float4 fsmain(VertexOut in [[stage_in]], device FragmentShaderArguments &values [[buffer(0)]])
+                {
+                    return 0.5 * in.color + 0.5 * float4(values.colorTexture.sample(values.textureSampler, in.uv));
+                }
+    `;
+
+    const shaderModule = device.createShaderModule({ code: mslSource, isWHLSL: false, hints: [ {layout: "auto" }, ] });
+    
+    /* GPUPipelineStageDescriptors */
+    const vertexStageDescriptor = {
+        module: shaderModule,
+        entryPoint: "vsmain",
+        buffers: [
+            {
+                arrayStride: vertexStride,
+                attributes: [
+                {
+                    // position
+                    shaderLocation: 0,
+                    offset: 0,
+                    format: 'float32x4',
+                },
+                {
+                    // color
+                    shaderLocation: 0,
+                    offset: 4 * 4,
+                    format: 'float32x4',
+                },
+                {
+                    // uv
+                    shaderLocation: 1,
+                    offset: 4 * 8,
+                    format: 'float32x2',
+                },
+              ],
+            },
+        ],
+    };
+
+    const fragmentStageDescriptor = { module: shaderModule, entryPoint: "fsmain", targets: [ {format: "bgra8unorm" }, ],  };
+
+    /* GPURenderPipelineDescriptor */
+
+    const renderPipelineDescriptor = {
+        layout: "auto",
+        vertex: vertexStageDescriptor,
+        fragment: fragmentStageDescriptor,
+        primitive: {
+            topology: "triangle-list",
+            cullMode: "back"
+        },
+    };
+    /* GPURenderPipeline */
+    const renderPipeline = device.createRenderPipeline(renderPipelineDescriptor);
+    
+    /*** Swap Chain Setup ***/
+    function frameUpdate() {
+        const secondsBuffer = new Float32Array(3);
+        const d = new Date();
+        const seconds = d.getMilliseconds() / 1000.0 + d.getSeconds();
+        secondsBuffer.set([seconds*10 * (6.28318530718 / 60.0),
+                          seconds*5 * (6.28318530718 / 60.0),
+                          seconds*1 * (6.28318530718 / 60.0)]);
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, 12);
+
+        const gpuContext = canvas.getContext("webgpu");
+        
+        /* GPUCanvasConfiguration */
+        const canvasConfiguration = { device: device, format: "bgra8unorm" };
+        gpuContext.configure(canvasConfiguration);
+        /* GPUTexture */
+        const currentTexture = gpuContext.getCurrentTexture();
+        
+        /*** Render Pass Setup ***/
+        
+        /* Acquire Texture To Render To */
+        
+        /* GPUTextureView */
+        const renderAttachment = currentTexture.createView();
+        
+        /* GPUColor */
+        const darkBlue = { r: 0.15, g: 0.15, b: 0.5, a: 1 };
+        
+        /* GPURenderPassColorATtachmentDescriptor */
+        const colorAttachmentDescriptor = {
+            view: renderAttachment,
+            loadOp: "clear",
+            storeOp: "store",
+            clearColor: darkBlue
+        };
+        
+        /* GPURenderPassDescriptor */
+        const renderPassDescriptor = { colorAttachments: [colorAttachmentDescriptor] };
+        
+        /*** Rendering ***/
+        
+        /* GPUCommandEncoder */
+        const commandEncoder = device.createCommandEncoder();
+        /* GPURenderPassEncoder */
+        const renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+        
+        renderPassEncoder.setPipeline(renderPipeline);
+        renderPassEncoder.setVertexBuffer(0, vertexBuffer, 0);
+        renderPassEncoder.setBindGroup(0, uniformBindGroup);
+        renderPassEncoder.draw(36, 1, 0, 0); // 36 vertices, 1 instance, 0th vertex, 0th instance.
+        renderPassEncoder.end();
+        
+        /* GPUComamndBuffer */
+        const commandBuffer = commandEncoder.finish();
+        
+        /* GPUQueue */
+        const queue = device.queue;
+        queue.submit([commandBuffer]);
+
+        requestAnimationFrame(frameUpdate);
+    }
+
+    requestAnimationFrame(frameUpdate);
+}
+
+window.addEventListener("DOMContentLoaded", helloCube);

--- a/Websites/webkit.org/demos/webgpu/textured-cube-vs-input-buffers.html
+++ b/Websites/webkit.org/demos/webgpu/textured-cube-vs-input-buffers.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=600">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+<title>WebGPU Textured Cube using Vertex Shader Input Buffers</title>
+<link rel="stylesheet" href="css/style.css">
+<style>
+body {
+    font-family: system-ui;
+    color: #f7f7ff;
+    background-color: rgb(38, 38, 127);
+    text-align: center;
+}
+canvas {
+    margin: 0 auto;
+}
+</style>
+</head>
+<body>
+<div id="contents">
+    <h1>Textured Cube using Vertex Shader Input Buffers</h1>
+    <canvas></canvas>
+</div>
+<div id="error">
+    <h2>WebGPU not available</h2>
+    <p>
+        Make sure you are on a system with WebGPU enabled. In
+        Safari, first make sure the Developer Menu is visible (Preferences >
+        Advanced), then Develop > Experimental Features > WebGPU.
+    </p>
+    <p>
+        In addition, you must be using Safari Technology Preview 92 or above.
+        You can get the latest STP <a href="https://developer.apple.com/safari/download/">here</a>.
+    </p>
+</div>
+<script src="scripts/textured-cube-vs-input-buffers.js"></script>
+</body>
+</html>


### PR DESCRIPTION
#### 33055b844de35a1cefaa284d17333063b237290d
<pre>
[WebGPU] Support vertex shader input buffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=249636">https://bugs.webkit.org/show_bug.cgi?id=249636</a>
&lt;radar://103490410&gt;

Reviewed by Dean Jackson.

Configure the pipeline state to support vertex input
buffers.

This was tested against external WebGPU samples but
I will add a local test case while the review is on-going.

* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setBindGroup):
Offset the bind group vertex buffer by the number of
vertex shader input buffers.

(WebGPU::RenderPassEncoder::setPipeline):
Cache the number of vertex shader input buffers.

* Source/WebGPU/WebGPU/RenderPipeline.h:
(WebGPU::RenderPipeline::create):
(WebGPU::RenderPipeline::vertexShaderInputBufferCount const):
Return the number of vertex shader input buffers.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::validateRenderPipeline):
(WebGPU::vertexFormat):
(WebGPU::stepFunction):
(WebGPU::createVertexDescriptor):
(WebGPU::Device::createRenderPipeline):
(WebGPU::RenderPipeline::RenderPipeline):
Configure the vertex shader input buffer state.

* Websites/webkit.org/demos/webgpu/scripts/textured-cube-vs-input-buffers.js: Added.
(async helloCube.frameUpdate):
(async helloCube):
* Websites/webkit.org/demos/webgpu/textured-cube-vs-input-buffers.html: Added.
Add sample test show use of vertex shader input buffers.

Canonical link: <a href="https://commits.webkit.org/258234@main">https://commits.webkit.org/258234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ac64501f823316ff1a27c4aa744a60a53d1888f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110555 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1298 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93676 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108387 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35175 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23289 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4067 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24803 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4110 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10215 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44282 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5666 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5868 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->