### PR TITLE
Import dom/xslt/sort.html WPT test

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -209,6 +209,7 @@
     "web-platform-tests/dom/nodes/ParentNode-querySelector-All.xht": "skip",
     "web-platform-tests/dom/traversal": "import",
     "web-platform-tests/dom/traversal/unfinished": "skip",
+    "web-platform-tests/dom/xslt": "import",
     "web-platform-tests/domparsing": "import",
     "web-platform-tests/domxpath": "import",
     "web-platform-tests/domxpath/xml_xpath_runner.html": "skip",

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -3892,6 +3892,7 @@
         "web-platform-tests/dom/traversal/unfinished/008.xml",
         "web-platform-tests/dom/traversal/unfinished/009.xml",
         "web-platform-tests/dom/traversal/unfinished/010.xml",
+        "web-platform-tests/dom/xslt/sort-ref.html",
         "web-platform-tests/domxpath/001.html",
         "web-platform-tests/domxpath/xml_xpath_tests.xml",
         "web-platform-tests/encoding/legacy-mb-japanese/euc-jp/eucjp_chars-cseucpkdfmtjapanese.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/xslt/sort-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/xslt/sort-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://bugs.chromium.org/p/chromium/issues/detail?id=1399858">
+
+<div>
+  <div>1</div>
+  <div>2</div>
+  <div>3</div>
+  <div>7</div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/xslt/sort-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/xslt/sort-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://bugs.chromium.org/p/chromium/issues/detail?id=1399858">
+
+<div>
+  <div>1</div>
+  <div>2</div>
+  <div>3</div>
+  <div>7</div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/xslt/sort.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/xslt/sort.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<link rel=match href="sort-ref.html">
+
+<body>
+  <div id="container"></div>
+</body>
+
+<script type="text/xml" id="sampleXml">
+  <root>
+    <node id="1" />
+    <node id="7" />
+    <node id="3" />
+    <node id="2" />
+  </root>
+</script>
+
+<script type="text/xml" id="sampleXsl">
+  <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:msxsl="urn:schemas-microsoft-com:xslt">
+
+    <xsl:template match="/">
+      <xsl:apply-templates select="//node">
+        <xsl:sort select="@id" data-type="number" />
+      </xsl:apply-templates>
+    </xsl:template>
+
+    <xsl:template match="node">
+      <div>
+        <xsl:value-of select="@id"/>
+      </div>
+    </xsl:template>
+
+  </xsl:stylesheet>
+</script>
+
+<script>
+  let parser = new DOMParser();
+  const xslStyleSheet = parser.parseFromString(document.getElementById('sampleXsl').textContent, 'text/xml');
+
+  const xsltProcessor = new XSLTProcessor();
+  xsltProcessor.importStylesheet(xslStyleSheet);
+
+  parser = new DOMParser();
+  const xmlDoc = parser.parseFromString(document.getElementById('sampleXml').textContent, 'text/xml');
+
+  const fragment = xsltProcessor.transformToFragment(xmlDoc, document);
+
+  document.getElementById('container').appendChild(fragment);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/xslt/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/xslt/w3c-import.log
@@ -17,6 +17,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/dom/xslt/README.md
 /LayoutTests/imported/w3c/web-platform-tests/dom/xslt/externalScript.js
 /LayoutTests/imported/w3c/web-platform-tests/dom/xslt/invalid-output-encoding-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/xslt/sort-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/xslt/sort-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/xslt/sort.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/xslt/strip-space-crash.xml
 /LayoutTests/imported/w3c/web-platform-tests/dom/xslt/transformToFragment-on-node-from-inactive-document-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/xslt/transformToFragment.tentative.window.js


### PR DESCRIPTION
#### 626bbc4f3b03af0abc2a6fded3c8b72654da8442
<pre>
Import dom/xslt/sort.html WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=249691">https://bugs.webkit.org/show_bug.cgi?id=249691</a>
&lt;rdar://103579714&gt;

Reviewed by Tim Nguyen.

Import WPT test that was added to identify an upstream libxslt
regression.

Upstream commit:  <a href="https://github.com/web-platform-tests/wpt/commit/44dd0f4cb0faa3154c5da2aff4c9e1405447e532">https://github.com/web-platform-tests/wpt/commit/44dd0f4cb0faa3154c5da2aff4c9e1405447e532</a>

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/dom/xslt/sort-expected.html: Add.
* LayoutTests/imported/w3c/web-platform-tests/dom/xslt/sort-ref.html: Add.
* LayoutTests/imported/w3c/web-platform-tests/dom/xslt/sort.html: Add.
* LayoutTests/imported/w3c/web-platform-tests/dom/xslt/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/258196@main">https://commits.webkit.org/258196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13ab7f8772baf6e5e497264eccd92d214eaca3b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101204 "Failed to checkout and rebase branch from PR 7947") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/10359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/34259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/110489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/11295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/1226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/108321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106987 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/11295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/34259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/93606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/11295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/34259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/34259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/4048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/1226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/10151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/34259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2954 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->