### PR TITLE
Clean up WebKitLegacy's LayerFlushController/WebViewLayerFlushScheduler

### DIFF
--- a/Source/WebKitLegacy/SourcesCocoa.txt
+++ b/Source/WebKitLegacy/SourcesCocoa.txt
@@ -185,3 +185,4 @@ mac/WebView/WebScriptDebugger.mm
 mac/WebView/WebScriptDebugDelegate.mm
 mac/WebView/WebScriptWorld.mm
 mac/WebView/WebView.mm
+mac/WebView/WebViewRenderingUpdateScheduler.mm

--- a/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
+++ b/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		06693DDD0BFBA85200216072 /* WebInspectorClient.mm in Sources */ = {isa = PBXBuildFile; fileRef = 06693DDB0BFBA85200216072 /* WebInspectorClient.mm */; };
 		072E5F451ABF88750003B164 /* WebMediaPlaybackTargetPicker.h in Headers */ = {isa = PBXBuildFile; fileRef = 072E5F431ABF88750003B164 /* WebMediaPlaybackTargetPicker.h */; };
 		072E5F461ABF88750003B164 /* WebMediaPlaybackTargetPicker.mm in Sources */ = {isa = PBXBuildFile; fileRef = 072E5F441ABF88750003B164 /* WebMediaPlaybackTargetPicker.mm */; };
+		0FBE258429551487009DA69F /* WebViewRenderingUpdateScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FBE258229551487009DA69F /* WebViewRenderingUpdateScheduler.h */; };
 		1430C12C1B2C5DF700DEA01D /* WebViewGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1430C12A1B2C5DF700DEA01D /* WebViewGroup.cpp */; };
 		1430C12D1B2C5DF700DEA01D /* WebViewGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 1430C12B1B2C5DF700DEA01D /* WebViewGroup.h */; };
 		14D8252F0AF955090004F057 /* WebChromeClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 14D8252D0AF955090004F057 /* WebChromeClient.h */; };
@@ -729,6 +730,8 @@
 		06693DDB0BFBA85200216072 /* WebInspectorClient.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebInspectorClient.mm; sourceTree = "<group>"; };
 		072E5F431ABF88750003B164 /* WebMediaPlaybackTargetPicker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebMediaPlaybackTargetPicker.h; sourceTree = "<group>"; };
 		072E5F441ABF88750003B164 /* WebMediaPlaybackTargetPicker.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebMediaPlaybackTargetPicker.mm; sourceTree = "<group>"; };
+		0FBE258129551486009DA69F /* WebViewRenderingUpdateScheduler.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebViewRenderingUpdateScheduler.mm; sourceTree = "<group>"; };
+		0FBE258229551487009DA69F /* WebViewRenderingUpdateScheduler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebViewRenderingUpdateScheduler.h; sourceTree = "<group>"; };
 		1430C12A1B2C5DF700DEA01D /* WebViewGroup.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; name = WebViewGroup.cpp; path = WebCoreSupport/WebViewGroup.cpp; sourceTree = SOURCE_ROOT; };
 		1430C12B1B2C5DF700DEA01D /* WebViewGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebViewGroup.h; path = WebCoreSupport/WebViewGroup.h; sourceTree = SOURCE_ROOT; };
 		14D8252D0AF955090004F057 /* WebChromeClient.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = WebChromeClient.h; sourceTree = "<group>"; };
@@ -2060,6 +2063,8 @@
 				BC2E464C0FD8A96800A9D9DE /* WebViewData.mm */,
 				930D02BB06275F640076701E /* WebViewInternal.h */,
 				51A8B57D0428353A00CA2D3A /* WebViewPrivate.h */,
+				0FBE258229551487009DA69F /* WebViewRenderingUpdateScheduler.h */,
+				0FBE258129551486009DA69F /* WebViewRenderingUpdateScheduler.mm */,
 				C1D8112C202CED0600EE74F9 /* WebWindowAnimation.h */,
 				C1D8112D202CED0700EE74F9 /* WebWindowAnimation.mm */,
 			);
@@ -3130,6 +3135,7 @@
 				1430C12D1B2C5DF700DEA01D /* WebViewGroup.h in Headers */,
 				9398109B0824BF01008DF038 /* WebViewInternal.h in Headers */,
 				939810710824BF01008DF038 /* WebViewPrivate.h in Headers */,
+				0FBE258429551487009DA69F /* WebViewRenderingUpdateScheduler.h in Headers */,
 				A10C1D761820300E0036883A /* WebVisiblePosition.h in Headers */,
 				A10C1D781820300E0036883A /* WebVisiblePositionInternal.h in Headers */,
 				1AC7176F1A26568A002E3115 /* WebVisitedLinkStore.h in Headers */,

--- a/Source/WebKitLegacy/mac/WebView/WebViewData.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebViewData.mm
@@ -34,6 +34,7 @@
 #import "WebSelectionServiceController.h"
 #import "WebViewGroup.h"
 #import "WebViewInternal.h"
+#import "WebViewRenderingUpdateScheduler.h"
 #import <JavaScriptCore/InitializeThreading.h>
 #import <WebCore/AlternativeTextUIController.h>
 #import <WebCore/HistoryItem.h>
@@ -47,9 +48,6 @@
 
 #if PLATFORM(IOS_FAMILY)
 #import "WebGeolocationProviderIOS.h"
-#import <WebCore/RuntimeApplicationChecks.h>
-#import <WebCore/WebCoreThread.h>
-#import <WebCore/WebCoreThreadInternal.h>
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
@@ -63,82 +61,6 @@
 
 BOOL applicationIsTerminating = NO;
 int pluginDatabaseClientCount = 0;
-
-static CFRunLoopRef currentRunLoop()
-{
-#if PLATFORM(IOS_FAMILY)
-    // A race condition during WebView deallocation can lead to a crash if the layer sync run loop
-    // observer is added to the main run loop <rdar://problem/9798550>. However, for responsiveness,
-    // we still allow this, see <rdar://problem/7403328>. Since the race condition and subsequent
-    // crash are especially troublesome for iBooks, we never allow the observer to be added to the
-    // main run loop in iBooks.
-    if (WebCore::CocoaApplication::isIBooks())
-        return WebThreadRunLoop();
-#endif
-    return CFRunLoopGetCurrent();
-}
-
-void LayerFlushController::scheduleLayerFlush()
-{
-    m_layerFlushScheduler.schedule();
-}
-
-void LayerFlushController::invalidate()
-{
-    m_layerFlushScheduler.invalidate();
-    m_webView = nullptr;
-}
-
-LayerFlushController::LayerFlushController(WebView* webView)
-    : m_webView(webView)
-    , m_layerFlushScheduler(this)
-{
-    ASSERT_ARG(webView, webView);
-}
-
-WebViewLayerFlushScheduler::WebViewLayerFlushScheduler(LayerFlushController* flushController)
-    : m_flushController(flushController)
-{
-    m_runLoopObserver = makeUnique<WebCore::RunLoopObserver>(static_cast<CFIndex>(WebCore::RunLoopObserver::WellKnownRunLoopOrders::LayerFlush), [this]() {
-        this->layerFlushCallback();
-    });
-}
-
-WebViewLayerFlushScheduler::~WebViewLayerFlushScheduler()
-{
-}
-
-void WebViewLayerFlushScheduler::schedule()
-{
-    if (m_insideCallback)
-        m_rescheduledInsideCallback = true;
-
-    m_runLoopObserver->schedule(currentRunLoop());
-}
-
-void WebViewLayerFlushScheduler::invalidate()
-{
-    m_runLoopObserver->invalidate();
-}
-
-void WebViewLayerFlushScheduler::layerFlushCallback()
-{
-#if PLATFORM(IOS_FAMILY)
-    // Normally the layer flush callback happens before the web lock auto-unlock observer runs.
-    // However if the flush is rescheduled from the callback it may get pushed past it, to the next cycle.
-    WebThreadLock();
-#endif
-
-    @autoreleasepool {
-        RefPtr<LayerFlushController> protector = m_flushController;
-
-        SetForScope insideCallbackScope(m_insideCallback, true);
-        m_rescheduledInsideCallback = false;
-
-        if (m_flushController->flushLayers() && !m_rescheduledInsideCallback)
-            invalidate();
-    }
-}
 
 #if PLATFORM(MAC)
 

--- a/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
@@ -145,7 +145,13 @@ WebLayoutMilestones kitLayoutMilestones(OptionSet<WebCore::LayoutMilestone>);
 
 - (BOOL)_needsOneShotDrawingSynchronization;
 - (void)_setNeedsOneShotDrawingSynchronization:(BOOL)needsSynchronization;
+
 - (void)_scheduleUpdateRendering;
+- (void)_updateRendering;
+
+- (void)_willStartRenderingUpdateDisplay;
+- (void)_didCompleteRenderingUpdateDisplay;
+
 - (BOOL)_flushCompositingChanges;
 
 #if USE(AUTOCORRECTION_PANEL)

--- a/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebCore/RunLoopObserver.h>
+#import <wtf/FastMalloc.h>
+
+@class WebView;
+
+class WebViewRenderingUpdateScheduler {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit WebViewRenderingUpdateScheduler(WebView*);
+    ~WebViewRenderingUpdateScheduler();
+
+    void scheduleRenderingUpdate();
+    void invalidate();
+
+    void didCompleteRenderingUpdateDisplay();
+    
+private:
+
+    void registerCACommitHandlers();
+
+    void renderingUpdateRunLoopObserverCallback();
+    void updateRendering();
+
+    WebView* m_webView;
+
+    std::unique_ptr<WebCore::RunLoopObserver> m_renderingUpdateRunLoopObserver;
+    bool m_insideCallback { false };
+    bool m_rescheduledInsideCallback { false };
+    bool m_haveRegisteredCommitHandlers { false };
+};

--- a/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import "WebViewRenderingUpdateScheduler.h"
+
+#import "WebViewInternal.h"
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
+
+#if PLATFORM(IOS_FAMILY)
+#import <WebCore/RuntimeApplicationChecks.h>
+#import <WebCore/WebCoreThread.h>
+#import <WebCore/WebCoreThreadInternal.h>
+#endif
+
+WebViewRenderingUpdateScheduler::WebViewRenderingUpdateScheduler(WebView* webView)
+    : m_webView(webView)
+{
+    ASSERT_ARG(webView, webView);
+
+    m_renderingUpdateRunLoopObserver = makeUnique<WebCore::RunLoopObserver>(static_cast<CFIndex>(WebCore::RunLoopObserver::WellKnownRunLoopOrders::LayerFlush), [this]() {
+        this->renderingUpdateRunLoopObserverCallback();
+    });
+}
+
+WebViewRenderingUpdateScheduler::~WebViewRenderingUpdateScheduler() = default;
+
+void WebViewRenderingUpdateScheduler::scheduleRenderingUpdate()
+{
+    if (m_insideCallback)
+        m_rescheduledInsideCallback = true;
+
+    m_renderingUpdateRunLoopObserver->schedule();
+}
+
+void WebViewRenderingUpdateScheduler::invalidate()
+{
+    m_webView = nullptr;
+    m_renderingUpdateRunLoopObserver->invalidate();
+}
+
+void WebViewRenderingUpdateScheduler::didCompleteRenderingUpdateDisplay()
+{
+    m_haveRegisteredCommitHandlers = false;
+}
+
+void WebViewRenderingUpdateScheduler::registerCACommitHandlers()
+{
+    if (m_haveRegisteredCommitHandlers)
+        return;
+
+    WebView* webView = m_webView;
+    [CATransaction addCommitHandler:^{
+        [webView _willStartRenderingUpdateDisplay];
+    } forPhase:kCATransactionPhasePreLayout];
+
+    [CATransaction addCommitHandler:^{
+        [webView _didCompleteRenderingUpdateDisplay];
+    } forPhase:kCATransactionPhasePostCommit];
+    
+    m_haveRegisteredCommitHandlers = true;
+}
+
+void WebViewRenderingUpdateScheduler::renderingUpdateRunLoopObserverCallback()
+{
+#if PLATFORM(IOS_FAMILY)
+    // Normally the layer flush callback happens before the web lock auto-unlock observer runs.
+    // However if the flush is rescheduled from the callback it may get pushed past it, to the next cycle.
+    WebThreadLock();
+#endif
+
+    SetForScope insideCallbackScope(m_insideCallback, true);
+    m_rescheduledInsideCallback = false;
+
+    updateRendering();
+    registerCACommitHandlers();
+
+    if (!m_rescheduledInsideCallback)
+        m_renderingUpdateRunLoopObserver->invalidate();
+}
+
+/*
+    Note: Much of the following is obsolete.
+    
+    The order of events with compositing updates is this:
+
+   Start of runloop                                        End of runloop
+        |                                                       |
+      --|-------------------------------------------------------|--
+           ^         ^                                        ^
+           |         |                                        |
+    NSWindow update, |                                     CA commit
+     NSView drawing  |
+        flush        |
+                layerSyncRunLoopObserverCallBack
+
+    To avoid flashing, we have to ensure that compositing changes (rendered via
+    the CoreAnimation rendering display link) appear on screen at the same time
+    as content painted into the window via the normal WebCore rendering path.
+
+    CoreAnimation will commit any layer changes at the end of the runloop via
+    its "CA commit" observer. Those changes can then appear onscreen at any time
+    when the display link fires, which can result in unsynchronized rendering.
+
+    To fix this, the GraphicsLayerCA code in WebCore does not change the CA
+    layer tree during style changes and layout; it stores up all changes and
+    commits them via flushCompositingState(). There are then two situations in
+    which we can call flushCompositingState():
+
+    1. When painting. FrameView::paintContents() makes a call to flushCompositingState().
+
+    2. When style changes/layout have made changes to the layer tree which do not
+       result in painting. In this case we need a run loop observer to do a
+       flushCompositingState() at an appropriate time. The observer will keep firing
+       until the time is right (essentially when there are no more pending layouts).
+*/
+
+void WebViewRenderingUpdateScheduler::updateRendering()
+{
+    @autoreleasepool {
+#if PLATFORM(MAC)
+        NSWindow *window = [m_webView window];
+#endif // PLATFORM(MAC)
+
+        [m_webView _updateRendering];
+
+#if PLATFORM(MAC)
+        // AppKit may have disabled screen updates, thinking an upcoming window flush will re-enable them.
+        // In case setNeedsDisplayInRect() has prevented the window from needing to be flushed, re-enable screen
+        // updates here.
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        if (![window isFlushWindowDisabled])
+            [window _enableScreenUpdatesIfNeeded];
+        ALLOW_DEPRECATED_DECLARATIONS_END
+#endif
+    }
+}


### PR DESCRIPTION
#### 66783d616f3d0e3fd47f2a05e5ae7387ba5f5732
<pre>
Clean up WebKitLegacy&apos;s LayerFlushController/WebViewLayerFlushScheduler
<a href="https://bugs.webkit.org/show_bug.cgi?id=249826">https://bugs.webkit.org/show_bug.cgi?id=249826</a>
rdar://103653788

Reviewed by Tim Horton.

In WebKitLegacy, both LayerFlushController and WebViewLayerFlushScheduler existed, where
LayerFlushController owned a WebViewLayerFlushScheduler. These classes can be combined.

Confusingly, LayerFlushController was mostly implemented in WebViewData.mm, but LayerFlushController::flushLayers()
was in WebView.mm, making it hard to find.

So combine the classes into WebViewRenderingUpdateScheduler which lives in its own file. This class
does not need to be RefCounted. WebView methods that it calls are declared in WebViewInternal.h.

An iBooks-specific quirk is removed since Books no longer uses UIWebView.

* Source/WebKitLegacy/SourcesCocoa.txt:
* Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _close]):
(-[WebView close]):
(-[WebView _scheduleUpdateRendering]):
(-[WebView _updateRendering]):
(-[WebView _willStartRenderingUpdateDisplay]):
(-[WebView _didCompleteRenderingUpdateDisplay]):
(LayerFlushController::flushLayers): Deleted.
* Source/WebKitLegacy/mac/WebView/WebViewData.h:
(): Deleted.
(LayerFlushController::create): Deleted.
(LayerFlushController::didCompleteRenderingUpdateDisplay): Deleted.
* Source/WebKitLegacy/mac/WebView/WebViewData.mm:
(currentRunLoop): Deleted.
(LayerFlushController::scheduleLayerFlush): Deleted.
(LayerFlushController::invalidate): Deleted.
(LayerFlushController::LayerFlushController): Deleted.
(WebViewLayerFlushScheduler::WebViewLayerFlushScheduler): Deleted.
(WebViewLayerFlushScheduler::~WebViewLayerFlushScheduler): Deleted.
(WebViewLayerFlushScheduler::schedule): Deleted.
(WebViewLayerFlushScheduler::invalidate): Deleted.
(WebViewLayerFlushScheduler::layerFlushCallback): Deleted.
* Source/WebKitLegacy/mac/WebView/WebViewInternal.h:
* Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.h: Added.
* Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm: Added.
(currentRunLoop):
(WebViewRenderingUpdateScheduler::WebViewRenderingUpdateScheduler):
(WebViewRenderingUpdateScheduler::scheduleRenderingUpdate):
(WebViewRenderingUpdateScheduler::invalidate):
(WebViewRenderingUpdateScheduler::didCompleteRenderingUpdateDisplay):
(WebViewRenderingUpdateScheduler::registerCACommitHandlers):
(WebViewRenderingUpdateScheduler::renderingUpdateRunLoopObserverCallback):
(WebViewRenderingUpdateScheduler::updateRendering):

Canonical link: <a href="https://commits.webkit.org/258283@main">https://commits.webkit.org/258283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26f4426055b88986bd456c67262e0171e37798ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110720 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170975 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1461 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93836 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108537 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107231 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92035 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/35318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/90691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/23443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/78317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4209 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24954 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4272 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/1375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10358 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44443 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5695 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6034 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->