### PR TITLE
Element::attachDeclarativeShadow should set IsAvailableToElementInternals

### DIFF
--- a/LayoutTests/fast/shadow-dom/element-internals-exposes-declarative-shadow-root-expected.txt
+++ b/LayoutTests/fast/shadow-dom/element-internals-exposes-declarative-shadow-root-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Declarative Shadow DOM in "closed" mode is exposed via ElementInternals.prototype.shadowRoot
 PASS Declarative Shadow DOM in "open" mode is exposed via ElementInternals.prototype.shadowRoot
-PASS Declarative Shadow DOM in "closed" mode is not exposed via ElementInternals.prototype.shadowRoot after calling attachShadow
-PASS Declarative Shadow DOM in "open" mode is not exposed via ElementInternals.prototype.shadowRoot after calling attachShadow
+PASS Declarative Shadow DOM in "closed" mode is exposed via ElementInternals.prototype.shadowRoot after calling attachShadow
+PASS Declarative Shadow DOM in "open" mode is exposed via ElementInternals.prototype.shadowRoot after calling attachShadow
 

--- a/LayoutTests/fast/shadow-dom/element-internals-exposes-declarative-shadow-root.html
+++ b/LayoutTests/fast/shadow-dom/element-internals-exposes-declarative-shadow-root.html
@@ -20,15 +20,10 @@
     </template>
 </component-3>
 <component-4>
-    <template shadowrootmode="closed">
+    <template shadowrootmode="open">
         <slot>hello, world.</slot>
     </template>
 </component-4>
-<component-5>
-    <template shadowrootmode="closed">
-        <slot>hello, world.</slot>
-    </template>
-</component-5>
 <script>
 
 promise_test(async function () {
@@ -72,10 +67,10 @@ promise_test(async function () {
         }
     });
     assert_true(!!internals);
-    assert_equals(internals.shadowRoot, null);
+    assert_true(!!internals.shadowRoot);
     assert_equals(shadowRoot.mode, 'closed');
     assert_equals(shadowRoot.innerHTML, '');
-}, 'Declarative Shadow DOM in "closed" mode is not exposed via ElementInternals.prototype.shadowRoot after calling attachShadow');
+}, 'Declarative Shadow DOM in "closed" mode is exposed via ElementInternals.prototype.shadowRoot after calling attachShadow');
 
 promise_test(async function () {
     let internals = null;
@@ -88,10 +83,10 @@ promise_test(async function () {
         }
     });
     assert_true(!!internals);
-    assert_equals(internals.shadowRoot, null);
-    assert_equals(shadowRoot.mode, 'closed');
+    assert_true(!!internals.shadowRoot);
+    assert_equals(shadowRoot.mode, 'open');
     assert_equals(shadowRoot.innerHTML, '');
-}, 'Declarative Shadow DOM in "open" mode is not exposed via ElementInternals.prototype.shadowRoot after calling attachShadow');
+}, 'Declarative Shadow DOM in "open" mode is exposed via ElementInternals.prototype.shadowRoot after calling attachShadow');
 
 </script>
 </body>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2779,6 +2779,7 @@ ExceptionOr<ShadowRoot&> Element::attachDeclarativeShadow(ShadowRootMode mode, b
         return exceptionOrShadowRoot.releaseException();
     auto& shadowRoot = exceptionOrShadowRoot.releaseReturnValue();
     shadowRoot.setIsDeclarativeShadowRoot(true);
+    shadowRoot.setIsAvailableToElementInternals(true);
     return shadowRoot;
 }
 

--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -45,7 +45,7 @@ ShadowRoot* ElementInternals::shadowRoot() const
     auto* shadowRoot = element->shadowRoot();
     if (!shadowRoot)
         return nullptr;
-    if (!shadowRoot->isAvailableToElementInternals() && !shadowRoot->isDeclarativeShadowRoot())
+    if (!shadowRoot->isAvailableToElementInternals())
         return nullptr;
     return shadowRoot;
 }

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -81,6 +81,7 @@ public:
     bool isCloneable() const { return m_isCloneable; }
 
     bool isAvailableToElementInternals() const { return m_availableToElementInternals; }
+    void setIsAvailableToElementInternals(bool flag) { m_availableToElementInternals = flag; }
     bool isDeclarativeShadowRoot() const { return m_isDeclarativeShadowRoot; }
     void setIsDeclarativeShadowRoot(bool flag) { m_isDeclarativeShadowRoot = flag; }
 


### PR DESCRIPTION
#### d26eba5eb7ab2fc3f968705e31b7d965d25bafd8
<pre>
Element::attachDeclarativeShadow should set IsAvailableToElementInternals
<a href="https://bugs.webkit.org/show_bug.cgi?id=249668">https://bugs.webkit.org/show_bug.cgi?id=249668</a>

Reviewed by Chris Dumez.

Make Element::attachDeclarativeShadow set ShadowRoot::m_isAttachDeclarativeShadow flag
instead of checking isDeclarativeShadowRoot in ElementInternals::shadowRoot.

Also update the assertions in the test to match the latest spec PR.

* LayoutTests/fast/shadow-dom/element-internals-exposes-declarative-shadow-root-expected.txt:
* LayoutTests/fast/shadow-dom/element-internals-exposes-declarative-shadow-root.html:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::attachDeclarativeShadow)
* Source/WebCore/dom/ElementInternals.cpp:
(WebCore::ElementInternals::shadowRoot const):
* Source/WebCore/dom/ShadowRoot.h:

Canonical link: <a href="https://commits.webkit.org/258231@main">https://commits.webkit.org/258231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/943910fb5c7889eabf18c54a5bff79316e3fe06d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 🧪 win ](https://ews-build.webkit.org/#/builders/Windows-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-9-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5659 "Built successfully and passed tests") | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-9-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | | | | 
<!--EWS-Status-Bubble-End-->