### PR TITLE
[SVG2] Stop accepting 'defer' in preserveAspectRatio

### DIFF
--- a/LayoutTests/svg/dom/preserve-aspect-ratio-parser-expected.txt
+++ b/LayoutTests/svg/dom/preserve-aspect-ratio-parser-expected.txt
@@ -116,19 +116,19 @@ PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SV
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE
 
 Test string: 'defer xMinYMin'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMIN
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMidYMin'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMIN
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMaxYMin'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMIN
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMinYMid'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMID
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMidYMid'
@@ -136,35 +136,35 @@ PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SV
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMaxYMid'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMID
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMinYMax'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMAX
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMidYMax'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMAX
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMaxYMax'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMAX
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMinYMin meet'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMIN
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMidYMin meet'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMIN
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMaxYMin meet'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMIN
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMinYMid meet'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMID
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMidYMid meet'
@@ -172,56 +172,56 @@ PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SV
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMaxYMid meet'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMID
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMinYMax meet'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMAX
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMidYMax meet'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMAX
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMaxYMax meet'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMAX
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
 PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMinYMin slice'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMIN
-PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
+PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMidYMin slice'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMIN
-PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
+PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMaxYMin slice'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMIN
-PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
+PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMinYMid slice'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMID
-PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
+PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMidYMid slice'
 PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
-PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE
+PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMaxYMid slice'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMID
-PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
+PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMinYMax slice'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMAX
-PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
+PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMidYMax slice'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMAX
-PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
+PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Test string: 'defer xMaxYMax slice'
-PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMAX
-PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE
+PASS imageElement.preserveAspectRatio.baseVal.align is SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID
+PASS imageElement.preserveAspectRatio.baseVal.meetOrSlice is SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET
 
 Tests for some whitespace cases.
 

--- a/LayoutTests/svg/dom/preserve-aspect-ratio-parser.html
+++ b/LayoutTests/svg/dom/preserve-aspect-ratio-parser.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
@@ -52,35 +52,35 @@ parsePreserveAspectRatio("xMinYMax slice", "SVGPreserveAspectRatio.SVG_PRESERVEA
 parsePreserveAspectRatio("xMidYMax slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMAX", "SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE");
 parsePreserveAspectRatio("xMaxYMax slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMAX", "SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE");
 
-parsePreserveAspectRatio("defer xMinYMin", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMIN", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
-parsePreserveAspectRatio("defer xMidYMin", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMIN", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
-parsePreserveAspectRatio("defer xMaxYMin", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMIN", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
-parsePreserveAspectRatio("defer xMinYMid", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMinYMin", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMidYMin", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMaxYMin", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMinYMid", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
 parsePreserveAspectRatio("defer xMidYMid", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
-parsePreserveAspectRatio("defer xMaxYMid", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
-parsePreserveAspectRatio("defer xMinYMax", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMAX", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
-parsePreserveAspectRatio("defer xMidYMax", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMAX", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
-parsePreserveAspectRatio("defer xMaxYMax", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMAX", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMaxYMid", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMinYMax", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMidYMax", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMaxYMax", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
 
-parsePreserveAspectRatio("defer xMinYMin meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMIN", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
-parsePreserveAspectRatio("defer xMidYMin meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMIN", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
-parsePreserveAspectRatio("defer xMaxYMin meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMIN", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
-parsePreserveAspectRatio("defer xMinYMid meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMinYMin meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMidYMin meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMaxYMin meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMinYMid meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
 parsePreserveAspectRatio("defer xMidYMid meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
-parsePreserveAspectRatio("defer xMaxYMid meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
-parsePreserveAspectRatio("defer xMinYMax meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMAX", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
-parsePreserveAspectRatio("defer xMidYMax meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMAX", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
-parsePreserveAspectRatio("defer xMaxYMax meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMAX", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMaxYMid meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMinYMax meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMidYMax meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMaxYMax meet", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
 
-parsePreserveAspectRatio("defer xMinYMin slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMIN", "SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE");
-parsePreserveAspectRatio("defer xMidYMin slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMIN", "SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE");
-parsePreserveAspectRatio("defer xMaxYMin slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMIN", "SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE");
-parsePreserveAspectRatio("defer xMinYMid slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE");
-parsePreserveAspectRatio("defer xMidYMid slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE");
-parsePreserveAspectRatio("defer xMaxYMid slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE");
-parsePreserveAspectRatio("defer xMinYMax slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMINYMAX", "SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE");
-parsePreserveAspectRatio("defer xMidYMax slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMAX", "SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE");
-parsePreserveAspectRatio("defer xMaxYMax slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMAXYMAX", "SVGPreserveAspectRatio.SVG_MEETORSLICE_SLICE");
+parsePreserveAspectRatio("defer xMinYMin slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMidYMin slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMaxYMin slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMinYMid slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMidYMid slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMaxYMid slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMinYMax slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMidYMax slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
+parsePreserveAspectRatio("defer xMaxYMax slice", "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
 
 debug('Tests for some whitespace cases.');
 debug('');
@@ -128,6 +128,5 @@ parsePreserveAspectRatio("slice xMinYMin", "SVGPreserveAspectRatio.SVG_PRESERVEA
 parsePreserveAspectRatio("xMinYMin" + String.fromCharCode(0xa0), "SVGPreserveAspectRatio.SVG_PRESERVEASPECTRATIO_XMIDYMID", "SVGPreserveAspectRatio.SVG_MEETORSLICE_MEET");
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp
+++ b/Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp
@@ -2,6 +2,8 @@
  * Copyright (C) 2004, 2005, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
  * Copyright (C) 2010 Dirk Schulze <krit@webkit.org>
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -92,20 +94,6 @@ template<typename CharacterType> bool SVGPreserveAspectRatioValue::parseInternal
 
     if (!skipOptionalSVGSpaces(buffer))
         return false;
-
-    if (*buffer == 'd') {
-        if (!skipCharactersExactly(buffer, deferDesc<CharacterType>)) {
-            LOG_ERROR("Skipped to parse except for *defer* value.");
-            return false;
-        }
-
-        // FIXME: We just ignore the "defer" here.
-        if (buffer.atEnd())
-            return true;
-
-        if (!skipOptionalSVGSpaces(buffer))
-            return false;
-    }
 
     if (*buffer == 'n') {
         if (!skipCharactersExactly(buffer, noneDesc<CharacterType>)) {


### PR DESCRIPTION
#### e68929af9f25c8dc918b90c0613befa20d4d3085
<pre>
[SVG2] Stop accepting &apos;defer&apos; in preserveAspectRatio

[SVG2] Stop accepting &apos;defer&apos; in preserveAspectRatio
<a href="https://bugs.webkit.org/show_bug.cgi?id=249112">https://bugs.webkit.org/show_bug.cgi?id=249112</a>

Reviewed by Simon Fraser.

This patch is to align with SVG2 Web-Specification[1] and remove &quot;defer&quot; support in &quot;preserveAspectRatio&quot;.

[1] <a href="https://www.w3.org/2015/06/12-svg-minutes.html#item11">https://www.w3.org/2015/06/12-svg-minutes.html#item11</a>

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=198601

This patch will allow Webkit to match with other browsers as well and
will throw parse error when encountering &apos;defer&apos; keyword.

* Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp:
(SVGPreserveAspectRatioValue::parseInternal): Remove &apos;defer&apos; parse support
* LayoutTests/svg/dom/preserve-aspect-ratio-parser.html: Rebaselined
* LayoutTests/svg/dom/preserve-aspect-ratio-parser-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/258253@main">https://commits.webkit.org/258253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43f32a530247a4e259f02ee1c4c1676300429e96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110594 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170868 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1330 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93712 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108420 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35204 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78204 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4099 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24838 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1264 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44322 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5678 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5912 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->