### PR TITLE
Fix behavior of nested click event on label element with checkbox

### DIFF
--- a/LayoutTests/fast/forms/checkbox-nested-click-event-on-label-expected.txt
+++ b/LayoutTests/fast/forms/checkbox-nested-click-event-on-label-expected.txt
@@ -1,0 +1,11 @@
+checkbox1 checkbox2
+Tests nested click event on label element with checkbox
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.getElementById('ch2').checked is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/checkbox-nested-click-event-on-label.html
+++ b/LayoutTests/fast/forms/checkbox-nested-click-event-on-label.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<input type="checkbox" name="ch1" id="ch1" value="1" /><label id="for_ch1" for="ch1">checkbox1</label>
+<input type="checkbox" name="ch2" id="ch2" value="2" /><label id="for_ch2" for="ch2">checkbox2</label>
+<p id="description"></p>
+<div id="console"></div>
+<script src="../../resources/js-test.js"></script>
+<script>
+    description('Tests nested click event on label element with checkbox');
+    document.getElementById('ch1').addEventListener('click', function() {
+        document.getElementById('for_ch2').click();
+    }, false);
+    document.getElementById('for_ch1').click();
+    shouldBeTrue("document.getElementById('ch2').checked");
+</script>

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -2,8 +2,9 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -34,6 +35,7 @@
 #include "HTMLNames.h"
 #include "SelectionRestorationMode.h"
 #include <wtf/IsoMallocInlines.h>
+#include <wtf/SetForScope.h>
 
 namespace WebCore {
 
@@ -130,9 +132,7 @@ bool HTMLLabelElement::isEventTargetedAtInteractiveDescendants(Event& event) con
 }
 void HTMLLabelElement::defaultEventHandler(Event& event)
 {
-    static bool processingClick = false;
-
-    if (event.type() == eventNames().clickEvent && !processingClick) {
+    if (event.type() == eventNames().clickEvent && !m_processingClick) {
         auto control = this->control();
 
         // If we can't find a control or if the control received the click
@@ -151,15 +151,13 @@ void HTMLLabelElement::defaultEventHandler(Event& event)
             return;
         }
 
-        processingClick = true;
+        SetForScope processingClick(m_processingClick, true);
 
         control->dispatchSimulatedClick(&event);
 
         document().updateLayoutIgnorePendingStylesheets();
         if (control->isMouseFocusable())
             control->focus({ { }, { }, { }, FocusTrigger::Click, { } });
-
-        processingClick = false;
 
         event.setDefaultHandled();
     }

--- a/Source/WebCore/html/HTMLLabelElement.h
+++ b/Source/WebCore/html/HTMLLabelElement.h
@@ -2,7 +2,8 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -57,6 +58,8 @@ private:
     void focus(const FocusOptions&) final;
 
     bool isInteractiveContent() const final { return true; }
+
+    bool m_processingClick { false };
 };
 
 } //namespace


### PR DESCRIPTION
#### 4ee89ea3f12cb36cc05e36f80c77c73553e62d28
<pre>
Fix behavior of nested click event on label element with checkbox

Fix behavior of nested click event on label element with checkbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=249789">https://bugs.webkit.org/show_bug.cgi?id=249789</a>

Reviewed by Ryosuke Niwa.

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=183243

This patch removes static variable in HTMLLabelElement::defaultEventHandler, which interferes with handling of nested event on another label element. This is to promote this variable to class variable in the header so this interference can be avoided.

* Source/WebCore/html/HTMLLabelElement.cpp:
(HTMLLabelElement::defaultEventHandler): removed static variable and rename usage with SetForScope
* Source/WebCore/html/HTMLLabelElement.h: Add bool &apos;m_processingClick&apos; with false
* LayoutTests/fast/form/checkbox-nested-click-event-on-label.html: Add Test Case
* LayoutTests/fast/form/checkbox-nested-click-event-on-label-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/258287@main">https://commits.webkit.org/258287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b86c523ff71606b3654c642526d35766c098edf7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110705 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170963 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1446 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93823 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108522 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92019 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35302 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23427 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4195 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24938 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4257 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1365 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44426 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5700 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6020 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->