### PR TITLE
Give up on stretching columns if they have already reached max height

### DIFF
--- a/LayoutTests/fast/multicol/unbreakable-content-taller-than-height-crash-expected.txt
+++ b/LayoutTests/fast/multicol/unbreakable-content-taller-than-height-crash-expected.txt
@@ -1,0 +1,5 @@
+Test that unbreakable content inside a multicol container that's taller than the specified height of the multicol container doesn't cause an assertion failure.
+
+PASS if no crash or assertion failure.
+
+x

--- a/LayoutTests/fast/multicol/unbreakable-content-taller-than-height-crash.html
+++ b/LayoutTests/fast/multicol/unbreakable-content-taller-than-height-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<p>Test that unbreakable content inside a multicol container that's taller than the specified height
+    of the multicol container doesn't cause an assertion failure.</p>
+<p>PASS if no crash or assertion failure.</p>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+</script>
+<div style="-webkit-columns:2; height:0.2em;">
+    x
+</div>

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2012 Apple Inc.  All rights reserved.
+ * Copyright (C) 2012-2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2015 Google Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -240,6 +241,13 @@ LayoutUnit RenderMultiColumnSet::calculateBalancedHeight(bool initial) const
         // Too many forced breaks to allow any implicit breaks. Initial balancing should already
         // have set a good height. There's nothing more we should do.
         return m_computedColumnHeight + sizeContainmentShortage;
+    }
+
+    if (m_computedColumnHeight >= m_maxColumnHeight) {
+        // We cannot stretch any further. We'll just have to live with the overflowing columns. This
+        // typically happens if the max column height is less than the height of the tallest piece
+        // of unbreakable content (e.g. lines).
+        return m_computedColumnHeight;
     }
 
     // If the initial guessed column height wasn't enough, stretch it now. Stretch by the lowest


### PR DESCRIPTION
#### 3edf242b588be169967f082cdef66d7e21878448
<pre>
Give up on stretching columns if they have already reached max height

Give up on stretching columns if they have already reached max height
<a href="https://bugs.webkit.org/show_bug.cgi?id=249705">https://bugs.webkit.org/show_bug.cgi?id=249705</a>

Reviewed by Alan Baradlay.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=192636

This doesn&apos;t change any behavior (column heights were already clamped against
max height), but it avoids an assertion failure that would occur if no space
shortage is recorded during a render pass. Unbreakable content (lines) that&apos;s
taller than the column (max) height don&apos;t record space shortage, as columns
cannot be stretched beyond the (max) height anyway.

* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
(RenderMultiColumnSet::calculateBalancedHeight): Add if condition to restrict column height
* LayoutTests/fast/multicol/unbreakable-content-taller-than-height-crash.html: Add Test Case
* LayoutTests/fast/multicol/unbreakable-content-taller-than-height-crash-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/258230@main">https://commits.webkit.org/258230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6cedf1e32317e6f8c14143412e9e2df9642a433

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110460 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170737 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1196 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93571 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108290 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35115 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90478 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78109 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3972 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24718 "Found 1 new test failure: imported/w3c/web-platform-tests/webstorage/event_case_sensitive.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1140 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44206 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5664 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5773 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->