### PR TITLE
[GPU Process] [FormControls] Add a ControlPart for ProgressBar

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1744,6 +1744,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/controls/ControlStyle.h
     platform/graphics/controls/MeterPart.h
     platform/graphics/controls/PlatformControl.h
+    platform/graphics/controls/ProgressBarPart.h
     platform/graphics/controls/TextAreaPart.h
     platform/graphics/controls/TextFieldPart.h
     platform/graphics/controls/ToggleButtonPart.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2203,6 +2203,7 @@ platform/graphics/controls/ControlPart.cpp
 platform/graphics/controls/ControlPartType.cpp
 platform/graphics/controls/ControlStyle.cpp
 platform/graphics/controls/MeterPart.cpp
+platform/graphics/controls/ProgressBarPart.cpp
 platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp
 platform/graphics/displaylists/DisplayList.cpp
 platform/graphics/displaylists/DisplayListDrawingContext.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -466,6 +466,7 @@ platform/graphics/mac/controls/ButtonControlMac.mm
 platform/graphics/mac/controls/ControlFactoryMac.mm
 platform/graphics/mac/controls/ControlMac.mm
 platform/graphics/mac/controls/MeterMac.mm
+platform/graphics/mac/controls/ProgressBarMac.mm
 platform/graphics/mac/controls/TextAreaMac.mm
 platform/graphics/mac/controls/TextFieldMac.mm
 platform/graphics/mac/controls/ToggleButtonMac.mm

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class MeterPart;
 class PlatformControl;
+class ProgressBarPart;
 class TextAreaPart;
 class TextFieldPart;
 class ToggleButtonPart;
@@ -43,6 +44,7 @@ public:
     static ControlFactory& sharedControlFactory();
 
     virtual std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) = 0;
+    virtual std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) = 0;

--- a/Source/WebCore/platform/graphics/controls/ControlPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.cpp
@@ -58,6 +58,16 @@ FloatSize ControlPart::sizeForBounds(const FloatRect& bounds, const ControlStyle
     return platformControl->sizeForBounds(bounds);
 }
 
+FloatRect ControlPart::rectForBounds(const FloatRect& bounds, const ControlStyle& style)
+{
+    auto platformControl = this->platformControl();
+    if (!platformControl)
+        return bounds;
+
+    platformControl->updateCellStates(bounds, style);
+    return platformControl->rectForBounds(bounds, style);
+}
+
 void ControlPart::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style) const
 {
     auto platformControl = this->platformControl();

--- a/Source/WebCore/platform/graphics/controls/ControlPart.h
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.h
@@ -46,6 +46,7 @@ public:
     void setControlFactory(ControlFactory* controlFactory) { m_controlFactory = controlFactory; }
 
     FloatSize sizeForBounds(const FloatRect& bounds, const ControlStyle&);
+    FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&);
     void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) const;
 
 protected:

--- a/Source/WebCore/platform/graphics/controls/ControlStyle.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlStyle.cpp
@@ -51,8 +51,8 @@ TextStream& operator<<(TextStream& ts, ControlStyle::State state)
     case ControlStyle::State::Default:
         ts << "default";
         break;
-    case ControlStyle::State::WindowInactive:
-        ts << "window-inactive";
+    case ControlStyle::State::WindowActive:
+        ts << "window-active";
         break;
     case ControlStyle::State::Indeterminate:
         ts << "indeterminate";

--- a/Source/WebCore/platform/graphics/controls/ControlStyle.h
+++ b/Source/WebCore/platform/graphics/controls/ControlStyle.h
@@ -41,7 +41,7 @@ struct ControlStyle {
         Enabled             = 1 << 3,
         Checked             = 1 << 4,
         Default             = 1 << 5,
-        WindowInactive      = 1 << 6,
+        WindowActive        = 1 << 6,
         Indeterminate       = 1 << 7,
         SpinUp              = 1 << 8, // Sub-state for HoverState and PressedState.
         Presenting          = 1 << 9,

--- a/Source/WebCore/platform/graphics/controls/PlatformControl.h
+++ b/Source/WebCore/platform/graphics/controls/PlatformControl.h
@@ -50,7 +50,9 @@ public:
     virtual void updateCellStates(const FloatRect&, const ControlStyle&) { }
 
     virtual FloatSize sizeForBounds(const FloatRect& bounds) const { return bounds.size(); }
-    
+
+    virtual FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const { return bounds; }
+
     virtual void draw(GraphicsContext&, const FloatRect&, float, const ControlStyle&) { }
 
 protected:

--- a/Source/WebCore/platform/graphics/controls/ProgressBarPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/ProgressBarPart.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ProgressBarPart.h"
+
+#include "ControlFactory.h"
+
+namespace WebCore {
+
+Ref<ProgressBarPart> ProgressBarPart::create(double position, const Seconds& animationStartTime)
+{
+    return adoptRef(*new ProgressBarPart(position, animationStartTime));
+}
+
+ProgressBarPart::ProgressBarPart(double position, const Seconds& animationStartTime)
+    : ControlPart(ControlPartType::ProgressBar)
+    , m_position(position)
+    , m_animationStartTime(animationStartTime)
+{
+}
+
+std::unique_ptr<PlatformControl> ProgressBarPart::createPlatformControl()
+{
+    return controlFactory().createPlatformProgressBar(*this);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/ProgressBarPart.h
+++ b/Source/WebCore/platform/graphics/controls/ProgressBarPart.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlPart.h"
+#include <wtf/Seconds.h>
+
+namespace WebCore {
+
+class ProgressBarPart : public ControlPart {
+public:
+    WEBCORE_EXPORT static Ref<ProgressBarPart> create(double position, const Seconds& animationStartTime);
+
+    double position() const { return m_position; }
+    Seconds animationStartTime() const { return m_animationStartTime; }
+
+private:
+    ProgressBarPart(double position, const Seconds& animationStartTime);
+
+    std::unique_ptr<PlatformControl> createPlatformControl() override;
+
+    double m_position;
+    Seconds m_animationStartTime;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CONTROL_PART(ProgressBar)

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm
@@ -75,7 +75,7 @@ void ButtonControlMac::updateCellStates(const FloatRect& rect, const ControlStyl
     // a view in a window whose key state can be detected.
 
     // Only update if we have to, since AppKit does work even if the size is the same.
-    auto controlSize = calculateControlSize(rect.size(), style);
+    auto controlSize = controlSizeForSize(rect.size(), style);
     if (controlSize != [m_buttonCell controlSize])
         [m_buttonCell setControlSize:controlSize];
 }

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -39,6 +39,7 @@ public:
     NSView *drawingView(const FloatRect&, const ControlStyle&) const;
 
     std::unique_ptr<PlatformControl> createPlatformMeter(MeterPart&) override;
+    std::unique_ptr<PlatformControl> createPlatformProgressBar(ProgressBarPart&) override;
     std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) override;
     std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) override;
     std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) override;

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import "MeterMac.h"
+#import "ProgressBarMac.h"
 #import "TextAreaMac.h"
 #import "TextFieldMac.h"
 #import "ToggleButtonMac.h"
@@ -124,6 +125,11 @@ NSTextFieldCell* ControlFactoryMac::textFieldCell() const
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformMeter(MeterPart& part)
 {
     return makeUnique<MeterMac>(part, *this, levelIndicatorCell());
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformProgressBar(ProgressBarPart& part)
+{
+    return makeUnique<ProgressBarMac>(part, *this);
 }
 
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformTextArea(TextAreaPart& part)

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.h
@@ -43,11 +43,16 @@ public:
 
 protected:
     static bool userPrefersContrast();
+    static FloatRect inflatedRect(const FloatRect& bounds, const FloatSize&, const IntOutsets&, const ControlStyle&);
 
     virtual IntSize cellSize(NSControlSize, const ControlStyle&) const { return { }; };
     virtual IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const { return { }; };
 
-    NSControlSize calculateControlSize(const FloatSize&, const ControlStyle&) const;
+    NSControlSize controlSizeForFont(const ControlStyle&) const;
+    NSControlSize controlSizeForSystemFont(const ControlStyle&) const;
+    NSControlSize controlSizeForSize(const FloatSize&, const ControlStyle&) const;
+
+    IntSize sizeForSystemFont(const ControlStyle&) const;
 
     void setFocusRingClipRect(const FloatRect& clipBounds) override;
 

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
@@ -31,6 +31,8 @@
 
 namespace WebCore {
 
+class MeterPart;
+
 class MeterMac : public ControlMac {
 public:
     MeterMac(MeterPart& owningMeterPart, ControlFactoryMac&, NSLevelIndicatorCell*);

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ControlMac.h"
+
+namespace WebCore {
+
+class ProgressBarPart;
+
+class ProgressBarMac : public ControlMac {
+public:
+    ProgressBarMac(ProgressBarPart&, ControlFactoryMac&);
+
+private:
+    const ProgressBarPart& owningProgressBarPart() const { return downcast<ProgressBarPart>(m_owningPart); }
+
+    IntSize cellSize(NSControlSize, const ControlStyle&) const final;
+    IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const final;
+
+    FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const override;
+
+    void draw(GraphicsContext&, const FloatRect&, float deviceScaleFactor, const ControlStyle&) override;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ProgressBarMac.h"
+
+#if PLATFORM(MAC)
+
+#import "GraphicsContext.h"
+#import "LocalDefaultSystemAppearance.h"
+#import "ProgressBarPart.h"
+
+namespace WebCore {
+
+ProgressBarMac::ProgressBarMac(ProgressBarPart& owningPart, ControlFactoryMac& controlFactory)
+    : ControlMac(owningPart, controlFactory)
+{
+}
+
+IntSize ProgressBarMac::cellSize(NSControlSize controlSize, const ControlStyle&) const
+{
+    static const std::array<IntSize, 4> sizes =
+    {
+        IntSize(0, 20),
+        IntSize(0, 12),
+        IntSize(0, 12),
+        IntSize(0, 20)
+    };
+    return sizes[controlSize];
+}
+
+IntOutsets ProgressBarMac::cellOutsets(NSControlSize controlSize, const ControlStyle&) const
+{
+    static const IntOutsets cellOutsets[] = {
+        // top right bottom left
+        { 0, 0, 1, 0 },
+        { 0, 0, 1, 0 },
+        { 0, 0, 1, 0 },
+        { 0, 0, 1, 0 },
+    };
+    return cellOutsets[controlSize];
+}
+
+FloatRect ProgressBarMac::rectForBounds(const FloatRect& bounds, const ControlStyle& style) const
+{
+    int minimumProgressBarHeight = sizeForSystemFont(style).height();
+    if (bounds.height() > minimumProgressBarHeight)
+        return bounds;
+
+    auto controlSize = controlSizeForFont(style);
+    auto size = cellSize(controlSize, style);
+    auto outsets = cellOutsets(controlSize, style);
+
+    size.scale(style.zoomFactor);
+    size.setWidth(bounds.width());
+
+    // Make enough room for the shadow.
+    return inflatedRect(bounds, size, outsets, style);
+}
+
+void ProgressBarMac::draw(GraphicsContext& context, const FloatRect& rect, float deviceScaleFactor, const ControlStyle& style)
+{
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+
+    auto inflatedRect = rectForBounds(rect, style);
+    auto imageBuffer = context.createImageBuffer(inflatedRect.size(), deviceScaleFactor);
+    if (!imageBuffer)
+        return;
+
+    ContextContainer cgContextContainer(imageBuffer->context());
+    CGContextRef cgContext = cgContextContainer.context();
+
+    auto& progressBarPart = owningProgressBarPart();
+    auto controlSize = controlSizeForFont(style);
+    bool isIndeterminate = progressBarPart.position() < 0;
+    bool isActive = style.states.contains(ControlStyle::State::WindowActive);
+
+    auto coreUISizeForProgressBarSize = [](NSControlSize size) -> CFStringRef {
+        switch (size) {
+        case NSControlSizeMini:
+        case NSControlSizeSmall:
+            return kCUISizeSmall;
+        case NSControlSizeRegular:
+        case NSControlSizeLarge:
+            return kCUISizeRegular;
+        }
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    };
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    [[NSAppearance currentAppearance] _drawInRect:NSMakeRect(0, 0, inflatedRect.width(), inflatedRect.height()) context:cgContext options:@{
+    ALLOW_DEPRECATED_DECLARATIONS_END
+        (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)(isIndeterminate ? kCUIWidgetProgressIndeterminateBar : kCUIWidgetProgressBar),
+        (__bridge NSString *)kCUIValueKey: @(isIndeterminate ? 1 : std::min(nextafter(1.0, -1), progressBarPart.position())),
+        (__bridge NSString *)kCUISizeKey: (__bridge NSString *)coreUISizeForProgressBarSize(controlSize),
+        (__bridge NSString *)kCUIUserInterfaceLayoutDirectionKey: (__bridge NSString *)kCUIUserInterfaceLayoutDirectionLeftToRight,
+        (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
+        (__bridge NSString *)kCUIPresentationStateKey: (__bridge NSString *)(isActive ? kCUIPresentationStateActiveKey : kCUIPresentationStateInactive),
+        (__bridge NSString *)kCUIOrientationKey: (__bridge NSString *)kCUIOrientHorizontal,
+        (__bridge NSString *)kCUIAnimationStartTimeKey: @(progressBarPart.animationStartTime().seconds()),
+        (__bridge NSString *)kCUIAnimationTimeKey: @(MonotonicTime::now().secondsSinceEpoch().seconds())
+    }];
+
+    GraphicsContextStateSaver stateSaver(context);
+
+    if (style.states.contains(ControlStyle::State::RightToLeft)) {
+        context.translate(2 * inflatedRect.x() + inflatedRect.width(), 0);
+        context.scale(FloatSize(-1, 1));
+    }
+
+    context.drawConsumingImageBuffer(WTFMove(imageBuffer), inflatedRect.location());
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h
@@ -31,6 +31,8 @@
 
 namespace WebCore {
 
+class TextFieldPart;
+
 class TextFieldMac final : public ControlMac {
 public:
     TextFieldMac(TextFieldPart& owningPart, ControlFactoryMac&, NSTextFieldCell *);

--- a/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h
@@ -28,9 +28,10 @@
 #if PLATFORM(MAC)
 
 #import "ButtonControlMac.h"
-#import "ToggleButtonPart.h"
 
 namespace WebCore {
+
+class ToggleButtonPart;
 
 class ToggleButtonMac final : public ButtonControlMac {
 public:

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -47,7 +47,9 @@
 #include "MeterPart.h"
 #include "Page.h"
 #include "PaintInfo.h"
+#include "ProgressBarPart.h"
 #include "RenderMeter.h"
+#include "RenderProgress.h"
 #include "RenderStyle.h"
 #include "RenderView.h"
 #include "ShadowPseudoIds.h"
@@ -483,6 +485,13 @@ static RefPtr<ControlPart> createMeterPartForRenderer(const RenderObject& render
     return MeterPart::create(gaugeRegion, element->value(), element->min(), element->max());
 }
 
+static RefPtr<ControlPart> createProgressBarPartForRenderer(const RenderObject& renderer)
+{
+    ASSERT(is<RenderProgress>(renderer));
+    const auto& renderProgress = downcast<RenderProgress>(renderer);
+    return ProgressBarPart::create(renderProgress.position(), renderProgress.animationStartTime().secondsSinceEpoch());
+}
+
 RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer) const
 {
     ControlPartType type = renderer.style().effectiveAppearance();
@@ -508,6 +517,8 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
         return createMeterPartForRenderer(renderer);
 
     case ControlPartType::ProgressBar:
+        return createProgressBarPartForRenderer(renderer);
+
     case ControlPartType::SliderHorizontal:
     case ControlPartType::SliderVertical:
     case ControlPartType::SearchField:
@@ -572,8 +583,8 @@ OptionSet<ControlStyle::State> RenderTheme::extractControlStyleStatesForRenderer
         states.add(ControlStyle::State::Checked);
     if (isDefault(renderer))
         states.add(ControlStyle::State::Default);
-    if (!isActive(renderer))
-        states.add(ControlStyle::State::WindowInactive);
+    if (isActive(renderer))
+        states.add(ControlStyle::State::WindowActive);
     if (isIndeterminate(renderer))
         states.add(ControlStyle::State::Indeterminate);
     if (isPresenting(renderer))
@@ -1458,7 +1469,7 @@ void RenderTheme::adjustProgressBarStyle(RenderStyle&, const Element*) const
 {
 }
 
-IntRect RenderTheme::progressBarRectForBounds(const RenderObject&, const IntRect& bounds) const
+IntRect RenderTheme::progressBarRectForBounds(const RenderProgress&, const IntRect& bounds) const
 {
     return bounds;
 }

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -213,7 +213,7 @@ public:
     virtual Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const;
     // Returns the duration of the animation for the progress bar.
     virtual Seconds animationDurationForProgressBar(const RenderProgress&) const;
-    virtual IntRect progressBarRectForBounds(const RenderObject&, const IntRect&) const;
+    virtual IntRect progressBarRectForBounds(const RenderProgress&, const IntRect&) const;
 
     virtual FloatSize meterSizeForBounds(const RenderMeter&, const FloatRect&) const;
     virtual bool supportsMeter(ControlPartType, const HTMLMeterElement&) const;

--- a/Source/WebCore/rendering/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/RenderThemeAdwaita.cpp
@@ -466,7 +466,7 @@ Seconds RenderThemeAdwaita::animationDurationForProgressBar(const RenderProgress
     return progressAnimationFrameRate * progressAnimationFrameCount;
 }
 
-IntRect RenderThemeAdwaita::progressBarRectForBounds(const RenderObject&, const IntRect& bounds) const
+IntRect RenderThemeAdwaita::progressBarRectForBounds(const RenderProgress&, const IntRect& bounds) const
 {
     return { bounds.x(), bounds.y(), bounds.width(), progressBarSize };
 }

--- a/Source/WebCore/rendering/RenderThemeAdwaita.h
+++ b/Source/WebCore/rendering/RenderThemeAdwaita.h
@@ -85,7 +85,7 @@ private:
 
     Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const final;
     Seconds animationDurationForProgressBar(const RenderProgress&) const final;
-    IntRect progressBarRectForBounds(const RenderObject&, const IntRect&) const final;
+    IntRect progressBarRectForBounds(const RenderProgress&, const IntRect&) const final;
     bool paintProgressBar(const RenderObject&, const PaintInfo&, const IntRect&) final;
 
     bool paintSliderTrack(const RenderObject&, const PaintInfo&, const IntRect&) final;

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -88,7 +88,7 @@ public:
 
     // Returns the repeat interval of the animation for the progress bar.
     Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const final;
-    IntRect progressBarRectForBounds(const RenderObject&, const IntRect&) const final;
+    IntRect progressBarRectForBounds(const RenderProgress&, const IntRect&) const final;
 
     // Controls color values returned from platformFocusRingColor(). systemColor() will be used when false.
     bool usesTestModeFocusRingColor() const;
@@ -118,7 +118,6 @@ private:
     void adjustMenuListButtonStyle(RenderStyle&, const Element*) const final;
 
     void adjustProgressBarStyle(RenderStyle&, const Element*) const final;
-    bool paintProgressBar(const RenderObject&, const PaintInfo&, const IntRect&) final;
 
     bool paintSliderTrack(const RenderObject&, const PaintInfo&, const IntRect&) final;
     void adjustSliderTrackStyle(RenderStyle&, const Element*) const final;
@@ -200,10 +199,6 @@ private:
     NSCell *listButton() const;
 #endif
 
-    int minimumProgressBarHeight(const RenderStyle&) const;
-    const IntSize* progressBarSizes() const;
-    const int* progressBarMargins(NSControlSize) const;
-    
 #if ENABLE(SERVICE_CONTROLS)
     bool paintImageControlsButton(const RenderObject&, const PaintInfo&, const IntRect&) final;
     IntSize imageControlsButtonSize() const final;

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -30,7 +30,7 @@ class WTF::URL {
     uint8_t timeFlags()
 }
 
-class WTF::Seconds {
+[AdditionalEncoder=StreamConnectionEncoder] class WTF::Seconds {
     double value()
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -80,6 +80,7 @@
 #include <WebCore/Pasteboard.h>
 #include <WebCore/PerspectiveTransformOperation.h>
 #include <WebCore/PluginData.h>
+#include <WebCore/ProgressBarPart.h>
 #include <WebCore/PromisedAttachmentInfo.h>
 #include <WebCore/ProtectionSpace.h>
 #include <WebCore/RectEdges.h>
@@ -1547,6 +1548,9 @@ void ArgumentCoder<ControlPart>::encode(Encoder& encoder, const ControlPart& par
         break;
 
     case WebCore::ControlPartType::ProgressBar:
+        encoder << downcast<WebCore::ProgressBarPart>(part);
+        break;
+
     case WebCore::ControlPartType::SliderHorizontal:
     case WebCore::ControlPartType::SliderVertical:
     case WebCore::ControlPartType::SearchField:
@@ -1617,7 +1621,14 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
         break;
     }
 
-    case WebCore::ControlPartType::ProgressBar:
+    case WebCore::ControlPartType::ProgressBar: {
+        std::optional<Ref<WebCore::ProgressBarPart>> progressBarPart;
+        decoder >> progressBarPart;
+        if (progressBarPart)
+            return WTFMove(*progressBarPart);
+        break;
+    }
+
     case WebCore::ControlPartType::SliderHorizontal:
     case WebCore::ControlPartType::SliderVertical:
     case WebCore::ControlPartType::SearchField:

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2346,7 +2346,7 @@ enum class WebCore::FetchHeadersGuard : uint8_t {
     Enabled,
     Checked,
     Default,
-    WindowInactive,
+    WindowActive,
     Indeterminate,
     SpinUp,
     Presenting,
@@ -2424,6 +2424,11 @@ enum class WebCore::ControlPartType : uint8_t {
     double maximum();
 };
 
+[Return=Ref, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ProgressBarPart {
+    double position();
+    Seconds animationStartTime();
+};
+
 enum class WebCore::HasInsecureContent : bool
 
 header: <WebCore/ModalContainerTypes.h>
@@ -2439,4 +2444,3 @@ header: <WebCore/ModalContainerTypes.h>
     PlaybackWasPrevented,
     MediaIsMainContent,
 };
-


### PR DESCRIPTION
#### 1674cd025bc6a390cb98dbe576137d3b4a24f873
<pre>
[GPU Process] [FormControls] Add a ControlPart for ProgressBar
<a href="https://bugs.webkit.org/show_bug.cgi?id=249675">https://bugs.webkit.org/show_bug.cgi?id=249675</a>
rdar://103569550

Reviewed by Aditya Keerthi.

The ProgressBarPart will handle drawing the progress bar form control. On macOS,
AppKit will be used to draw the platform control through the class ProgressBarMac.

ProgressBarPart will hold the attributes: &apos;position&apos; and &apos;animationStartTime&apos; which
control the display of the progress bar.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/ControlPart.cpp:
(WebCore::ControlPart::rectForBounds):
* Source/WebCore/platform/graphics/controls/ControlPart.h:
* Source/WebCore/platform/graphics/controls/ControlStyle.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/controls/ControlStyle.h:
* Source/WebCore/platform/graphics/controls/PlatformControl.h:
(WebCore::PlatformControl::rectForBounds const):
* Source/WebCore/platform/graphics/controls/ProgressBarPart.cpp: Copied from Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h.(WebCore::ProgressBarPart::create):
(WebCore::ProgressBarPart::ProgressBarPart):
(WebCore::ProgressBarPart::createPlatformControl):
* Source/WebCore/platform/graphics/controls/ProgressBarPart.h: Copied from Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h.
(WebCore::ProgressBarPart::position const):
(WebCore::ProgressBarPart::animationStartTime const):
* Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm:
(WebCore::ButtonControlMac::updateCellStates):
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::createPlatformProgressBar):
* Source/WebCore/platform/graphics/mac/controls/ControlMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::ControlMac::inflatedRect):
(WebCore::ControlMac::controlSizeForFont const):
(WebCore::ControlMac::controlSizeForSystemFont const):
(WebCore::ControlMac::controlSizeForSize const):
(WebCore::ControlMac::sizeForSystemFont const):
(WebCore::ControlMac::setFocusRingClipRect):
(WebCore::ControlMac::updateCellStates):
(WebCore::ControlMac::calculateControlSize const): Deleted.
* Source/WebCore/platform/graphics/mac/controls/MeterMac.h:
* Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h: Copied from Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h.
(WebCore::ProgressBarMac::owningProgressBarPart const):
* Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm: Added.
(WebCore::ProgressBarMac::ProgressBarMac):
(WebCore::ProgressBarMac::cellSize const):
(WebCore::ProgressBarMac::cellOutsets const):
(WebCore::ProgressBarMac::rectForBounds const):
(WebCore::ProgressBarMac::draw):
* Source/WebCore/platform/graphics/mac/controls/TextFieldMac.h:
* Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::createProgressBarPartForRenderer):
(WebCore::RenderTheme::createControlPart const):
(WebCore::RenderTheme::extractControlStyleStatesForRenderer const):
(WebCore::RenderTheme::progressBarRectForBounds const):
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::progressBarRectForBounds const):
* Source/WebCore/rendering/RenderThemeAdwaita.h:
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
(WebCore::RenderThemeMac::progressBarRectForBounds const):
(-[WebCoreTextFieldCell _adjustedCoreUIDrawOptionsForDrawingBordersOnly:]): Deleted.
(-[WebCoreTextFieldCell _coreUIDrawOptionsWithFrame:inView:includeFocus:]): Deleted.
(-[WebCoreTextFieldCell _coreUIDrawOptionsWithFrame:inView:includeFocus:maskOnly:]): Deleted.
(WebCore::RenderThemeMac::progressBarSizes const): Deleted.
(WebCore::RenderThemeMac::progressBarMargins const): Deleted.
(WebCore::RenderThemeMac::minimumProgressBarHeight const): Deleted.
(WebCore::RenderThemeMac::paintProgressBar): Deleted.
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::encode):
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/258408@main">https://commits.webkit.org/258408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a75f529ff23e243bbdad2dbdf742caf1fa84fba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111201 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1929 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/108958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107646 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23853 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25339 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4687 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/10767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44826 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5763 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6439 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->