### PR TITLE
Fix css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows.html WPT test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt
@@ -12,7 +12,7 @@ PASS Can set 'grid-auto-columns' to a length: -3.14em
 PASS Can set 'grid-auto-columns' to a length: 3.14cm
 PASS Can set 'grid-auto-columns' to a length: calc(0px + 0em)
 PASS Can set 'grid-auto-columns' to a percent: 0%
-FAIL Can set 'grid-auto-columns' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'grid-auto-columns' to a percent: -3.14%
 PASS Can set 'grid-auto-columns' to a percent: 3.14%
 PASS Can set 'grid-auto-columns' to a percent: calc(0% + 0%)
 PASS Can set 'grid-auto-columns' to a flexible length: 0fr
@@ -48,7 +48,7 @@ PASS Can set 'grid-auto-rows' to a length: -3.14em
 PASS Can set 'grid-auto-rows' to a length: 3.14cm
 PASS Can set 'grid-auto-rows' to a length: calc(0px + 0em)
 PASS Can set 'grid-auto-rows' to a percent: 0%
-FAIL Can set 'grid-auto-rows' to a percent: -3.14% assert_approx_equals: expected -3.14 +/- 0.000001 but got 0
+PASS Can set 'grid-auto-rows' to a percent: -3.14%
 PASS Can set 'grid-auto-rows' to a percent: 3.14%
 PASS Can set 'grid-auto-rows' to a percent: calc(0% + 0%)
 PASS Can set 'grid-auto-rows' to a flexible length: 0fr

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows.html
@@ -13,6 +13,15 @@
 <script>
 'use strict';
 
+function assert_is_equal_with_clamping_percentage(input, result) {
+  const percent = input.to('percent').value;
+
+  if (percent < 0)
+    assert_style_value_equals(result, new CSSUnitValue(0, 'percent'));
+  else
+    assert_style_value_equals(result, new CSSUnitValue(percent, 'percent'));
+}
+
 // grid-auto-columns/rows are list-valued.
 // Run list-valued tests here too.
 for (const suffix of ['columns', 'rows']) {
@@ -26,7 +35,8 @@ for (const suffix of ['columns', 'rows']) {
     },
     {
       syntax: '<percentage>',
-      specified: assert_is_equal_with_range_handling
+      specified: assert_is_equal_with_range_handling,
+      computed: assert_is_equal_with_clamping_percentage
     },
     { syntax: '<flex>' },
   ]);


### PR DESCRIPTION
#### 7a882e1d6fb98671ae732b8769a699b3a153a5b8
<pre>
Fix css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows.html WPT test
<a href="https://bugs.webkit.org/show_bug.cgi?id=249829">https://bugs.webkit.org/show_bug.cgi?id=249829</a>

Reviewed by Simon Fraser.

Fix css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows.html
WPT test to match the specification:
- <a href="https://w3c.github.io/csswg-drafts/css-grid/#auto-tracks">https://w3c.github.io/csswg-drafts/css-grid/#auto-tracks</a>
- <a href="https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-size">https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-size</a>
- <a href="https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-breadth">https://w3c.github.io/csswg-drafts/css-grid/#typedef-track-breadth</a>

The specification indicates that the track size cannot be a negative value.
However, the tests expects -3.14% as computed value in one of the checks.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/grid-auto-columns-rows.html:

Canonical link: <a href="https://commits.webkit.org/258296@main">https://commits.webkit.org/258296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/613baed883a900acd174b6fa4d6a13d4cb14af11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110693 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170953 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1431 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108512 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92011 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35303 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78303 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4185 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24930 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1348 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44418 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6007 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/3000 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->