### PR TITLE
Setting `font-weight` property to 3.14 returns 3 as computed value instead of 3.14

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt
@@ -15,7 +15,7 @@ FAIL Can set 'font-stretch' to the 'extra-expanded' keyword: extra-expanded asse
 FAIL Can set 'font-stretch' to the 'ultra-expanded' keyword: ultra-expanded assert_equals: expected "CSSKeywordValue" but got "CSSUnitValue"
 PASS Can set 'font-stretch' to a percent: 0%
 FAIL Can set 'font-stretch' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'font-stretch' to a percent: 3.14% assert_approx_equals: expected 3.14 +/- 0.000001 but got 3
+PASS Can set 'font-stretch' to a percent: 3.14%
 PASS Can set 'font-stretch' to a percent: calc(0% + 0%)
 PASS Setting 'font-stretch' to a length: 0px throws TypeError
 PASS Setting 'font-stretch' to a length: -3.14em throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt
@@ -10,7 +10,7 @@ PASS Can set 'font-weight' to the 'bolder' keyword: bolder
 PASS Can set 'font-weight' to the 'lighter' keyword: lighter
 PASS Can set 'font-weight' to a number: 0
 FAIL Can set 'font-weight' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
-FAIL Can set 'font-weight' to a number: 3.14 assert_approx_equals: expected 3.14 +/- 0.000001 but got 3
+PASS Can set 'font-weight' to a number: 3.14
 PASS Can set 'font-weight' to a number: calc(2 + 3)
 PASS Setting 'font-weight' to a length: 0px throws TypeError
 PASS Setting 'font-weight' to a length: -3.14em throws TypeError

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -589,7 +589,7 @@ static inline FontSelectionValue blendFunc(FontSelectionValue from, FontSelectio
     return FontSelectionValue(std::max(0.0f, blendFunc(static_cast<float>(from), static_cast<float>(to), context)));
 }
 
-static inline std::optional<FontSelectionValue> blendFunc(std::optional<FontSelectionValue> from, std::optional<FontSelectionValue> to, const CSSPropertyBlendingContext& context)
+static inline std::optional<float> blendFunc(std::optional<float> from, std::optional<float> to, const CSSPropertyBlendingContext& context)
 {
     return blendFunc(*from, *to, context);
 }
@@ -2465,7 +2465,7 @@ private:
     void (RenderStyle::*m_setter)(const StyleColor&);
 };
 
-class PropertyWrapperFontWeight final : public PropertyWrapper<FontSelectionValue> {
+class PropertyWrapperFontWeight final : public PropertyWrapper<float> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     PropertyWrapperFontWeight()
@@ -2481,7 +2481,7 @@ private:
     }
 };
 
-class PropertyWrapperFontStyle final : public PropertyWrapper<std::optional<FontSelectionValue>> {
+class PropertyWrapperFontStyle final : public PropertyWrapper<std::optional<float>> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     PropertyWrapperFontStyle()
@@ -3448,7 +3448,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
 #endif
         new PropertyWrapperFontSizeAdjust,
         new PropertyWrapperFontWeight,
-        new PropertyWrapper<FontSelectionValue>(CSSPropertyFontStretch, &RenderStyle::fontStretch, &RenderStyle::setFontStretch),
+        new PropertyWrapper<float>(CSSPropertyFontStretch, &RenderStyle::fontStretch, &RenderStyle::setFontStretch),
         new PropertyWrapperFontStyle,
         new PropertyWrapper<TextDecorationThickness>(CSSPropertyTextDecorationThickness, &RenderStyle::textDecorationThickness, &RenderStyle::setTextDecorationThickness),
         new PropertyWrapper<TextUnderlineOffset>(CSSPropertyTextUnderlineOffset, &RenderStyle::textUnderlineOffset, &RenderStyle::setTextUnderlineOffset),

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -175,12 +175,12 @@ static FontSelectionRange calculateWeightRange(CSSValue& value)
         auto& value1 = downcast<CSSPrimitiveValue>(*valueList.item(1));
         auto result0 = Style::BuilderConverter::convertFontWeightFromValue(value0);
         auto result1 = Style::BuilderConverter::convertFontWeightFromValue(value1);
-        return { result0, result1 };
+        return { FontSelectionValue::clampFloat(result0), FontSelectionValue::clampFloat(result1) };
     }
 
     ASSERT(is<CSSPrimitiveValue>(value));
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-    FontSelectionValue result = Style::BuilderConverter::convertFontWeightFromValue(primitiveValue);
+    auto result = FontSelectionValue::clampFloat(Style::BuilderConverter::convertFontWeightFromValue(primitiveValue));
     return { result, result };
 }
 
@@ -212,12 +212,12 @@ static FontSelectionRange calculateStretchRange(CSSValue& value)
         auto& value1 = downcast<CSSPrimitiveValue>(*valueList.item(1));
         auto result0 = Style::BuilderConverter::convertFontStretchFromValue(value0);
         auto result1 = Style::BuilderConverter::convertFontStretchFromValue(value1);
-        return { result0, result1 };
+        return { FontSelectionValue::clampFloat(result0), FontSelectionValue::clampFloat(result1) };
     }
 
     ASSERT(is<CSSPrimitiveValue>(value));
     const auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-    FontSelectionValue result = Style::BuilderConverter::convertFontStretchFromValue(primitiveValue);
+    FontSelectionValue result = FontSelectionValue::clampFloat(Style::BuilderConverter::convertFontStretchFromValue(primitiveValue));
     return { result, result };
 }
 

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2278,9 +2278,9 @@ static Ref<CSSPrimitiveValue> fontPalette(const RenderStyle& style)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-static Ref<CSSPrimitiveValue> fontWeight(FontSelectionValue weight)
+static Ref<CSSPrimitiveValue> fontWeight(float weight)
 {
-    return CSSValuePool::singleton().createValue(static_cast<float>(weight), CSSUnitType::CSS_NUMBER);
+    return CSSValuePool::singleton().createValue(weight, CSSUnitType::CSS_NUMBER);
 }
 
 static Ref<CSSPrimitiveValue> fontWeight(const RenderStyle& style)
@@ -2288,9 +2288,9 @@ static Ref<CSSPrimitiveValue> fontWeight(const RenderStyle& style)
     return fontWeight(style.fontDescription().weight());
 }
 
-static Ref<CSSPrimitiveValue> fontStretch(FontSelectionValue stretch)
+static Ref<CSSPrimitiveValue> fontStretch(float stretch)
 {
-    return CSSValuePool::singleton().createValue(static_cast<float>(stretch), CSSUnitType::CSS_PERCENTAGE);
+    return CSSValuePool::singleton().createValue(stretch, CSSUnitType::CSS_PERCENTAGE);
 }
 
 static Ref<CSSPrimitiveValue> fontStretch(const RenderStyle& style)
@@ -2298,7 +2298,7 @@ static Ref<CSSPrimitiveValue> fontStretch(const RenderStyle& style)
     return fontStretch(style.fontDescription().stretch());
 }
 
-static Ref<CSSValue> fontStyle(std::optional<FontSelectionValue> italic, FontStyleAxis axis)
+static Ref<CSSValue> fontStyle(std::optional<float> italic, FontStyleAxis axis)
 {
     if (auto keyword = fontStyleKeyword(italic, axis))
         return CSSValuePool::singleton().createIdentifierValue(keyword.value());
@@ -2802,7 +2802,7 @@ String ComputedStyleExtractor::customPropertyText(const AtomString& propertyName
 static Ref<CSSFontValue> fontShorthandValue(const RenderStyle& style, ComputedStyleExtractor::PropertyValueType valueType)
 {
     auto& description = style.fontDescription();
-    auto fontStretch = fontStretchKeyword(description.stretch());
+    auto fontStretch = fontStretchKeyword(FontSelectionValue::clampFloat(description.stretch()));
     auto fontStyle = fontStyleKeyword(description.italic(), description.fontStyleAxis());
 
     auto propertiesResetByShorthandAreExpressible = [&] {

--- a/Source/WebCore/css/FontSelectionValueInlines.h
+++ b/Source/WebCore/css/FontSelectionValueInlines.h
@@ -116,11 +116,14 @@ inline std::optional<FontSelectionValue> fontStretchValue(CSSValueID value)
     }
 }
 
-inline std::optional<CSSValueID> fontStyleKeyword(std::optional<FontSelectionValue> style, FontStyleAxis axis)
+inline std::optional<CSSValueID> fontStyleKeyword(std::optional<float> style, FontStyleAxis axis)
 {
-    if (!style || style.value() == normalItalicValue())
+    if (!style)
         return CSSValueNormal;
-    if (style.value() == italicValue())
+    auto clampedStyle = FontSelectionValue::clampFloat(*style);
+    if (clampedStyle == normalItalicValue())
+        return CSSValueNormal;
+    if (clampedStyle == italicValue())
         return axis == FontStyleAxis::ital ? CSSValueItalic : CSSValueOblique;
     return std::nullopt;
 }

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -164,8 +164,8 @@ public:
     const AtomString& familyAt(unsigned i) const { return m_fontDescription.familyAt(i); }
 
     // A std::nullopt return value indicates "font-style: normal".
-    std::optional<FontSelectionValue> italic() const { return m_fontDescription.italic(); }
-    FontSelectionValue weight() const { return m_fontDescription.weight(); }
+    std::optional<FontSelectionValue> italic() const { return m_fontDescription.italic() ? std::optional { FontSelectionValue::clampFloat(*m_fontDescription.italic()) } : std::nullopt; }
+    FontSelectionValue weight() const { return FontSelectionValue::clampFloat(m_fontDescription.weight()); }
     FontWidthVariant widthVariant() const { return m_fontDescription.widthVariant(); }
 
     bool isPlatformFont() const { return m_fonts->isForPlatformFont(); }

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
@@ -45,7 +45,10 @@ struct SameSizeAsFontCascadeDescription {
     FontVariantAlternates alternates;
     AtomString string;
     AtomString string2;
-    int16_t fontSelectionRequest[3];
+    struct {
+        float a[2];
+        std::optional<float> b;
+    } fontSelectionRequest;
     float size;
     std::optional<float> sizeAdjust;
     unsigned bitfields1;
@@ -66,25 +69,25 @@ FontCascadeDescription::FontCascadeDescription()
 {
 }
 
-FontSelectionValue FontCascadeDescription::lighterWeight(FontSelectionValue weight)
+float FontCascadeDescription::lighterWeight(float weight)
 {
-    if (weight < FontSelectionValue(100))
+    if (weight < 100)
         return weight;
-    if (weight < FontSelectionValue(550))
-        return FontSelectionValue(100);
-    if (weight < FontSelectionValue(750))
-        return FontSelectionValue(400);
-    return FontSelectionValue(700);
+    if (weight < 550)
+        return 100;
+    if (weight < 750)
+        return 400;
+    return 700;
 }
 
-FontSelectionValue FontCascadeDescription::bolderWeight(FontSelectionValue weight)
+float FontCascadeDescription::bolderWeight(float weight)
 {
-    if (weight < FontSelectionValue(350))
-        return FontSelectionValue(400);
-    if (weight < FontSelectionValue(550))
-        return FontSelectionValue(700);
-    if (weight < FontSelectionValue(900))
-        return FontSelectionValue(900);
+    if (weight < 350)
+        return 400;
+    if (weight < 550)
+        return 700;
+    if (weight < 900)
+        return 900;
     return weight;
 }
 

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -66,10 +66,10 @@ public:
 
     float specifiedSize() const { return m_specifiedSize; }
     bool isAbsoluteSize() const { return m_isAbsoluteSize; }
-    FontSelectionValue lighterWeight() const { return lighterWeight(weight()); }
-    FontSelectionValue bolderWeight() const { return bolderWeight(weight()); }
-    static FontSelectionValue lighterWeight(FontSelectionValue);
-    static FontSelectionValue bolderWeight(FontSelectionValue);
+    float lighterWeight() const { return lighterWeight(weight()); }
+    float bolderWeight() const { return bolderWeight(weight()); }
+    static float lighterWeight(float);
+    static float bolderWeight(float);
 
     // only use fixed default size when there is only one font family, and that family is "monospace"
     bool useFixedDefaultSize() const { return familyCount() == 1 && firstFamily() == monospaceFamily; }

--- a/Source/WebCore/platform/graphics/FontDescription.h
+++ b/Source/WebCore/platform/graphics/FontDescription.h
@@ -46,10 +46,10 @@ public:
 
     float computedSize() const { return m_computedSize; }
     unsigned computedPixelSize() const { return unsigned(m_computedSize + 0.5f); }
-    std::optional<FontSelectionValue> italic() const { return m_fontSelectionRequest.slope; }
+    std::optional<float> italic() const { return m_fontSelectionRequest.slope; }
     std::optional<float> fontSizeAdjust() const { return m_sizeAdjust; }
-    FontSelectionValue stretch() const { return m_fontSelectionRequest.width; }
-    FontSelectionValue weight() const { return m_fontSelectionRequest.weight; }
+    float stretch() const { return m_fontSelectionRequest.width; }
+    float weight() const { return m_fontSelectionRequest.weight; }
     FontSelectionRequest fontSelectionRequest() const { return m_fontSelectionRequest; }
     FontRenderingMode renderingMode() const { return static_cast<FontRenderingMode>(m_renderingMode); }
     TextRenderingMode textRenderingMode() const { return static_cast<TextRenderingMode>(m_textRendering); }
@@ -109,10 +109,10 @@ public:
 
     void setComputedSize(float s) { m_computedSize = clampToFloat(s); }
     void setFontSizeAdjust(std::optional<float> sizeAdjust) { m_sizeAdjust = sizeAdjust; }
-    void setItalic(std::optional<FontSelectionValue> italic) { m_fontSelectionRequest.slope = italic; }
-    void setStretch(FontSelectionValue stretch) { m_fontSelectionRequest.width = stretch; }
+    void setItalic(std::optional<float> italic) { m_fontSelectionRequest.slope = italic; }
+    void setStretch(float stretch) { m_fontSelectionRequest.width = stretch; }
     void setIsItalic(bool isItalic) { setItalic(isItalic ? std::optional<FontSelectionValue> { italicValue() } : std::optional<FontSelectionValue> { }); }
-    void setWeight(FontSelectionValue weight) { m_fontSelectionRequest.weight = weight; }
+    void setWeight(float weight) { m_fontSelectionRequest.weight = weight; }
     void setRenderingMode(FontRenderingMode mode) { m_renderingMode = static_cast<unsigned>(mode); }
     void setTextRenderingMode(TextRenderingMode rendering) { m_textRendering = static_cast<unsigned>(rendering); }
     void setOrientation(FontOrientation orientation) { m_orientation = static_cast<unsigned>(orientation); }

--- a/Source/WebCore/platform/graphics/FontSelectionAlgorithm.cpp
+++ b/Source/WebCore/platform/graphics/FontSelectionAlgorithm.cpp
@@ -45,28 +45,29 @@ auto FontSelectionAlgorithm::stretchDistance(Capabilities capabilities) const ->
 {
     auto width = capabilities.width;
     ASSERT(width.isValid());
-    if (width.includes(m_request.width))
-        return { FontSelectionValue(), m_request.width };
+    auto requestWidth = FontSelectionValue::clampFloat(m_request.width);
+    if (width.includes(requestWidth))
+        return { FontSelectionValue(), requestWidth };
 
-    if (m_request.width > normalStretchValue()) {
-        if (width.minimum > m_request.width)
-            return { width.minimum - m_request.width, width.minimum };
-        ASSERT(width.maximum < m_request.width);
-        auto threshold = std::max(m_request.width, m_capabilitiesBounds.width.maximum);
+    if (requestWidth > normalStretchValue()) {
+        if (width.minimum > requestWidth)
+            return { width.minimum - requestWidth, width.minimum };
+        ASSERT(width.maximum < requestWidth);
+        auto threshold = std::max(requestWidth, m_capabilitiesBounds.width.maximum);
         return { threshold - width.maximum, width.maximum };
     }
 
-    if (width.maximum < m_request.width)
-        return { m_request.width - width.maximum, width.maximum };
-    ASSERT(width.minimum > m_request.width);
-    auto threshold = std::min(m_request.width, m_capabilitiesBounds.width.minimum);
+    if (width.maximum < requestWidth)
+        return { requestWidth - width.maximum, width.maximum };
+    ASSERT(width.minimum > requestWidth);
+    auto threshold = std::min(requestWidth, m_capabilitiesBounds.width.minimum);
     return { width.minimum - threshold, width.minimum };
 }
 
 auto FontSelectionAlgorithm::styleDistance(Capabilities capabilities) const -> DistanceResult
 {
     auto slope = capabilities.slope;
-    auto requestSlope = m_request.slope.value_or(normalItalicValue());
+    auto requestSlope = m_request.slope ? FontSelectionValue::clampFloat(*m_request.slope) : normalItalicValue();
     ASSERT(slope.isValid());
     if (slope.includes(requestSlope))
         return { FontSelectionValue(), requestSlope };
@@ -110,30 +111,31 @@ auto FontSelectionAlgorithm::weightDistance(Capabilities capabilities) const -> 
 {
     auto weight = capabilities.weight;
     ASSERT(weight.isValid());
-    if (weight.includes(m_request.weight))
-        return { FontSelectionValue(), m_request.weight };
+    auto requestWeight = FontSelectionValue::clampFloat(m_request.weight);
+    if (weight.includes(requestWeight))
+        return { FontSelectionValue(), requestWeight };
 
-    if (m_request.weight >= lowerWeightSearchThreshold() && m_request.weight <= upperWeightSearchThreshold()) {
-        if (weight.minimum > m_request.weight && weight.minimum <= upperWeightSearchThreshold())
-            return { weight.minimum - m_request.weight, weight.minimum };
-        if (weight.maximum < m_request.weight)
+    if (requestWeight >= lowerWeightSearchThreshold() && requestWeight <= upperWeightSearchThreshold()) {
+        if (weight.minimum > requestWeight && weight.minimum <= upperWeightSearchThreshold())
+            return { weight.minimum - requestWeight, weight.minimum };
+        if (weight.maximum < requestWeight)
             return { upperWeightSearchThreshold() - weight.maximum, weight.maximum };
         ASSERT(weight.minimum > upperWeightSearchThreshold());
-        auto threshold = std::min(m_request.weight, m_capabilitiesBounds.weight.minimum);
+        auto threshold = std::min(requestWeight, m_capabilitiesBounds.weight.minimum);
         return { weight.minimum - threshold, weight.minimum };
     }
-    if (m_request.weight < lowerWeightSearchThreshold()) {
-        if (weight.maximum < m_request.weight)
-            return { m_request.weight - weight.maximum, weight.maximum };
-        ASSERT(weight.minimum > m_request.weight);
-        auto threshold = std::min(m_request.weight, m_capabilitiesBounds.weight.minimum);
+    if (requestWeight < lowerWeightSearchThreshold()) {
+        if (weight.maximum < requestWeight)
+            return { requestWeight - weight.maximum, weight.maximum };
+        ASSERT(weight.minimum > requestWeight);
+        auto threshold = std::min(requestWeight, m_capabilitiesBounds.weight.minimum);
         return { weight.minimum - threshold, weight.minimum };
     }
-    ASSERT(m_request.weight >= upperWeightSearchThreshold());
-    if (weight.minimum > m_request.weight)
-        return { weight.minimum - m_request.weight, weight.minimum };
-    ASSERT(weight.maximum < m_request.weight);
-    auto threshold = std::max(m_request.weight, m_capabilitiesBounds.weight.maximum);
+    ASSERT(requestWeight >= upperWeightSearchThreshold());
+    if (weight.minimum > requestWeight)
+        return { weight.minimum - requestWeight, weight.minimum };
+    ASSERT(weight.maximum < requestWeight);
+    auto threshold = std::max(requestWeight, m_capabilitiesBounds.weight.maximum);
     return { threshold - weight.maximum, weight.maximum };
 }
 

--- a/Source/WebCore/platform/graphics/FontSelectionAlgorithm.h
+++ b/Source/WebCore/platform/graphics/FontSelectionAlgorithm.h
@@ -195,9 +195,9 @@ constexpr FontSelectionValue italicThreshold()
     return FontSelectionValue { 20 };
 }
 
-constexpr bool isItalic(std::optional<FontSelectionValue> fontWeight)
+constexpr bool isItalic(std::optional<float> fontWeight)
 {
-    return fontWeight && fontWeight.value() >= italicThreshold();
+    return fontWeight && FontSelectionValue::clampFloat(fontWeight.value()) >= italicThreshold();
 }
 
 constexpr FontSelectionValue normalItalicValue()
@@ -233,6 +233,11 @@ constexpr FontSelectionValue lightWeightValue()
 constexpr bool isFontWeightBold(FontSelectionValue fontWeight)
 {
     return fontWeight >= boldThreshold();
+}
+
+constexpr bool isFontWeightBold(float fontWeight)
+{
+    return isFontWeightBold(FontSelectionValue::clampFloat(fontWeight));
 }
 
 constexpr FontSelectionValue lowerWeightSearchThreshold()
@@ -377,10 +382,10 @@ inline void add(Hasher& hasher, const FontSelectionRange& range)
 }
 
 struct FontSelectionRequest {
-    using Value = FontSelectionValue;
+    using Value = float;
 
-    Value weight;
-    Value width;
+    float weight;
+    float width;
 
     // FIXME: We are using an optional here to be able to distinguish between an explicit
     // or implicit slope (for "italic" and "oblique") and the "normal" value which has no

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -1221,7 +1221,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacters(const FontDescription& descr
     if (!fullName.isEmpty())
         m_fontNamesRequiringSystemFallbackForPrewarming.add(fullName);
 
-    auto result = lookupFallbackFont(platformData.font(), description.weight(), description.computedLocale(), description.shouldAllowUserInstalledFonts(), characters, length);
+    auto result = lookupFallbackFont(platformData.font(), FontSelectionValue::clampFloat(description.weight()), description.computedLocale(), description.shouldAllowUserInstalledFonts(), characters, length);
     result = preparePlatformFont(result.get(), description, { });
 
     if (!result)

--- a/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
@@ -256,8 +256,8 @@ SystemFontDatabaseCoreText::CascadeListParameters SystemFontDatabaseCoreText::sy
     result.italic = isItalic(description.italic());
     result.allowUserInstalledFonts = allowUserInstalledFonts;
 
-    result.weight = mapWeight(description.weight());
-    result.width = mapWidth(description.stretch());
+    result.weight = mapWeight(FontSelectionValue::clampFloat(description.weight()));
+    result.width = mapWidth(FontSelectionValue::clampFloat(description.stretch()));
 
     switch (systemFontKind) {
     case SystemFontKind::SystemUI: {

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
@@ -86,7 +86,7 @@ bool FontCache::configurePatternForFontDescription(FcPattern* pattern, const Fon
 {
     if (!FcPatternAddInteger(pattern, FC_SLANT, fontDescription.italic() ? FC_SLANT_ITALIC : FC_SLANT_ROMAN))
         return false;
-    if (!FcPatternAddInteger(pattern, FC_WEIGHT, fontWeightToFontconfigWeight(fontDescription.weight())))
+    if (!FcPatternAddInteger(pattern, FC_WEIGHT, fontWeightToFontconfigWeight(FontSelectionValue::clampFloat(fontDescription.weight()))))
         return false;
     if (!FcPatternAddDouble(pattern, FC_PIXEL_SIZE, fontDescription.computedPixelSize()))
         return false;

--- a/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
@@ -655,7 +655,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
     // This masks rounding errors related to the HFONT metrics being  different from the CGFont metrics.
     // FIXME: We will eventually want subpixel precision for GDI mode, but the scaled rendering doesn't
     // look as nice. That may be solvable though.
-    LONG weight = adjustedGDIFontWeight(toGDIFontWeight(fontDescription.weight()), family);
+    LONG weight = adjustedGDIFontWeight(toGDIFontWeight(FontSelectionValue::clampFloat(fontDescription.weight())), family);
     auto hfont = createGDIFont(family, weight, isItalic(fontDescription.italic()),
         fontDescription.computedPixelSize() * (useGDI ? 1 : 32), useGDI);
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2107,7 +2107,7 @@ void RenderStyle::setFontVariationSettings(FontVariationSettings settings)
     fontCascade().update(selector);
 }
 
-void RenderStyle::setFontWeight(FontSelectionValue value)
+void RenderStyle::setFontWeight(float value)
 {
     auto selector = fontCascade().fontSelector();
     auto description = fontDescription();
@@ -2117,7 +2117,7 @@ void RenderStyle::setFontWeight(FontSelectionValue value)
     fontCascade().update(selector);
 }
 
-void RenderStyle::setFontStretch(FontSelectionValue value)
+void RenderStyle::setFontStretch(float value)
 {
     auto selector = fontCascade().fontSelector();
     auto description = fontDescription();
@@ -2127,7 +2127,7 @@ void RenderStyle::setFontStretch(FontSelectionValue value)
     fontCascade().update(selector);
 }
 
-void RenderStyle::setFontItalic(std::optional<FontSelectionValue> value)
+void RenderStyle::setFontItalic(std::optional<float> value)
 {
     auto selector = fontCascade().fontSelector();
     auto description = fontDescription();

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -377,9 +377,9 @@ public:
     std::pair<FontOrientation, NonCJKGlyphOrientation> fontAndGlyphOrientation();
 
     FontVariationSettings fontVariationSettings() const { return fontDescription().variationSettings(); }
-    FontSelectionValue fontWeight() const { return fontDescription().weight(); }
-    FontSelectionValue fontStretch() const { return fontDescription().stretch(); }
-    std::optional<FontSelectionValue> fontItalic() const { return fontDescription().italic(); }
+    float fontWeight() const { return fontDescription().weight(); }
+    float fontStretch() const { return fontDescription().stretch(); }
+    std::optional<float> fontItalic() const { return fontDescription().italic(); }
     FontPalette fontPalette() const { return fontDescription().fontPalette(); }
 
     const Length& textIndent() const { return m_rareInheritedData->indent; }
@@ -1043,9 +1043,9 @@ public:
     void setFontSizeAdjust(std::optional<float>);
 
     void setFontVariationSettings(FontVariationSettings);
-    void setFontWeight(FontSelectionValue);
-    void setFontStretch(FontSelectionValue);
-    void setFontItalic(std::optional<FontSelectionValue>);
+    void setFontWeight(float);
+    void setFontStretch(float);
+    void setFontItalic(std::optional<float>);
     void setFontPalette(FontPalette);
 
     void setColor(const Color&);

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -145,12 +145,12 @@ public:
 #endif
     static FontFeatureSettings convertFontFeatureSettings(BuilderState&, const CSSValue&);
     static bool convertSmoothScrolling(BuilderState&, const CSSValue&);
-    static FontSelectionValue convertFontWeightFromValue(const CSSValue&);
-    static FontSelectionValue convertFontStretchFromValue(const CSSValue&);
+    static float convertFontWeightFromValue(const CSSValue&);
+    static float convertFontStretchFromValue(const CSSValue&);
     static FontSelectionValue convertFontStyleAngle(const CSSValue&);
     static std::optional<FontSelectionValue> convertFontStyleFromValue(const CSSValue&);
-    static FontSelectionValue convertFontWeight(BuilderState&, const CSSValue&);
-    static FontSelectionValue convertFontStretch(BuilderState&, const CSSValue&);
+    static float convertFontWeight(BuilderState&, const CSSValue&);
+    static float convertFontStretch(BuilderState&, const CSSValue&);
     static FontSelectionValue convertFontStyle(BuilderState&, const CSSValue&);
     static FontVariationSettings convertFontVariationSettings(BuilderState&, const CSSValue&);
     static SVGLengthValue convertSVGLengthValue(BuilderState&, const CSSValue&, ShouldConvertNumberToPxLength = ShouldConvertNumberToPxLength::No);
@@ -1418,12 +1418,12 @@ inline FontFeatureSettings BuilderConverter::convertFontFeatureSettings(BuilderS
     return settings;
 }
 
-inline FontSelectionValue BuilderConverter::convertFontWeightFromValue(const CSSValue& value)
+inline float BuilderConverter::convertFontWeightFromValue(const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
 
     if (primitiveValue.isNumber())
-        return FontSelectionValue::clampFloat(primitiveValue.floatValue());
+        return primitiveValue.floatValue();
 
     ASSERT(primitiveValue.isValueID());
     switch (primitiveValue.valueID()) {
@@ -1440,12 +1440,12 @@ inline FontSelectionValue BuilderConverter::convertFontWeightFromValue(const CSS
     }
 }
 
-inline FontSelectionValue BuilderConverter::convertFontStretchFromValue(const CSSValue& value)
+inline float BuilderConverter::convertFontStretchFromValue(const CSSValue& value)
 {
     const auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
 
     if (primitiveValue.isPercentage())
-        return FontSelectionValue::clampFloat(primitiveValue.floatValue());
+        return primitiveValue.floatValue();
 
     ASSERT(primitiveValue.isValueID());
     if (auto value = fontStretchValue(primitiveValue.valueID()))
@@ -1472,7 +1472,7 @@ inline std::optional<FontSelectionValue> BuilderConverter::convertFontStyleFromV
     return italicValue();
 }
 
-inline FontSelectionValue BuilderConverter::convertFontWeight(BuilderState& builderState, const CSSValue& value)
+inline float BuilderConverter::convertFontWeight(BuilderState& builderState, const CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     if (primitiveValue.isValueID()) {
@@ -1482,12 +1482,12 @@ inline FontSelectionValue BuilderConverter::convertFontWeight(BuilderState& buil
         if (valueID == CSSValueLighter)
             return FontCascadeDescription::lighterWeight(builderState.parentStyle().fontDescription().weight());
         if (CSSPropertyParserHelpers::isSystemFontShorthand(valueID))
-            return SystemFontDatabase::singleton().systemFontShorthandWeight(CSSPropertyParserHelpers::lowerFontShorthand(valueID));
+            return static_cast<float>(SystemFontDatabase::singleton().systemFontShorthandWeight(CSSPropertyParserHelpers::lowerFontShorthand(valueID)));
     }
     return convertFontWeightFromValue(value);
 }
 
-inline FontSelectionValue BuilderConverter::convertFontStretch(BuilderState&, const CSSValue& value)
+inline float BuilderConverter::convertFontStretch(BuilderState&, const CSSValue& value)
 {
     return convertFontStretchFromValue(value);
 }

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1847,7 +1847,7 @@ inline float BuilderCustom::determineRubyTextSizeMultiplier(BuilderState& builde
     return 0.25f;
 }
 
-static inline void applyFontStyle(BuilderState& state, std::optional<FontSelectionValue> slope, FontStyleAxis axis)
+static inline void applyFontStyle(BuilderState& state, std::optional<float> slope, FontStyleAxis axis)
 {
     auto& description = state.fontDescription();
     if (description.italic() == slope && description.fontStyleAxis() == axis)

--- a/Source/WebCore/style/StyleResolveForFontRaw.cpp
+++ b/Source/WebCore/style/StyleResolveForFontRaw.cpp
@@ -165,9 +165,9 @@ std::optional<FontCascade> resolveForFontRaw(const FontRaw& fontRaw, FontCascade
             case CSSValueBold:
                 return boldWeightValue();
             case CSSValueBolder:
-                return FontCascadeDescription::bolderWeight(fontDescription.weight());
+                return FontSelectionValue::clampFloat(FontCascadeDescription::bolderWeight(fontDescription.weight()));
             case CSSValueLighter:
-                return FontCascadeDescription::lighterWeight(fontDescription.weight());
+                return FontSelectionValue::clampFloat(FontCascadeDescription::lighterWeight(fontDescription.weight()));
             default:
                 ASSERT_NOT_REACHED();
                 return normalWeightValue();

--- a/Source/WebKitLegacy/win/DOMCoreClasses.cpp
+++ b/Source/WebKitLegacy/win/DOMCoreClasses.cpp
@@ -41,6 +41,7 @@
 #include <WebCore/Event.h>
 #include <WebCore/Font.h>
 #include <WebCore/FontCascade.h>
+#include <WebCore/FontSelectionAlgorithm.h>
 #include <WebCore/Frame.h>
 #include <WebCore/HTMLCollection.h>
 #include <WebCore/HTMLFormElement.h>


### PR DESCRIPTION
#### 5b6f40dd17401e16eb854942f1c495ca0e642039
<pre>
Setting `font-weight` property to 3.14 returns 3 as computed value instead of 3.14
<a href="https://bugs.webkit.org/show_bug.cgi?id=249726">https://bugs.webkit.org/show_bug.cgi?id=249726</a>

Reviewed by NOBODY (OOPS!).

When setting the `font-weight` and `font-stretch` properties to 3.14, we would get
3 as computed value, instead of 3.14. This didn&apos;t match the specification or other
browsers. It was also causing us to fail some WPT tests.

The reason for this is that we were storing this values as FontSelectionValue
instead of float, which would lose a lot of precision. To address the issue, I am
now storing those as float.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-stretch-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::calculateWeightRange):
(WebCore::calculateStretchRange):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::fontWeight):
(WebCore::fontStretch):
(WebCore::fontStyle):
(WebCore::fontShorthandValue):
* Source/WebCore/css/FontSelectionValueInlines.h:
(WebCore::fontStyleKeyword):
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::italic const):
(WebCore::FontCascade::weight const):
* Source/WebCore/platform/graphics/FontCascadeDescription.cpp:
(WebCore::FontCascadeDescription::lighterWeight):
(WebCore::FontCascadeDescription::bolderWeight):
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
(WebCore::FontCascadeDescription::lighterWeight const):
(WebCore::FontCascadeDescription::bolderWeight const):
* Source/WebCore/platform/graphics/FontDescription.h:
(WebCore::FontDescription::italic const):
(WebCore::FontDescription::stretch const):
(WebCore::FontDescription::weight const):
(WebCore::FontDescription::setItalic):
(WebCore::FontDescription::setStretch):
(WebCore::FontDescription::setWeight):
* Source/WebCore/platform/graphics/FontSelectionAlgorithm.cpp:
(WebCore::FontSelectionAlgorithm::stretchDistance const):
(WebCore::FontSelectionAlgorithm::styleDistance const):
(WebCore::FontSelectionAlgorithm::weightDistance const):
* Source/WebCore/platform/graphics/FontSelectionAlgorithm.h:
(WebCore::isItalic):
(WebCore::isFontWeightBold):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::FontCache::systemFallbackForCharacters):
* Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp:
(WebCore::SystemFontDatabaseCoreText::systemFontParameters):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::setFontWeight):
(WebCore::RenderStyle::setFontStretch):
(WebCore::RenderStyle::setFontItalic):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::fontWeight const):
(WebCore::RenderStyle::fontStretch const):
(WebCore::RenderStyle::fontItalic const):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertFontWeightFromValue):
(WebCore::Style::BuilderConverter::convertFontStretchFromValue):
(WebCore::Style::BuilderConverter::convertFontWeight):
(WebCore::Style::BuilderConverter::convertFontStretch):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::applyFontStyle):
* Source/WebCore/style/StyleResolveForFontRaw.cpp:
(WebCore::Style::resolveForFontRaw):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b6f40dd17401e16eb854942f1c495ca0e642039

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110572 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170851 "Hash 5b6f40dd for PR 7976 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1313 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93691 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108402 "Hash 5b6f40dd for PR 7976 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107080 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8662 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-fonts/animations/font-stretch-interpolation.html, imported/w3c/web-platform-tests/css/css-fonts/variations/font-stretch.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91900 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35187 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-fonts/animations/font-stretch-interpolation.html, imported/w3c/web-platform-tests/css/css-fonts/variations/font-stretch.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90564 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23306 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-fonts/animations/font-stretch-interpolation.html, imported/w3c/web-platform-tests/css/css-fonts/variations/font-stretch.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78186 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4082 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24820 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-fonts/animations/font-stretch-interpolation.html, imported/w3c/web-platform-tests/css/css-fonts/variations/font-stretch.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4127 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1247 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-fonts/animations/font-stretch-interpolation.html, imported/w3c/web-platform-tests/css/css-fonts/variations/font-stretch.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44299 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5889 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->