### PR TITLE
Make all FileSystemSyncAccessHandle methods sync

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-close.https.tentative.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-close.https.tentative.worker-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL SyncAccessHandle.close is idempotent assert_equals: expected (undefined) undefined but got (object) object "[object Promise]"
-FAIL SyncAccessHandle.read fails after SyncAccessHandle.close assert_equals: expected (undefined) undefined but got (object) object "[object Promise]"
-FAIL SyncAccessHandle.write fails after SyncAccessHandle.close assert_equals: expected (undefined) undefined but got (object) object "[object Promise]"
-FAIL SyncAccessHandle.flush fails after SyncAccessHandle.close assert_equals: expected (undefined) undefined but got (object) object "[object Promise]"
-FAIL SyncAccessHandle.getSize fails after SyncAccessHandle.close assert_equals: expected (undefined) undefined but got (object) object "[object Promise]"
-FAIL SyncAccessHandle.truncate fails after SyncAccessHandle.handle.close assert_equals: expected (undefined) undefined but got (object) object "[object Promise]"
+FAIL SyncAccessHandle.close is idempotent promise_test: Unhandled rejection with value: object "InvalidStateError: AccessHandle is closed"
+FAIL SyncAccessHandle.read fails after SyncAccessHandle.close promise_test: Unhandled rejection with value: object "InvalidStateError: AccessHandle is closed"
+FAIL SyncAccessHandle.write fails after SyncAccessHandle.close promise_test: Unhandled rejection with value: object "InvalidStateError: AccessHandle is closed"
+FAIL SyncAccessHandle.flush fails after SyncAccessHandle.close promise_test: Unhandled rejection with value: object "InvalidStateError: AccessHandle is closed"
+FAIL SyncAccessHandle.getSize fails after SyncAccessHandle.close promise_test: Unhandled rejection with value: object "InvalidStateError: AccessHandle is closed"
+FAIL SyncAccessHandle.truncate fails after SyncAccessHandle.handle.close promise_test: Unhandled rejection with value: object "InvalidStateError: AccessHandle is closed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-flush.https.tentative.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-flush.https.tentative.worker-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Test flush on an empty file.
-FAIL SyncAccessHandle.read returns bytes written by SyncAccessHandle.write after SyncAccessHandle.flush promise_test: Unhandled rejection with value: object "InvalidStateError: Access handle has unfinished operation"
+PASS SyncAccessHandle.read returns bytes written by SyncAccessHandle.write after SyncAccessHandle.flush
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-getSize.https.tentative.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-getSize.https.tentative.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL test SyncAccessHandle.getSize after SyncAccessHandle.write assert_equals: expected (number) 0 but got (object) object "[object Promise]"
+PASS test SyncAccessHandle.getSize after SyncAccessHandle.write
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-truncate.https.tentative.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-truncate.https.tentative.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL test SyncAccessHandle.truncate with different sizes assert_equals: expected (number) 4 but got (object) object "[object Promise]"
-FAIL test SyncAccessHandle.truncate after SyncAccessHandle.write promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
+PASS test SyncAccessHandle.truncate with different sizes
+PASS test SyncAccessHandle.truncate after SyncAccessHandle.write
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/idlharness.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/idlharness.https.any.worker-expected.txt
@@ -49,17 +49,9 @@ PASS FileSystemSyncAccessHandle interface: existence and properties of interface
 PASS FileSystemSyncAccessHandle interface: existence and properties of interface prototype object's @@unscopables property
 PASS FileSystemSyncAccessHandle interface: operation read(BufferSource, optional FileSystemReadWriteOptions)
 PASS FileSystemSyncAccessHandle interface: operation write(BufferSource, optional FileSystemReadWriteOptions)
-FAIL FileSystemSyncAccessHandle interface: operation truncate(unsigned long long) assert_throws_js: calling operation with this = null didn't throw TypeError function "function () {
-            fn.apply(obj, args);
-        }" did not throw
-FAIL FileSystemSyncAccessHandle interface: operation getSize() assert_throws_js: calling operation with this = null didn't throw TypeError function "function () {
-            fn.apply(obj, args);
-        }" did not throw
-FAIL FileSystemSyncAccessHandle interface: operation flush() assert_throws_js: calling operation with this = null didn't throw TypeError function "function () {
-            fn.apply(obj, args);
-        }" did not throw
-FAIL FileSystemSyncAccessHandle interface: operation close() assert_throws_js: calling operation with this = null didn't throw TypeError function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS FileSystemSyncAccessHandle interface: operation truncate(unsigned long long)
+PASS FileSystemSyncAccessHandle interface: operation getSize()
+PASS FileSystemSyncAccessHandle interface: operation flush()
+PASS FileSystemSyncAccessHandle interface: operation close()
 PASS StorageManager interface: operation getDirectory()
 

--- a/LayoutTests/storage/filesystemaccess/resources/sync-access-handle-basics.js
+++ b/LayoutTests/storage/filesystemaccess/resources/sync-access-handle-basics.js
@@ -46,13 +46,13 @@ function createSyncAccessHandle(fromHandle)
 
 function getSize(accessHandle) 
 {
-    accessHandle.getSize().then((result) => {
-        size = result;
+    try {
+        size = accessHandle.getSize();
         shouldBe("size", "0");
         createSecondSyncAcessHandle(fileHandle);
-    }).catch((error) => {
+    } catch(error) {
         finishTest(error);
-    });
+    }
 }
 
 function createSecondSyncAcessHandle(fromHandle) 
@@ -73,12 +73,13 @@ function createSecondSyncAcessHandle(fromHandle)
 
 function close() 
 {
-    accessHandle1.close().then((result) => {
+    try {
+        accessHandle1.close();
         debug("accessHandle1 is closed");
         createSecondSyncAcessHandle(fileHandle);
-    }).catch((error) => {
+    } catch(error) {
         finishTest(error);
-    });
+    }
 }
 
 getDirectory();

--- a/LayoutTests/storage/filesystemaccess/resources/sync-access-handle-read-write.js
+++ b/LayoutTests/storage/filesystemaccess/resources/sync-access-handle-read-write.js
@@ -55,7 +55,7 @@ async function test()
         await rootHandle.removeEntry("sync-access-handle.txt").then(() => { }, () => { });
         var fileHandle = await rootHandle.getFileHandle("sync-access-handle.txt", { "create" : true  });
         accessHandle = await fileHandle.createSyncAccessHandle();
-        fileSize = await accessHandle.getSize();
+        fileSize = accessHandle.getSize();
         shouldBe("fileSize", "0");
 
         debug("test read() and write():");
@@ -75,22 +75,22 @@ async function test()
         shouldThrow("accessHandle.write(new ArrayBuffer(1), { \"at\" : Number.MAX_SAFE_INTEGER })");
 
         debug("test flush():");
-        await accessHandle.flush();
-        fileSize = await accessHandle.getSize();
+        accessHandle.flush();
+        fileSize = accessHandle.getSize();
         shouldBe("fileSize", "totalWriteSize");
 
         debug("test truncate():");
-        await accessHandle.truncate(4);
-        await accessHandle.flush();
-        fileSize = await accessHandle.getSize();
+        accessHandle.truncate(4);
+        accessHandle.flush();
+        fileSize = accessHandle.getSize();
         shouldBe("fileSize", "4");
 
         debug("test write() with pending operation:");
         evalAndLog("accessHandle.truncate(0)");
         readBuffer = new ArrayBuffer(4);
-        shouldThrow("accessHandle.read(readBuffer, { \"at\" : 0 })");
+        shouldBe("accessHandle.read(readBuffer, { \"at\" : 0 })", "0");
 
-        await accessHandle.close();
+        accessHandle.close();
         finishTest();
     } catch (error) {
         finishTest(error);

--- a/LayoutTests/storage/filesystemaccess/sync-access-handle-close-worker-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/sync-access-handle-close-worker-expected.txt
@@ -4,24 +4,15 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 Starting worker: resources/sync-access-handle-close.js
-[Worker] test after invoking close():
+[Worker] test closing handle:
 [Worker] testing getSize
-PASS [Worker] error.toString() is "InvalidStateError: AccessHandle is closing or closed"
+PASS [Worker] error.toString() is "InvalidStateError: AccessHandle is closed"
 [Worker] testing flush
-PASS [Worker] error.toString() is "InvalidStateError: AccessHandle is closing or closed"
+PASS [Worker] error.toString() is "InvalidStateError: AccessHandle is closed"
 [Worker] testing read
-PASS [Worker] error.toString() is "InvalidStateError: AccessHandle is closing or closed"
+PASS [Worker] error.toString() is "InvalidStateError: AccessHandle is closed"
 [Worker] testing write
-PASS [Worker] error.toString() is "InvalidStateError: AccessHandle is closing or closed"
-[Worker] test after close() is done:
-[Worker] testing getSize
-PASS [Worker] error.toString() is "InvalidStateError: AccessHandle is closing or closed"
-[Worker] testing flush
-PASS [Worker] error.toString() is "InvalidStateError: AccessHandle is closing or closed"
-[Worker] testing read
-PASS [Worker] error.toString() is "InvalidStateError: AccessHandle is closing or closed"
-[Worker] testing write
-PASS [Worker] error.toString() is "InvalidStateError: AccessHandle is closing or closed"
+PASS [Worker] error.toString() is "InvalidStateError: AccessHandle is closed"
 [Worker] test closing multiple handles:
 [Worker] Create and close access handles successfully
 PASS successfullyParsed is true

--- a/LayoutTests/storage/filesystemaccess/sync-access-handle-read-write-worker-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/sync-access-handle-read-write-worker-expected.txt
@@ -27,7 +27,7 @@ PASS [Worker] fileSize is totalWriteSize
 PASS [Worker] fileSize is 4
 [Worker] test write() with pending operation:
 [Worker] accessHandle.truncate(0)
-PASS [Worker] accessHandle.read(readBuffer, { "at" : 0 }) threw exception InvalidStateError: Access handle has unfinished operation.
+PASS [Worker] accessHandle.read(readBuffer, { "at" : 0 }) is 0
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.cpp
@@ -84,7 +84,7 @@ void FileSystemFileHandle::createSyncAccessHandle(DOMPromiseDeferred<IDLInterfac
 
         auto* context = protectedThis->scriptExecutionContext();
         if (!context) {
-            protectedThis->closeSyncAccessHandle(identifier, { });
+            protectedThis->closeSyncAccessHandle(identifier);
             return promise.reject(Exception { InvalidStateError, "Context has stopped"_s });
         }
 
@@ -92,12 +92,12 @@ void FileSystemFileHandle::createSyncAccessHandle(DOMPromiseDeferred<IDLInterfac
     });
 }
 
-void FileSystemFileHandle::closeSyncAccessHandle(FileSystemSyncAccessHandleIdentifier accessHandleIdentifier, CompletionHandler<void(ExceptionOr<void>&&)>&& completionHandler)
+void FileSystemFileHandle::closeSyncAccessHandle(FileSystemSyncAccessHandleIdentifier accessHandleIdentifier)
 {
     if (isClosed())
-        return completionHandler(Exception { InvalidStateError, "Handle is closed"_s });
+        return;
 
-    connection().closeSyncAccessHandle(identifier(), accessHandleIdentifier, WTFMove(completionHandler));
+    connection().closeSyncAccessHandle(identifier(), accessHandleIdentifier);
 }
 
 void FileSystemFileHandle::registerSyncAccessHandle(FileSystemSyncAccessHandleIdentifier identifier, FileSystemSyncAccessHandle& handle)

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.h
@@ -41,7 +41,7 @@ public:
     void getFile(DOMPromiseDeferred<IDLInterface<File>>&&);
 
     void createSyncAccessHandle(DOMPromiseDeferred<IDLInterface<FileSystemSyncAccessHandle>>&&);
-    void closeSyncAccessHandle(FileSystemSyncAccessHandleIdentifier, CompletionHandler<void(ExceptionOr<void>&&)>&&);
+    void closeSyncAccessHandle(FileSystemSyncAccessHandleIdentifier);
     void registerSyncAccessHandle(FileSystemSyncAccessHandleIdentifier, FileSystemSyncAccessHandle&);
     void unregisterSyncAccessHandle(FileSystemSyncAccessHandleIdentifier);
 

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.h
@@ -64,7 +64,7 @@ public:
     virtual void resolve(FileSystemHandleIdentifier, FileSystemHandleIdentifier, ResolveCallback&&) = 0;
     virtual void getFile(FileSystemHandleIdentifier, StringCallback&&) = 0;
     virtual void createSyncAccessHandle(FileSystemHandleIdentifier, GetAccessHandleCallback&&) = 0;
-    virtual void closeSyncAccessHandle(FileSystemHandleIdentifier, FileSystemSyncAccessHandleIdentifier, VoidCallback&&) = 0;
+    virtual void closeSyncAccessHandle(FileSystemHandleIdentifier, FileSystemSyncAccessHandleIdentifier) = 0;
     virtual void registerSyncAccessHandle(FileSystemSyncAccessHandleIdentifier, ScriptExecutionContextIdentifier) = 0;
     virtual void unregisterSyncAccessHandle(FileSystemSyncAccessHandleIdentifier) = 0;
     virtual void invalidateAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier) = 0;

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.idl
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.idl
@@ -29,10 +29,10 @@
     Exposed=DedicatedWorker,
     SecureContext
 ] interface FileSystemSyncAccessHandle {
-    Promise<undefined> truncate([EnforceRange] unsigned long long size);
-    Promise<unsigned long long> getSize();
-    Promise<undefined> flush();
-    Promise<undefined> close();
+    undefined truncate([EnforceRange] unsigned long long newSize);
+    unsigned long long getSize();
+    undefined flush();
+    undefined close();
     unsigned long long read([AllowShared] (ArrayBufferView or ArrayBuffer) buffer, optional FilesystemReadWriteOptions options = {});
     unsigned long long write([AllowShared] (ArrayBufferView or ArrayBuffer) buffer, optional FilesystemReadWriteOptions options = {});
 };

--- a/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
@@ -72,7 +72,7 @@ private:
     void getHandle(FileSystemHandleIdentifier, const String& name, GetHandleCallback&&) final;
     void getFile(FileSystemHandleIdentifier, StringCallback&&) final;
     void createSyncAccessHandle(FileSystemHandleIdentifier, FileSystemStorageConnection::GetAccessHandleCallback&&) final;
-    void closeSyncAccessHandle(FileSystemHandleIdentifier, FileSystemSyncAccessHandleIdentifier, FileSystemStorageConnection::VoidCallback&&) final;
+    void closeSyncAccessHandle(FileSystemHandleIdentifier, FileSystemSyncAccessHandleIdentifier) final;
     void registerSyncAccessHandle(FileSystemSyncAccessHandleIdentifier, ScriptExecutionContextIdentifier) final { };
     void unregisterSyncAccessHandle(FileSystemSyncAccessHandleIdentifier) final;
     void invalidateAccessHandle(FileSystemSyncAccessHandleIdentifier) final;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -480,15 +480,12 @@ void NetworkStorageManager::createSyncAccessHandle(WebCore::FileSystemHandleIden
     completionHandler(handle->createSyncAccessHandle());
 }
 
-void NetworkStorageManager::closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier, CompletionHandler<void(std::optional<FileSystemStorageError>)>&& completionHandler)
+void NetworkStorageManager::closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier)
 {
     ASSERT(!RunLoop::isMain());
 
-    auto handle = m_fileSystemStorageHandleRegistry->getHandle(identifier);
-    if (!handle)
-        return completionHandler(FileSystemStorageError::Unknown);
-
-    completionHandler(handle->closeSyncAccessHandle(accessHandleIdentifier));
+    if (auto handle = m_fileSystemStorageHandleRegistry->getHandle(identifier))
+        handle->closeSyncAccessHandle(accessHandleIdentifier);
 }
 
 void NetworkStorageManager::getHandleNames(WebCore::FileSystemHandleIdentifier identifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -140,7 +140,7 @@ private:
     void getFile(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<String, FileSystemStorageError>)>&&);
     using AccessHandleInfo = std::pair<WebCore::FileSystemSyncAccessHandleIdentifier, IPC::SharedFileHandle>;
     void createSyncAccessHandle(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<AccessHandleInfo, FileSystemStorageError>)>&&);
-    void closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
+    void closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier);
     void getHandleNames(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&&);
     void getHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, CompletionHandler<void(Expected<std::pair<WebCore::FileSystemHandleIdentifier, bool>, FileSystemStorageError>)>&&);
     

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -36,7 +36,7 @@
     Move(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier destinationIdentifier, String newName) -> (std::optional<WebKit::FileSystemStorageError> result)
     GetFile(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<String, WebKit::FileSystemStorageError> result)
     CreateSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<std::pair<WebCore::FileSystemSyncAccessHandleIdentifier, IPC::SharedFileHandle>, WebKit::FileSystemStorageError> result)
-    CloseSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier) -> (std::optional<WebKit::FileSystemStorageError> result)
+    CloseSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier)
     GetHandleNames(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<Vector<String>, WebKit::FileSystemStorageError> result)
     GetHandle(WebCore::FileSystemHandleIdentifier identifier, String name) -> (Expected<std::pair<WebCore::FileSystemHandleIdentifier, bool>, WebKit::FileSystemStorageError> result) WantsConnection
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
@@ -153,14 +153,12 @@ void WebFileSystemStorageConnection::createSyncAccessHandle(WebCore::FileSystemH
     });
 }
 
-void WebFileSystemStorageConnection::closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier, VoidCallback&& completionHandler)
+void WebFileSystemStorageConnection::closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier)
 {
     if (!m_connection)
-        return completionHandler(WebCore::Exception { WebCore::UnknownError, "Connection is lost"_s });
+        return;
 
-    m_connection->sendWithAsyncReply(Messages::NetworkStorageManager::CloseSyncAccessHandle(identifier, accessHandleIdentifier), [completionHandler = WTFMove(completionHandler)](auto error) mutable {
-        completionHandler(convertToExceptionOr(error));
-    });
+    m_connection->send(Messages::NetworkStorageManager::CloseSyncAccessHandle(identifier, accessHandleIdentifier), 0);
 }
 
 void WebFileSystemStorageConnection::getHandleNames(WebCore::FileSystemHandleIdentifier identifier, FileSystemStorageConnection::GetHandleNamesCallback&& completionHandler)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
@@ -85,7 +85,7 @@ private:
     void getFile(WebCore::FileSystemHandleIdentifier, StringCallback&&) final;
 
     void createSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemStorageConnection::GetAccessHandleCallback&&) final;
-    void closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, WebCore::FileSystemStorageConnection::VoidCallback&&) final;
+    void closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier) final;
     void registerSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier, WebCore::ScriptExecutionContextIdentifier) final;
     void unregisterSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier) final;
     void invalidateAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier) final;


### PR DESCRIPTION
#### acd30cd156726cd87885b18b46e6c7444e3e4eda
<pre>
Make all FileSystemSyncAccessHandle methods sync
<a href="https://bugs.webkit.org/show_bug.cgi?id=247071">https://bugs.webkit.org/show_bug.cgi?id=247071</a>
rdar://problem/101620396

Reviewed by Youenn Fablet.

To match latest spec: <a href="https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle.">https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle.</a> Chrome has already shipped it.

* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-close.https.tentative.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-flush.https.tentative.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-getSize.https.tentative.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemSyncAccessHandle-truncate.https.tentative.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/idlharness.https.any.worker-expected.txt:
* LayoutTests/storage/filesystemaccess/resources/sync-access-handle-basics.js:
* LayoutTests/storage/filesystemaccess/resources/sync-access-handle-close.js:
(testFunction):
(testFunctions):
(async testMultipleHandles):
(async test):
(testSyncFunction): Deleted.
(async testAsyncFunction): Deleted.
(async testFunctions): Deleted.
* LayoutTests/storage/filesystemaccess/resources/sync-access-handle-read-write.js:
(async test):
* LayoutTests/storage/filesystemaccess/sync-access-handle-close-worker-expected.txt:
* LayoutTests/storage/filesystemaccess/sync-access-handle-read-write-worker-expected.txt:
* Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.cpp:
(WebCore::FileSystemFileHandle::createSyncAccessHandle):
(WebCore::FileSystemFileHandle::closeSyncAccessHandle):
* Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp:
(WebCore::FileSystemSyncAccessHandle::~FileSystemSyncAccessHandle):
(WebCore::FileSystemSyncAccessHandle::truncate):
(WebCore::FileSystemSyncAccessHandle::getSize):
(WebCore::FileSystemSyncAccessHandle::flush):
(WebCore::FileSystemSyncAccessHandle::close):
(WebCore::FileSystemSyncAccessHandle::closeInternal):
(WebCore::FileSystemSyncAccessHandle::read):
(WebCore::FileSystemSyncAccessHandle::write):
(WebCore::FileSystemSyncAccessHandle::stop):
(WebCore::FileSystemSyncAccessHandle::invalidate):
(WebCore::FileSystemSyncAccessHandle::isClosingOrClosed const): Deleted.
(WebCore::FileSystemSyncAccessHandle::closeFile): Deleted.
(WebCore::FileSystemSyncAccessHandle::didCloseFile): Deleted.
(WebCore::FileSystemSyncAccessHandle::closeBackend): Deleted.
(WebCore::FileSystemSyncAccessHandle::didCloseBackend): Deleted.
(WebCore::FileSystemSyncAccessHandle::completePromise): Deleted.
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.idl:
* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.cpp:
(WebCore::WorkerFileSystemStorageConnection::closeSyncAccessHandle):
* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::closeSyncAccessHandle):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp:
(WebKit::WebFileSystemStorageConnection::closeSyncAccessHandle):
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h:

Canonical link: <a href="https://commits.webkit.org/258473@main">https://commits.webkit.org/258473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f82b26e8c412095cbacabfaa0aecb6673a88d7fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111352 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171549 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/106002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2086 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94423 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109102 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37125 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91173 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24044 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4742 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25472 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1921 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44960 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5811 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6587 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->