### PR TITLE
Add a "post rendering frame" hook

### DIFF
--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -207,6 +207,7 @@ void InspectorTimelineAgent::internalStart(std::optional<int>&& maxCallStackDept
         m_runLoopNestingLevel++;
     });
 
+    // FIXME: This won't work correctly with RemoteLayerTreeDrawingArea: webkit.org/b/249796. Detecting FrameEnd needs to be handled at the DrawingArea level.
     m_frameStopObserver = makeUnique<RunLoopObserver>(static_cast<CFIndex>(RunLoopObserver::WellKnownRunLoopOrders::InspectorFrameEnd), [this]() {
         if (!m_tracking || m_environment.debugger()->isPaused())
             return;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1940,6 +1940,15 @@ void Page::didCompleteRenderingUpdateDisplay()
     m_inspectorController->didComposite(mainFrame());
 }
 
+void Page::didCompleteRenderingFrame()
+{
+    LOG_WITH_STREAM(EventLoop, stream << "Page " << this << " didCompleteRenderingFrame()");
+
+    // FIXME: This is where we'd call requestPostAnimationFrame callbacks: webkit.org/b/249798.
+    // FIXME: Run WindowEventLoop tasks from here: webkit.org/b/249684.
+    // FIXME: Drive InspectorFrameEnd from here; webkit.org/b/249796.
+}
+
 void Page::prioritizeVisibleResources()
 {
     if (loadSchedulingMode() == LoadSchedulingMode::Direct)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -644,6 +644,8 @@ public:
     // layers to the platform compositor.
     WEBCORE_EXPORT void willStartRenderingUpdateDisplay();
     WEBCORE_EXPORT void didCompleteRenderingUpdateDisplay();
+    // Called after didCompleteRenderingUpdateDisplay, but in the same run loop iteration (i.e. before zero-delay timers triggered from the rendering update).
+    WEBCORE_EXPORT void didCompleteRenderingFrame();
 
     // Schedule a rendering update that coordinates with display refresh.
     WEBCORE_EXPORT void scheduleRenderingUpdate(OptionSet<RenderingUpdateStep> requestedSteps);

--- a/Source/WebCore/platform/cf/RunLoopObserver.cpp
+++ b/Source/WebCore/platform/cf/RunLoopObserver.cpp
@@ -56,7 +56,8 @@ void RunLoopObserver::schedule(CFRunLoopRef runLoop, CFRunLoopActivity activity)
         return;
 
     CFRunLoopObserverContext context = { 0, this, 0, 0, 0 };
-    m_runLoopObserver = adoptCF(CFRunLoopObserverCreate(0, activity, true, m_order, runLoopObserverFired, &context));
+    constexpr bool repeats = true;
+    m_runLoopObserver = adoptCF(CFRunLoopObserverCreate(kCFAllocatorDefault, activity, repeats, m_order, runLoopObserverFired, &context));
 
     CFRunLoopAddObserver(runLoop, m_runLoopObserver.get(), kCFRunLoopCommonModes);
 }

--- a/Source/WebCore/platform/cf/RunLoopObserver.h
+++ b/Source/WebCore/platform/cf/RunLoopObserver.h
@@ -51,10 +51,11 @@ public:
 
     enum class WellKnownRunLoopOrders : CFIndex {
         CoreAnimationCommit     = 2000000,
-        LayerFlush              = CoreAnimationCommit - 1,
+        RenderingUpdate         = CoreAnimationCommit - 1,
         ActivityStateChange     = CoreAnimationCommit - 2,
         InspectorFrameBegin     = 0,
-        InspectorFrameEnd       = CoreAnimationCommit + 1 
+        InspectorFrameEnd       = CoreAnimationCommit + 1,
+        PostRenderingUpdate     = CoreAnimationCommit + 2,
     };
 
 protected:

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
@@ -127,6 +127,11 @@ void DrawingArea::didCompleteRenderingUpdateDisplay()
     m_webPage.didCompleteRenderingUpdateDisplay();
 }
 
+void DrawingArea::didCompleteRenderingFrame()
+{
+    m_webPage.didCompleteRenderingFrame();
+}
+
 bool DrawingArea::supportsGPUProcessRendering(DrawingAreaType type)
 {
     switch (type) {

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -124,6 +124,8 @@ public:
 
     virtual void willStartRenderingUpdateDisplay();
     virtual void didCompleteRenderingUpdateDisplay();
+    // Called after didCompleteRenderingUpdateDisplay, but in the same run loop iteration.
+    virtual void didCompleteRenderingFrame();
 
     virtual void dispatchAfterEnsuringUpdatedScrollPosition(WTF::Function<void ()>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -368,8 +368,10 @@ void RemoteLayerTreeDrawingArea::updateRendering()
 
         RunLoop::main().dispatch([pageID] {
             if (auto* webPage = WebProcess::singleton().webPage(pageID)) {
-                if (auto* drawingArea = dynamicDowncast<RemoteLayerTreeDrawingArea>(webPage->drawingArea()))
+                if (auto* drawingArea = dynamicDowncast<RemoteLayerTreeDrawingArea>(webPage->drawingArea())) {
                     drawingArea->didCompleteRenderingUpdateDisplay();
+                    drawingArea->didCompleteRenderingFrame();
+                }
             }
         });
     });

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4527,6 +4527,13 @@ void WebPage::didCompleteRenderingUpdateDisplay()
     m_page->didCompleteRenderingUpdateDisplay();
 }
 
+void WebPage::didCompleteRenderingFrame()
+{
+    if (m_isClosed)
+        return;
+    m_page->didCompleteRenderingFrame();
+}
+
 void WebPage::releaseMemory(Critical)
 {
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -434,6 +434,8 @@ public:
 
     void willStartRenderingUpdateDisplay();
     void didCompleteRenderingUpdateDisplay();
+    // Called after didCompleteRenderingUpdateDisplay, but in the same run loop iteration.
+    void didCompleteRenderingFrame();
 
     void releaseMemory(WTF::Critical);
 

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
@@ -137,9 +137,13 @@ private:
 
     void sendPendingNewlyReachedPaintingMilestones();
 
-    void updateRenderingRunLoopCallback();
-    void invalidateRenderingUpdateRunLoopObserver();
     void scheduleRenderingUpdateRunLoopObserver();
+    void invalidateRenderingUpdateRunLoopObserver();
+    void renderingUpdateRunLoopCallback();
+
+    void schedulePostRenderingUpdateRunLoopObserver();
+    void invalidatePostRenderingUpdateRunLoopObserver();
+    void postRenderingUpdateRunLoopCallback();
 
     void startRenderThrottlingTimer();
     void renderThrottlingTimerFired();
@@ -167,7 +171,8 @@ private:
     OptionSet<WebCore::LayoutMilestone> m_pendingNewlyReachedPaintingMilestones;
     Vector<CallbackID> m_pendingCallbackIDs;
 
-    std::unique_ptr<WebCore::RunLoopObserver> m_renderUpdateRunLoopObserver;
+    std::unique_ptr<WebCore::RunLoopObserver> m_renderingUpdateRunLoopObserver;
+    std::unique_ptr<WebCore::RunLoopObserver> m_postRenderingUpdateRunLoopObserver;
 
     bool m_isPaintingSuspended { false };
     bool m_inUpdateGeometry { false };

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -8849,6 +8849,12 @@ FORWARD(toggleUnderline)
         _private->renderingUpdateScheduler->didCompleteRenderingUpdateDisplay();
 }
 
+- (void)_didCompleteRenderingFrame
+{
+    if (_private->page)
+        _private->page->didCompleteRenderingFrame();
+}
+
 - (BOOL)_flushCompositingChanges
 {
     auto* frame = [self _mainCoreFrame];

--- a/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
@@ -151,6 +151,7 @@ WebLayoutMilestones kitLayoutMilestones(OptionSet<WebCore::LayoutMilestone>);
 
 - (void)_willStartRenderingUpdateDisplay;
 - (void)_didCompleteRenderingUpdateDisplay;
+- (void)_didCompleteRenderingFrame;
 
 - (BOOL)_flushCompositingChanges;
 

--- a/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.h
@@ -40,15 +40,19 @@ public:
     void didCompleteRenderingUpdateDisplay();
     
 private:
-
     void registerCACommitHandlers();
 
     void renderingUpdateRunLoopObserverCallback();
     void updateRendering();
 
+    void schedulePostRenderingUpdate();
+    void postRenderingUpdateCallback();
+
     WebView* m_webView;
 
     std::unique_ptr<WebCore::RunLoopObserver> m_renderingUpdateRunLoopObserver;
+    std::unique_ptr<WebCore::RunLoopObserver> m_postRenderingUpdateRunLoopObserver;
+
     bool m_insideCallback { false };
     bool m_rescheduledInsideCallback { false };
     bool m_haveRegisteredCommitHandlers { false };


### PR DESCRIPTION
#### bf82da4c0e3bbd409f44510fa9f3d1891808d770
<pre>
Add a &quot;post rendering frame&quot; hook
<a href="https://bugs.webkit.org/show_bug.cgi?id=249807">https://bugs.webkit.org/show_bug.cgi?id=249807</a>
rdar://103648840

Reviewed by Chris Dumez and Ryosuke Niwa.

We need to add a Page-level &quot;post rendering frame&quot; hook so we can do things like hook up
postRequestAnimationFrame() (webkit.org/b/249798), possibly run the WindowEventLoop
(webkit.org/b/249684) and correctly implement Inspectors &quot;frame end&quot; event (webkit.org/b/249796).

For Core Animation-driven drawing clients (TiledCoreAnimationDrawingArea, WebKitLegacy) we want this
post-rendering frame hook to run after CA&apos;s runloop observer returns, since this callback may run
arbitrary script at some point and we need to avoid any possible re-entrancy issues. So we use a
second CFRunLoopObserver, ordered as CoreAnimationCommit+2 (after InspectorFrameEnd).

For RemoteLayerTreeDrawingArea, we can just call the entry point after
didCompleteRenderingUpdateDisplay().

* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::internalStart):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCompleteRenderingFrame):
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/cf/RunLoopObserver.cpp:
(WebCore::RunLoopObserver::schedule):
* Source/WebCore/platform/cf/RunLoopObserver.h: Modernize terminology: LayerFlush -&gt; RenderingUpdate and add PostRenderingUpdate.
* Source/WebKit/WebProcess/WebPage/DrawingArea.cpp:
(WebKit::DrawingArea::didCompleteRenderingFrame):
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didCompleteRenderingFrame):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::TiledCoreAnimationDrawingArea):
(WebKit::TiledCoreAnimationDrawingArea::~TiledCoreAnimationDrawingArea):
(WebKit::TiledCoreAnimationDrawingArea::setLayerTreeStateIsFrozen):
(WebKit::TiledCoreAnimationDrawingArea::dispatchAfterEnsuringUpdatedScrollPosition):
(WebKit::TiledCoreAnimationDrawingArea::didCompleteRenderingUpdateDisplay):
(WebKit::TiledCoreAnimationDrawingArea::scheduleRenderingUpdateRunLoopObserver):
(WebKit::TiledCoreAnimationDrawingArea::invalidateRenderingUpdateRunLoopObserver):
(WebKit::TiledCoreAnimationDrawingArea::renderingUpdateRunLoopCallback):
(WebKit::TiledCoreAnimationDrawingArea::schedulePostRenderingUpdateRunLoopObserver):
(WebKit::TiledCoreAnimationDrawingArea::invalidatePostRenderingUpdateRunLoopObserver):
(WebKit::TiledCoreAnimationDrawingArea::postRenderingUpdateRunLoopCallback):
(WebKit::TiledCoreAnimationDrawingArea::updateRenderingRunLoopCallback): Deleted.
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _didCompleteRenderingUpdateDisplay]):
* Source/WebKitLegacy/mac/WebView/WebViewData.mm:
(WebViewLayerFlushScheduler::WebViewLayerFlushScheduler):

Canonical link: <a href="https://commits.webkit.org/258311@main">https://commits.webkit.org/258311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/118d365780a18b63524cf2eb368ce62ce8b8211b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110748 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171003 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1531 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93870 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108565 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107258 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92062 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35348 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78347 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4235 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24980 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1436 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44469 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5706 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6060 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->