### PR TITLE
Encode 128 bits for IPC's destination identifier

### DIFF
--- a/Source/WTF/wtf/Int128.h
+++ b/Source/WTF/wtf/Int128.h
@@ -40,6 +40,9 @@
 #include <iosfwd>
 #include <limits>
 #include <utility>
+#include <wtf/ArgumentCoder.h>
+#include <wtf/HashFunctions.h>
+#include <wtf/HashTraits.h>
 #include <wtf/Platform.h>
 
 #if COMPILER(MSVC)
@@ -1264,10 +1267,78 @@ using UInt128 = UInt128Impl;
 using Int128 = Int128Impl;
 #endif
 
+template<> struct DefaultHash<UInt128> {
+    static unsigned hash(const UInt128& i) { return pairIntHash(static_cast<uint64_t>(i >> 64), static_cast<uint64_t>(i)); }
+    static bool equal(const UInt128& a, const UInt128& b) { return a == b; }
+    static constexpr bool safeToCompareToEmptyOrDeleted = true;
+};
+template<> struct DefaultHash<Int128> {
+    static unsigned hash(const UInt128& i) { return pairIntHash(static_cast<uint64_t>(i >> 64), static_cast<uint64_t>(i)); }
+    static bool equal(const Int128& a, const Int128& b) { return a == b; }
+    static constexpr bool safeToCompareToEmptyOrDeleted = true;
+};
+
+template<> struct HashTraits<UInt128> : GenericHashTraits<UInt128> {
+    static constexpr bool emptyValueIsZero = true;
+    static void constructDeletedValue(UInt128& slot) { slot = static_cast<UInt128>(-1); }
+    static bool isDeletedValue(UInt128 value) { return value == static_cast<UInt128>(-1); }
+};
+
+template<> struct HashTraits<Int128> : GenericHashTraits<Int128> {
+    static constexpr bool emptyValueIsZero = true;
+    static void constructDeletedValue(Int128& slot) { slot = static_cast<Int128>(-1); }
+    static bool isDeletedValue(Int128 value) { return value == static_cast<Int128>(-1); }
+};
+
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, UInt128);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, Int128);
 
 }  // namespace WTF
+
+namespace IPC {
+template<> struct ArgumentCoder<WTF::UInt128> {
+    template<typename Encoder> static void encode(Encoder& encoder, const WTF::UInt128& i)
+    {
+        encoder << static_cast<uint64_t>(i >> 64);
+        encoder << static_cast<uint64_t>(i);
+    }
+    template<typename Decoder> static std::optional<WTF::UInt128> decode(Decoder& decoder)
+    {
+        std::optional<uint64_t> high;
+        decoder >> high;
+        if (!high)
+            return std::nullopt;
+
+        std::optional<uint64_t> low;
+        decoder >> low;
+        if (!low)
+            return std::nullopt;
+
+        return (static_cast<WTF::UInt128>(*high) << 64) | *low;
+    }
+};
+template<> struct ArgumentCoder<WTF::Int128> {
+    template<typename Encoder> static void encode(Encoder& encoder, const WTF::Int128& i)
+    {
+        encoder << static_cast<int64_t>(i >> 64);
+        encoder << static_cast<int64_t>(i);
+    }
+    template<typename Decoder> static std::optional<WTF::Int128> decode(Decoder& decoder)
+    {
+        std::optional<int64_t> high;
+        decoder >> high;
+        if (!high)
+            return std::nullopt;
+
+        std::optional<uint64_t> low;
+        decoder >> low;
+        if (!low)
+            return std::nullopt;
+
+        return (static_cast<WTF::Int128>(*high) << 64) | *low;
+    }
+};
+}
 
 using WTF::Int128;
 using WTF::UInt128;

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -28,6 +28,7 @@
 #include <atomic>
 #include <mutex>
 #include <wtf/HashTraits.h>
+#include <wtf/Int128.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/TextStream.h>
 #include <wtf/text/WTFString.h>
@@ -131,7 +132,7 @@ public:
     };
 
 private:
-    template<typename U> friend ObjectIdentifier<U> makeObjectIdentifier(uint64_t);
+    template<typename U> friend ObjectIdentifier<U> makeObjectIdentifier(UInt128);
     friend struct HashTraits<ObjectIdentifier>;
     template<typename U> friend struct ObjectIdentifierHash;
 
@@ -147,9 +148,10 @@ private:
     inline static bool m_generationProtected { false };
 };
 
-template<typename T> inline ObjectIdentifier<T> makeObjectIdentifier(uint64_t identifier)
+template<typename T> inline ObjectIdentifier<T> makeObjectIdentifier(UInt128 identifier)
 {
-    return ObjectIdentifier<T> { identifier };
+    ASSERT(identifier == static_cast<uint64_t>(identifier));
+    return ObjectIdentifier<T> { static_cast<uint64_t>(identifier) };
 }
 
 template<typename T> inline void add(Hasher& hasher, ObjectIdentifier<T> identifier)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -205,7 +205,7 @@ void NetworkProcess::didReceiveMessage(IPC::Connection& connection, IPC::Decoder
 {
     ASSERT(parentProcessConnection() == &connection);
     if (parentProcessConnection() != &connection) {
-        WTFLogAlways("Ignored message '%s' because it did not come from the UIProcess (destination=%" PRIu64 ")", description(decoder.messageName()), decoder.destinationID());
+        WTFLogAlways("Ignored message '%s' because it did not come from the UIProcess (destination=%" PRIu64 ")", description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
         ASSERT_NOT_REACHED();
         return;
     }
@@ -232,7 +232,7 @@ bool NetworkProcess::didReceiveSyncMessage(IPC::Connection& connection, IPC::Dec
 {
     ASSERT(parentProcessConnection() == &connection);
     if (parentProcessConnection() != &connection) {
-        WTFLogAlways("Ignored message '%s' because it did not come from the UIProcess (destination=%" PRIu64 ")", description(decoder.messageName()), decoder.destinationID());
+        WTFLogAlways("Ignored message '%s' because it did not come from the UIProcess (destination=%" PRIu64 ")", description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));
         ASSERT_NOT_REACHED();
         return false;
     }
@@ -2061,7 +2061,7 @@ void NetworkProcess::continueWillSendRequest(DownloadID downloadID, WebCore::Res
 
 void NetworkProcess::findPendingDownloadLocation(NetworkDataTask& networkDataTask, ResponseCompletionHandler&& completionHandler, const ResourceResponse& response)
 {
-    uint64_t destinationID = networkDataTask.pendingDownloadID().toUInt64();
+    UInt128 destinationID = networkDataTask.pendingDownloadID().toUInt64();
 
     String suggestedFilename = networkDataTask.suggestedFilename();
 

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -242,8 +242,8 @@ public:
     // Adds a message receive queue that dispatches through WorkQueue to WorkQueueMessageReceiver.
     // Keeps the WorkQueue and the WorkQueueMessageReceiver alive. Dispatched tasks keep WorkQueueMessageReceiver alive.
     // destinationID == 0 matches all ids.
-    void addWorkQueueMessageReceiver(ReceiverName, WorkQueue&, WorkQueueMessageReceiver&, uint64_t destinationID = 0);
-    void removeWorkQueueMessageReceiver(ReceiverName, uint64_t destinationID = 0);
+    void addWorkQueueMessageReceiver(ReceiverName, WorkQueue&, WorkQueueMessageReceiver&, UInt128 destinationID = 0);
+    void removeWorkQueueMessageReceiver(ReceiverName, UInt128 destinationID = 0);
 
     // Adds a message receive queue that dispatches through FunctionDispatcher.
     // `FunctionDispatcher` will be used in any thread.
@@ -251,16 +251,16 @@ public:
     // until `removeMessageReceiver()` for same receiver name, destination id returns.
     // The caller is responsible for making sure the `MessageReceiver` is alive when the dispatched functions
     // are run.
-    void addMessageReceiver(FunctionDispatcher&, MessageReceiver&, ReceiverName, uint64_t destinationID = 0);
-    void removeMessageReceiver(ReceiverName, uint64_t destinationID = 0);
+    void addMessageReceiver(FunctionDispatcher&, MessageReceiver&, ReceiverName, UInt128 destinationID = 0);
+    void removeMessageReceiver(ReceiverName, UInt128 destinationID = 0);
 
     bool open(Client&, SerialFunctionDispatcher& = RunLoop::current());
     void invalidate();
     void markCurrentlyDispatchedMessageAsInvalid();
 
-    template<typename T, typename C> AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID = 0, OptionSet<SendOption> = { }); // Thread-safe.
-    template<typename T> bool send(T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt); // Thread-safe.
-    template<typename T> static bool send(UniqueID, T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt); // Thread-safe.
+    template<typename T, typename C> AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, UInt128 destinationID = 0, OptionSet<SendOption> = { }); // Thread-safe.
+    template<typename T> bool send(T&& message, UInt128 destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt); // Thread-safe.
+    template<typename T> static bool send(UniqueID, T&& message, UInt128 destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt); // Thread-safe.
 
     // Sync senders should check the SendSyncResult for true/false in case they need to know if the result was really received.
     // Sync senders should hold on to the SendSyncResult in case they reference the contents of the reply via DataRefererence / ArrayReference.
@@ -291,9 +291,8 @@ public:
         }
     };
 
-    template<typename T> SendSyncResult<T> sendSync(T&& message, uint64_t destinationID, Timeout = Timeout::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { }); // Main thread only.
-
-    template<typename> bool waitForAndDispatchImmediately(uint64_t destinationID, Timeout, OptionSet<WaitForOption> waitForOptions = { }); // Main thread only.
+    template<typename T> SendSyncResult<T> sendSync(T&& message, UInt128 destinationID, Timeout = Timeout::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { }); // Main thread only.
+    template<typename> bool waitForAndDispatchImmediately(UInt128 destinationID, Timeout, OptionSet<WaitForOption> waitForOptions = { }); // Main thread only.
     template<typename> bool waitForAsyncReplyAndDispatchImmediately(AsyncReplyID, Timeout); // Main thread only.
 
     // Thread-safe.
@@ -331,7 +330,7 @@ public:
         AsyncReplyID replyID;
     };
     bool sendMessageWithAsyncReply(UniqueRef<Encoder>&&, AsyncReplyHandler, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> = std::nullopt);
-    UniqueRef<Encoder> createSyncMessageEncoder(MessageName, uint64_t destinationID, SyncRequestID&);
+    UniqueRef<Encoder> createSyncMessageEncoder(MessageName, UInt128 destinationID, SyncRequestID&);
     std::unique_ptr<Decoder> sendSyncMessage(SyncRequestID, UniqueRef<Encoder>&&, Timeout, OptionSet<SendSyncOption> sendSyncOptions);
     bool sendSyncReply(UniqueRef<Encoder>&&);
 
@@ -366,7 +365,7 @@ public:
     void setIgnoreInvalidMessageForTesting() { m_ignoreInvalidMessageForTesting = true; }
     bool ignoreInvalidMessageForTesting() const { return m_ignoreInvalidMessageForTesting; }
     void dispatchIncomingMessageForTesting(std::unique_ptr<Decoder>&&);
-    std::unique_ptr<Decoder> waitForMessageForTesting(MessageName, uint64_t destinationID, Timeout, OptionSet<WaitForOption>);
+    std::unique_ptr<Decoder> waitForMessageForTesting(MessageName, UInt128 destinationID, Timeout, OptionSet<WaitForOption>);
 #endif
 
     void dispatchMessageReceiverMessage(MessageReceiver&, std::unique_ptr<Decoder>&&);
@@ -389,8 +388,8 @@ private:
     bool isIncomingMessagesThrottlingEnabled() const { return m_incomingMessagesThrottlingLevel.has_value(); }
 
     static HashMap<IPC::Connection::UniqueID, Connection*>& connectionMap() WTF_REQUIRES_LOCK(s_connectionMapLock);
-
-    std::unique_ptr<Decoder> waitForMessage(MessageName, uint64_t destinationID, Timeout, OptionSet<WaitForOption>);
+    
+    std::unique_ptr<Decoder> waitForMessage(MessageName, UInt128 destinationID, Timeout, OptionSet<WaitForOption>);
 
     SyncRequestID makeSyncRequestID() { return SyncRequestID::generateThreadSafe(); }
     bool pushPendingSyncRequestID(SyncRequestID);
@@ -576,7 +575,7 @@ private:
 };
 
 template<typename T>
-bool Connection::send(T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
+bool Connection::send(T&& message, UInt128 destinationID, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
 {
     static_assert(!T::isSync, "Async message expected");
 
@@ -587,7 +586,7 @@ bool Connection::send(T&& message, uint64_t destinationID, OptionSet<SendOption>
 }
 
 template<typename T>
-bool Connection::send(UniqueID connectionID, T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
+bool Connection::send(UniqueID connectionID, T&& message, UInt128 destinationID, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
 {
     Locker locker { s_connectionMapLock };
     auto* connection = connectionMap().get(connectionID);
@@ -597,7 +596,7 @@ bool Connection::send(UniqueID connectionID, T&& message, uint64_t destinationID
 }
 
 template<typename T, typename C>
-Connection::AsyncReplyID Connection::sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption> sendOptions)
+Connection::AsyncReplyID Connection::sendWithAsyncReply(T&& message, C&& completionHandler, UInt128 destinationID, OptionSet<SendOption> sendOptions)
 {
     static_assert(!T::isSync, "Async message expected");
     auto handler = makeAsyncReplyHandler<T>(WTFMove(completionHandler));
@@ -609,7 +608,7 @@ Connection::AsyncReplyID Connection::sendWithAsyncReply(T&& message, C&& complet
     return { };
 }
 
-template<typename T> Connection::SendSyncResult<T> Connection::sendSync(T&& message, uint64_t destinationID, Timeout timeout, OptionSet<SendSyncOption> sendSyncOptions)
+template<typename T> Connection::SendSyncResult<T> Connection::sendSync(T&& message, UInt128 destinationID, Timeout timeout, OptionSet<SendSyncOption> sendSyncOptions)
 {
     static_assert(T::isSync, "Sync message expected");
     SyncRequestID syncRequestID;
@@ -636,7 +635,7 @@ template<typename T> Connection::SendSyncResult<T> Connection::sendSync(T&& mess
     return result;
 }
 
-template<typename T> bool Connection::waitForAndDispatchImmediately(uint64_t destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)
+template<typename T> bool Connection::waitForAndDispatchImmediately(UInt128 destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)
 {
     std::unique_ptr<Decoder> decoder = waitForMessage(T::name(), destinationID, timeout, waitForOptions);
     if (!decoder)
@@ -655,8 +654,8 @@ template<typename T> bool Connection::waitForAsyncReplyAndDispatchImmediately(As
         return false;
 
     ASSERT(decoder->messageReceiverName() == ReceiverName::AsyncReply);
-    ASSERT(decoder->destinationID() == replyID.toUInt64());
-    auto handler = takeAsyncReplyHandler(makeObjectIdentifier<AsyncReplyIDType>(decoder->destinationID()));
+    ASSERT(replyID.toUInt64() == static_cast<uint64_t>(decoder->destinationID()));
+    auto handler = takeAsyncReplyHandler(makeObjectIdentifier<AsyncReplyIDType>(static_cast<uint64_t>(decoder->destinationID())));
     if (!handler) {
         ASSERT_NOT_REACHED();
         return false;
@@ -666,7 +665,7 @@ template<typename T> bool Connection::waitForAsyncReplyAndDispatchImmediately(As
 }
 
 #if ENABLE(IPC_TESTING_API)
-inline std::unique_ptr<Decoder> Connection::waitForMessageForTesting(MessageName messageName, uint64_t destinationID, Timeout timeout, OptionSet<WaitForOption> options)
+inline std::unique_ptr<Decoder> Connection::waitForMessageForTesting(MessageName messageName, UInt128 destinationID, Timeout timeout, OptionSet<WaitForOption> options)
 {
     return waitForMessage(messageName, destinationID, timeout, options);
 }

--- a/Source/WebKit/Platform/IPC/Decoder.cpp
+++ b/Source/WebKit/Platform/IPC/Decoder.cpp
@@ -78,7 +78,7 @@ Decoder::Decoder(const uint8_t* buffer, size_t bufferSize, BufferDeallocator&& b
     , m_bufferDeallocator { WTFMove(bufferDeallocator) }
     , m_attachments { WTFMove(attachments) }
 {
-    if (UNLIKELY(reinterpret_cast<uintptr_t>(m_buffer) % alignof(uint64_t))) {
+    if (UNLIKELY(reinterpret_cast<uintptr_t>(m_buffer) % alignof(UInt128))) {
         markInvalid();
         return;
     }
@@ -93,7 +93,7 @@ Decoder::Decoder(const uint8_t* buffer, size_t bufferSize, BufferDeallocator&& b
         return;
 }
 
-Decoder::Decoder(const uint8_t* stream, size_t streamSize, uint64_t destinationID)
+Decoder::Decoder(const uint8_t* stream, size_t streamSize, UInt128 destinationID)
     : m_buffer { stream }
     , m_bufferPos { m_buffer }
     , m_bufferEnd { m_buffer + streamSize }

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -51,7 +51,7 @@ public:
     static std::unique_ptr<Decoder> create(const uint8_t* buffer, size_t bufferSize, Vector<Attachment>&&);
     using BufferDeallocator = Function<void(const uint8_t*, size_t)>;
     static std::unique_ptr<Decoder> create(const uint8_t* buffer, size_t bufferSize, BufferDeallocator&&, Vector<Attachment>&&);
-    Decoder(const uint8_t* stream, size_t streamSize, uint64_t destinationID);
+    Decoder(const uint8_t* stream, size_t streamSize, UInt128 destinationID);
 
     ~Decoder();
 
@@ -62,7 +62,7 @@ public:
 
     ReceiverName messageReceiverName() const { return receiverName(m_messageName); }
     MessageName messageName() const { return m_messageName; }
-    uint64_t destinationID() const { return m_destinationID; }
+    UInt128 destinationID() const { return m_destinationID; }
     bool matches(const ReceiverMatcher& matcher) const { return matcher.matches(messageReceiverName(), destinationID()); }
 
     bool isSyncMessage() const { return messageIsSync(messageName()); }
@@ -170,8 +170,8 @@ private:
     OptionSet<MessageFlags> m_messageFlags;
     MessageName m_messageName;
 
-    uint64_t m_destinationID;
     bool m_isAllowedWhenWaitingForSyncReplyOverride { false };
+    UInt128 m_destinationID;
 
 #if PLATFORM(MAC)
     ImportanceAssertion m_importanceAssertion;

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -63,7 +63,7 @@ static inline void freeBuffer(void* addr, size_t size)
 #endif
 }
 
-Encoder::Encoder(MessageName messageName, uint64_t destinationID)
+Encoder::Encoder(MessageName messageName, UInt128 destinationID)
     : m_messageName(messageName)
     , m_destinationID(destinationID)
 {

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -29,6 +29,7 @@
 #include "MessageNames.h"
 #include <WebCore/SharedBuffer.h>
 #include <wtf/Forward.h>
+#include <wtf/Int128.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Vector.h>
 
@@ -42,7 +43,7 @@ template<typename, typename> struct ArgumentCoder;
 class Encoder final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    Encoder(MessageName, uint64_t destinationID);
+    Encoder(MessageName, UInt128 destinationID);
     ~Encoder();
 
     Encoder(const Encoder&) = delete;
@@ -52,7 +53,7 @@ public:
 
     ReceiverName messageReceiverName() const { return receiverName(m_messageName); }
     MessageName messageName() const { return m_messageName; }
-    uint64_t destinationID() const { return m_destinationID; }
+    UInt128 destinationID() const { return m_destinationID; }
 
     bool isSyncMessage() const { return messageIsSync(messageName()); }
 
@@ -95,7 +96,7 @@ private:
     OptionSet<MessageFlags>& messageFlags();
 
     MessageName m_messageName;
-    uint64_t m_destinationID;
+    UInt128 m_destinationID;
 
     uint8_t m_inlineBuffer[512];
 

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h
@@ -29,6 +29,7 @@
 #include "MessageReceiveQueue.h"
 #include <variant>
 #include <wtf/HashMap.h>
+#include <wtf/Int128.h>
 
 namespace IPC {
 
@@ -52,7 +53,7 @@ public:
 private:
     using StoreType = std::variant<MessageReceiveQueue*, std::unique_ptr<MessageReceiveQueue>>;
     void addImpl(StoreType&&, const ReceiverMatcher&);
-    using QueueMap = HashMap<std::pair<uint8_t, uint64_t>, StoreType>;
+    using QueueMap = HashMap<std::pair<uint8_t, UInt128>, StoreType>;
     // Key is ReceiverName. FIXME: make it possible to use ReceiverName.
     using AnyIDQueueMap = HashMap<uint8_t, StoreType>;
     QueueMap m_queues;

--- a/Source/WebKit/Platform/IPC/MessageReceiverMap.cpp
+++ b/Source/WebKit/Platform/IPC/MessageReceiverMap.cpp
@@ -47,7 +47,7 @@ void MessageReceiverMap::addMessageReceiver(ReceiverName messageReceiverName, Me
     m_globalMessageReceivers.set(messageReceiverName, messageReceiver);
 }
 
-void MessageReceiverMap::addMessageReceiver(ReceiverName messageReceiverName, uint64_t destinationID, MessageReceiver& messageReceiver)
+void MessageReceiverMap::addMessageReceiver(ReceiverName messageReceiverName, UInt128 destinationID, MessageReceiver& messageReceiver)
 {
     ASSERT(destinationID);
     ASSERT(!m_messageReceivers.contains(std::make_pair(messageReceiverName, destinationID)));
@@ -70,7 +70,7 @@ void MessageReceiverMap::removeMessageReceiver(ReceiverName messageReceiverName)
     m_globalMessageReceivers.remove(it);
 }
 
-void MessageReceiverMap::removeMessageReceiver(ReceiverName messageReceiverName, uint64_t destinationID)
+void MessageReceiverMap::removeMessageReceiver(ReceiverName messageReceiverName, UInt128 destinationID)
 {
     auto it = m_messageReceivers.find(std::make_pair(messageReceiverName, destinationID));
     if (it == m_messageReceivers.end()) {

--- a/Source/WebKit/Platform/IPC/MessageReceiverMap.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiverMap.h
@@ -43,10 +43,10 @@ public:
     ~MessageReceiverMap();
 
     void addMessageReceiver(ReceiverName, MessageReceiver&);
-    void addMessageReceiver(ReceiverName, uint64_t destinationID, MessageReceiver&);
+    void addMessageReceiver(ReceiverName, UInt128 destinationID, MessageReceiver&);
 
     void removeMessageReceiver(ReceiverName);
-    void removeMessageReceiver(ReceiverName, uint64_t destinationID);
+    void removeMessageReceiver(ReceiverName, UInt128 destinationID);
     void removeMessageReceiver(MessageReceiver&);
 
     void invalidate();
@@ -58,7 +58,7 @@ private:
     // Message receivers that don't require a destination ID.
     HashMap<ReceiverName, WeakPtr<MessageReceiver>, WTF::IntHash<ReceiverName>, WTF::StrongEnumHashTraits<ReceiverName>> m_globalMessageReceivers;
 
-    HashMap<std::pair<ReceiverName, uint64_t>, WeakPtr<MessageReceiver>, DefaultHash<std::pair<ReceiverName, uint64_t>>, PairHashTraits<WTF::StrongEnumHashTraits<ReceiverName>, HashTraits<uint64_t>>> m_messageReceivers;
+    HashMap<std::pair<ReceiverName, UInt128>, WeakPtr<MessageReceiver>, DefaultHash<std::pair<ReceiverName, UInt128>>, PairHashTraits<WTF::StrongEnumHashTraits<ReceiverName>, HashTraits<UInt128>>> m_messageReceivers;
 };
 
 };

--- a/Source/WebKit/Platform/IPC/MessageSender.h
+++ b/Source/WebKit/Platform/IPC/MessageSender.h
@@ -27,6 +27,7 @@
 
 #include <wtf/Assertions.h>
 #include "Connection.h"
+#include <wtf/Int128.h>
 #include <wtf/UniqueRef.h>
 
 namespace IPC {
@@ -40,7 +41,7 @@ public:
         return send(WTFMove(message), messageSenderDestinationID(), sendOptions);
     }
 
-    template<typename T> bool send(T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { })
+    template<typename T> bool send(T&& message, UInt128 destinationID, OptionSet<SendOption> sendOptions = { })
     {
         static_assert(!T::isSync, "Message is sync!");
 
@@ -66,7 +67,7 @@ public:
     }
 
     template<typename T>
-    SendSyncResult<T> sendSync(T&& message, uint64_t destinationID, Timeout timeout = Timeout::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { })
+    SendSyncResult<T> sendSync(T&& message, UInt128 destinationID, Timeout timeout = Timeout::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { })
     {
         if (auto* connection = messageSenderConnection())
             return connection->sendSync(WTFMove(message), destinationID, timeout, sendSyncOptions);
@@ -89,7 +90,7 @@ public:
     }
 
     template<typename T, typename C>
-    AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption> sendOptions = { })
+    AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, UInt128 destinationID, OptionSet<SendOption> sendOptions = { })
     {
         static_assert(!T::isSync, "Async message expected");
 

--- a/Source/WebKit/Platform/IPC/ReceiverMatcher.h
+++ b/Source/WebKit/Platform/IPC/ReceiverMatcher.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <optional>
+#include <wtf/Int128.h>
 
 namespace IPC {
 
@@ -41,27 +42,27 @@ struct ReceiverMatcher {
 
     // Matches message to specific receiver, specific destination ID.
     // Note: destinationID == 0 matches only 0 ids.
-    ReceiverMatcher(ReceiverName receiverName, uint64_t destinationID)
+    ReceiverMatcher(ReceiverName receiverName, UInt128 destinationID)
         : receiverName(receiverName)
         , destinationID(destinationID)
     {
     }
 
     // Creates a matcher from parameters where destinationID == 0 means any destintation ID. Deprecated.
-    static ReceiverMatcher createWithZeroAsAnyDestination(ReceiverName receiverName, uint64_t destinationID)
+    static ReceiverMatcher createWithZeroAsAnyDestination(ReceiverName receiverName, UInt128 destinationID)
     {
         if (destinationID)
             return ReceiverMatcher { receiverName, destinationID };
         return ReceiverMatcher { receiverName };
     }
 
-    bool matches(ReceiverName matchReceiverName, uint64_t matchDestinationID) const
+    bool matches(ReceiverName matchReceiverName, UInt128 matchDestinationID) const
     {
         return !receiverName || (*receiverName == matchReceiverName && (!destinationID || *destinationID == matchDestinationID));
     }
 
     std::optional<ReceiverName> receiverName;
-    std::optional<uint64_t> destinationID;
+    std::optional<UInt128> destinationID;
 };
 
 }

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -110,7 +110,7 @@ private:
     bool trySendStream(Span&, T& message, AdditionalData&&...);
     template<typename T>
     std::optional<SendSyncResult<T>> trySendSyncStream(T& message, Timeout, Span&);
-    bool trySendDestinationIDIfNeeded(uint64_t destinationID, Timeout);
+    bool trySendDestinationIDIfNeeded(UInt128 destinationID, Timeout);
     void sendProcessOutOfStreamMessage(Span&&);
 
     std::optional<Span> tryAcquire(Timeout);
@@ -151,7 +151,7 @@ private:
         Connection::Client& m_receiver;
     };
     std::optional<DedicatedConnectionClient> m_dedicatedConnectionClient;
-    uint64_t m_currentDestinationID { 0 };
+    UInt128 m_currentDestinationID { 0 };
     size_t m_clientOffset { 0 };
     StreamConnectionBuffer m_buffer;
     struct Semaphores {
@@ -300,7 +300,7 @@ std::optional<StreamClientConnection::SendSyncResult<T>> StreamClientConnection:
     return result;
 }
 
-inline bool StreamClientConnection::trySendDestinationIDIfNeeded(uint64_t destinationID, Timeout timeout)
+inline bool StreamClientConnection::trySendDestinationIDIfNeeded(UInt128 destinationID, Timeout timeout)
 {
     if (destinationID == m_currentDestinationID)
         return true;

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -86,7 +86,7 @@ void StreamServerConnection::invalidate()
     m_connection->invalidate();
 }
 
-void StreamServerConnection::startReceivingMessages(StreamMessageReceiver& receiver, ReceiverName receiverName, uint64_t destinationID)
+void StreamServerConnection::startReceivingMessages(StreamMessageReceiver& receiver, ReceiverName receiverName, UInt128 destinationID)
 {
     {
         auto key = std::make_pair(static_cast<uint8_t>(receiverName), destinationID);
@@ -97,7 +97,7 @@ void StreamServerConnection::startReceivingMessages(StreamMessageReceiver& recei
     m_workQueue.addStreamConnection(*this);
 }
 
-void StreamServerConnection::stopReceivingMessages(ReceiverName receiverName, uint64_t destinationID)
+void StreamServerConnection::stopReceivingMessages(ReceiverName receiverName, UInt128 destinationID)
 {
     m_workQueue.removeStreamConnection(*this);
 
@@ -254,7 +254,7 @@ StreamServerConnection::DispatchResult StreamServerConnection::dispatchStreamMes
 
 bool StreamServerConnection::processSetStreamDestinationID(Decoder&& decoder, RefPtr<StreamMessageReceiver>& currentReceiver)
 {
-    uint64_t destinationID = 0;
+    UInt128 destinationID = 0;
     if (!decoder.decode(destinationID)) {
         m_connection->dispatchDidReceiveInvalidMessage(decoder.messageName());
         return false;

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -64,9 +64,9 @@ public:
     static Ref<StreamServerConnection> create(Handle&&, StreamConnectionWorkQueue&);
     ~StreamServerConnection() final;
 
-    void startReceivingMessages(StreamMessageReceiver&, ReceiverName, uint64_t destinationID);
+    void startReceivingMessages(StreamMessageReceiver&, ReceiverName, UInt128 destinationID);
     // Stops the message receipt. Note: already received messages might still be delivered.
-    void stopReceivingMessages(ReceiverName, uint64_t destinationID);
+    void stopReceivingMessages(ReceiverName, UInt128 destinationID);
 
     Connection& connection() { return m_connection; }
 
@@ -132,9 +132,9 @@ private:
 
     bool m_isDispatchingStreamMessage { false };
     Lock m_receiversLock;
-    using ReceiversMap = HashMap<std::pair<uint8_t, uint64_t>, Ref<StreamMessageReceiver>>;
+    using ReceiversMap = HashMap<std::pair<uint8_t, UInt128>, Ref<StreamMessageReceiver>>;
     ReceiversMap m_receivers WTF_GUARDED_BY_LOCK(m_receiversLock);
-    uint64_t m_currentDestinationID { 0 };
+    UInt128 m_currentDestinationID { 0 };
 
     friend class StreamConnectionWorkQueue;
 };

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1040,7 +1040,7 @@ def generate_message_handler(receiver):
             result.append('    if (connection.connection().ignoreInvalidMessageForTesting())\n')
             result.append('        return;\n')
             result.append('#endif // ENABLE(IPC_TESTING_API)\n')
-            result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());\n')
+            result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));\n')
         result.append('}\n')
     else:
         receive_variant = receiver.name if receiver.has_attribute(LEGACY_RECEIVER_ATTRIBUTE) else ''
@@ -1061,7 +1061,7 @@ def generate_message_handler(receiver):
             result.append('    if (connection.ignoreInvalidMessageForTesting())\n')
             result.append('        return;\n')
             result.append('#endif // ENABLE(IPC_TESTING_API)\n')
-            result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());\n')
+            result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));\n')
         result.append('}\n')
 
     if not receiver.has_attribute(STREAM_ATTRIBUTE) and (sync_messages or receiver.has_attribute(WANTS_DISPATCH_MESSAGE_ATTRIBUTE)):
@@ -1081,7 +1081,7 @@ def generate_message_handler(receiver):
         result.append('    if (connection.ignoreInvalidMessageForTesting())\n')
         result.append('        return false;\n')
         result.append('#endif // ENABLE(IPC_TESTING_API)\n')
-        result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());\n')
+        result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()));\n')
         result.append('    return false;\n')
         result.append('}\n')
 

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -130,12 +130,12 @@ void AuxiliaryProcess::addMessageReceiver(IPC::ReceiverName messageReceiverName,
     m_messageReceiverMap.addMessageReceiver(messageReceiverName, messageReceiver);
 }
 
-void AuxiliaryProcess::addMessageReceiver(IPC::ReceiverName messageReceiverName, uint64_t destinationID, IPC::MessageReceiver& messageReceiver)
+void AuxiliaryProcess::addMessageReceiver(IPC::ReceiverName messageReceiverName, UInt128 destinationID, IPC::MessageReceiver& messageReceiver)
 {
     m_messageReceiverMap.addMessageReceiver(messageReceiverName, destinationID, messageReceiver);
 }
 
-void AuxiliaryProcess::removeMessageReceiver(IPC::ReceiverName messageReceiverName, uint64_t destinationID)
+void AuxiliaryProcess::removeMessageReceiver(IPC::ReceiverName messageReceiverName, UInt128 destinationID)
 {
     m_messageReceiverMap.removeMessageReceiver(messageReceiverName, destinationID);
 }

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -66,8 +66,8 @@ public:
     void enableTermination();
 
     void addMessageReceiver(IPC::ReceiverName, IPC::MessageReceiver&);
-    void addMessageReceiver(IPC::ReceiverName, uint64_t destinationID, IPC::MessageReceiver&);
-    void removeMessageReceiver(IPC::ReceiverName, uint64_t destinationID);
+    void addMessageReceiver(IPC::ReceiverName, UInt128 destinationID, IPC::MessageReceiver&);
+    void removeMessageReceiver(IPC::ReceiverName, UInt128 destinationID);
     void removeMessageReceiver(IPC::ReceiverName);
     void removeMessageReceiver(IPC::MessageReceiver&);
     

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -254,12 +254,12 @@ void AuxiliaryProcessProxy::addMessageReceiver(IPC::ReceiverName messageReceiver
     m_messageReceiverMap.addMessageReceiver(messageReceiverName, messageReceiver);
 }
 
-void AuxiliaryProcessProxy::addMessageReceiver(IPC::ReceiverName messageReceiverName, uint64_t destinationID, IPC::MessageReceiver& messageReceiver)
+void AuxiliaryProcessProxy::addMessageReceiver(IPC::ReceiverName messageReceiverName, UInt128 destinationID, IPC::MessageReceiver& messageReceiver)
 {
     m_messageReceiverMap.addMessageReceiver(messageReceiverName, destinationID, messageReceiver);
 }
 
-void AuxiliaryProcessProxy::removeMessageReceiver(IPC::ReceiverName messageReceiverName, uint64_t destinationID)
+void AuxiliaryProcessProxy::removeMessageReceiver(IPC::ReceiverName messageReceiverName, UInt128 destinationID)
 {
     m_messageReceiverMap.removeMessageReceiver(messageReceiverName, destinationID);
 }

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -60,14 +60,15 @@ public:
 
     virtual ProcessThrottler& throttler() = 0;
 
-    template<typename T> bool send(T&& message, uint64_t destinationID, OptionSet<IPC::SendOption> sendOptions = { });
+    template<typename T> bool send(T&& message, UInt128 destinationID, OptionSet<IPC::SendOption> sendOptions = { });
 
     template<typename T> using SendSyncResult = IPC::Connection::SendSyncResult<T>;
-    template<typename T> SendSyncResult<T> sendSync(T&& message, uint64_t destinationID, IPC::Timeout = 1_s, OptionSet<IPC::SendSyncOption> sendSyncOptions = { });
+    template<typename T> SendSyncResult<T> sendSync(T&& message, UInt128 destinationID, IPC::Timeout = 1_s, OptionSet<IPC::SendSyncOption> sendSyncOptions = { });
 
     enum class ShouldStartProcessThrottlerActivity : bool { No, Yes };
+
     using AsyncReplyID = IPC::Connection::AsyncReplyID;
-    template<typename T, typename C> AsyncReplyID sendWithAsyncReply(T&&, C&&, uint64_t destinationID = 0, OptionSet<IPC::SendOption> = { }, ShouldStartProcessThrottlerActivity = ShouldStartProcessThrottlerActivity::Yes);
+    template<typename T, typename C> AsyncReplyID sendWithAsyncReply(T&&, C&&, UInt128 destinationID = 0, OptionSet<IPC::SendOption> = { }, ShouldStartProcessThrottlerActivity = ShouldStartProcessThrottlerActivity::Yes);
     
     template<typename T, typename U>
     bool send(T&& message, ObjectIdentifier<U> destinationID, OptionSet<IPC::SendOption> sendOptions = { })
@@ -98,8 +99,8 @@ public:
     }
 
     void addMessageReceiver(IPC::ReceiverName, IPC::MessageReceiver&);
-    void addMessageReceiver(IPC::ReceiverName, uint64_t destinationID, IPC::MessageReceiver&);
-    void removeMessageReceiver(IPC::ReceiverName, uint64_t destinationID);
+    void addMessageReceiver(IPC::ReceiverName, UInt128 destinationID, IPC::MessageReceiver&);
+    void removeMessageReceiver(IPC::ReceiverName, UInt128 destinationID);
     void removeMessageReceiver(IPC::ReceiverName);
     
     template <typename T>
@@ -217,7 +218,7 @@ private:
 };
 
 template<typename T>
-bool AuxiliaryProcessProxy::send(T&& message, uint64_t destinationID, OptionSet<IPC::SendOption> sendOptions)
+bool AuxiliaryProcessProxy::send(T&& message, UInt128 destinationID, OptionSet<IPC::SendOption> sendOptions)
 {
     static_assert(!T::isSync, "Async message expected");
 
@@ -228,7 +229,7 @@ bool AuxiliaryProcessProxy::send(T&& message, uint64_t destinationID, OptionSet<
 }
 
 template<typename T>
-AuxiliaryProcessProxy::SendSyncResult<T> AuxiliaryProcessProxy::sendSync(T&& message, uint64_t destinationID, IPC::Timeout timeout, OptionSet<IPC::SendSyncOption> sendSyncOptions)
+AuxiliaryProcessProxy::SendSyncResult<T> AuxiliaryProcessProxy::sendSync(T&& message, UInt128 destinationID, IPC::Timeout timeout, OptionSet<IPC::SendSyncOption> sendSyncOptions)
 {
     static_assert(T::isSync, "Sync message expected");
 
@@ -241,7 +242,7 @@ AuxiliaryProcessProxy::SendSyncResult<T> AuxiliaryProcessProxy::sendSync(T&& mes
 }
 
 template<typename T, typename C>
-AuxiliaryProcessProxy::AsyncReplyID AuxiliaryProcessProxy::sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<IPC::SendOption> sendOptions, ShouldStartProcessThrottlerActivity shouldStartProcessThrottlerActivity)
+AuxiliaryProcessProxy::AsyncReplyID AuxiliaryProcessProxy::sendWithAsyncReply(T&& message, C&& completionHandler, UInt128 destinationID, OptionSet<IPC::SendOption> sendOptions, ShouldStartProcessThrottlerActivity shouldStartProcessThrottlerActivity)
 {
     static_assert(!T::isSync, "Async message expected");
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1459,7 +1459,7 @@ void WebProcessPool::addMessageReceiver(IPC::ReceiverName messageReceiverName, I
     m_messageReceiverMap.addMessageReceiver(messageReceiverName, messageReceiver);
 }
 
-void WebProcessPool::addMessageReceiver(IPC::ReceiverName messageReceiverName, uint64_t destinationID, IPC::MessageReceiver& messageReceiver)
+void WebProcessPool::addMessageReceiver(IPC::ReceiverName messageReceiverName, UInt128 destinationID, IPC::MessageReceiver& messageReceiver)
 {
     m_messageReceiverMap.addMessageReceiver(messageReceiverName, destinationID, messageReceiver);
 }
@@ -1469,7 +1469,7 @@ void WebProcessPool::removeMessageReceiver(IPC::ReceiverName messageReceiverName
     m_messageReceiverMap.removeMessageReceiver(messageReceiverName);
 }
 
-void WebProcessPool::removeMessageReceiver(IPC::ReceiverName messageReceiverName, uint64_t destinationID)
+void WebProcessPool::removeMessageReceiver(IPC::ReceiverName messageReceiverName, UInt128 destinationID)
 {
     m_messageReceiverMap.removeMessageReceiver(messageReceiverName, destinationID);
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -163,9 +163,9 @@ public:
     }
 
     void addMessageReceiver(IPC::ReceiverName, IPC::MessageReceiver&);
-    void addMessageReceiver(IPC::ReceiverName, uint64_t destinationID, IPC::MessageReceiver&);
+    void addMessageReceiver(IPC::ReceiverName, UInt128 destinationID, IPC::MessageReceiver&);
     void removeMessageReceiver(IPC::ReceiverName);
-    void removeMessageReceiver(IPC::ReceiverName, uint64_t destinationID);
+    void removeMessageReceiver(IPC::ReceiverName, UInt128 destinationID);
 
     WebBackForwardCache& backForwardCache() { return m_backForwardCache.get(); }
     

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -200,8 +200,8 @@ static JSValueRef evaluateJavaScriptCallback(JSContextRef context, JSObjectRef f
         return JSValueMakeUndefined(context);
 
     WebCore::FrameIdentifier frameID {
-        makeObjectIdentifier<WebCore::FrameIdentifierType>(JSValueToNumber(context, arguments[0], exception)),
-        makeObjectIdentifier<WebCore::ProcessIdentifierType>(JSValueToNumber(context, arguments[1], exception))
+        makeObjectIdentifier<WebCore::FrameIdentifierType>(static_cast<UInt128>(JSValueToNumber(context, arguments[0], exception))),
+        makeObjectIdentifier<WebCore::ProcessIdentifierType>(static_cast<UInt128>(JSValueToNumber(context, arguments[1], exception)))
     };
     uint64_t callbackID = JSValueToNumber(context, arguments[2], exception);
     if (JSValueIsString(context, arguments[3])) {

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -956,7 +956,7 @@ void WebProcess::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& de
         return;
     }
 
-    LOG_ERROR("Unhandled web process message '%s' (destination: %" PRIu64 " pid: %d)", description(decoder.messageName()), decoder.destinationID(), static_cast<int>(getCurrentProcessID()));
+    LOG_ERROR("Unhandled web process message '%s' (destination: %" PRIu64 " pid: %d)", description(decoder.messageName()), static_cast<uint64_t>(decoder.destinationID()), static_cast<int>(getCurrentProcessID()));
 }
 
 void WebProcess::didClose(IPC::Connection& connection)

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -410,7 +410,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendAsync)
     dispatchAndWait(runLoop, [&] {
         ASSERT_TRUE(openB());
         for (uint64_t i = 100u; i < 160u; ++i) {
-            b()->sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&, j = i] (uint64_t value) {
+            b()->sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&, j = i] (UInt128 value) {
                 if (!value)
                     WTFLogAlways("GOT: %llu", j);
                 EXPECT_GE(value, 100u);

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -34,7 +34,7 @@ namespace TestWebKitAPI {
 
 struct MessageInfo {
     IPC::MessageName messageName;
-    uint64_t destinationID;
+    UInt128 destinationID;
 };
 
 struct MockTestMessage1 {
@@ -50,7 +50,7 @@ struct MockTestMessageWithAsyncReply1 {
     // If WebPage_GetBytecodeProfileReply is removed, just use another one.
     static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::WebPage_GetBytecodeProfileReply; }
     std::tuple<> arguments() { return { }; }
-    using ReplyArguments = std::tuple<uint64_t>;
+    using ReplyArguments = std::tuple<UInt128>;
 };
 
 class MockConnectionClient final : public IPC::Connection::Client {

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -45,7 +45,7 @@ using TestObjectIdentifier = ObjectIdentifier<TestObjectIdentifierTag>;
 
 struct MessageInfo {
     IPC::MessageName messageName;
-    uint64_t destinationID;
+    UInt128 destinationID;
 };
 
 struct MockStreamTestMessage1 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -412,7 +412,7 @@ TEST(IPCTestingAPI, CanInterceptAlert)
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"args[2].type"].UTF8String, "String");
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"args[2].value"].UTF8String, "ok");
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"typeof(messages[0].syncRequestID)"].UTF8String, "number");
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"messages[0].destinationID"].intValue,
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"messages[0].destinationID[0]"].intValue,
         [webView stringByEvaluatingJavaScript:@"IPC.webPageProxyID.toString()"].intValue);
 }
 
@@ -444,7 +444,7 @@ TEST(IPCTestingAPI, CanInterceptHasStorageAccess)
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"targetMessage.arguments[3].type"].UTF8String, "uint64_t");
     EXPECT_EQ([webView stringByEvaluatingJavaScript:@"targetMessage.arguments[3].value"].intValue, [webView stringByEvaluatingJavaScript:@"IPC.pageID.toString()"].intValue);
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"typeof(targetMessage.syncRequestID)"].UTF8String, "undefined");
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"targetMessage.destinationID"].intValue, 0);
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"targetMessage.destinationID[0]"].intValue, 0);
 }
 #endif
 
@@ -477,7 +477,7 @@ TEST(IPCTestingAPI, CanInterceptFindString)
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"args[2].type"].UTF8String, "uint32_t");
     EXPECT_EQ([webView stringByEvaluatingJavaScript:@"args[2].value"].intValue, 1);
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"typeof(messages[0].syncRequestID)"].UTF8String, "undefined");
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"messages[0].destinationID"].intValue,
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"messages[0].destinationID[0]"].intValue,
         [webView stringByEvaluatingJavaScript:@"IPC.webPageProxyID.toString()"].intValue);
 }
 


### PR DESCRIPTION
#### 096f18835da5d23891a76c17b4f010f057dcdee2
<pre>
Encode 128 bits for IPC&apos;s destination identifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=248929">https://bugs.webkit.org/show_bug.cgi?id=248929</a>

Reviewed by Alex Christensen.

This will allow me to fit a FrameIdentifier which is 128 bits.

* Source/WTF/wtf/Int128.h:
(WTF::DefaultHash&lt;UInt128&gt;::hash):
(WTF::DefaultHash&lt;UInt128&gt;::equal):
(WTF::DefaultHash&lt;Int128&gt;::hash):
(WTF::DefaultHash&lt;Int128&gt;::equal):
(WTF::HashTraits&lt;UInt128&gt;::constructDeletedValue):
(WTF::HashTraits&lt;UInt128&gt;::isDeletedValue):
(WTF::HashTraits&lt;Int128&gt;::constructDeletedValue):
(WTF::HashTraits&lt;Int128&gt;::isDeletedValue):
(IPC::ArgumentCoder&lt;WTF::UInt128&gt;::encode):
(IPC::ArgumentCoder&lt;WTF::UInt128&gt;::decode):
(IPC::ArgumentCoder&lt;WTF::Int128&gt;::encode):
(IPC::ArgumentCoder&lt;WTF::Int128&gt;::decode):
* Source/WTF/wtf/ObjectIdentifier.h:
(WTF::makeObjectIdentifier):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::didReceiveMessage):
(WebKit::NetworkProcess::didReceiveSyncMessage):
(WebKit::NetworkProcess::findPendingDownloadLocation):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::WaitForMessageState::WaitForMessageState):
(IPC::Connection::SyncMessageState::dispatchMessages):
(IPC::Connection::addWorkQueueMessageReceiver):
(IPC::Connection::removeWorkQueueMessageReceiver):
(IPC::Connection::addMessageReceiver):
(IPC::Connection::removeMessageReceiver):
(IPC::Connection::createSyncMessageEncoder):
(IPC::Connection::waitForMessage):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendWithAsyncReply):
(IPC::Connection::send):
(IPC::Connection::sendSync):
(IPC::Connection::waitForAndDispatchImmediately):
(IPC::Connection::waitForAsyncReplyAndDispatchImmediately):
(IPC::Connection::waitForMessageForTesting):
* Source/WebKit/Platform/IPC/Decoder.cpp:
(IPC::Decoder::Decoder):
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::destinationID const):
* Source/WebKit/Platform/IPC/Encoder.cpp:
(IPC::Encoder::Encoder):
* Source/WebKit/Platform/IPC/Encoder.h:
* Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h:
* Source/WebKit/Platform/IPC/MessageReceiverMap.cpp:
(IPC::MessageReceiverMap::addMessageReceiver):
(IPC::MessageReceiverMap::removeMessageReceiver):
* Source/WebKit/Platform/IPC/MessageReceiverMap.h:
* Source/WebKit/Platform/IPC/MessageSender.h:
(IPC::MessageSender::send):
(IPC::MessageSender::sendSync):
(IPC::MessageSender::sendWithAsyncReply):
* Source/WebKit/Platform/IPC/ReceiverMatcher.h:
(IPC::ReceiverMatcher::ReceiverMatcher):
(IPC::ReceiverMatcher::createWithZeroAsAnyDestination):
(IPC::ReceiverMatcher::matches const):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::trySendDestinationIDIfNeeded):
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::startReceivingMessages):
(IPC::StreamServerConnection::stopReceivingMessages):
(IPC::StreamServerConnection::processSetStreamDestinationID):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Scripts/webkit/messages.py:
(generate_message_handler):
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::addMessageReceiver):
(WebKit::AuxiliaryProcess::removeMessageReceiver):
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::addMessageReceiver):
(WebKit::AuxiliaryProcessProxy::removeMessageReceiver):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::send):
(WebKit::AuxiliaryProcessProxy::sendSync):
(WebKit::AuxiliaryProcessProxy::sendWithAsyncReply):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::addMessageReceiver):
(WebKit::WebProcessPool::removeMessageReceiver):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::evaluateJavaScriptCallback):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage):
(WebKit::IPCTestingAPI::JSMessageListener::jsDescriptionFromDecoder):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::didReceiveMessage):
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:

Canonical link: <a href="https://commits.webkit.org/258484@main">https://commits.webkit.org/258484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f6c840c7addfa1bcf731157eba8072cbeee84c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111418 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171594 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2149 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94474 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109154 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37162 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/105620 "Found 1 webkitpy python3 test failure: webkit.messages_unittest.GeneratedFileContentsTest.test_receiver") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91224 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78887 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/92445 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4795 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25527 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88656 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2421 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4904 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1968 "Found 1 new test failure: storage/indexeddb/request-with-null-open-db-request.html (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29479 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45023 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91575 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6652 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20473 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3069 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->