### PR TITLE
[CSS-Typed-OM] `transition-duration` property shouldn't allow negative values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'transition-duration' to CSS-wide keywords: unset
 PASS Can set 'transition-duration' to CSS-wide keywords: revert
 PASS Can set 'transition-duration' to var() references:  var(--A)
 PASS Can set 'transition-duration' to a time: 0s
-FAIL Can set 'transition-duration' to a time: -3.14ms Invalid values
+PASS Can set 'transition-duration' to a time: -3.14ms
 PASS Can set 'transition-duration' to a time: 3.14s
 PASS Can set 'transition-duration' to a time: calc(0s + 0ms)
 PASS Setting 'transition-duration' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration.html
@@ -13,7 +13,17 @@
 'use strict';
 
 runListValuedPropertyTests('transition-duration', [
-  { syntax: '<time>' },
+  {
+    syntax: '<time>',
+    specified: assert_is_equal_with_range_handling,
+    computed: (input, result) => {
+      const time = input.to('s').value;
+      if (time < 0)
+        assert_style_value_equals(result, new CSSUnitValue(0, 's'));
+      else
+        assert_style_value_equals(result, new CSSUnitValue(time, 's'));
+    }
+  },
 ]);
 
 </script>

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -254,6 +254,7 @@ static bool isValueOutOfRangeForProperty(CSSPropertyID propertyID, double value,
     case CSSPropertyStrokeDasharray:
     case CSSPropertyStrokeMiterlimit:
     case CSSPropertyStrokeWidth:
+    case CSSPropertyTransitionDuration:
         return value < 0;
     case CSSPropertyFontWeight:
         return value < 1 || value > 1000;


### PR DESCRIPTION
#### ab21f8049d3417478d88f55de3dcd783e7f06a42
<pre>
[CSS-Typed-OM] `transition-duration` property shouldn&apos;t allow negative values
<a href="https://bugs.webkit.org/show_bug.cgi?id=249800">https://bugs.webkit.org/show_bug.cgi?id=249800</a>

Reviewed by Simon Fraser.

`transition-duration` property shouldn&apos;t allow negative values, as per:
- <a href="https://w3c.github.io/csswg-drafts/css-transitions/#transition-duration-property">https://w3c.github.io/csswg-drafts/css-transitions/#transition-duration-property</a>

This means that StylePropertyMap.set() should wrap the value in a `calc()` when
negative, and that the computed value should be clamped to [0, inf].

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/transition-duration.html:
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::isValueOutOfRangeForProperty):

Canonical link: <a href="https://commits.webkit.org/258295@main">https://commits.webkit.org/258295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9684fcea7b9021faea82e58e98461dad77145c2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110701 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170959 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1440 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93819 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108518 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92014 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35299 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90672 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegateReload (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78299 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4191 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24933 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1361 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44421 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6016 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2996 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->