### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/radius.html WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'r' to CSS-wide keywords: unset
 PASS Can set 'r' to CSS-wide keywords: revert
 PASS Can set 'r' to var() references:  var(--A)
 PASS Can set 'r' to a percent: 0%
-FAIL Can set 'r' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'r' to a percent: -3.14%
 PASS Can set 'r' to a percent: 3.14%
 PASS Can set 'r' to a percent: calc(0% + 0%)
 PASS Can set 'r' to a length: 0px
@@ -37,7 +37,7 @@ PASS Can set 'rx' to CSS-wide keywords: revert
 PASS Can set 'rx' to var() references:  var(--A)
 PASS Can set 'rx' to the 'auto' keyword: auto
 PASS Can set 'rx' to a percent: 0%
-FAIL Can set 'rx' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'rx' to a percent: -3.14%
 PASS Can set 'rx' to a percent: 3.14%
 PASS Can set 'rx' to a percent: calc(0% + 0%)
 PASS Can set 'rx' to a length: 0px
@@ -69,7 +69,7 @@ PASS Can set 'ry' to CSS-wide keywords: revert
 PASS Can set 'ry' to var() references:  var(--A)
 PASS Can set 'ry' to the 'auto' keyword: auto
 PASS Can set 'ry' to a percent: 0%
-FAIL Can set 'ry' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'ry' to a percent: -3.14%
 PASS Can set 'ry' to a percent: 3.14%
 PASS Can set 'ry' to a percent: calc(0% + 0%)
 PASS Can set 'ry' to a length: 0px

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius.html
@@ -13,10 +13,20 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 runPropertyTests('r', [
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<length>',
@@ -28,7 +38,8 @@ runPropertyTests('rx', [
   { syntax: 'auto' },
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<length>',
@@ -40,7 +51,8 @@ runPropertyTests('ry', [
   { syntax: 'auto' },
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<length>',


### PR DESCRIPTION
#### 75dd544f27c562803bcf7900245d1f96e938b787
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/radius.html WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=249819">https://bugs.webkit.org/show_bug.cgi?id=249819</a>

Reviewed by Simon Fraser.

Fix css/css-typed-om/the-stylepropertymap/properties/radius.html WPT test to
match the specification:
- <a href="https://svgwg.org/svg2-draft/geometry.html#R">https://svgwg.org/svg2-draft/geometry.html#R</a>
- <a href="https://svgwg.org/svg2-draft/geometry.html#RX">https://svgwg.org/svg2-draft/geometry.html#RX</a>
- <a href="https://svgwg.org/svg2-draft/geometry.html#RY">https://svgwg.org/svg2-draft/geometry.html#RY</a>

The specification indicates that the computed value for these should be
positive. However, one of the subtests was expected -3.14%.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/radius.html:

Canonical link: <a href="https://commits.webkit.org/258276@main">https://commits.webkit.org/258276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55fbd42b9d8b3b029c73a34cecdd384fb9995adb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110677 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1415 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93798 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108501 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107188 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91997 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35282 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23404 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4173 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1335 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10323 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44404 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5992 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2990 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->