### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/inline-size.html WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt
@@ -6,7 +6,7 @@ PASS Can set 'inline-size' to CSS-wide keywords: revert
 PASS Can set 'inline-size' to var() references:  var(--A)
 PASS Can set 'inline-size' to the 'auto' keyword: auto
 PASS Can set 'inline-size' to a percent: 0%
-FAIL Can set 'inline-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'inline-size' to a percent: -3.14%
 PASS Can set 'inline-size' to a percent: 3.14%
 PASS Can set 'inline-size' to a percent: calc(0% + 0%)
 PASS Can set 'inline-size' to a length: 0px
@@ -37,7 +37,7 @@ PASS Can set 'min-inline-size' to CSS-wide keywords: unset
 PASS Can set 'min-inline-size' to CSS-wide keywords: revert
 PASS Can set 'min-inline-size' to var() references:  var(--A)
 PASS Can set 'min-inline-size' to a percent: 0%
-FAIL Can set 'min-inline-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'min-inline-size' to a percent: -3.14%
 PASS Can set 'min-inline-size' to a percent: 3.14%
 PASS Can set 'min-inline-size' to a percent: calc(0% + 0%)
 PASS Can set 'min-inline-size' to a length: 0px
@@ -69,7 +69,7 @@ PASS Can set 'max-inline-size' to CSS-wide keywords: revert
 PASS Can set 'max-inline-size' to var() references:  var(--A)
 PASS Can set 'max-inline-size' to the 'none' keyword: none
 PASS Can set 'max-inline-size' to a percent: 0%
-FAIL Can set 'max-inline-size' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'max-inline-size' to a percent: -3.14%
 PASS Can set 'max-inline-size' to a percent: 3.14%
 PASS Can set 'max-inline-size' to a percent: calc(0% + 0%)
 PASS Can set 'max-inline-size' to a length: 0px

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size.html
@@ -13,11 +13,21 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 runPropertyTests('inline-size', [
   { syntax: 'auto' },
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<length>',
@@ -28,7 +38,8 @@ runPropertyTests('inline-size', [
 runPropertyTests('min-inline-size', [
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<length>',
@@ -40,7 +51,8 @@ runPropertyTests('max-inline-size', [
   { syntax: 'none' },
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<length>',


### PR DESCRIPTION
#### 1315b2b7f18d281b62e4ec66710a4c4b46d35f8b
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/inline-size.html WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=249824">https://bugs.webkit.org/show_bug.cgi?id=249824</a>

Reviewed by Simon Fraser.

Fix css/css-typed-om/the-stylepropertymap/properties/inline-size.html WPT test
to match the specification:
- <a href="https://w3c.github.io/csswg-drafts/css-logical/#propdef-min-inline-size">https://w3c.github.io/csswg-drafts/css-logical/#propdef-min-inline-size</a>
- <a href="https://w3c.github.io/csswg-drafts/css-logical/#propdef-max-inline-size">https://w3c.github.io/csswg-drafts/css-logical/#propdef-max-inline-size</a>
- <a href="https://w3c.github.io/csswg-drafts/css2/#propdef-max-width">https://w3c.github.io/csswg-drafts/css2/#propdef-max-width</a>
- <a href="https://w3c.github.io/csswg-drafts/css2/#propdef-min-width">https://w3c.github.io/csswg-drafts/css2/#propdef-min-width</a>

The specification says:
&quot;Negative values for min-width and max-width are illegal.&quot;

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/inline-size.html:

Canonical link: <a href="https://commits.webkit.org/258301@main">https://commits.webkit.org/258301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a92567c15bb0303c34e7bb2394d4a06a5bf41dc9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110746 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/171001 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1510 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93869 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108563 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107256 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/92058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4234 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4297 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10383 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/44465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6059 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3004 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->