### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/stroke-width.html WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt
@@ -9,7 +9,7 @@ PASS Can set 'stroke-width' to a length: -3.14em
 PASS Can set 'stroke-width' to a length: 3.14cm
 PASS Can set 'stroke-width' to a length: calc(0px + 0em)
 PASS Can set 'stroke-width' to a percent: 0%
-FAIL Can set 'stroke-width' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'stroke-width' to a percent: -3.14%
 PASS Can set 'stroke-width' to a percent: 3.14%
 PASS Can set 'stroke-width' to a percent: calc(0% + 0%)
 PASS Can set 'stroke-width' to a number: 0

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width.html
@@ -20,7 +20,14 @@ runListValuedPropertyTests('stroke-width', [
   },
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: (input, result) => {
+        const percent = input.to('percent').value;
+       if (percent < 0)
+         assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+       else
+         assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+    }
   },
   {
     syntax: '<number>',


### PR DESCRIPTION
#### 18173dd49a5f64aca7b6003186aa05b5d6441691
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/stroke-width.html WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=249803">https://bugs.webkit.org/show_bug.cgi?id=249803</a>

Reviewed by Simon Fraser.

Per the specification, `stroke-width`&apos;s computed value should be positive:
- <a href="https://svgwg.org/svg2-draft/painting.html#StrokeWidth">https://svgwg.org/svg2-draft/painting.html#StrokeWidth</a>

However, the test was setting `stroke-width` to &quot;calc(-3.14%)&quot; and expecting
&quot;-3.14s&quot; as computed value. With clamping, the computed value should be &quot;0%&quot; in
this case.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-width.html:

Canonical link: <a href="https://commits.webkit.org/258274@main">https://commits.webkit.org/258274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbe37cba30206b712a4a9bdcdb34a2ebe027f84c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110654 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170924 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1393 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93778 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108482 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91974 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35263 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23381 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4155 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24893 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4208 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44379 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5971 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2984 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->