### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows.html WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt
@@ -10,7 +10,7 @@ PASS Can set 'grid-template-columns' to a length: -3.14em
 PASS Can set 'grid-template-columns' to a length: 3.14cm
 PASS Can set 'grid-template-columns' to a length: calc(0px + 0em)
 PASS Can set 'grid-template-columns' to a percent: 0%
-FAIL Can set 'grid-template-columns' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'grid-template-columns' to a percent: -3.14%
 PASS Can set 'grid-template-columns' to a percent: 3.14%
 PASS Can set 'grid-template-columns' to a percent: calc(0% + 0%)
 PASS Can set 'grid-template-columns' to a flexible length: 0fr
@@ -44,7 +44,7 @@ PASS Can set 'grid-template-rows' to a length: -3.14em
 PASS Can set 'grid-template-rows' to a length: 3.14cm
 PASS Can set 'grid-template-rows' to a length: calc(0px + 0em)
 PASS Can set 'grid-template-rows' to a percent: 0%
-FAIL Can set 'grid-template-rows' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'grid-template-rows' to a percent: -3.14%
 PASS Can set 'grid-template-rows' to a percent: 3.14%
 PASS Can set 'grid-template-rows' to a percent: calc(0% + 0%)
 PASS Can set 'grid-template-rows' to a flexible length: 0fr

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows.html
@@ -13,6 +13,15 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 for (const suffix of ['columns', 'rows']) {
   runPropertyTests(`grid-template-${suffix}`, [
     { syntax: 'none' },
@@ -22,7 +31,8 @@ for (const suffix of ['columns', 'rows']) {
     },
     {
       syntax: '<percentage>',
-      specified: assert_is_equal_with_range_handling
+      specified: assert_is_equal_with_range_handling,
+      computed: assert_is_equal_with_clamping_percentage
     },
     {
       syntax: '<flex>',


### PR DESCRIPTION
#### a53256f89d96130ddb41da1d8ab949c3b1fa9acd
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows.html WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=249828">https://bugs.webkit.org/show_bug.cgi?id=249828</a>

Reviewed by Simon Fraser.

Fix css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows.html
WPT test to match the specification:
- <a href="https://w3c.github.io/csswg-drafts/css-grid/#track-sizing">https://w3c.github.io/csswg-drafts/css-grid/#track-sizing</a>
- <a href="https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-list">https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-list</a>
- <a href="https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-size">https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-size</a>
- <a href="https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-breadth">https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-breadth</a>

The specification indicates that the track size cannot be a negative value.
However, the test was expected -3.14% as computed value in one of the checks.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-template-columns-rows.html:

Canonical link: <a href="https://commits.webkit.org/258302@main">https://commits.webkit.org/258302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3389d45727e9c58de06074ecfa3585ccc5fed9ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110692 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170952 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1430 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93812 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108511 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35295 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90663 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegateNavigateFragment (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78295 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4184 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24928 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1351 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44416 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6006 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3005 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->