### PR TITLE
Changing WKScrollView's scale during animated resize causes permanent WKContentView offset

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1768,6 +1768,9 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 - (UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView
 {
+    if (_resizeAnimationView)
+        return nil;
+
     ASSERT(_scrollView == scrollView);
     return self._currentContentView;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm
@@ -528,4 +528,23 @@ TEST(AnimatedResize, ResizeWithWithSubsequentNoOpResizeIsNotCancelled)
     }
 }
 
+TEST(AnimatedResize, ScaleDuringAnimatedResizeDoesNotMoveContentViewFrameOrigin)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768)]);
+    [webView synchronouslyLoadTestPageNamed:@"large-red-square-image"];
+
+    [webView _beginAnimatedResizeWithUpdates:^{
+        [webView setFrame:CGRectMake(0, 0, [webView frame].size.width + 100, 400)];
+    }];
+
+    [webView _endAnimatedResize];
+
+    [[webView scrollView] setZoomScale:2];
+    [webView waitForNextPresentationUpdate];
+
+    auto frameOrigin = [webView wkContentView].frame.origin;
+    EXPECT_EQ(frameOrigin.x, 0);
+    EXPECT_EQ(frameOrigin.y, 0);
+}
+
 #endif


### PR DESCRIPTION
#### d517e2b34c072bfef2c557c912e365beb8475526
<pre>
Changing WKScrollView&apos;s scale during animated resize causes permanent WKContentView offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=249818">https://bugs.webkit.org/show_bug.cgi?id=249818</a>
rdar://102780985

Reviewed by Wenson Hsieh.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView viewForZoomingInScrollView:]):
During animated (and live-ish) resize, we install a transform-only view between
WKScrollView and WKContentView. If during this time the WKScrollView is
asked to change its scale, UIScrollView code tries to maintain the origin of
WKContentView (the viewForZooming), but ends up moving the WKContentView&apos;s
frame origin away from (0, 0) to do so. Nothing ever comes along and fixes up
WKContentView&apos;s frame origin, so the top left corner of the content comes
permanently detached from the top left xorner of the scroll view.

To avoid this, prevent scaling while the resizeAnimationView is installed.
We want to own the scale ourselves (that&apos;s the whole point of resizeAnimationView),
and will apply scale changes in the transaction that results in the removal
of the resizeAnimationView. And it doesn&apos;t really make sense to allow user-driven
scaling during this time, either (and doesn&apos;t work right at all).

* Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm:
(TEST):
Add a test that ensures that WKContentView&apos;s frame origin doesn&apos;t get thrown off
by changing the WKScrollView&apos;s scale while the resizeAnimationView is installed.

Canonical link: <a href="https://commits.webkit.org/258307@main">https://commits.webkit.org/258307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fce942b74f8482f97ac08d590ee55e7ac4cefcb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110676 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170941 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1414 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93797 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108500 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35280 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90648 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23402 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78277 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4172 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24914 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1334 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44402 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5705 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5991 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->