### PR TITLE
[GStreamer] ImageDecoder fixes

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
@@ -228,6 +228,16 @@ const ImageDecoderGStreamerSample* ImageDecoderGStreamer::sampleAtIndex(size_t i
     return toSample(iter);
 }
 
+ImageDecoderGStreamer::InnerDecoder::~InnerDecoder()
+{
+    GST_DEBUG_OBJECT(m_pipeline.get(), "Destructing decoder");
+    g_signal_handlers_disconnect_by_func(m_decodebin.get(), reinterpret_cast<gpointer>(decodebinPadAddedCallback), this);
+    auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
+    gst_bus_set_sync_handler(bus.get(), nullptr, nullptr, nullptr);
+    disconnectSimpleBusMessageCallback(m_pipeline.get());
+    gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
+}
+
 void ImageDecoderGStreamer::InnerDecoder::decodebinPadAddedCallback(ImageDecoderGStreamer::InnerDecoder* decoder, GstPad* pad)
 {
     decoder->connectDecoderPad(pad);

--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.h
@@ -96,11 +96,7 @@ private:
             m_memoryStream = adoptGRef(g_memory_input_stream_new_from_data(data, size, nullptr));
         }
 
-        ~InnerDecoder()
-        {
-            disconnectSimpleBusMessageCallback(m_pipeline.get());
-            gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
-        }
+        ~InnerDecoder();
 
         void run();
         EncodedDataStatus encodedDataStatus() const;


### PR DESCRIPTION
#### f28f93033a2c0fd176cd5a5ba6929fd5631760e7
<pre>
[GStreamer] ImageDecoder fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=249775">https://bugs.webkit.org/show_bug.cgi?id=249775</a>

Reviewed by Xabier Rodriguez-Calvar.

Before tearing down the decoder pipeline it is good practice to disconnect all message bus handlers
and also the decodebin pad-added signal handler.

* Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp:
(WebCore::ImageDecoderGStreamer::InnerDecoder::~InnerDecoder):
* Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/258293@main">https://commits.webkit.org/258293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bea76011f1f3d674f00a0842bedc15359b8c257

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110617 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170889 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1355 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93740 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108444 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35230 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78228 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4121 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24860 "Found 1 new test failure: media/video-playback-quality.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1284 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44345 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5702 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5934 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->