### PR TITLE
[CSS-Typed-OM] StylePropertyMap.set() should throw when trying to set a number for a property which doesn't allow it

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt
@@ -26,7 +26,7 @@ PASS Setting 'background-size' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'background-size' to a flexible length: 0fr throws TypeError
 PASS Setting 'background-size' to a flexible length: 1fr throws TypeError
 PASS Setting 'background-size' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'background-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'background-size' to a number: 0 throws TypeError
 PASS Setting 'background-size' to a number: -3.14 throws TypeError
 PASS Setting 'background-size' to a number: 3.14 throws TypeError
 PASS Setting 'background-size' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt
@@ -25,7 +25,7 @@ PASS Setting 'baseline-shift' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'baseline-shift' to a flexible length: 0fr throws TypeError
 PASS Setting 'baseline-shift' to a flexible length: 1fr throws TypeError
 PASS Setting 'baseline-shift' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'baseline-shift' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'baseline-shift' to a number: 0 throws TypeError
 PASS Setting 'baseline-shift' to a number: -3.14 throws TypeError
 PASS Setting 'baseline-shift' to a number: 3.14 throws TypeError
 PASS Setting 'baseline-shift' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'block-size' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'block-size' to a flexible length: 0fr throws TypeError
 PASS Setting 'block-size' to a flexible length: 1fr throws TypeError
 PASS Setting 'block-size' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'block-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'block-size' to a number: 0 throws TypeError
 PASS Setting 'block-size' to a number: -3.14 throws TypeError
 PASS Setting 'block-size' to a number: 3.14 throws TypeError
 PASS Setting 'block-size' to a number: calc(2 + 3) throws TypeError
@@ -55,7 +55,7 @@ PASS Setting 'min-block-size' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'min-block-size' to a flexible length: 0fr throws TypeError
 PASS Setting 'min-block-size' to a flexible length: 1fr throws TypeError
 PASS Setting 'min-block-size' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'min-block-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'min-block-size' to a number: 0 throws TypeError
 PASS Setting 'min-block-size' to a number: -3.14 throws TypeError
 PASS Setting 'min-block-size' to a number: 3.14 throws TypeError
 PASS Setting 'min-block-size' to a number: calc(2 + 3) throws TypeError
@@ -87,7 +87,7 @@ PASS Setting 'max-block-size' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'max-block-size' to a flexible length: 0fr throws TypeError
 PASS Setting 'max-block-size' to a flexible length: 1fr throws TypeError
 PASS Setting 'max-block-size' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'max-block-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'max-block-size' to a number: 0 throws TypeError
 PASS Setting 'max-block-size' to a number: -3.14 throws TypeError
 PASS Setting 'max-block-size' to a number: 3.14 throws TypeError
 PASS Setting 'max-block-size' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt
@@ -23,7 +23,7 @@ PASS Setting 'border-top-left-radius' to an angle: calc(0rad + 0deg) throws Type
 PASS Setting 'border-top-left-radius' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-top-left-radius' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-top-left-radius' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-top-left-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-top-left-radius' to a number: 0 throws TypeError
 PASS Setting 'border-top-left-radius' to a number: -3.14 throws TypeError
 PASS Setting 'border-top-left-radius' to a number: 3.14 throws TypeError
 PASS Setting 'border-top-left-radius' to a number: calc(2 + 3) throws TypeError
@@ -54,7 +54,7 @@ PASS Setting 'border-top-right-radius' to an angle: calc(0rad + 0deg) throws Typ
 PASS Setting 'border-top-right-radius' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-top-right-radius' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-top-right-radius' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-top-right-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-top-right-radius' to a number: 0 throws TypeError
 PASS Setting 'border-top-right-radius' to a number: -3.14 throws TypeError
 PASS Setting 'border-top-right-radius' to a number: 3.14 throws TypeError
 PASS Setting 'border-top-right-radius' to a number: calc(2 + 3) throws TypeError
@@ -85,7 +85,7 @@ PASS Setting 'border-bottom-left-radius' to an angle: calc(0rad + 0deg) throws T
 PASS Setting 'border-bottom-left-radius' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-bottom-left-radius' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-bottom-left-radius' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-bottom-left-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-bottom-left-radius' to a number: 0 throws TypeError
 PASS Setting 'border-bottom-left-radius' to a number: -3.14 throws TypeError
 PASS Setting 'border-bottom-left-radius' to a number: 3.14 throws TypeError
 PASS Setting 'border-bottom-left-radius' to a number: calc(2 + 3) throws TypeError
@@ -116,7 +116,7 @@ PASS Setting 'border-bottom-right-radius' to an angle: calc(0rad + 0deg) throws 
 PASS Setting 'border-bottom-right-radius' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-bottom-right-radius' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-bottom-right-radius' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-bottom-right-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-bottom-right-radius' to a number: 0 throws TypeError
 PASS Setting 'border-bottom-right-radius' to a number: -3.14 throws TypeError
 PASS Setting 'border-bottom-right-radius' to a number: 3.14 throws TypeError
 PASS Setting 'border-bottom-right-radius' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt
@@ -26,7 +26,7 @@ PASS Setting 'border-top-width' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'border-top-width' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-top-width' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-top-width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-top-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-top-width' to a number: 0 throws TypeError
 PASS Setting 'border-top-width' to a number: -3.14 throws TypeError
 PASS Setting 'border-top-width' to a number: 3.14 throws TypeError
 PASS Setting 'border-top-width' to a number: calc(2 + 3) throws TypeError
@@ -60,7 +60,7 @@ PASS Setting 'border-left-width' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'border-left-width' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-left-width' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-left-width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-left-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-left-width' to a number: 0 throws TypeError
 PASS Setting 'border-left-width' to a number: -3.14 throws TypeError
 PASS Setting 'border-left-width' to a number: 3.14 throws TypeError
 PASS Setting 'border-left-width' to a number: calc(2 + 3) throws TypeError
@@ -94,7 +94,7 @@ PASS Setting 'border-right-width' to an angle: calc(0rad + 0deg) throws TypeErro
 PASS Setting 'border-right-width' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-right-width' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-right-width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-right-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-right-width' to a number: 0 throws TypeError
 PASS Setting 'border-right-width' to a number: -3.14 throws TypeError
 PASS Setting 'border-right-width' to a number: 3.14 throws TypeError
 PASS Setting 'border-right-width' to a number: calc(2 + 3) throws TypeError
@@ -128,7 +128,7 @@ PASS Setting 'border-bottom-width' to an angle: calc(0rad + 0deg) throws TypeErr
 PASS Setting 'border-bottom-width' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-bottom-width' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-bottom-width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-bottom-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-bottom-width' to a number: 0 throws TypeError
 PASS Setting 'border-bottom-width' to a number: -3.14 throws TypeError
 PASS Setting 'border-bottom-width' to a number: 3.14 throws TypeError
 PASS Setting 'border-bottom-width' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/bottom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/bottom-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'bottom' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'bottom' to a flexible length: 0fr throws TypeError
 PASS Setting 'bottom' to a flexible length: 1fr throws TypeError
 PASS Setting 'bottom' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'bottom' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'bottom' to a number: 0 throws TypeError
 PASS Setting 'bottom' to a number: -3.14 throws TypeError
 PASS Setting 'bottom' to a number: 3.14 throws TypeError
 PASS Setting 'bottom' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt
@@ -23,7 +23,7 @@ PASS Setting 'cx' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'cx' to a flexible length: 0fr throws TypeError
 PASS Setting 'cx' to a flexible length: 1fr throws TypeError
 PASS Setting 'cx' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'cx' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'cx' to a number: 0 throws TypeError
 PASS Setting 'cx' to a number: -3.14 throws TypeError
 PASS Setting 'cx' to a number: 3.14 throws TypeError
 PASS Setting 'cx' to a number: calc(2 + 3) throws TypeError
@@ -54,7 +54,7 @@ PASS Setting 'cy' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'cy' to a flexible length: 0fr throws TypeError
 PASS Setting 'cy' to a flexible length: 1fr throws TypeError
 PASS Setting 'cy' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'cy' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'cy' to a number: 0 throws TypeError
 PASS Setting 'cy' to a number: -3.14 throws TypeError
 PASS Setting 'cy' to a number: 3.14 throws TypeError
 PASS Setting 'cy' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt
@@ -26,7 +26,7 @@ PASS Setting 'column-rule-width' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'column-rule-width' to a flexible length: 0fr throws TypeError
 PASS Setting 'column-rule-width' to a flexible length: 1fr throws TypeError
 PASS Setting 'column-rule-width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'column-rule-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'column-rule-width' to a number: 0 throws TypeError
 PASS Setting 'column-rule-width' to a number: -3.14 throws TypeError
 PASS Setting 'column-rule-width' to a number: 3.14 throws TypeError
 PASS Setting 'column-rule-width' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'column-width' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'column-width' to a flexible length: 0fr throws TypeError
 PASS Setting 'column-width' to a flexible length: 1fr throws TypeError
 PASS Setting 'column-width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'column-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'column-width' to a number: 0 throws TypeError
 PASS Setting 'column-width' to a number: -3.14 throws TypeError
 PASS Setting 'column-width' to a number: 3.14 throws TypeError
 PASS Setting 'column-width' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt
@@ -23,7 +23,7 @@ PASS Setting 'x' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'x' to a flexible length: 0fr throws TypeError
 PASS Setting 'x' to a flexible length: 1fr throws TypeError
 PASS Setting 'x' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'x' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'x' to a number: 0 throws TypeError
 PASS Setting 'x' to a number: -3.14 throws TypeError
 PASS Setting 'x' to a number: 3.14 throws TypeError
 PASS Setting 'x' to a number: calc(2 + 3) throws TypeError
@@ -54,7 +54,7 @@ PASS Setting 'y' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'y' to a flexible length: 0fr throws TypeError
 PASS Setting 'y' to a flexible length: 1fr throws TypeError
 PASS Setting 'y' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'y' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'y' to a number: 0 throws TypeError
 PASS Setting 'y' to a number: -3.14 throws TypeError
 PASS Setting 'y' to a number: 3.14 throws TypeError
 PASS Setting 'y' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt
@@ -28,7 +28,7 @@ PASS Setting 'flex-basis' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'flex-basis' to a flexible length: 0fr throws TypeError
 PASS Setting 'flex-basis' to a flexible length: 1fr throws TypeError
 PASS Setting 'flex-basis' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'flex-basis' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'flex-basis' to a number: 0 throws TypeError
 PASS Setting 'flex-basis' to a number: -3.14 throws TypeError
 PASS Setting 'flex-basis' to a number: 3.14 throws TypeError
 PASS Setting 'flex-basis' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt
@@ -32,7 +32,7 @@ PASS Setting 'font-size' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'font-size' to a flexible length: 0fr throws TypeError
 PASS Setting 'font-size' to a flexible length: 1fr throws TypeError
 PASS Setting 'font-size' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'font-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'font-size' to a number: 0 throws TypeError
 PASS Setting 'font-size' to a number: -3.14 throws TypeError
 PASS Setting 'font-size' to a number: 3.14 throws TypeError
 PASS Setting 'font-size' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'column-gap' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'column-gap' to a flexible length: 0fr throws TypeError
 PASS Setting 'column-gap' to a flexible length: 1fr throws TypeError
 PASS Setting 'column-gap' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'column-gap' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'column-gap' to a number: 0 throws TypeError
 PASS Setting 'column-gap' to a number: -3.14 throws TypeError
 PASS Setting 'column-gap' to a number: 3.14 throws TypeError
 PASS Setting 'column-gap' to a number: calc(2 + 3) throws TypeError
@@ -56,7 +56,7 @@ PASS Setting 'row-gap' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'row-gap' to a flexible length: 0fr throws TypeError
 PASS Setting 'row-gap' to a flexible length: 1fr throws TypeError
 PASS Setting 'row-gap' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'row-gap' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'row-gap' to a number: 0 throws TypeError
 PASS Setting 'row-gap' to a number: -3.14 throws TypeError
 PASS Setting 'row-gap' to a number: 3.14 throws TypeError
 PASS Setting 'row-gap' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
@@ -26,7 +26,7 @@ PASS Setting 'grid-auto-columns' to an angle: 3.14rad throws TypeError
 PASS Setting 'grid-auto-columns' to an angle: -3.14deg throws TypeError
 PASS Setting 'grid-auto-columns' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'grid-auto-columns' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'grid-auto-columns' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-auto-columns' to a number: 0 throws TypeError
 PASS Setting 'grid-auto-columns' to a number: -3.14 throws TypeError
 PASS Setting 'grid-auto-columns' to a number: 3.14 throws TypeError
 PASS Setting 'grid-auto-columns' to a number: calc(2 + 3) throws TypeError
@@ -62,7 +62,7 @@ PASS Setting 'grid-auto-rows' to an angle: 3.14rad throws TypeError
 PASS Setting 'grid-auto-rows' to an angle: -3.14deg throws TypeError
 PASS Setting 'grid-auto-rows' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'grid-auto-rows' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'grid-auto-rows' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-auto-rows' to a number: 0 throws TypeError
 PASS Setting 'grid-auto-rows' to a number: -3.14 throws TypeError
 PASS Setting 'grid-auto-rows' to a number: 3.14 throws TypeError
 PASS Setting 'grid-auto-rows' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt
@@ -27,7 +27,7 @@ PASS Setting 'grid-row-start' to a flexible length: -3.14fr throws TypeError
 PASS Setting 'grid-row-start' to a number: 0 throws TypeError
 PASS Setting 'grid-row-start' to a number: -3.14 throws TypeError
 PASS Setting 'grid-row-start' to a number: 3.14 throws TypeError
-FAIL Setting 'grid-row-start' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-row-start' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'grid-row-start' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'grid-row-start' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-row-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
@@ -62,7 +62,7 @@ PASS Setting 'grid-row-end' to a flexible length: -3.14fr throws TypeError
 PASS Setting 'grid-row-end' to a number: 0 throws TypeError
 PASS Setting 'grid-row-end' to a number: -3.14 throws TypeError
 PASS Setting 'grid-row-end' to a number: 3.14 throws TypeError
-FAIL Setting 'grid-row-end' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-row-end' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'grid-row-end' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'grid-row-end' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-row-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
@@ -97,7 +97,7 @@ PASS Setting 'grid-column-start' to a flexible length: -3.14fr throws TypeError
 PASS Setting 'grid-column-start' to a number: 0 throws TypeError
 PASS Setting 'grid-column-start' to a number: -3.14 throws TypeError
 PASS Setting 'grid-column-start' to a number: 3.14 throws TypeError
-FAIL Setting 'grid-column-start' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-column-start' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'grid-column-start' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'grid-column-start' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-column-start' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
@@ -132,7 +132,7 @@ PASS Setting 'grid-column-end' to a flexible length: -3.14fr throws TypeError
 PASS Setting 'grid-column-end' to a number: 0 throws TypeError
 PASS Setting 'grid-column-end' to a number: -3.14 throws TypeError
 PASS Setting 'grid-column-end' to a number: 3.14 throws TypeError
-FAIL Setting 'grid-column-end' to a number: calc(2 + 3) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-column-end' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'grid-column-end' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'grid-column-end' to a transform: perspective(10em) throws TypeError
 PASS Setting 'grid-column-end' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'grid-template-columns' to an angle: 3.14rad throws TypeError
 PASS Setting 'grid-template-columns' to an angle: -3.14deg throws TypeError
 PASS Setting 'grid-template-columns' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'grid-template-columns' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'grid-template-columns' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-template-columns' to a number: 0 throws TypeError
 PASS Setting 'grid-template-columns' to a number: -3.14 throws TypeError
 PASS Setting 'grid-template-columns' to a number: 3.14 throws TypeError
 PASS Setting 'grid-template-columns' to a number: calc(2 + 3) throws TypeError
@@ -58,7 +58,7 @@ PASS Setting 'grid-template-rows' to an angle: 3.14rad throws TypeError
 PASS Setting 'grid-template-rows' to an angle: -3.14deg throws TypeError
 PASS Setting 'grid-template-rows' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'grid-template-rows' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'grid-template-rows' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'grid-template-rows' to a number: 0 throws TypeError
 PASS Setting 'grid-template-rows' to a number: -3.14 throws TypeError
 PASS Setting 'grid-template-rows' to a number: 3.14 throws TypeError
 PASS Setting 'grid-template-rows' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'height' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'height' to a flexible length: 0fr throws TypeError
 PASS Setting 'height' to a flexible length: 1fr throws TypeError
 PASS Setting 'height' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'height' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'height' to a number: 0 throws TypeError
 PASS Setting 'height' to a number: -3.14 throws TypeError
 PASS Setting 'height' to a number: 3.14 throws TypeError
 PASS Setting 'height' to a number: calc(2 + 3) throws TypeError
@@ -55,7 +55,7 @@ PASS Setting 'min-height' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'min-height' to a flexible length: 0fr throws TypeError
 PASS Setting 'min-height' to a flexible length: 1fr throws TypeError
 PASS Setting 'min-height' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'min-height' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'min-height' to a number: 0 throws TypeError
 PASS Setting 'min-height' to a number: -3.14 throws TypeError
 PASS Setting 'min-height' to a number: 3.14 throws TypeError
 PASS Setting 'min-height' to a number: calc(2 + 3) throws TypeError
@@ -87,7 +87,7 @@ PASS Setting 'max-height' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'max-height' to a flexible length: 0fr throws TypeError
 PASS Setting 'max-height' to a flexible length: 1fr throws TypeError
 PASS Setting 'max-height' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'max-height' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'max-height' to a number: 0 throws TypeError
 PASS Setting 'max-height' to a number: -3.14 throws TypeError
 PASS Setting 'max-height' to a number: 3.14 throws TypeError
 PASS Setting 'max-height' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'inline-size' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'inline-size' to a flexible length: 0fr throws TypeError
 PASS Setting 'inline-size' to a flexible length: 1fr throws TypeError
 PASS Setting 'inline-size' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'inline-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'inline-size' to a number: 0 throws TypeError
 PASS Setting 'inline-size' to a number: -3.14 throws TypeError
 PASS Setting 'inline-size' to a number: 3.14 throws TypeError
 PASS Setting 'inline-size' to a number: calc(2 + 3) throws TypeError
@@ -55,7 +55,7 @@ PASS Setting 'min-inline-size' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'min-inline-size' to a flexible length: 0fr throws TypeError
 PASS Setting 'min-inline-size' to a flexible length: 1fr throws TypeError
 PASS Setting 'min-inline-size' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'min-inline-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'min-inline-size' to a number: 0 throws TypeError
 PASS Setting 'min-inline-size' to a number: -3.14 throws TypeError
 PASS Setting 'min-inline-size' to a number: 3.14 throws TypeError
 PASS Setting 'min-inline-size' to a number: calc(2 + 3) throws TypeError
@@ -87,7 +87,7 @@ PASS Setting 'max-inline-size' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'max-inline-size' to a flexible length: 0fr throws TypeError
 PASS Setting 'max-inline-size' to a flexible length: 1fr throws TypeError
 PASS Setting 'max-inline-size' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'max-inline-size' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'max-inline-size' to a number: 0 throws TypeError
 PASS Setting 'max-inline-size' to a number: -3.14 throws TypeError
 PASS Setting 'max-inline-size' to a number: 3.14 throws TypeError
 PASS Setting 'max-inline-size' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/left-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/left-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'left' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'left' to a flexible length: 0fr throws TypeError
 PASS Setting 'left' to a flexible length: 1fr throws TypeError
 PASS Setting 'left' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'left' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'left' to a number: 0 throws TypeError
 PASS Setting 'left' to a number: -3.14 throws TypeError
 PASS Setting 'left' to a number: 3.14 throws TypeError
 PASS Setting 'left' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'letter-spacing' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'letter-spacing' to a flexible length: 0fr throws TypeError
 PASS Setting 'letter-spacing' to a flexible length: 1fr throws TypeError
 PASS Setting 'letter-spacing' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'letter-spacing' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'letter-spacing' to a number: 0 throws TypeError
 PASS Setting 'letter-spacing' to a number: -3.14 throws TypeError
 PASS Setting 'letter-spacing' to a number: 3.14 throws TypeError
 PASS Setting 'letter-spacing' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
@@ -23,7 +23,7 @@ PASS Setting 'margin-block-start' to an angle: calc(0rad + 0deg) throws TypeErro
 PASS Setting 'margin-block-start' to a flexible length: 0fr throws TypeError
 PASS Setting 'margin-block-start' to a flexible length: 1fr throws TypeError
 PASS Setting 'margin-block-start' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'margin-block-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-block-start' to a number: 0 throws TypeError
 PASS Setting 'margin-block-start' to a number: -3.14 throws TypeError
 PASS Setting 'margin-block-start' to a number: 3.14 throws TypeError
 PASS Setting 'margin-block-start' to a number: calc(2 + 3) throws TypeError
@@ -54,7 +54,7 @@ PASS Setting 'margin-block-end' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'margin-block-end' to a flexible length: 0fr throws TypeError
 PASS Setting 'margin-block-end' to a flexible length: 1fr throws TypeError
 PASS Setting 'margin-block-end' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'margin-block-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-block-end' to a number: 0 throws TypeError
 PASS Setting 'margin-block-end' to a number: -3.14 throws TypeError
 PASS Setting 'margin-block-end' to a number: 3.14 throws TypeError
 PASS Setting 'margin-block-end' to a number: calc(2 + 3) throws TypeError
@@ -85,7 +85,7 @@ PASS Setting 'margin-inline-start' to an angle: calc(0rad + 0deg) throws TypeErr
 PASS Setting 'margin-inline-start' to a flexible length: 0fr throws TypeError
 PASS Setting 'margin-inline-start' to a flexible length: 1fr throws TypeError
 PASS Setting 'margin-inline-start' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'margin-inline-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-inline-start' to a number: 0 throws TypeError
 PASS Setting 'margin-inline-start' to a number: -3.14 throws TypeError
 PASS Setting 'margin-inline-start' to a number: 3.14 throws TypeError
 PASS Setting 'margin-inline-start' to a number: calc(2 + 3) throws TypeError
@@ -116,7 +116,7 @@ PASS Setting 'margin-inline-end' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'margin-inline-end' to a flexible length: 0fr throws TypeError
 PASS Setting 'margin-inline-end' to a flexible length: 1fr throws TypeError
 PASS Setting 'margin-inline-end' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'margin-inline-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-inline-end' to a number: 0 throws TypeError
 PASS Setting 'margin-inline-end' to a number: -3.14 throws TypeError
 PASS Setting 'margin-inline-end' to a number: 3.14 throws TypeError
 PASS Setting 'margin-inline-end' to a number: calc(2 + 3) throws TypeError
@@ -209,7 +209,7 @@ PASS Setting 'padding-block-start' to an angle: calc(0rad + 0deg) throws TypeErr
 PASS Setting 'padding-block-start' to a flexible length: 0fr throws TypeError
 PASS Setting 'padding-block-start' to a flexible length: 1fr throws TypeError
 PASS Setting 'padding-block-start' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'padding-block-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-block-start' to a number: 0 throws TypeError
 PASS Setting 'padding-block-start' to a number: -3.14 throws TypeError
 PASS Setting 'padding-block-start' to a number: 3.14 throws TypeError
 PASS Setting 'padding-block-start' to a number: calc(2 + 3) throws TypeError
@@ -240,7 +240,7 @@ PASS Setting 'padding-block-end' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'padding-block-end' to a flexible length: 0fr throws TypeError
 PASS Setting 'padding-block-end' to a flexible length: 1fr throws TypeError
 PASS Setting 'padding-block-end' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'padding-block-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-block-end' to a number: 0 throws TypeError
 PASS Setting 'padding-block-end' to a number: -3.14 throws TypeError
 PASS Setting 'padding-block-end' to a number: 3.14 throws TypeError
 PASS Setting 'padding-block-end' to a number: calc(2 + 3) throws TypeError
@@ -271,7 +271,7 @@ PASS Setting 'padding-inline-start' to an angle: calc(0rad + 0deg) throws TypeEr
 PASS Setting 'padding-inline-start' to a flexible length: 0fr throws TypeError
 PASS Setting 'padding-inline-start' to a flexible length: 1fr throws TypeError
 PASS Setting 'padding-inline-start' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'padding-inline-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-inline-start' to a number: 0 throws TypeError
 PASS Setting 'padding-inline-start' to a number: -3.14 throws TypeError
 PASS Setting 'padding-inline-start' to a number: 3.14 throws TypeError
 PASS Setting 'padding-inline-start' to a number: calc(2 + 3) throws TypeError
@@ -302,7 +302,7 @@ PASS Setting 'padding-inline-end' to an angle: calc(0rad + 0deg) throws TypeErro
 PASS Setting 'padding-inline-end' to a flexible length: 0fr throws TypeError
 PASS Setting 'padding-inline-end' to a flexible length: 1fr throws TypeError
 PASS Setting 'padding-inline-end' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'padding-inline-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-inline-end' to a number: 0 throws TypeError
 PASS Setting 'padding-inline-end' to a number: -3.14 throws TypeError
 PASS Setting 'padding-inline-end' to a number: 3.14 throws TypeError
 PASS Setting 'padding-inline-end' to a number: calc(2 + 3) throws TypeError
@@ -395,7 +395,7 @@ PASS Setting 'inset-block-start' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'inset-block-start' to a flexible length: 0fr throws TypeError
 PASS Setting 'inset-block-start' to a flexible length: 1fr throws TypeError
 PASS Setting 'inset-block-start' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'inset-block-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'inset-block-start' to a number: 0 throws TypeError
 PASS Setting 'inset-block-start' to a number: -3.14 throws TypeError
 PASS Setting 'inset-block-start' to a number: 3.14 throws TypeError
 PASS Setting 'inset-block-start' to a number: calc(2 + 3) throws TypeError
@@ -426,7 +426,7 @@ PASS Setting 'inset-block-end' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'inset-block-end' to a flexible length: 0fr throws TypeError
 PASS Setting 'inset-block-end' to a flexible length: 1fr throws TypeError
 PASS Setting 'inset-block-end' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'inset-block-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'inset-block-end' to a number: 0 throws TypeError
 PASS Setting 'inset-block-end' to a number: -3.14 throws TypeError
 PASS Setting 'inset-block-end' to a number: 3.14 throws TypeError
 PASS Setting 'inset-block-end' to a number: calc(2 + 3) throws TypeError
@@ -457,7 +457,7 @@ PASS Setting 'inset-inline-start' to an angle: calc(0rad + 0deg) throws TypeErro
 PASS Setting 'inset-inline-start' to a flexible length: 0fr throws TypeError
 PASS Setting 'inset-inline-start' to a flexible length: 1fr throws TypeError
 PASS Setting 'inset-inline-start' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'inset-inline-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'inset-inline-start' to a number: 0 throws TypeError
 PASS Setting 'inset-inline-start' to a number: -3.14 throws TypeError
 PASS Setting 'inset-inline-start' to a number: 3.14 throws TypeError
 PASS Setting 'inset-inline-start' to a number: calc(2 + 3) throws TypeError
@@ -488,7 +488,7 @@ PASS Setting 'inset-inline-end' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'inset-inline-end' to a flexible length: 0fr throws TypeError
 PASS Setting 'inset-inline-end' to a flexible length: 1fr throws TypeError
 PASS Setting 'inset-inline-end' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'inset-inline-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'inset-inline-end' to a number: 0 throws TypeError
 PASS Setting 'inset-inline-end' to a number: -3.14 throws TypeError
 PASS Setting 'inset-inline-end' to a number: 3.14 throws TypeError
 PASS Setting 'inset-inline-end' to a number: calc(2 + 3) throws TypeError
@@ -616,7 +616,7 @@ PASS Setting 'border-block-start-width' to an angle: calc(0rad + 0deg) throws Ty
 PASS Setting 'border-block-start-width' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-block-start-width' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-block-start-width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-block-start-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-block-start-width' to a number: 0 throws TypeError
 PASS Setting 'border-block-start-width' to a number: -3.14 throws TypeError
 PASS Setting 'border-block-start-width' to a number: 3.14 throws TypeError
 PASS Setting 'border-block-start-width' to a number: calc(2 + 3) throws TypeError
@@ -747,7 +747,7 @@ PASS Setting 'border-block-end-width' to an angle: calc(0rad + 0deg) throws Type
 PASS Setting 'border-block-end-width' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-block-end-width' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-block-end-width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-block-end-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-block-end-width' to a number: 0 throws TypeError
 PASS Setting 'border-block-end-width' to a number: -3.14 throws TypeError
 PASS Setting 'border-block-end-width' to a number: 3.14 throws TypeError
 PASS Setting 'border-block-end-width' to a number: calc(2 + 3) throws TypeError
@@ -878,7 +878,7 @@ PASS Setting 'border-inline-start-width' to an angle: calc(0rad + 0deg) throws T
 PASS Setting 'border-inline-start-width' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-inline-start-width' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-inline-start-width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-inline-start-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-inline-start-width' to a number: 0 throws TypeError
 PASS Setting 'border-inline-start-width' to a number: -3.14 throws TypeError
 PASS Setting 'border-inline-start-width' to a number: 3.14 throws TypeError
 PASS Setting 'border-inline-start-width' to a number: calc(2 + 3) throws TypeError
@@ -1009,7 +1009,7 @@ PASS Setting 'border-inline-end-width' to an angle: calc(0rad + 0deg) throws Typ
 PASS Setting 'border-inline-end-width' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-inline-end-width' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-inline-end-width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-inline-end-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-inline-end-width' to a number: 0 throws TypeError
 PASS Setting 'border-inline-end-width' to a number: -3.14 throws TypeError
 PASS Setting 'border-inline-end-width' to a number: 3.14 throws TypeError
 PASS Setting 'border-inline-end-width' to a number: calc(2 + 3) throws TypeError
@@ -1367,7 +1367,7 @@ PASS Setting 'border-start-start-radius' to an angle: calc(0rad + 0deg) throws T
 PASS Setting 'border-start-start-radius' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-start-start-radius' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-start-start-radius' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-start-start-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-start-start-radius' to a number: 0 throws TypeError
 PASS Setting 'border-start-start-radius' to a number: -3.14 throws TypeError
 PASS Setting 'border-start-start-radius' to a number: 3.14 throws TypeError
 PASS Setting 'border-start-start-radius' to a number: calc(2 + 3) throws TypeError
@@ -1398,7 +1398,7 @@ PASS Setting 'border-start-end-radius' to an angle: calc(0rad + 0deg) throws Typ
 PASS Setting 'border-start-end-radius' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-start-end-radius' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-start-end-radius' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-start-end-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-start-end-radius' to a number: 0 throws TypeError
 PASS Setting 'border-start-end-radius' to a number: -3.14 throws TypeError
 PASS Setting 'border-start-end-radius' to a number: 3.14 throws TypeError
 PASS Setting 'border-start-end-radius' to a number: calc(2 + 3) throws TypeError
@@ -1429,7 +1429,7 @@ PASS Setting 'border-end-start-radius' to an angle: calc(0rad + 0deg) throws Typ
 PASS Setting 'border-end-start-radius' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-end-start-radius' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-end-start-radius' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-end-start-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-end-start-radius' to a number: 0 throws TypeError
 PASS Setting 'border-end-start-radius' to a number: -3.14 throws TypeError
 PASS Setting 'border-end-start-radius' to a number: 3.14 throws TypeError
 PASS Setting 'border-end-start-radius' to a number: calc(2 + 3) throws TypeError
@@ -1460,7 +1460,7 @@ PASS Setting 'border-end-end-radius' to an angle: calc(0rad + 0deg) throws TypeE
 PASS Setting 'border-end-end-radius' to a flexible length: 0fr throws TypeError
 PASS Setting 'border-end-end-radius' to a flexible length: 1fr throws TypeError
 PASS Setting 'border-end-end-radius' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'border-end-end-radius' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'border-end-end-radius' to a number: 0 throws TypeError
 PASS Setting 'border-end-end-radius' to a number: -3.14 throws TypeError
 PASS Setting 'border-end-end-radius' to a number: 3.14 throws TypeError
 PASS Setting 'border-end-end-radius' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/margin-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'margin-top' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'margin-top' to a flexible length: 0fr throws TypeError
 PASS Setting 'margin-top' to a flexible length: 1fr throws TypeError
 PASS Setting 'margin-top' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'margin-top' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-top' to a number: 0 throws TypeError
 PASS Setting 'margin-top' to a number: -3.14 throws TypeError
 PASS Setting 'margin-top' to a number: 3.14 throws TypeError
 PASS Setting 'margin-top' to a number: calc(2 + 3) throws TypeError
@@ -56,7 +56,7 @@ PASS Setting 'margin-left' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'margin-left' to a flexible length: 0fr throws TypeError
 PASS Setting 'margin-left' to a flexible length: 1fr throws TypeError
 PASS Setting 'margin-left' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'margin-left' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-left' to a number: 0 throws TypeError
 PASS Setting 'margin-left' to a number: -3.14 throws TypeError
 PASS Setting 'margin-left' to a number: 3.14 throws TypeError
 PASS Setting 'margin-left' to a number: calc(2 + 3) throws TypeError
@@ -88,7 +88,7 @@ PASS Setting 'margin-right' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'margin-right' to a flexible length: 0fr throws TypeError
 PASS Setting 'margin-right' to a flexible length: 1fr throws TypeError
 PASS Setting 'margin-right' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'margin-right' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-right' to a number: 0 throws TypeError
 PASS Setting 'margin-right' to a number: -3.14 throws TypeError
 PASS Setting 'margin-right' to a number: 3.14 throws TypeError
 PASS Setting 'margin-right' to a number: calc(2 + 3) throws TypeError
@@ -120,7 +120,7 @@ PASS Setting 'margin-bottom' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'margin-bottom' to a flexible length: 0fr throws TypeError
 PASS Setting 'margin-bottom' to a flexible length: 1fr throws TypeError
 PASS Setting 'margin-bottom' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'margin-bottom' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'margin-bottom' to a number: 0 throws TypeError
 PASS Setting 'margin-bottom' to a number: -3.14 throws TypeError
 PASS Setting 'margin-bottom' to a number: 3.14 throws TypeError
 PASS Setting 'margin-bottom' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-distance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-distance-expected.txt
@@ -23,7 +23,7 @@ PASS Setting 'offset-distance' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'offset-distance' to a flexible length: 0fr throws TypeError
 PASS Setting 'offset-distance' to a flexible length: 1fr throws TypeError
 PASS Setting 'offset-distance' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'offset-distance' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'offset-distance' to a number: 0 throws TypeError
 PASS Setting 'offset-distance' to a number: -3.14 throws TypeError
 PASS Setting 'offset-distance' to a number: 3.14 throws TypeError
 PASS Setting 'offset-distance' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-offset-expected.txt
@@ -23,7 +23,7 @@ PASS Setting 'outline-offset' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'outline-offset' to a flexible length: 0fr throws TypeError
 PASS Setting 'outline-offset' to a flexible length: 1fr throws TypeError
 PASS Setting 'outline-offset' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'outline-offset' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'outline-offset' to a number: 0 throws TypeError
 PASS Setting 'outline-offset' to a number: -3.14 throws TypeError
 PASS Setting 'outline-offset' to a number: 3.14 throws TypeError
 PASS Setting 'outline-offset' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt
@@ -26,7 +26,7 @@ PASS Setting 'outline-width' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'outline-width' to a flexible length: 0fr throws TypeError
 PASS Setting 'outline-width' to a flexible length: 1fr throws TypeError
 PASS Setting 'outline-width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'outline-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'outline-width' to a number: 0 throws TypeError
 PASS Setting 'outline-width' to a number: -3.14 throws TypeError
 PASS Setting 'outline-width' to a number: 3.14 throws TypeError
 PASS Setting 'outline-width' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt
@@ -23,7 +23,7 @@ PASS Setting 'padding-top' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'padding-top' to a flexible length: 0fr throws TypeError
 PASS Setting 'padding-top' to a flexible length: 1fr throws TypeError
 PASS Setting 'padding-top' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'padding-top' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-top' to a number: 0 throws TypeError
 PASS Setting 'padding-top' to a number: -3.14 throws TypeError
 PASS Setting 'padding-top' to a number: 3.14 throws TypeError
 PASS Setting 'padding-top' to a number: calc(2 + 3) throws TypeError
@@ -54,7 +54,7 @@ PASS Setting 'padding-left' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'padding-left' to a flexible length: 0fr throws TypeError
 PASS Setting 'padding-left' to a flexible length: 1fr throws TypeError
 PASS Setting 'padding-left' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'padding-left' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-left' to a number: 0 throws TypeError
 PASS Setting 'padding-left' to a number: -3.14 throws TypeError
 PASS Setting 'padding-left' to a number: 3.14 throws TypeError
 PASS Setting 'padding-left' to a number: calc(2 + 3) throws TypeError
@@ -85,7 +85,7 @@ PASS Setting 'padding-right' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'padding-right' to a flexible length: 0fr throws TypeError
 PASS Setting 'padding-right' to a flexible length: 1fr throws TypeError
 PASS Setting 'padding-right' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'padding-right' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-right' to a number: 0 throws TypeError
 PASS Setting 'padding-right' to a number: -3.14 throws TypeError
 PASS Setting 'padding-right' to a number: 3.14 throws TypeError
 PASS Setting 'padding-right' to a number: calc(2 + 3) throws TypeError
@@ -116,7 +116,7 @@ PASS Setting 'padding-bottom' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'padding-bottom' to a flexible length: 0fr throws TypeError
 PASS Setting 'padding-bottom' to a flexible length: 1fr throws TypeError
 PASS Setting 'padding-bottom' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'padding-bottom' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'padding-bottom' to a number: 0 throws TypeError
 PASS Setting 'padding-bottom' to a number: -3.14 throws TypeError
 PASS Setting 'padding-bottom' to a number: 3.14 throws TypeError
 PASS Setting 'padding-bottom' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'perspective' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'perspective' to a flexible length: 0fr throws TypeError
 PASS Setting 'perspective' to a flexible length: 1fr throws TypeError
 PASS Setting 'perspective' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'perspective' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'perspective' to a number: 0 throws TypeError
 PASS Setting 'perspective' to a number: -3.14 throws TypeError
 PASS Setting 'perspective' to a number: 3.14 throws TypeError
 PASS Setting 'perspective' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt
@@ -23,7 +23,7 @@ PASS Setting 'r' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'r' to a flexible length: 0fr throws TypeError
 PASS Setting 'r' to a flexible length: 1fr throws TypeError
 PASS Setting 'r' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'r' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'r' to a number: 0 throws TypeError
 PASS Setting 'r' to a number: -3.14 throws TypeError
 PASS Setting 'r' to a number: 3.14 throws TypeError
 PASS Setting 'r' to a number: calc(2 + 3) throws TypeError
@@ -55,7 +55,7 @@ PASS Setting 'rx' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'rx' to a flexible length: 0fr throws TypeError
 PASS Setting 'rx' to a flexible length: 1fr throws TypeError
 PASS Setting 'rx' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'rx' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'rx' to a number: 0 throws TypeError
 PASS Setting 'rx' to a number: -3.14 throws TypeError
 PASS Setting 'rx' to a number: 3.14 throws TypeError
 PASS Setting 'rx' to a number: calc(2 + 3) throws TypeError
@@ -87,7 +87,7 @@ PASS Setting 'ry' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'ry' to a flexible length: 0fr throws TypeError
 PASS Setting 'ry' to a flexible length: 1fr throws TypeError
 PASS Setting 'ry' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'ry' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'ry' to a number: 0 throws TypeError
 PASS Setting 'ry' to a number: -3.14 throws TypeError
 PASS Setting 'ry' to a number: 3.14 throws TypeError
 PASS Setting 'ry' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/right-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/right-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'right' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'right' to a flexible length: 0fr throws TypeError
 PASS Setting 'right' to a flexible length: 1fr throws TypeError
 PASS Setting 'right' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'right' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'right' to a number: 0 throws TypeError
 PASS Setting 'right' to a number: -3.14 throws TypeError
 PASS Setting 'right' to a number: 3.14 throws TypeError
 PASS Setting 'right' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-margin-expected.txt
@@ -23,7 +23,7 @@ PASS Setting 'scroll-margin-top' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'scroll-margin-top' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-margin-top' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-margin-top' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-margin-top' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-top' to a number: 0 throws TypeError
 PASS Setting 'scroll-margin-top' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-margin-top' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-margin-top' to a number: calc(2 + 3) throws TypeError
@@ -54,7 +54,7 @@ PASS Setting 'scroll-margin-left' to an angle: calc(0rad + 0deg) throws TypeErro
 PASS Setting 'scroll-margin-left' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-margin-left' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-margin-left' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-margin-left' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-left' to a number: 0 throws TypeError
 PASS Setting 'scroll-margin-left' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-margin-left' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-margin-left' to a number: calc(2 + 3) throws TypeError
@@ -85,7 +85,7 @@ PASS Setting 'scroll-margin-right' to an angle: calc(0rad + 0deg) throws TypeErr
 PASS Setting 'scroll-margin-right' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-margin-right' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-margin-right' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-margin-right' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-right' to a number: 0 throws TypeError
 PASS Setting 'scroll-margin-right' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-margin-right' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-margin-right' to a number: calc(2 + 3) throws TypeError
@@ -116,7 +116,7 @@ PASS Setting 'scroll-margin-bottom' to an angle: calc(0rad + 0deg) throws TypeEr
 PASS Setting 'scroll-margin-bottom' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-margin-bottom' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-margin-bottom' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-margin-bottom' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-bottom' to a number: 0 throws TypeError
 PASS Setting 'scroll-margin-bottom' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-margin-bottom' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-margin-bottom' to a number: calc(2 + 3) throws TypeError
@@ -147,7 +147,7 @@ PASS Setting 'scroll-margin-inline-start' to an angle: calc(0rad + 0deg) throws 
 PASS Setting 'scroll-margin-inline-start' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-margin-inline-start' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-margin-inline-start' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-margin-inline-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-inline-start' to a number: 0 throws TypeError
 PASS Setting 'scroll-margin-inline-start' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-margin-inline-start' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-margin-inline-start' to a number: calc(2 + 3) throws TypeError
@@ -178,7 +178,7 @@ PASS Setting 'scroll-margin-block-start' to an angle: calc(0rad + 0deg) throws T
 PASS Setting 'scroll-margin-block-start' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-margin-block-start' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-margin-block-start' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-margin-block-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-block-start' to a number: 0 throws TypeError
 PASS Setting 'scroll-margin-block-start' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-margin-block-start' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-margin-block-start' to a number: calc(2 + 3) throws TypeError
@@ -209,7 +209,7 @@ PASS Setting 'scroll-margin-inline-end' to an angle: calc(0rad + 0deg) throws Ty
 PASS Setting 'scroll-margin-inline-end' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-margin-inline-end' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-margin-inline-end' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-margin-inline-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-inline-end' to a number: 0 throws TypeError
 PASS Setting 'scroll-margin-inline-end' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-margin-inline-end' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-margin-inline-end' to a number: calc(2 + 3) throws TypeError
@@ -240,7 +240,7 @@ PASS Setting 'scroll-margin-block-end' to an angle: calc(0rad + 0deg) throws Typ
 PASS Setting 'scroll-margin-block-end' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-margin-block-end' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-margin-block-end' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-margin-block-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-margin-block-end' to a number: 0 throws TypeError
 PASS Setting 'scroll-margin-block-end' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-margin-block-end' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-margin-block-end' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt
@@ -23,7 +23,7 @@ PASS Setting 'scroll-padding-top' to an angle: calc(0rad + 0deg) throws TypeErro
 PASS Setting 'scroll-padding-top' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-padding-top' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-padding-top' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-padding-top' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-top' to a number: 0 throws TypeError
 PASS Setting 'scroll-padding-top' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-padding-top' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-padding-top' to a number: calc(2 + 3) throws TypeError
@@ -54,7 +54,7 @@ PASS Setting 'scroll-padding-left' to an angle: calc(0rad + 0deg) throws TypeErr
 PASS Setting 'scroll-padding-left' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-padding-left' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-padding-left' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-padding-left' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-left' to a number: 0 throws TypeError
 PASS Setting 'scroll-padding-left' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-padding-left' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-padding-left' to a number: calc(2 + 3) throws TypeError
@@ -85,7 +85,7 @@ PASS Setting 'scroll-padding-right' to an angle: calc(0rad + 0deg) throws TypeEr
 PASS Setting 'scroll-padding-right' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-padding-right' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-padding-right' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-padding-right' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-right' to a number: 0 throws TypeError
 PASS Setting 'scroll-padding-right' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-padding-right' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-padding-right' to a number: calc(2 + 3) throws TypeError
@@ -116,7 +116,7 @@ PASS Setting 'scroll-padding-bottom' to an angle: calc(0rad + 0deg) throws TypeE
 PASS Setting 'scroll-padding-bottom' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-padding-bottom' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-padding-bottom' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-padding-bottom' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-bottom' to a number: 0 throws TypeError
 PASS Setting 'scroll-padding-bottom' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-padding-bottom' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-padding-bottom' to a number: calc(2 + 3) throws TypeError
@@ -147,7 +147,7 @@ PASS Setting 'scroll-padding-inline-start' to an angle: calc(0rad + 0deg) throws
 PASS Setting 'scroll-padding-inline-start' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-padding-inline-start' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-padding-inline-start' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-padding-inline-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-inline-start' to a number: 0 throws TypeError
 PASS Setting 'scroll-padding-inline-start' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-padding-inline-start' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-padding-inline-start' to a number: calc(2 + 3) throws TypeError
@@ -178,7 +178,7 @@ PASS Setting 'scroll-padding-block-start' to an angle: calc(0rad + 0deg) throws 
 PASS Setting 'scroll-padding-block-start' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-padding-block-start' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-padding-block-start' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-padding-block-start' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-block-start' to a number: 0 throws TypeError
 PASS Setting 'scroll-padding-block-start' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-padding-block-start' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-padding-block-start' to a number: calc(2 + 3) throws TypeError
@@ -209,7 +209,7 @@ PASS Setting 'scroll-padding-inline-end' to an angle: calc(0rad + 0deg) throws T
 PASS Setting 'scroll-padding-inline-end' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-padding-inline-end' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-padding-inline-end' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-padding-inline-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-inline-end' to a number: 0 throws TypeError
 PASS Setting 'scroll-padding-inline-end' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-padding-inline-end' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-padding-inline-end' to a number: calc(2 + 3) throws TypeError
@@ -240,7 +240,7 @@ PASS Setting 'scroll-padding-block-end' to an angle: calc(0rad + 0deg) throws Ty
 PASS Setting 'scroll-padding-block-end' to a flexible length: 0fr throws TypeError
 PASS Setting 'scroll-padding-block-end' to a flexible length: 1fr throws TypeError
 PASS Setting 'scroll-padding-block-end' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'scroll-padding-block-end' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'scroll-padding-block-end' to a number: 0 throws TypeError
 PASS Setting 'scroll-padding-block-end' to a number: -3.14 throws TypeError
 PASS Setting 'scroll-padding-block-end' to a number: 3.14 throws TypeError
 PASS Setting 'scroll-padding-block-end' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt
@@ -23,7 +23,7 @@ PASS Setting 'shape-margin' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'shape-margin' to a flexible length: 0fr throws TypeError
 PASS Setting 'shape-margin' to a flexible length: 1fr throws TypeError
 PASS Setting 'shape-margin' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'shape-margin' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'shape-margin' to a number: 0 throws TypeError
 PASS Setting 'shape-margin' to a number: -3.14 throws TypeError
 PASS Setting 'shape-margin' to a number: 3.14 throws TypeError
 PASS Setting 'shape-margin' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-thickness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-thickness-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'text-decoration-thickness' to an angle: calc(0rad + 0deg) throws T
 PASS Setting 'text-decoration-thickness' to a flexible length: 0fr throws TypeError
 PASS Setting 'text-decoration-thickness' to a flexible length: 1fr throws TypeError
 PASS Setting 'text-decoration-thickness' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'text-decoration-thickness' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'text-decoration-thickness' to a number: 0 throws TypeError
 PASS Setting 'text-decoration-thickness' to a number: -3.14 throws TypeError
 PASS Setting 'text-decoration-thickness' to a number: 3.14 throws TypeError
 PASS Setting 'text-decoration-thickness' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt
@@ -23,7 +23,7 @@ PASS Setting 'text-indent' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'text-indent' to a flexible length: 0fr throws TypeError
 PASS Setting 'text-indent' to a flexible length: 1fr throws TypeError
 PASS Setting 'text-indent' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'text-indent' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'text-indent' to a number: 0 throws TypeError
 PASS Setting 'text-indent' to a number: -3.14 throws TypeError
 PASS Setting 'text-indent' to a number: 3.14 throws TypeError
 PASS Setting 'text-indent' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'text-underline-offset' to an angle: calc(0rad + 0deg) throws TypeE
 PASS Setting 'text-underline-offset' to a flexible length: 0fr throws TypeError
 PASS Setting 'text-underline-offset' to a flexible length: 1fr throws TypeError
 PASS Setting 'text-underline-offset' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'text-underline-offset' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'text-underline-offset' to a number: 0 throws TypeError
 PASS Setting 'text-underline-offset' to a number: -3.14 throws TypeError
 PASS Setting 'text-underline-offset' to a number: 3.14 throws TypeError
 PASS Setting 'text-underline-offset' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/top-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/top-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'top' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'top' to a flexible length: 0fr throws TypeError
 PASS Setting 'top' to a flexible length: 1fr throws TypeError
 PASS Setting 'top' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'top' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'top' to a number: 0 throws TypeError
 PASS Setting 'top' to a number: -3.14 throws TypeError
 PASS Setting 'top' to a number: 3.14 throws TypeError
 PASS Setting 'top' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vertical-align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vertical-align-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'vertical-align' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'vertical-align' to a flexible length: 0fr throws TypeError
 PASS Setting 'vertical-align' to a flexible length: 1fr throws TypeError
 PASS Setting 'vertical-align' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'vertical-align' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'vertical-align' to a number: 0 throws TypeError
 PASS Setting 'vertical-align' to a number: -3.14 throws TypeError
 PASS Setting 'vertical-align' to a number: 3.14 throws TypeError
 PASS Setting 'vertical-align' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'width' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'width' to a flexible length: 0fr throws TypeError
 PASS Setting 'width' to a flexible length: 1fr throws TypeError
 PASS Setting 'width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'width' to a number: 0 throws TypeError
 PASS Setting 'width' to a number: -3.14 throws TypeError
 PASS Setting 'width' to a number: 3.14 throws TypeError
 PASS Setting 'width' to a number: calc(2 + 3) throws TypeError
@@ -55,7 +55,7 @@ PASS Setting 'min-width' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'min-width' to a flexible length: 0fr throws TypeError
 PASS Setting 'min-width' to a flexible length: 1fr throws TypeError
 PASS Setting 'min-width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'min-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'min-width' to a number: 0 throws TypeError
 PASS Setting 'min-width' to a number: -3.14 throws TypeError
 PASS Setting 'min-width' to a number: 3.14 throws TypeError
 PASS Setting 'min-width' to a number: calc(2 + 3) throws TypeError
@@ -87,7 +87,7 @@ PASS Setting 'max-width' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'max-width' to a flexible length: 0fr throws TypeError
 PASS Setting 'max-width' to a flexible length: 1fr throws TypeError
 PASS Setting 'max-width' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'max-width' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'max-width' to a number: 0 throws TypeError
 PASS Setting 'max-width' to a number: -3.14 throws TypeError
 PASS Setting 'max-width' to a number: 3.14 throws TypeError
 PASS Setting 'max-width' to a number: calc(2 + 3) throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-spacing-expected.txt
@@ -24,7 +24,7 @@ PASS Setting 'word-spacing' to an angle: calc(0rad + 0deg) throws TypeError
 PASS Setting 'word-spacing' to a flexible length: 0fr throws TypeError
 PASS Setting 'word-spacing' to a flexible length: 1fr throws TypeError
 PASS Setting 'word-spacing' to a flexible length: -3.14fr throws TypeError
-FAIL Setting 'word-spacing' to a number: 0 throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
+PASS Setting 'word-spacing' to a number: 0 throws TypeError
 PASS Setting 'word-spacing' to a number: -3.14 throws TypeError
 PASS Setting 'word-spacing' to a number: 3.14 throws TypeError
 PASS Setting 'word-spacing' to a number: calc(2 + 3) throws TypeError

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -189,6 +189,11 @@
         "the property name. For instance, if 'font-size' requires a custom parser, it",
         "would be named 'consumeFontSize'.",
         "",
+        "* custom-parser-allows-number-or-integer-input:",
+        "Indicates that the properties allows <number> or <integer> as input. We'd",
+        "normally rely on the grammar to detect this but it is not available when using",
+        "custom parsing",
+        "",
         "* parser-function:",
         "Indicates that the property requires a custom parser and that the parser function",
         "will be named whatever string is provided as the value.",
@@ -469,6 +474,7 @@
         "font-weight": {
             "inherited": true,
             "codegen-properties": {
+                "custom-parser-allows-number-or-integer-input": true,
                 "name-for-methods": "Weight",
                 "font-property": true,
                 "high-priority": true,
@@ -1894,7 +1900,8 @@
         "border-image-outset": {
             "codegen-properties": {
                 "custom": "All",
-                "custom-parser": true
+                "custom-parser": true,
+                "custom-parser-allows-number-or-integer-input": true
             },
             "specification": {
                 "category": "css-backgrounds",
@@ -1915,6 +1922,7 @@
             "codegen-properties": {
                 "custom": "All",
                 "custom-parser": true,
+                "custom-parser-allows-number-or-integer-input": true,
                 "parser-requires-current-property": true
             },
             "specification": {
@@ -1936,6 +1944,7 @@
             "codegen-properties": {
                 "custom": "All",
                 "custom-parser": true,
+                "custom-parser-allows-number-or-integer-input": true,
                 "parser-requires-current-property": true
             },
             "specification": {
@@ -4876,7 +4885,8 @@
                 "name-for-methods": "StrokeDashArray",
                 "converter": "StrokeDashArray",
                 "svg": true,
-                "custom-parser": true
+                "custom-parser": true,
+                "custom-parser-allows-number-or-integer-input": true
             },
             "specification": {
                 "category": "svg",

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -93,6 +93,7 @@ public:
     static UChar listValuedPropertySeparator(CSSPropertyID);
     static bool isListValuedProperty(CSSPropertyID propertyID) { return !!listValuedPropertySeparator(propertyID); }
     static Ref<CSSValueList> createListForProperty(CSSPropertyID);
+    static bool allowsNumberOrIntegerInput(CSSPropertyID);
 
     const StylePropertyMetadata& metadata() const { return m_metadata; }
 

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -110,6 +110,15 @@ ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& pr
     if (!value)
         return Exception { TypeError, "Invalid values"_s };
 
+    // The CSS Parser may silently convert number values to lengths. However, CSS Typed OM doesn't allow this so
+    // we do some pre-validation.
+    // FIXME: Eventually, we should be able to generate most of the validation code and not rely on the CSS parser
+    // at all.
+    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(*value); primitiveValue && primitiveValue->isNumberOrInteger()) {
+        if (!CSSProperty::allowsNumberOrIntegerInput(propertyID))
+            return Exception { TypeError, "Invalid value: This property doesn't allow <number> input"_s };
+    }
+
     if (!setProperty(propertyID, value.releaseNonNull()))
         return Exception { TypeError, "Invalid values"_s };
 

--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
@@ -399,6 +399,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
             'converter': self.validate_string,
             'custom': self.validate_string,
             'custom-parser': self.validate_boolean,
+            'custom-parser-allows-number-or-integer-input': self.validate_boolean,
             'enable-if': self.validate_string,
             'fast-path-inherited': self.validate_boolean,
             'fill-layer-property': self.validate_boolean,


### PR DESCRIPTION
#### add3c9105b58aa55330c85298e09b10ddaad6039
<pre>
[CSS-Typed-OM] StylePropertyMap.set() should throw when trying to set a number for a property which doesn&apos;t allow it
<a href="https://bugs.webkit.org/show_bug.cgi?id=249685">https://bugs.webkit.org/show_bug.cgi?id=249685</a>

Reviewed by Sam Weinig.

StylePropertyMap.set() should throw when trying to set a number for a property
which doesn&apos;t allow it.

We previously relied on our CSS parser for validation. However, CSS parsing is
more permissive than CSS Typed OM is some cases. In particular, the CSS parser
will append &quot;px&quot; to numbers in some cases for properties that need a &lt;length&gt;.

For CSS Typed OM, the type needs to match exactly:
- <a href="https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue-match-a-grammar">https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue-match-a-grammar</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/block-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/bottom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/center-coordinate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/coordinate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/flex-basis-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/gap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-start-end-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/left-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/letter-spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/offset-distance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/perspective-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/right-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/shape-margin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-thickness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-indent-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/top-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/vertical-align-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/word-spacing-expected.txt:
* Source/WebCore/css/CSSProperty.h:
* Source/WebCore/css/process-css-properties.py:
(GenerateCSSPropertyNames):
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::propertyAllowsNumberOrIntegerInput):
(WebCore::StylePropertyMap::set):

Canonical link: <a href="https://commits.webkit.org/258242@main">https://commits.webkit.org/258242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16911bba45cb76b5d9df860a75f991eed2b39dbb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110547 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170828 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1290 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93668 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108379 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35168 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78167 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4059 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24801 "Found 1 new test failure: media/video-seek-have-nothing.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4102 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1227 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44280 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5860 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2969 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->