### PR TITLE
REGRESSION (256812@main): [macOS] ASSERTION FAILED: m_element in WebKit::WebFullScreenManager::setAnimatingFullScreen()

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ExitFullscreenOnEnterPiP.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ExitFullscreenOnEnterPiP.mm
@@ -66,7 +66,12 @@ static bool didExitFullscreen;
 
 namespace TestWebKitAPI {
 
+// FIXME: Re-enable this test once webkit.org/b/248093 is resolved.
+#if !defined(NDEBUG)
+TEST(ExitFullscreenOnEnterPiP, DISABLED_VideoFullscreen)
+#else
 TEST(ExitFullscreenOnEnterPiP, VideoFullscreen)
+#endif
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration preferences]._fullScreenEnabled = YES;
@@ -96,7 +101,8 @@ TEST(ExitFullscreenOnEnterPiP, VideoFullscreen)
 }
 
 // FIXME: Re-enable this test for Big Sur once webkit.org/b/245241 is resolved
-#if (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED < 120000)
+// FIXME: Re-enable this test once webkit.org/b/248093 is resolved.
+#if (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED < 120000) || !defined(NDEBUG)
 TEST(ExitFullscreenOnEnterPiP, DISABLED_ElementFullscreen)
 #else
 TEST(ExitFullscreenOnEnterPiP, ElementFullscreen)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
@@ -269,7 +269,8 @@ TEST(FullscreenVideoTextRecognition, AddVideoAfterEnteringFullscreen)
 }
 
 // FIXME: Re-enable this test for iOS once webkit.org/b/248094 is resolved
-#if PLATFORM(IOS)
+// FIXME: Re-enable this test once webkit.org/b/248093 is resolved.
+#if PLATFORM(IOS) || !defined(NDEBUG)
 TEST(FullscreenVideoTextRecognition, DISABLED_DoNotAnalyzeVideoAfterExitingFullscreen)
 #else
 TEST(FullscreenVideoTextRecognition, DoNotAnalyzeVideoAfterExitingFullscreen)

--- a/Tools/TestWebKitAPI/Tests/mac/FullscreenFocus.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FullscreenFocus.mm
@@ -55,7 +55,12 @@ static bool didExitFullscreen;
 
 namespace TestWebKitAPI {
 
+// FIXME: Re-enable this test once webkit.org/b/248093 is resolved.
+#if !defined(NDEBUG)
+TEST(Fullscreen, DISABLED_Focus)
+#else
 TEST(Fullscreen, Focus)
+#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration preferences]._fullScreenEnabled = YES;


### PR DESCRIPTION
#### b395978636569fd60db66a10953190802b1b79fa
<pre>
REGRESSION (256812@main): [macOS] ASSERTION FAILED: m_element in WebKit::WebFullScreenManager::setAnimatingFullScreen()
<a href="https://bugs.webkit.org/show_bug.cgi?id=248093">https://bugs.webkit.org/show_bug.cgi?id=248093</a>
rdar://102522154

Unreviewed test gardening.

Disable the tests in the debug configuration.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ExitFullscreenOnEnterPiP.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm:
* Tools/TestWebKitAPI/Tests/mac/FullscreenFocus.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/258258@main">https://commits.webkit.org/258258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/566df1585b390a7f78c693698108cb00c6920521

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101386 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/10544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/34444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/110658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11494 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/1397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/108486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107168 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/34444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/93782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/34444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/93782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/4158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/34444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/4212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/1397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/10308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/34444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/5975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2977 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->