### PR TITLE
[CSS-Typed-OM] Cannot set `z-index` property to -3.14

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt
@@ -9,7 +9,7 @@ PASS Can set 'background-size' to a length: -3.14em
 PASS Can set 'background-size' to a length: 3.14cm
 PASS Can set 'background-size' to a length: calc(0px + 0em)
 PASS Can set 'background-size' to a percent: 0%
-FAIL Can set 'background-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'background-size' to a percent: -3.14%
 PASS Can set 'background-size' to a percent: 3.14%
 PASS Can set 'background-size' to a percent: calc(0% + 0%)
 PASS Can set 'background-size' to the 'auto' keyword: auto

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt
@@ -9,7 +9,7 @@ PASS Can set 'font-weight' to the 'bold' keyword: bold
 PASS Can set 'font-weight' to the 'bolder' keyword: bolder
 PASS Can set 'font-weight' to the 'lighter' keyword: lighter
 PASS Can set 'font-weight' to a number: 0
-FAIL Can set 'font-weight' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+FAIL Can set 'font-weight' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got -3
 FAIL Can set 'font-weight' to a number: 3.14 assert_approx_equals: expected 3.14 +/- 0.000001 but got 3
 PASS Can set 'font-weight' to a number: calc(2 + 3)
 PASS Setting 'font-weight' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'order' to CSS-wide keywords: unset
 PASS Can set 'order' to CSS-wide keywords: revert
 PASS Can set 'order' to var() references:  var(--A)
 PASS Can set 'order' to a number: 0
-FAIL Can set 'order' to a number: -3.14 assert_approx_equals: expected -3 +/- 0.000001 but got 0
+PASS Can set 'order' to a number: -3.14
 PASS Can set 'order' to a number: 3.14
 PASS Can set 'order' to a number: calc(2 + 3)
 PASS Setting 'order' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt
@@ -6,7 +6,7 @@ PASS Can set 'z-index' to CSS-wide keywords: revert
 PASS Can set 'z-index' to var() references:  var(--A)
 PASS Can set 'z-index' to the 'auto' keyword: auto
 PASS Can set 'z-index' to a number: 0
-FAIL Can set 'z-index' to a number: -3.14 assert_approx_equals: expected -3 +/- 0.000001 but got 0
+PASS Can set 'z-index' to a number: -3.14
 PASS Can set 'z-index' to a number: 3.14
 PASS Can set 'z-index' to a number: calc(2 + 3)
 PASS Setting 'z-index' to a length: 0px throws TypeError

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -340,7 +340,8 @@ void CSSToStyleMap::mapAnimationDuration(Animation& animation, const CSSValue& v
     if (!is<CSSPrimitiveValue>(value))
         return;
 
-    animation.setDuration(downcast<CSSPrimitiveValue>(value).computeTime<double, CSSPrimitiveValue::Seconds>());
+    auto duration = std::max<double>(downcast<CSSPrimitiveValue>(value).computeTime<double, CSSPrimitiveValue::Seconds>(), 0);
+    animation.setDuration(duration);
 }
 
 void CSSToStyleMap::mapAnimationFillMode(Animation& layer, const CSSValue& value)

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -48,12 +48,14 @@ enum class CSSUnitType : uint8_t;
 enum class CalculationCategory : uint8_t;
 enum class ValueRange : uint8_t;
 
+enum class ShouldClampToNonNegative : bool { No, Yes };
+
 class CSSCalcValue final : public CSSValue {
 public:
     static RefPtr<CSSCalcValue> create(CSSValueID function, const CSSParserTokenRange&, CalculationCategory destinationCategory, ValueRange, const CSSCalcSymbolTable&, bool allowsNegativePercentage = false);
     static RefPtr<CSSCalcValue> create(CSSValueID function, const CSSParserTokenRange&, CalculationCategory destinationCategory, ValueRange);
     static RefPtr<CSSCalcValue> create(const CalculationValue&, const RenderStyle&);
-    static RefPtr<CSSCalcValue> create(Ref<CSSCalcExpressionNode>&&, bool allowsNegativePercentage = false);
+    static RefPtr<CSSCalcValue> create(Ref<CSSCalcExpressionNode>&&, ShouldClampToNonNegative = ShouldClampToNonNegative::No);
     ~CSSCalcValue();
 
     CalculationCategory category() const;
@@ -79,7 +81,7 @@ public:
     const CSSCalcExpressionNode& expressionNode() const { return m_expression; }
 
 private:
-    CSSCalcValue(Ref<CSSCalcExpressionNode>&&, bool shouldClampToNonNegative);
+    CSSCalcValue(Ref<CSSCalcExpressionNode>&&, ShouldClampToNonNegative);
 
     double clampToPermittedRange(double) const;
 

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -271,7 +271,7 @@ RefPtr<CSSValue> CSSUnitValue::toCSSValueWithProperty(CSSPropertyID propertyID) 
         auto sumNode = CSSCalcOperationNode::createSum(Vector { node.releaseNonNull() });
         if (!sumNode)
             return nullptr;
-        return CSSPrimitiveValue::create(CSSCalcValue::create(sumNode.releaseNonNull(), true /* allowsNegativePercentage */));
+        return CSSPrimitiveValue::create(CSSCalcValue::create(sumNode.releaseNonNull()));
     }
     return toCSSValue();
 }


### PR DESCRIPTION
#### c4ae09ba56fd393845a4b84a186a292c52f8f440
<pre>
[CSS-Typed-OM] Cannot set `z-index` property to -3.14
<a href="https://bugs.webkit.org/show_bug.cgi?id=249788">https://bugs.webkit.org/show_bug.cgi?id=249788</a>

Reviewed by Antti Koivisto.

We couldn&apos;t set the `z-index` property to -3.14 using the CSS Typed OM API. We
would expect -3 as computed value, however, WebKit was returning 0.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-weight-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/order-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/z-index-expected.txt:
Rebaseline WPT tests now that more checks are passing.

* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapAnimationDuration):
Make sure we clamp the duration to [0, inf] to avoid hitting an assertion later
on. We can end up with a negative duration when using calc().

* Source/WebCore/css/calc/CSSCalcValue.h:
Fix confusingly named parameter. It did the exact opposite of that it claimed.

* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::CSSUnitValue::toCSSValueWithProperty const):
When we wrap the out of range value in a calc(), make sure we allow negative
values, like we were trying to do (but the parameter&apos;s name didn&apos;t match the
actual behavior).

Canonical link: <a href="https://commits.webkit.org/258265@main">https://commits.webkit.org/258265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ae22d1d61a06064e8bd63a4d9bebbc9eec235cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110646 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170917 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1385 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93769 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108475 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35255 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23372 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78252 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4148 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24884 "Found 1 new test failure: media/video-playback-quality.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1309 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44370 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5962 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2980 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->