### PR TITLE
HitTest for LegacyInlineFlowBox should take care of border-radius

### DIFF
--- a/LayoutTests/fast/borders/border-hittest-inlineFlowBox-expected.txt
+++ b/LayoutTests/fast/borders/border-hittest-inlineFlowBox-expected.txt
@@ -1,0 +1,19 @@
+Two lines with 
+a hard line break.
+BC
+DE
+If this test passes, area outside border radius is body element.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS elementInTopLeftCorner.nodeName is "DIV"
+PASS elementInTopLeftCorner.nodeName is "SPAN"
+PASS elementInTopLeftCorner.nodeName is "DIV"
+PASS elementInTopLeftCorner.nodeName is "BODY"
+PASS elementInTopLeftCorner.nodeName is "BODY"
+PASS elementInTopLeftCorner.nodeName is "SPAN"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/borders/border-hittest-inlineFlowBox.html
+++ b/LayoutTests/fast/borders/border-hittest-inlineFlowBox.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+span {
+    background-color: lightgray;
+    border-radius: 2em;
+    padding: 1em;
+    line-height: 4em;
+}
+
+label {
+    padding: 2em;
+    background-color: lightgreen;
+    border-radius: 2em;
+}
+
+div {
+    margin: 2em;
+}
+</style>
+<div>
+<span id="A">
+Two lines with <br/>a hard line break.
+</span>
+</div>
+<div>
+<span id="B">B<label id="C">C</label></span>
+</div>
+<div>
+<span id="D" style="padding: 2em;">D<label id="E" style="padding: 1em;">E</label></span>
+</div>
+<script>
+test(() => {
+  const rect = document.getElementById('A').getClientRects()[0];
+  const elementInTopLeftCorner = document.elementFromPoint(rect.left, rect.top);
+  assert_equals(elementInTopLeftCorner.nodeName, 'DIV');
+}, 'Hit test outside round-cornered border of the first line of span#A');
+
+test(() => {
+  const rect = document.getElementById('A').getClientRects()[1];
+  const elementInTopLeftCorner = document.elementFromPoint(rect.left, rect.top);
+  assert_equals(elementInTopLeftCorner.nodeName, 'SPAN');
+}, 'Hit test top left corner of the second line of span#A');
+
+test(() => {
+  const rect = document.getElementById('B').getBoundingClientRect();
+  const elementInTopLeftCorner = document.elementFromPoint(rect.left, rect.top);
+  assert_equals(elementInTopLeftCorner.nodeName, 'DIV');
+}, 'Hit test outside round-cornered border of span#B');
+
+test(() => {
+  const rect = document.getElementById('C').getBoundingClientRect();
+  const elementInTopLeftCorner = document.elementFromPoint(rect.left, rect.top);
+  assert_equals(elementInTopLeftCorner.nodeName, 'BODY');
+}, 'Hit test outside round-cornered border of label#C');
+
+test(() => {
+  const rect = document.getElementById('D').getBoundingClientRect();
+  const elementInTopLeftCorner = document.elementFromPoint(rect.left, rect.top);
+  assert_equals(elementInTopLeftCorner.nodeName, 'BODY');
+}, 'Hit test outside round-cornered border of span#D');
+
+test(() => {
+  const rect = document.getElementById('E').getBoundingClientRect();
+  const elementInTopLeftCorner = document.elementFromPoint(rect.left, rect.top);
+  assert_equals(elementInTopLeftCorner.nodeName, 'SPAN');
+}, 'Hit test outside round-cornered border of label#E');
+</script>

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -1067,6 +1068,14 @@ bool LegacyInlineFlowBox::nodeAtPoint(const HitTestRequest& request, HitTestResu
         }
     }
 
+    if (renderer().style().hasBorderRadius()) {
+        LayoutRect borderRect = logicalFrameRect();
+        borderRect.moveBy(accumulatedOffset);
+        FloatRoundedRect border = renderer().style().getRoundedBorderFor(borderRect, includeLogicalLeftEdge(), includeLogicalRightEdge());
+        if (!locationInContainer.intersects(border))
+        return false;
+    }
+    
     // Now check ourselves. Pixel snap hit testing.
     if (!renderer().visibleToHitTesting(request))
         return false;


### PR DESCRIPTION
<pre>
HitTest for LegacyInlineFlowBox should take care of border-radius
<a href="https://bugs.webkit.org/show_bug.cgi?id=249555">https://bugs.webkit.org/show_bug.cgi?id=249555</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?revision=192994&view=revision">https://src.chromium.org/viewvc/blink?revision=192994&view=revision</a>

Current behavior of hit testing works properly for RenderBlock and InlineBox having border
style but doesn't take care of LegacyInlineFlowBox with border style and hence returns the
wrong element. This patch adds the implementation for border style handling in order
to try to match other browsers.

* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(LegacyInlineFlowBox::nodeAtPoint): Add hit testing to account for border radius
* LayoutTests/fast/borders/border-hittest-inlineFlowBox.html: Add Test Case
* LayoutTests/fast/borders/border-hittest-inlineFlowBox-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73612e977bd5630cc2e0aba15063087ce215d4dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101100 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10253 "Hash 73612e97 for PR 7935 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34149 "Hash 73612e97 for PR 7935 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110398 "Hash 73612e97 for PR 7935 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170649 "Hash 73612e97 for PR 7935 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105086 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11185 "Hash 73612e97 for PR 7935 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1128 "Hash 73612e97 for PR 7935 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93509 "Hash 73612e97 for PR 7935 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108227 "Hash 73612e97 for PR 7935 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106882 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/11185 "Hash 73612e97 for PR 7935 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/34149 "Hash 73612e97 for PR 7935 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/93509 "Hash 73612e97 for PR 7935 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/11185 "Hash 73612e97 for PR 7935 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/34149 "Hash 73612e97 for PR 7935 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/93509 "Hash 73612e97 for PR 7935 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3911 "Hash 73612e97 for PR 7935 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/34149 "Hash 73612e97 for PR 7935 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3947 "Hash 73612e97 for PR 7935 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/1128 "Hash 73612e97 for PR 7935 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10056 "Hash 73612e97 for PR 7935 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/34149 "Hash 73612e97 for PR 7935 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5710 "Hash 73612e97 for PR 7935 does not build (failure)") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->