### PR TITLE
Fix assertion failure when glyph ID 0 of a font that has a "VORG" table in vertical flow

### DIFF
--- a/LayoutTests/fast/writing-mode/vorg-glyph-zero-crash-expected.txt
+++ b/LayoutTests/fast/writing-mode/vorg-glyph-zero-crash-expected.txt
@@ -1,0 +1,3 @@
+Make sure assertion does not fail for glpyh ID 0 of a font that has a "VORG" table in vertical flow.
+
+￿

--- a/LayoutTests/fast/writing-mode/vorg-glyph-zero-crash.html
+++ b/LayoutTests/fast/writing-mode/vorg-glyph-zero-crash.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+.test {
+    -webkit-writing-mode:vertical-rl;
+    font-family:'Hiragino Kaku Gothic ProN';
+}
+</style>
+<p>Make sure assertion does not fail for glpyh ID 0 of a font that has a "VORG" table in vertical flow.
+<div class="test">&#xFFFF;</div>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+document.body.offsetTop;
+</script>

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012 Koji Ishii <kojiishi@gmail.com>
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -523,6 +524,7 @@ void OpenTypeVerticalData::getVerticalTranslationsForGlyphs(const Font* font, co
 
         // For Y, try VORG first.
         if (useVORG) {
+            if (glyph) {
             int16_t vertOriginYFUnit = m_vertOriginY.get(glyph);
             if (vertOriginYFUnit) {
                 outXYArray[1] = -vertOriginYFUnit * sizePerUnit;
@@ -532,6 +534,7 @@ void OpenTypeVerticalData::getVerticalTranslationsForGlyphs(const Font* font, co
                 defaultVertOriginY = -m_defaultVertOriginY * sizePerUnit;
             outXYArray[1] = defaultVertOriginY;
             continue;
+            }
         }
 
         // If no VORG, try vmtx next.


### PR DESCRIPTION
<pre>
Fix assertion failure when glyph ID 0 of a font that has a "VORG" table in vertical flow
<a href="https://bugs.webkit.org/show_bug.cgi?id=249317">https://bugs.webkit.org/show_bug.cgi?id=249317</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?revision=195946&view=revision">https://src.chromium.org/viewvc/blink?revision=195946&view=revision</a>

In OpenType, glyph ID 0 is recommended for ".notdef"[1]. Rendering the glyph of a font
that has "VORG" table fails assertion in HashTable::lookup, since 0 is not
safeToCompareToEmptyOrDeleted.

It's a regular (non-RELEASE) ASSERT, but Mac and Adobe fonts usually have this table, so
some tests fail only on Mac.

Since it's a ".notdef" glyph, the fix is to use the default value.

[1] <a href="https://www.microsoft.com/typography/otspec/recom.htm">https://www.microsoft.com/typography/otspec/recom.htm</a>

* Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp:
(OpenTypeVerticalData::getVerticalTranslationForGlyphs): Add "if" condition for glyph
* LayoutTests/fast/writing-mode/vorg-glyph-zero-crash.html: Add Test Case
* LayoutTests/fast/writing-mode/vorg-glyph-zero-crash-expected.txt: Add Test Case Expectations
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54d795ffab65db1dbfd12e9a5a78787e53c0923f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110430 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170717 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1163 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93539 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108260 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91783 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35093 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90449 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78088 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3941 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24675 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3986 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1120 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44185 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5741 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->