### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/padding.html WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt
@@ -5,7 +5,7 @@ PASS Can set 'padding-top' to CSS-wide keywords: unset
 PASS Can set 'padding-top' to CSS-wide keywords: revert
 PASS Can set 'padding-top' to var() references:  var(--A)
 PASS Can set 'padding-top' to a percent: 0%
-FAIL Can set 'padding-top' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-top' to a percent: -3.14%
 PASS Can set 'padding-top' to a percent: 3.14%
 PASS Can set 'padding-top' to a percent: calc(0% + 0%)
 PASS Can set 'padding-top' to a length: 0px
@@ -36,7 +36,7 @@ PASS Can set 'padding-left' to CSS-wide keywords: unset
 PASS Can set 'padding-left' to CSS-wide keywords: revert
 PASS Can set 'padding-left' to var() references:  var(--A)
 PASS Can set 'padding-left' to a percent: 0%
-FAIL Can set 'padding-left' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-left' to a percent: -3.14%
 PASS Can set 'padding-left' to a percent: 3.14%
 PASS Can set 'padding-left' to a percent: calc(0% + 0%)
 PASS Can set 'padding-left' to a length: 0px
@@ -67,7 +67,7 @@ PASS Can set 'padding-right' to CSS-wide keywords: unset
 PASS Can set 'padding-right' to CSS-wide keywords: revert
 PASS Can set 'padding-right' to var() references:  var(--A)
 PASS Can set 'padding-right' to a percent: 0%
-FAIL Can set 'padding-right' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-right' to a percent: -3.14%
 PASS Can set 'padding-right' to a percent: 3.14%
 PASS Can set 'padding-right' to a percent: calc(0% + 0%)
 PASS Can set 'padding-right' to a length: 0px
@@ -98,7 +98,7 @@ PASS Can set 'padding-bottom' to CSS-wide keywords: unset
 PASS Can set 'padding-bottom' to CSS-wide keywords: revert
 PASS Can set 'padding-bottom' to var() references:  var(--A)
 PASS Can set 'padding-bottom' to a percent: 0%
-FAIL Can set 'padding-bottom' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'padding-bottom' to a percent: -3.14%
 PASS Can set 'padding-bottom' to a percent: 3.14%
 PASS Can set 'padding-bottom' to a percent: calc(0% + 0%)
 PASS Can set 'padding-bottom' to a length: 0px

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding.html
@@ -13,11 +13,21 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 for (const suffix of ['top', 'left', 'right', 'bottom']) {
   runPropertyTests('padding-' + suffix, [
     {
       syntax: '<percentage>',
-      specified: assert_is_equal_with_range_handling
+      specified: assert_is_equal_with_range_handling,
+      computed: assert_is_equal_with_clamping_percentage
     },
     {
       syntax: '<length>',


### PR DESCRIPTION
#### 510e90c7e27fe96354206fa905ffb6f882958117
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/padding.html WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=249821">https://bugs.webkit.org/show_bug.cgi?id=249821</a>

Reviewed by Simon Fraser.

Fix css/css-typed-om/the-stylepropertymap/properties/padding.html WPT test to
match the specification:
- <a href="https://w3c.github.io/csswg-drafts/css-box/#padding-physical">https://w3c.github.io/csswg-drafts/css-box/#padding-physical</a>

The specification indicates that negative values are not allowed for these
properties. However, the test was expecting -3.14% for one of the subtests.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/padding.html:

Canonical link: <a href="https://commits.webkit.org/258275@main">https://commits.webkit.org/258275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0e57cccde3408eb8f8e73eed5627ed715c29a51

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110679 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170944 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1417 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93800 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108503 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107190 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91994 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35281 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23401 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4175 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24913 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4230 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/10325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44401 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5994 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2991 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->