### PR TITLE
Route the rest of the WebNavigation events from WebFrameLoaderClient to the extension event listeners.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -123,6 +123,9 @@ private:
 
     // MARK: webNavigation support.
     void didStartProvisionalLoadForFrame(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL targetURL);
+    void didCommitLoadForFrame(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
+    void didFinishLoadForFrame(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
+    void didFailLoadForFrame(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
 
     Ref<WebExtensionControllerConfiguration> m_configuration;
     WebExtensionControllerIdentifier m_identifier;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
@@ -29,6 +29,9 @@ messages -> WebExtensionController {
 
     // webNavigation support.
     DidStartProvisionalLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
+    DidCommitLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
+    DidFinishLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
+    DidFailLoadForFrame(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
 
 }
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -59,6 +59,70 @@ void WebExtensionContextProxy::dispatchWebNavigationOnBeforeNavigateEvent(WebPag
     });
 }
 
+void WebExtensionContextProxy::dispatchWebNavigationOnCommittedEvent(WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL frameURL)
+{
+    NSDictionary *navigationDetails = @{
+        @"url": [(NSURL *)frameURL absoluteString],
+
+        // FIXME: We should be passing more arguments here and these arguments should have the correct values.
+        @"tabId": @(pageID.toUInt64()),
+        @"frameId": @(frameID.object().toUInt64())
+    };
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        auto& webNavigationObject = namespaceObject.webNavigation();
+        webNavigationObject.onCommitted().invokeListenersWithArgument(navigationDetails, frameURL);
+    });
+}
+
+void WebExtensionContextProxy::dispatchWebNavigationOnDOMContentLoadedEvent(WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL frameURL)
+{
+    NSDictionary *navigationDetails = @{
+        @"url": [(NSURL *)frameURL absoluteString],
+
+        // FIXME: We should be passing more arguments here and these arguments should have the correct values.
+        @"tabId": @(pageID.toUInt64()),
+        @"frameId": @(frameID.object().toUInt64())
+    };
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        auto& webNavigationObject = namespaceObject.webNavigation();
+        webNavigationObject.onDOMContentLoaded().invokeListenersWithArgument(navigationDetails, frameURL);
+    });
+}
+
+void WebExtensionContextProxy::dispatchWebNavigationOnCompletedEvent(WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL frameURL)
+{
+    NSDictionary *navigationDetails = @{
+        @"url": [(NSURL *)frameURL absoluteString],
+
+        // FIXME: We should be passing more arguments here and these arguments should have the correct values.
+        @"tabId": @(pageID.toUInt64()),
+        @"frameId": @(frameID.object().toUInt64())
+    };
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        auto& webNavigationObject = namespaceObject.webNavigation();
+        webNavigationObject.onCompleted().invokeListenersWithArgument(navigationDetails, frameURL);
+    });
+}
+
+void WebExtensionContextProxy::dispatchWebNavigationOnErrorOccurredEvent(WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL frameURL)
+{
+    NSDictionary *navigationDetails = @{
+        @"url": [(NSURL *)frameURL absoluteString],
+
+        // FIXME: We should be passing more arguments here and these arguments should have the correct values.
+        @"tabId": @(pageID.toUInt64()),
+        @"frameId": @(frameID.object().toUInt64())
+    };
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        auto& webNavigationObject = namespaceObject.webNavigation();
+        webNavigationObject.onErrorOccurred().invokeListenersWithArgument(navigationDetails, frameURL);
+    });
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
@@ -102,9 +102,26 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
     JSObjectSetProperty(context, globalObject, toJSString("chrome").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
 }
 
+// MARK: webNavigation support
+
 void WebExtensionControllerProxy::didStartProvisionalLoadForFrame(WebPage& page, WebFrame& frame, const URL& url)
 {
     WebProcess::singleton().send(Messages::WebExtensionController::DidStartProvisionalLoadForFrame(page.webPageProxyIdentifier(), frame.frameID(), url), identifier());
+}
+
+void WebExtensionControllerProxy::didCommitLoadForFrame(WebPage& page, WebFrame& frame, const URL& url)
+{
+    WebProcess::singleton().send(Messages::WebExtensionController::DidCommitLoadForFrame(page.webPageProxyIdentifier(), frame.frameID(), url), identifier());
+}
+
+void WebExtensionControllerProxy::didFinishLoadForFrame(WebPage& page, WebFrame& frame, const URL& url)
+{
+    WebProcess::singleton().send(Messages::WebExtensionController::DidFinishLoadForFrame(page.webPageProxyIdentifier(), frame.frameID(), url), identifier());
+}
+
+void WebExtensionControllerProxy::didFailLoadForFrame(WebPage& page, WebFrame& frame, const URL& url)
+{
+    WebProcess::singleton().send(Messages::WebExtensionController::DidFailLoadForFrame(page.webPageProxyIdentifier(), frame.frameID(), url), identifier());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -81,6 +81,10 @@ private:
 
     // webNavigation support
     void dispatchWebNavigationOnBeforeNavigateEvent(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
+    void dispatchWebNavigationOnCommittedEvent(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
+    void dispatchWebNavigationOnDOMContentLoadedEvent(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
+    void dispatchWebNavigationOnCompletedEvent(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
+    void dispatchWebNavigationOnErrorOccurredEvent(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
 
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -29,6 +29,10 @@ messages -> WebExtensionContextProxy {
 
     // webNavigation support
     DispatchWebNavigationOnBeforeNavigateEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
+    DispatchWebNavigationOnCommittedEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
+    DispatchWebNavigationOnDOMContentLoadedEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
+    DispatchWebNavigationOnCompletedEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
+    DispatchWebNavigationOnErrorOccurredEvent(WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
 
 }
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -66,6 +66,10 @@ public:
 
     // webNavigation support.
     void didStartProvisionalLoadForFrame(WebPage&, WebFrame&, const URL&);
+    void didCommitLoadForFrame(WebPage&, WebFrame&, const URL&);
+    void didFinishLoadForFrame(WebPage&, WebFrame&, const URL&);
+    // FIXME: Include the error here.
+    void didFailLoadForFrame(WebPage&, WebFrame&, const URL&);
 #endif
 
 private:

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -600,6 +600,12 @@ void WebFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureConten
     });
     hasInsecureContent = hasInsecureContent ? *hasInsecureContent : (certificateInfo.containsNonRootSHA1SignedCertificate() ? HasInsecureContent::Yes : HasInsecureContent::No);
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+    // Notify the extensions controller.
+    if (auto* extensionControllerProxy = webPage->webExtensionControllerProxy())
+        extensionControllerProxy->didCommitLoadForFrame(*webPage, m_frame, m_frame->url());
+#endif
+
     // Notify the UIProcess.
     webPage->send(Messages::WebPageProxy::DidCommitLoadForFrame(m_frame->frameID(), m_frame->info(), documentLoader.request(), documentLoader.navigationID(), documentLoader.response().mimeType(), m_frameHasCustomContentProvider, m_frame->coreFrame()->loader().loadType(), certificateInfo, usedLegacyTLS, wasPrivateRelayed, m_frame->coreFrame()->document()->isPluginDocument(), *hasInsecureContent, documentLoader.mouseEventPolicy(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
     webPage->didCommitLoad(m_frame.ptr());
@@ -666,6 +672,12 @@ void WebFrameLoaderClient::dispatchDidFailLoad(const ResourceError& error)
     // Notify the bundle client.
     webPage->injectedBundleLoaderClient().didFailLoadWithErrorForFrame(*webPage, m_frame, error, userData);
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+    // Notify the extensions controller.
+    if (auto* extensionControllerProxy = webPage->webExtensionControllerProxy())
+        extensionControllerProxy->didFailLoadForFrame(*webPage, m_frame, m_frame->url());
+#endif
+
     // Notify the UIProcess.
     webPage->send(Messages::WebPageProxy::DidFailLoadForFrame(m_frame->frameID(), m_frame->info(), documentLoader.request(), navigationID, error, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
 
@@ -706,6 +718,12 @@ void WebFrameLoaderClient::dispatchDidFinishLoad()
 
     // Notify the bundle client.
     webPage->injectedBundleLoaderClient().didFinishLoadForFrame(*webPage, m_frame, userData);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    // Notify the extensions controller.
+    if (auto* extensionControllerProxy = webPage->webExtensionControllerProxy())
+        extensionControllerProxy->didFinishLoadForFrame(*webPage, m_frame, m_frame->url());
+#endif
 
     // Notify the UIProcess.
     webPage->send(Messages::WebPageProxy::DidFinishLoadForFrame(m_frame->frameID(), m_frame->info(), documentLoader->request(), navigationID, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));


### PR DESCRIPTION
#### d2610dc0dedb035d810463243743ee6c12136d2e
<pre>
Route the rest of the WebNavigation events from WebFrameLoaderClient to the extension event listeners.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249683">https://bugs.webkit.org/show_bug.cgi?id=249683</a>
rdar://102820594

Reviewed by Timothy Hatcher.

This patch allows WebFrameLoaderClient to tell web extensions code about the various stages of frame loading.

The flow is:
- WebFrameLoaderClient sends a message to the WebExtensionController using IPC.
- WebExtensionController iterates over all the WebExtensionContexts and:
        - Sends a message to their WebExtensionContextProxy using IPC.

WebFrameLoaderClient::dispatchDidCommitLoad -&gt; onCommitted and onDOMContentLoaded
WebFrameLoaderClient::dispatchDidFinishLoad -&gt; onCompleted
WebFrameLoaderClient::dispatchDidFailLoad -&gt; onErrorOccurred

And then the WebExtensionContextProxy will fire the event on the extension pages that listen to it.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::didCommitLoadForFrame): Call into the WebExtensionContextProxy.
(WebKit::WebExtensionController::didFinishLoadForFrame): Ditto.
(WebKit::WebExtensionController::didFailLoadForFrame): Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in:
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::dispatchWebNavigationOnCommittedEvent): Iterate the namespace objects and call the
relevant listeners.
(WebKit::WebExtensionContextProxy::dispatchWebNavigationOnDOMContentLoadedEvent): Ditto.
(WebKit::WebExtensionContextProxy::dispatchWebNavigationOnCompletedEvent): Ditto.
(WebKit::WebExtensionContextProxy::dispatchWebNavigationOnErrorOccurredEvent): Ditto.
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm:
(WebKit::WebExtensionControllerProxy::didCommitLoadForFrame): Send a message to the WebExtensionController in the UI process.
(WebKit::WebExtensionControllerProxy::didFinishLoadForFrame): Ditto.
(WebKit::WebExtensionControllerProxy::didFailLoadForFrame): Ditto.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDidCommitLoad): Call into WebExtensionControllerProxy.
(WebKit::WebFrameLoaderClient::dispatchDidFailLoad): Ditto.
(WebKit::WebFrameLoaderClient::dispatchDidFinishLoad): Ditto.

Canonical link: <a href="https://commits.webkit.org/258594@main">https://commits.webkit.org/258594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1754e635e337024375ba03af10a568ee57520d3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111715 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2473 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/109433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108214 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24354 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/5044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25777 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5196 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/2219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45270 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5897 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/6937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->