### PR TITLE
Consider focusability even when tabs-to-links is enabled for <svg:a>

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1056,6 +1056,7 @@ scrollbars/scrolling-by-page-accounting-top-fixed-elements-with-negative-top-on-
 scrollbars/scrolling-by-page-ignoring-hidden-fixed-elements-on-keyboard-spacebar.html [ Skip ]
 scrollbars/scrolling-by-page-ignoring-transparent-fixed-elements-on-keyboard-spacebar.html [ Skip ]
 storage/domstorage/sessionstorage/set-item-synchronous-keydown.html [ Skip ]
+svg/custom/display-none-a-does-not-stop-focus-navigation.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/input-change-event-properties.html [ Skip ]

--- a/LayoutTests/svg/custom/display-none-a-does-not-stop-focus-navigation-expected.txt
+++ b/LayoutTests/svg/custom/display-none-a-does-not-stop-focus-navigation-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS SVG <a> which is display none does not block focus traversal
+

--- a/LayoutTests/svg/custom/display-none-a-does-not-stop-focus-navigation.html
+++ b/LayoutTests/svg/custom/display-none-a-does-not-stop-focus-navigation.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ TabsToLinks=true ] -->
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<input id="input1"></input>
+<svg display="none" width="100" height="100">
+  <a xlink:href="#foo">
+    <text y="20">Link</text>
+  </a>
+</svg>
+<input id="input2"></input>
+<script>
+test(function() {
+    input1.focus();
+    assert_equals(document.activeElement, input1);
+    eventSender.keyDown('\t');
+    assert_equals(document.activeElement, input2);
+}, 'SVG <a> which is display none does not block focus traversal');
+</script>

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -2,7 +2,8 @@
  * Copyright (C) 2004, 2005, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2007 Rob Buis <buis@kde.org>
  * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
- * Copyright (C) 2010-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -189,8 +190,8 @@ bool SVGAElement::isKeyboardFocusable(KeyboardEvent* event) const
     if (isFocusable() && Element::supportsFocus())
         return SVGElement::isKeyboardFocusable(event);
 
-    if (isLink())
-        return document().frame()->eventHandler().tabsToLinks(event);
+    if (isLink() && !document().frame()->eventHandler().tabsToLinks(event))
+        return false;
 
     return SVGElement::isKeyboardFocusable(event);
 }


### PR DESCRIPTION
#### a8188f2bba91c479e8fadfdc9bbdbeb3d1a0e3e1
<pre>
Consider focusability even when tabs-to-links is enabled for &lt;svg:a&gt;

Consider focusability even when tabs-to-links is enabled for &lt;svg:a&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=249546">https://bugs.webkit.org/show_bug.cgi?id=249546</a>

Reviewed by Aditya Keerthi.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/ad66827206bf24e41a4afa7dd7c3083157506c6c">https://chromium.googlesource.com/chromium/src.git/+/ad66827206bf24e41a4afa7dd7c3083157506c6c</a>

SVGAElement::isKeyboardFocusable could end up returning &apos;true&apos; even when
the element wasn&apos;t focusable (because it had &quot;display: none&quot; and hence
no renderer) because the value of the &apos;tabsToLinks&apos; setting would be
returned without further checks. Because it wasn&apos;t focusable
setFocusedElement would not do anything, and focus would remain where it
was previously.
Make sure the focusable check is considered in this case. This makes the
SVGAElement version of this code look the same as the HTMLAnchorElement
version.

* Source/WebCore/svg/SVGAElement.cpp:
(SVGAElement::isKeyboardEvent): Update logic to ensure focus check is done and return accordingly
* LayoutTests/svg/custom/display-none-a-does-not-stop-focus-navigation.html: Add Test Case
* LayoutTests/svg/custom/display-none-a-does-not-stop-focus-navigation-expected.txt: Add Test Case Expectation
* LayoutTests/platform/ios/TestExpectations: Added test to skip on iOS since it does not support &apos;keyDown&apos;

Canonical link: <a href="https://commits.webkit.org/258228@main">https://commits.webkit.org/258228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd387d404511340b45e14ba4f12c52d6af79a50f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110462 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170739 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1198 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93573 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108292 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35117 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23205 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78111 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3974 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24721 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1142 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44209 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5662 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5775 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->