### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/scroll-padding.html WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'scroll-padding-top' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-top' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-top' to var() references:  var(--A)
 PASS Can set 'scroll-padding-top' to a percent: 0%
-FAIL Can set 'scroll-padding-top' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'scroll-padding-top' to a percent: -3.14%
 PASS Can set 'scroll-padding-top' to a percent: 3.14%
 PASS Can set 'scroll-padding-top' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-top' to a length: 0px
@@ -36,7 +36,7 @@ PASS Can set 'scroll-padding-left' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-left' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-left' to var() references:  var(--A)
 PASS Can set 'scroll-padding-left' to a percent: 0%
-FAIL Can set 'scroll-padding-left' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'scroll-padding-left' to a percent: -3.14%
 PASS Can set 'scroll-padding-left' to a percent: 3.14%
 PASS Can set 'scroll-padding-left' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-left' to a length: 0px
@@ -67,7 +67,7 @@ PASS Can set 'scroll-padding-right' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-right' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-right' to var() references:  var(--A)
 PASS Can set 'scroll-padding-right' to a percent: 0%
-FAIL Can set 'scroll-padding-right' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'scroll-padding-right' to a percent: -3.14%
 PASS Can set 'scroll-padding-right' to a percent: 3.14%
 PASS Can set 'scroll-padding-right' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-right' to a length: 0px
@@ -98,7 +98,7 @@ PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-bottom' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-bottom' to var() references:  var(--A)
 PASS Can set 'scroll-padding-bottom' to a percent: 0%
-FAIL Can set 'scroll-padding-bottom' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'scroll-padding-bottom' to a percent: -3.14%
 PASS Can set 'scroll-padding-bottom' to a percent: 3.14%
 PASS Can set 'scroll-padding-bottom' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-bottom' to a length: 0px
@@ -129,7 +129,7 @@ PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-inline-start' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-inline-start' to var() references:  var(--A)
 PASS Can set 'scroll-padding-inline-start' to a percent: 0%
-FAIL Can set 'scroll-padding-inline-start' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'scroll-padding-inline-start' to a percent: -3.14%
 PASS Can set 'scroll-padding-inline-start' to a percent: 3.14%
 PASS Can set 'scroll-padding-inline-start' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-inline-start' to a length: 0px
@@ -160,7 +160,7 @@ PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-block-start' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-block-start' to var() references:  var(--A)
 PASS Can set 'scroll-padding-block-start' to a percent: 0%
-FAIL Can set 'scroll-padding-block-start' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'scroll-padding-block-start' to a percent: -3.14%
 PASS Can set 'scroll-padding-block-start' to a percent: 3.14%
 PASS Can set 'scroll-padding-block-start' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-block-start' to a length: 0px
@@ -191,7 +191,7 @@ PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-inline-end' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-inline-end' to var() references:  var(--A)
 PASS Can set 'scroll-padding-inline-end' to a percent: 0%
-FAIL Can set 'scroll-padding-inline-end' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'scroll-padding-inline-end' to a percent: -3.14%
 PASS Can set 'scroll-padding-inline-end' to a percent: 3.14%
 PASS Can set 'scroll-padding-inline-end' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-inline-end' to a length: 0px
@@ -222,7 +222,7 @@ PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: unset
 PASS Can set 'scroll-padding-block-end' to CSS-wide keywords: revert
 PASS Can set 'scroll-padding-block-end' to var() references:  var(--A)
 PASS Can set 'scroll-padding-block-end' to a percent: 0%
-FAIL Can set 'scroll-padding-block-end' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'scroll-padding-block-end' to a percent: -3.14%
 PASS Can set 'scroll-padding-block-end' to a percent: 3.14%
 PASS Can set 'scroll-padding-block-end' to a percent: calc(0% + 0%)
 PASS Can set 'scroll-padding-block-end' to a length: 0px

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding.html
@@ -13,11 +13,21 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 for (const suffix of ['top', 'left', 'right', 'bottom']) {
   runPropertyTests('scroll-padding-' + suffix, [
     {
       syntax: '<percentage>',
-      specified: assert_is_equal_with_range_handling
+      specified: assert_is_equal_with_range_handling,
+      computed: assert_is_equal_with_clamping_percentage
     },
     {
       syntax: '<length>',
@@ -30,11 +40,12 @@ for (const suffix of ['inline-start', 'block-start', 'inline-end', 'block-end'])
   runPropertyTests('scroll-padding-' + suffix, [
     {
       syntax: '<percentage>',
-      specified: assert_is_equal_with_range_handling
+      specified: assert_is_equal_with_range_handling,
+      computed: assert_is_equal_with_clamping_percentage
     },
     {
       syntax: '<length>',
-      specified: assert_is_equal_with_range_handling
+      specified: assert_is_equal_with_range_handling,
     },
   ]);
 }


### PR DESCRIPTION
#### 99f516e7d63b7adcf03c62b0147c0c4eb089e7df
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/scroll-padding.html WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=249816">https://bugs.webkit.org/show_bug.cgi?id=249816</a>

Reviewed by Simon Fraser.

Fix css/css-typed-om/the-stylepropertymap/properties/scroll-padding.html WPT
test to match the specification:
- <a href="https://w3c.github.io/csswg-drafts/css-scroll-snap/#padding-longhands-logical">https://w3c.github.io/csswg-drafts/css-scroll-snap/#padding-longhands-logical</a>
- <a href="https://w3c.github.io/csswg-drafts/css-scroll-snap/#padding-longhands-physical">https://w3c.github.io/csswg-drafts/css-scroll-snap/#padding-longhands-physical</a>

The test was expecting a -3.14% as computed value for one of the subtests.
However, the specification indicates that negative values are not allowed.
The computed value should thus be clamped to 0%.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scroll-padding.html:

Canonical link: <a href="https://commits.webkit.org/258273@main">https://commits.webkit.org/258273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84b823e462580a19ec0e5c860a3dc53a37b85992

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110674 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1412 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93795 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108498 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107185 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91991 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23398 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4170 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4225 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10320 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44398 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5989 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2989 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->