### PR TITLE
Interaction: Have to tap twice to navigate on YouTube search results

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -177,6 +177,22 @@ bool Quirks::hasBrokenEncryptedMediaAPISupportQuirk() const
     return m_hasBrokenEncryptedMediaAPISupportQuirk.value();
 }
 
+bool Quirks::shouldDisableContentChangeObserver() const
+{
+    if (!needsQuirks())
+        return false;
+    
+    auto& topDocument = m_document->topDocument();
+    
+    auto host = topDocument.url().host();
+    auto isYouTube = host.endsWith(".youtube.com"_s) || host == "youtube.com"_s;
+    
+    if (isYouTube && (topDocument.url().path().startsWithIgnoringASCIICase("/results"_s) || topDocument.url().path().startsWithIgnoringASCIICase("/watch"_s)))
+        return true;
+
+    return false;
+}
+
 bool Quirks::shouldDisableContentChangeObserverTouchEventAdjustment() const
 {
     if (!needsQuirks())

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -86,6 +86,7 @@ public:
 
     bool needsMillisecondResolutionForHighResTimeStamp() const;
 
+    WEBCORE_EXPORT bool shouldDisableContentChangeObserver() const;
     WEBCORE_EXPORT bool shouldDispatchSyntheticMouseEventsWhenModifyingSelection() const;
     WEBCORE_EXPORT bool shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas() const;
     WEBCORE_EXPORT bool isTouchBarUpdateSupressedForHiddenContentEditable() const;

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -62,6 +62,11 @@ static bool isHiddenBehindFullscreenElement(const Node& descendantCandidate)
 }
 #endif
 
+bool ContentChangeObserver::isContentChangeObserverEnabled()
+{
+    return m_document.settings().contentChangeObserverEnabled() && !m_document.quirks().shouldDisableContentChangeObserver();
+}
+
 bool ContentChangeObserver::isVisuallyHidden(const Node& node)
 {
     if (!node.renderStyle())
@@ -204,7 +209,7 @@ void ContentChangeObserver::didPreventDefaultForEvent(Frame& mainFrame)
 
 void ContentChangeObserver::startContentObservationForDuration(Seconds duration)
 {
-    if (!m_document.settings().contentChangeObserverEnabled())
+    if (!isContentChangeObserverEnabled())
         return;
     ASSERT(!hasVisibleChangeState());
     LOG_WITH_STREAM(ContentObservation, stream << "startContentObservationForDuration: start observing the content for " << duration.milliseconds() << "ms");
@@ -220,7 +225,7 @@ void ContentChangeObserver::completeDurationBasedContentObservation()
 
 void ContentChangeObserver::didAddTransition(const Element& element, const Animation& transition)
 {
-    if (!m_document.settings().contentChangeObserverEnabled())
+    if (!isContentChangeObserverEnabled())
         return;
     if (hasVisibleChangeState())
         return;
@@ -281,7 +286,7 @@ void ContentChangeObserver::didRemoveTransition(const Element& element, CSSPrope
 
 void ContentChangeObserver::didInstallDOMTimer(const DOMTimer& timer, Seconds timeout, bool singleShot)
 {
-    if (!m_document.settings().contentChangeObserverEnabled())
+    if (!isContentChangeObserverEnabled())
         return;
     if (!isObservingContentChanges())
         return;
@@ -427,7 +432,7 @@ void ContentChangeObserver::willDetachPage()
 
 void ContentChangeObserver::rendererWillBeDestroyed(const Element& element)
 { 
-    if (!m_document.settings().contentChangeObserverEnabled())
+    if (!isContentChangeObserverEnabled())
         return;
     if (!isObservingContentChanges())
         return;
@@ -459,7 +464,7 @@ void ContentChangeObserver::elementDidBecomeHidden(const Element& element)
 void ContentChangeObserver::touchEventDidStart(PlatformEvent::Type eventType)
 {
 #if ENABLE(TOUCH_EVENTS)
-    if (!m_document.settings().contentChangeObserverEnabled() || m_document.quirks().shouldDisableContentChangeObserverTouchEventAdjustment())
+    if (!isContentChangeObserverEnabled() || m_document.quirks().shouldDisableContentChangeObserverTouchEventAdjustment())
         return;
     if (eventType != PlatformEvent::Type::TouchStart)
         return;
@@ -476,7 +481,7 @@ void ContentChangeObserver::touchEventDidFinish()
 #if ENABLE(TOUCH_EVENTS)
     if (!isTouchEventBeingDispatched())
         return;
-    ASSERT(m_document.settings().contentChangeObserverEnabled());
+    ASSERT(isContentChangeObserverEnabled());
     LOG(ContentObservation, "touchEventDidFinish: touch start event finished.");
     setTouchEventIsBeingDispatched(false);
     adjustObservedState(Event::EndedTouchStartEventDispatching);
@@ -485,7 +490,7 @@ void ContentChangeObserver::touchEventDidFinish()
 
 void ContentChangeObserver::mouseMovedDidStart()
 {
-    if (!m_document.settings().contentChangeObserverEnabled())
+    if (!isContentChangeObserverEnabled())
         return;
     LOG(ContentObservation, "mouseMovedDidStart: mouseMoved started.");
     setMouseMovedEventIsBeingDispatched(true);
@@ -496,7 +501,7 @@ void ContentChangeObserver::mouseMovedDidFinish()
 {
     if (!isMouseMovedEventBeingDispatched())
         return;
-    ASSERT(m_document.settings().contentChangeObserverEnabled());
+    ASSERT(isContentChangeObserverEnabled());
     LOG(ContentObservation, "mouseMovedDidFinish: mouseMoved finished.");
     adjustObservedState(Event::EndedMouseMovedEventDispatching);
     setMouseMovedEventIsBeingDispatched(false);

--- a/Source/WebCore/page/ios/ContentChangeObserver.h
+++ b/Source/WebCore/page/ios/ContentChangeObserver.h
@@ -184,6 +184,8 @@ private:
 
     enum class ElementHadRenderer { No, Yes };
     bool isConsideredActionableContent(const Element&, ElementHadRenderer) const;
+    
+    bool isContentChangeObserverEnabled();
 
     enum class Event {
         StartedTouchStartEventDispatching,

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -752,7 +752,7 @@ void WebPage::handleSyntheticClick(Node& nodeRespondingToClick, const WebCore::F
     auto isFirstSyntheticClickOnPage = !m_hasHandledSyntheticClick;
     m_hasHandledSyntheticClick = true;
 
-    if (!respondingDocument.settings().contentChangeObserverEnabled() || respondingDocument.quirks().shouldIgnoreContentObservationForSyntheticClick(isFirstSyntheticClickOnPage)) {
+    if (!respondingDocument.settings().contentChangeObserverEnabled() || respondingDocument.quirks().shouldDisableContentChangeObserver() || respondingDocument.quirks().shouldIgnoreContentObservationForSyntheticClick(isFirstSyntheticClickOnPage)) {
         completeSyntheticClick(nodeRespondingToClick, location, modifiers, WebCore::OneFingerTap, pointerId);
         return;
     }
@@ -875,7 +875,7 @@ void WebPage::completeSyntheticClick(Node& nodeRespondingToClick, const WebCore:
     RefPtr<Frame> newFocusedFrame = CheckedRef(m_page->focusController())->focusedFrame();
     RefPtr<Element> newFocusedElement = newFocusedFrame ? newFocusedFrame->document()->focusedElement() : nullptr;
 
-    if (nodeRespondingToClick.document().settings().contentChangeObserverEnabled()) {
+    if (nodeRespondingToClick.document().settings().contentChangeObserverEnabled() && !nodeRespondingToClick.document().quirks().shouldDisableContentChangeObserver()) {
         auto& document = nodeRespondingToClick.document();
         // Dispatch mouseOut to dismiss tooltip content when tapping on the control bar buttons (cc, settings).
         if (document.quirks().needsYouTubeMouseOutQuirk()) {


### PR DESCRIPTION
#### 7eb369c661c68dfc878641ff4228bf3c12cdac96
<pre>
Interaction: Have to tap twice to navigate on YouTube search results
<a href="https://bugs.webkit.org/show_bug.cgi?id=249740">https://bugs.webkit.org/show_bug.cgi?id=249740</a>
rdar://101981614

Reviewed by Tim Horton.

The Content Change Observer is triggered on the YouTube search page due to some
additional information that is presented on hover. This new UI isn&apos;t interactable
with additional clicks, so we should just ignore the CCO in this case and let the
click fully register which allows the link to be followed with one click instead of
two.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDisableContentChangeObserver const):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/ios/ContentChangeObserver.cpp:
(WebCore::isContentChangeObserverEnabled):
(WebCore::ContentChangeObserver::startContentObservationForDuration):
(WebCore::ContentChangeObserver::didAddTransition):
(WebCore::ContentChangeObserver::didInstallDOMTimer):
(WebCore::ContentChangeObserver::rendererWillBeDestroyed):
(WebCore::ContentChangeObserver::touchEventDidStart):
(WebCore::ContentChangeObserver::touchEventDidFinish):
(WebCore::ContentChangeObserver::mouseMovedDidStart):
(WebCore::ContentChangeObserver::mouseMovedDidFinish):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::handleSyntheticClick):
(WebKit::WebPage::completeSyntheticClick):

Canonical link: <a href="https://commits.webkit.org/258414@main">https://commits.webkit.org/258414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/558107034b2378c294cce5f1f22451394c3758de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111209 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171410 "Failed to checkout and rebase branch from PR 7983") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1937 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108965 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107654 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/9172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/94281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/94281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4609 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25351 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4695 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1791 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/10774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44838 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5769 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6447 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->