### PR TITLE
REGRESSION (macOS 11): Form controls don't paint with an inactive appearance in non-key windows

### DIFF
--- a/LayoutTests/fast/forms/select/mac-wk2/inactive-appearance-expected-mismatch.html
+++ b/LayoutTests/fast/forms/select/mac-wk2/inactive-appearance-expected-mismatch.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <select>
+        <option>Test</option>
+    </select>
+</body>
+</html>

--- a/LayoutTests/fast/forms/select/mac-wk2/inactive-appearance.html
+++ b/LayoutTests/fast/forms/select/mac-wk2/inactive-appearance.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="../../../../resources/js-test.js"></script>
+        <script src="../../../../resources/ui-helper.js"></script>
+    </head>
+<body>
+    <select>
+        <option>Test</option>
+    </select>
+</body>
+<script>
+
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    if (window.internals)
+        window.internals.setPageIsFocusedAndActive(false);
+
+    await UIHelper.renderingUpdate();
+    finishJSTest();
+});
+
+</script>
+</html>

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm
@@ -41,6 +41,8 @@ ButtonControlMac::ButtonControlMac(ControlPart& part, ControlFactoryMac& control
 
 void ButtonControlMac::updateCellStates(const FloatRect& rect, const ControlStyle& style)
 {
+    ControlMac::updateCellStates(rect, style);
+
     const auto& states = style.states;
 
     // Pressed state

--- a/Source/WebCore/platform/graphics/mac/controls/WebControlView.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/WebControlView.mm
@@ -130,6 +130,11 @@ static NSRect _clipBounds;
     return self;
 }
 
+- (NSWindow *)_viewRoot
+{
+    return _window.get();
+}
+
 - (void)addSubview:(NSView *)subview
 {
     // By doing nothing in this method we forbid controls from adding subviews.

--- a/Source/WebCore/platform/mac/ThemeMac.mm
+++ b/Source/WebCore/platform/mac/ThemeMac.mm
@@ -118,6 +118,11 @@ static bool _useFormSemanticContext;
     return self;
 }
 
+- (NSWindow *)_viewRoot
+{
+    return _window.get();
+}
+
 - (void)addSubview:(NSView *)subview
 {
     // By doing nothing in this method we forbid controls from adding subviews.


### PR DESCRIPTION
#### 456497bb8c15309d0367d551c5c81d3ea4c62747
<pre>
REGRESSION (macOS 11): Form controls don&apos;t paint with an inactive appearance in non-key windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=249355">https://bugs.webkit.org/show_bug.cgi?id=249355</a>
rdar://103379662

Reviewed by Simon Fraser.

Before macOS 11, WebKit was able to paint form controls with an inactive
appearance by overriding `-[NSView window]` on the control view used for
painting, returning an `NSWindow` with custom return values for
`hasKeyAppearance` and `isKeyWindow`.

However, in macOS 11, AppKit began deriving the inactive state using a
&quot;view root&quot;, which is not necessarily an `NSWindow`. The &quot;view root&quot; is only
computed when a view is added to the view hierarchy. Since WebKit&apos;s control
view used for painting is not a part of the view hierarchy, it ends up having
a `nil` &quot;view root&quot;, and AppKit falls back to the active appearance.

To fix, `-[NSView _viewRoot]` is overridden on WebKit&apos;s control views to return
an `NSWindow` with the appropriate state. Additionally, a layout test is added
to detect regressions in this behavior.

* LayoutTests/fast/forms/select/mac-wk2/inactive-appearance-expected-mismatch.html: Added.
* LayoutTests/fast/forms/select/mac-wk2/inactive-appearance.html: Added.
* Source/WebCore/platform/graphics/mac/controls/ButtonControlMac.mm:
(WebCore::ButtonControlMac::updateCellStates):

Fix a regression from 258177@main, where checkboxes and radio buttons stopped
update the window active state before drawing.

* Source/WebCore/platform/graphics/mac/controls/WebControlView.mm:
(-[WebControlView _viewRoot]):
* Source/WebCore/platform/mac/ThemeMac.mm:
(-[WebCoreThemeView _viewRoot]):

Canonical link: <a href="https://commits.webkit.org/258294@main">https://commits.webkit.org/258294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0af75020ad112ff1f12366d0a64d478463605c3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110621 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170893 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1359 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93743 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108448 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35233 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78231 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4124 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24867 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1288 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44351 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5937 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2995 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->