### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/stop-opacity.html WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity-expected.txt
@@ -8,14 +8,14 @@ PASS Can set 'stop-opacity' to a number: 0
 PASS Can set 'stop-opacity' to a number: -3.14
 PASS Can set 'stop-opacity' to a number: 3.14
 PASS Can set 'stop-opacity' to a number: calc(2 + 3)
+PASS Can set 'stop-opacity' to a percent: 0%
+PASS Can set 'stop-opacity' to a percent: -3.14%
+PASS Can set 'stop-opacity' to a percent: 3.14%
+PASS Can set 'stop-opacity' to a percent: calc(0% + 0%)
 PASS Setting 'stop-opacity' to a length: 0px throws TypeError
 PASS Setting 'stop-opacity' to a length: -3.14em throws TypeError
 PASS Setting 'stop-opacity' to a length: 3.14cm throws TypeError
 PASS Setting 'stop-opacity' to a length: calc(0px + 0em) throws TypeError
-FAIL Setting 'stop-opacity' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stop-opacity' to a percent: -3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stop-opacity' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'stop-opacity' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'stop-opacity' to a time: 0s throws TypeError
 PASS Setting 'stop-opacity' to a time: -3.14ms throws TypeError
 PASS Setting 'stop-opacity' to a time: 3.14s throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity.html
@@ -13,7 +13,7 @@
 <script>
 'use strict';
 
-function assert_is_equal_with_clamping(input, result) {
+function assert_is_equal_with_clamping_number(input, result) {
   const number = input.to('number');
 
   if (number.value < 0)
@@ -24,10 +24,25 @@ function assert_is_equal_with_clamping(input, result) {
     assert_style_value_equals(result, input);
 }
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const number = input.to('percent').value / 100.;
+
+  if (number < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'number'));
+  else if (number > 1)
+    assert_style_value_equals(result, new CSSUnitValue(1, 'number'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(number, 'number'));
+}
+
 runPropertyTests('stop-opacity', [
   {
     syntax: '<number>',
-    computed: assert_is_equal_with_clamping
+    computed: assert_is_equal_with_clamping_number
+  },
+  {
+    syntax: '<percentage>',
+    computed: assert_is_equal_with_clamping_percentage
   },
 ]);
 


### PR DESCRIPTION
#### 7f5f7218ee4a7e24f3f8db2dbfc3086cb4b01c52
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/stop-opacity.html WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=249814">https://bugs.webkit.org/show_bug.cgi?id=249814</a>

Reviewed by Simon Fraser.

Fix css/css-typed-om/the-stylepropertymap/properties/stop-opacity.html WPT test
to match the specification:
- <a href="https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty">https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty</a>

This property should allow percentages, not just numbers. Also, the computed
value should be a number in the [0, 1] range, with percentages converted to
numbers.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/stop-opacity.html:

Canonical link: <a href="https://commits.webkit.org/258272@main">https://commits.webkit.org/258272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39a304e1498b0fd56afbcb577ef85f4e2f1f2060

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110670 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170937 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1409 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93793 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108496 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107181 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91989 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35277 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23396 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4168 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4223 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1330 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44396 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5987 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2988 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->