### PR TITLE
Generalize willStartPlatformRenderingUpdate/didCompleteRenderingUpdateDisplay() and call for all configurations

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1916,8 +1916,10 @@ void Page::renderingUpdateCompleted()
     }
 }
 
-void Page::willStartPlatformRenderingUpdate()
+void Page::willStartRenderingUpdateDisplay()
 {
+    LOG_WITH_STREAM(EventLoop, stream << "Page " << this << " willStartRenderingUpdateDisplay()");
+
     // Inspector's use of "composite" is rather innacurate. On Apple platforms, the "composite" step happens
     // in another process; these hooks wrap the non-WebKit CA commit time which is mostly painting-related.
     m_inspectorController->willComposite(mainFrame());
@@ -1926,8 +1928,10 @@ void Page::willStartPlatformRenderingUpdate()
         m_scrollingCoordinator->willStartPlatformRenderingUpdate();
 }
 
-void Page::didCompletePlatformRenderingUpdate()
+void Page::didCompleteRenderingUpdateDisplay()
 {
+    LOG_WITH_STREAM(EventLoop, stream << "Page " << this << " didCompleteRenderingUpdateDisplay()");
+
     if (m_scrollingCoordinator)
         m_scrollingCoordinator->didCompletePlatformRenderingUpdate();
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -637,7 +637,13 @@ public:
     WEBCORE_EXPORT void updateRendering();
     // A call to updateRendering() that is not followed by a call to finalizeRenderingUpdate().
     WEBCORE_EXPORT void isolatedUpdateRendering();
+    // Called when the rendering update steps are complete, but before painting.
     WEBCORE_EXPORT void finalizeRenderingUpdate(OptionSet<FinalizeRenderingUpdateFlags>);
+
+    // Called before and after the "display" steps of the rendering update: painting, and when we push
+    // layers to the platform compositor.
+    WEBCORE_EXPORT void willStartRenderingUpdateDisplay();
+    WEBCORE_EXPORT void didCompleteRenderingUpdateDisplay();
 
     // Schedule a rendering update that coordinates with display refresh.
     WEBCORE_EXPORT void scheduleRenderingUpdate(OptionSet<RenderingUpdateStep> requestedSteps);
@@ -647,11 +653,6 @@ public:
 
     WEBCORE_EXPORT void startTrackingRenderingUpdates();
     WEBCORE_EXPORT unsigned renderingUpdateCount() const;
-
-    // A "platform rendering update" here describes the work done by the system graphics framework before work is submitted to the system compositor.
-    // On macOS, this is a CoreAnimation commit.
-    WEBCORE_EXPORT void willStartPlatformRenderingUpdate();
-    WEBCORE_EXPORT void didCompletePlatformRenderingUpdate();
 
     WEBCORE_EXPORT void suspendScriptedAnimations();
     WEBCORE_EXPORT void resumeScriptedAnimations();

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
@@ -117,6 +117,16 @@ RefPtr<WebCore::DisplayRefreshMonitor> DrawingArea::createDisplayRefreshMonitor(
     return nullptr;
 }
 
+void DrawingArea::willStartRenderingUpdateDisplay()
+{
+    m_webPage.willStartRenderingUpdateDisplay();
+}
+
+void DrawingArea::didCompleteRenderingUpdateDisplay()
+{
+    m_webPage.didCompleteRenderingUpdateDisplay();
+}
+
 bool DrawingArea::supportsGPUProcessRendering(DrawingAreaType type)
 {
     switch (type) {

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -122,6 +122,9 @@ public:
     virtual void setRootCompositingLayer(WebCore::GraphicsLayer*) = 0;
     virtual void triggerRenderingUpdate() = 0;
 
+    virtual void willStartRenderingUpdateDisplay();
+    virtual void didCompleteRenderingUpdateDisplay();
+
     virtual void dispatchAfterEnsuringUpdatedScrollPosition(WTF::Function<void ()>&&);
 
     virtual void activityStateDidChange(OptionSet<WebCore::ActivityState::Flag>, ActivityStateChangeID, CompletionHandler<void()>&& completionHandler) { completionHandler(); };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -111,9 +111,9 @@ private:
 
     void updateRootLayers();
 
-    void addCommitHandlers();
     void updateRendering();
     void startRenderingUpdateTimer();
+    void didCompleteRenderingUpdateDisplay() override;
 
     WebCore::TiledBacking* mainFrameTiledBacking() const;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4513,18 +4513,18 @@ void WebPage::finalizeRenderingUpdate(OptionSet<FinalizeRenderingUpdateFlags> fl
 #endif
 }
 
-void WebPage::willStartPlatformRenderingUpdate()
+void WebPage::willStartRenderingUpdateDisplay()
 {
     if (m_isClosed)
         return;
-    m_page->willStartPlatformRenderingUpdate();
+    m_page->willStartRenderingUpdateDisplay();
 }
 
-void WebPage::didCompletePlatformRenderingUpdate()
+void WebPage::didCompleteRenderingUpdateDisplay()
 {
     if (m_isClosed)
         return;
-    m_page->didCompletePlatformRenderingUpdate();
+    m_page->didCompleteRenderingUpdateDisplay();
 }
 
 void WebPage::releaseMemory(Critical)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -432,6 +432,9 @@ public:
     bool shouldTriggerRenderingUpdate(unsigned rescheduledRenderingUpdateCount) const;
     void finalizeRenderingUpdate(OptionSet<WebCore::FinalizeRenderingUpdateFlags>);
 
+    void willStartRenderingUpdateDisplay();
+    void didCompleteRenderingUpdateDisplay();
+
     void releaseMemory(WTF::Critical);
 
     unsigned remoteImagesCountForTesting() const;
@@ -1440,9 +1443,6 @@ public:
 
     bool userIsInteracting() const { return m_userIsInteracting; }
     void setUserIsInteracting(bool userIsInteracting) { m_userIsInteracting = userIsInteracting; }
-
-    bool firstFlushAfterCommit() const { return m_firstFlushAfterCommit; }
-    void setFirstFlushAfterCommit(bool f) { m_firstFlushAfterCommit = f; }
 
 #if PLATFORM(IOS_FAMILY)
     // This excludes layout overflow, includes borders.

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
@@ -92,8 +92,10 @@ private:
     bool addMilestonesToDispatch(OptionSet<WebCore::LayoutMilestone> paintMilestones) override;
 
     void addCommitHandlers();
+
     enum class UpdateRenderingType { Normal, TransientZoom };
     void updateRendering(UpdateRenderingType = UpdateRenderingType::Normal);
+    void didCompleteRenderingUpdateDisplay() override;
 
     // Message handlers.
     void updateGeometry(const WebCore::IntSize& viewSize, bool flushSynchronously, const WTF::MachSendRight& fencePort) override;
@@ -175,6 +177,7 @@ private:
     bool m_needsSendEnterAcceleratedCompositingMode { true };
     bool m_needsSendDidFirstLayerFlush { true };
     bool m_shouldHandleActivityStateChangeCallbacks { false };
+    bool m_haveRegisteredHandlersForNextCommit { false };
 };
 
 inline bool TiledCoreAnimationDrawingArea::addMilestonesToDispatch(OptionSet<WebCore::LayoutMilestone> paintMilestones)

--- a/Source/WebKitLegacy/mac/WebView/WebViewData.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewData.h
@@ -133,6 +133,7 @@ public:
     
     // FIXME: Rename to use 'updateRendering' terminology.
     bool flushLayers();
+    void didCompleteRenderingUpdateDisplay() { m_haveRegisteredCommitHandlers = false; }
     
     void scheduleLayerFlush();
     void invalidate();
@@ -142,6 +143,7 @@ private:
     
     WebView* m_webView;
     WebViewLayerFlushScheduler m_layerFlushScheduler;
+    bool m_haveRegisteredCommitHandlers { false };
 };
 
 @interface WebWindowVisibilityObserver : NSObject {


### PR DESCRIPTION
#### 9f0c7ac64f9afed660b778006cd576ca9715e259
<pre>
Generalize willStartPlatformRenderingUpdate/didCompleteRenderingUpdateDisplay() and call for all configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=249750">https://bugs.webkit.org/show_bug.cgi?id=249750</a>
rdar://103614410

Reviewed by Tim Horton.

Add functions to WebPage and Page that get called before and after the &quot;commit layer tree and paint&quot; part
of a rendering update. In TiledCoreAnimationDrawingArea and WebKitLegacy which use Core Animation rendering,
this time period equates to the start and end of the CA commit. In RemoteLayerTreeDrawingArea, it starts
when we build the layer tree transaction, and ends when the buffer flushing is complete.

Web inspector uses these hooks to build its &quot;commit&quot; timeline events. Previously, these events were
broken on iOS because RemoteLayerTreeDrawingArea erroneously used CA commit handlers in an environment
where there is no real CA commit (webkit.org/b/249736). And in WebKitLegacy, we&apos;ll now also correctly
generate these events. Now there is only one call site for inspector composite hooks.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::willStartRenderingUpdateDisplay):
(WebCore::Page::didCompleteRenderingUpdateDisplay):
(WebCore::Page::willStartPlatformRenderingUpdate): Deleted.
(WebCore::Page::didCompletePlatformRenderingUpdate): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.cpp:
(WebKit::DrawingArea::willStartRenderingUpdateDisplay):
(WebKit::DrawingArea::didCompleteRenderingUpdateDisplay):
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
(WebKit::RemoteLayerTreeDrawingArea::didCompleteRenderingUpdateDisplay):
(WebKit::RemoteLayerTreeDrawingArea::addCommitHandlers): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::willStartRenderingUpdateDisplay):
(WebKit::WebPage::didCompleteRenderingUpdateDisplay):
(WebKit::WebPage::willStartPlatformRenderingUpdate): Deleted.
(WebKit::WebPage::didCompletePlatformRenderingUpdate): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::firstFlushAfterCommit const): Deleted.
(WebKit::WebPage::setFirstFlushAfterCommit): Deleted.
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::sendPendingNewlyReachedPaintingMilestones):
(WebKit::TiledCoreAnimationDrawingArea::didCompleteRenderingUpdateDisplay):
(WebKit::TiledCoreAnimationDrawingArea::addCommitHandlers):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _willStartRenderingUpdateDisplay]):
(-[WebView _didCompleteRenderingUpdateDisplay]):
(LayerFlushController::flushLayers):
* Source/WebKitLegacy/mac/WebView/WebViewData.h:
(LayerFlushController::didCompleteRenderingUpdateDisplay):

Canonical link: <a href="https://commits.webkit.org/258248@main">https://commits.webkit.org/258248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b024fce9da57d564e35542876b1b5c57a0d2ba43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110536 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170817 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1279 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93655 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108368 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35158 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23275 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78156 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4048 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24789 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1216 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44268 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5674 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5848 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->