### PR TITLE
[ews-build.webkit.org] Use TwistedAdditions in place of Twisted requests

### DIFF
--- a/Tools/CISupport/ews-build/twisted_additions.py
+++ b/Tools/CISupport/ews-build/twisted_additions.py
@@ -24,6 +24,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import calendar
+import datetime
 import json
 import os
 import re
@@ -32,7 +34,7 @@ import twisted
 from twisted.internet import defer, error, interfaces, protocol, reactor, task
 from twisted.web.client import Agent
 from twisted.web.http_headers import Headers
-from twisted.web import http, _newclient
+from twisted.web import iweb, http, _newclient
 
 from zope.interface import implementer
 
@@ -182,6 +184,32 @@ class TwistedAdditions(object):
         def json(self):
             return json.loads(self.text)
 
+    @implementer(iweb.IBodyProducer)
+    class JSONProducer(object):
+        @classmethod
+        def serialize(cls, obj):
+            if isinstance(obj, datetime.datetime):
+                return int(calendar.timegm(obj.timetuple()))
+            raise TypeError("Type %s not serializable" % type(obj))
+
+        def __init__(self, data):
+            try:
+                self.body = json.dumps(data, default=self.serialize).encode('utf-8')
+            except TypeError:
+                self.body = ''
+            self.length = len(self.body)
+
+        def startProducing(self, consumer):
+            if self.body:
+                consumer.write(self.body)
+            return succeed(None)
+
+        def pauseProducing(self):
+            pass
+
+        def stopProducing(self):
+            pass
+
     class Printer(protocol.Protocol):
         def __init__(self, finished):
             self.finished = finished
@@ -195,7 +223,7 @@ class TwistedAdditions(object):
 
     @classmethod
     @defer.inlineCallbacks
-    def request(cls, url, type=None, params=None, headers=None, logger=None, timeout=10):
+    def request(cls, url, type=None, params=None, headers=None, logger=None, timeout=10, json=None):
         logger = logger or (lambda _: None)
         typ = type or b'GET'
 
@@ -219,7 +247,8 @@ class TwistedAdditions(object):
             else:
                 agent = Agent(reactor, connectTimeout=timeout)
 
-            response = yield agent.request(typ, url.encode('utf-8'), Headers(headers))
+            body = JSONProducer(json) if json else None
+            response = yield agent.request(typ, url.encode('utf-8'), Headers(headers), body)
             finished = defer.Deferred()
             response.deliverBody(cls.Printer(finished))
             data = yield finished


### PR DESCRIPTION
#### fa3e08712e3219aed72097238ae77493974a5092
<pre>
[ews-build.webkit.org] Use TwistedAdditions in place of Twisted requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=249663">https://bugs.webkit.org/show_bug.cgi?id=249663</a>
rdar://103564994

Reviewed by Dewei Zhu.

* Tools/CISupport/ews-build/events.py:
(Events):
(Events.sendDataToEWS):
(Events.sendDataToGitHub):
(JSONProducer): Moved to twisted_additions.
* Tools/CISupport/ews-build/twisted_additions.py:
(TwistedAdditions.JSONProducer): Moved from events.py.
(TwistedAdditions.request): Allow caller to POST data.

Canonical link: <a href="https://commits.webkit.org/258542@main">https://commits.webkit.org/258542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26fbdc266ad5cc8398ed8e33313d41a8999c22d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110537 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170818 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1280 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108369 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35160 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90531 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23276 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78158 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4049 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24790 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1218 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/100173 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44269 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5849 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3097 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->