### PR TITLE
[@property] Whitespaces around initial-value should be trimmed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt
@@ -10,5 +10,5 @@ PASS Transitioning from initial value
 PASS Transitioning from specified value
 FAIL Transition triggered by initial value change assert_equals: expected "150px" but got "200px"
 PASS No transition when changing types
-FAIL No transition when removing @property rule assert_equals: expected " 100px" but got "100px"
+PASS No transition when removing @property rule
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation.html
@@ -258,7 +258,7 @@ test_with_at_property({
 test(() => {
   let name = generate_name();
   with_style_node(`div { ${name}: 100px; transition: ${name} steps(2, start) 100s; }`, () => {
-    assert_equals(getComputedStyle(div).getPropertyValue(name), ' 100px');
+    assert_equals(getComputedStyle(div).getPropertyValue(name), '100px');
 
     let style1 = document.createElement('style');
     style1.textContent = `
@@ -287,7 +287,7 @@ test(() => {
       // (making the computed value a token sequence again). We should snap
       // to the new token sequence.
       style1.remove();
-      assert_equals(getComputedStyle(div).getPropertyValue(name), ' 400px');
+      assert_equals(getComputedStyle(div).getPropertyValue(name), '400px');
     } finally {
       style1.remove();
       style2.remove();

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom.html
@@ -180,18 +180,18 @@ test_inherits('--initial-value-only', false);
 
 // CSSPropertyRule.initialValue
 
-test_initial_value('--valid', ' red');
-test_initial_value('--valid-reverse', ' 0px');
+test_initial_value('--valid', 'red');
+test_initial_value('--valid-reverse', '0px');
 test_initial_value('--valid-universal', null);
-test_initial_value('--valid-whitespace', ' red, blue');
-test_initial_value('--vALId', ' red');
+test_initial_value('--valid-whitespace', 'red, blue');
+test_initial_value('--vALId', 'red');
 
 test_initial_value('--no-descriptors', null);
-test_initial_value('--no-syntax', ' red');
-test_initial_value('--no-inherits', ' red');
+test_initial_value('--no-syntax', 'red');
+test_initial_value('--no-inherits', 'red');
 test_initial_value('--no-initial-value', null);
 test_initial_value('--syntax-only', null);
 test_initial_value('--inherits-only', null);
-test_initial_value('--initial-value-only', ' red');
+test_initial_value('--initial-value-only', 'red');
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-shadow-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL @property rules in shadow trees should have no effect assert_equals: expected " calc(1px + 1px)" but got "2px"
+FAIL @property rules in shadow trees should have no effect assert_equals: expected "calc(1px + 1px)" but got "2px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-shadow.html
@@ -38,9 +38,9 @@ test(() => {
   root.append(template.content.cloneNode(true));
   let inside = root.querySelector('#inside');
   assert_equals(getComputedStyle(outside).getPropertyValue('--x'), '2px');
-  assert_equals(getComputedStyle(outside).getPropertyValue('--y'), ' calc(1px + 1px)');
+  assert_equals(getComputedStyle(outside).getPropertyValue('--y'), 'calc(1px + 1px)');
   assert_equals(getComputedStyle(inside).getPropertyValue('--x'), '2px');
-  assert_equals(getComputedStyle(inside).getPropertyValue('--y'), ' calc(1px + 1px)');
+  assert_equals(getComputedStyle(inside).getPropertyValue('--y'), 'calc(1px + 1px)');
 }, '@property rules in shadow trees should have no effect');
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/determine-registration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/determine-registration-expected.txt
@@ -5,8 +5,8 @@ PASS @property later in document order wins
 PASS @property later in stylesheet wins
 PASS CSS.registerProperty determines the registration when uncontested
 PASS @property registrations are cleared when rule removed
-FAIL Computed value becomes token sequence when @property is removed assert_equals: expected " calc(1px + 1px)" but got "calc(1px + 1px)"
-FAIL Inherited status is reflected in computed styles when @property is removed assert_equals: expected " 10px" but got "10px"
+PASS Computed value becomes token sequence when @property is removed
+FAIL Inherited status is reflected in computed styles when @property is removed assert_equals: expected "0px" but got "10px"
 PASS Invalid @property rule (missing syntax) does not overwrite previous valid rule
 PASS Invalid @property rule (missing inherits descriptor) does not overwrite previous valid rule
 PASS Invalid @property rule (missing initial-value) does not overwrite previous valid rule

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/determine-registration.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/determine-registration.html
@@ -101,7 +101,7 @@ test(() => {
 
   with_style_node(`div { ${name}: calc(1px + 1px); }`, () => {
     // ${name} should be a token sequence at this point.
-    assert_equals(getComputedStyle(div).getPropertyValue(name), ' calc(1px + 1px)');
+    assert_equals(getComputedStyle(div).getPropertyValue(name), 'calc(1px + 1px)');
 
     with_at_property({
       name: name,
@@ -114,7 +114,7 @@ test(() => {
     });
 
     // ${name} should be a token sequence again.
-    assert_equals(getComputedStyle(div).getPropertyValue(name), ' calc(1px + 1px)');
+    assert_equals(getComputedStyle(div).getPropertyValue(name), 'calc(1px + 1px)');
   });
 }, 'Computed value becomes token sequence when @property is removed');
 
@@ -122,7 +122,7 @@ test(() => {
   let name = generate_name();
 
   with_style_node(`#outer { ${name}: 10px; }`, () => {
-    assert_equals(getComputedStyle(div).getPropertyValue(name), ' 10px');
+    assert_equals(getComputedStyle(div).getPropertyValue(name), '10px');
 
     with_at_property({
       name: name,
@@ -134,7 +134,7 @@ test(() => {
       assert_equals(getComputedStyle(div).getPropertyValue(name), '0px');
     });
 
-    assert_equals(getComputedStyle(div).getPropertyValue(name), ' 10px');
+    assert_equals(getComputedStyle(div).getPropertyValue(name), '10px');
   });
 }, 'Inherited status is reflected in computed styles when @property is removed');
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-cssom-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL CSSOM setters function as expected for unregistered properties assert_equals: expected " 10px" but got "10px"
+PASS CSSOM setters function as expected for unregistered properties
 PASS CSS.registerProperty
-FAIL Formerly valid values are still readable from inline styles but are computed as the unset value assert_equals: expected "5" but got ""
+PASS Formerly valid values are still readable from inline styles but are computed as the unset value
 PASS Values not matching the registered type can still be set
 PASS Values can be removed from inline styles
 PASS Stylesheets can be modified by CSSOM

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-cssom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-cssom.html
@@ -25,8 +25,8 @@ var sheetStyle = document.styleSheets[0].cssRules[0].style;
 
 test(function() {
   // Nothing registered yet, whatever you specify works
-  assert_equals(computedStyle.getPropertyValue('--length'), ' 10px');
-  assert_equals(computedStyle.getPropertyValue('--color'), ' red');
+  assert_equals(computedStyle.getPropertyValue('--length'), '10px');
+  assert_equals(computedStyle.getPropertyValue('--color'), 'red');
 
   inlineStyle.setProperty('--length', '5');
   inlineStyle.setProperty('--color', 'hello');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL var() references work with registered properties assert_equals: expected " 20px" but got "20px"
+PASS var() references work with registered properties
 PASS References to registered var()-properties work in registered lists
 PASS References to mixed registered and unregistered var()-properties work in registered lists
 PASS Registered lists may be concatenated

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties.html
@@ -54,9 +54,9 @@ test(function() {
     assert_equals(computedStyle.getPropertyValue('--registered-length-5'), '70px');
     assert_equals(computedStyle.getPropertyValue('--registered-length-6'), '80px');
     assert_equals(computedStyle.getPropertyValue('--registered-length-7'), '123px');
-    assert_equals(computedStyle.getPropertyValue('--length-1'), ' 20px');
-    assert_equals(computedStyle.getPropertyValue('--length-2'), ' 10px');
-    assert_equals(computedStyle.getPropertyValue('--length-3'), ' calc(123px + 123px)');
+    assert_equals(computedStyle.getPropertyValue('--length-1'), '20px');
+    assert_equals(computedStyle.getPropertyValue('--length-2'), '10px');
+    assert_equals(computedStyle.getPropertyValue('--length-3'), 'calc(123px + 123px)');
     assert_equals(computedStyle.getPropertyValue('--registered-length-invalid'), '15px');
 
     assert_equals(computedStyle.getPropertyValue('--registered-token-stream-1'), '');

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -88,7 +88,6 @@ public:
     static bool isInLogicalPropertyGroup(CSSPropertyID);
     static bool areInSameLogicalPropertyGroupWithDifferentMappingLogic(CSSPropertyID, CSSPropertyID);
     static bool isDescriptorOnly(CSSPropertyID);
-    static bool shouldPreserveWhitespace(CSSPropertyID);
     static bool isColorProperty(CSSPropertyID);
     static UChar listValuedPropertySeparator(CSSPropertyID);
     static bool isListValuedProperty(CSSPropertyID propertyID) { return !!listValuedPropertySeparator(propertyID); }

--- a/Source/WebCore/css/CSSPropertyRule.cpp
+++ b/Source/WebCore/css/CSSPropertyRule.cpp
@@ -90,7 +90,7 @@ String CSSPropertyRule::cssText() const
         builder.append("inherits: ", *descriptor.inherits ? "true" : "false", "; ");
 
     if (descriptor.initialValue)
-        builder.append("initial-value:", initialValue(), "; ");
+        builder.append("initial-value: ", initialValue(), "; ");
 
     builder.append("}");
 

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -1164,12 +1164,11 @@ void CSSParserImpl::consumeDeclaration(CSSParserTokenRange range, StyleRuleType 
     if (range.consume().type() != ColonToken)
         return; // Parse error
 
-    if (!CSSProperty::shouldPreserveWhitespace(propertyID))
-        range.consumeWhitespace();
+    range.consumeWhitespace();
 
     auto declarationValueEnd = range.end();
     bool important = false;
-    if (!range.atEnd() && !CSSProperty::isDescriptorOnly(propertyID)) {
+    if (!range.atEnd()) {
         auto end = range.end();
         removeTrailingWhitespace(range, end);
         declarationValueEnd = end;

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -206,9 +206,7 @@ bool CSSPropertyParser::parseValue(CSSPropertyID propertyID, bool important, con
 {
     int parsedPropertiesSize = parsedProperties.size();
     
-    auto consumeWhitespace = !CSSProperty::shouldPreserveWhitespace(propertyID);
-
-    CSSPropertyParser parser(range, context, &parsedProperties, consumeWhitespace);
+    CSSPropertyParser parser(range, context, &parsedProperties);
 
     bool parseSuccess;
     if (ruleType == StyleRuleType::FontFace)

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -1320,10 +1320,6 @@ class PropertiesAndDescriptors:
     def all_descriptor_only(self):
         return (descriptor for descriptor in self.all_descriptors if descriptor.name not in self.style.all_by_name)
 
-    @property
-    def all_preserving_whitespace(self):
-        return (property for property in self.all_unique if property.codegen_properties.parser_grammar and property.codegen_properties.parser_grammar.preserve_whitespace)
-
     # Returns the set of settings-flags used by any property or descriptor. Uniqued and sorted lexically.
     @property
     def settings_flags(self):
@@ -1919,12 +1915,6 @@ class Grammar:
 
     def perform_fixups_for_values_references(self, values):
         self.root_term = self.root_term.perform_fixups_for_values_references(values)
-
-    @property
-    def preserve_whitespace(self):
-        if isinstance(self.root_term, ReferenceTerm) and isinstance(self.root_term.builtin, BuiltinDeclarationValueConsumer):
-            return True
-        return False
 
     @property
     def has_fast_path_keyword_terms(self):
@@ -2688,12 +2678,6 @@ class GenerateCSSPropertyNames:
                 to=writer,
                 signature="bool CSSProperty::isDescriptorOnly(CSSPropertyID id)",
                 iterable=self.properties_and_descriptors.all_descriptor_only
-            )
-
-            self.generation_context.generate_property_id_switch_function_bool(
-                to=writer,
-                signature="bool CSSProperty::shouldPreserveWhitespace(CSSPropertyID id)",
-                iterable=self.properties_and_descriptors.all_preserving_whitespace
             )
 
             self._generate_css_property_settings_constructor(


### PR DESCRIPTION
#### 4f0ccda887910822ac9532cc9c50f9953be91d89
<pre>
[@property] Whitespaces around initial-value should be trimmed
<a href="https://bugs.webkit.org/show_bug.cgi?id=249770">https://bugs.webkit.org/show_bug.cgi?id=249770</a>
&lt;rdar://problem/103636334&gt;

Reviewed by Tim Nguyen.

Partially revert <a href="https://commits.webkit.org/258215@main.">https://commits.webkit.org/258215@main.</a> It turns out that WebKit whitespace handling for custom properties
(where whitespace is always trimmed) is correct per <a href="https://drafts.csswg.org/css-syntax-3/#consume-declaration">https://drafts.csswg.org/css-syntax-3/#consume-declaration</a> and this applies to
the `initial-value` property too.

This is tested by imported/w3c/web-platform-tests/css/css-syntax/declarations-trim-whitespace.html which we pass and other engines fail.

Update the @property tests to the spec.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-animation.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-cssom.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-shadow.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/determine-registration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/determine-registration.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-cssom.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/var-reference-registered-properties.html:
* Source/WebCore/css/CSSPropertyRule.cpp:
(WebCore::CSSPropertyRule::cssText const):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeDeclaration):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseValue):
* Source/WebCore/css/process-css-properties.py:
(PropertiesAndDescriptors.all_descriptor_only):
(Grammar.perform_fixups_for_values_references):
(GenerateCSSPropertyNames):
(PropertiesAndDescriptors.all_preserving_whitespace): Deleted.
(Grammar.preserve_whitespace): Deleted.

Canonical link: <a href="https://commits.webkit.org/258245@main">https://commits.webkit.org/258245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/caec735e772e0666b2465be45aed07c5e00709c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110615 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170887 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1353 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93738 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108442 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35229 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23346 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4119 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1281 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10268 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44343 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5673 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5932 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->