### PR TITLE
Make marked text underline extraction more robust

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4636,6 +4636,12 @@ NSArray *WebViewImpl::validAttributesForMarkedText()
 #if USE(APPLE_INTERNAL_SDK)
 #include <WebKitAdditions/WebViewImplAdditions.mm>
 #else
+static Vector<WebCore::CompositionUnderline> extractInitialUnderlines(NSAttributedString *string)
+{
+    return { };
+}
+#endif
+
 static Vector<WebCore::CompositionUnderline> extractUnderlines(NSAttributedString *string)
 {
     Vector<WebCore::CompositionUnderline> result;
@@ -4660,7 +4666,6 @@ static Vector<WebCore::CompositionUnderline> extractUnderlines(NSAttributedStrin
 
     return result;
 }
-#endif
 
 static bool eventKeyCodeIsZeroOrNumLockOrFn(NSEvent *event)
 {
@@ -4934,7 +4939,8 @@ void WebViewImpl::setMarkedText(id string, NSRange selectedRange, NSRange replac
     if (isAttributedString) {
         // FIXME: We ignore most attributes from the string, so an input method cannot specify e.g. a font or a glyph variation.
         text = [string string];
-        underlines = extractUnderlines(string);
+        auto initialUnderlines = extractInitialUnderlines(string);
+        underlines = !initialUnderlines.isEmpty() ? initialUnderlines : extractUnderlines(string);
     } else {
         text = string;
         underlines.append(WebCore::CompositionUnderline(0, [text length], WebCore::CompositionUnderlineColor::TextColor, WebCore::Color::black, false));


### PR DESCRIPTION
#### 1f780152de0c0fee3ab199e72349d60949233663
<pre>
Make marked text underline extraction more robust
<a href="https://bugs.webkit.org/show_bug.cgi?id=249755">https://bugs.webkit.org/show_bug.cgi?id=249755</a>
rdar://103603264

Reviewed by Wenson Hsieh.

* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::radiiForUnderline):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintCompositionUnderlines):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::extractInitialUnderlines):
(WebKit::extractUnderlines):
(WebKit::WebViewImpl::setMarkedText):

Canonical link: <a href="https://commits.webkit.org/258249@main">https://commits.webkit.org/258249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a12eeedfc4915cedd929ff74ba21cbe1ca3bccd7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110549 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170830 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1292 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93670 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108381 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91882 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35169 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23288 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78168 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4061 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24802 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1229 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44281 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5675 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5862 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->