### PR TITLE
Ensure transferred max size is floored by transferred min size in RenderReplaced::computeIntrinsicSizesConstrainedByTransferredMinMaxSizes.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-041-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-041-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-041.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-041.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Replaced Element 041</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-sizing-4/#aspect-ratio-size-transfers">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html"/>
+<meta name="assert" content="Replaced element transferred max size should be floored by transferred min size" />
+<style>
+div {
+    width: 0px;
+}
+img {
+    min-width: 100px;
+    max-width: 100%;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 0px">
+<img src="/css/support/60x60-green.png">
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5445,6 +5445,8 @@ std::pair<LayoutUnit, LayoutUnit> RenderBox::computeMinMaxLogicalWidthFromAspect
         if (LayoutUnit blockMaxSize = constrainLogicalHeightByMinMax(LayoutUnit::max(), std::nullopt); blockMaxSize != LayoutUnit::max())
             transferredMaxSize = inlineSizeFromAspectRatio(borderAndPaddingLogicalWidth(), borderAndPaddingLogicalHeight(), *aspectRatio, style().boxSizingForAspectRatio(), blockMaxSize, style().aspectRatioType(), isRenderReplaced());
     }
+    // Spec says the transferred max size should be floored by the transferred min size
+    transferredMaxSize = std::max(transferredMinSize, transferredMaxSize);
     return { transferredMinSize, transferredMaxSize };
 }
 
@@ -5465,6 +5467,8 @@ std::pair<LayoutUnit, LayoutUnit> RenderBox::computeMinMaxLogicalHeightFromAspec
         if (LayoutUnit inlineMaxSize = computeLogicalWidthInFragmentUsing(MaxSize, style().logicalMaxWidth(), containingBlockLogicalWidthForContent(), *containingBlock(), nullptr); inlineMaxSize != LayoutUnit::max())
             transferredMaxSize = blockSizeFromAspectRatio(borderAndPaddingLogicalWidth(), borderAndPaddingLogicalHeight(), *aspectRatio, style().boxSizingForAspectRatio(), inlineMaxSize, style().aspectRatioType(), isRenderReplaced());
     }
+    // Spec says the transferred max size should be floored by the transferred min size 
+    transferredMaxSize = std::max(transferredMinSize, transferredMaxSize);
     return { transferredMinSize, transferredMaxSize };
 }
 


### PR DESCRIPTION
#### 28c5d0e82b0f2b000aa18734a3f2345ed9cfd86e
<pre>
Ensure transferred max size is floored by transferred min size in RenderReplaced::computeIntrinsicSizesConstrainedByTransferredMinMaxSizes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249617">https://bugs.webkit.org/show_bug.cgi?id=249617</a>
rdar://103537352

Reviewed by Alan Baradlay.

Addresses a regression introduced by a change inside of
computeIntrinsicSizesConstrainedByTransferredMinMaxSizes. This method is
supposed to compute the intrinsic size and ratio of a replaced element and
also restrict that size if there are any transferred min/max constraints
that are violated. This code was not checking if the transferred max size
became smaller than the transferred min size. The max size is supposed to
be floored by the min size in order to avoid this scenario.

One situation in which this can happen is when we are computing the
min/max logical height, the containing block has an available width
of 0px, and the max-width specified is percentage based. When the call
to computeLogicalWidthInFragmentUsing returns, it will return a value of
0px when it resolves the percentage based max-width. Then, any specified
value of min-width greater than 0px will cause this issue. The new code
added addresses this issue by setting the max size to
max(min size, max size).

Ideally, we would be able to use RenderBox::constrainLogicalMinMaxSizesByAspectRatio,
which has this logic for us, but my attempt to do this was causing issues
when replaced elements were inside a flexbox.

Spec reference: <a href="https://www.w3.org/TR/css-sizing-4/#aspect-ratio-size-transfers">https://www.w3.org/TR/css-sizing-4/#aspect-ratio-size-transfers</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-041-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-041.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeMinMaxLogicalWidthFromAspectRatio const):
(WebCore::RenderBox::computeMinMaxLogicalHeightFromAspectRatio const):

Canonical link: <a href="https://commits.webkit.org/258210@main">https://commits.webkit.org/258210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c08984354fe998f82f77d2b4db0ba3f2620e72ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110483 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170764 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105187 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1220 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108315 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8577 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35129 "layout-tests (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23225 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78124 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3994 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1161 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44226 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5644 "Build was cancelled. Recent messages:Cleaned up git repository; 'python3 Tools/Scripts/git-webkit ...'; Checked out pull request; Verified commit is squashed; Reviewed by Alan Baradlay; Validated commit message; killing old processes; Compiled WebKit (cancelled)") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5795 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2962 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->