### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit.html WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'stroke-miterlimit' to CSS-wide keywords: unset
 PASS Can set 'stroke-miterlimit' to CSS-wide keywords: revert
 PASS Can set 'stroke-miterlimit' to var() references:  var(--A)
 PASS Can set 'stroke-miterlimit' to a number: 0
-FAIL Can set 'stroke-miterlimit' to a number: -3.14 assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'stroke-miterlimit' to a number: -3.14
 PASS Can set 'stroke-miterlimit' to a number: 3.14
 PASS Can set 'stroke-miterlimit' to a number: calc(2 + 3)
 PASS Setting 'stroke-miterlimit' to a length: 0px throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit.html
@@ -16,7 +16,14 @@
 runPropertyTests('stroke-miterlimit', [
   {
     syntax: '<number>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: (input, result) => {
+      const number = input.to('number');
+      if (number.value < 0)
+        assert_style_value_equals(result, new CSSUnitValue(0, 'number'));
+      else
+        assert_style_value_equals(result, new CSSUnitValue(number.value, 'number'));
+    }
   },
 ]);
 


### PR DESCRIPTION
#### 499791b1b462a4c85e74f308813f6f33373c68ea
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit.html WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=249808">https://bugs.webkit.org/show_bug.cgi?id=249808</a>

Reviewed by Simon Fraser.

Fix css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit.html WPT
test to match the specification:
- <a href="https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty">https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty</a>

The specification indicates that negative values shouldn&apos;t be allowed. However,
the test was expecting a computed value of -3.14 for one of the subtests.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-miterlimit.html:

Canonical link: <a href="https://commits.webkit.org/258298@main">https://commits.webkit.org/258298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/627c70c5746823c085bc474d86107a948283366b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110703 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170961 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1444 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93821 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108520 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92015 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35300 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78300 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4193 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24934 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1360 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44422 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6018 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3003 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->