### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/stroke-opacity.html WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity-expected.txt
@@ -8,14 +8,14 @@ PASS Can set 'stroke-opacity' to a number: 0
 PASS Can set 'stroke-opacity' to a number: -3.14
 PASS Can set 'stroke-opacity' to a number: 3.14
 PASS Can set 'stroke-opacity' to a number: calc(2 + 3)
+PASS Can set 'stroke-opacity' to a percent: 0%
+PASS Can set 'stroke-opacity' to a percent: -3.14%
+PASS Can set 'stroke-opacity' to a percent: 3.14%
+PASS Can set 'stroke-opacity' to a percent: calc(0% + 0%)
 PASS Setting 'stroke-opacity' to a length: 0px throws TypeError
 PASS Setting 'stroke-opacity' to a length: -3.14em throws TypeError
 PASS Setting 'stroke-opacity' to a length: 3.14cm throws TypeError
 PASS Setting 'stroke-opacity' to a length: calc(0px + 0em) throws TypeError
-FAIL Setting 'stroke-opacity' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stroke-opacity' to a percent: -3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stroke-opacity' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stroke-opacity' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'stroke-opacity' to a time: 0s throws TypeError
 PASS Setting 'stroke-opacity' to a time: -3.14ms throws TypeError
 PASS Setting 'stroke-opacity' to a time: 3.14s throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity.html
@@ -13,7 +13,7 @@
 <script>
 'use strict';
 
-function assert_is_equal_with_clamping(input, result) {
+function assert_is_equal_with_clamping_number(input, result) {
   const number = input.to('number');
 
   if (number.value < 0)
@@ -24,11 +24,25 @@ function assert_is_equal_with_clamping(input, result) {
     assert_style_value_equals(result, input);
 }
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const number = input.to('percent').value / 100.;
+
+  if (number < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'number'));
+  else if (number > 1)
+    assert_style_value_equals(result, new CSSUnitValue(100, 'number'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(number, 'number'));
+}
+
 runPropertyTests('stroke-opacity', [
   {
     syntax: '<number>',
-    computed: assert_is_equal_with_clamping
+    computed: assert_is_equal_with_clamping_number
   },
+  { syntax: '<percentage>',
+    computed: assert_is_equal_with_clamping_percentage
+  }
 ]);
 
 </script>


### PR DESCRIPTION
#### 95e3bdf7a6db3900efedb262705e217b1dbddf2c
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/stroke-opacity.html WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=249806">https://bugs.webkit.org/show_bug.cgi?id=249806</a>

Reviewed by Simon Fraser.

Fix css/css-typed-om/the-stylepropertymap/properties/stroke-opacity.html WPT
test to match the specification:
- <a href="https://svgwg.org/svg2-draft/painting.html#StrokeOpacity">https://svgwg.org/svg2-draft/painting.html#StrokeOpacity</a>

The specification says that both &lt;number&gt; and &lt;percentage&gt; are allowed.
However, the test was only allowing &lt;number&gt;.

Also, per the specification, the computed value should be a number within the 0
and 1 range (with percentages converted to numbers).

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-opacity.html:

Canonical link: <a href="https://commits.webkit.org/258270@main">https://commits.webkit.org/258270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c25a82479cabfa5b24d315148bf014fb8067500b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110659 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170928 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1398 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93783 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108487 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107169 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35267 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23384 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4159 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24896 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4213 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1317 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44383 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5976 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2983 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->