### PR TITLE
[Cocoa] Softlink macros are not thread safe

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -64,10 +64,12 @@ private:
     void registerForDeviceNotifications();
     void updateCachedAVCaptureDevices();
     Vector<CaptureDevice> retrieveCaptureDevices();
+    RetainPtr<NSArray> currentCameras();
 
     RetainPtr<WebCoreAVCaptureDeviceManagerObserver> m_objcObserver;
     Vector<CaptureDevice> m_devices;
     RetainPtr<NSMutableArray> m_avCaptureDevices;
+    RetainPtr<NSArray> m_avCaptureDeviceTypes;
     bool m_isInitialized { false };
 
     Ref<WorkQueue> m_dispatchQueue;

--- a/Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -59,6 +59,24 @@ using namespace WebCore;
 
 namespace WebCore {
 
+static NSMutableArray<NSString*>* cameraCaptureDeviceTypes()
+{
+    ASSERT(isMainThread());
+    NSMutableArray<NSString*>* deviceTypes = [[NSMutableArray alloc] initWithArray:
+        @[AVCaptureDeviceTypeBuiltInWideAngleCamera,
+          AVCaptureDeviceTypeBuiltInTelephotoCamera,
+          AVCaptureDeviceTypeBuiltInUltraWideCamera,
+#if PLATFORM(MAC)
+          AVCaptureDeviceTypeExternalUnknown,
+#endif
+        ]
+    ];
+    if (PAL::canLoad_AVFoundation_AVCaptureDeviceTypeDeskViewCamera())
+        [deviceTypes addObject:AVCaptureDeviceTypeDeskViewCamera];
+
+    return deviceTypes;
+}
+
 void AVCaptureDeviceManager::computeCaptureDevices(CompletionHandler<void()>&& callback)
 {
     if (!m_isInitialized) {
@@ -91,25 +109,10 @@ inline static bool deviceIsAvailable(AVCaptureDevice *device)
     return true;
 }
 
-static RetainPtr<NSArray<AVCaptureDevice *>> currentCameras()
+RetainPtr<NSArray> AVCaptureDeviceManager::currentCameras()
 {
-    static NSMutableArray *deviceTypes;
-    if (!deviceTypes) {
-        deviceTypes = [[NSMutableArray alloc] initWithArray:
-            @[AVCaptureDeviceTypeBuiltInWideAngleCamera,
-              AVCaptureDeviceTypeBuiltInTelephotoCamera,
-              AVCaptureDeviceTypeBuiltInUltraWideCamera,
-#if PLATFORM(MAC)
-              AVCaptureDeviceTypeExternalUnknown,
-#endif
-            ]
-        ];
-        if (PAL::canLoad_AVFoundation_AVCaptureDeviceTypeDeskViewCamera())
-            [deviceTypes addObject:AVCaptureDeviceTypeDeskViewCamera];
-    }
-
     AVCaptureDeviceDiscoverySession *discoverySession = [PAL::getAVCaptureDeviceDiscoverySessionClass()
-        discoverySessionWithDeviceTypes:deviceTypes
+        discoverySessionWithDeviceTypes:m_avCaptureDeviceTypes.get()
         mediaType:AVMediaTypeVideo
         position:AVCaptureDevicePositionUnspecified
     ];
@@ -244,7 +247,8 @@ AVCaptureDeviceManager& AVCaptureDeviceManager::singleton()
 }
 
 AVCaptureDeviceManager::AVCaptureDeviceManager()
-    : m_objcObserver(adoptNS([[WebCoreAVCaptureDeviceManagerObserver alloc] initWithCallback: this]))
+    : m_objcObserver(adoptNS([[WebCoreAVCaptureDeviceManagerObserver alloc] initWithCallback:this]))
+    , m_avCaptureDeviceTypes(adoptNS(cameraCaptureDeviceTypes()))
     , m_dispatchQueue(WorkQueue::create("com.apple.WebKit.AVCaptureDeviceManager"))
 {
 }


### PR DESCRIPTION
#### b96cc31eec98eb98b7f2e0967e9d3199f7879d97
<pre>
[Cocoa] Softlink macros are not thread safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=249725">https://bugs.webkit.org/show_bug.cgi?id=249725</a>
rdar://103003618

Reviewed by Dean Jackson.

Load and cache AVCaptureDeviceType constants in the AVCaptureDeviceManager constructor,
which is always called on the main thread, so they can be used on the dispatch queue
used to discover the current capture devices.

* Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.mm:
(WebCore::AVCaptureDeviceManager::currentCameras): Use m_avCaptureDeviceTypes instead
of the soft link functions directly.
(WebCore::AVCaptureDeviceManager::AVCaptureDeviceManager): Cache AVCaptureDeviceType constants.
(WebCore::currentCameras): Deleted.

Canonical link: <a href="https://commits.webkit.org/258244@main">https://commits.webkit.org/258244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83bd1bf648c62ca7bd1b70b198845adefc75d4d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101217 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110500 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170787 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1237 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93621 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108336 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91846 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35142 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90502 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78138 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4011 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24766 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4061 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1194 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44241 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5815 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2971 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->