### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/height.html WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt
@@ -6,7 +6,7 @@ PASS Can set 'height' to CSS-wide keywords: revert
 PASS Can set 'height' to var() references:  var(--A)
 PASS Can set 'height' to the 'auto' keyword: auto
 PASS Can set 'height' to a percent: 0%
-FAIL Can set 'height' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'height' to a percent: -3.14%
 PASS Can set 'height' to a percent: 3.14%
 PASS Can set 'height' to a percent: calc(0% + 0%)
 PASS Can set 'height' to a length: 0px
@@ -37,7 +37,7 @@ PASS Can set 'min-height' to CSS-wide keywords: unset
 PASS Can set 'min-height' to CSS-wide keywords: revert
 PASS Can set 'min-height' to var() references:  var(--A)
 PASS Can set 'min-height' to a percent: 0%
-FAIL Can set 'min-height' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'min-height' to a percent: -3.14%
 PASS Can set 'min-height' to a percent: 3.14%
 PASS Can set 'min-height' to a percent: calc(0% + 0%)
 PASS Can set 'min-height' to a length: 0px
@@ -69,7 +69,7 @@ PASS Can set 'max-height' to CSS-wide keywords: revert
 PASS Can set 'max-height' to var() references:  var(--A)
 PASS Can set 'max-height' to the 'none' keyword: none
 PASS Can set 'max-height' to a percent: 0%
-FAIL Can set 'max-height' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'max-height' to a percent: -3.14%
 PASS Can set 'max-height' to a percent: 3.14%
 PASS Can set 'max-height' to a percent: calc(0% + 0%)
 PASS Can set 'max-height' to a length: 0px

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height.html
@@ -13,16 +13,33 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 runPropertyTests('height', [
   { syntax: 'auto' },
-  { syntax: '<percentage>', specified: assert_is_equal_with_range_handling },
-  { syntax: '<length>', specified: assert_is_equal_with_range_handling },
+  {
+    syntax: '<percentage>',
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
+  },
+  {
+    syntax: '<length>',
+    specified: assert_is_equal_with_range_handling
+  },
 ]);
 
 runPropertyTests('min-height', [
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<length>',
@@ -34,7 +51,8 @@ runPropertyTests('max-height', [
   { syntax: 'none' },
   {
     syntax: '<percentage>',
-    specified: assert_is_equal_with_range_handling
+    specified: assert_is_equal_with_range_handling,
+    computed: assert_is_equal_with_clamping_percentage
   },
   {
     syntax: '<length>',


### PR DESCRIPTION
#### ec49be126ec5821d41c4722c3d0ce49ca1465044
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/height.html WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=249825">https://bugs.webkit.org/show_bug.cgi?id=249825</a>

Reviewed by Simon Fraser.

Fix css/css-typed-om/the-stylepropertymap/properties/height.html WPT test to
match the specification:
- <a href="https://w3c.github.io/csswg-drafts/css-sizing/#preferred-size-properties">https://w3c.github.io/csswg-drafts/css-sizing/#preferred-size-properties</a>
- <a href="https://w3c.github.io/csswg-drafts/css-sizing/#max-size-properties">https://w3c.github.io/csswg-drafts/css-sizing/#max-size-properties</a>

The specification indicates that negative values are not allowed for these
properties. However, one of the subtests expects -3.14% as computed value.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/height.html:

Canonical link: <a href="https://commits.webkit.org/258297@main">https://commits.webkit.org/258297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2509e5503a09b99f94450702dc4d0bcb713800a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110690 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170950 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1428 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108509 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35290 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78287 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4182 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24926 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1349 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10331 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44414 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6004 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2999 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->