### PR TITLE
[WK2] Daemon::Decoder::decodeFixedLengthReference() should return a Span

### DIFF
--- a/Source/WebKit/Platform/IPC/DaemonCoders.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.cpp
@@ -141,10 +141,10 @@ std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decode(
     decoder >> length;
     if (!length)
         return std::nullopt;
-    auto* bytes = decoder.decodeFixedLengthReference(*length);
-    if (!bytes)
+    Span<const uint8_t> bytes = decoder.decodeFixedLengthReference(*length);
+    if (bytes.size() != *length)
         return std::nullopt;
-    auto trust = adoptCF(SecTrustDeserialize(adoptCF(CFDataCreate(nullptr, bytes, *length)).get(), nullptr));
+    auto trust = adoptCF(SecTrustDeserialize(adoptCF(CFDataCreate(nullptr, bytes.data(), bytes.size())).get(), nullptr));
     if (!trust)
         return std::nullopt;
     return WebCore::CertificateInfo(WTFMove(trust));

--- a/Source/WebKit/Platform/IPC/DaemonDecoder.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonDecoder.cpp
@@ -49,13 +49,13 @@ bool Decoder::decodeFixedLengthData(uint8_t* data, size_t size)
     return true;
 }
 
-const uint8_t* Decoder::decodeFixedLengthReference(size_t size)
+Span<const uint8_t> Decoder::decodeFixedLengthReference(size_t size)
 {
     if (!bufferIsLargeEnoughToContainBytes(size))
-        return nullptr;
+        return { };
     const uint8_t* data = m_buffer.data() + m_bufferPosition;
     m_bufferPosition += size;
-    return data;
+    return { data, size };
 }
 
 } // namespace Daemon

--- a/Source/WebKit/Platform/IPC/DaemonDecoder.h
+++ b/Source/WebKit/Platform/IPC/DaemonDecoder.h
@@ -60,7 +60,7 @@ public:
     }
 
     WARN_UNUSED_RETURN bool decodeFixedLengthData(uint8_t* data, size_t);
-    const uint8_t* decodeFixedLengthReference(size_t);
+    Span<const uint8_t> decodeFixedLengthReference(size_t);
 
 private:
     WARN_UNUSED_RETURN bool bufferIsLargeEnoughToContainBytes(size_t) const;


### PR DESCRIPTION
#### fc52838b1ca2a502b206c398f5f08df1d6803e9e
<pre>
[WK2] Daemon::Decoder::decodeFixedLengthReference() should return a Span
<a href="https://bugs.webkit.org/show_bug.cgi?id=249704">https://bugs.webkit.org/show_bug.cgi?id=249704</a>

Reviewed by Kimmo Kinnunen.

Instead of a raw pointer, Daemon::Decoder::decodeFixedLengthReference()
should return a Span&lt;const uint8&gt; object describing the memory area
retrieved from the decoder.

The sole use in CertificateInfo decoding is adjusted. To test the Span&apos;s
validity, the Span&apos;s size is compared to the requested size, which will
be the same when retrieval from the decoder succeeds.

* Source/WebKit/Platform/IPC/DaemonCoders.cpp:
(WebKit::Daemon::Coder&lt;WebCore::CertificateInfo&gt;::decode):
* Source/WebKit/Platform/IPC/DaemonDecoder.cpp:
(WebKit::Daemon::Decoder::decodeFixedLengthReference):
* Source/WebKit/Platform/IPC/DaemonDecoder.h:

Canonical link: <a href="https://commits.webkit.org/258193@main">https://commits.webkit.org/258193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/599d5fca6688ba58a7f696cfcca55e054696984e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110459 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1195 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93570 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108289 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35114 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78108 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3971 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24719 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1139 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44207 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5630 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5772 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->