### PR TITLE
Input file thumbnail size doesn't change when zooming with Cmd+ or Cmd-

### DIFF
--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -46,18 +46,22 @@ using namespace HTMLNames;
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderFileUploadControl);
 
-const int afterButtonSpacing = 4;
-#if !PLATFORM(IOS_FAMILY)
-const int iconHeight = 16;
-const int iconWidth = 16;
-const int iconFilenameSpacing = 2;
-const int defaultWidthNumChars = 34;
-#else
-// On iOS the icon height matches the button height, to maximize the icon size.
-const int iconFilenameSpacing = afterButtonSpacing;
-const int defaultWidthNumChars = 38;
+constexpr int afterButtonSpacing = 4;
+constexpr int buttonShadowHeight = 2;
+
+#if !PLATFORM(COCOA)
+// On Cocoa platforms the icon height matches the button height, to maximize the icon size.
+constexpr int iconHeight = 16;
+constexpr int iconWidth = 16;
 #endif
-const int buttonShadowHeight = 2;
+
+#if !PLATFORM(IOS_FAMILY)
+constexpr int iconFilenameSpacing = 2;
+constexpr int defaultWidthNumChars = 34;
+#else
+constexpr int iconFilenameSpacing = afterButtonSpacing;
+constexpr int defaultWidthNumChars = 38;
+#endif
 
 RenderFileUploadControl::RenderFileUploadControl(HTMLInputElement& input, RenderStyle&& style)
     : RenderBlockFlow(input, WTFMove(style))
@@ -97,7 +101,7 @@ static int nodeWidth(Node* node)
     return (node && node->renderBox()) ? roundToInt(node->renderBox()->size().width()) : 0;
 }
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(COCOA)
 static int nodeHeight(Node* node)
 {
     return (node && node->renderBox()) ? roundToInt(node->renderBox()->size().height()) : 0;
@@ -106,7 +110,7 @@ static int nodeHeight(Node* node)
 
 int RenderFileUploadControl::maxFilenameWidth() const
 {
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(COCOA)
     int iconWidth = nodeHeight(uploadButton());
 #endif
     return std::max(0, snappedIntRect(contentBoxRect()).width() - nodeWidth(uploadButton()) - afterButtonSpacing
@@ -142,8 +146,7 @@ void RenderFileUploadControl::paintControl(PaintInfo& paintInfo, const LayoutPoi
         const String& displayedFilename = fileTextValue();
         const FontCascade& font = style().fontCascade();
         TextRun textRun = constructTextRun(displayedFilename, style(), ExpansionBehavior::allowRightOnly(), RespectDirection | RespectDirectionOverride);
-
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(COCOA)
         int iconHeight = nodeHeight(uploadButton());
         int iconWidth = iconHeight;
 #endif


### PR DESCRIPTION
#### cdb7be107d145a1b61f4d939ec3b1d4aa2fa4a16
<pre>
Input file thumbnail size doesn&apos;t change when zooming with Cmd+ or Cmd-
<a href="https://bugs.webkit.org/show_bug.cgi?id=247638">https://bugs.webkit.org/show_bug.cgi?id=247638</a>
rdar://102385998

Reviewed by Aditya Keerthi.

This PR just removes some `IOS_FAMILY` guards so that macOS behavior matches iOS.

* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::nodeHeight):
(WebCore::RenderFileUploadControl::maxFilenameWidth const):
(WebCore::RenderFileUploadControl::paintControl):

Canonical link: <a href="https://commits.webkit.org/258277@main">https://commits.webkit.org/258277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90a46f56f560d96eda73466502ac9cb864fe5ddb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110643 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170914 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1382 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93766 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108472 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35252 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78249 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4145 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24886 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1307 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10295 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44372 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5692 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5959 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->