### PR TITLE
Add some network connection integrity testing support

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -124,6 +124,8 @@ struct WKAppPrivacyReportTestingData {
 
 - (void)_setConnectedToHardwareConsoleForTesting:(BOOL)connected;
 
++ (void)_setLookalikeCharacterStringsForTesting:(NSArray<NSString *> *)strings;
+
 @end
 
 typedef NS_ENUM(NSInteger, _WKMediaSessionReadyState) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -471,6 +471,17 @@
 #endif
 }
 
++ (void)_setLookalikeCharacterStringsForTesting:(NSArray<NSString *> *)strings
+{
+    // FIXME: Remove this method and simply swizzle out the appropriate platform API, once we're able to
+    // call into the API from within the application process.
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+    WebKit::WebPageProxy::cachedLookalikeStrings() = makeVector<String>(strings);
+#else
+    UNUSED_PARAM(strings);
+#endif
+}
+
 - (void)_createMediaSessionCoordinatorForTesting:(id <_WKMediaSessionCoordinator>)privateCoordinator completionHandler:(void(^)(BOOL))completionHandler
 {
 #if ENABLE(MEDIA_SESSION_COORDINATOR)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2096,6 +2096,10 @@ public:
     void createMediaSessionCoordinator(Ref<MediaSessionCoordinatorProxyPrivate>&&, CompletionHandler<void(bool)>&&);
 #endif
 
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+    static Vector<String>& cachedLookalikeStrings();
+#endif
+
     bool lastNavigationWasAppInitiated() const { return m_lastNavigationWasAppInitiated; }
 
 #if PLATFORM(COCOA)
@@ -2715,7 +2719,6 @@ private:
 #endif
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
-    static Vector<String>& cachedLookalikeStrings();
     void updateLookalikeCharacterStringsIfNeeded();
 #endif
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1180,6 +1180,7 @@
 		F4A2E64F28455D3A0001FEEF /* open-in-new-tab.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A2E64E28455D230001FEEF /* open-in-new-tab.html */; };
 		F4A32EC41F05F3850047C544 /* dragstart-change-selection-offscreen.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A32EC31F05F3780047C544 /* dragstart-change-selection-offscreen.html */; };
 		F4A32ECB1F0643370047C544 /* contenteditable-in-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A32ECA1F0642F40047C544 /* contenteditable-in-iframe.html */; };
+		F4A715A82950C8D900B4D0D6 /* NetworkConnectionIntegrityTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4A715A72950C8D900B4D0D6 /* NetworkConnectionIntegrityTests.mm */; };
 		F4A7CE782662D6E800228685 /* TouchEventTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4A7CE772662D6E800228685 /* TouchEventTests.mm */; };
 		F4A7CE7A2662D86C00228685 /* active-touch-events.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A7CE792662D83E00228685 /* active-touch-events.html */; };
 		F4A9202F1FEE34E900F59590 /* apple-data-url.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4A9202E1FEE34C800F59590 /* apple-data-url.html */; };
@@ -3438,6 +3439,7 @@
 		F4A2E64E28455D230001FEEF /* open-in-new-tab.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "open-in-new-tab.html"; sourceTree = "<group>"; };
 		F4A32EC31F05F3780047C544 /* dragstart-change-selection-offscreen.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "dragstart-change-selection-offscreen.html"; sourceTree = "<group>"; };
 		F4A32ECA1F0642F40047C544 /* contenteditable-in-iframe.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "contenteditable-in-iframe.html"; sourceTree = "<group>"; };
+		F4A715A72950C8D900B4D0D6 /* NetworkConnectionIntegrityTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkConnectionIntegrityTests.mm; sourceTree = "<group>"; };
 		F4A7CE772662D6E800228685 /* TouchEventTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TouchEventTests.mm; sourceTree = "<group>"; };
 		F4A7CE792662D83E00228685 /* active-touch-events.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "active-touch-events.html"; sourceTree = "<group>"; };
 		F4A9202E1FEE34C800F59590 /* apple-data-url.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "apple-data-url.html"; sourceTree = "<group>"; };
@@ -3741,6 +3743,7 @@
 				F460F656261116EA0064F2B6 /* InjectedBundleHitTest.mm */,
 				E35B908123F60DD0000011FF /* LocalizedDeviceModel.mm */,
 				1CF087D725ED7F73004148CB /* MobileAssetSandboxCheck.mm */,
+				F4A715A72950C8D900B4D0D6 /* NetworkConnectionIntegrityTests.mm */,
 				C104BC1E2547237100C078C9 /* OverrideAppleLanguagesPreference.mm */,
 				E325C90623E3870200BC7D3B /* PictureInPictureSupport.mm */,
 				C15CBB3E23FB177A00300CC7 /* PreferenceChanges.mm */,
@@ -6345,6 +6348,7 @@
 				7C83E0B61D0A64B300FEBCF3 /* ModalAlertsSPI.cpp in Sources */,
 				7CCE7F011A411AE600447C4C /* MouseMoveAfterCrash.cpp in Sources */,
 				F4010B8024DA24AC00A876E2 /* NavigationSwipeTests.mm in Sources */,
+				F4A715A82950C8D900B4D0D6 /* NetworkConnectionIntegrityTests.mm in Sources */,
 				9B19CDA01F06DFE3000548DD /* NetworkProcessCrashWithPendingConnection.mm in Sources */,
 				7CCE7F021A411AE600447C4C /* NewFirstVisuallyNonEmptyLayout.cpp in Sources */,
 				7CCE7F031A411AE600447C4C /* NewFirstVisuallyNonEmptyLayoutFails.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/NetworkConnectionIntegrityTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/NetworkConnectionIntegrityTests.mm
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/NetworkConnectionIntegrityTestsAdditions.mm>)
+#import <WebKitAdditions/NetworkConnectionIntegrityTestsAdditions.mm>
+#endif


### PR DESCRIPTION
#### 453e83b1e53fb91bb95f5ca7f20855b68c2f1be1
<pre>
Add some network connection integrity testing support
<a href="https://bugs.webkit.org/show_bug.cgi?id=249651">https://bugs.webkit.org/show_bug.cgi?id=249651</a>

Reviewed by Aditya Keerthi.

Add support for API tests for lookalike character sanitization.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:

Leave a FIXME here, explaining that this testing hook can be removed once the API calls into the
associated system framework can happen directly in the UI process, without having to go through the
network process.

(+[WKWebView _setLookalikeCharacterStringsForTesting:]):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/NetworkConnectionIntegrityTests.mm: Added.

Add a WebKitAdditions extension point, which will contain the new API tests.

Canonical link: <a href="https://commits.webkit.org/258192@main">https://commits.webkit.org/258192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4ae6e0bd7137fb07db2309e0b6f4c9e204ea590

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110407 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170657 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1140 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93517 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108237 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35076 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23135 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78070 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3919 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24652 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1064 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44160 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5629 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5719 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->