### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/opacity.html WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity-expected.txt
@@ -8,14 +8,14 @@ PASS Can set 'opacity' to a number: 0
 PASS Can set 'opacity' to a number: -3.14
 PASS Can set 'opacity' to a number: 3.14
 PASS Can set 'opacity' to a number: calc(2 + 3)
+PASS Can set 'opacity' to a percent: 0%
+PASS Can set 'opacity' to a percent: -3.14%
+PASS Can set 'opacity' to a percent: 3.14%
+PASS Can set 'opacity' to a percent: calc(0% + 0%)
 PASS Setting 'opacity' to a length: 0px throws TypeError
 PASS Setting 'opacity' to a length: -3.14em throws TypeError
 PASS Setting 'opacity' to a length: 3.14cm throws TypeError
 PASS Setting 'opacity' to a length: calc(0px + 0em) throws TypeError
-FAIL Setting 'opacity' to a percent: 0% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'opacity' to a percent: -3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'opacity' to a percent: 3.14% throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
-FAIL Setting 'opacity' to a percent: calc(0% + 0%) throws TypeError assert_throws_js: function "() => styleMap.set(propertyName, example.input)" did not throw
 PASS Setting 'opacity' to a time: 0s throws TypeError
 PASS Setting 'opacity' to a time: -3.14ms throws TypeError
 PASS Setting 'opacity' to a time: 3.14s throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity.html
@@ -13,7 +13,7 @@
 <script>
 'use strict';
 
-function assert_is_equal_with_clamping(input, result) {
+function assert_is_equal_with_clamping_number(input, result) {
   const number = input.to('number');
 
   if (number.value < 0)
@@ -24,11 +24,26 @@ function assert_is_equal_with_clamping(input, result) {
     assert_style_value_equals(result, input);
 }
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const number = input.to('percent').value / 100.;
+
+  if (number < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'number'));
+  else if (number > 1)
+    assert_style_value_equals(result, new CSSUnitValue(100, 'number'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(number, 'number'));
+}
+
 runPropertyTests('opacity', [
   {
     syntax: '<number>',
-    computed: assert_is_equal_with_clamping
+    computed: assert_is_equal_with_clamping_number
   },
+  {
+    syntax: '<percentage>',
+    computed: assert_is_equal_with_clamping_percentage
+  }
 ]);
 
 </script>


### PR DESCRIPTION
#### c2f53e71142310d9c02ed77d26ee9a58d62725e4
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/opacity.html WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=249823">https://bugs.webkit.org/show_bug.cgi?id=249823</a>

Reviewed by Simon Fraser.

Fix css/css-typed-om/the-stylepropertymap/properties/opacity.html WPT test to
match the specification:
- <a href="https://w3c.github.io/csswg-drafts/css-color/#transparency">https://w3c.github.io/csswg-drafts/css-color/#transparency</a>

The `opacity` property should allow percentages and these percentages should
get converted to a number in the [0, 1] range in the computed value.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/opacity.html:

Canonical link: <a href="https://commits.webkit.org/258299@main">https://commits.webkit.org/258299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8b2cb9be53763b071dc8f8afac4ccb548f519fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110694 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170954 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1432 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93814 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108513 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35304 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90666 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegateReload (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78304 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4186 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24929 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1350 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44417 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6008 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2997 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->