### PR TITLE
[CSS-Typed-OM] Make sure `orphans` & `widows` value gets clamped to [1, inf]

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt
@@ -4,8 +4,8 @@ PASS Can set 'orphans' to CSS-wide keywords: inherit
 PASS Can set 'orphans' to CSS-wide keywords: unset
 PASS Can set 'orphans' to CSS-wide keywords: revert
 PASS Can set 'orphans' to var() references:  var(--A)
-FAIL Can set 'orphans' to a number: 0 assert_approx_equals: expected 1 +/- 0.000001 but got 0
-FAIL Can set 'orphans' to a number: -3.14 assert_approx_equals: expected 1 +/- 0.000001 but got 0
+PASS Can set 'orphans' to a number: 0
+PASS Can set 'orphans' to a number: -3.14
 PASS Can set 'orphans' to a number: 3.14
 PASS Can set 'orphans' to a number: calc(2 + 3)
 PASS Setting 'orphans' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt
@@ -4,8 +4,8 @@ PASS Can set 'widows' to CSS-wide keywords: inherit
 PASS Can set 'widows' to CSS-wide keywords: unset
 PASS Can set 'widows' to CSS-wide keywords: revert
 PASS Can set 'widows' to var() references:  var(--A)
-FAIL Can set 'widows' to a number: 0 assert_approx_equals: expected 1 +/- 0.000001 but got 0
-FAIL Can set 'widows' to a number: -3.14 assert_approx_equals: expected 1 +/- 0.000001 but got 0
+PASS Can set 'widows' to a number: 0
+PASS Can set 'widows' to a number: -3.14
 PASS Can set 'widows' to a number: 3.14
 PASS Can set 'widows' to a number: calc(2 + 3)
 PASS Setting 'widows' to a length: 0px throws TypeError

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1205,10 +1205,10 @@ public:
     }
 
     void setHasAutoWidows() { SET_VAR(m_rareInheritedData, hasAutoWidows, true); SET_VAR(m_rareInheritedData, widows, initialWidows()); }
-    void setWidows(unsigned short w) { SET_VAR(m_rareInheritedData, hasAutoWidows, false); SET_VAR(m_rareInheritedData, widows, w); }
+    void setWidows(unsigned short w) { SET_VAR(m_rareInheritedData, hasAutoWidows, false); SET_VAR(m_rareInheritedData, widows, std::max<unsigned short>(w, 1)); }
 
     void setHasAutoOrphans() { SET_VAR(m_rareInheritedData, hasAutoOrphans, true); SET_VAR(m_rareInheritedData, orphans, initialOrphans()); }
-    void setOrphans(unsigned short o) { SET_VAR(m_rareInheritedData, hasAutoOrphans, false); SET_VAR(m_rareInheritedData, orphans, o); }
+    void setOrphans(unsigned short o) { SET_VAR(m_rareInheritedData, hasAutoOrphans, false); SET_VAR(m_rareInheritedData, orphans, std::max<unsigned short>(o, 1)); }
 
     // CSS3 Setters
     void setOutlineOffset(float v) { SET_VAR(m_backgroundData, outline.m_offset, v); }


### PR DESCRIPTION
#### fffeff450095e2a4ee3fd22e7461c062a72c117f
<pre>
[CSS-Typed-OM] Make sure `orphans` &amp; `widows` value gets clamped to [1, inf]
<a href="https://bugs.webkit.org/show_bug.cgi?id=249758">https://bugs.webkit.org/show_bug.cgi?id=249758</a>

Reviewed by Alan Baradlay.

Make sure `orphans` &amp; `widows` value gets clamped to [1, inf], as per:
- <a href="https://w3c.github.io/csswg-drafts/css-break/#widows-orphans">https://w3c.github.io/csswg-drafts/css-break/#widows-orphans</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/orphans-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/widows-expected.txt:
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::setWidows):
(WebCore::RenderStyle::setOrphans):

Canonical link: <a href="https://commits.webkit.org/258243@main">https://commits.webkit.org/258243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/963e4a62f216847933aab95e8811266050406abc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110565 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170844 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1306 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93684 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108395 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35181 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78180 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4075 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24815 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4120 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1241 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44294 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5878 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2970 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->