### PR TITLE
REGRESSION (258175@main?): [ iOS Debug ] TestWebKitAPI.InAppBrowserPrivacy.AppBoundDomainAllowsServiceWorkers is a consistent failure

### DIFF
--- a/Source/WebCore/workers/service/server/RegistrationDatabase.h
+++ b/Source/WebCore/workers/service/server/RegistrationDatabase.h
@@ -69,17 +69,18 @@ private:
     void postTaskToWorkQueue(Function<void()>&&);
 
     // Methods to be run on the work queue.
-    bool openSQLiteDatabase(const String& fullFilename);
+    void openSQLiteDatabase(const String& fullFilename, CompletionHandler<void(bool)>&&);
     String ensureValidRecordsTable();
-    String importRecords();
+    void importRecords(CompletionHandler<void(String)>&&);
     void importRecordsIfNecessary();
-    bool doPushChanges(const Vector<ServiceWorkerContextData>&, const Vector<ServiceWorkerRegistrationKey>&);
+    void doPushChanges(Vector<ServiceWorkerContextData>&&, Vector<ServiceWorkerRegistrationKey>&&, CompletionHandler<void(bool, Vector<ServiceWorkerContextData>&&, Vector<ServiceWorkerRegistrationKey>&&)>&&);
+    void doPushChangesWithOpenDatabase(Vector<ServiceWorkerContextData>&&, Vector<ServiceWorkerRegistrationKey>&&, CompletionHandler<void(bool, Vector<ServiceWorkerContextData>&&, Vector<ServiceWorkerRegistrationKey>&&)>&&);
     void doClearOrigin(const SecurityOrigin&);
     SWScriptStorage& scriptStorage();
     String scriptStorageDirectory() const;
 
     // Replies to the main thread.
-    void addRegistrationToStore(ServiceWorkerContextData&&);
+    void addRegistrationToStore(ServiceWorkerContextData&&, CompletionHandler<void()>&&);
     void databaseFailedToOpen();
     void databaseOpenedAndRecordsImported(); 
 

--- a/Source/WebCore/workers/service/server/RegistrationStore.cpp
+++ b/Source/WebCore/workers/service/server/RegistrationStore.cpp
@@ -119,13 +119,14 @@ void RegistrationStore::removeRegistration(const ServiceWorkerRegistrationKey& k
     scheduleDatabasePushIfNecessary();
 }
 
-void RegistrationStore::addRegistrationFromDatabase(ServiceWorkerContextData&& data)
+void RegistrationStore::addRegistrationFromDatabase(ServiceWorkerContextData&& data, CompletionHandler<void()>&& completionHandler)
 {
+    ASSERT(isMainThread());
     ASSERT(!data.registration.key.isEmpty());
     if (data.registration.key.isEmpty())
-        return;
+        return completionHandler();
 
-    m_server.addRegistrationFromStore(WTFMove(data));
+    m_server.addRegistrationFromStore(WTFMove(data), WTFMove(completionHandler));
 }
 
 void RegistrationStore::didSaveWorkerScriptsToDisk(ServiceWorkerIdentifier serviceWorkerIdentifier, ScriptBuffer&& mainScript, MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>&& importedScripts)

--- a/Source/WebCore/workers/service/server/RegistrationStore.h
+++ b/Source/WebCore/workers/service/server/RegistrationStore.h
@@ -61,7 +61,7 @@ public:
     void removeRegistration(const ServiceWorkerRegistrationKey&);
 
     // Callbacks from the database
-    void addRegistrationFromDatabase(ServiceWorkerContextData&&);
+    void addRegistrationFromDatabase(ServiceWorkerContextData&&, CompletionHandler<void()>&&);
     void databaseFailedToOpen();
     void databaseOpenedAndRecordsImported();
     void didSaveWorkerScriptsToDisk(ServiceWorkerIdentifier, ScriptBuffer&& mainScript, MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>&& importedScripts);

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -200,7 +200,7 @@ public:
 
     void resolveRegistrationReadyRequests(SWServerRegistration&);
 
-    void addRegistrationFromStore(ServiceWorkerContextData&&);
+    void addRegistrationFromStore(ServiceWorkerContextData&&, CompletionHandler<void()>&&);
     void didSaveWorkerScriptsToDisk(ServiceWorkerIdentifier, ScriptBuffer&& mainScript, MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>&& importedScripts);
     void registrationStoreImportComplete();
     void registrationStoreDatabaseFailedToOpen();


### PR DESCRIPTION
#### 5ea941c44c076d3def9773c5cd5691b8f4a41c1b
<pre>
REGRESSION (258175@main?): [ iOS Debug ] TestWebKitAPI.InAppBrowserPrivacy.AppBoundDomainAllowsServiceWorkers is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=249723">https://bugs.webkit.org/show_bug.cgi?id=249723</a>
&lt;rdar://problem/103601970&gt;

Reviewed by Brady Eidson.

There was a race condition because we were assuming that SWServer::addRegistrationFromStore always completes immediately.
This is true most of the time, except during process startup.  So if we remove all service worker registrations as the first
thing we do with a network process, sometimes we would see a call to SWServer::addRegistration after we thought we had completed
removing all the service worker registrations, but only if m_hasReceivedAppBoundDomains is false.  This was seen by the API
test TestWebKitAPI.InAppBrowserPrivacy.AppBoundDomainAllowsServiceWorkers running after a test that left a service worker
registration on the disk.

* Source/WebCore/workers/service/server/RegistrationDatabase.cpp:
(WebCore::RegistrationDatabase::openSQLiteDatabase):
(WebCore::RegistrationDatabase::importRecordsIfNecessary):
(WebCore::RegistrationDatabase::schedulePushChanges):
(WebCore::RegistrationDatabase::doPushChanges):
(WebCore::RegistrationDatabase::doPushChangesWithOpenDatabase):
(WebCore::RegistrationDatabase::importRecords):
(WebCore::RegistrationDatabase::addRegistrationToStore):
(WebCore::RegistrationDatabase::databaseFailedToOpen):
(WebCore::RegistrationDatabase::databaseOpenedAndRecordsImported):
* Source/WebCore/workers/service/server/RegistrationDatabase.h:
* Source/WebCore/workers/service/server/RegistrationStore.cpp:
(WebCore::RegistrationStore::addRegistrationFromDatabase):
* Source/WebCore/workers/service/server/RegistrationStore.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::addRegistrationFromStore):
* Source/WebCore/workers/service/server/SWServer.h:

Canonical link: <a href="https://commits.webkit.org/258268@main">https://commits.webkit.org/258268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cffa43692d2db1d9deae3896c0bef553b2c6d830

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110633 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170905 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1371 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93755 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108462 "Hash cffa4369 for PR 7998 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8713 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35244 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78243 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4136 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1299 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44361 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5949 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2981 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->