### PR TITLE
[@property] Validate universal syntax initial value as <declaration-value>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
@@ -137,15 +137,15 @@ PASS syntax:'<custom-ident>+', initialValue:'foo unset bar' is invalid
 PASS syntax:'<custom-ident>+', initialValue:'foo revert bar' is invalid
 PASS syntax:'<custom-ident>+', initialValue:'foo revert-layer bar' is invalid
 PASS syntax:'<custom-ident>+', initialValue:'foo default bar' is invalid
-FAIL syntax:'*', initialValue:')' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
-FAIL syntax:'*', initialValue:'([)]' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
-FAIL syntax:'*', initialValue:'whee!' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
-FAIL syntax:'*', initialValue:'"
-' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
-FAIL syntax:'*', initialValue:'url(moo '')' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
-FAIL syntax:'*', initialValue:'semi;colon' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
-FAIL syntax:'*', initialValue:'var(invalid var ref)' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
-FAIL syntax:'*', initialValue:'var(--foo)' is invalid assert_throws_dom: function "() => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false})" did not throw
+PASS syntax:'*', initialValue:')' is invalid
+PASS syntax:'*', initialValue:'([)]' is invalid
+PASS syntax:'*', initialValue:'whee!' is invalid
+PASS syntax:'*', initialValue:'"
+' is invalid
+PASS syntax:'*', initialValue:'url(moo '')' is invalid
+PASS syntax:'*', initialValue:'semi;colon' is invalid
+PASS syntax:'*', initialValue:'var(invalid var ref)' is invalid
+PASS syntax:'*', initialValue:'var(--foo)' is invalid
 PASS syntax:'banana', initialValue:'bAnAnA' is invalid
 PASS syntax:'<length>', initialValue:'var(--moo)' is invalid
 PASS syntax:'<length>', initialValue:'10' is invalid

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -111,6 +111,8 @@ public:
     Vector<CSSParserToken> tokens() const;
     bool equals(const CSSCustomPropertyValue&) const;
 
+    Ref<const CSSVariableData> asVariableData() const;
+
 private:
     CSSCustomPropertyValue(const AtomString& name, VariantValue&& value)
         : CSSValue(CustomPropertyClass)

--- a/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
+++ b/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
@@ -66,18 +66,13 @@ ExceptionOr<void> DOMCSSRegisterCustomProperty::registerProperty(Document& docum
         if (!dependencies.isEmpty())
             return Exception { SyntaxError, "The given initial value must be computationally independent."_s };
 
-        Style::MatchResult matchResult;
-
         auto parentStyle = RenderStyle::clone(*style);
-        Style::Builder dummyBuilder(*style, { document, parentStyle }, matchResult, { });
+        Style::Builder dummyBuilder(*style, { document, parentStyle }, { }, { });
 
-        initialValue = CSSPropertyParser::parseTypedCustomPropertyValue(descriptor.name, *syntax, tokenizer.tokenRange(), dummyBuilder.state(), { document });
+        initialValue = CSSPropertyParser::parseTypedCustomPropertyInitialValue(descriptor.name, *syntax, tokenizer.tokenRange(), dummyBuilder.state(), { document });
 
-        if (!initialValue || !initialValue->isResolved())
+        if (!initialValue)
             return Exception { SyntaxError, "The given initial value does not parse for the given syntax."_s };
-
-        if (initialValue->containsCSSWideKeyword())
-            return Exception { SyntaxError, "The intitial value cannot be a CSS-wide keyword."_s };
     }
 
     auto property = CSSRegisteredCustomProperty {

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -344,7 +344,7 @@ public:
         AtomString name;
         String syntax { };
         std::optional<bool> inherits { };
-        RefPtr<CSSVariableData> initialValue { };
+        RefPtr<const CSSVariableData> initialValue { };
     };
     static Ref<StyleRuleProperty> create(Descriptor&&);
     Ref<StyleRuleProperty> copy() const { return adoptRef(*new StyleRuleProperty(*this)); }

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -996,11 +996,9 @@ RefPtr<StyleRuleProperty> CSSParserImpl::consumePropertyRule(CSSParserTokenRange
         case CSSPropertyInherits:
             propertyDescriptor.inherits = downcast<CSSPrimitiveValue>(*property.value()).valueID() == CSSValueTrue;
             break;
-        case CSSPropertyInitialValue: {
-            auto& customPropertyValue = downcast<CSSCustomPropertyValue>(*property.value());
-            propertyDescriptor.initialValue = std::get<Ref<CSSVariableData>>(customPropertyValue.value()).copyRef();
+        case CSSPropertyInitialValue:
+            propertyDescriptor.initialValue = downcast<CSSCustomPropertyValue>(*property.value()).asVariableData();
             break;
-        }
         default:
             break;
         };

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -269,6 +269,22 @@ RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(
     return value;
 }
 
+RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyInitialValue(const AtomString& name, const CSSCustomPropertySyntax& syntax, CSSParserTokenRange tokens, Style::BuilderState& builderState, const CSSParserContext& context)
+{
+    if (syntax.isUniversal())
+        return CSSVariableParser::parseInitialValueForUniversalSyntax(name, tokens);
+
+    CSSPropertyParser parser(tokens, context, nullptr, false);
+    RefPtr<CSSCustomPropertyValue> value = parser.parseTypedCustomPropertyValue(name, syntax, builderState);
+    if (!value || !parser.m_range.atEnd())
+        return nullptr;
+
+    if (value->containsCSSWideKeyword())
+        return nullptr;
+
+    return value;
+}
+
 void CSSPropertyParser::collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax& syntax, bool isRoot, HashSet<CSSPropertyID>& dependencies, const CSSParserTokenRange& tokens, const CSSParserContext& context)
 {
     CSSPropertyParser parser(tokens, context, nullptr);

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -45,13 +45,13 @@ class BuilderState;
 class CSSPropertyParser {
     WTF_MAKE_NONCOPYABLE(CSSPropertyParser);
 public:
-    static bool parseValue(CSSPropertyID, bool important,
-        const CSSParserTokenRange&, const CSSParserContext&,
-        Vector<CSSProperty, 256>&, StyleRuleType);
+    static bool parseValue(CSSPropertyID, bool important, const CSSParserTokenRange&, const CSSParserContext&, Vector<CSSProperty, 256>&, StyleRuleType);
 
     // Parses a non-shorthand CSS property
     static RefPtr<CSSValue> parseSingleValue(CSSPropertyID, const CSSParserTokenRange&, const CSSParserContext&);
+
     static bool canParseTypedCustomPropertyValue(const CSSCustomPropertySyntax&, const CSSParserTokenRange&, const CSSParserContext&);
+    static RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyInitialValue(const AtomString&, const CSSCustomPropertySyntax&, CSSParserTokenRange, Style::BuilderState&, const CSSParserContext&);
     static RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const CSSCustomPropertySyntax&, const CSSParserTokenRange&, Style::BuilderState&, const CSSParserContext&);
     static void collectParsedCustomPropertyValueDependencies(const CSSCustomPropertySyntax&, bool isRoot, HashSet<CSSPropertyID>& dependencies, const CSSParserTokenRange&, const CSSParserContext&);
 
@@ -64,6 +64,7 @@ private:
     bool parseValueStart(CSSPropertyID, bool important);
     bool consumeCSSWideKeyword(CSSPropertyID, bool important);
     RefPtr<CSSValue> parseSingleValue(CSSPropertyID, CSSPropertyID = CSSPropertyInvalid);
+    
     std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> consumeCustomPropertyValueWithSyntax(const CSSCustomPropertySyntax&);
     bool canParseTypedCustomPropertyValue(const CSSCustomPropertySyntax&);
     RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const CSSCustomPropertySyntax&, Style::BuilderState&);

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -73,6 +73,7 @@
 #include "CSSTransformListValue.h"
 #include "CSSValuePool.h"
 #include "CSSVariableData.h"
+#include "CSSVariableParser.h"
 #include "CalculationCategory.h"
 #include "ColorConversion.h"
 #include "ColorInterpolation.h"
@@ -8449,7 +8450,7 @@ RefPtr<CSSValue> consumeCounterStyleSpeakAs(CSSParserTokenRange& range)
 // https://drafts.css-houdini.org/css-properties-values-api/#initial-value-descriptor
 RefPtr<CSSValue> consumePropertyInitialValue(CSSParserTokenRange& range)
 {
-    return CSSCustomPropertyValue::createSyntaxAll(nullAtom(), CSSVariableData::create(range.consumeAll()));
+    return CSSVariableParser::parseDeclarationValue(nullAtom(), range.consumeAll(), strictCSSParserContext());
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -341,7 +341,6 @@ RefPtr<CSSValue> consumeCounterStyleSpeakAs(CSSParserTokenRange&);
 
 RefPtr<CSSValue> consumePropertyInitialValue(CSSParserTokenRange&);
 
-
 // Template and inline implementations are at the bottom of the file for readability.
 
 template<typename... emptyBaseCase> bool identMatches(CSSValueID)

--- a/Source/WebCore/css/parser/CSSVariableParser.cpp
+++ b/Source/WebCore/css/parser/CSSVariableParser.cpp
@@ -183,4 +183,20 @@ RefPtr<CSSCustomPropertyValue> CSSVariableParser::parseDeclarationValue(const At
     return CSSCustomPropertyValue::createUnresolved(variableName, type);
 }
 
+RefPtr<CSSCustomPropertyValue> CSSVariableParser::parseInitialValueForUniversalSyntax(const AtomString& variableName, CSSParserTokenRange range)
+{
+    if (range.atEnd())
+        return nullptr;
+
+    bool hasReferences;
+    CSSValueID valueID = classifyVariableRange(range, hasReferences, strictCSSParserContext());
+
+    if (hasReferences)
+        return nullptr;
+    if (valueID != CSSValueInternalVariableValue)
+        return nullptr;
+
+    return CSSCustomPropertyValue::createSyntaxAll(variableName, CSSVariableData::create(range));
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSVariableParser.h
+++ b/Source/WebCore/css/parser/CSSVariableParser.h
@@ -43,6 +43,7 @@ public:
     static bool containsValidVariableReferences(CSSParserTokenRange, const CSSParserContext&);
 
     static RefPtr<CSSCustomPropertyValue> parseDeclarationValue(const AtomString&, CSSParserTokenRange, const CSSParserContext&);
+    static RefPtr<CSSCustomPropertyValue> parseInitialValueForUniversalSyntax(const AtomString&, CSSParserTokenRange);
 
     static bool isValidVariableName(const CSSParserToken&);
     static bool isValidVariableName(const String&);


### PR DESCRIPTION
#### aca85912a52befcceed52e1055a2de75b303765e
<pre>
[@property] Validate universal syntax initial value as &lt;declaration-value&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=249708">https://bugs.webkit.org/show_bug.cgi?id=249708</a>
rdar://103595129

Reviewed by Dean Jackson.

Initial value for &quot;*&quot; syntax can&apos;t be quite any token sequence.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt:
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::containsCSSWideKeyword const):

Simplify. Only the simple case is needed.

(WebCore::CSSCustomPropertyValue::asVariableData const):

Add a helper.

* Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp:
(WebCore::DOMCSSRegisterCustomProperty::registerProperty):
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumePropertyRule):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseTypedCustomPropertyInitialValue):

Add a separate function for initial value parsing.

* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumePropertyInitialValue):

Consume property as &lt;declaration-value&gt;.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/css/parser/CSSVariableParser.cpp:
(WebCore::CSSVariableParser::parseInitialValueForUniversalSyntax):

Add a helper that also verifies no var() is being used.

* Source/WebCore/css/parser/CSSVariableParser.h:
* Source/WebCore/style/CustomPropertyRegistry.cpp:
(WebCore::Style::CustomPropertyRegistry::registerFromStylesheet):

Also return an explicit &quot;guaranteed-invalid&quot; value instead of a null. This doesn&apos;t change behavior.

Canonical link: <a href="https://commits.webkit.org/258204@main">https://commits.webkit.org/258204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e30edfb722a6a890d2aaa47f7e0bf9509fe01a3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110463 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170747 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1199 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93574 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108293 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91813 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35122 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78116 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3975 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24727 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1143 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44212 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5637 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5776 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->