### PR TITLE
[@property] <declaration-value> used in initial-value descriptor should preserve whitespace

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom-expected.txt
@@ -49,16 +49,16 @@ PASS Rule for --no-initial-value returns expected value for CSSPropertyRule.inhe
 PASS Rule for --syntax-only returns expected value for CSSPropertyRule.inherits
 PASS Rule for --inherits-only returns expected value for CSSPropertyRule.inherits
 PASS Rule for --initial-value-only returns expected value for CSSPropertyRule.inherits
-FAIL Rule for --valid returns expected value for CSSPropertyRule.initialValue assert_equals: expected " red" but got "red"
-FAIL Rule for --valid-reverse returns expected value for CSSPropertyRule.initialValue assert_equals: expected " 0px" but got "0px"
+PASS Rule for --valid returns expected value for CSSPropertyRule.initialValue
+PASS Rule for --valid-reverse returns expected value for CSSPropertyRule.initialValue
 PASS Rule for --valid-universal returns expected value for CSSPropertyRule.initialValue
-FAIL Rule for --valid-whitespace returns expected value for CSSPropertyRule.initialValue assert_equals: expected " red, blue" but got "red, blue"
-FAIL Rule for --vALId returns expected value for CSSPropertyRule.initialValue assert_equals: expected " red" but got "red"
+PASS Rule for --valid-whitespace returns expected value for CSSPropertyRule.initialValue
+PASS Rule for --vALId returns expected value for CSSPropertyRule.initialValue
 PASS Rule for --no-descriptors returns expected value for CSSPropertyRule.initialValue
-FAIL Rule for --no-syntax returns expected value for CSSPropertyRule.initialValue assert_equals: expected " red" but got "red"
-FAIL Rule for --no-inherits returns expected value for CSSPropertyRule.initialValue assert_equals: expected " red" but got "red"
+PASS Rule for --no-syntax returns expected value for CSSPropertyRule.initialValue
+PASS Rule for --no-inherits returns expected value for CSSPropertyRule.initialValue
 PASS Rule for --no-initial-value returns expected value for CSSPropertyRule.initialValue
 PASS Rule for --syntax-only returns expected value for CSSPropertyRule.initialValue
 PASS Rule for --inherits-only returns expected value for CSSPropertyRule.initialValue
-FAIL Rule for --initial-value-only returns expected value for CSSPropertyRule.initialValue assert_equals: expected " red" but got "red"
+PASS Rule for --initial-value-only returns expected value for CSSPropertyRule.initialValue
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -8943,7 +8943,7 @@
             "initial-value": {
                 "codegen-properties": {
                     "settings-flag": "cssCustomPropertiesAndValuesEnabled",
-                    "parser-function": "consumePropertyInitialValue"
+                    "parser-grammar": "<declaration-value>"
                 },
                 "specification": {
                     "category": "css-properties-and-values",

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -88,6 +88,7 @@ public:
     static bool isInLogicalPropertyGroup(CSSPropertyID);
     static bool areInSameLogicalPropertyGroupWithDifferentMappingLogic(CSSPropertyID, CSSPropertyID);
     static bool isDescriptorOnly(CSSPropertyID);
+    static bool shouldPreserveWhitespace(CSSPropertyID);
     static bool isColorProperty(CSSPropertyID);
     static UChar listValuedPropertySeparator(CSSPropertyID);
     static bool isListValuedProperty(CSSPropertyID propertyID) { return !!listValuedPropertySeparator(propertyID); }

--- a/Source/WebCore/css/CSSPropertyRule.cpp
+++ b/Source/WebCore/css/CSSPropertyRule.cpp
@@ -90,7 +90,7 @@ String CSSPropertyRule::cssText() const
         builder.append("inherits: ", *descriptor.inherits ? "true" : "false", "; ");
 
     if (descriptor.initialValue)
-        builder.append("initial-value: ", initialValue(), "; ");
+        builder.append("initial-value:", initialValue(), "; ");
 
     builder.append("}");
 

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -1163,11 +1163,13 @@ void CSSParserImpl::consumeDeclaration(CSSParserTokenRange range, StyleRuleType 
     auto propertyID = token.parseAsCSSPropertyID();
     if (range.consume().type() != ColonToken)
         return; // Parse error
-    range.consumeWhitespace();
+
+    if (!CSSProperty::shouldPreserveWhitespace(propertyID))
+        range.consumeWhitespace();
 
     auto declarationValueEnd = range.end();
     bool important = false;
-    if (!range.atEnd()) {
+    if (!range.atEnd() && !CSSProperty::isDescriptorOnly(propertyID)) {
         auto end = range.end();
         removeTrailingWhitespace(range, end);
         declarationValueEnd = end;

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -205,10 +205,12 @@ void CSSPropertyParser::addExpandedPropertyForValue(CSSPropertyID property, Ref<
 bool CSSPropertyParser::parseValue(CSSPropertyID propertyID, bool important, const CSSParserTokenRange& range, const CSSParserContext& context, ParsedPropertyVector& parsedProperties, StyleRuleType ruleType)
 {
     int parsedPropertiesSize = parsedProperties.size();
+    
+    auto consumeWhitespace = !CSSProperty::shouldPreserveWhitespace(propertyID);
 
-    CSSPropertyParser parser(range, context, &parsedProperties);
+    CSSPropertyParser parser(range, context, &parsedProperties, consumeWhitespace);
+
     bool parseSuccess;
-
     if (ruleType == StyleRuleType::FontFace)
         parseSuccess = parser.parseFontFaceDescriptor(propertyID);
     else if (ruleType == StyleRuleType::FontPaletteValues)

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -8445,12 +8445,9 @@ RefPtr<CSSValue> consumeCounterStyleSpeakAs(CSSParserTokenRange& range)
     return consumeCounterStyleName(range);
 }
 
-// MARK: @property
-
-// https://drafts.css-houdini.org/css-properties-values-api/#initial-value-descriptor
-RefPtr<CSSValue> consumePropertyInitialValue(CSSParserTokenRange& range)
+RefPtr<CSSValue> consumeDeclarationValue(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    return CSSVariableParser::parseDeclarationValue(nullAtom(), range.consumeAll(), strictCSSParserContext());
+    return CSSVariableParser::parseDeclarationValue(nullAtom(), range.consumeAll(), context);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -317,6 +317,7 @@ RefPtr<CSSValue> consumeColorScheme(CSSParserTokenRange&);
 #endif
 RefPtr<CSSValue> consumeOffsetRotate(CSSParserTokenRange&, CSSParserMode);
 
+RefPtr<CSSValue> consumeDeclarationValue(CSSParserTokenRange&, const CSSParserContext&);
 
 // @font-face descriptor consumers:
 
@@ -336,10 +337,6 @@ RefPtr<CSSValue> consumeCounterStylePad(CSSParserTokenRange&, const CSSParserCon
 RefPtr<CSSValue> consumeCounterStyleSymbols(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeCounterStyleAdditiveSymbols(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeCounterStyleSpeakAs(CSSParserTokenRange&);
-
-// @property descriptor consumers:
-
-RefPtr<CSSValue> consumePropertyInitialValue(CSSParserTokenRange&);
 
 // Template and inline implementations are at the bottom of the file for readability.
 


### PR DESCRIPTION
#### 11eb340cd2d87f5b32d8b746e829eda7ab2f2d18
<pre>
[@property] &lt;declaration-value&gt; used in initial-value descriptor should preserve whitespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=249731">https://bugs.webkit.org/show_bug.cgi?id=249731</a>
rdar://103607902

Reviewed by Sam Weinig.

The &apos;initial-value&apos; descriptor has syntax &lt;declaration-value&gt; and it should preserve whitespace.

<a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom-expected.txt:
* Source/WebCore/css/CSSProperties.json:

Use parser-grammar: &quot;&lt;declaration-value&gt;&quot;

* Source/WebCore/css/CSSProperty.h:
* Source/WebCore/css/CSSPropertyRule.cpp:
(WebCore::CSSPropertyRule::cssText const):

Don&apos;t add extra space when serializing.

* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeDeclaration):

Trim whitespace conditionally.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseValue):

Trim whitespace conditionally.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeDeclarationValue):
(WebCore::CSSPropertyParserHelpers::consumePropertyInitialValue): Deleted.
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/css/process-css-properties.py:
(PropertiesAndDescriptors):
(PropertiesAndDescriptors.all_preserving_whitespace):
(ReferenceTerm):

Add a build-in type for &lt;declaration-value&gt;.

(Grammar):
(Grammar.preserve_whitespace):

Those have a special property that they preserve whitespace.

(GenerateCSSPropertyNames):

Generate Property::shouldPreserveWhitespace().

Canonical link: <a href="https://commits.webkit.org/258215@main">https://commits.webkit.org/258215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5273f427b56569cd4c0a4c19c376b4d1850b1610

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110514 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105216 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1258 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108347 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107012 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/93633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4026 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24773 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/4071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/10177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44250 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5646 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5826 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->