### PR TITLE
Fix unused warnings

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
@@ -136,6 +136,9 @@ void MediaKeys::setServerCertificate(const BufferSource& serverCertificate, Ref<
     // 5.1. Use this object's cdm instance to process certificate.
     ALWAYS_LOG(identifier);
     m_instance->setServerCertificate(WTFMove(certificate), [this, protectedThis = Ref { *this }, promise = WTFMove(promise), identifier = WTFMove(identifier)] (auto success) {
+#if RELEASE_LOG_DISABLED
+        UNUSED_PARAM(this);
+#endif
         // 5.2. If the preceding step failed, resolve promise with a new DOMException whose name is the appropriate error name.
         // 5.1. [Else,] Resolve promise with true.
         if (success == CDMInstance::Failed) {

--- a/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
@@ -70,15 +70,18 @@ struct LogArgument<std::optional<T>> {
 
 namespace WebCore {
 
+#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
 template<typename... Arguments>
 inline void infoLog(Logger& logger, const Arguments&... arguments)
 {
-#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
     logger.info(LogEME, arguments...);
-#else
-    UNUSED_PARAM(logger);
-#endif
 }
+#else
+template<typename... Arguments>
+inline void infoLog(Logger&, const Arguments&...)
+{
+}
+#endif
 
 static void tryNextSupportedConfiguration(Document&, RefPtr<CDM>&&, Vector<MediaKeySystemConfiguration>&&, RefPtr<DeferredPromise>&&, Ref<Logger>&&, Logger::LogSiteIdentifier&&);
 

--- a/Source/WebDriver/Session.cpp
+++ b/Source/WebDriver/Session.cpp
@@ -577,7 +577,7 @@ void Session::switchToBrowsingContext(const String& toplevelBrowsingContext, con
     auto parameters = JSON::Object::create();
     parameters->setString("browsingContextHandle"_s, toplevelBrowsingContext);
     parameters->setString("frameHandle"_s, browsingContext);
-    m_host->sendCommandToBackend("switchToBrowsingContext"_s, WTFMove(parameters), [this, completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) {
+    m_host->sendCommandToBackend("switchToBrowsingContext"_s, WTFMove(parameters), [completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) {
         if (response.isError) {
             completionHandler(CommandResult::fail(WTFMove(response.responseObject)));
             return;

--- a/Source/WebDriver/playstation/WebDriverServicePlayStation.cpp
+++ b/Source/WebDriver/playstation/WebDriverServicePlayStation.cpp
@@ -50,7 +50,7 @@ Capabilities WebDriverService::platformCapabilities()
     return capabilities;
 }
 
-bool WebDriverService::platformCompareBrowserVersions(const String& requiredVersion, const String& proposedVersion)
+bool WebDriverService::platformCompareBrowserVersions(const String&, const String&)
 {
     return true;
 }

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -45,10 +45,12 @@ static constexpr bool mediaSourceEnabledValue = false;
 static constexpr bool mediaSourceEnabledValue = true;
 #endif
 
+#if ENABLE(GPU_PROCESS)
 #if PLATFORM(IOS_FAMILY)
 static constexpr bool fullGPUProcessEnabledValue = true;
 #else
 static constexpr bool fullGPUProcessEnabledValue = false;
+#endif
 #endif
 
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### dc5576a450d6a1c45f2fd9b567cff2d4446c20b0
<pre>
Fix unused warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=249734">https://bugs.webkit.org/show_bug.cgi?id=249734</a>

Reviewed by Yusuke Suzuki.

* Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp:
* Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp:
* Source/WebDriver/Session.cpp:
* Source/WebDriver/playstation/WebDriverServicePlayStation.cpp:
* Tools/WebKitTestRunner/TestOptions.cpp:

Canonical link: <a href="https://commits.webkit.org/258251@main">https://commits.webkit.org/258251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e36cc89b4b0c28b973fb18cde7b9186acb075ac1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110611 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170883 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1349 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93735 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108438 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35226 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78224 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4116 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24854 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1278 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44339 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5676 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5929 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->