### PR TITLE
[WK2] Add Span-handling methods to IPC encoder, decoder classes

### DIFF
--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -69,6 +69,8 @@ public:
     void wrapForTesting(UniqueRef<Encoder>&&);
 
     void encodeFixedLengthData(const uint8_t* data, size_t, size_t alignment);
+    template<typename T, size_t Extent>
+    void encodeSpan(const Span<T, Extent>&);
 
     template<typename T>
     Encoder& operator<<(T&& t)
@@ -108,5 +110,11 @@ private:
 
     Vector<Attachment> m_attachments;
 };
+
+template<typename T, size_t Extent>
+inline void Encoder::encodeSpan(const Span<T, Extent>& data)
+{
+    encodeFixedLengthData(reinterpret_cast<const uint8_t*>(data.data()), data.size_bytes(), alignof(T));
+}
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
@@ -68,6 +68,12 @@ public:
         return true;
     }
 
+    template<typename T, size_t Extent>
+    bool encodeSpan(const Span<T, Extent>& data)
+    {
+        return encodeFixedLengthData(reinterpret_cast<const uint8_t*>(data.data()), data.size_bytes(), alignof(T));
+    }
+
     template<typename T>
     StreamConnectionEncoder& operator<<(T&& t)
     {


### PR DESCRIPTION
#### 80ea526b2a16a6365775453d8821f5d481aed02e
<pre>
[WK2] Add Span-handling methods to IPC encoder, decoder classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=249732">https://bugs.webkit.org/show_bug.cgi?id=249732</a>

Reviewed by Kimmo Kinnunen.

Encoder::encodeSpan() and StreamConnectionEncoder::encodeSpan() are added,
accepting a Span object and relaying the data pointer, byte size and alignment
values to their encodeFixedLengthData() methods. Once encodeSpan() is adopted
everywhere, encodeFixedLengthData() will be removable.

Decoder::decodeSpan() is added, returning a Span object for a given type and
size that spans across the appropriate area of the Decoder&apos;s data. decodeSpan()
handles overflow checking and buffer capacity validation, returning a null Span
if any of those checks fails.

Encoding of Span objects through the ArgumentCoder specialization changes a bit,
but only to match the decoding. For Spans with dynamic extent, the size is
encoded first. But if the size is empty, there&apos;s no data encoding, since there
is none. This differs from previous behavior where empty Span data would still
go through to the Encoder::encodeFixedLengthData() call and potentially align
the buffer data for the given type, something that wasn&apos;t mirrored during
decoding.

Decoding of Span objects through ArgumentCoder is a bit different to the
semantics of Decoder::decodeSpan(). For Spans with dynamic extent, in case of
zero size, a null Span is returned, i.e. null data pointer and zero size. In all
other successful cases, a non-empty Span will be returned.

Test cases are added to the ArgumentCoderTests suite, covering empty and
non-empty spans of both trivial data and aligned structs.

* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::decodeSpan):
* Source/WebKit/Platform/IPC/Encoder.h:
(IPC::Encoder::encodeSpan):
* Source/WebKit/Platform/IPC/StreamConnectionEncoder.h:
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::TYPED_TEST_P):
(TestWebKitAPI::calculateEncodedSize):

Canonical link: <a href="https://commits.webkit.org/258875@main">https://commits.webkit.org/258875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b696f91679f8d0c933d503d26ba555c9ebb674c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/103213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12338 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/36210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112460 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/172657 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/107166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/3242 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95438 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110661 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10260 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/36210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37894 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/92082 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/36210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79623 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5741 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/36210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2856 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11901 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/36210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6100 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7660 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->