### PR TITLE
Notify networking stack that download is media related

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -868,6 +868,8 @@ ExceptionOr<void> MediaSource::removeSourceBuffer(SourceBuffer& buffer)
     // 12. Destroy all resources for sourceBuffer.
     buffer.removedFromMediaSource();
 
+    notifyElementUpdateMediaState();
+
     return { };
 }
 
@@ -1117,7 +1119,16 @@ void MediaSource::regenerateActiveSourceBuffers()
     for (auto& sourceBuffer : *m_activeSourceBuffers)
         sourceBuffer->setBufferedDirty(true);
 
+    notifyElementUpdateMediaState();
+
     updateBufferedIfNeeded();
+}
+
+void MediaSource::notifyElementUpdateMediaState() const
+{
+    if (!mediaElement())
+        return;
+    mediaElement()->updateMediaState();
 }
 
 void MediaSource::updateBufferedIfNeeded()

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -161,6 +161,7 @@ private:
 
     void regenerateActiveSourceBuffers();
     void updateBufferedIfNeeded();
+    void notifyElementUpdateMediaState() const;
 
     void completeSeek();
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -156,6 +156,7 @@
 #if ENABLE(MEDIA_SOURCE)
 #include "DOMWindow.h"
 #include "MediaSource.h"
+#include "SourceBufferList.h"
 #endif
 
 #if ENABLE(MEDIA_STREAM)
@@ -8435,6 +8436,8 @@ void HTMLMediaElement::scheduleUpdateMediaState()
     });
 }
 
+#endif
+
 void HTMLMediaElement::updateMediaState()
 {
     MediaProducerMediaStateFlags state = mediaState();
@@ -8442,11 +8445,12 @@ void HTMLMediaElement::updateMediaState()
         return;
 
     m_mediaState = state;
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
     mediaSession().mediaStateDidChange(m_mediaState);
+#endif
 
     document().updateIsPlayingMedia();
 }
-#endif
 
 MediaProducerMediaStateFlags HTMLMediaElement::mediaState() const
 {
@@ -8475,6 +8479,12 @@ MediaProducerMediaStateFlags HTMLMediaElement::mediaState() const
         state.add(MediaProducerMediaState::DidPlayToEnd);
 #else
     UNUSED_VARIABLE(hasAudio);
+#endif
+
+#if ENABLE(MEDIA_SOURCE)
+    // We can assume that if we have active source buffers, later networking activity (such as stream or XHR requests) will be media related.
+    if (m_mediaSource && m_mediaSource->activeSourceBuffers() && m_mediaSource->activeSourceBuffers()->length())
+        state.add(MediaProducerMediaState::HasStreamingActivity);
 #endif
 
     if (!isPlaying())

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -626,6 +626,8 @@ public:
 
     bool hasSource() const { return hasCurrentSrc() || srcObject(); }
 
+    void updateMediaState();
+
 protected:
     HTMLMediaElement(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLMediaElement();
@@ -977,7 +979,6 @@ private:
     void resumeFromDocumentSuspension() final;
 
     void scheduleUpdateMediaState();
-    void updateMediaState();
     bool hasPlaybackTargetAvailabilityListeners() const { return m_hasPlaybackTargetAvailabilityListeners; }
 #endif
 
@@ -1260,8 +1261,9 @@ private:
     bool m_settingMediaStreamSrcObject { false };
 #endif
 
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
     MediaProducerMediaStateFlags m_mediaState;
+
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
     MonotonicTime m_currentPlaybackTargetIsWirelessEventFiredTime;
     bool m_hasPlaybackTargetAvailabilityListeners { false };
     bool m_failedToPlayToWirelessTarget { false };

--- a/Source/WebCore/page/MediaProducer.h
+++ b/Source/WebCore/page/MediaProducer.h
@@ -59,6 +59,7 @@ enum class MediaProducerMediaState : uint32_t {
     HasActiveSystemAudioCaptureDevice = 1 << 24,
     HasMutedSystemAudioCaptureDevice = 1 << 25,
     HasInterruptedSystemAudioCaptureDevice = 1 << 26,
+    HasStreamingActivity = 1 << 27,
 };
 using MediaProducerMediaStateFlags = OptionSet<MediaProducerMediaState>;
 
@@ -179,7 +180,8 @@ template<> struct EnumTraits<WebCore::MediaProducerMediaState> {
         WebCore::MediaProducerMediaState::HasInterruptedWindowCaptureDevice,
         WebCore::MediaProducerMediaState::HasActiveSystemAudioCaptureDevice,
         WebCore::MediaProducerMediaState::HasMutedSystemAudioCaptureDevice,
-        WebCore::MediaProducerMediaState::HasInterruptedSystemAudioCaptureDevice
+        WebCore::MediaProducerMediaState::HasInterruptedSystemAudioCaptureDevice,
+        WebCore::MediaProducerMediaState::HasStreamingActivity
     >;
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -170,6 +170,8 @@ static CFStringRef AppleColorPreferencesChangedNotification = CFSTR("AppleColorP
 
 static NSString * const WebKitSuppressMemoryPressureHandlerDefaultsKey = @"WebKitSuppressMemoryPressureHandler";
 
+static NSString * const WebKitMediaStreamingActivity = @"WebKitMediaStreamingActivity";
+
 #if ENABLE(TRACKING_PREVENTION) && !RELEASE_LOG_DISABLED
 static NSString * const WebKitLogCookieInformationDefaultsKey = @"WebKitLogCookieInformation";
 #endif
@@ -1259,5 +1261,10 @@ void WebProcessPool::registerHighDynamicRangeChangeCallback()
     } };
 }
 #endif // PLATFORM(MAC) || PLATFORM(IOS)
+
+void WebProcessPool::notifyMediaStreamingActivity(bool activity)
+{
+    [[NSNotificationCenter defaultCenter] postNotificationName:WebKitMediaStreamingActivity object:[NSNumber numberWithBool:activity]];
+}
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10074,7 +10074,7 @@ void WebPageProxy::updatePlayingMediaDidChange(MediaProducerMediaStateFlags newS
     MediaProducerMediaStateFlags playingMediaMask { MediaProducerMediaState::IsPlayingAudio, MediaProducerMediaState::IsPlayingVideo };
     MediaProducerMediaStateFlags oldState = m_mediaState;
 
-    bool playingAudioChanges = (oldState.contains(MediaProducerMediaState::IsPlayingAudio)) != (newState.contains(MediaProducerMediaState::IsPlayingAudio));
+    bool playingAudioChanges = oldState.contains(MediaProducerMediaState::IsPlayingAudio) != newState.contains(MediaProducerMediaState::IsPlayingAudio);
     if (playingAudioChanges)
         pageClient().isPlayingAudioWillChange();
     m_mediaState = newState;
@@ -10102,6 +10102,9 @@ void WebPageProxy::updatePlayingMediaDidChange(MediaProducerMediaStateFlags newS
         videoControlsManagerDidChange();
 
     m_process->updateAudibleMediaAssertions();
+    bool mediaStreamingChanges = oldState.contains(MediaProducerMediaState::HasStreamingActivity) != newState.contains(MediaProducerMediaState::HasStreamingActivity);
+    if (mediaStreamingChanges)
+        m_process->updateMediaStreamingActivity();
 }
 
 void WebPageProxy::updateReportedMediaCaptureState()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1608,6 +1608,7 @@ public:
     bool isShowingNavigationGestureSnapshot() const { return m_isShowingNavigationGestureSnapshot; }
 
     bool isPlayingAudio() const { return !!(m_mediaState & WebCore::MediaProducerMediaState::IsPlayingAudio); }
+    bool hasMediaStreaming() const { return !!(m_mediaState & WebCore::MediaProducerMediaState::HasStreamingActivity); }
     void isPlayingMediaDidChange(WebCore::MediaProducerMediaStateFlags);
     void updateReportedMediaCaptureState();
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -210,6 +210,7 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
     , m_backForwardCache(makeUniqueRef<WebBackForwardCache>(*this))
     , m_webProcessCache(makeUniqueRef<WebProcessCache>(*this))
     , m_webProcessWithAudibleMediaCounter([this](RefCounterEvent) { updateAudibleMediaAssertions(); })
+    , m_webProcessWithMediaStreamingCounter([this](RefCounterEvent) { updateMediaStreamingActivity(); })
 {
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
@@ -2126,6 +2127,32 @@ void WebProcessPool::updateAudibleMediaAssertions()
         , gpuProcess() ? RefPtr<ProcessAssertion> { ProcessAssertion::create(gpuProcess()->processIdentifier(), "WebKit Media Playback"_s, ProcessAssertionType::MediaPlayback) } : nullptr
 #endif
     };
+}
+
+WebProcessWithMediaStreamingToken WebProcessPool::webProcessWithMediaStreamingToken() const
+{
+    return m_webProcessWithMediaStreamingCounter.count();
+}
+
+void WebProcessPool::updateMediaStreamingActivity()
+{
+    if (!m_webProcessWithMediaStreamingCounter.value()) {
+        WEBPROCESSPOOL_RELEASE_LOG(ProcessSuspension, "updateMediaStreamingActivity: The number of processes with media networking now zero. Notify network.");
+        m_mediaStreamingActivity = false;
+#if PLATFORM(COCOA)
+        notifyMediaStreamingActivity(false);
+#endif
+        return;
+    }
+
+    if (m_mediaStreamingActivity)
+        return;
+
+    WEBPROCESSPOOL_RELEASE_LOG(ProcessSuspension, "updateMediaStreamingActivity: The number of processes with media networking is now greater than zero. Notify network.");
+    m_mediaStreamingActivity = true;
+#if PLATFORM(COCOA)
+    notifyMediaStreamingActivity(true);
+#endif
 }
 
 void WebProcessPool::setUseSeparateServiceWorkerProcess(bool useSeparateServiceWorkerProcess)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -408,6 +408,8 @@ public:
 
     NSMutableDictionary *ensureBundleParameters();
     NSMutableDictionary *bundleParameters() { return m_bundleParameters.get(); }
+
+    void notifyMediaStreamingActivity(bool);
 #else
     void updateProcessSuppressionState() const { }
 #endif
@@ -494,6 +496,7 @@ public:
 #endif
 
     WebProcessWithAudibleMediaToken webProcessWithAudibleMediaToken() const;
+    WebProcessWithMediaStreamingToken webProcessWithMediaStreamingToken() const;
 
     void disableDelayedWebProcessLaunch() { m_isDelayedWebProcessLaunchDisabled = true; }
 
@@ -558,6 +561,7 @@ private:
 
     void updateProcessAssertions();
     void updateAudibleMediaAssertions();
+    void updateMediaStreamingActivity();
 
     // IPC::MessageReceiver.
     // Implemented in generated WebProcessPoolMessageReceiver.cpp
@@ -804,6 +808,9 @@ private:
 #endif
     };
     std::optional<AudibleMediaActivity> m_audibleMediaActivity;
+
+    WebProcessWithMediaStreamingCounter m_webProcessWithMediaStreamingCounter;
+    bool m_mediaStreamingActivity { false };
 
 #if PLATFORM(PLAYSTATION)
     int32_t m_userId { -1 };

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -133,6 +133,9 @@ typedef BackgroundWebProcessCounter::Token BackgroundWebProcessToken;
 enum WebProcessWithAudibleMediaCounterType { };
 using WebProcessWithAudibleMediaCounter = RefCounter<WebProcessWithAudibleMediaCounterType>;
 using WebProcessWithAudibleMediaToken = WebProcessWithAudibleMediaCounter::Token;
+enum WebProcessWithMediaStreamingCounterType { };
+using WebProcessWithMediaStreamingCounter = RefCounter<WebProcessWithMediaStreamingCounterType>;
+using WebProcessWithMediaStreamingToken = WebProcessWithMediaStreamingCounter::Token;
 enum class CheckBackForwardList : bool { No, Yes };
 
 class WebProcessProxy : public AuxiliaryProcessProxy, private ProcessThrottlerClient {
@@ -383,6 +386,7 @@ public:
 #endif
 
     void updateAudibleMediaAssertions();
+    void updateMediaStreamingActivity();
 
     void setRemoteWorkerUserAgent(const String&);
     void updateRemoteWorkerPreferencesStore(const WebPreferencesStore&);
@@ -716,6 +720,8 @@ private:
         WebProcessWithAudibleMediaToken token;
     };
     std::optional<AudibleMediaActivity> m_audibleMediaActivity;
+
+    std::optional<WebProcessWithMediaStreamingToken> m_mediaStreamingActivity;
 
     ShutdownPreventingScopeCounter m_shutdownPreventingScopeCounter;
 

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -275,6 +275,7 @@ Tests/WebKitCocoa/WKNSDictionaryEmptyDictionaryCrash.mm
 Tests/WebKitCocoa/WKNSNumber.mm
 Tests/WebKitCocoa/WKNavigationResponse.mm
 Tests/WebKitCocoa/WKObject.mm
+Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm
 Tests/WebKitCocoa/WKPDFView.mm
 Tests/WebKitCocoa/WKPrinting.mm
 Tests/WebKitCocoa/WKProcessPoolConfiguration.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2344,6 +2344,7 @@
 		4BFDFFA8131477770061F24B /* HitTestResultNodeHandle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HitTestResultNodeHandle.cpp; sourceTree = "<group>"; };
 		4C453A43294A468200D91D2B /* Ahem-10000A.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Ahem-10000A.ttf"; sourceTree = "<group>"; };
 		4CC961E4294A36A000483F06 /* LockdownModeFonts.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = LockdownModeFonts.html; path = Tests/WebKitCocoa/LockdownModeFonts.html; sourceTree = SOURCE_ROOT; };
+		5102ED872950538D0053243E /* WKPageHasMediaStreamingActivity.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKPageHasMediaStreamingActivity.mm; sourceTree = "<group>"; };
 		5104776F1D298D85009747EB /* IDBDeleteRecovery.sqlite3 */ = {isa = PBXFileReference; lastKnownFileType = file; path = IDBDeleteRecovery.sqlite3; sourceTree = "<group>"; };
 		510477701D298D85009747EB /* IDBDeleteRecovery.sqlite3-shm */ = {isa = PBXFileReference; lastKnownFileType = file; path = "IDBDeleteRecovery.sqlite3-shm"; sourceTree = "<group>"; };
 		510477711D298D85009747EB /* IDBDeleteRecovery.sqlite3-wal */ = {isa = PBXFileReference; lastKnownFileType = file; path = "IDBDeleteRecovery.sqlite3-wal"; sourceTree = "<group>"; };
@@ -4082,6 +4083,7 @@
 				DF4B273821A47727009BD1CA /* WKNSDictionaryEmptyDictionaryCrash.mm */,
 				375E0E151D66674400EFEC2C /* WKNSNumber.mm */,
 				37B47E2E1D64E7CA005F4EFF /* WKObject.mm */,
+				5102ED872950538D0053243E /* WKPageHasMediaStreamingActivity.mm */,
 				2D00065D1C1F58940088E6A7 /* WKPDFView.mm */,
 				1CC4C74A288909F600A3B23D /* WKPrinting.mm */,
 				3781746C2198AE2400062C26 /* WKProcessPoolConfiguration.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/file-with-mse.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/file-with-mse.html
@@ -15,6 +15,12 @@
           request.send();
       }
 
+      function unloadVideo()
+      {
+          var video = document.getElementById('test-video');
+          video.src = "";
+      }
+
       function load(event)
       {
           source = new MediaSource();
@@ -36,6 +42,7 @@
     </p>
     <p>
         <button onclick="playVideo()">Play video</button>
+        <button onclick="unloadVideo()">Unload video</button>
     </p>
 </body>
 </html>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "PlatformUtilities.h"
+#import "PlatformWebView.h"
+#import "Test.h"
+#import <JavaScriptCore/JavaScriptCore.h>
+#import <WebKit/WKPagePrivate.h>
+#import <WebKit/WKPreferencesPrivate.h>
+
+// This test loads file-with-video.html. Then it calls a JavaScript method to create a source buffer and play the video,
+// waits for WKMediaNetworkingActivity notification to be fired.
+
+namespace TestWebKitAPI {
+
+static NSString * const WebKitMediaStreamingActivity = @"WebKitMediaStreamingActivity";
+
+TEST(WebKit, MSEHasMediaStreamingActivity)
+{
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    [[configuration preferences] _setMediaSourceEnabled:YES];
+    [[configuration preferences] _setAllowFileAccessFromFileURLs:YES];
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"file-with-mse"];
+
+    // Bail out of the test early if the platform does not support MSE.
+    if (![[webView objectByEvaluatingJavaScript:@"window.MediaSource !== undefined"] boolValue])
+        return;
+
+    __block bool isMediaStreamingChanged = false;
+    __block bool isMediaStreaming = false;
+
+    auto localeChangeObserver = [[NSNotificationCenter defaultCenter] addObserverForName:WebKitMediaStreamingActivity object: nil queue: nil usingBlock:^(NSNotification *note) {
+        isMediaStreamingChanged = true;
+        if ([[note object] isKindOfClass:[NSNumber class]])
+            isMediaStreaming = [[note object] boolValue];
+    }];
+
+    [webView objectByEvaluatingJavaScript:@"playVideo()"];
+    Util::run(&isMediaStreamingChanged);
+    EXPECT_TRUE(isMediaStreaming);
+
+    isMediaStreamingChanged = false;
+    [webView objectByEvaluatingJavaScript:@"unloadVideo()"];
+    Util::run(&isMediaStreamingChanged);
+    EXPECT_FALSE(isMediaStreaming);
+
+    [[NSNotificationCenter defaultCenter] removeObserver:localeChangeObserver];
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 3b0ed39e4c4b90ad8d625560562dec5709c72cbd
<pre>
Notify networking stack that download is media related
<a href="https://bugs.webkit.org/show_bug.cgi?id=249569">https://bugs.webkit.org/show_bug.cgi?id=249569</a>
rdar://103046339

Reviewed by Youenn Fablet.

Send a system notification when a networking operation is likely
going to be related to media playback.
For now the heuristic is rather primitive: if we have an active source buffer
linked to a media element we assume that all further networking operation in the
page is media related.
The notification is produced by the UI process whenever a content process
has an active source buffers, and when all have been deleted.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::removeSourceBuffer):
(WebCore::MediaSource::regenerateActiveSourceBuffers):
(WebCore::MediaSource::notifyElementUpdateMediaState const):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::updateMediaState):
(WebCore::HTMLMediaElement::mediaState const):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/MediaProducer.h:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::notifyMediaNetworkingActivity):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updatePlayingMediaDidChange):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::m_webProcessWithMediaNetworkingCounter):
(WebKit::WebProcessPool::webProcessWithMediaNetworkingToken const):
(WebKit::WebProcessPool::updateMediaNetworkingActivity):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shutDown):
(WebKit::WebProcessProxy::removeWebPage):
(WebKit::WebProcessProxy::updateMediaNetworkingActivity):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaNetworkingActivity.mm: Added.
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKit/file-with-mse.html:

Canonical link: <a href="https://commits.webkit.org/258232@main">https://commits.webkit.org/258232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15bab3372c072d87a744c9df71290d228f74b812

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110556 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1299 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93677 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108388 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107059 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23294 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24808 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4111 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/10216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44287 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5658 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5869 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->