### PR TITLE
Update 'assert-selection.js' from Chromium to latest version since now RegExp lookbehind assertions is supported

### DIFF
--- a/LayoutTests/editing/inserting/insert-space-expected.txt
+++ b/LayoutTests/editing/inserting/insert-space-expected.txt
@@ -1,16 +1,14 @@
 
 
-Harness Error (FAIL), message = Test named "Insert a &nbsp; instead of plain space when it is inserted before the text node that has a leading plain space" passed a function to `test` that returned a value.
-
 PASS insert a plain space in the middle of text node
 PASS insert a plain space between two inserted text nodes
 PASS Insert a &nbsp; instead of plain space when it is inserted before the empty text node
 PASS Insert a &nbsp; instead of plain space when it is inserted before the text node that has a leading plain space
-FAIL Insert spaces into the editable <div> that only has <br> and space as child LayoutTests/resources/assert-selection.js:588:30
+FAIL Insert spaces into the editable <div> that only has <br> and space as child resources/assert-selection.js:939:30
 	 expected <div contenteditable>   | </div>,
 	 but got  <div contenteditable>   |</div>,
 	 sameupto <div contenteditable>   |
-FAIL Insert spaces into the editable <div> that only has <br> and enter as child LayoutTests/resources/assert-selection.js:588:30
+FAIL Insert spaces into the editable <div> that only has <br> and enter as child resources/assert-selection.js:939:30
 	 expected <div contenteditable>   |
 </div>,
 	 but got  <div contenteditable>   |</div>,


### PR DESCRIPTION
#### d41b2a8b640c7af24bcb7fe0be005a19264479d1
<pre>
Update &apos;assert-selection.js&apos; from Chromium to latest version since now RegExp lookbehind assertions is supported

Update &apos;assert-selection.js&apos; from Chromium to latest version since now RegExp lookbehind assertions is supported
<a href="https://bugs.webkit.org/show_bug.cgi?id=249309">https://bugs.webkit.org/show_bug.cgi?id=249309</a>

Reviewed by Ryosuke Niwa.

This patch is to update testing script used for HTML editing test cases, which are merged from Blink / Chromium. Previously, Webkit was using old version, which didn&apos;t had requirement of &quot;RegEx Lookbehind&quot; but now since it is supported, we can updated to latest and also update any test expectations as well.

* LayoutTests/resources/assert-selection.js: Update
* LayoutTests/editing/inserting/insert-space-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/258229@main">https://commits.webkit.org/258229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f0dd717687706eb3bf2e22c0e5d8cff39e281d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110458 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170735 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1194 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108288 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91801 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35111 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90477 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23201 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-line-clamp-001.tentative.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78105 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3970 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24717 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1138 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10118 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44205 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5663 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5771 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->