### PR TITLE
ariaErrorMessageElements should be ariaErrorMessageElement

### DIFF
--- a/LayoutTests/accessibility/ARIA-reflection-expected.txt
+++ b/LayoutTests/accessibility/ARIA-reflection-expected.txt
@@ -102,7 +102,7 @@ PASS element.getAttribute(currentAttribute) is dataAttribute
 element.setAttribute("aria-disabled", otherData);
 PASS element[currentProperty] is otherDataProperty
 
-Test ariaErrorMessageElements < - > aria-errormessage
+Test ariaErrorMessageElement < - > aria-errormessage
 PASS element[currentProperty] is null
 PASS element.getAttribute(currentAttribute) is null
 PASS element.getAttribute(currentAttribute) is ""

--- a/LayoutTests/accessibility/ARIA-reflection.html
+++ b/LayoutTests/accessibility/ARIA-reflection.html
@@ -26,6 +26,7 @@
     function isElementReflectionProperty(property) {
         switch (property) {
             case "ariaActiveDescendantElement":
+            case "ariaErrorMessageElement":
                 return true;
         }
         return false;
@@ -36,7 +37,6 @@
             case "ariaControlsElements":
             case "ariaDescribedByElements":
             case "ariaDetailsElements":
-            case "ariaErrorMessageElements":
             case "ariaFlowToElements":
             case "ariaLabelledByElements":
             case "ariaOwnsElements":

--- a/LayoutTests/accessibility/custom-elements/describedby-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/describedby-expected.txt
@@ -8,9 +8,8 @@ PASS accessibilityController.accessibleElementById("custom-1").helpText is "AXHe
 PASS accessibilityController.accessibleElementById("custom-1").detailsElements().length is 2
 PASS accessibilityController.accessibleElementById("custom-1").detailsElements()[0].domIdentifier is "details1"
 PASS accessibilityController.accessibleElementById("custom-1").detailsElements()[1].domIdentifier is "details2"
-PASS accessibilityController.accessibleElementById("custom-1").errorMessageElements().length is 2
+PASS accessibilityController.accessibleElementById("custom-1").errorMessageElements().length is 1
 PASS accessibilityController.accessibleElementById("custom-1").errorMessageElements()[0].domIdentifier is "error1"
-PASS accessibilityController.accessibleElementById("custom-1").errorMessageElements()[1].domIdentifier is "error2"
 PASS accessibilityController.accessibleElementById("custom-2").role is "AXRole: AXCheckBox"
 PASS accessibilityController.accessibleElementById("custom-2").helpText is "AXHelp: some description"
 PASS accessibilityController.accessibleElementById("custom-2").detailsElements().length is 1

--- a/LayoutTests/accessibility/custom-elements/describedby-shadow-expected.txt
+++ b/LayoutTests/accessibility/custom-elements/describedby-shadow-expected.txt
@@ -9,17 +9,14 @@ PASS internals.ariaDescribedByElements[1] is document.querySelectorAll(".note")[
 PASS internals.ariaDetailsElements.length is 2
 PASS internals.ariaDetailsElements[0] is document.querySelectorAll(".details")[0]
 PASS internals.ariaDetailsElements[1] is document.querySelectorAll(".details")[1]
-PASS internals.ariaErrorMessageElements.length is 2
-PASS internals.ariaErrorMessageElements[0] is document.querySelectorAll(".error")[0]
-PASS internals.ariaErrorMessageElements[1] is document.querySelectorAll(".error")[1]
+PASS internals.ariaErrorMessageElement is document.querySelector(".error")
 PASS accessibilityController.accessibleElementById("custom-1").role is "AXRole: AXCheckBox"
 PASS accessibilityController.accessibleElementById("custom-1").helpText is "AXHelp: some description other description"
 PASS accessibilityController.accessibleElementById("custom-1").detailsElements().length is 2
 PASS accessibilityController.accessibleElementById("custom-1").detailsElements()[0].domIdentifier is "details1"
 PASS accessibilityController.accessibleElementById("custom-1").detailsElements()[1].domIdentifier is "details2"
-PASS accessibilityController.accessibleElementById("custom-1").errorMessageElements().length is 2
+PASS accessibilityController.accessibleElementById("custom-1").errorMessageElements().length is 1
 PASS accessibilityController.accessibleElementById("custom-1").errorMessageElements()[0].domIdentifier is "error1"
-PASS accessibilityController.accessibleElementById("custom-1").errorMessageElements()[1].domIdentifier is "error2"
 PASS successfullyParsed is true
 
 TEST COMPLETE
@@ -28,4 +25,3 @@ other description
 some details
 other details
 some error
-other error

--- a/LayoutTests/accessibility/custom-elements/describedby-shadow.html
+++ b/LayoutTests/accessibility/custom-elements/describedby-shadow.html
@@ -9,7 +9,6 @@
 <div id="details1" class="details">some details</div>
 <div id="details2" class="details">other details</div>
 <div id="error1" class="error">some error</div>
-<div id="error2" class="error">other error</div>
 <script>
 
 class CustomElement extends HTMLElement {
@@ -20,16 +19,14 @@ class CustomElement extends HTMLElement {
         internals.role = 'checkbox';
         internals.ariaDescribedByElements = Array.from(document.querySelectorAll('.note'));
         internals.ariaDetailsElements = Array.from(document.querySelectorAll('.details'));
-        internals.ariaErrorMessageElements = Array.from(document.querySelectorAll('.error'));
+        internals.ariaErrorMessageElement = document.querySelector('.error');          
         shouldBe('internals.ariaDescribedByElements.length', '2');
         shouldBe('internals.ariaDescribedByElements[0]', 'document.querySelectorAll(".note")[0]');
         shouldBe('internals.ariaDescribedByElements[1]', 'document.querySelectorAll(".note")[1]');
         shouldBe('internals.ariaDetailsElements.length', '2');
         shouldBe('internals.ariaDetailsElements[0]', 'document.querySelectorAll(".details")[0]');
         shouldBe('internals.ariaDetailsElements[1]', 'document.querySelectorAll(".details")[1]');
-        shouldBe('internals.ariaErrorMessageElements.length', '2');
-        shouldBe('internals.ariaErrorMessageElements[0]', 'document.querySelectorAll(".error")[0]');
-        shouldBe('internals.ariaErrorMessageElements[1]', 'document.querySelectorAll(".error")[1]');
+        shouldBe('internals.ariaErrorMessageElement', 'document.querySelector(".error")');
     }
 }
 customElements.define('custom-element', CustomElement);
@@ -48,9 +45,8 @@ else {
     shouldBe('accessibilityController.accessibleElementById("custom-1").detailsElements().length', '2');
     shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").detailsElements()[0].domIdentifier', 'details1');
     shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").detailsElements()[1].domIdentifier', 'details2');
-    shouldBe('accessibilityController.accessibleElementById("custom-1").errorMessageElements().length', '2');
+    shouldBe('accessibilityController.accessibleElementById("custom-1").errorMessageElements().length', '1');
     shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").errorMessageElements()[0].domIdentifier', 'error1');
-    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").errorMessageElements()[1].domIdentifier', 'error2');
 }
 
 </script>

--- a/LayoutTests/accessibility/custom-elements/describedby.html
+++ b/LayoutTests/accessibility/custom-elements/describedby.html
@@ -21,7 +21,7 @@ customElements.define('custom-element', class CustomElement extends HTMLElement 
         internals.role = 'checkbox';
         internals.ariaDescribedByElements = Array.from(document.querySelectorAll('.note'));
         internals.ariaDetailsElements = Array.from(document.querySelectorAll('.details'));
-        internals.ariaErrorMessageElements = Array.from(document.querySelectorAll('.error'));
+        internals.ariaErrorMessageElement = document.querySelector('.error');
     }
 });
 
@@ -34,9 +34,8 @@ else {
     shouldBe('accessibilityController.accessibleElementById("custom-1").detailsElements().length', '2');
     shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").detailsElements()[0].domIdentifier', 'details1');
     shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").detailsElements()[1].domIdentifier', 'details2');
-    shouldBe('accessibilityController.accessibleElementById("custom-1").errorMessageElements().length', '2');
+    shouldBe('accessibilityController.accessibleElementById("custom-1").errorMessageElements().length', '1');
     shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").errorMessageElements()[0].domIdentifier', 'error1');
-    shouldBeEqualToString('accessibilityController.accessibleElementById("custom-1").errorMessageElements()[1].domIdentifier', 'error2');
     shouldBeEqualToString('accessibilityController.accessibleElementById("custom-2").role', 'AXRole: AXCheckBox');
     shouldBeEqualToString('accessibilityController.accessibleElementById("custom-2").helpText', 'AXHelp: some description');
     shouldBe('accessibilityController.accessibleElementById("custom-2").detailsElements().length', '1');

--- a/LayoutTests/accessibility/element-reflection-ariaerrormessage-expected.txt
+++ b/LayoutTests/accessibility/element-reflection-ariaerrormessage-expected.txt
@@ -1,4 +1,4 @@
-Checks that element reflection is exposed to the a11y tree for 'ariaErrorMessageElements'
+Checks that element reflection is exposed to the a11y tree for 'ariaErrorMessageElement'
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -8,8 +8,6 @@ PASS axTarget2.ariaErrorMessageElementAtIndex(0).isEqual(axError2) is true
 PASS axTarget2.ariaErrorMessageElementAtIndex(0).isEqual(axError1) is true
 PASS axInnerTarget.ariaErrorMessageElementAtIndex(0).isEqual(axError3) is true
 PASS axTarget2.ariaErrorMessageElementAtIndex(0).isEqual(axError1) is true
-PASS axTarget2.ariaErrorMessageElementAtIndex(1).isEqual(axError2) is true
-PASS axTarget2.ariaErrorMessageElementAtIndex(2).isEqual(axError3) is true
 PASS axTarget4.ariaErrorMessageElementAtIndex(0).isEqual(axErrorMessage4) is true
 PASS axTarget5.ariaErrorMessageElementAtIndex(0).isEqual(axErrorMessage5) is true
 PASS successfullyParsed is true

--- a/LayoutTests/accessibility/element-reflection-ariaerrormessage.html
+++ b/LayoutTests/accessibility/element-reflection-ariaerrormessage.html
@@ -21,7 +21,7 @@
       let target = document.createElement("div");
       target.id = "innertarget";
       target.textContent = "Target 3";
-      target.ariaErrorMessageElements = [error3];
+      target.ariaErrorMessageElement = error3;
       this.shadowRoot.appendChild(target);
     }
   }
@@ -39,22 +39,22 @@
       target.textContent = "Target 5";
       this.shadowRoot.appendChild(error);
       this.shadowRoot.appendChild(target);
-      target.ariaErrorMessageElements = [error];
+      target.ariaErrorMessageElement = error;
       document.body.appendChild(error);
     }
   }
   customElements.define("x-custom", XCustom);
 
-  description("Checks that element reflection is exposed to the a11y tree for 'ariaErrorMessageElements'");
+  description("Checks that element reflection is exposed to the a11y tree for 'ariaErrorMessageElement'");
   if (!window.accessibilityController) {
     debug("This test requires accessibilityController");
   } else {
-    target1.ariaErrorMessageElements = [error1];
+    target1.ariaErrorMessageElement = error1;
     var axError1 = accessibilityController.accessibleElementById("error1");
     var axTarget1 = accessibilityController.accessibleElementById("target1");
     shouldBeTrue("axTarget1.ariaErrorMessageElementAtIndex(0).isEqual(axError1)");
 
-    target2.ariaErrorMessageElements = [document.getElementsByClassName("error")[0]];
+    target2.ariaErrorMessageElement = document.getElementsByClassName("error")[0];
     var wrapper = accessibilityController.accessibleElementById("wrapper");
     var axError2 = wrapper.childAtIndex(0);
     var axTarget2 = accessibilityController.accessibleElementById("target2");
@@ -66,12 +66,10 @@
     var axInnerTarget = accessibilityController.accessibleElementById("innertarget");
     shouldBeTrue("axInnerTarget.ariaErrorMessageElementAtIndex(0).isEqual(axError3)");
 
-    target2.ariaErrorMessageElements = [error1, document.getElementsByClassName("error")[0], error3];
+    target2.ariaErrorMessageElement = error1;
     shouldBeTrue("axTarget2.ariaErrorMessageElementAtIndex(0).isEqual(axError1)");
-    shouldBeTrue("axTarget2.ariaErrorMessageElementAtIndex(1).isEqual(axError2)");
-    shouldBeTrue("axTarget2.ariaErrorMessageElementAtIndex(2).isEqual(axError3)");
 
-    target4.ariaErrorMessageElements = [error4];
+    target4.ariaErrorMessageElement = error4;
     error4.id = "error4-new";
     var axErrorMessage4 = accessibilityController.accessibleElementById("error4-new");
     var axTarget4 = accessibilityController.accessibleElementById("target4");

--- a/LayoutTests/fast/custom-elements/reactions-for-aria-element-attributes-expected.txt
+++ b/LayoutTests/fast/custom-elements/reactions-for-aria-element-attributes-expected.txt
@@ -7,8 +7,8 @@ PASS ariaDescribedByElements in Element must enqueue an attributeChanged reactio
 PASS ariaDescribedByElements in Element must enqueue an attributeChanged reaction when replacing an existing attribute
 PASS ariaDetailsElements in Element must enqueue an attributeChanged reaction when adding aria-details content attribute
 PASS ariaDetailsElements in Element must enqueue an attributeChanged reaction when replacing an existing attribute
-PASS ariaErrorMessageElements in Element must enqueue an attributeChanged reaction when adding aria-errormessage content attribute
-PASS ariaErrorMessageElements in Element must enqueue an attributeChanged reaction when replacing an existing attribute
+PASS ariaErrorMessageElement in Element must enqueue an attributeChanged reaction when adding aria-errormessage content attribute
+PASS ariaErrorMessageElement in Element must enqueue an attributeChanged reaction when replacing an existing attribute
 PASS ariaFlowToElements in Element must enqueue an attributeChanged reaction when adding aria-flowto content attribute
 PASS ariaFlowToElements in Element must enqueue an attributeChanged reaction when replacing an existing attribute
 PASS ariaLabelledByElements in Element must enqueue an attributeChanged reaction when adding aria-labelledby content attribute

--- a/LayoutTests/fast/custom-elements/reactions-for-aria-element-attributes.html
+++ b/LayoutTests/fast/custom-elements/reactions-for-aria-element-attributes.html
@@ -55,7 +55,7 @@ testElementReflectAttribute('ariaActiveDescendantElement', 'aria-activedescendan
 testElementReflectAttribute('ariaControlsElements', 'aria-controls', [dummy1], [dummy2], 'ariaControlsElements in Element');
 testElementReflectAttribute('ariaDescribedByElements', 'aria-describedby', [dummy1], [dummy2], 'ariaDescribedByElements in Element');
 testElementReflectAttribute('ariaDetailsElements', 'aria-details', [dummy1], [dummy2], 'ariaDetailsElements in Element');
-testElementReflectAttribute('ariaErrorMessageElements', 'aria-errormessage', [dummy1], [dummy2], 'ariaErrorMessageElements in Element');
+testElementReflectAttribute('ariaErrorMessageElement', 'aria-errormessage', dummy1, dummy2, 'ariaErrorMessageElement in Element');
 testElementReflectAttribute('ariaFlowToElements', 'aria-flowto', [dummy1], [dummy2], 'ariaFlowToElements in Element');
 testElementReflectAttribute('ariaLabelledByElements', 'aria-labelledby', [dummy1], [dummy2], 'ariaLabelledByElements in Element')
 testElementReflectAttribute('ariaOwnsElements', 'aria-owns', [dummy1], [dummy2], 'ariaOwnsElements in Element')

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-accessibility-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-accessibility-expected.txt
@@ -13,7 +13,7 @@ PASS ariaCurrent is defined in ElementInternals
 PASS ariaDescribedByElements is defined in ElementInternals
 PASS ariaDetailsElements is defined in ElementInternals
 PASS ariaDisabled is defined in ElementInternals
-FAIL ariaErrorMessageElement is defined in ElementInternals assert_inherits: property "ariaErrorMessageElement" not found in prototype chain
+PASS ariaErrorMessageElement is defined in ElementInternals
 PASS ariaExpanded is defined in ElementInternals
 PASS ariaFlowToElements is defined in ElementInternals
 PASS ariaHasPopup is defined in ElementInternals

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/aria-element-reflection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/aria-element-reflection-expected.txt
@@ -43,7 +43,7 @@ PASS aria-activedescendant element reflection
 PASS If the content attribute is set directly, the IDL attribute getter always returns the first element whose ID matches the content attribute.
 PASS Setting the IDL attribute to an element which is not the first element in DOM order with its ID causes the content attribute to be an empty string
 PASS Setting an element reference that crosses into a shadow tree is disallowed, but setting one that is in a shadow inclusive ancestor is allowed.
-FAIL aria-errormessage assert_equals: expected (string) "" but got (object) null
+PASS aria-errormessage
 PASS aria-details
 PASS Deleting a reflected element should return null for the IDL attribute and the content attribute will be empty.
 PASS Changing the ID of an element doesn't lose the reference.

--- a/Source/WebCore/accessibility/AriaAttributes.idl
+++ b/Source/WebCore/accessibility/AriaAttributes.idl
@@ -38,7 +38,7 @@ interface mixin AriaAttributes {
     [CEReactions, CustomGetter, Reflect=aria_describedby, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaDescribedByElements;
     [CEReactions, CustomGetter, Reflect=aria_details, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaDetailsElements;
     [CEReactions, Reflect=aria_disabled]         attribute DOMString? ariaDisabled;
-    [CEReactions, CustomGetter, Reflect=aria_errormessage, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaErrorMessageElements;
+    [CEReactions, Reflect=aria_errormessage, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute Element? ariaErrorMessageElement;
     [CEReactions, Reflect=aria_expanded]         attribute DOMString? ariaExpanded;
     [CEReactions, CustomGetter, Reflect=aria_flowto, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaFlowToElements;
     [CEReactions, Reflect=aria_haspopup]         attribute DOMString? ariaHasPopup;

--- a/Source/WebCore/bindings/js/JSElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementCustom.cpp
@@ -128,11 +128,6 @@ JSValue JSElement::ariaDetailsElements(JSGlobalObject& lexicalGlobalObject) cons
     return getElementsArrayAttribute(lexicalGlobalObject, *this, WebCore::HTMLNames::aria_detailsAttr);
 }
 
-JSValue JSElement::ariaErrorMessageElements(JSGlobalObject& lexicalGlobalObject) const
-{
-    return getElementsArrayAttribute(lexicalGlobalObject, *this, WebCore::HTMLNames::aria_errormessageAttr);
-}
-
 JSValue JSElement::ariaFlowToElements(JSGlobalObject& lexicalGlobalObject) const
 {
     return getElementsArrayAttribute(lexicalGlobalObject, *this, WebCore::HTMLNames::aria_flowtoAttr);

--- a/Source/WebCore/bindings/js/JSElementInternalsCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementInternalsCustom.cpp
@@ -81,11 +81,6 @@ JSValue JSElementInternals::ariaDetailsElements(JSGlobalObject& lexicalGlobalObj
     return getElementsArrayAttribute(lexicalGlobalObject, *this, WebCore::HTMLNames::aria_detailsAttr);
 }
 
-JSValue JSElementInternals::ariaErrorMessageElements(JSGlobalObject& lexicalGlobalObject) const
-{
-    return getElementsArrayAttribute(lexicalGlobalObject, *this, WebCore::HTMLNames::aria_errormessageAttr);
-}
-
 JSValue JSElementInternals::ariaFlowToElements(JSGlobalObject& lexicalGlobalObject) const
 {
     return getElementsArrayAttribute(lexicalGlobalObject, *this, WebCore::HTMLNames::aria_flowtoAttr);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2020,7 +2020,8 @@ static inline AtomString makeIdForStyleResolution(const AtomString& value, bool 
 
 bool Element::isElementReflectionAttribute(const QualifiedName& name)
 {
-    return name == HTMLNames::aria_activedescendantAttr;
+    return name == HTMLNames::aria_activedescendantAttr
+        || name == HTMLNames::aria_errormessageAttr;
 }
 
 bool Element::isElementsArrayReflectionAttribute(const QualifiedName& name)
@@ -2028,7 +2029,6 @@ bool Element::isElementsArrayReflectionAttribute(const QualifiedName& name)
     return name == HTMLNames::aria_controlsAttr
         || name == HTMLNames::aria_describedbyAttr
         || name == HTMLNames::aria_detailsAttr
-        || name == HTMLNames::aria_errormessageAttr
         || name == HTMLNames::aria_flowtoAttr
         || name == HTMLNames::aria_labelledbyAttr
         || name == HTMLNames::aria_ownsAttr;

--- a/Source/WebCore/dom/ElementInternals.idl
+++ b/Source/WebCore/dom/ElementInternals.idl
@@ -45,7 +45,7 @@
     [CEReactions, CustomGetter, Reflect=aria_describedby, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute FrozenArray<Element>? ariaDescribedByElements;
     [CEReactions, CustomGetter, Reflect=aria_details, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute FrozenArray<Element>? ariaDetailsElements;
     [CEReactions, Reflect=aria_disabled, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaDisabled;
-    [CEReactions, CustomGetter, Reflect=aria_errormessage, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute FrozenArray<Element>? ariaErrorMessageElements;
+    [CEReactions, Reflect=aria_errormessage, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute Element? ariaErrorMessageElement;
     [CEReactions, Reflect=aria_expanded, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaExpanded;
     [CEReactions, CustomGetter, Reflect=aria_flowto, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute FrozenArray<Element>? ariaFlowToElements;
     [CEReactions, Reflect=aria_haspopup, EnabledBySetting=DefaultARIAForCustomElementsEnabled] attribute DOMString? ariaHasPopup;


### PR DESCRIPTION
#### 14a11aaaaeca355c0f4174b3cbf957bef255c5d5
<pre>
ariaErrorMessageElements should be ariaErrorMessageElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=249752">https://bugs.webkit.org/show_bug.cgi?id=249752</a>

Reviewed by NOBODY (OOPS!).

Replace ariaErrorMessageElements with ariaErrorMessageElement per spec:
<a href="https://w3c.github.io/aria/#accessibilityroleandproperties-correspondence">https://w3c.github.io/aria/#accessibilityroleandproperties-correspondence</a>

* LayoutTests/accessibility/ARIA-reflection-expected.txt:
* LayoutTests/accessibility/ARIA-reflection.html:
* LayoutTests/accessibility/custom-elements/describedby-expected.txt:
* LayoutTests/accessibility/custom-elements/describedby-shadow-expected.txt:
* LayoutTests/accessibility/custom-elements/describedby-shadow.html:
* LayoutTests/accessibility/custom-elements/describedby.html:
* LayoutTests/accessibility/element-reflection-ariaerrormessage-expected.txt:
* LayoutTests/accessibility/element-reflection-ariaerrormessage.html:
* LayoutTests/fast/custom-elements/reactions-for-aria-element-attributes-expected.txt:
* LayoutTests/fast/custom-elements/reactions-for-aria-element-attributes.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-accessibility-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/aria-element-reflection-expected.txt:
* Source/WebCore/accessibility/AriaAttributes.idl:
* Source/WebCore/bindings/js/JSElementCustom.cpp:
(WebCore::JSElement::ariaErrorMessageElements const): Deleted.
* Source/WebCore/bindings/js/JSElementInternalsCustom.cpp:
(WebCore::JSElementInternals::ariaErrorMessageElements const): Deleted.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isElementReflectionAttribute):
(WebCore::Element::isElementsArrayReflectionAttribute):
* Source/WebCore/dom/ElementInternals.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14a11aaaaeca355c0f4174b3cbf957bef255c5d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110582 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170859 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1321 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93715 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108410 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35213 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23315 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78211 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4090 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24829 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1254 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44312 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5901 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->