### PR TITLE
Remove non-BNF parser grammar support from CSSProperties.json

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9272,11 +9272,8 @@
             }
         },
         "<-webkit-absolute-size>": {
-            "grammar": {
-                "kind": "keyword",
-                "value": "-webkit-xxx-large",
-                "aliased-to": "xxx-large"
-            },
+            "grammar": "-webkit-xxx-large",
+            "aliased-to": "xxx-large",
             "status": "non-standard"
         },
         "<relative-size>": {

--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
@@ -171,9 +171,10 @@ class JSONCSSPropertiesChecker(JSONChecker):
 
     def check_shared_grammar_rule(self, rule_name, rule_value):
         keys_and_validators = {
+            'aliased-to': self.validate_string,
             'comment': self.validate_comment,
             'exported': self.validate_boolean,
-            'grammar': self.validate_grammar,
+            'grammar': self.validate_string,
             'specification': self.validate_specification,
             'status': self.validate_status,
         }
@@ -280,34 +281,6 @@ class JSONCSSPropertiesChecker(JSONChecker):
         else:
             self.check_codegen_properties(property_name, value)
 
-    def validate_grammar(self, property_name, property_key, key, value):
-        self.validate_grammar_term(property_name, property_key, key, value)
-
-    def validate_grammar_term(self, property_name, property_key, key, value):
-        if isinstance(value, dict):
-            keys_and_validators = {
-                'aliased-to': self.validate_string,
-                'comment': self.validate_comment,
-                'enable-if': self.validate_string,
-                'kind': self.validate_string,
-                'settings-flag': self.validate_string,
-                'single-value-optimization': self.validate_boolean,
-                'status': self.validate_status,
-                'value': self.validate_grammar_term,
-            }
-
-            for key, value in value.items():
-                if key not in keys_and_validators:
-                    self._handle_style_error(0, 'json/syntax', 5, 'dictionary for "parser-grammar" of property "%s" has unexpected key "%s".' % (property_name, key))
-                    return
-
-                keys_and_validators[key](property_name, "", key, value)
-        elif isinstance(value, list):
-            for entry in value:
-                self.validate_grammar_term(property_name, "", "", entry)
-        else:
-            self.validate_string(property_name, property_key, key, value)
-
     def validate_logical_property_group(self, property_name, property_key, key, value):
         self.validate_type(property_name, property_key, key, value, dict)
 
@@ -413,7 +386,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
             'longhands': self.validate_array,
             'name-for-methods': self.validate_string,
             'parser-exported': self.validate_boolean,
-            'parser-grammar': self.validate_grammar,
+            'parser-grammar': self.validate_string,
             'parser-grammar-comment': self.validate_comment,
             'parser-function': self.validate_string,
             'parser-requires-additional-parameters': self.validate_array,


### PR DESCRIPTION
#### 620bddfab051da187dd5f765b9e14859b7f326b8
<pre>
Remove non-BNF parser grammar support from CSSProperties.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=249754">https://bugs.webkit.org/show_bug.cgi?id=249754</a>
rdar://103617021

Reviewed by Antti Koivisto.

Now that we have the BNF parser in process-css-properties.py, we no
longer need to support the adhoc JSON structure based grammars. There
was one remaining use of it specify an aliased keyword, which was
switched to marking the need for the aliasing on the outer shared
rule instead.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/process-css-properties.py:
* Tools/Scripts/webkitpy/style/checkers/jsonchecker.py:

Canonical link: <a href="https://commits.webkit.org/258344@main">https://commits.webkit.org/258344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d9128964fae8203af1629db50bcecbc31e7b0a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110901 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171116 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105563 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1641 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93976 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108675 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35437 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/105101 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90807 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78436 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4336 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25078 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1533 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44566 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5723 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6165 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->