### PR TITLE
Make sure rows are updated during simplified layout

### DIFF
--- a/LayoutTests/fast/table/table-overflow-crash-expected.txt
+++ b/LayoutTests/fast/table/table-overflow-crash-expected.txt
@@ -1,0 +1,2 @@
+Test passes if it does not CRASH in debug. Note, this test does not have a DOCTYPE as the failure does not reproduce with a DOCTYPE.
+if (window.testRunner) testRunner.dumpAsText(); document.execCommand("selectAll"); document.designMode = "On"; document.execCommand("italic")

--- a/LayoutTests/fast/table/table-overflow-crash.html
+++ b/LayoutTests/fast/table/table-overflow-crash.html
@@ -1,0 +1,23 @@
+<style>
+    rt, script, body {
+      outline-style: solid;
+      position: absolute;
+      will-change: transform;
+      display: table-cell;
+      border-spacing: 4499;
+    }
+    </style>
+    Test passes if it does not CRASH in debug.
+    Note, this test does not have a DOCTYPE as the failure does not
+    reproduce with a DOCTYPE.
+    <rt>
+    <menu></menu>
+    <script>
+      if (window.testRunner)
+        testRunner.dumpAsText();
+    
+      document.execCommand("selectAll");
+      document.designMode = "On";
+      document.execCommand("italic")
+    </script>
+    

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -4,7 +4,8 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  *
  * This library is free software; you can redistribute it and/or
@@ -419,6 +420,7 @@ void RenderTable::simplifiedNormalFlowLayout()
         caption->layoutIfNeeded();
     for (RenderTableSection* section = topSection(); section; section = sectionBelow(section)) {
         section->layoutIfNeeded();
+        section->layoutRows();
         section->computeOverflowFromCells();
     }
 }


### PR DESCRIPTION
#### 0a821c7d68ea240665ed1a0aaceefe1bddbebb5f
<pre>
Make sure rows are updated during simplified layout

Make sure rows are updated during simplified layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=249707">https://bugs.webkit.org/show_bug.cgi?id=249707</a>

Reviewed by Alan Baradlay.

Merge - <a href="https://src.chromium.org/viewvc/blink?revision=191146&amp">https://src.chromium.org/viewvc/blink?revision=191146&amp</a>;view=revision

When we are calling RenderTable::simplifiedNormalFlowLayout(), we have to
make sure that we call section-&gt;layoutRows() before we do the
section-&gt;computeOverflowFromCells(). The call to layoutRows is needed because
it will reset and update the m_forceSlowPaintPathWithOverflowingCell
flag which causes to fail the ASSERT.

* Source/WebCore/rendering/RenderTable.cpp:
(RenderTable::simplifiedNormalFlowLayout): Add &quot;layoutRows&quot; before &quot;computeOverflowFromCells&quot;
* LayoutTests/fast/table/table-overflow-crash.html: Add Test Case
* LayoutTests/fast/table/table-overflow-crash-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/258227@main">https://commits.webkit.org/258227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71d4fa34f21e0517f35e727dc115fe9866a35295

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110461 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170738 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1197 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93572 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108291 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35116 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90479 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78110 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3973 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24720 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1141 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44208 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5661 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5774 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->