### PR TITLE
[WPE] Temporarily disable ENBALE_COG by default

### DIFF
--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -123,7 +123,9 @@ if (ENABLE_DEVELOPER_MODE)
     WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_API_TESTS PRIVATE ON)
     WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_LAYOUT_TESTS PRIVATE ON)
     WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_MINIBROWSER PUBLIC ON)
-    WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_COG PRIVATE ON)
+    # FIXME: this is temporarily off to make it easier to land API changes.
+    # Turn this back to ON around time of 2.39.90 release.
+    WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_COG PRIVATE OFF)
 endif ()
 
 # Enable variation fonts when cairo >= 1.16, fontconfig >= 2.13.0, freetype >= 2.9.0 and harfbuzz >= 1.4.2.


### PR DESCRIPTION
#### 14ab13ec3b93c2dbc37d3098ca641d41950463dd
<pre>
[WPE] Temporarily disable ENBALE_COG by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=249791">https://bugs.webkit.org/show_bug.cgi?id=249791</a>

Reviewed by NOBODY (OOPS!).

It&apos;s time to start making breaking changes for the WPE 2.0 API version,
but we cannot actually do this currently because our ENABLE_COG option
depends on an external checkout of cog that already depends on WPE 2.0.
Removing API that cog uses results in WPE port build failure. But we
also cannot plausibly change cog to use new APIs that do not yet exist
in WebKit because we cannot commit them because we have not yet updated
cog. Aaah, it&apos;s circular!

I see two workable options:

 1. WebKit must depend on side branches of cog, where cog is modified to
    account for WebKit API changes that have not yet landed in WebKit.
 2. Simply turn off ENABLE_COG for now, and reenable right before
    releasing 2.39.90, when the API stabilizes.

My preference is option 2 because that would be easier for WebKit
development, although it risks that we forget to keep cog in good shape.
We&apos;ll want to remember to turn cog on again in February when the API is
frozen.

* Source/cmake/OptionsWPE.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14ab13ec3b93c2dbc37d3098ca641d41950463dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110632 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1370 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93771 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108461 "Hash 14ab13ec for PR 8011 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35256 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78253 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91798 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4135 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24874 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87930 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1704 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1298 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29304 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44358 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90828 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5948 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20293 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->