### PR TITLE
Prevent the WindowEventLoop tasks from running between trigger an rendering update and the end of that update

### DIFF
--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -54,6 +54,7 @@ public:
     CustomElementQueue& backupElementQueue();
 
     WEBCORE_EXPORT static void breakToAllowRenderingUpdate();
+    WEBCORE_EXPORT static void didCompleteRenderingUpdate();
 
 private:
     static Ref<WindowEventLoop> create(const String&);
@@ -82,6 +83,7 @@ private:
 
     std::unique_ptr<CustomElementQueue> m_customElementQueue;
     bool m_processingBackupElementQueue { false };
+    static bool s_renderingUpdateIsImminent;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -114,6 +114,7 @@ private:
     void addCommitHandlers();
     void updateRendering();
     void startRenderingUpdateTimer();
+    void updateRenderingTimerFired();
 
     WebCore::TiledBacking* mainFrameTiledBacking() const;
 

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -935,6 +935,7 @@ void TiledCoreAnimationDrawingArea::updateRenderingRunLoopCallback()
     tracePoint(RenderingUpdateRunLoopObserverEnd, 0);
 
     updateRendering();
+    WebCore::WindowEventLoop::didCompleteRenderingUpdate();
 }
 
 void TiledCoreAnimationDrawingArea::invalidateRenderingUpdateRunLoopObserver()


### PR DESCRIPTION
#### a0545feda59635239be83c1b71bba494c1a35eb8
<pre>
Prevent the WindowEventLoop tasks from running between trigger an rendering update and the end of that update
<a href="https://bugs.webkit.org/show_bug.cgi?id=249684">https://bugs.webkit.org/show_bug.cgi?id=249684</a>
rdar://103575958

Reviewed by NOBODY (OOPS!).

It&apos;s impossible to write non-flakey layout tests that involve async/await and requestAnimationFrame, because
their ordering depends on exactly when the Microtask that resumes the async function runs, and that&apos;s sensitive
to when the WindowEventLoop zero-delay timer fires.

Rendering updates are scheduled (generally at a 60Hz cadence) via display refresh callbacks, but each
one is then triggered from that callback via a CFRunLoopObserver in TiledCoreAnimationDrawingArea, and
a zero-delay timer in RemoteLayerTreeDrawingArea.

If the WindowEventLoop timer fires between scheduling the CFRunLoopObserver and it firing, then we get
a different ordering behavior, where an async function can resume with a different ordering relative to
requestAnimationFrame callbacks.

Fix by re-scheduling the WindowEventLoop timer if it fires between the `scheduleRenderingUpdateRunLoopObserver()`
and the `updateRenderingRunLoopCallback()` for TiledCoreAnimationDrawingArea.

RemoteLayerTreeDrawingArea uses timers, so this may not be as much of an issue there, but do the same thing for
consistency. Also, now that we&apos;re using RemoteLayerTreeDrawingArea on macOS with UI-side compositing, add the
call to `WindowEventLoop::breakToAllowRenderingUpdate()` there too.

* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::didReachTimeToRun):
(WebCore::WindowEventLoop::breakToAllowRenderingUpdate):
(WebCore::WindowEventLoop::didCompleteRenderingUpdate):
* Source/WebCore/dom/WindowEventLoop.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::RemoteLayerTreeDrawingArea):
(WebKit::RemoteLayerTreeDrawingArea::triggerRenderingUpdate):
(WebKit::RemoteLayerTreeDrawingArea::updateRenderingTimerFired):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::updateRenderingRunLoopCallback):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0545feda59635239be83c1b71bba494c1a35eb8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110412 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170662 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1145 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93522 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108242 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106903 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8527 "Found 60 new test failures: editing/selection/ios/change-selection-by-tapping.html, fast/canvas/image-pattern-rotate.html, fast/dom/frame-src-javascript-url-async.html, fast/events/ios/tab-cycle.html, fast/hidpi/image-set-units.html, fast/images/exif-orientation-image-object.html, fast/mediastream/media-stream-track-source-failure.html, fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html, http/tests/app-privacy-report/app-attribution-beacon-isnotappinitiated.html, http/tests/app-privacy-report/user-attribution-cors-preflight-redirect.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35082 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90421 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegateNavigateFragment (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78076 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3924 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24655 "Found 14 new test failures: fast/attachment/attachment-image-controls-basic.html, fast/dom/frame-src-javascript-url-async.html, fast/frames/out-of-document-iframe-has-child-frame.html, fast/loader/stateobjects/pushstate-with-fragment-urls-and-hashchange.html, http/tests/messaging/cross-domain-message-event-dispatch.html, http/tests/misc/object-image-load-outlives-gc-without-crashing.html, http/tests/navigation/lockedhistory-iframe.html, imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/event-order/same-document-traverse-immediate.html, imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/scroll-restoration-fragment-scrolling-samedoc.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/cloneNode.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3965 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1066 "Found 6 new test failures: fast/events/selectionchange-user-initiated.html, fast/frames/out-of-document-iframe-has-child-frame.html, fast/loader/stateobjects/pushstate-with-fragment-urls-and-hashchange.html, http/tests/messaging/cross-domain-message-event-dispatch.html, http/tests/navigation/lockedhistory-iframe.html, resize-observer/observe-element-from-other-frame.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44165 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5724 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->