### PR TITLE
RemoteRenderingBackend, GPU and GraphicsContextGL are opening the stream connection in inconsistent manner

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -74,7 +74,7 @@ Ref<RemoteGraphicsContextGL> RemoteGraphicsContextGL::create(GPUConnectionToWebP
 
 RemoteGraphicsContextGL::RemoteGraphicsContextGL(GPUConnectionToWebProcess& gpuConnectionToWebProcess, GraphicsContextGLIdentifier graphicsContextGLIdentifier, RemoteRenderingBackend& renderingBackend, IPC::StreamServerConnection::Handle&& connectionHandle)
     : m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
-    , m_streamConnection(IPC::StreamServerConnection::create(WTFMove(connectionHandle), remoteGraphicsContextGLStreamWorkQueue()))
+    , m_streamConnection(IPC::StreamServerConnection::create(WTFMove(connectionHandle)))
     , m_graphicsContextGLIdentifier(graphicsContextGLIdentifier)
     , m_renderingBackend(renderingBackend)
 #if ENABLE(VIDEO)
@@ -124,7 +124,7 @@ void RemoteGraphicsContextGL::workQueueInitialize(WebCore::GraphicsContextGLAttr
 {
     assertIsCurrent(workQueue());
     platformWorkQueueInitialize(WTFMove(attributes));
-    m_streamConnection->open();
+    m_streamConnection->open(workQueue());
     if (m_context) {
         m_context->setClient(this);
         String extensions = m_context->getString(GraphicsContextGL::EXTENSIONS);
@@ -138,12 +138,12 @@ void RemoteGraphicsContextGL::workQueueInitialize(WebCore::GraphicsContextGLAttr
 void RemoteGraphicsContextGL::workQueueUninitialize()
 {
     assertIsCurrent(workQueue());
-    m_streamConnection->invalidate();
     if (m_context) {
         m_context->setClient(nullptr);
         m_context = nullptr;
         m_streamConnection->stopReceivingMessages(Messages::RemoteGraphicsContextGL::messageReceiverName(), m_graphicsContextGLIdentifier.toUInt64());
     }
+    m_streamConnection->invalidate();
     m_streamConnection = nullptr;
     m_renderingResourcesRequest = { };
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -106,6 +106,8 @@ public:
 private:
     RemoteRenderingBackend(GPUConnectionToWebProcess&, RemoteRenderingBackendCreationParameters&&, IPC::StreamServerConnection::Handle&&);
     void startListeningForIPC();
+    void workQueueInitialize();
+    void workQueueUninitialize();
 
     // IPC::MessageSender.
     IPC::Connection* messageSenderConnection() const override;
@@ -138,6 +140,7 @@ private:
     void cacheFontWithQualifiedIdentifier(Ref<WebCore::Font>&&, QualifiedRenderingResourceIdentifier);
 
     void prepareLayerBuffersForDisplay(const PrepareBackingStoreBuffersInputData&, PrepareBackingStoreBuffersOutputData&);
+    IPC::StreamConnectionWorkQueue& workQueue() const { return m_workQueue; }
 
     Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     Ref<IPC::StreamServerConnection> m_streamConnection;
@@ -149,10 +152,7 @@ private:
 #if HAVE(IOSURFACE)
     Ref<WebCore::IOSurfacePool> m_ioSurfacePool;
 #endif
-
-    Lock m_remoteDisplayListsLock;
-    bool m_canRegisterRemoteDisplayLists WTF_GUARDED_BY_LOCK(m_remoteDisplayListsLock) { false };
-    HashMap<QualifiedRenderingResourceIdentifier, Ref<RemoteDisplayListRecorder>> m_remoteDisplayLists WTF_GUARDED_BY_CAPABILITY(m_remoteDisplayListsLock);
+    HashMap<QualifiedRenderingResourceIdentifier, Ref<RemoteDisplayListRecorder>> m_remoteDisplayLists WTF_GUARDED_BY_CAPABILITY(workQueue());
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp
@@ -85,7 +85,7 @@ void StreamConnectionWorkQueue::stopAndWaitForCompletion(WTF::Function<void()>&&
     {
         Locker locker { m_lock };
         m_cleanupFunction = WTFMove(cleanupFunction);
-        processingThread = WTFMove(m_processingThread);
+        processingThread = m_processingThread;
     }
     m_shouldQuit = true;
     if (!processingThread)
@@ -93,6 +93,10 @@ void StreamConnectionWorkQueue::stopAndWaitForCompletion(WTF::Function<void()>&&
     ASSERT(Thread::current().uid() != processingThread->uid());
     wakeUp();
     processingThread->waitForCompletion();
+    {
+        Locker locker { m_lock };
+        m_processingThread = nullptr;
+    }
 }
 
 void StreamConnectionWorkQueue::wakeUp()
@@ -160,4 +164,5 @@ void StreamConnectionWorkQueue::assertIsCurrent() const
     WTF::assertIsCurrent(*m_processingThread);
 }
 #endif
+
 }

--- a/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h
@@ -36,7 +36,7 @@
 
 namespace IPC {
 
-class WTF_CAPABILITY("is current") StreamConnectionWorkQueue final : public FunctionDispatcher, public ThreadSafeRefCounted<StreamConnectionWorkQueue> {
+class WTF_CAPABILITY("is current") StreamConnectionWorkQueue final : public SerialFunctionDispatcher, public ThreadSafeRefCounted<StreamConnectionWorkQueue> {
 public:
     static Ref<StreamConnectionWorkQueue> create(const char* name)
     {
@@ -47,19 +47,19 @@ public:
     ~StreamConnectionWorkQueue();
     void addStreamConnection(StreamServerConnection&);
     void removeStreamConnection(StreamServerConnection&);
-
-    void dispatch(WTF::Function<void()>&&) final;
     void stopAndWaitForCompletion(WTF::Function<void()>&& cleanupFunction = nullptr);
-
     void wakeUp();
-
     Semaphore& wakeUpSemaphore();
+
+    // SerialFunctionDispatcher
+    void dispatch(WTF::Function<void()>&&) final;
+#if ASSERT_ENABLED
+    void assertIsCurrent() const final;
+#endif
+
 private:
     void startProcessingThread() WTF_REQUIRES_LOCK(m_lock);
     void processStreams();
-#if ASSERT_ENABLED
-    void assertIsCurrent() const;
-#endif
 
     const char* const m_name;
 

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -31,34 +31,17 @@
 #include <mutex>
 #include <wtf/NeverDestroyed.h>
 namespace IPC {
-namespace {
-// FIXME(http://webkit.org/b/238986): Workaround for not being able to deliver messages from the dedicated connection to the work queue the client uses.
-class DedicatedConnectionClient final : public Connection::Client {
-    WTF_MAKE_FAST_ALLOCATED;
-    WTF_MAKE_NONCOPYABLE(DedicatedConnectionClient);
-public:
-    DedicatedConnectionClient() = default;
-    // Connection::Client.
-    void didReceiveMessage(Connection& connection, Decoder& decoder) final { ASSERT_NOT_REACHED(); }
-    bool didReceiveSyncMessage(Connection& connection, Decoder& decoder, UniqueRef<Encoder>& replyEncoder) final { ASSERT_NOT_REACHED(); return false; }
-    void didClose(Connection&) final { } // Client is expected to listen to Connection::didClose() from the connection it sent to the dedicated connection to.
-    void didReceiveInvalidMessage(Connection&, MessageName) final { ASSERT_NOT_REACHED(); } // The sender is expected to be trusted, so all invalid messages are programming errors.
-private:
-};
 
-}
-
-Ref<StreamServerConnection> StreamServerConnection::create(Handle&& handle, StreamConnectionWorkQueue& workQueue)
+Ref<StreamServerConnection> StreamServerConnection::create(Handle&& handle)
 {
     auto connection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTFMove(handle.outOfStreamConnection) });
     auto buffer = StreamConnectionBuffer::map(WTFMove(handle.buffer));
     RELEASE_ASSERT(buffer); // FIXME: make callers call this outside constructor.
-    return adoptRef(*new StreamServerConnection(WTFMove(connection), WTFMove(*buffer), workQueue));
+    return adoptRef(*new StreamServerConnection(WTFMove(connection), WTFMove(*buffer)));
 }
 
-StreamServerConnection::StreamServerConnection(Ref<Connection> connection, StreamConnectionBuffer&& stream, StreamConnectionWorkQueue& workQueue)
+StreamServerConnection::StreamServerConnection(Ref<Connection> connection, StreamConnectionBuffer&& stream)
     : m_connection(WTFMove(connection))
-    , m_workQueue(workQueue)
     , m_buffer(WTFMove(stream))
 {
 }
@@ -68,22 +51,23 @@ StreamServerConnection::~StreamServerConnection()
     ASSERT(!m_connection->isValid());
 }
 
-void StreamServerConnection::open()
+void StreamServerConnection::open(StreamConnectionWorkQueue& workQueue)
 {
-    static LazyNeverDestroyed<DedicatedConnectionClient> s_dedicatedConnectionClient;
-    static std::once_flag s_onceFlag;
-    std::call_once(s_onceFlag, [] {
-        s_dedicatedConnectionClient.construct();
-    });
+    m_workQueue = &workQueue;
     // FIXME(http://webkit.org/b/238986): Workaround for not being able to deliver messages from the dedicated connection to the work queue the client uses.
     m_connection->addMessageReceiveQueue(*this, { });
-    m_connection->open(s_dedicatedConnectionClient.get());
+    m_connection->open(*this, *m_workQueue);
 }
 
 void StreamServerConnection::invalidate()
 {
+    if (!m_workQueue)
+        return;
     m_connection->removeMessageReceiveQueue({ });
     m_connection->invalidate();
+    m_workQueue = nullptr;
+    Locker locker { m_outOfStreamMessagesLock };
+        if (m_outOfStreamMessages.isEmpty())
 }
 
 void StreamServerConnection::startReceivingMessages(StreamMessageReceiver& receiver, ReceiverName receiverName, uint64_t destinationID)
@@ -94,12 +78,14 @@ void StreamServerConnection::startReceivingMessages(StreamMessageReceiver& recei
         ASSERT(!m_receivers.contains(key));
         m_receivers.add(key, receiver);
     }
-    m_workQueue.addStreamConnection(*this);
+    ASSERT(m_workQueue); // FIXME: this will be moved to open().
+    m_workQueue->addStreamConnection(*this);
 }
 
 void StreamServerConnection::stopReceivingMessages(ReceiverName receiverName, uint64_t destinationID)
 {
-    m_workQueue.removeStreamConnection(*this);
+    ASSERT(m_workQueue); // FIXME: this will be moved to open().
+    m_workQueue->removeStreamConnection(*this);
 
     auto key = std::make_pair(static_cast<uint8_t>(receiverName), destinationID);
     Locker locker { m_receiversLock };
@@ -113,7 +99,31 @@ void StreamServerConnection::enqueueMessage(Connection&, std::unique_ptr<Decoder
         Locker locker { m_outOfStreamMessagesLock };
         m_outOfStreamMessages.append(WTFMove(message));
     }
-    m_workQueue.wakeUp();
+    ASSERT(m_workQueue);
+    m_workQueue->wakeUp();
+}
+
+void StreamServerConnection::didReceiveMessage(Connection&, Decoder&)
+{
+    // All messages go to message queue.
+    ASSERT_NOT_REACHED();
+}
+bool StreamServerConnection::didReceiveSyncMessage(Connection&, Decoder&, UniqueRef<Encoder>&)
+{
+    // All messages go to message queue.
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
+void StreamServerConnection::didClose(Connection&)
+{
+    // Client is expected to listen to didClose from the main connection.
+}
+
+void StreamServerConnection::didReceiveInvalidMessage(Connection&, MessageName)
+{
+    // The sender is expected to be trusted, so all invalid messages are programming errors.
+    ASSERT_NOT_REACHED();
 }
 
 std::optional<StreamServerConnection::Span> StreamServerConnection::tryAcquire()

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -51,7 +51,7 @@ class StreamConnectionWorkQueue;
 //   void didReceiveStreamMessage(StreamServerConnection&, Decoder&);
 //
 // The StreamServerConnection does not trust the StreamClientConnection.
-class StreamServerConnection final : public ThreadSafeRefCounted<StreamServerConnection>, private MessageReceiveQueue {
+class StreamServerConnection final : public ThreadSafeRefCounted<StreamServerConnection>, private MessageReceiveQueue, private Connection::Client {
     WTF_MAKE_NONCOPYABLE(StreamServerConnection);
 public:
     using AsyncReplyID = Connection::AsyncReplyID;
@@ -61,7 +61,7 @@ public:
         void encode(Encoder&) const;
         static std::optional<Handle> decode(Decoder&);
     };
-    static Ref<StreamServerConnection> create(Handle&&, StreamConnectionWorkQueue&);
+    static Ref<StreamServerConnection> create(Handle&&);
     ~StreamServerConnection() final;
 
     void startReceivingMessages(StreamMessageReceiver&, ReceiverName, uint64_t destinationID);
@@ -76,7 +76,7 @@ public:
     };
     DispatchResult dispatchStreamMessages(size_t messageLimit);
 
-    void open();
+    void open(StreamConnectionWorkQueue&);
     void invalidate();
     template<typename T, typename U> bool send(T&& message, ObjectIdentifier<U> destinationID);
 
@@ -89,10 +89,16 @@ public:
     Semaphore& clientWaitSemaphore() { return m_clientWaitSemaphore; }
 
 private:
-    StreamServerConnection(Ref<Connection>, StreamConnectionBuffer&&, StreamConnectionWorkQueue&);
+    StreamServerConnection(Ref<Connection>, StreamConnectionBuffer&&);
 
     // MessageReceiveQueue
     void enqueueMessage(Connection&, std::unique_ptr<Decoder>&&) final;
+
+    // Connection::Client
+    void didReceiveMessage(Connection&, Decoder&) final;
+    bool didReceiveSyncMessage(Connection&, Decoder&, UniqueRef<Encoder>&) final;
+    void didClose(Connection&) final;
+    void didReceiveInvalidMessage(Connection&, MessageName) final;
 
     struct Span {
         uint8_t* data;
@@ -122,7 +128,7 @@ private:
 
     Ref<IPC::Connection> m_connection;
     Semaphore m_clientWaitSemaphore;
-    StreamConnectionWorkQueue& m_workQueue;
+    RefPtr<StreamConnectionWorkQueue> m_workQueue;
 
     size_t m_serverOffset { 0 };
     StreamConnectionBuffer m_buffer;

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -49,7 +49,7 @@ RefPtr<IPCStreamTester> IPCStreamTester::create(IPCStreamTesterIdentifier identi
 
 IPCStreamTester::IPCStreamTester(IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle&& connectionHandle)
     : m_workQueue(IPC::StreamConnectionWorkQueue::create("IPCStreamTester work queue"))
-    , m_streamConnection(IPC::StreamServerConnection::create(WTFMove(connectionHandle), workQueue()))
+    , m_streamConnection(IPC::StreamServerConnection::create(WTFMove(connectionHandle)))
     , m_identifier(identifier)
 {
 }
@@ -58,17 +58,19 @@ IPCStreamTester::~IPCStreamTester() = default;
 
 void IPCStreamTester::initialize()
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::IPCStreamTester::messageReceiverName(), m_identifier.toUInt64());
-    m_streamConnection->open();
     workQueue().dispatch([this] {
+        m_streamConnection->open(workQueue());
+        m_streamConnection->startReceivingMessages(*this, Messages::IPCStreamTester::messageReceiverName(), m_identifier.toUInt64());
         m_streamConnection->send(Messages::IPCStreamTesterProxy::WasCreated(workQueue().wakeUpSemaphore(), m_streamConnection->clientWaitSemaphore()), m_identifier);
     });
 }
 
 void IPCStreamTester::stopListeningForIPC(Ref<IPCStreamTester>&& refFromConnection)
 {
-    m_streamConnection->invalidate();
-    m_streamConnection->stopReceivingMessages(Messages::IPCStreamTester::messageReceiverName(), m_identifier.toUInt64());
+    workQueue().dispatch([this] {
+        m_streamConnection->stopReceivingMessages(Messages::IPCStreamTester::messageReceiverName(), m_identifier.toUInt64());
+        m_streamConnection->invalidate();
+    });
     workQueue().stopAndWaitForCompletion();
 }
 

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -172,7 +172,7 @@ public:
     {
         WTF::initializeMainThread();
         auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(10000);
-        auto serverConnection = IPC::StreamServerConnection::create(WTFMove(serverConnectionHandle), *m_workQueue);
+        auto serverConnection = IPC::StreamServerConnection::create(WTFMove(serverConnectionHandle));
         m_clientConnection = WTFMove(clientConnection);
         m_serverConnection = WTFMove(serverConnection);
     }
@@ -203,7 +203,7 @@ protected:
 TEST_F(StreamConnectionTest, OpenConnections)
 {
     m_clientConnection->open(m_mockClientReceiver);
-    m_serverConnection->open();
+    m_serverConnection->open(*m_workQueue);
     m_serverConnection->invalidate();
     m_mockClientReceiver.waitUntilClosed();
     m_clientConnection->invalidate();
@@ -212,7 +212,7 @@ TEST_F(StreamConnectionTest, OpenConnections)
 TEST_F(StreamConnectionTest, SendMessage)
 {
     m_clientConnection->open(m_mockClientReceiver);
-    m_serverConnection->open();
+    m_serverConnection->open(*m_workQueue);
     RefPtr<MockStreamMessageReceiver> mockServerReceiver = adoptRef(new MockStreamMessageReceiver);
     m_serverConnection->startReceivingMessages(*mockServerReceiver, IPC::receiverName(MockStreamTestMessage1::name()), 77);
     for (uint64_t i = 0u; i < 55u; ++i)
@@ -237,7 +237,7 @@ TEST_F(StreamConnectionTest, SendMessage)
 TEST_F(StreamConnectionTest, SendAsyncReplyMessage)
 {
     m_clientConnection->open(m_mockClientReceiver);
-    m_serverConnection->open();
+    m_serverConnection->open(*m_workQueue);
     RefPtr<MockStreamMessageReceiver> mockServerReceiver = adoptRef(new MockStreamMessageReceiver);
     mockServerReceiver->setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
         using AsyncReplyID =IPC::StreamServerConnection::AsyncReplyID;
@@ -266,7 +266,7 @@ TEST_F(StreamConnectionTest, SendAsyncReplyMessage)
 TEST_F(StreamConnectionTest, SendAsyncReplyMessageCancel)
 {
     m_clientConnection->open(m_mockClientReceiver);
-    m_serverConnection->open();
+    m_serverConnection->open(*m_workQueue);
     RefPtr<MockStreamMessageReceiver> mockServerReceiver = adoptRef(new MockStreamMessageReceiver);
     mockServerReceiver->setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
         using AsyncReplyID =IPC::StreamServerConnection::AsyncReplyID;


### PR DESCRIPTION
#### 29f758c522aa369f8affcc0143572507eca5bfa4
<pre>
RemoteRenderingBackend, GPU and GraphicsContextGL are opening the stream connection in inconsistent manner
<a href="https://bugs.webkit.org/show_bug.cgi?id=249769">https://bugs.webkit.org/show_bug.cgi?id=249769</a>
rdar://103635894

Reviewed by NOBODY (OOPS!).

Aling IPC::StreamServerConnection with IPC::Connection and adjust the
callers:
 - open(dispatcher) is currently called in the dispatcher of the connection.
 - open(dispatcher) takes the dispatcher as the argument instead
   of passing it in the constructor
 - invalidate is currently called in the dispatcher of the connection.

Make StreamConnectionWorkQueue a SerialFunctionDispatcher. This way
it is the dispatcher that IPC::Connection is opened in.

Open the StreamServerConnection in the work queue. Currently other options
are not really thread-safe.

Start receiving the messages for a particular instances in the work queue.

Stop receiving the messagse for a particular instance in the work queue.

Invalidate the StreamServerConneciton in the work queue. Currently other
optionas are not really thread-safe.

The messages stop being processed after all receivers are removed and
invalidate() has been called.

For RemoteRenderingBackend, historically the problem was that
the teardown process above took place in main thread,
and the work queue could add more receivers (imagebuffers, displaylist
recorders) after the teardown. Now that the teardown is run in
the work queue, the stream processing is stopped and no other
task will be run after the shutdown task executes. This
means we can remove the lock and state controlling whether
new displaylist recorders could be added.

RemoteRenderingBackend will use dispatch(func)+stopAndWaitForCompletion()
instead of stopAndWaitForCompletion(func). The latter is not
thread-safe or consistent implementation and the func part will be
removed in the future. As explained above, calling the invalidate() in
the func is expected to guarantee that the func is the last invocation
of the work queue.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::RemoteGraphicsContextGL):
(WebKit::RemoteGraphicsContextGL::workQueueInitialize):
(WebKit::RemoteGraphicsContextGL::workQueueUninitialize):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::RemoteRenderingBackend):
(WebKit::RemoteRenderingBackend::startListeningForIPC):
(WebKit::RemoteRenderingBackend::stopListeningForIPC):
(WebKit::RemoteRenderingBackend::workQueueInitialize):
(WebKit::RemoteRenderingBackend::workQueueUninitialize):
(WebKit::RemoteRenderingBackend::didCreateImageBufferBackend):
(WebKit::RemoteRenderingBackend::releaseResourceWithQualifiedIdentifier):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
(WebKit::RemoteRenderingBackend::workQueue const):
(WebKit::RemoteRenderingBackend::WTF_GUARDED_BY_LOCK): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::RemoteGPU):
(WebKit::RemoteGPU::initialize):
(WebKit::RemoteGPU::stopListeningForIPC):
(WebKit::RemoteGPU::workQueueInitialize):
(WebKit::RemoteGPU::workQueueUninitialize):
* Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp:
(IPC::StreamConnectionWorkQueue::stopAndWaitForCompletion):
Avoid moving the thread away from the queue during stop.
Otherwise the tasks running before stop is done cannot
assert that the work queue is current.

* Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::create):
(IPC::StreamServerConnection::StreamServerConnection):
(IPC::StreamServerConnection::open):
(IPC::StreamServerConnection::invalidate):
(IPC::StreamServerConnection::startReceivingMessages):
(IPC::StreamServerConnection::stopReceivingMessages):
(IPC::StreamServerConnection::enqueueMessage):
(IPC::StreamServerConnection::didReceiveMessage):
(IPC::StreamServerConnection::didReceiveSyncMessage):
(IPC::StreamServerConnection::didClose):
(IPC::StreamServerConnection::didReceiveInvalidMessage):
(): Deleted.
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::IPCStreamTester):
(WebKit::IPCStreamTester::initialize):
(WebKit::IPCStreamTester::stopListeningForIPC):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::TEST_F):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29f758c522aa369f8affcc0143572507eca5bfa4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101335 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10494 "Hash 29f758c5 for PR 8002 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34394 "Hash 29f758c5 for PR 8002 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110608 "Hash 29f758c5 for PR 8002 does not build (failure)") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170880 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105316 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11440 "Hash 29f758c5 for PR 8002 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1346 "Hash 29f758c5 for PR 8002 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93732 "Hash 29f758c5 for PR 8002 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108435 "Hash 29f758c5 for PR 8002 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107118 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/11440 "Hash 29f758c5 for PR 8002 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/34394 "Hash 29f758c5 for PR 8002 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/93732 "Hash 29f758c5 for PR 8002 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/11440 "Hash 29f758c5 for PR 8002 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/34394 "Hash 29f758c5 for PR 8002 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/93732 "Hash 29f758c5 for PR 8002 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4113 "Hash 29f758c5 for PR 8002 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/34394 "Hash 29f758c5 for PR 8002 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4164 "Hash 29f758c5 for PR 8002 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/1346 "Hash 29f758c5 for PR 8002 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10261 "Hash 29f758c5 for PR 8002 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/34394 "Hash 29f758c5 for PR 8002 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5926 "Hash 29f758c5 for PR 8002 does not build (failure)") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->