### PR TITLE
Improve WASM OMG logging

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -3854,6 +3854,7 @@
 		4B78E099294427D2003C6682 /* B3Const128Value.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = B3Const128Value.h; path = b3/B3Const128Value.h; sourceTree = "<group>"; };
 		4B78E09A294427D2003C6682 /* B3SIMDValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = B3SIMDValue.h; path = b3/B3SIMDValue.h; sourceTree = "<group>"; };
 		4B78E09B294427D2003C6682 /* B3Const128Value.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3Const128Value.cpp; path = b3/B3Const128Value.cpp; sourceTree = "<group>"; };
+		4B8F57F32953B29600090D27 /* SIMDInfo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SIMDInfo.cpp; sourceTree = "<group>"; };
 		4BBA4CD428FF5FE5003EBFC4 /* Width.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Width.h; sourceTree = "<group>"; };
 		4BC18E5428FDE6C800ECD68D /* SIMDInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SIMDInfo.h; sourceTree = "<group>"; };
 		4BDF15B128FF912800D36BA1 /* Width.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Width.cpp; sourceTree = "<group>"; };
@@ -6753,6 +6754,7 @@
 				0F24E54B17EE274900ABB217 /* ScratchRegisterAllocator.h */,
 				0FEE98421A89227500754E93 /* SetupVarargsFrame.cpp */,
 				0FEE98401A8865B600754E93 /* SetupVarargsFrame.h */,
+				4B8F57F32953B29600090D27 /* SIMDInfo.cpp */,
 				4BC18E5428FDE6C800ECD68D /* SIMDInfo.h */,
 				6B731CC02647A8370014646F /* SlowPathCall.cpp */,
 				A709F2EF17A0AC0400512E98 /* SlowPathCall.h */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -697,6 +697,7 @@ jit/RegisterAtOffsetList.cpp
 jit/RegisterSet.cpp
 jit/ScratchRegisterAllocator.cpp
 jit/SetupVarargsFrame.cpp
+jit/SIMDInfo.cpp
 jit/SlowPathCall.cpp
 jit/TagRegistersMode.cpp
 jit/ThunkGenerators.cpp

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -290,14 +290,13 @@ public:
     }
     bool usesSIMD() const
     {
+        // See also: WasmModuleInformation::isSIMDFunction().
         if (!Options::useWebAssemblySIMD())
             return false;
-        // The LLInt is responsible for discovering this.
-        // If we can't run using it, then we should be conservative.
-        if (!Options::useWasmLLInt())
-            return true;
         if (Options::forceAllFunctionsToUseSIMD())
             return true;
+        // The LLInt discovers this value.
+        ASSERT(Options::useWasmLLInt());
         return m_usesSIMD;
     }
 

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -52,7 +52,9 @@ namespace JSC { namespace B3 {
 #if ASSERT_ENABLED
 String Value::generateCompilerConstructionSite()
 {
-    if (!Options::dumpDisassembly())
+    if (!Options::dumpDisassembly() && !Options::dumpBBQDisassembly()
+        && !Options::dumpOMGDisassembly() && !Options::dumpFTLDisassembly()
+        && !Options::dumpDFGDisassembly())
         return emptyString();
 
     StringPrintStream s;

--- a/Source/JavaScriptCore/jit/SIMDInfo.cpp
+++ b/Source/JavaScriptCore/jit/SIMDInfo.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SIMDInfo.h"
+
+namespace WTF {
+
+void printInternal(PrintStream& out, JSC::SIMDLane lane)
+{
+    switch (lane) {
+    case JSC::SIMDLane::i8x16:
+        out.print("i8x16");
+        break;
+    case JSC::SIMDLane::i16x8:
+        out.print("i16x8");
+        break;
+    case JSC::SIMDLane::i32x4:
+        out.print("i32x4");
+        break;
+    case JSC::SIMDLane::f32x4:
+        out.print("f32x4");
+        break;
+    case JSC::SIMDLane::i64x2:
+        out.print("i64x2");
+        break;
+    case JSC::SIMDLane::f64x2:
+        out.print("f64x2");
+        break;
+    case JSC::SIMDLane::v128:
+        out.print("v128");
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
+void printInternal(PrintStream& out, JSC::SIMDSignMode mode)
+{
+    switch (mode) {
+    case JSC::SIMDSignMode::None:
+        out.print("SignMode::None");
+        break;
+    case JSC::SIMDSignMode::Signed:
+        out.print("SignMode::Signed");
+        break;
+    case JSC::SIMDSignMode::Unsigned:
+        out.print("SignMode::Unsigned");
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
+void printInternal(PrintStream& out, JSC::v128_t v)
+{
+    out.print("{ ", v.u32x4[0], ", ", v.u32x4[1], ", ", v.u32x4[2], ", ", v.u32x4[3], " }");
+}
+
+} // namespace WTF

--- a/Source/JavaScriptCore/jit/SIMDInfo.h
+++ b/Source/JavaScriptCore/jit/SIMDInfo.h
@@ -172,50 +172,10 @@ constexpr unsigned elementByteSize(SIMDLane simdLane)
 
 namespace WTF {
 
-inline void printInternal(PrintStream& out, JSC::SIMDLane lane)
-{
-    switch (lane) {
-    case JSC::SIMDLane::i8x16:
-        out.print("i8x16");
-        break;
-    case JSC::SIMDLane::i16x8:
-        out.print("i16x8");
-        break;
-    case JSC::SIMDLane::i32x4:
-        out.print("i32x4");
-        break;
-    case JSC::SIMDLane::f32x4:
-        out.print("f32x4");
-        break;
-    case JSC::SIMDLane::i64x2:
-        out.print("i64x2");
-        break;
-    case JSC::SIMDLane::f64x2:
-        out.print("f64x2");
-        break;
-    case JSC::SIMDLane::v128:
-        out.print("v128");
-        break;
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-}
+void printInternal(PrintStream& out, JSC::SIMDLane lane);
 
-inline void printInternal(PrintStream& out, JSC::SIMDSignMode mode)
-{
-    switch (mode) {
-    case JSC::SIMDSignMode::None:
-        out.print("SignMode::None");
-        break;
-    case JSC::SIMDSignMode::Signed:
-        out.print("SignMode::Signed");
-        break;
-    case JSC::SIMDSignMode::Unsigned:
-        out.print("SignMode::Unsigned");
-        break;
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-}
+void printInternal(PrintStream& out, JSC::SIMDSignMode mode);
+
+void printInternal(PrintStream& out, JSC::v128_t v);
 
 } // namespace WTF

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -664,6 +664,12 @@ void Options::notifyOptionsChanged()
 
         if (Options::forceAllFunctionsToUseSIMD() && !Options::useWebAssemblySIMD())
             Options::forceAllFunctionsToUseSIMD() = false;
+
+        if (Options::useWebAssemblySIMD() && !Options::useWasmLLInt()) {
+            // The LLInt is responsible for discovering if functions use SIMD.
+            // If we can't run using it, then we should be conservative.
+            Options::forceAllFunctionsToUseSIMD() = true;
+        }
     }
 
     if (Options::dumpFuzzerAgentPredictions())

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -68,6 +68,10 @@
 
 namespace JSC { namespace Wasm {
 
+namespace WasmAirIRGeneratorInternal {
+    static constexpr bool verbose = false;
+}
+
 using namespace B3::Air;
 
 /*
@@ -2776,8 +2780,10 @@ void AirIRGeneratorBase<Derived, ExpressionType>::emitLoopTierUpCheck(uint32_t l
         // First argument is the countdown location.
         ASSERT(params.value()->numChildren() >= 1);
         StackMap values(params.value()->numChildren() - 1);
-        for (unsigned i = 1; i < params.value()->numChildren(); ++i)
+        for (unsigned i = 1; i < params.value()->numChildren(); ++i) {
+            dataLogLnIf(WasmAirIRGeneratorInternal::verbose, "OSR loop patchpoint param[", i, "] = ", params[i]);
             values[i - 1] = OSREntryValue(params[i], params.value()->child(i)->type());
+        }
 
         OSREntryData& osrEntryData = m_tierUp->addOSREntryData(m_functionIndex, loopIndex, WTFMove(values));
         OSREntryData* osrEntryDataPtr = &osrEntryData;

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -99,7 +99,21 @@ struct ModuleInformation : public ThreadSafeRefCounted<ModuleInformation> {
     bool isDeclaredException(uint32_t index) const { return m_declaredExceptions.contains(index); }
     void addDeclaredException(uint32_t index) { m_declaredExceptions.set(index); }
 
-    bool isSIMDFunction(uint32_t index) const { ASSERT(index <= internalFunctionCount()); ASSERT(functions[index].finishedValidating); return functions[index].isSIMDFunction; }
+    bool isSIMDFunction(uint32_t index) const
+    {
+        ASSERT(index <= internalFunctionCount());
+        ASSERT(functions[index].finishedValidating);
+
+        // See also: B3Procedure::usesSIMD().
+        if (!Options::useWebAssemblySIMD())
+            return false;
+        if (Options::forceAllFunctionsToUseSIMD())
+            return true;
+        // The LLInt discovers this value.
+        ASSERT(Options::useWasmLLInt());
+
+        return functions[index].isSIMDFunction;
+    }
     void addSIMDFunction(uint32_t index) { ASSERT(index <= internalFunctionCount()); ASSERT(!functions[index].finishedValidating); functions[index].isSIMDFunction = true; }
     void doneSeeingFunction(uint32_t index) { ASSERT(!functions[index].finishedValidating); functions[index].finishedValidating = true; }
 

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.h
@@ -52,6 +52,7 @@ private:
     // For some reason friendship doesn't extend to parent classes...
     using Base::m_lock;
 
+    void dumpDisassembly(CompilationContext&, LinkBuffer&);
     bool isComplete() const final { return m_completed; }
     void complete() WTF_REQUIRES_LOCK(m_lock) final
     {

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.h
@@ -54,6 +54,7 @@ private:
     // For some reason friendship doesn't extend to parent classes...
     using Base::m_lock;
 
+    void dumpDisassembly(CompilationContext&, LinkBuffer&);
     bool isComplete() const final { return m_completed; }
     void complete() WTF_REQUIRES_LOCK(m_lock) final
     {

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -63,6 +63,10 @@ IGNORE_WARNINGS_BEGIN("frame-address")
 
 namespace JSC { namespace Wasm {
 
+namespace WasmOperationsInternal {
+    static constexpr bool verbose = false;
+}
+
 #if ENABLE(WEBASSEMBLY_B3JIT)
 static bool shouldTriggerOMGCompile(TierUpCount& tierUp, OMGCallee* replacement, uint32_t functionIndex)
 {


### PR DESCRIPTION
#### bfbe6b3ede3cb6ba92287e5d45660aad57388343
<pre>
Improve WASM OMG logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=249738">https://bugs.webkit.org/show_bug.cgi?id=249738</a>
rdar://103609640

Reviewed by Yusuke Suzuki.

Improve WASM debug logging and disassembly output for the WASM OMG tier.

* Source/JavaScriptCore/b3/B3Procedure.h:
(JSC::B3::Procedure::usesSIMD const):
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::generateCompilerConstructionSite):
* Source/JavaScriptCore/jit/SIMDInfo.h:
(WTF::printInternal):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::ExpressionType&gt;::emitLoopTierUpCheck):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::dumpDisassembly):
(JSC::Wasm::BBQPlan::work):
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
(JSC::Wasm::ModuleInformation::isSIMDFunction const):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::dumpDisassembly):
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOMGPlan.h:
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::dumpDisassembly):
(JSC::Wasm::OSREntryPlan::work):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:

Canonical link: <a href="https://commits.webkit.org/258225@main">https://commits.webkit.org/258225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16926bc0e998afd22c9343e509117f38fd78aa7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101254 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110535 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170816 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1278 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93659 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108367 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8628 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23274 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91708 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4047 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24788 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87827 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1614 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1215 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29286 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10196 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44267 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90722 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5657 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5847 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20273 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->