### PR TITLE
[WebGPU] Support module constants in vertex and fragment shaders

### DIFF
--- a/Source/WebGPU/WebGPU/ShaderModule.h
+++ b/Source/WebGPU/WebGPU/ShaderModule.h
@@ -58,7 +58,7 @@ public:
     void getCompilationInfo(CompletionHandler<void(WGPUCompilationInfoRequestStatus, const WGPUCompilationInfo&)>&& callback);
     void setLabel(String&&);
 
-    id<MTLFunction> getNamedFunction(const String& name) const;
+    id<MTLFunction> getNamedFunction(const String& name, const HashMap<String, double>& keyValueReplacements) const;
 
     bool isValid() const { return !std::holds_alternative<std::monostate>(m_checkResult); }
 
@@ -86,6 +86,8 @@ private:
     const id<MTLLibrary> m_library { nil }; // This is only non-null if we could compile the module early.
 
     const Ref<Device> m_device;
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250441 - this needs to be populated from the compiler
+    HashMap<String, String> m_constantIdentifiersToNames;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -74,8 +74,10 @@ id<MTLLibrary> ShaderModule::createLibrary(id<MTLDevice> device, const String& m
     NSError *error = nil;
     // FIXME(PERFORMANCE): Run the asynchronous version of this
     id<MTLLibrary> library = [device newLibraryWithSource:msl options:options error:&error];
-    if (error)
+    if (error) {
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250442
         WTFLogAlways("MSL compilation error: %@", error);
+    }
     library.label = label;
     return library;
 }
@@ -239,9 +241,56 @@ void ShaderModule::setLabel(String&& label)
         m_library.label = label;
 }
 
-id<MTLFunction> ShaderModule::getNamedFunction(const String& name) const
+id<MTLFunction> ShaderModule::getNamedFunction(const String& name, const HashMap<String, double>& keyValueReplacements) const
 {
-    return [m_library newFunctionWithName:name];
+    auto originalFunction = [m_library newFunctionWithName:name];
+    if (!keyValueReplacements.size())
+        return originalFunction;
+
+    NSDictionary<NSString *, MTLFunctionConstant *> *originalFunctionConstants = [originalFunction functionConstantsDictionary];
+    MTLFunctionConstantValues *constantValues = [MTLFunctionConstantValues new];
+    for (auto& kvp : keyValueReplacements) {
+        auto it = m_constantIdentifiersToNames.find(kvp.key);
+        auto& constantName = it != m_constantIdentifiersToNames.end() ? it->value : kvp.key;
+
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250444 - it would be preferable
+        // to get the type information from the WGSL compiler so we don't have to call
+        // -[MTLLibrary newFunctionWithName:] twice
+        MTLDataType dataType = [originalFunctionConstants objectForKey:constantName].type;
+        union {
+            bool b;
+            int32_t i;
+            uint32_t u;
+            float f;
+            __fp16 h;
+        } v;
+        if (dataType == MTLDataTypeFloat)
+            v.f = static_cast<decltype(v.f)>(kvp.value);
+        else if (dataType == MTLDataTypeHalf)
+            v.h = static_cast<decltype(v.h)>(kvp.value);
+        else if (dataType == MTLDataTypeInt)
+            v.i = static_cast<decltype(v.i)>(kvp.value);
+        else if (dataType == MTLDataTypeUInt)
+            v.u = static_cast<decltype(v.u)>(kvp.value);
+        else if (dataType == MTLDataTypeBool)
+            v.b = static_cast<decltype(v.b)>(kvp.value);
+        else {
+            ASSERT_NOT_REACHED("Unsupported MTLFunctionConstant data type");
+            return nil;
+        }
+
+        [constantValues setConstantValue:&v type:dataType withName:constantName];
+    }
+
+    NSError *error;
+    id<MTLFunction> result = [m_library newFunctionWithName:name constantValues:constantValues error:&error];
+
+    if (error) {
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250442
+        WTFLogAlways("MSL compilation error: %@", error);
+    }
+
+    return result;
 }
 
 WGSL::PipelineLayout ShaderModule::convertPipelineLayout(const PipelineLayout& pipelineLayout)

--- a/Websites/webkit.org/demos/webgpu/scripts/textured-cube-shader-constants.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/textured-cube-shader-constants.js
@@ -1,0 +1,341 @@
+async function helloCube() {
+    if (!navigator.gpu || GPUBufferUsage.COPY_SRC === undefined) {
+        document.body.className = 'error';
+        return;
+    }
+
+    const canvas = document.querySelector("canvas");
+    canvas.width = 600;
+    canvas.height = 600;
+    
+    const adapter = await navigator.gpu.requestAdapter();
+    const device = await adapter.requestDevice();
+    
+    /*** Vertex Buffer Setup ***/
+    
+    /* Vertex Data */
+    const vertexStride = 10 * 4;
+    const vertexDataSize = vertexStride * 36;
+    
+    /* GPUBufferDfescriptor */
+    const vertexDataBufferDescriptor = {
+        size: vertexDataSize,
+        usage: GPUBufferUsage.VERTEX,
+        mappedAtCreation: true
+    };
+
+    /* GPUBuffer */
+    const vertexBuffer = device.createBuffer(vertexDataBufferDescriptor);
+    const vertexWriteArray = new Float32Array(vertexBuffer.getMappedRange());
+    vertexWriteArray.set([
+        // float4 position, float4 color, float2 uv
+        .5, -.5, .5, 1,   1, 0, 1, 1,  1, 1,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  0, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,  0, 0,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  1, 0,
+        .5, -.5, .5, 1,   1, 0, 1, 1,  1, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,  0, 0,
+
+        .5, .5, .5, 1,    1, 1, 1, 1,  1, 1,
+        .5, -.5, .5, 1,   1, 0, 1, 1,  0, 1,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  0, 0,
+        .5, .5, -.5, 1,   1, 1, 0, 1,  1, 0,
+        .5, .5, .5, 1,    1, 1, 1, 1,  1, 1,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  0, 0,
+
+        -.5, .5, .5, 1,   0, 1, 1, 1,  1, 1,
+        .5, .5, .5, 1,    1, 1, 1, 1,  0, 1,
+        .5, .5, -.5, 1,   1, 1, 0, 1,  0, 0,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  1, 0,
+        -.5, .5, .5, 1,   0, 1, 1, 1,  1, 1,
+        .5, .5, -.5, 1,   1, 1, 0, 1,  0, 0,
+
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  1, 1,
+        -.5, .5, .5, 1,   0, 1, 1, 1,  0, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  0, 0,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,  1, 0,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  1, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  0, 0,
+
+        .5, .5, .5, 1,    1, 1, 1, 1,  1, 1,
+        -.5, .5, .5, 1,   0, 1, 1, 1,  0, 1,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  0, 0,
+        -.5, -.5, .5, 1,  0, 0, 1, 1,  0, 0,
+        .5, -.5, .5, 1,   1, 0, 1, 1,  1, 0,
+        .5, .5, .5, 1,    1, 1, 1, 1,  1, 1,
+    
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  1, 1,
+        -.5, -.5, -.5, 1, 0, 0, 0, 1,  0, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  0, 0,
+        .5, .5, -.5, 1,   1, 1, 0, 1,  1, 0,
+        .5, -.5, -.5, 1,  1, 0, 0, 1,  1, 1,
+        -.5, .5, -.5, 1,  0, 1, 0, 1,  0, 0,
+    ]);
+    vertexBuffer.unmap();
+    
+    const uniformBufferSize = 12;
+    const uniformBuffer = device.createBuffer({
+        size: uniformBufferSize,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    
+    /* GPUTexture */
+    const image = new Image();
+    const imageLoadPromise = new Promise(resolve => {
+        image.onload = () => resolve();
+        image.src = "resources/webkit-logo.png"
+    });
+    await Promise.resolve(imageLoadPromise);
+
+    const textureSize = {
+        width: image.width,
+        height: image.height,
+        depth: 1
+    };
+
+    const textureDescriptor = {
+        size: textureSize,
+        arrayLayerCount: 1,
+        mipLevelCount: 1,
+        sampleCount: 1,
+        dimension: "2d",
+        format: "bgra8unorm",
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST
+    };
+    const texture = device.createTexture(textureDescriptor);
+    
+    const imageBitmap = await createImageBitmap(image);
+
+    device.queue.copyExternalImageToTexture(
+        { source: imageBitmap },
+        { texture: texture },
+        [image.width, image.height]
+    );
+
+    const sampler = device.createSampler({
+        magFilter: "linear",
+        minFilter: "linear"
+    });
+
+    /*** Shader Setup ***/
+    
+    const uniformBindGroupLayout = device.createBindGroupLayout({ entries: [
+        { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: {} },
+        { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: {} },
+        { binding: 2, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
+    ] });
+
+    const uniformBindGroup = device.createBindGroup({
+        layout: uniformBindGroupLayout,
+        entries: [
+          {
+            binding: 0,
+            resource: {
+              buffer: uniformBuffer,
+              offset: 0
+            },
+          },
+          {
+            binding: 1,
+            resource: texture.createView(),
+          },
+          {
+            binding: 2,
+            resource: sampler,
+          },
+        ],
+      });
+
+    const mslSource = `
+                #define vertexInputPackedFloatSize 10
+                #include <metal_stdlib>
+                using namespace metal;
+    
+                constant float alphaMultiplier [[function_constant(0)]];
+                constant float betaMultiplier [[function_constant(1)]];
+                constant float gammaMultiplier [[function_constant(2)]];
+                constant float textureMultiplier [[function_constant(3)]];
+                constant float colorMultiplier [[function_constant(4)]];
+    
+                struct VertexIn {
+                   float4 position [[attribute(0)]];
+                   float4 color [[attribute(1)]];
+                   float2 uv [[attribute(2)]];
+                };
+    
+                struct VertexOut {
+                   float4 position [[position]];
+                   float4 color;
+                   float2 uv;
+                };
+    
+                struct VertexShaderArguments {
+                    device float *time [[id(0)]];
+                };
+    
+                struct FragmentShaderArguments {
+                    texture2d<half> colorTexture;
+                    sampler textureSampler;
+                };
+    
+                vertex VertexOut vsmain(VertexIn vin [[stage_in]], const device VertexShaderArguments &values [[buffer(1)]])
+                {
+                    VertexOut vout;
+                    float alpha = values.time[0] * alphaMultiplier;
+                    float beta = values.time[1] * betaMultiplier;
+                    float gamma = values.time[2] * gammaMultiplier;
+                    float cA = cos(alpha);
+                    float sA = sin(alpha);
+                    float cB = cos(beta);
+                    float sB = sin(beta);
+                    float cG = cos(gamma);
+                    float sG = sin(gamma);
+    
+                    float4x4 m = float4x4(cA * cB,  sA * cB,   -sB, 0,
+                                          cA*sB*sG - sA*cG,  sA*sB*sG + cA*cG,   cB * sG, 0,
+                                          cA*sB*cG + sA*sG, sA*sB*cG - cA*sG, cB * cG, 0,
+                                          0,     0,     0, 1);
+                    vout.position = vin.position * m;
+                    vout.position.z = (vout.position.z + 0.5) * 0.5;
+                    vout.color = vin.color;
+                    vout.uv = vin.uv;
+                    return vout;
+                }
+
+                fragment float4 fsmain(VertexOut in [[stage_in]], device FragmentShaderArguments &values [[buffer(0)]])
+                {
+                    return colorMultiplier * in.color + textureMultiplier * float4(values.colorTexture.sample(values.textureSampler, in.uv));
+                }
+    `;
+
+    const shaderModule = device.createShaderModule({ code: mslSource, isWHLSL: false, hints: [ {layout: "auto" }, ] });
+
+    const milliseconds = (new Date()).getMilliseconds()
+    
+    /* GPUPipelineStageDescriptors */
+    const vertexStageDescriptor = {
+        module: shaderModule,
+        entryPoint: "vsmain",
+        buffers: [
+            {
+                arrayStride: vertexStride,
+                attributes: [
+                {
+                    // position
+                    shaderLocation: 0,
+                    offset: 0,
+                    format: 'float32x4',
+                },
+                {
+                    // color
+                    shaderLocation: 0,
+                    offset: 4 * 4,
+                    format: 'float32x4',
+                },
+                {
+                    // uv
+                    shaderLocation: 1,
+                    offset: 4 * 8,
+                    format: 'float32x2',
+                },
+              ],
+            },
+        ],
+        constants: {
+            alphaMultiplier: milliseconds % 2 + 1.0,
+            betaMultiplier: milliseconds % 4 + 1.0,
+            gammaMultiplier: milliseconds % 8 + 1.0
+        },
+    };
+
+    const textureConstant = .1 * (milliseconds % 10 + 1.0);
+    const fragmentStageDescriptor = {
+        module: shaderModule,
+        entryPoint: "fsmain",
+        targets: [ {format: "bgra8unorm" }, ],
+        constants: {
+            textureMultiplier: textureConstant,
+            colorMultiplier: 1.0 - textureConstant,
+        },
+    };
+
+    /* GPURenderPipelineDescriptor */
+
+    const renderPipelineDescriptor = {
+        layout: "auto",
+        vertex: vertexStageDescriptor,
+        fragment: fragmentStageDescriptor,
+        primitive: {
+            topology: "triangle-list",
+            cullMode: "back"
+        },
+    };
+    /* GPURenderPipeline */
+    const renderPipeline = device.createRenderPipeline(renderPipelineDescriptor);
+    
+    /*** Swap Chain Setup ***/
+    function frameUpdate() {
+        const secondsBuffer = new Float32Array(3);
+        const d = new Date();
+        const seconds = d.getMilliseconds() / 1000.0 + d.getSeconds();
+        secondsBuffer.set([seconds*10 * (6.28318530718 / 60.0),
+                          seconds*5 * (6.28318530718 / 60.0),
+                          seconds*1 * (6.28318530718 / 60.0)]);
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, 12);
+
+        const gpuContext = canvas.getContext("webgpu");
+        
+        /* GPUCanvasConfiguration */
+        const canvasConfiguration = { device: device, format: "bgra8unorm" };
+        gpuContext.configure(canvasConfiguration);
+        /* GPUTexture */
+        const currentTexture = gpuContext.getCurrentTexture();
+        
+        /*** Render Pass Setup ***/
+        
+        /* Acquire Texture To Render To */
+        
+        /* GPUTextureView */
+        const renderAttachment = currentTexture.createView();
+        
+        /* GPUColor */
+        const darkBlue = { r: 0.15, g: 0.15, b: 0.5, a: 1 };
+        
+        /* GPURenderPassColorATtachmentDescriptor */
+        const colorAttachmentDescriptor = {
+            view: renderAttachment,
+            loadOp: "clear",
+            storeOp: "store",
+            clearColor: darkBlue
+        };
+        
+        /* GPURenderPassDescriptor */
+        const renderPassDescriptor = { colorAttachments: [colorAttachmentDescriptor] };
+        
+        /*** Rendering ***/
+        
+        /* GPUCommandEncoder */
+        const commandEncoder = device.createCommandEncoder();
+        /* GPURenderPassEncoder */
+        const renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+        
+        renderPassEncoder.setPipeline(renderPipeline);
+        renderPassEncoder.setVertexBuffer(0, vertexBuffer, 0);
+        renderPassEncoder.setBindGroup(0, uniformBindGroup);
+        renderPassEncoder.draw(36, 1, 0, 0); // 36 vertices, 1 instance, 0th vertex, 0th instance.
+        renderPassEncoder.end();
+        
+        /* GPUComamndBuffer */
+        const commandBuffer = commandEncoder.finish();
+        
+        /* GPUQueue */
+        const queue = device.queue;
+        queue.submit([commandBuffer]);
+
+        requestAnimationFrame(frameUpdate);
+    }
+
+    requestAnimationFrame(frameUpdate);
+}
+
+window.addEventListener("DOMContentLoaded", helloCube);

--- a/Websites/webkit.org/demos/webgpu/textured-cube-shader-constants.html
+++ b/Websites/webkit.org/demos/webgpu/textured-cube-shader-constants.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=600">
+<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+<title>WebGPU Textured Cube using GPUPipelineConstantValues</title>
+<link rel="stylesheet" href="css/style.css">
+<style>
+body {
+    font-family: system-ui;
+    color: #f7f7ff;
+    background-color: rgb(38, 38, 127);
+    text-align: center;
+}
+canvas {
+    margin: 0 auto;
+}
+</style>
+</head>
+<body>
+<div id="contents">
+    <h1>Textured Cube using GPUPipelineConstantValues</h1>
+    <canvas></canvas>
+</div>
+<div id="error">
+    <h2>WebGPU not available</h2>
+    <p>
+        Make sure you are on a system with WebGPU enabled. In
+        Safari, first make sure the Developer Menu is visible (Preferences >
+        Advanced), then Develop > Experimental Features > WebGPU.
+    </p>
+    <p>
+        In addition, you must be using Safari Technology Preview 92 or above.
+        You can get the latest STP <a href="https://developer.apple.com/safari/download/">here</a>.
+    </p>
+</div>
+<script src="scripts/textured-cube-shader-constants.js"></script>
+</body>
+</html>


### PR DESCRIPTION
#### c4287bb1ee99f7e34944ec7e8a962df6e452bbc9
<pre>
[WebGPU] Support module constants in vertex and fragment shaders
<a href="https://bugs.webkit.org/show_bug.cgi?id=249793">https://bugs.webkit.org/show_bug.cgi?id=249793</a>
&lt;radar://103490403&gt;

Reviewed by Myles C. Maxfield.

There are multiple ways to support module constants. One way
is to use MTLFunctionConstantValues which allows for shader
specialization after the shader is already compiled, however
it does require invoking the compiling again.

This is what this patch implements.

Alternatively we could defer compilation to render pipeline
creation, but that has the drawback of more compilations when
many pipeline objects are created.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::validateRenderPipeline):
(WebGPU::buildKeyValueReplacements):
(WebGPU::Device::createRenderPipeline):
Build a hash map containing the names of the constants and their values.

* Source/WebGPU/WebGPU/ShaderModule.h:
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::getNamedFunction const):
Support named function constants. In the future, we need to get the correct
type information from the compiler instead of assuming the type is float.

* Websites/webkit.org/demos/webgpu/scripts/textured-cube-shader-constants.js: Added.
(async helloCube.frameUpdate):
(async helloCube):
* Websites/webkit.org/demos/webgpu/textured-cube-shader-constants.html: Added.
Add a test which illustrates in the behavior.

Canonical link: <a href="https://commits.webkit.org/258808@main">https://commits.webkit.org/258808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7960b22a8af8cc25ebbfd6b15e9a3ec9f114767a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/12079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/112208 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/13099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2983 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/95198 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/110169 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/10061 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/93251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/37697 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/91902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24792 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/79427 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5516 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/26201 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2656 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45699 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6063 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7420 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->