### PR TITLE
[WebAssembly SIMD] Get WasmB3IRGenerator to parity on Intel

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -1293,9 +1293,20 @@ private:
         auto lane = value->simdLane();
         bool isFloatingPoint = scalarTypeIsFloatingPoint(lane);
         auto cond = isFloatingPoint ? doubleCond : relCond;
+        auto condKind = isFloatingPoint ? Arg::DoubleCond : Arg::RelCond;
         RELEASE_ASSERT(cond);
-        append(isFloatingPoint ? Air::CompareFloatingPointVector : Air::CompareIntegerVector, 
-            cond, Arg::simdInfo(value->simdInfo()), tmp(value->child(0)), tmp(value->child(1)), tmp(value));
+        Air::Opcode airOp = isFloatingPoint ? Air::CompareFloatingPointVector : Air::CompareIntegerVector;
+        if (isValidForm(airOp, condKind, Arg::SIMDInfo, Arg::Tmp, Arg::Tmp, Arg::Tmp)) {
+            append(airOp,
+                cond, Arg::simdInfo(value->simdInfo()), tmp(value->child(0)), tmp(value->child(1)), tmp(value));
+            return;
+        }
+        if (isValidForm(airOp, condKind, Arg::SIMDInfo, Arg::Tmp, Arg::Tmp, Arg::Tmp, Arg::Tmp)) {
+            append(airOp,
+                cond, Arg::simdInfo(value->simdInfo()), tmp(value->child(0)), tmp(value->child(1)), tmp(value), m_code.newTmp(FP));
+            return;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
     }
 
     void emitSIMDCompare(Air::Arg cond)
@@ -1333,7 +1344,16 @@ private:
     void emitSIMDUnaryOp(Air::Opcode op)
     {
         SIMDValue* value = m_value->as<SIMDValue>();
-        append(op, Arg::simdInfo(value->simdInfo()), tmp(value->child(0)), tmp(value));
+
+        if (isValidForm(op, Arg::SIMDInfo, Arg::Tmp, Arg::Tmp)) {
+            append(op, Arg::simdInfo(value->simdInfo()), tmp(value->child(0)), tmp(value));
+            return;
+        }
+        if (isValidForm(op, Arg::SIMDInfo, Arg::Tmp, Arg::Tmp, Arg::Tmp)) {
+            append(op, Arg::simdInfo(value->simdInfo()), tmp(value->child(0)), tmp(value), m_code.newTmp(FP));
+            return;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
     }
 
     void emitSIMDMonomorphicUnaryOp(Air::Opcode op)
@@ -3798,8 +3818,11 @@ private:
             default:
                 RELEASE_ASSERT_NOT_REACHED();
             }
-            append(op, scalar, tmp(value));
-            return;
+            if (isValidForm(op, Arg::Tmp, Arg::Tmp)) {
+                append(op, scalar, tmp(value));
+                return;
+            }
+            RELEASE_ASSERT_NOT_REACHED();
         }
 
         case B3::VectorShr:
@@ -3814,9 +3837,9 @@ private:
 
             Tmp shiftAmount = m_code.newTmp(B3::GP);
             Tmp shiftVector = m_code.newTmp(B3::FP);
-            append(And32, Arg::bitImm(mask), shift, shiftAmount);
 
             if constexpr (isARM64()) {
+                append(And32, Arg::bitImm(mask), shift, shiftAmount);
                 if (value->opcode() == VectorShr) {
                     // ARM64 doesn't have a version of this instruction for right shift. Instead, if the input to
                     // left shift is negative, it's a right shift by the absolute value of that amount.
@@ -3829,7 +3852,37 @@ private:
             }
             
             if constexpr (isX86()) {
-                append(VectorSplatInt8, shiftAmount, shiftVector);
+                append(Move, shift, shiftAmount);
+                append(And32, Arg::imm(mask), shiftAmount);
+                if (value->opcode() == VectorShr && value->signMode() == SIMDSignMode::Signed && value->simdLane() == SIMDLane::i64x2) {
+                    // x86 has no SIMD 64-bit signed right shift instruction, so we scalarize it here.
+                    Tmp lower = m_code.newTmp(B3::GP);
+                    Tmp upper = m_code.newTmp(B3::GP);
+                    Tmp result = tmp(value);
+
+                    append(Move, shiftAmount, m_ecx);
+                    append(VectorExtractLaneInt64, Arg::imm(0), v, lower);
+                    append(VectorExtractLaneInt64, Arg::imm(1), v, upper);
+                    append(Rshift64, m_ecx, lower);
+                    append(Rshift64, m_ecx, upper);
+                    append(VectorReplaceLaneInt64, Arg::imm(0), lower, result);
+                    append(VectorReplaceLaneInt64, Arg::imm(1), upper, result);
+                    return;
+                }
+
+                // Unlike ARM, x86 expects the shift provided as a *scalar*, stored in the lower 64 bits of a vector register.
+                // So, we don't need to splat the shift amount like we do on ARM.
+                append(Move64ToDouble, shiftAmount, shiftVector);
+
+                // 8-bit shifts are pretty involved to implement on Intel, so they get their own instruction type with extra temps.
+                if (value->opcode() == VectorShl && value->simdLane() == SIMDLane::i8x16) {
+                    append(VectorUshl8, v, shiftVector, tmp(value), m_code.newTmp(B3::FP), m_code.newTmp(B3::FP));
+                    return;
+                }
+                if (value->opcode() == VectorShr && value->simdLane() == SIMDLane::i8x16) {
+                    append(value->signMode() == SIMDSignMode::Signed ? VectorSshr8 : VectorUshr8, v, shiftVector, tmp(value), m_code.newTmp(B3::FP), m_code.newTmp(B3::FP));
+                    return;
+                }
 
                 if (value->opcode() == VectorShl)
                     append(VectorUshl, Arg::simdInfo(value->simdInfo()), v, shiftVector, tmp(value));
@@ -3887,7 +3940,12 @@ private:
             emitSIMDBinaryOp(Air::VectorMul);
             return;
         case B3::VectorDotProduct:
-            emitSIMDMonomorphicBinaryOp</* scratch = */ 1>(Air::VectorDotProduct);
+            if (isX86())
+                emitSIMDMonomorphicBinaryOp(Air::VectorDotProduct);
+            else if (isARM64())
+                emitSIMDMonomorphicBinaryOp</* scratch = */ 1>(Air::VectorDotProduct);
+            else
+                RELEASE_ASSERT_NOT_REACHED();
             return; 
         case B3::VectorDiv:
             emitSIMDBinaryOp(Air::VectorDiv);
@@ -3899,11 +3957,25 @@ private:
             emitSIMDBinaryOp(Air::VectorMax);
             return;
         case B3::VectorPmin:
-            emitSIMDBinaryOp</* scratch = */ 1>(Air::VectorPmin);
-            return;
+            if (isX86()) {
+                emitSIMDBinaryOp(Air::VectorPmin);
+                return;
+            }
+            if (isARM64()) {
+                emitSIMDBinaryOp</* scratch = */ 1>(Air::VectorPmin);
+                return;
+            }
+            RELEASE_ASSERT_NOT_REACHED();
         case B3::VectorPmax:
-            emitSIMDBinaryOp</* scratch = */ 1>(Air::VectorPmax);
-            return; 
+            if (isX86()) {
+                emitSIMDBinaryOp(Air::VectorPmax);
+                return;
+            }
+            if (isARM64()) {
+                emitSIMDBinaryOp</* scratch = */ 1>(Air::VectorPmax);
+                return;
+            }
+            RELEASE_ASSERT_NOT_REACHED();
         case B3::VectorNarrow:
             emitSIMDBinaryOp</* scratch = */ 1>(Air::VectorNarrow);
             return; 
@@ -3923,6 +3995,11 @@ private:
             emitSIMDUnaryOp(Air::VectorNot);
             return;
         case B3::VectorAbs:
+            if (isX86() && m_value->as<SIMDValue>()->simdLane() == SIMDLane::i64x2) {
+                SIMDValue* value = m_value->as<SIMDValue>();
+                append(VectorAbsInt64, tmp(value->child(0)), tmp(value), m_code.newTmp(B3::FP));
+                return;
+            }
             emitSIMDUnaryOp(Air::VectorAbs);
             return;
         case B3::VectorNeg:
@@ -3941,12 +4018,47 @@ private:
             emitSIMDUnaryOp(Air::VectorTrunc);
             return;
         case B3::VectorTruncSat:
+            if (isX86()) {
+                SIMDValue* value = m_value->as<SIMDValue>();
+                Tmp v = tmp(value->child(0));
+                Tmp result = tmp(value);
+
+                switch (value->simdLane()) {
+                case SIMDLane::f64x2:
+                    if (value->signMode() == SIMDSignMode::Signed)
+                        append(VectorTruncSatSignedFloat64, v, result, m_code.newTmp(B3::GP), m_code.newTmp(B3::FP));
+                    else
+                        append(VectorTruncSatUnsignedFloat64, v, result, m_code.newTmp(B3::GP), m_code.newTmp(B3::FP));
+                    return;
+                case SIMDLane::f32x4:
+                    if (value->signMode() == SIMDSignMode::Signed)
+                        append(Air::VectorTruncSat, Arg::simdInfo(value->simdInfo()), v, result, m_code.newTmp(B3::GP), m_code.newTmp(B3::FP), m_code.newTmp(B3::FP));
+                    else
+                        append(VectorTruncSatUnsignedFloat32, v, result, m_code.newTmp(B3::GP), m_code.newTmp(B3::FP), m_code.newTmp(B3::FP));
+                    return;
+                default:
+                    RELEASE_ASSERT_NOT_REACHED();
+                }
+            }
             emitSIMDUnaryOp(Air::VectorTruncSat);
             return;
         case B3::VectorConvert:
+            if (isX86() && m_value->as<SIMDValue>()->signMode() == SIMDSignMode::Unsigned) {
+                SIMDValue* value = m_value->as<SIMDValue>();
+                append(VectorConvertUnsigned, tmp(value->child(0)), tmp(value), m_code.newTmp(B3::FP));
+                return;
+            }
             emitSIMDUnaryOp(Air::VectorConvert);
             return;
         case B3::VectorConvertLow:
+            if (isX86()) {
+                SIMDValue* value = m_value->as<SIMDValue>();
+                if (value->signMode() == SIMDSignMode::Signed)
+                    append(VectorConvertLowSignedInt32, tmp(value->child(0)), tmp(value));
+                else
+                    append(VectorConvertLowUnsignedInt32, tmp(value->child(0)), tmp(value), m_code.newTmp(B3::GP), m_code.newTmp(B3::FP));
+                return;
+            }
             emitSIMDUnaryOp(Air::VectorConvertLow);
             return;
         case B3::VectorNearest:
@@ -3988,9 +4100,22 @@ private:
             return;
         }
         case B3::VectorExtaddPairwise:
+            if (isX86()) {
+                SIMDValue* value = m_value->as<SIMDValue>();
+                if (value->simdLane() == SIMDLane::i16x8 && value->signMode() == SIMDSignMode::Unsigned)
+                    append(VectorExtaddPairwiseUnsignedInt16, tmp(value->child(0)), tmp(value), m_code.newTmp(B3::FP));
+                else
+                    append(Air::VectorExtaddPairwise, Arg::simdInfo(value->simdInfo()), tmp(value->child(0)), tmp(value), m_code.newTmp(B3::GP), m_code.newTmp(B3::FP));
+                return;
+            }
             emitSIMDUnaryOp(Air::VectorExtaddPairwise);
             return;
         case B3::VectorMulSat:
+            if constexpr (isX86()) {
+                SIMDValue* value = m_value->as<SIMDValue>();
+                append(Air::VectorMulSat, tmp(value->child(0)), tmp(value->child(1)), tmp(value), m_code.newTmp(GP), m_code.newTmp(FP));
+                return;
+            }
             emitSIMDMonomorphicBinaryOp(Air::VectorMulSat);
             return;
         case B3::VectorSwizzle:

--- a/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
@@ -375,6 +375,20 @@ void lowerMacros(Code& code)
                 inst = Inst();
             };
 
+            auto handleVectorExtaddPairwise = [&] {
+                SIMDInfo simdInfo = inst.args[0].simdInfo();
+
+                if (!isX86() || simdInfo.lane != SIMDLane::i16x8 || simdInfo.signMode != SIMDSignMode::Unsigned)
+                    return;
+
+                Tmp vec = inst.args[1].tmp();
+                Tmp dst = inst.args[2].tmp();
+                auto* origin = inst.origin;
+
+                insertionSet.insert(instIndex, VectorExtaddPairwiseUnsignedInt16, origin, vec, dst, code.newTmp(FP));
+                inst = Inst();
+            };
+
             auto handleVectorBitmask = [&] {
                 if (!isARM64())
                     return;
@@ -480,6 +494,9 @@ void lowerMacros(Code& code)
                 break;
             case VectorMax:
                 handleVectorMax();
+                break;
+            case VectorExtaddPairwise:
+                handleVectorExtaddPairwise();
                 break;
             default:
                 break;

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
@@ -236,16 +236,16 @@ public:
         AIR_OP_CASE(AnyTrue)
         AIR_OP_CASE(AllTrue)
         result = tmpForType(Types::I32);
-        if (isX86() && (op == SIMDLaneOperation::AllTrue || op == SIMDLaneOperation::Bitmask)) {
-            append(airOp, Arg::simdInfo(info), v, result, tmpForType(Types::V128));
-            return { };
-        }
         if (isValidForm(airOp, Arg::Tmp, Arg::Tmp)) {
             append(airOp, v, result);
             return { };
         }
         if (isValidForm(airOp, Arg::SIMDInfo, Arg::Tmp, Arg::Tmp)) {
             append(airOp, Arg::simdInfo(info), v, result);
+            return { };
+        }
+        if (isValidForm(airOp, Arg::SIMDInfo, Arg::Tmp, Arg::Tmp, Arg::Tmp)) {
+            append(airOp, Arg::simdInfo(info), v, result, tmpForType(Types::V128));
             return { };
         }
         RELEASE_ASSERT_NOT_REACHED();
@@ -357,14 +357,6 @@ public:
                 return { };
             }
 
-            if (airOp == B3::Air::VectorExtaddPairwise) {
-                if (info.lane == SIMDLane::i16x8 && info.signMode == SIMDSignMode::Unsigned)
-                    append(VectorExtaddPairwiseUnsignedInt16, v, result, tmpForType(Types::V128));
-                else
-                    append(airOp, Arg::simdInfo(info), v, result, tmpForType(Types::I64), tmpForType(Types::V128));
-                return { };
-            }
-
             if (airOp == B3::Air::VectorConvert && info.signMode == SIMDSignMode::Unsigned) {
                 append(VectorConvertUnsigned, v, result, tmpForType(Types::V128));
                 return { };
@@ -398,6 +390,10 @@ public:
             }
         }
 
+        if (isX86() && airOp == VectorExtaddPairwise) {
+            append(airOp, Arg::simdInfo(info), v, result, tmpForType(Types::I64), tmpForType(Types::V128));
+            return { };
+        }
         if (isValidForm(airOp, Arg::Tmp, Arg::Tmp)) {
             append(airOp, v, result);
             return { };
@@ -458,6 +454,8 @@ public:
                     break;
                 case MacroAssembler::GreaterThanOrEqual:
                     if (info.lane == SIMDLane::i64x2) {
+                        // Note: rhs and lhs are reversed here, we are semantically negating LessThan. GreaterThan is
+                        // just better supported on AVX.
                         append(airOp, Arg::relCond(MacroAssembler::GreaterThan), Arg::simdInfo(info), rhs, lhs, result, scratch);
                         append(VectorXor, Arg::simdInfo({ SIMDLane::v128, SIMDSignMode::None }), result, addConstant(allOnes), result);
                     } else

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -391,6 +391,7 @@ public:
         B3_OP_CASE(TruncSat)
         B3_OP_CASE(Not)
         B3_OP_CASE(Neg)
+
         result = push(m_currentBlock->appendNew<SIMDValue>(m_proc, origin(), b3Op, B3::V128, info,
             get(v)));
         return { };
@@ -465,6 +466,7 @@ public:
                 break;
             }
         }
+
         result = push(m_currentBlock->appendNew<SIMDValue>(m_proc, origin(), b3Op, B3::V128, info,
             get(lhs), get(rhs)));
         return { };
@@ -492,6 +494,7 @@ public:
         B3_OP_CASE(SubSat)
         B3_OP_CASE(Max)
         B3_OP_CASE(Min)
+
         result = push(m_currentBlock->appendNew<SIMDValue>(m_proc, origin(), b3Op, B3::V128, info,
             get(a), get(b)));
         return { };

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -587,7 +587,7 @@ $architecture = determineArchitecture unless $architecture
 $isFTLPlatform = !($architecture == "x86" || $architecture == "arm" || $architecture == "mips" || $architecture == "riscv64" || $hostOS == "windows" || $hostOS == "playstation")
 # Special case armv7, we want to run the wasm tests temporarily without B3/Air support
 $isWasmPlatform = $isFTLPlatform || $architecture == "arm"
-$isSIMDPlatform = $architecture == "arm64"
+$isSIMDPlatform = $architecture == "arm64" || $architecture == "x86_64"
 
 if $architecture == "x86"
     # The JIT is temporarily disabled on this platform since


### PR DESCRIPTION
#### 08944322951dfdb47c7a53273eb55cba2482d000
<pre>
[WebAssembly SIMD] Get WasmB3IRGenerator to parity on Intel
<a href="https://bugs.webkit.org/show_bug.cgi?id=249745">https://bugs.webkit.org/show_bug.cgi?id=249745</a>
rdar://103613145

Reviewed by Yusuke Suzuki.

Adds complete support for WebAssembly SIMD instructions to WasmB3IRGenerator. With this,
every WebAssembly SIMD instruction is supported on Intel in every JSC compiler tier. Because
of this, this patch also enables SIMD stress tests on x86_64 by default.

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::addSIMDI_V):
(JSC::Wasm::AirIRGenerator64::addSIMDRelOp):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::addSIMDV_V):
(JSC::Wasm::B3IRGenerator::addSIMDRelOp):
(JSC::Wasm::B3IRGenerator::addSIMDSwizzleHelperX86):
(JSC::Wasm::B3IRGenerator::addSIMDV_VV):
(JSC::Wasm::B3IRGenerator::addSIMDExtmul):
(JSC::Wasm::B3IRGenerator::addSIMDShuffle):
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/258286@main">https://commits.webkit.org/258286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d07b3f23d28148ba51abbfb9dec7b78e93c9931

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110716 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170972 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105426 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1457 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108533 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107228 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92031 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35314 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23440 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91873 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4206 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24951 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88019 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1792 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1372 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29319 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44439 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90919 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5696 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6031 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20308 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->