### PR TITLE
[run-webkit-tests] Run largest shards first

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py
@@ -300,15 +300,15 @@ class SharderTests(unittest.TestCase):
     def test_shard_by_dir(self):
         result = self.get_shards(num_workers=2, fully_parallel=False)
 
-        self.assert_shards(result,
-            [('animations', ['animations/keyframes.html']),
-             ('dom/html/level2/html', ['dom/html/level2/html/HTMLAnchorElement03.html',
-                                      'dom/html/level2/html/HTMLAnchorElement06.html']),
-             ('fast/css', ['fast/css/display-none-inline-style-change-crash.html']),
-             ('http/tests/security', ['http/tests/security/view-source-no-refresh.html']),
-             ('http/tests/websocket/tests', ['http/tests/websocket/tests/unicode.htm', 'http/tests/websocket/tests/websocket-protocol-ignored.html']),
-             ('http/tests/xmlhttprequest', ['http/tests/xmlhttprequest/supported-xml-content-types.html']),
-             ('ietestcenter/Javascript', ['ietestcenter/Javascript/11.1.5_4-4-c-1.html'])])
+        self.assert_shards(result, [
+            ('http/tests/websocket/tests', ['http/tests/websocket/tests/unicode.htm', 'http/tests/websocket/tests/websocket-protocol-ignored.html']),
+            ('http/tests/security', ['http/tests/security/view-source-no-refresh.html']),
+            ('http/tests/xmlhttprequest', ['http/tests/xmlhttprequest/supported-xml-content-types.html']),
+            ('dom/html/level2/html', ['dom/html/level2/html/HTMLAnchorElement03.html', 'dom/html/level2/html/HTMLAnchorElement06.html']),
+            ('animations', ['animations/keyframes.html']),
+            ('fast/css', ['fast/css/display-none-inline-style-change-crash.html']),
+            ('ietestcenter/Javascript', ['ietestcenter/Javascript/11.1.5_4-4-c-1.html']),
+        ])
 
     def test_shard_every_file(self):
         result = self.get_shards(num_workers=2, fully_parallel=True)


### PR DESCRIPTION
#### 7c24f5486272e5ec5c88a01e5959d691c3a28f59
<pre>
[run-webkit-tests] Run largest shards first
<a href="https://bugs.webkit.org/show_bug.cgi?id=228429">https://bugs.webkit.org/show_bug.cgi?id=228429</a>
rdar://81184667

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py:
(TestShard.__init__): Estimate runtime of each shard.
(TestShard.__getstate__): Pass shard_time_estimate between processes.
(TestShard.__setstate__): Ditto.
(Sharder._shard_by_directory):
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py:
(SharderTests.test_shard_by_dir):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c24f5486272e5ec5c88a01e5959d691c3a28f59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6336 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4949 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5188 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6352 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2981 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9288 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4012 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4337 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5709 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5971 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4562 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3910 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4919 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4306 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1203 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8369 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5052 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4668 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1316 "Passed tests") | 
<!--EWS-Status-Bubble-End-->