### PR TITLE
Computed value for stroke-dasharray should be in px

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt
@@ -6,8 +6,8 @@ PASS Can set 'stroke-dasharray' to CSS-wide keywords: revert
 PASS Can set 'stroke-dasharray' to var() references:  var(--A)
 PASS Can set 'stroke-dasharray' to the 'none' keyword: none
 PASS Can set 'stroke-dasharray' to a length: 0px
-FAIL Can set 'stroke-dasharray' to a length: -3.14em assert_equals: unit expected "px" but got "em"
-FAIL Can set 'stroke-dasharray' to a length: 3.14cm assert_equals: unit expected "px" but got "cm"
+PASS Can set 'stroke-dasharray' to a length: -3.14em
+PASS Can set 'stroke-dasharray' to a length: 3.14cm
 PASS Can set 'stroke-dasharray' to a length: calc(0px + 0em)
 PASS Can set 'stroke-dasharray' to a percent: 0%
 FAIL Can set 'stroke-dasharray' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/strokeDasharray-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/strokeDasharray-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL strokeDasharray responsive to style changes assert_not_equals: got disallowed value "10em, 10em"
+FAIL strokeDasharray responsive to style changes assert_not_equals: got disallowed value "0px, 0px"
 

--- a/Source/WebCore/css/SVGCSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/SVGCSSComputedStyleDeclaration.cpp
@@ -56,8 +56,14 @@ static Ref<CSSValue> strokeDashArrayToCSSValueList(const Vector<SVGLengthValue>&
         return CSSPrimitiveValue::createIdentifier(CSSValueNone);
 
     auto list = CSSValueList::createCommaSeparated();
-    for (auto& length : dashes)
-        list->append(length.toCSSPrimitiveValue());
+    for (auto& length : dashes) {
+        auto primitiveValue = length.toCSSPrimitiveValue();
+        // Computed lengths should always be in 'px' unit.
+        if (primitiveValue->isLength() && primitiveValue->primitiveType() != CSSUnitType::CSS_PX)
+            list->append(CSSPrimitiveValue::create(primitiveValue->doubleValue(CSSUnitType::CSS_PX), CSSUnitType::CSS_PX));
+        else
+            list->append(WTFMove(primitiveValue));
+    }
 
     return list;
 }


### PR DESCRIPTION
#### a618c9c0e8e382fd9557d620e9a378714d18f9e6
<pre>
Computed value for stroke-dasharray should be in px
<a href="https://bugs.webkit.org/show_bug.cgi?id=249813">https://bugs.webkit.org/show_bug.cgi?id=249813</a>

Reviewed by Simon Fraser.

Computed value for stroke-dasharray should be in px:
- <a href="https://svgwg.org/svg2-draft/painting.html#StrokeDashing">https://svgwg.org/svg2-draft/painting.html#StrokeDashing</a>

Previously, we would only convert other length units to px when applied to a
SVG element, not for other kinds of elements.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stroke-dasharray-expected.txt:
* Source/WebCore/css/SVGCSSComputedStyleDeclaration.cpp:
(WebCore::strokeDashArrayToCSSValueList):

Canonical link: <a href="https://commits.webkit.org/258300@main">https://commits.webkit.org/258300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab11fbbdb756a9c9201d2a5b29fbcb182e0f588a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110708 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170965 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105418 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1449 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93826 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108525 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107220 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35307 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90681 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23434 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78307 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4198 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24945 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1363 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44433 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6023 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3002 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->